### PR TITLE
Remove confusingly useless codepath

### DIFF
--- a/src/mongoc/mongoc-cursor.c
+++ b/src/mongoc/mongoc-cursor.c
@@ -541,10 +541,6 @@ _mongoc_cursor_query (mongoc_cursor_t *cursor)
    }
 
    if (_mongoc_cursor_unwrap_failure(cursor)) {
-      if ((cursor->error.domain == MONGOC_ERROR_QUERY) &&
-          (cursor->error.code == MONGOC_ERROR_QUERY_NOT_TAILABLE)) {
-         cursor->failed = true;
-      }
       GOTO (failure);
    }
 


### PR DESCRIPTION
The `failure` label starts by setting cursor->failed = true
irregardless of the failure, so this isn't needed at all