### PR TITLE
Use void and size_t types for mongoc_iovec_t on windows

### DIFF
--- a/doc/mongoc_iovec_t.page
+++ b/doc/mongoc_iovec_t.page
@@ -22,8 +22,8 @@
 #ifdef _WIN32
 typedef struct
 {
-   u_long  iov_len;
-   char   *iov_base;
+   void   *iov_base;
+   size_t  iov_len;
 } mongoc_iovec_t;
 #else
 typedef struct iovec mongoc_iovec_t;

--- a/src/mongoc/mongoc-iovec.h
+++ b/src/mongoc/mongoc-iovec.h
@@ -32,8 +32,8 @@ BSON_BEGIN_DECLS
 #ifdef _WIN32
 typedef struct
 {
-   u_long  iov_len;
-   char   *iov_base;
+   void   *iov_base;
+   size_t  iov_len;
 } mongoc_iovec_t;
 #else
 typedef struct iovec mongoc_iovec_t;


### PR DESCRIPTION
In [linux](http://linux.die.net/include/bits/uio.h) and [freebsd](http://fxr.watson.org/fxr/source/sys/_iovec.h) iovec struct defined as:
```
struct iovec
{
  void *iov_base;	/* Pointer to data.  */
  size_t iov_len;	/* Length of data.  */
};
```
in windows u_long defined as:
```
// WinSock2.h
typedef unsigned long   u_long;
```
so there is inconsistency between windows and other OS