### PR TITLE
Check for closed sockets before attempting a rpc

### DIFF
--- a/src/mongoc/mongoc-cluster-private.h
+++ b/src/mongoc/mongoc-cluster-private.h
@@ -78,6 +78,7 @@ typedef struct
    int32_t             max_wire_version;
    int32_t             max_write_batch_size;
    char               *replSet;
+   int64_t             last_read_msec;
 } mongoc_cluster_node_t;
 
 

--- a/src/mongoc/mongoc-socket.c
+++ b/src/mongoc/mongoc-socket.c
@@ -1069,3 +1069,28 @@ mongoc_socket_getnameinfo (mongoc_socket_t *sock) /* IN */
 
    RETURN (NULL);
 }
+
+
+bool
+mongoc_socket_check_closed (mongoc_socket_t *sock) /* IN */
+{
+   bool closed = false;
+   char buf [1];
+   ssize_t r;
+
+   if (_mongoc_socket_wait (sock->sd, POLLIN, 0)) {
+      sock->errno_ = 0;
+
+      r = recv (sock->sd, buf, 1, MSG_PEEK);
+
+      if (r < 0) {
+         _mongoc_socket_capture_errno (sock);
+      }
+
+      if (r < 1) {
+         closed = true;
+      }
+   }
+
+   return closed;
+}

--- a/src/mongoc/mongoc-socket.h
+++ b/src/mongoc/mongoc-socket.h
@@ -86,6 +86,7 @@ ssize_t          mongoc_socket_sendv      (mongoc_socket_t       *sock,
                                            mongoc_iovec_t        *iov,
                                            size_t                 iovcnt,
                                            int64_t                expire_at);
+bool             mongoc_socket_check_closed (mongoc_socket_t       *sock);
 
 
 BSON_END_DECLS

--- a/src/mongoc/mongoc-stream-buffered.c
+++ b/src/mongoc/mongoc-stream-buffered.c
@@ -244,6 +244,15 @@ _mongoc_stream_buffered_get_base_stream (mongoc_stream_t *stream) /* IN */
 }
 
 
+static bool
+_mongoc_stream_buffered_check_closed (mongoc_stream_t *stream) /* IN */
+{
+   mongoc_stream_buffered_t *buffered = (mongoc_stream_buffered_t *)stream;
+   bson_return_val_if_fail(stream, -1);
+   return mongoc_stream_check_closed (buffered->base_stream);
+}
+
+
 /*
  *--------------------------------------------------------------------------
  *
@@ -283,6 +292,7 @@ mongoc_stream_buffered_new (mongoc_stream_t *base_stream, /* IN */
    stream->stream.writev = mongoc_stream_buffered_writev;
    stream->stream.readv = mongoc_stream_buffered_readv;
    stream->stream.get_base_stream = _mongoc_stream_buffered_get_base_stream;
+   stream->stream.check_closed = _mongoc_stream_buffered_check_closed;
 
    stream->base_stream = base_stream;
 

--- a/src/mongoc/mongoc-stream-file.c
+++ b/src/mongoc/mongoc-stream-file.c
@@ -167,6 +167,13 @@ _mongoc_stream_file_writev (mongoc_stream_t *stream,       /* IN */
 }
 
 
