### PR TITLE
Fix error while compile using vs10 on windows:

### DIFF
--- a/src/mongoc/mongoc-database.c
+++ b/src/mongoc/mongoc-database.c
@@ -671,6 +671,7 @@ _mongoc_database_get_collection_info_legacy (mongoc_database_t *database,
 
    /* Filtering on name needs to be handled differently for old servers. */
    if (filter && bson_iter_init_find (&iter, filter, "name")) {
+      bson_string_t *buf;
       /* on legacy servers, this must be a string (i.e. not a regex) */
       if (!BSON_ITER_HOLDS_UTF8 (&iter)) {
          bson_set_error (error,
@@ -684,7 +685,7 @@ _mongoc_database_get_collection_info_legacy (mongoc_database_t *database,
       bson_init (&legacy_filter);
       bson_copy_to_excluding_noinit (filter, &legacy_filter, "name", NULL);
       /* We must db-qualify filters on name. */
-      bson_string_t *buf = bson_string_new (database->name);
+      buf = bson_string_new (database->name);
       bson_string_append_c (buf, '.');
       bson_string_append (buf, col_filter);
       BSON_APPEND_UTF8 (&legacy_filter, "name", buf->str);


### PR DESCRIPTION
mongoc-database.c(687): error C2275: 'bson_string_t' : illegal use of this type as an expression
