### PR TITLE
Conditionally compile SSL and SASL

### DIFF
--- a/src/mongoc/mongoc-b64-private.h
+++ b/src/mongoc/mongoc-b64-private.h
@@ -179,6 +179,8 @@ b64_ntop (uint8_t const *src,
    return (int)datalength;
 }
 
+#ifdef MONGOC_ENABLE_SSL
+
 /* (From RFC1521 and draft-ietf-dnssec-secext-03.txt)
    The following encoding technique is taken from RFC 1521 by Borenstein
    and Freed.  It is reproduced here in a slightly edited form for
@@ -501,7 +503,6 @@ b64_pton_len(char const *src)
 	return (tarindex);
 }
 
-
 static int
 b64_pton(char const *src, uint8_t *target, size_t targsize)
 {
@@ -513,3 +514,5 @@ b64_pton(char const *src, uint8_t *target, size_t targsize)
 	else
 		return b64_pton_len (src);
 }
+
+#endif

--- a/src/mongoc/mongoc-rand.c
+++ b/src/mongoc/mongoc-rand.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#ifdef MONGOC_ENABLE_SSL
+
 #include "mongoc-rand.h"
 #include "mongoc-rand-private.h"
 
@@ -40,3 +42,5 @@ void mongoc_rand_add(const void* buf, int num, double entropy) {
 int mongoc_rand_status(void) {
     return RAND_status();
 }
+
+#endif

--- a/src/mongoc/mongoc-sasl.c
+++ b/src/mongoc/mongoc-sasl.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#ifdef MONGOC_ENABLE_SASL
 
 #include <string.h>
 
@@ -346,3 +347,5 @@ _mongoc_sasl_step (mongoc_sasl_t *sasl,
 
    return true;
 }
+
+#endif

--- a/src/mongoc/mongoc-scram.c
+++ b/src/mongoc/mongoc-scram.c
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+#ifdef MONGOC_ENABLE_SSL
 
 #include <string.h>
 
@@ -799,3 +800,5 @@ _mongoc_scram_step (mongoc_scram_t *scram,
 
    return true;
 }
+
+#endif

--- a/src/mongoc/mongoc-ssl.c
+++ b/src/mongoc/mongoc-ssl.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#ifdef MONGOC_ENABLE_SSL
 
 #include <bson.h>
 #include <limits.h>
@@ -548,3 +549,5 @@ _mongoc_ssl_thread_cleanup (void)
    }
    OPENSSL_free (gMongocSslThreadLocks);
 }
+
+#endif

--- a/src/mongoc/mongoc-stream-tls.c
+++ b/src/mongoc/mongoc-stream-tls.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#ifdef MONGOC_ENABLE_SSL
 
 #include <bson.h>
 
@@ -799,3 +800,5 @@ mongoc_stream_tls_new (mongoc_stream_t  *base_stream,
 
    return (mongoc_stream_t *)tls;
 }
+
+#endif


### PR DESCRIPTION
This allows building *.[ch] even when libssl and/or libsasl are not available.

This helps get the library to build for iOS, and similarly would help for build the library under any third-party build system.

Sort of an aside: on Mac OS libssl is deprecated. iOS has never shipped with it. On Mac OS the headers are in /usr/include but aren't available when building an iOS project.

Ideally, someday, libmongoc would support both libssl and Common Crypto, Apple's implementation.