+static bool
+_mongoc_stream_file_check_closed (mongoc_stream_t *stream) /* IN */
+{
+   return false;
+}
+
+
 mongoc_stream_t *
 mongoc_stream_file_new (int fd) /* IN */
 {
@@ -181,6 +188,7 @@ mongoc_stream_file_new (int fd) /* IN */
    stream->vtable.flush = _mongoc_stream_file_flush;
    stream->vtable.readv = _mongoc_stream_file_readv;
    stream->vtable.writev = _mongoc_stream_file_writev;
+   stream->vtable.check_closed = _mongoc_stream_file_check_closed;
    stream->fd = fd;
 
    return (mongoc_stream_t *)stream;

--- a/src/mongoc/mongoc-stream-gridfs.c
+++ b/src/mongoc/mongoc-stream-gridfs.c
@@ -139,6 +139,13 @@ _mongoc_stream_gridfs_writev (mongoc_stream_t *stream,
 }
 
 
+static bool
+_mongoc_stream_gridfs_check_closed (mongoc_stream_t *stream) /* IN */
+{
+   return false;
+}
+
+
 mongoc_stream_t *
 mongoc_stream_gridfs_new (mongoc_gridfs_file_t *file)
 {
@@ -156,6 +163,7 @@ mongoc_stream_gridfs_new (mongoc_gridfs_file_t *file)
    stream->stream.flush = _mongoc_stream_gridfs_flush;
    stream->stream.writev = _mongoc_stream_gridfs_writev;
    stream->stream.readv = _mongoc_stream_gridfs_readv;
+   stream->stream.check_closed = _mongoc_stream_gridfs_check_closed;
 
    mongoc_counter_streams_active_inc ();
 

--- a/src/mongoc/mongoc-stream-socket.c
+++ b/src/mongoc/mongoc-stream-socket.c
@@ -210,6 +210,23 @@ mongoc_stream_socket_get_socket (mongoc_stream_socket_t *stream) /* IN */
 }
 
 
+static bool
+_mongoc_stream_socket_check_closed (mongoc_stream_t *stream) /* IN */
+{
+   mongoc_stream_socket_t *ss = (mongoc_stream_socket_t *)stream;
+
+   ENTRY;
+
+   bson_return_val_if_fail (stream, true);
+
+   if (ss->sock) {
+      RETURN (mongoc_socket_check_closed (ss->sock));
+   }
+
+   RETURN (true);
+}
+
+
 /*
  *--------------------------------------------------------------------------
  *
@@ -242,6 +259,7 @@ mongoc_stream_socket_new (mongoc_socket_t *sock) /* IN */
    stream->vtable.readv = _mongoc_stream_socket_readv;
    stream->vtable.writev = _mongoc_stream_socket_writev;
    stream->vtable.setsockopt = _mongoc_stream_socket_setsockopt;
+   stream->vtable.check_closed = _mongoc_stream_socket_check_closed;
    stream->sock = sock;
 
    return (mongoc_stream_t *)stream;

--- a/src/mongoc/mongoc-stream-tls.c
+++ b/src/mongoc/mongoc-stream-tls.c
@@ -721,6 +721,15 @@ _mongoc_stream_tls_get_base_stream (mongoc_stream_t *stream)
 }
 
 
+static bool
+_mongoc_stream_tls_check_closed (mongoc_stream_t *stream) /* IN */
+{
+   mongoc_stream_tls_t *tls = (mongoc_stream_tls_t *)stream;
+   bson_return_val_if_fail(stream, -1);
+   return mongoc_stream_check_closed (tls->base_stream);
+}
+
+
 /*
  *--------------------------------------------------------------------------
  *
@@ -779,6 +788,7 @@ mongoc_stream_tls_new (mongoc_stream_t  *base_stream,
    tls->parent.readv = _mongoc_stream_tls_readv;
    tls->parent.setsockopt = _mongoc_stream_tls_setsockopt;
    tls->parent.get_base_stream = _mongoc_stream_tls_get_base_stream;
+   tls->parent.check_closed = _mongoc_stream_tls_check_closed;
    tls->weak_cert_validation = opt->weak_cert_validation;
    tls->bio = bio_ssl;
    tls->ctx = ssl_ctx;

--- a/src/mongoc/mongoc-stream.c
+++ b/src/mongoc/mongoc-stream.c
@@ -239,3 +239,18 @@ mongoc_stream_get_base_stream (mongoc_stream_t *stream) /* IN */
 
    return NULL;
 }
+
+
+bool
+mongoc_stream_check_closed (mongoc_stream_t *stream)
+{
+   int ret;
+
+   ENTRY;
+
+   bson_return_val_if_fail(stream, -1);
+
+   ret = stream->check_closed(stream);
+
+   RETURN (ret);
+}

--- a/src/mongoc/mongoc-stream.h
+++ b/src/mongoc/mongoc-stream.h
@@ -52,7 +52,8 @@ struct _mongoc_stream_t
                                         void            *optval,
                                         socklen_t        optlen);
    mongoc_stream_t *(*get_base_stream) (mongoc_stream_t *stream);
-   void            *padding [8];
+   bool             (*check_closed)    (mongoc_stream_t *stream);
+   void            *padding [7];
 };
 
 
