### PR TITLE
client: Fix setting of the connectTimeoutMS value

### DIFF
--- a/src/mongoc/mongoc-client.c
+++ b/src/mongoc/mongoc-client.c
@@ -93,7 +93,7 @@ mongoc_client_connect_tcp (const mongoc_uri_t       *uri,
    bson_return_val_if_fail (host, NULL);
 
    if ((options = mongoc_uri_get_options (uri)) &&
-       bson_iter_init_find (&iter, options, "connecttimeoutms") &&
+       bson_iter_init_find_case (&iter, options, "connecttimeoutms") &&
        BSON_ITER_HOLDS_INT32 (&iter)) {
       if (!(connecttimeoutms = bson_iter_int32(&iter))) {
          connecttimeoutms = MONGOC_DEFAULT_CONNECTTIMEOUTMS;


### PR DESCRIPTION
When specifying the connectTimeoutMS option in the URI e.g

    ?connectTimeoutMS=250

this would be added internally under the name as specified, ie in this
case connectTimeoutMS however when mongoc_client_connect_tcp() comes to
look for this setting, it does so case sensitively as all lowercase, i.e

    if ((options = mongoc_uri_get_options (uri)) &&
        bson_iter_init_find (&iter, options, "connecttimeoutms") &&

and won't find the setting and will use the default connectTimeoutMS
value instead.

It should use bson_iter_init_find_case() instead for a case insensitive
search.

Signed-off-by: Andrew Clayton <andrew@digital-domain.net>