### PR TITLE
Fix for gridfs file seek if page == NULL

### DIFF
--- a/src/mongoc/mongoc-gridfs-file.c
+++ b/src/mongoc/mongoc-gridfs-file.c
@@ -720,21 +720,21 @@ mongoc_gridfs_file_seek (mongoc_gridfs_file_t *file,
 
    BSON_ASSERT (file->length > (int64_t)offset);
 
-   if (offset / file->chunk_size != file->pos / file->chunk_size) {
-      /** no longer on the same page */
+   if (file->page) {
+      if (offset / file->chunk_size != file->pos / file->chunk_size) {
+         /** no longer on the same page */
 
-      if (file->page) {
          if (_mongoc_gridfs_file_page_is_dirty (file->page)) {
             _mongoc_gridfs_file_flush_page (file);
          } else {
             _mongoc_gridfs_file_page_destroy (file->page);
             file->page = NULL;
          }
-      }
 
-      /** we'll pick up the seek when we fetch a page on the next action.  We lazily load */
-   } else {
-      _mongoc_gridfs_file_page_seek (file->page, offset % file->chunk_size);
+         /** we'll pick up the seek when we fetch a page on the next action.  We lazily load */
+      } else {
+         _mongoc_gridfs_file_page_seek (file->page, offset % file->chunk_size);
+      }
    }
 
    file->pos = offset;


### PR DESCRIPTION
[Last gridfs fix](https://github.com/mongodb/mongo-c-driver/commit/e42287710db3ee3aa7412a804d32d78d119d6198)  don't cover case when page == NULL.

```
if (offset / file->chunk_size != file->pos / file->chunk_size) {
  ...
} else {
   _mongoc_gridfs_file_page_seek (file->page, offset % file->chunk_size);
}
```
If page == NULL, pos == 0 and offset < chunk_size it will try to seek in NULL page