### PR TITLE
CDRIVER-437 Add authMechanismProperties to URI

### DIFF
--- a/build/cmake/libmongoc-ssl.def
+++ b/build/cmake/libmongoc-ssl.def
@@ -182,8 +182,10 @@ mongoc_uri_copy
 mongoc_uri_destroy
 mongoc_uri_get_auth_mechanism
 mongoc_uri_get_auth_source
+mongoc_uri_get_credentials
 mongoc_uri_get_database
 mongoc_uri_get_hosts
+mongoc_uri_get_mechanism_properties
 mongoc_uri_get_options
 mongoc_uri_get_password
 mongoc_uri_get_read_prefs

--- a/src/libmongoc.symbols
+++ b/src/libmongoc.symbols
@@ -191,8 +191,10 @@ mongoc_uri_copy
 mongoc_uri_destroy
 mongoc_uri_get_auth_mechanism
 mongoc_uri_get_auth_source
+mongoc_uri_get_credentials
 mongoc_uri_get_database
 mongoc_uri_get_hosts
+mongoc_uri_get_mechanism_properties
 mongoc_uri_get_options
 mongoc_uri_get_password
 mongoc_uri_get_read_prefs

--- a/src/mongoc/mongoc-uri.c
+++ b/src/mongoc/mongoc-uri.c
@@ -39,10 +39,10 @@ struct _mongoc_uri_t
    char                   *password;
    char                   *database;
    bson_t                  options;
+   bson_t                  credentials;
    bson_t                  read_prefs;
    mongoc_write_concern_t *write_concern;
 };
-
 
 static void
 mongoc_uri_do_unescape (char **str)
@@ -86,10 +86,32 @@ mongoc_uri_append_host (mongoc_uri_t  *uri,
    }
 }
 
