### PR TITLE
Update connection string parser to support ssl=prefer

### DIFF
--- a/src/mongoc/mongoc-client.c
+++ b/src/mongoc/mongoc-client.c
@@ -690,8 +690,8 @@ mongoc_client_new (const char *uri_string)
    options = mongoc_uri_get_options (uri);
 
    if (bson_iter_init_find (&iter, options, "ssl") &&
-       BSON_ITER_HOLDS_BOOL (&iter) &&
-       bson_iter_bool (&iter)) {
+       BSON_ITER_HOLDS_INT32 (&iter) &&
+       bson_iter_int32 (&iter)) {
       has_ssl = true;
    }
 

--- a/src/mongoc/mongoc-uri.c
+++ b/src/mongoc/mongoc-uri.c
@@ -490,12 +490,20 @@ mongoc_uri_parse_option (mongoc_uri_t *uri,
    } else if (!strcasecmp(key, "canonicalizeHostname") ||
               !strcasecmp(key, "journal") ||
               !strcasecmp(key, "safe") ||
-              !strcasecmp(key, "slaveok") ||
-              !strcasecmp(key, "ssl")) {
+              !strcasecmp(key, "slaveok")) {
       bson_append_bool (&uri->options, key, -1,
                         (0 == strcasecmp (value, "true")) ||
                         (0 == strcasecmp (value, "t")) ||
                         (0 == strcmp (value, "1")));
+   } else if (!strcasecmp(key, "ssl")) {
+	   if (!strcasecmp (value, "prefer")) {
+		   bson_append_int32(&uri->options, key, -1, 2);
+	   } else {
+		   bson_append_int32 (&uri->options, key, -1,
+				   (0 == strcasecmp (value, "true")) ||
+				   (0 == strcasecmp (value, "t")) ||
+				   (0 == strcmp (value, "1")));
+	   }
    } else if (!strcasecmp(key, "readpreferencetags")) {
       mongoc_uri_parse_tags(uri, value, &uri->read_prefs);
    } else if (!strcasecmp(key, "authmechanism") ||
@@ -992,6 +1000,6 @@ mongoc_uri_get_ssl (const mongoc_uri_t *uri) /* IN */
    bson_return_val_if_fail (uri, false);
 
    return (bson_iter_init_find_case (&iter, &uri->options, "ssl") &&
-           BSON_ITER_HOLDS_BOOL (&iter) &&
-           bson_iter_bool (&iter));
+           BSON_ITER_HOLDS_INT32 (&iter) &&
+           bson_iter_int32 (&iter));
 }

--- a/tests/test-mongoc-uri.c
+++ b/tests/test-mongoc-uri.c
@@ -98,6 +98,16 @@ test_mongoc_uri_new (void)
    ASSERT(!bson_iter_next(&iter));
    mongoc_uri_destroy(uri);
 
+   uri = mongoc_uri_new("mongodb://localhost/a?ssl=prefer");
+   options = mongoc_uri_get_options(uri);
+   ASSERT(options);
+   ASSERT(bson_iter_init(&iter, options));
+   ASSERT(bson_iter_find_case(&iter, "ssl"));
+   ASSERT(BSON_ITER_HOLDS_INT32(&iter));
+   ASSERT(bson_iter_int32(&iter) == 2);
+   ASSERT(!bson_iter_next(&iter));
+   mongoc_uri_destroy(uri);
+
    uri = mongoc_uri_new("mongodb://localhost/a?slaveok=true&ssl=false&journal=true");
    options = mongoc_uri_get_options(uri);
    ASSERT(options);
@@ -107,8 +117,8 @@ test_mongoc_uri_new (void)
    ASSERT(BSON_ITER_HOLDS_BOOL(&iter));
    ASSERT(bson_iter_bool(&iter));
    ASSERT(bson_iter_find_case(&iter, "ssl"));
-   ASSERT(BSON_ITER_HOLDS_BOOL(&iter));
-   ASSERT(!bson_iter_bool(&iter));
+   ASSERT(BSON_ITER_HOLDS_INT32(&iter));
+   ASSERT(!bson_iter_int32(&iter));
    ASSERT(bson_iter_find_case(&iter, "journal"));
    ASSERT(BSON_ITER_HOLDS_BOOL(&iter));
    ASSERT(bson_iter_bool(&iter));


### PR DESCRIPTION
This is needed when upgrading a MongoDB cluster from non-ssl to ssl
without a downtime.
