### PR TITLE
CDRIVER-427 move header include guard above checks

### DIFF
--- a/src/mongoc/mongoc-array-private.h
+++ b/src/mongoc/mongoc-array-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_ARRAY_PRIVATE_H
+#define MONGOC_ARRAY_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_ARRAY_PRIVATE_H
-#define MONGOC_ARRAY_PRIVATE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-buffer-private.h
+++ b/src/mongoc/mongoc-buffer-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_BUFFER_PRIVATE_H
+#define MONGOC_BUFFER_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_BUFFER_PRIVATE_H
-#define MONGOC_BUFFER_PRIVATE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-bulk-operation-private.h
+++ b/src/mongoc/mongoc-bulk-operation-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_BULK_OPERATION_PRIVATE_H
+#define MONGOC_BULK_OPERATION_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_BULK_OPERATION_PRIVATE_H
-#define MONGOC_BULK_OPERATION_PRIVATE_H
-
 
 #include "mongoc-array-private.h"
 #include "mongoc-client.h"

--- a/src/mongoc/mongoc-client-pool.h
+++ b/src/mongoc/mongoc-client-pool.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_CLIENT_POOL_H
+#define MONGOC_CLIENT_POOL_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_CLIENT_POOL_H
-#define MONGOC_CLIENT_POOL_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-client-private.h
+++ b/src/mongoc/mongoc-client-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_CLIENT_PRIVATE_H
+#define MONGOC_CLIENT_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_CLIENT_PRIVATE_H
-#define MONGOC_CLIENT_PRIVATE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-client.h
+++ b/src/mongoc/mongoc-client.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_CLIENT_H
+#define MONGOC_CLIENT_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_CLIENT_H
-#define MONGOC_CLIENT_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-cluster-private.h
+++ b/src/mongoc/mongoc-cluster-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_CLUSTER_PRIVATE_H
+#define MONGOC_CLUSTER_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_CLUSTER_PRIVATE_H
-#define MONGOC_CLUSTER_PRIVATE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-collection-private.h
+++ b/src/mongoc/mongoc-collection-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_COLLECTION_PRIVATE_H
+#define MONGOC_COLLECTION_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_COLLECTION_PRIVATE_H
-#define MONGOC_COLLECTION_PRIVATE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-collection.h
+++ b/src/mongoc/mongoc-collection.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_COLLECTION_H
+#define MONGOC_COLLECTION_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_COLLECTION_H
-#define MONGOC_COLLECTION_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-counters-private.h
+++ b/src/mongoc/mongoc-counters-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_COUNTERS_PRIVATE_H
+#define MONGOC_COUNTERS_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_COUNTERS_PRIVATE_H
-#define MONGOC_COUNTERS_PRIVATE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-cursor-array-private.h
+++ b/src/mongoc/mongoc-cursor-array-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_CURSOR_ARRAY_PRIVATE_H
+#define MONGOC_CURSOR_ARRAY_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_CURSOR_ARRAY_PRIVATE_H
-#define MONGOC_CURSOR_ARRAY_PRIVATE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-cursor-cursorid-private.h
+++ b/src/mongoc/mongoc-cursor-cursorid-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_CURSOR_CURSORID_PRIVATE_H
+#define MONGOC_CURSOR_CURSORID_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_CURSOR_CURSORID_PRIVATE_H
-#define MONGOC_CURSOR_CURSORID_PRIVATE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-cursor-private.h
+++ b/src/mongoc/mongoc-cursor-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_CURSOR_PRIVATE_H
+#define MONGOC_CURSOR_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_CURSOR_PRIVATE_H
-#define MONGOC_CURSOR_PRIVATE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-cursor.h
+++ b/src/mongoc/mongoc-cursor.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_CURSOR_H
+#define MONGOC_CURSOR_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_CURSOR_H
-#define MONGOC_CURSOR_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-database-private.h
+++ b/src/mongoc/mongoc-database-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_DATABASE_PRIVATE_H
+#define MONGOC_DATABASE_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_DATABASE_PRIVATE_H
-#define MONGOC_DATABASE_PRIVATE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-database.h
+++ b/src/mongoc/mongoc-database.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_DATABASE_H
+#define MONGOC_DATABASE_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_DATABASE_H
-#define MONGOC_DATABASE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-errno-private.h
+++ b/src/mongoc/mongoc-errno-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_ERRNO_PRIVATE_H
+#define MONGOC_ERRNO_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_ERRNO_PRIVATE_H
-#define MONGOC_ERRNO_PRIVATE_H
-
 
 #include <bson.h>
 #include <errno.h>