+/*
+ *--------------------------------------------------------------------------
+ *
+ * scan_to_unichar --
+ *
+ *       Scans 'str' until either a character matching 'match' is found,
+ *       until one of the characters in 'terminators' is encountered, or
+ *       until we reach the end of 'str'.
+ *
+ *       NOTE: 'terminators' may not include multibyte UTF-8 characters.
+ *
+ * Returns:
+ *       If 'match' is found, returns a copy of the section of 'str' before
+ *       that character.  Otherwise, returns NULL.
+ *
+ * Side Effects:
+ *       If 'match' is found, sets 'end' to begin at the matching character
+ *       in 'str'.
+ *
+ *--------------------------------------------------------------------------
+ */
 
 static char *
 scan_to_unichar (const char      *str,
-                 bson_unichar_t   stop,
+                 bson_unichar_t   match,
+                 const char      *terminators,
                  const char     **end)
 {
    bson_unichar_t c;
@@ -97,15 +119,21 @@ scan_to_unichar (const char      *str,
 
    for (iter = str;
         iter && *iter && (c = bson_utf8_get_char(iter));
-        iter = bson_utf8_next_char(iter))
-   {
-      if (c == stop) {
+        iter = bson_utf8_next_char(iter)) {
+      if (c == match) {
          *end = iter;
          return bson_strndup(str, iter - str);
       } else if (c == '\\') {
          iter = bson_utf8_next_char(iter);
          if (!bson_utf8_get_char(iter)) {
             break;
+         }
+      } else {
+         const char *term_iter;
+         for (term_iter = terminators; *term_iter; term_iter++) {
+            if (c == *term_iter) {
+               return NULL;
+            }
          }
       }
    }
@@ -138,8 +166,8 @@ mongoc_uri_parse_userpass (mongoc_uri_t  *uri,
    const char *end_user;
    char *s;
 
-   if ((s = scan_to_unichar(str, '@', &end_userpass))) {
-      if ((uri->username = scan_to_unichar(s, ':', &end_user))) {
+   if ((s = scan_to_unichar(str, '@', "", &end_userpass))) {
+      if ((uri->username = scan_to_unichar(s, ':', "", &end_user))) {
          uri->password = bson_strdup(end_user + 1);
       } else {
          uri->username = bson_strndup(str, end_userpass - str);
@@ -175,7 +203,7 @@ mongoc_uri_parse_host6 (mongoc_uri_t  *uri,
 #endif
    }
 
-   hostname = scan_to_unichar (str + 1, ']', &end_host);
+   hostname = scan_to_unichar (str + 1, ']', "", &end_host);
 
    mongoc_uri_do_unescape (&hostname);
    mongoc_uri_append_host (uri, hostname, port);
@@ -197,7 +225,7 @@ mongoc_uri_parse_host (mongoc_uri_t  *uri,
       return mongoc_uri_parse_host6 (uri, str);
    }
 
-   if ((hostname = scan_to_unichar(str, ':', &end_host))) {
+   if ((hostname = scan_to_unichar(str, ':', "?/,", &end_host))) {
       end_host++;
       if (!isdigit(*end_host)) {
          bson_free(hostname);
@@ -234,7 +262,7 @@ _mongoc_host_list_from_string (mongoc_host_list_t *host_list,
 
    memset(host_list, 0, sizeof *host_list);
 
-   if ((hostname = scan_to_unichar(host_and_port, ':', &end_host))) {
+   if ((hostname = scan_to_unichar(host_and_port, ':', "", &end_host))) {
       end_host++;
       if (!isdigit(*end_host)) {
          bson_free(hostname);
@@ -305,7 +333,7 @@ again:
          str++;
          goto again;
       }
-   } else if ((s = scan_to_unichar(str, ',', &end_hostport))) {
+   } else if ((s = scan_to_unichar(str, ',', "/", &end_hostport))) {
       if (!mongoc_uri_parse_host(uri, s)) {
          bson_free(s);
          return false;
@@ -314,8 +342,8 @@ again:
       str = end_hostport + 1;
       ret = true;
       goto again;
-   } else if ((s = scan_to_unichar(str, '/', &end_hostport)) ||
-              (s = scan_to_unichar(str, '?', &end_hostport))) {
+   } else if ((s = scan_to_unichar(str, '/', "", &end_hostport)) ||
+              (s = scan_to_unichar(str, '?', "", &end_hostport))) {
       if (!mongoc_uri_parse_host(uri, s)) {
          bson_free(s);
          return false;
@@ -342,7 +370,7 @@ mongoc_uri_parse_database (mongoc_uri_t  *uri,
 {
    const char *end_database;
 
-   if ((uri->database = scan_to_unichar(str, '?', &end_database))) {
+   if ((uri->database = scan_to_unichar(str, '?', "", &end_database))) {
       *end = end_database;
    } else if (*str) {
       uri->database = bson_strdup(str);
@@ -354,6 +382,36 @@ mongoc_uri_parse_database (mongoc_uri_t  *uri,
    return true;
 }
 
+
+static bool
+mongoc_uri_parse_auth_mechanism_properties (mongoc_uri_t *uri,
+                                            const char   *str)
+{
+   char *field;
+   char *value;
+   const char *end_scan;
+   bson_t properties;
+
+   bson_init(&properties);
+
+   /* build up the properties document */
+   while ((field = scan_to_unichar(str, ':', "&", &end_scan))) {
+      str = end_scan + 1;
+      if (!(value = scan_to_unichar(str, ',', ":&", &end_scan))) {
+         value = bson_strdup(str);
+         end_scan = str + strlen(value);
+      }
+      str = end_scan + 1;
+      bson_append_utf8(&properties, field, -1, value, -1);
+      bson_free(field);
+      bson_free(value);
+   }
+
+   /* append our auth properties to our credentials */
+   bson_append_document(&uri->credentials, "mechanismProperties",
+                        -1, (const bson_t *)&properties);
+   return true;
+}
 
 static void
 mongoc_uri_parse_tags (mongoc_uri_t *uri, /* IN */
@@ -371,8 +429,8 @@ mongoc_uri_parse_tags (mongoc_uri_t *uri, /* IN */
    bson_init(&b);
 
 again:
-   if ((keyval = scan_to_unichar(str, ',', &end_keyval))) {
-      if ((key = scan_to_unichar(keyval, ':', &end_key))) {
+   if ((keyval = scan_to_unichar(str, ',', "", &end_keyval))) {
+      if ((key = scan_to_unichar(keyval, ':', "", &end_key))) {
          bson_append_utf8(&b, key, -1, end_key + 1, -1);
          bson_free(key);
       }
@@ -380,7 +438,7 @@ again:
       str = end_keyval + 1;
       goto again;
    } else {
-      if ((key = scan_to_unichar(str, ':', &end_key))) {
+       if ((key = scan_to_unichar(str, ':', "", &end_key))) {
          bson_append_utf8(&b, key, -1, end_key + 1, -1);
          bson_free(key);
       }
@@ -402,7 +460,7 @@ mongoc_uri_parse_option (mongoc_uri_t *uri,
    char *key;
    char *value;
 
-   if (!(key = scan_to_unichar(str, '=', &end_key))) {
+   if (!(key = scan_to_unichar(str, '=', "", &end_key))) {
       return false;
    }
 
@@ -439,6 +497,15 @@ mongoc_uri_parse_option (mongoc_uri_t *uri,
                         (0 == strcmp (value, "1")));
    } else if (!strcasecmp(key, "readpreferencetags")) {
       mongoc_uri_parse_tags(uri, value, &uri->read_prefs);
+   } else if (!strcasecmp(key, "authmechanism") ||
+              !strcasecmp(key, "authsource")) {
+      bson_append_utf8(&uri->credentials, key, -1, value, -1);
+   } else if (!strcasecmp(key, "authmechanismproperties")) {
+      if (!mongoc_uri_parse_auth_mechanism_properties(uri, value)) {
+         bson_free(key);
+         bson_free(value);
+         return false;
+      }
    } else {
       bson_append_utf8(&uri->options, key, -1, value, -1);
    }
@@ -458,7 +525,7 @@ mongoc_uri_parse_options (mongoc_uri_t *uri,
    char *option;
 
 again:
-   if ((option = scan_to_unichar(str, '&', &end_option))) {
+   if ((option = scan_to_unichar(str, '&', "", &end_option))) {
       if (!mongoc_uri_parse_option(uri, option)) {
          bson_free(option);
          return false;
@@ -475,6 +542,32 @@ again:
    return true;
 }
 
+
+static bool
+mongoc_uri_finalize_auth (mongoc_uri_t *uri) {
+   bson_iter_t iter;
+   const char *source = NULL;
+   const char *mechanism = mongoc_uri_get_auth_mechanism(uri);
+
+   if (bson_iter_init_find_case(&iter, &uri->credentials, "authSource")) {
+      source = bson_iter_utf8(&iter, NULL);
+   }
+
+   /* authSource with GSSAPI or X509 should always be external */
+   if (mechanism) {
+      if (!strcasecmp(mechanism, "GSSAPI") ||
+          !strcasecmp(mechanism, "MONGODB-X509")) {
+         if (source) {
+            if (strcasecmp(source, "$external")) {
+               return false;
+            }
+         } else {
+            bson_append_utf8(&uri->credentials, "authsource", -1, "$external", -1);
+         }
+      }
+   }
+   return true;
+}
 
 static bool
 mongoc_uri_parse (mongoc_uri_t *uri,
@@ -512,7 +605,7 @@ mongoc_uri_parse (mongoc_uri_t *uri,
       break;
    }
 
-   return true;
+   return mongoc_uri_finalize_auth(uri);
 }
 
 
@@ -540,6 +633,14 @@ mongoc_uri_get_replica_set (const mongoc_uri_t *uri)
 }
 
 
+const bson_t *
+mongoc_uri_get_credentials (const mongoc_uri_t *uri)
+{
+   bson_return_val_if_fail(uri, NULL);
+   return &uri->credentials;
+}
+
+
 const char *
 mongoc_uri_get_auth_mechanism (const mongoc_uri_t *uri)
 {
@@ -547,12 +648,36 @@ mongoc_uri_get_auth_mechanism (const mongoc_uri_t *uri)
 
    bson_return_val_if_fail (uri, NULL);
 
-   if (bson_iter_init_find_case (&iter, &uri->options, "authMechanism") &&
+   if (bson_iter_init_find_case (&iter, &uri->credentials, "authMechanism") &&
        BSON_ITER_HOLDS_UTF8 (&iter)) {
       return bson_iter_utf8 (&iter, NULL);
    }
 
    return NULL;
+}
+
+
+bool
+mongoc_uri_get_mechanism_properties (const mongoc_uri_t *uri, bson_t *properties)
+{
+   bson_iter_t iter;
+
+   if (!uri) {
+      return false;
+   }
+
+   if (bson_iter_init_find_case (&iter, &uri->credentials, "mechanismProperties") &&
+      BSON_ITER_HOLDS_DOCUMENT (&iter)) {
+      uint32_t len = 0;
+      const uint8_t *data = NULL;
+
+      bson_iter_document (&iter, &len, &data);
+      bson_init_static (properties, data, len);
+
+      return true;
+   }
+
+   return false;
 }
 
 
@@ -636,6 +761,7 @@ mongoc_uri_new (const char *uri_string)
 
    uri = bson_malloc0(sizeof *uri);
    bson_init(&uri->options);
+   bson_init(&uri->credentials);
    bson_init(&uri->read_prefs);
 
    if (!uri_string) {
@@ -704,7 +830,7 @@ mongoc_uri_get_auth_source (const mongoc_uri_t *uri)
 
    bson_return_val_if_fail(uri, NULL);
 
-   if (bson_iter_init_find_case(&iter, &uri->options, "authSource")) {
+   if (bson_iter_init_find_case(&iter, &uri->credentials, "authSource")) {
       return bson_iter_utf8(&iter, NULL);
    }
 
@@ -736,6 +862,7 @@ mongoc_uri_destroy (mongoc_uri_t *uri)
       bson_free(uri->database);
       bson_free(uri->username);
       bson_destroy(&uri->options);
+      bson_destroy(&uri->credentials);
       bson_destroy(&uri->read_prefs);
       mongoc_write_concern_destroy(uri->write_concern);
 

--- a/src/mongoc/mongoc-uri.h
+++ b/src/mongoc/mongoc-uri.h
@@ -38,26 +38,29 @@ BSON_BEGIN_DECLS
 typedef struct _mongoc_uri_t mongoc_uri_t;
 
 
-mongoc_uri_t                 *mongoc_uri_copy               (const mongoc_uri_t *uri);
-void                          mongoc_uri_destroy            (mongoc_uri_t       *uri);
-mongoc_uri_t                 *mongoc_uri_new                (const char         *uri_string)
+mongoc_uri_t                 *mongoc_uri_copy                     (const mongoc_uri_t *uri);
+void                          mongoc_uri_destroy                  (mongoc_uri_t       *uri);
+mongoc_uri_t                 *mongoc_uri_new                      (const char         *uri_string)
    BSON_GNUC_WARN_UNUSED_RESULT;
-mongoc_uri_t                 *mongoc_uri_new_for_host_port  (const char         *hostname,
-                                                             uint16_t            port)
+mongoc_uri_t                 *mongoc_uri_new_for_host_port        (const char         *hostname,
+                                                                         uint16_t      port)
    BSON_GNUC_WARN_UNUSED_RESULT;
-const mongoc_host_list_t     *mongoc_uri_get_hosts          (const mongoc_uri_t *uri);
-const char                   *mongoc_uri_get_database       (const mongoc_uri_t *uri);
-const bson_t                 *mongoc_uri_get_options        (const mongoc_uri_t *uri);
-const char                   *mongoc_uri_get_password       (const mongoc_uri_t *uri);
-const bson_t                 *mongoc_uri_get_read_prefs     (const mongoc_uri_t *uri);
-const char                   *mongoc_uri_get_replica_set    (const mongoc_uri_t *uri);
-const char                   *mongoc_uri_get_string         (const mongoc_uri_t *uri);
-const char                   *mongoc_uri_get_username       (const mongoc_uri_t *uri);
-const char                   *mongoc_uri_get_auth_source    (const mongoc_uri_t *uri);
-const char                   *mongoc_uri_get_auth_mechanism (const mongoc_uri_t *uri);
-bool                          mongoc_uri_get_ssl            (const mongoc_uri_t *uri);
-char                         *mongoc_uri_unescape           (const char         *escaped_string);
-const mongoc_write_concern_t *mongoc_uri_get_write_concern  (const mongoc_uri_t *uri);
+const mongoc_host_list_t     *mongoc_uri_get_hosts                (const mongoc_uri_t *uri);
+const char                   *mongoc_uri_get_database             (const mongoc_uri_t *uri);
+const bson_t                 *mongoc_uri_get_options              (const mongoc_uri_t *uri);
+const char                   *mongoc_uri_get_password             (const mongoc_uri_t *uri);
+const bson_t                 *mongoc_uri_get_read_prefs           (const mongoc_uri_t *uri);
+const char                   *mongoc_uri_get_replica_set          (const mongoc_uri_t *uri);
+const char                   *mongoc_uri_get_string               (const mongoc_uri_t *uri);
+const char                   *mongoc_uri_get_username             (const mongoc_uri_t *uri);
+const bson_t                 *mongoc_uri_get_credentials          (const mongoc_uri_t *uri);
+const char                   *mongoc_uri_get_auth_source          (const mongoc_uri_t *uri);
+const char                   *mongoc_uri_get_auth_mechanism       (const mongoc_uri_t *uri);
+bool                          mongoc_uri_get_mechanism_properties (const mongoc_uri_t *uri,
+                                                                         bson_t       *properties);
+bool                          mongoc_uri_get_ssl                  (const mongoc_uri_t *uri);
+char                         *mongoc_uri_unescape                 (const char         *escaped_string);
+const mongoc_write_concern_t *mongoc_uri_get_write_concern        (const mongoc_uri_t *uri);
 
 
 BSON_END_DECLS


### PR DESCRIPTION
This pull request attempts to bring us up-to-spec with respect to parsing auth-related things out of URI strings.  It changes a few things:

-adds the set of tests outlined in the spec
-moves auth-related options (`authSource`, `authMechanism`, and the new `authMechanismProperties`) to the URI's "credentials" instead of storing them in its "options."  Username and Password were and are still stored separately.
-credentials can be accessed via `mongoc_uri_get_credentials(...)` (this won't include username and password)
-`authMechanismProperties` can be accessed separately via `mongoc_uri_get_mechanism_properties(...)`
-`scan_to_unichar(...)` now takes a string of "terminator" characters, and if it cannot find the provided "match" character before reaching a terminator, it treats that as a failure.
