### PR TITLE
Bulk API fixes

### DIFF
--- a/src/mongoc/mongoc-write-command-private.h
+++ b/src/mongoc/mongoc-write-command-private.h
@@ -54,6 +54,7 @@ typedef struct
          bson_t   *documents;
          uint32_t  n_documents;
          uint32_t  n_merged;
+         uint32_t  current_n_documents;
       } insert;
       struct {
          uint8_t   ordered : 1;


### PR DESCRIPTION
o We didn't manage the index offsetting correctly for bulk inserts.
o We didn't massage errors into writeErrors for legacy operations

---

This gets things working on 2.4 and 2.6.  What do you think of the approach?