--- a/src/mongoc/mongoc-error.h
+++ b/src/mongoc/mongoc-error.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_ERRORS_H
+#define MONGOC_ERRORS_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_ERRORS_H
-#define MONGOC_ERRORS_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-flags.h
+++ b/src/mongoc/mongoc-flags.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_FLAGS_H
+#define MONGOC_FLAGS_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_FLAGS_H
-#define MONGOC_FLAGS_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-gridfs-file-list-private.h
+++ b/src/mongoc/mongoc-gridfs-file-list-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_GRIDFS_FILE_LIST_PRIVATE_H
+#define MONGOC_GRIDFS_FILE_LIST_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_GRIDFS_FILE_LIST_PRIVATE_H
-#define MONGOC_GRIDFS_FILE_LIST_PRIVATE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-gridfs-file-list.h
+++ b/src/mongoc/mongoc-gridfs-file-list.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_GRIDFS_FILE_LIST_H
+#define MONGOC_GRIDFS_FILE_LIST_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_GRIDFS_FILE_LIST_H
-#define MONGOC_GRIDFS_FILE_LIST_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-gridfs-file-page-private.h
+++ b/src/mongoc/mongoc-gridfs-file-page-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_GRIDFS_FILE_PAGE_PRIVATE_H
+#define MONGOC_GRIDFS_FILE_PAGE_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_GRIDFS_FILE_PAGE_PRIVATE_H
-#define MONGOC_GRIDFS_FILE_PAGE_PRIVATE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-gridfs-file-page.h
+++ b/src/mongoc/mongoc-gridfs-file-page.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_GRIDFS_FILE_PAGE_H
+#define MONGOC_GRIDFS_FILE_PAGE_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_GRIDFS_FILE_PAGE_H
-#define MONGOC_GRIDFS_FILE_PAGE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-gridfs-file-private.h
+++ b/src/mongoc/mongoc-gridfs-file-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_GRIDFS_FILE_PRIVATE_H
+#define MONGOC_GRIDFS_FILE_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_GRIDFS_FILE_PRIVATE_H
-#define MONGOC_GRIDFS_FILE_PRIVATE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-gridfs-file.h
+++ b/src/mongoc/mongoc-gridfs-file.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_GRIDFS_FILE_H
+#define MONGOC_GRIDFS_FILE_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_GRIDFS_FILE_H
-#define MONGOC_GRIDFS_FILE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-gridfs-private.h
+++ b/src/mongoc/mongoc-gridfs-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_GRIDFS_PRIVATE_H
+#define MONGOC_GRIDFS_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_GRIDFS_PRIVATE_H
-#define MONGOC_GRIDFS_PRIVATE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-gridfs.h
+++ b/src/mongoc/mongoc-gridfs.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_GRIDFS_H
+#define MONGOC_GRIDFS_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_GRIDFS_H
-#define MONGOC_GRIDFS_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-host-list-private.h
+++ b/src/mongoc/mongoc-host-list-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_HOST_LIST_PRIVATE_H
+#define MONGOC_HOST_LIST_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_HOST_LIST_PRIVATE_H
-#define MONGOC_HOST_LIST_PRIVATE_H
-
 
 #include "mongoc-host-list.h"
 

