### PR TITLE
Connection pool improvements

### DIFF
--- a/src/mongoc/mongoc-bulk-operation.c
+++ b/src/mongoc/mongoc-bulk-operation.c
@@ -370,6 +370,13 @@ mongoc_bulk_operation_set_write_concern (mongoc_bulk_operation_t      *bulk,
    }
 }
 
+const mongoc_write_concern_t *
+mongoc_bulk_operation_get_write_concern (mongoc_bulk_operation_t *bulk)
+{
+   bson_return_if_fail (bulk);
+   return bulk->write_concern;
+}
+
 
 void
 mongoc_bulk_operation_set_database (mongoc_bulk_operation_t *bulk,

--- a/src/mongoc/mongoc-bulk-operation.h
+++ b/src/mongoc/mongoc-bulk-operation.h
@@ -76,7 +76,7 @@ void                     mongoc_bulk_operation_set_client        (mongoc_bulk_op
                                                                   void                         *client);
 void                     mongoc_bulk_operation_set_hint          (mongoc_bulk_operation_t      *bulk,
                                                                   uint32_t                      hint);
-
+const mongoc_write_concern_t *mongoc_bulk_operation_get_write_concern (mongoc_bulk_operation_t *bulk);
 
 BSON_END_DECLS
 


### PR DESCRIPTION
In case we have more than "min_pool_size" connections in the pool, pushing one connection back to the pool will result in the LRU connection being destroyed.

Furthermore, unhealthy connections will be tried to repaired before returning them to the pool. 

A first simple test has been included.