### PR TITLE
Move "Falling back to malloc for counters." warning inside #ifdef. 

### DIFF
--- a/src/mongoc/mongoc-counters.c
+++ b/src/mongoc/mongoc-counters.c
@@ -199,9 +199,8 @@ failure:
    close (fd);
 
 use_malloc:
+   MONGOC_WARNING("Falling back to malloc for counters.");
 #endif
-
-   MONGOC_WARNING ("Falling back to malloc for counters.");
 
    gCounterFallback = bson_malloc0 (size);
    atexit (mongoc_counters_destroy);


### PR DESCRIPTION
It seems this warning is unix-specific and should not appears on windows.
On windows always used malloc and this warning useless, it makes sense only for unix if shared memory segment is not used.
