### PR TITLE
Be gentle to user provided BSON include path and only modify if really found by cmake script

### DIFF
--- a/build/cmake/FindBSON.cmake
+++ b/build/cmake/FindBSON.cmake
@@ -19,7 +19,9 @@ find_path(BSON_INCLUDE_DIR
     include
 )
 
+if(${BSON_INCLUDE_DIR})
 set(BSON_INCLUDE_DIR "${BSON_INCLUDE_DIR}/libbson-1.0")
+endif()
 
 if(WIN32 AND NOT CYGWIN)
   if(MSVC)


### PR DESCRIPTION
Minor fix: if bson can't be found automatically, user-provided path will inadvertently be modified by script and thus point to wrong directory.
