### PR TITLE
build: remove set_ssl_opts from libmongoc.def

### DIFF
--- a/build/cmake/libmongoc.def
+++ b/build/cmake/libmongoc.def
@@ -30,7 +30,6 @@ mongoc_client_pool_destroy
 mongoc_client_pool_new
 mongoc_client_pool_pop
 mongoc_client_pool_push
-mongoc_client_pool_set_ssl_opts
 mongoc_client_pool_try_pop
 mongoc_client_set_read_prefs
 mongoc_client_set_stream_initiator


### PR DESCRIPTION
Removed a reference to `mongoc_client_pool_set_ssl_opts()` from
libmongoc.def.

This fixes a bug when building with cmake: configuring it with `--without-ssl` still had this extra reference.

Credit to @Machyne and @hanumantmk