--- a/src/mongoc/mongoc-host-list.h
+++ b/src/mongoc/mongoc-host-list.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_HOST_LIST_H
+#define MONGOC_HOST_LIST_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_HOST_LIST_H
-#define MONGOC_HOST_LIST_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-index.h
+++ b/src/mongoc/mongoc-index.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_INDEX_H
+#define MONGOC_INDEX_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_INDEX_H
-#define MONGOC_INDEX_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-init.h
+++ b/src/mongoc/mongoc-init.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_INIT_H
+#define MONGOC_INIT_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_INIT_H
-#define MONGOC_INIT_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-list-private.h
+++ b/src/mongoc/mongoc-list-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_LIST_H
+#define MONGOC_LIST_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_LIST_H
-#define MONGOC_LIST_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-log.h
+++ b/src/mongoc/mongoc-log.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_LOG_H
+#define MONGOC_LOG_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_LOG_H
-#define MONGOC_LOG_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-matcher-op-private.h
+++ b/src/mongoc/mongoc-matcher-op-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_MATCHER_OP_PRIVATE_H
+#define MONGOC_MATCHER_OP_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_MATCHER_OP_PRIVATE_H
-#define MONGOC_MATCHER_OP_PRIVATE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-matcher-private.h
+++ b/src/mongoc/mongoc-matcher-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_MATCHER_PRIVATE_H
+#define MONGOC_MATCHER_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_MATCHER_PRIVATE_H
-#define MONGOC_MATCHER_PRIVATE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-matcher.h
+++ b/src/mongoc/mongoc-matcher.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_MATCHER_H
+#define MONGOC_MATCHER_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_MATCHER_H
-#define MONGOC_MATCHER_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-opcode.h
+++ b/src/mongoc/mongoc-opcode.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_OPCODE_H
+#define MONGOC_OPCODE_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_OPCODE_H
-#define MONGOC_OPCODE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-queue-private.h
+++ b/src/mongoc/mongoc-queue-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_QUEUE_PRIVATE_H
+#define MONGOC_QUEUE_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_QUEUE_PRIVATE_H
-#define MONGOC_QUEUE_PRIVATE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-read-prefs-private.h
+++ b/src/mongoc/mongoc-read-prefs-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_READ_PREFS_PRIVATE_H
+#define MONGOC_READ_PREFS_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_READ_PREFS_PRIVATE_H
-#define MONGOC_READ_PREFS_PRIVATE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-read-prefs.h
+++ b/src/mongoc/mongoc-read-prefs.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_READ_PREFS_H
+#define MONGOC_READ_PREFS_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_READ_PREFS_H
-#define MONGOC_READ_PREFS_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-rpc-private.h
+++ b/src/mongoc/mongoc-rpc-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_RPC_PRIVATE_H
+#define MONGOC_RPC_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_RPC_PRIVATE_H
-#define MONGOC_RPC_PRIVATE_H
-
 
 #include <bson.h>
 #include <stddef.h>

--- a/src/mongoc/mongoc-sasl-private.h
+++ b/src/mongoc/mongoc-sasl-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_SASL_PRIVATE_H
+#define MONGOC_SASL_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_SASL_PRIVATE_H
-#define MONGOC_SASL_PRIVATE_H
-
 
 #include <bson.h>
 #include <sasl/sasl.h>

--- a/src/mongoc/mongoc-socket.h
+++ b/src/mongoc/mongoc-socket.h
@@ -14,16 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_SOCKET_H
+#define MONGOC_SOCKET_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-
-#ifndef MONGOC_SOCKET_H
-#define MONGOC_SOCKET_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-ssl-private.h
+++ b/src/mongoc/mongoc-ssl-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_SSL_PRIVATE_H
+#define MONGOC_SSL_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_SSL_PRIVATE_H
-#define MONGOC_SSL_PRIVATE_H
-
 
 #include <bson.h>
 #include <openssl/bio.h>

--- a/src/mongoc/mongoc-ssl.h
+++ b/src/mongoc/mongoc-ssl.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_SSL_H
+#define MONGOC_SSL_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_SSL_H
-#define MONGOC_SSL_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-stream-buffered.h
+++ b/src/mongoc/mongoc-stream-buffered.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_STREAM_BUFFERED_H
+#define MONGOC_STREAM_BUFFERED_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_STREAM_BUFFERED_H
-#define MONGOC_STREAM_BUFFERED_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-stream-file.h
+++ b/src/mongoc/mongoc-stream-file.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_STREAM_FILE_H
+#define MONGOC_STREAM_FILE_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_STREAM_FILE_H
-#define MONGOC_STREAM_FILE_H
-
 
 #include "mongoc-stream.h"
 

