### PR TITLE
Change mongoc_gridfs_file_seek delta type from uint64_t to int64_t

### DIFF
--- a/doc/mongoc_gridfs_file_seek.page
+++ b/doc/mongoc_gridfs_file_seek.page
@@ -14,7 +14,7 @@
     <title>Synopsis</title>
     <synopsis><code mime="text/x-csrc"><![CDATA[int
 mongoc_gridfs_file_seek (mongoc_gridfs_file_t *file,
-                         uint64_t              delta,
+                         int64_t               delta,
                          int                   whence);
 ]]></code></synopsis>
   </section>

--- a/src/mongoc/mongoc-gridfs-file.c
+++ b/src/mongoc/mongoc-gridfs-file.c
@@ -694,7 +694,7 @@ _mongoc_gridfs_file_refresh_page (mongoc_gridfs_file_t *file)
  */
 int
 mongoc_gridfs_file_seek (mongoc_gridfs_file_t *file,
-                         uint64_t         delta,
+                         int64_t               delta,
                          int                   whence)
 {
    uint64_t offset;

--- a/src/mongoc/mongoc-gridfs-file.h
+++ b/src/mongoc/mongoc-gridfs-file.h
@@ -79,7 +79,7 @@ ssize_t  mongoc_gridfs_file_readv           (mongoc_gridfs_file_t *file,
                                              size_t                min_bytes,
                                              uint32_t              timeout_msec);
 int      mongoc_gridfs_file_seek            (mongoc_gridfs_file_t *file,
-                                             uint64_t              delta,
+                                             int64_t               delta,
                                              int                   whence);
 uint64_t mongoc_gridfs_file_tell            (mongoc_gridfs_file_t *file);
 bool     mongoc_gridfs_file_save            (mongoc_gridfs_file_t *file);


### PR DESCRIPTION
If whence == SEEK_END it's required(according to implementation) to pass negative delta to achieve offset from end. In addition fseek's offset is declared as signed and if this function mimicing fseek it should be signed too.