### PR TITLE
CDRIVER-464: Add function to retrieve and set batch_size

### DIFF
--- a/src/mongoc/mongoc-cursor.c
+++ b/src/mongoc/mongoc-cursor.c
@@ -1056,6 +1056,22 @@ mongoc_cursor_current (const mongoc_cursor_t *cursor) /* IN */
 }
 
 
+void
+mongoc_cursor_set_batch_size (mongoc_cursor_t *cursor,
+                              uint32_t         batch_size)
+{
+   bson_return_if_fail (cursor);
+   cursor->batch_size = batch_size;
+}
+
+uint32_t
+mongoc_cursor_get_batch_size (const mongoc_cursor_t *cursor)
+{
+   bson_return_val_if_fail (cursor, 0);
+
+   return cursor->batch_size;
+}
+
 uint32_t
 mongoc_cursor_get_hint (const mongoc_cursor_t *cursor)
 {

--- a/src/mongoc/mongoc-cursor.h
+++ b/src/mongoc/mongoc-cursor.h
@@ -43,6 +43,9 @@ void             mongoc_cursor_get_host (mongoc_cursor_t        *cursor,
                                          mongoc_host_list_t     *host);
 bool             mongoc_cursor_is_alive (const mongoc_cursor_t  *cursor);
 const bson_t    *mongoc_cursor_current  (const mongoc_cursor_t  *cursor);
+void             mongoc_cursor_set_batch_size (mongoc_cursor_t  *cursor,
+                                               uint32_t          batch_size);
+uint32_t         mongoc_cursor_get_batch_size (const mongoc_cursor_t *cursor);
 uint32_t         mongoc_cursor_get_hint (const mongoc_cursor_t  *cursor);
 
 


### PR DESCRIPTION
The batch size needs to be tweakable between getmores

Added:
uint32_t mongoc_cursor_get_batch_size (const mongoc_cursor_t *cursor)
void mongoc_cursor_set_batch_size (mongoc_cursor_t *cursor, uint32_t batch_size)
