### PR TITLE
CDRIVER-492: Report WriteConcern error on writes

### DIFF
--- a/src/mongoc/mongoc-write-command-private.h
+++ b/src/mongoc/mongoc-write-command-private.h
@@ -76,7 +76,7 @@ typedef struct
    uint32_t     n_commands;
    bson_t       upserted;
    bson_t       writeErrors;
-   bson_t       writeConcernErrors;
+   bson_t       writeConcernError;
    bool         failed;
    bson_error_t error;
    uint32_t     upsert_append_count;


### PR DESCRIPTION
Renamed the field, and fixed the failure check.
There can only ever be one WriteConcernError, which is a bson object
containing the code (int), errInfo (object) and errmsg (cstring),
so there is no arrays to merge.