@@ -79,6 +80,7 @@ int              mongoc_stream_setsockopt      (mongoc_stream_t       *stream,
                                                 int                    optname,
                                                 void                  *optval,
                                                 socklen_t              optlen);
+bool             mongoc_stream_check_closed    (mongoc_stream_t       *stream);
 
 
 BSON_END_DECLS

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -89,6 +89,7 @@ test_libmongoc_SOURCES = \
 	tests/test-mongoc-queue.c \
 	tests/test-mongoc-read-prefs.c \
 	tests/test-mongoc-rpc.c \
+	tests/test-mongoc-socket.c \
 	tests/test-mongoc-stream.c \
 	tests/test-mongoc-uri.c \
 	tests/test-mongoc-write-concern.c \

--- a/tests/test-libmongoc.c
+++ b/tests/test-libmongoc.c
@@ -40,6 +40,7 @@ extern void test_matcher_install          (TestSuite *suite);
 extern void test_queue_install            (TestSuite *suite);
 extern void test_read_prefs_install       (TestSuite *suite);
 extern void test_rpc_install              (TestSuite *suite);
+extern void test_socket_install           (TestSuite *suite);
 extern void test_stream_install           (TestSuite *suite);
 extern void test_uri_install              (TestSuite *suite);
 extern void test_write_command_install    (TestSuite *suite);
