### PR TITLE
CDRIVER-294 make mongoc-ssl thread safe

### DIFF
--- a/src/libmongoc.symbols
+++ b/src/libmongoc.symbols
@@ -1,3 +1,4 @@
+mongoc_cleanup
 mongoc_client_command
 mongoc_client_command_simple
 mongoc_client_destroy

--- a/src/mongoc/mongoc-init.c
+++ b/src/mongoc/mongoc-init.c
@@ -62,6 +62,25 @@ mongoc_init (void)
    mongoc_once (&once, _mongoc_do_init);
 }
 
+static MONGOC_ONCE_FUN( _mongoc_do_cleanup)
+{
+#ifdef MONGOC_ENABLE_SSL
+   _mongoc_ssl_cleanup();
+#endif
+
+#ifdef _WIN32
+   WSASCleanup ();
+#endif
+
+   MONGOC_ONCE_RETURN;
+}
+
+void
+mongoc_cleanup (void)
+{
+   static mongoc_once_t once = MONGOC_ONCE_INIT;
+   mongoc_once (&once, _mongoc_do_cleanup);
+}
 
 /*
  * On GCC, just use __attribute__((constructor)) to perform initialization
@@ -73,5 +92,12 @@ static void
 _mongoc_init_ctor (void)
 {
    mongoc_init ();
+}
+
+static void _mongoc_init_dtor (void) __attribute__((destructor));
+static void
+_mongoc_init_dtor (void)
+{
+   mongoc_cleanup ();
 }
 #endif

--- a/src/mongoc/mongoc-init.h
+++ b/src/mongoc/mongoc-init.h
@@ -32,6 +32,9 @@ BSON_BEGIN_DECLS
 void
 mongoc_init(void);
 
+void
+mongoc_cleanup(void);
+
 BSON_END_DECLS
 
 

--- a/src/mongoc/mongoc-ssl-private.h
+++ b/src/mongoc/mongoc-ssl-private.h
@@ -50,6 +50,9 @@ void
 _mongoc_ssl_init (void)
    BSON_GNUC_INTERNAL;
 
+void
+_mongoc_ssl_cleanup (void)
+   BSON_GNUC_INTERNAL;
 
 BSON_END_DECLS
 

--- a/tests/echo-server.c
+++ b/tests/echo-server.c
@@ -80,5 +80,7 @@ main (int   argc,
       mongoc_thread_create (&thread, client_thread, client_stream);
    }
 
+   mongoc_cleanup();
+
    return 0;
 }

--- a/tests/test-libmongoc.c
+++ b/tests/test-libmongoc.c
@@ -116,5 +116,7 @@ main (int   argc,
 
    TestSuite_Destroy (&suite);
 
+   mongoc_cleanup();
+
    return ret;
 }

--- a/tests/test-load.c
+++ b/tests/test-load.c
@@ -125,5 +125,7 @@ main (int   argc,
    mongoc_uri_destroy(uri);
    mongoc_client_pool_destroy(pool);
 
+   mongoc_cleanup();
+
    return 0;
 }

--- a/tests/test-replica-set-ssl.c
+++ b/tests/test-replica-set-ssl.c
@@ -100,5 +100,7 @@ main (int   argc,   /* IN */
    bson_free(gTestCAFile);
    bson_free(gTestPEMFileLocalhost);
 
+   mongoc_cleanup();
+
    return 0;
 }

--- a/tests/test-replica-set.c
+++ b/tests/test-replica-set.c
@@ -315,5 +315,7 @@ main (int   argc,   /* IN */
    ha_replica_set_shutdown(replica_set);
    ha_replica_set_destroy(replica_set);
 
+   mongoc_cleanup();
+
    return 0;
 }

--- a/tests/test-sharded-cluster.c
+++ b/tests/test-sharded-cluster.c
@@ -77,5 +77,7 @@ main (int argc,
 
    ha_sharded_cluster_shutdown(cluster);
 
+   mongoc_cleanup();
+
    return 0;
 }


### PR DESCRIPTION
Use
- CRYPTO_set_locking_callback
- CRYPTO_set_id_callback

to make mongoc-ssl thread safe (openssl needs locking and thread id
primitives appropriate to your platform, we provide pthreads and win32).

hooks startup into mongoc_init and cleanup into mongoc_cleanup
