### PR TITLE
Fix link error while compiling using vs10 on windows:

### DIFF
--- a/build/cmake/libmongoc-ssl.def
+++ b/build/cmake/libmongoc-ssl.def
@@ -143,9 +143,6 @@ mongoc_log_set_handler
 mongoc_matcher_destroy
 mongoc_matcher_match
 mongoc_matcher_new
-mongoc_rand_add
-mongoc_rand_seed
-mongoc_rand_status
 mongoc_read_prefs_add_tag
 mongoc_read_prefs_copy
 mongoc_read_prefs_destroy

--- a/build/cmake/libmongoc.def
+++ b/build/cmake/libmongoc.def
@@ -141,9 +141,6 @@ mongoc_log_set_handler
 mongoc_matcher_destroy
 mongoc_matcher_match
 mongoc_matcher_new
-mongoc_rand_add
-mongoc_rand_seed
-mongoc_rand_status
 mongoc_read_prefs_add_tag
 mongoc_read_prefs_copy
 mongoc_read_prefs_destroy


### PR DESCRIPTION
error LNK2001: unresolved external symbol mongoc_rand_add   libmongoc.def

See related compilation error: https://github.com/mongodb/mongo-c-driver/pull/117
