### PR TITLE
Client pool improvements

### DIFF
--- a/src/mongoc/mongoc-client-pool.c
+++ b/src/mongoc/mongoc-client-pool.c
@@ -19,6 +19,8 @@
 #include "mongoc-client-pool.h"
 #include "mongoc-queue-private.h"
 #include "mongoc-thread-private.h"
+#include "mongoc-cluster-private.h"
+#include "mongoc-client-private.h"
 #include "mongoc-trace.h"
 
 
@@ -196,20 +198,44 @@ mongoc_client_pool_push (mongoc_client_pool_t *pool,
    bson_return_if_fail(pool);
    bson_return_if_fail(client);
 
-   /*
-    * TODO: Shutdown old client connections.
-    */
+   if (pool->size > pool->min_pool_size) {
+      mongoc_client_t *old_client;
+      old_client = _mongoc_queue_pop_head (&pool->queue);
+      mongoc_client_destroy (old_client);
+      pool->size--;
+   }
 
-   /*
-    * TODO: We should try to make a client healthy again if it
-    *       is unhealthy since this is typically where a thread
-    *       is done with its work.
-    */
+   if ((client->cluster.state == MONGOC_CLUSTER_STATE_HEALTHY) || 
+       (client->cluster.state == MONGOC_CLUSTER_STATE_BORN)) {
+      mongoc_mutex_lock (&pool->mutex);
+      _mongoc_queue_push_tail (&pool->queue, client);
+   } else if (_mongoc_cluster_reconnect (&client->cluster, NULL)) {
+      mongoc_mutex_lock (&pool->mutex);
+      _mongoc_queue_push_tail (&pool->queue, client);
+   }else {
+      mongoc_client_destroy (client);
+      mongoc_mutex_lock (&pool->mutex);
+      pool->size--;
+   }
 
-   mongoc_mutex_lock(&pool->mutex);
-   _mongoc_queue_push_head(&pool->queue, client);
    mongoc_cond_signal(&pool->cond);
    mongoc_mutex_unlock(&pool->mutex);
 
    EXIT;
+}
+
+size_t
+mongoc_client_pool_get_size (mongoc_client_pool_t *pool)
+{
+   ENTRY;
+
+   bson_return_if_fail (pool);
+
+   size_t size = 0;
+
+   mongoc_mutex_lock (&pool->mutex);
+   size = pool->size;
+   mongoc_mutex_unlock (&pool->mutex);
+
+   RETURN (size);   
 }

--- a/src/mongoc/mongoc-client-pool.h
+++ b/src/mongoc/mongoc-client-pool.h
@@ -48,6 +48,7 @@ void                  mongoc_client_pool_set_ssl_opts (mongoc_client_pool_t   *p
                                                        const mongoc_ssl_opt_t *opts);
 #endif
 
+size_t 				  mongoc_client_pool_get_size(mongoc_client_pool_t *pool);
 
 BSON_END_DECLS
 

--- a/tests/test-mongoc-client-pool.c
+++ b/tests/test-mongoc-client-pool.c
@@ -1,4 +1,6 @@
 #include <mongoc.h>
+#include "mongoc-array-private.h"
+
 
 #include "TestSuite.h"
 
@@ -37,10 +39,44 @@ test_mongoc_client_pool_try_pop (void)
    mongoc_client_pool_destroy(pool);
 }
 
+static void
+test_mongoc_client_pool_min_size_dispose (void)
+{
+   mongoc_client_pool_t *pool;
+   mongoc_client_t *client;
+   mongoc_uri_t *uri;
+   mongoc_array_t conns;
+   int i;
+
+   _mongoc_array_init(&conns, sizeof client);
+
+   uri = mongoc_uri_new("mongodb://127.0.0.1?maxpoolsize=10&minpoolsize=3");
+   pool = mongoc_client_pool_new(uri);
+
+   for (i = 0; i < 10; i++) {
+      client = mongoc_client_pool_pop(pool);
+      assert(client);
+      _mongoc_array_append_val(&conns, client);
+      assert(mongoc_client_pool_get_size(pool) == i+1);
+   }
+   
+   for (i = 0; i < 10; i++) {
+      client = _mongoc_array_index(&conns,mongoc_client_t *, i);
+      assert(client);
+      mongoc_client_pool_push(pool, client);
+   }
+
+   assert(mongoc_client_pool_get_size(pool) == 3);
+   _mongoc_array_clear(&conns);
+   _mongoc_array_destroy(&conns);
+   mongoc_uri_destroy(uri);
+   mongoc_client_pool_destroy(pool);
+}
 
 void
 test_client_pool_install (TestSuite *suite)
 {
    TestSuite_Add (suite, "/ClientPool/basic", test_mongoc_client_pool_basic);
    TestSuite_Add (suite, "/ClientPool/try_pop", test_mongoc_client_pool_try_pop);
+   TestSuite_Add (suite, "/ClientPool/min_size_dispose", test_mongoc_client_pool_min_size_dispose);
 }


### PR DESCRIPTION
In case we have more than "min_pool_size" connections in the pool, pushing one connection back to the pool will result in the LRU connection being destroyed.

Furthermore, unhealthy connections will be tried to repaired before returning them to the pool.

This is basically a cleaned up version of PR #171