### PR TITLE
CDRIVER-466: Add mongoc_cursor_get_id()

### DIFF
--- a/src/mongoc/mongoc-cursor.c
+++ b/src/mongoc/mongoc-cursor.c
@@ -1063,3 +1063,13 @@ mongoc_cursor_get_hint (const mongoc_cursor_t *cursor)
 
    return cursor->hint;
 }
+
+
+uint64_t
+mongoc_cursor_get_id (const mongoc_cursor_t  *cursor)
+{
+   BSON_ASSERT(cursor);
+
+   return cursor->rpc.reply.cursor_id;
+}
+

--- a/src/mongoc/mongoc-cursor.h
+++ b/src/mongoc/mongoc-cursor.h
@@ -44,6 +44,7 @@ void             mongoc_cursor_get_host (mongoc_cursor_t        *cursor,
 bool             mongoc_cursor_is_alive (const mongoc_cursor_t  *cursor);
 const bson_t    *mongoc_cursor_current  (const mongoc_cursor_t  *cursor);
 uint32_t         mongoc_cursor_get_hint (const mongoc_cursor_t  *cursor);
+uint64_t         mongoc_cursor_get_id   (const mongoc_cursor_t  *cursor);
 
 
 BSON_END_DECLS


### PR DESCRIPTION
These can be retrieved by calling currentOp, but its impossible to map
them to specific cursor. We can just as well expose the id rather then
having the user guessing