@@ -143,6 +144,7 @@ main (int   argc,
    test_queue_install (&suite);
    test_read_prefs_install (&suite);
    test_rpc_install (&suite);
+   test_socket_install (&suite);
    test_stream_install (&suite);
    test_uri_install (&suite);
    test_write_concern_install (&suite);

--- a/tests/test-mongoc-socket.c
+++ b/tests/test-mongoc-socket.c
@@ -1,0 +1,188 @@
+#include <fcntl.h>
+#include <mongoc.h>
+
+#include "mongoc-tests.h"
+#include "mongoc-thread-private.h"
+#include "TestSuite.h"
+
+#include "test-libmongoc.h"
+
+#undef MONGOC_LOG_DOMAIN
+#define MONGOC_LOG_DOMAIN "socket-test"
+
+#define TIMEOUT 10000
+
+
+typedef struct
+{
+   unsigned short server_port;
+   mongoc_cond_t  cond;
+   mongoc_mutex_t cond_mutex;
+   bool           closed_socket;
+} socket_test_data_t;
+
+
+static void *
+socket_test_server (void *data_)
+{
+   socket_test_data_t *data = (socket_test_data_t *)data_;
+   struct sockaddr_in server_addr = { 0 };
+   mongoc_socket_t *listen_sock;
+   mongoc_socket_t *conn_sock;
+   mongoc_stream_t *stream;
+   mongoc_iovec_t iov;
+   socklen_t sock_len;
+   ssize_t r;
+   char buf[5];
+
+   iov.iov_base = buf;
+   iov.iov_len = sizeof (buf);
+
+   listen_sock = mongoc_socket_new (AF_INET, SOCK_STREAM, 0);
+   assert (listen_sock);
+
+   server_addr.sin_family = AF_INET;
+   server_addr.sin_addr.s_addr = htonl (INADDR_LOOPBACK);
+   server_addr.sin_port = htons (0);
+
+   r = mongoc_socket_bind (listen_sock,
+                           (struct sockaddr *)&server_addr,
+                           sizeof server_addr);
+   assert (r == 0);
+
+   sock_len = sizeof(server_addr);
+   r = mongoc_socket_getsockname (listen_sock, (struct sockaddr *)&server_addr, &sock_len);
+   assert(r == 0);
+
+   r = mongoc_socket_listen (listen_sock, 10);
+   assert(r == 0);
+
+   mongoc_mutex_lock(&data->cond_mutex);
+   data->server_port = ntohs(server_addr.sin_port);
+   mongoc_cond_signal(&data->cond);
+   mongoc_mutex_unlock(&data->cond_mutex);
+
+   conn_sock = mongoc_socket_accept (listen_sock, -1);
+   assert (conn_sock);
+
+   stream = mongoc_stream_socket_new (conn_sock);
+   assert (stream);
+
+   r = mongoc_stream_readv (stream, &iov, 1, 5, TIMEOUT);
+   assert (r == 5);
+   assert (strcmp (buf, "ping") == 0);
+
+   strcpy (buf, "pong");
+
+   r = mongoc_stream_writev (stream, &iov, 1, TIMEOUT);
+   assert (r == 5);
+
+   mongoc_stream_destroy (stream);
+
+   mongoc_mutex_lock(&data->cond_mutex);
+   data->closed_socket = true;
+   mongoc_cond_signal(&data->cond);
+   mongoc_mutex_unlock(&data->cond_mutex);
+
+   mongoc_socket_destroy (listen_sock);
+
+   return NULL;
+}
+
+
+static void *
+socket_test_client (void *data_)
+{
+   socket_test_data_t *data = (socket_test_data_t *)data_;
+   mongoc_socket_t *conn_sock;
+   char buf[5];
+   ssize_t r;
+   bool closed;
+   struct sockaddr_in server_addr = { 0 };
+   mongoc_stream_t *stream;
+   mongoc_iovec_t iov;
+
+   iov.iov_base = buf;
+   iov.iov_len = sizeof (buf);
+
+   conn_sock = mongoc_socket_new (AF_INET, SOCK_STREAM, 0);
+   assert (conn_sock);
+
+   mongoc_mutex_lock(&data->cond_mutex);
+   while (! data->server_port) {
+      mongoc_cond_wait(&data->cond, &data->cond_mutex);
+   }
+   mongoc_mutex_unlock(&data->cond_mutex);
+
+   server_addr.sin_family = AF_INET;
+   server_addr.sin_port = htons(data->server_port);
+   server_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+   r = mongoc_socket_connect (conn_sock, (struct sockaddr *)&server_addr, sizeof(server_addr), -1);
+   assert (r == 0);
+
+   stream = mongoc_stream_socket_new (conn_sock);
+
+   strcpy (buf, "ping");
+
+   closed = mongoc_stream_check_closed (stream);
+   assert (closed == false);
+
+   r = mongoc_stream_writev (stream, &iov, 1, TIMEOUT);
+   assert (r == 5);
+
+   closed = mongoc_stream_check_closed (stream);
+   assert (closed == false);
+
+   r = mongoc_stream_readv (stream, &iov, 1, 5, TIMEOUT);
+   assert (r == 5);
+   assert (strcmp (buf, "pong") == 0);
+
+   closed = mongoc_stream_check_closed (stream);
+   assert (closed == false);
+
+   mongoc_mutex_lock(&data->cond_mutex);
+   while (! data->closed_socket) {
+      mongoc_cond_wait(&data->cond, &data->cond_mutex);
+   }
+   mongoc_mutex_unlock(&data->cond_mutex);
+
+   closed = mongoc_stream_check_closed (stream);
+   assert (closed == true);
+
+   mongoc_stream_destroy (stream);
+
+   return NULL;
+}
+
+
+static void
+test_mongoc_socket_check_closed (void)
+{
+   socket_test_data_t data = { 0 };
+   mongoc_thread_t threads[2];
+   int i, r;
+
+   mongoc_mutex_init (&data.cond_mutex);
+   mongoc_cond_init (&data.cond);
+
+   r = mongoc_thread_create (threads, &socket_test_server, &data);
+   assert (r == 0);
+
+   r = mongoc_thread_create (threads + 1, &socket_test_client, &data);
+   assert (r == 0);
+
+   for (i = 0; i < 2; i++) {
+      r = mongoc_thread_join (threads[i]);
+      assert (r == 0);
+   }
+
+   mongoc_mutex_destroy (&data.cond_mutex);
+   mongoc_cond_destroy (&data.cond);
+}
+
+void
+test_socket_install (TestSuite *suite)
+{
+   TestSuite_Add (suite, "/Socket/check_closed", test_mongoc_socket_check_closed);
+}


### PR DESCRIPTION
Ensure that the socket we've selected has been read from within a
second.  If it hasn't, check if it's closed by polling for readability
and if that works, MSG_PEEK'ing a single byte.  If we get eof, or an
error, we can assume it's broken.  This lets us avoid a large class of
transient network failures.
