### PR TITLE
added support for accessing getLastError document.

### DIFF
--- a/build/cmake/libmongoc-ssl.def
+++ b/build/cmake/libmongoc-ssl.def
@@ -29,6 +29,7 @@ mongoc_collection_drop
 mongoc_collection_drop_index
 mongoc_collection_ensure_index
 mongoc_collection_find
+mongoc_collection_get_last_error
 mongoc_collection_get_name
 mongoc_collection_get_read_prefs
 mongoc_collection_get_write_concern

--- a/build/cmake/libmongoc.def
+++ b/build/cmake/libmongoc.def
@@ -28,6 +28,7 @@ mongoc_collection_drop
 mongoc_collection_drop_index
 mongoc_collection_ensure_index
 mongoc_collection_find
+mongoc_collection_get_last_error
 mongoc_collection_get_name
 mongoc_collection_get_read_prefs
 mongoc_collection_get_write_concern

--- a/doc/mongoc_collection_get_last_error.txt
+++ b/doc/mongoc_collection_get_last_error.txt
@@ -1,0 +1,46 @@
+mongoc_collection_get_last_error(3)
+=============================
+
+
+NAME
+----
+mongoc_collection_get_last_error - Returns getLastError document.
+
+
+SYNOPSIS
+--------
+[source,c]
+-----------------------
+bson_t *
+mongoc_collection_get_last_error (const mongoc_collection_t *collection);
+-----------------------
+
+
+DESCRIPTION
+-----------
+The _mongoc_collection_get_last_error()_ function shall return getLastError
+document, according to write_concern on last executed command for current
+collection instance.
+
+write_concern must be at least MONGOC_WRITE_CONCERN_W_DEFAULT (1) in
+last command execution for getLastError to be available.
+
+Last executed command must be any of:
+_mongoc_collection_insert()_
+_mongoc_collection_insert_bulk()_
+_mongoc_collection_update()_
+_mongoc_collection_delete()_
+_mongoc_collection_save()_
+_mongoc_collection_ensure_index()_
+
+
+RETURN VALUE
+------------
+A newly allocated bson_t getLastError document, that *must* be destroyed
+with _bson_destroy()_. Or NULL if no getLastError present.
+
+
+AUTHORS
+-------
+
+This page was written by MongoDB Inc.

--- a/doc/mongoc_symbols.txt
+++ b/doc/mongoc_symbols.txt
@@ -29,6 +29,7 @@ linkmongoc:mongoc_collection_drop[3] +
 linkmongoc:mongoc_collection_drop_index[3] +
 linkmongoc:mongoc_collection_ensure_index[3] +
 linkmongoc:mongoc_collection_find[3] +
+linkmongoc:mongoc_collection_get_last_error[3] +
 linkmongoc:mongoc_collection_get_name[3] +
 linkmongoc:mongoc_collection_get_read_prefs[3] +
 linkmongoc:mongoc_collection_get_write_concern[3] +

--- a/src/libmongoc.symbols
+++ b/src/libmongoc.symbols
@@ -29,6 +29,7 @@ mongoc_collection_drop
 mongoc_collection_drop_index
 mongoc_collection_ensure_index
 mongoc_collection_find
+mongoc_collection_get_last_error
 mongoc_collection_get_name
 mongoc_collection_get_read_prefs
 mongoc_collection_get_write_concern

--- a/src/mongoc/mongoc-client-private.h
+++ b/src/mongoc/mongoc-client-private.h
@@ -74,7 +74,7 @@ bool             _mongoc_client_recv          (mongoc_client_t              *cli
                                                mongoc_buffer_t              *buffer,
                                                uint32_t                      hint,
                                                bson_error_t                 *error);
-bool             _mongoc_client_recv_gle      (mongoc_client_t              *client,
+bool             _mongoc_client_recv_gle      (mongoc_collection_t          *collection,
                                                uint32_t                      hint,
                                                bson_error_t                 *error);
 uint32_t         _mongoc_client_stamp         (mongoc_client_t              *client,

--- a/src/mongoc/mongoc-collection-private.h
+++ b/src/mongoc/mongoc-collection-private.h
@@ -40,6 +40,7 @@ struct _mongoc_collection_t
 
    mongoc_read_prefs_t    *read_prefs;
    mongoc_write_concern_t *write_concern;
+   bson_t *gle;
 };
 
 

--- a/src/mongoc/mongoc-collection.h
+++ b/src/mongoc/mongoc-collection.h
@@ -114,6 +114,7 @@ const mongoc_write_concern_t *mongoc_collection_get_write_concern    (const mong
 void                          mongoc_collection_set_write_concern    (mongoc_collection_t           *collection,
                                                                       const mongoc_write_concern_t  *write_concern);
 const char                   *mongoc_collection_get_name             (mongoc_collection_t           *collection);
+bson_t                       *mongoc_collection_get_last_error       (const mongoc_collection_t *collection);
 char                         *mongoc_collection_keys_to_index_string (const bson_t                  *keys);
 
 


### PR DESCRIPTION
new: mongoc_collection_get_last_error().
Documentation added.
Related to: https://jira.mongodb.org/browse/CDRIVER-295
