### PR TITLE
Missing entry call

### DIFF
--- a/src/mongoc/mongoc-cursor.c
+++ b/src/mongoc/mongoc-cursor.c
@@ -348,6 +348,8 @@ mongoc_cursor_destroy (mongoc_cursor_t *cursor)
 {
    BSON_ASSERT(cursor);
 
+   ENTRY;
+
    if (cursor->iface.destroy) {
       cursor->iface.destroy(cursor);
    } else {


### PR DESCRIPTION
Was interesting seeing tracing leaving a function it didn't enter