--- a/src/mongoc/mongoc-stream-gridfs.h
+++ b/src/mongoc/mongoc-stream-gridfs.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_STREAM_GRIDFS_H
+#define MONGOC_STREAM_GRIDFS_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_STREAM_GRIDFS_H
-#define MONGOC_STREAM_GRIDFS_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-stream-private.h
+++ b/src/mongoc/mongoc-stream-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_STREAM_PRIVATE_H
+#define MONGOC_STREAM_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_STREAM_PRIVATE_H
-#define MONGOC_STREAM_PRIVATE_H
-
 
 #include "mongoc-iovec.h"
 #include "mongoc-stream.h"

--- a/src/mongoc/mongoc-stream-socket.h
+++ b/src/mongoc/mongoc-stream-socket.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_STREAM_SOCKET_H
+#define MONGOC_STREAM_SOCKET_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_STREAM_SOCKET_H
-#define MONGOC_STREAM_SOCKET_H
-
 
 #include "mongoc-socket.h"
 #include "mongoc-stream.h"

--- a/src/mongoc/mongoc-stream-tls.h
+++ b/src/mongoc/mongoc-stream-tls.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_STREAM_TLS_H
+#define MONGOC_STREAM_TLS_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_STREAM_TLS_H
-#define MONGOC_STREAM_TLS_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-stream.h
+++ b/src/mongoc/mongoc-stream.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_STREAM_H
+#define MONGOC_STREAM_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_STREAM_H
-#define MONGOC_STREAM_H
-
 
 #include "mongoc-iovec.h"
 #include "mongoc-socket.h"

--- a/src/mongoc/mongoc-thread-private.h
+++ b/src/mongoc/mongoc-thread-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_THREAD_PRIVATE_H
+#define MONGOC_THREAD_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_THREAD_PRIVATE_H
-#define MONGOC_THREAD_PRIVATE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-uri.h
+++ b/src/mongoc/mongoc-uri.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_URI_H
+#define MONGOC_URI_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_URI_H
-#define MONGOC_URI_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-util-private.h
+++ b/src/mongoc/mongoc-util-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_UTIL_PRIVATE_H
+#define MONGOC_UTIL_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_UTIL_PRIVATE_H
-#define MONGOC_UTIL_PRIVATE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-write-command-private.h
+++ b/src/mongoc/mongoc-write-command-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_WRITE_COMMAND_PRIVATE_H
+#define MONGOC_WRITE_COMMAND_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_WRITE_COMMAND_PRIVATE_H
-#define MONGOC_WRITE_COMMAND_PRIVATE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-write-concern-private.h
+++ b/src/mongoc/mongoc-write-concern-private.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_WRITE_CONCERN_PRIVATE_H
+#define MONGOC_WRITE_CONCERN_PRIVATE_H
 
 #if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
 #error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_WRITE_CONCERN_PRIVATE_H
-#define MONGOC_WRITE_CONCERN_PRIVATE_H
-
 
 #include <bson.h>
 

--- a/src/mongoc/mongoc-write-concern.h
+++ b/src/mongoc/mongoc-write-concern.h
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
+#ifndef MONGOC_WRITE_CONCERN_H
+#define MONGOC_WRITE_CONCERN_H
 
 #if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
 # error "Only <mongoc.h> can be included directly."
 #endif
-
-
-#ifndef MONGOC_WRITE_CONCERN_H
-#define MONGOC_WRITE_CONCERN_H
-
 
 #include <bson.h>
 


### PR DESCRIPTION
Seems to work including the file jeremy mentioned with this test program:

``` c
#include <stdio.h>
#include "mongoc.h"
#include "mongoc-bulk-operation-private.h"

int main() {
    printf("works\n");
    return 0;
}
```

``` sh
gcc -I./include/libmongoc-1.0 -I./include/libbson-1.0 test.c -DMONGOC_I_AM_A_DRIVER -o test
```
