### PR TITLE
CDRIVER-536 hostnames are normalized to lowercase

### DIFF
--- a/src/mongoc/Makefile.am
+++ b/src/mongoc/Makefile.am
@@ -77,6 +77,7 @@ INST_H_FILES = \
 	src/mongoc/mongoc-thread-private.h \
 	src/mongoc/mongoc-trace.h \
 	src/mongoc/mongoc-uri.h \
+	src/mongoc/mongoc-uri-private.h \
 	src/mongoc/mongoc-util-private.h \
 	src/mongoc/mongoc-version.h \
 	src/mongoc/mongoc-write-command-private.h \

--- a/src/mongoc/mongoc-uri-private.h
+++ b/src/mongoc/mongoc-uri-private.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MONGOC_URI_PRIVATE_H
+#define MONGOC_URI_PRIVATE_H
+
+#if !defined (MONGOC_I_AM_A_DRIVER) && !defined (MONGOC_COMPILATION)
+#error "Only <mongoc.h> can be included directly."
+#endif
+
+#include "mongoc-uri.h"
+
+
+BSON_BEGIN_DECLS
+
+
+void
+mongoc_uri_lowercase_hostname (const char *src,
+                               char       *buf /* OUT */,
+                               int         len);
+
+
+BSON_BEGIN_DECLS
+
+
+#endif /* MONGOC_URI_PRIVATE_H */

--- a/tests/test-mongoc-uri.c
+++ b/tests/test-mongoc-uri.c
@@ -41,6 +41,14 @@ test_mongoc_uri_new (void)
    ASSERT(uri);
    mongoc_uri_destroy(uri);
 
+   /* should normalize to lowercase */
+   uri = mongoc_uri_new ("mongodb://cRaZyHoStNaMe");
+   assert (uri);
+   hosts = mongoc_uri_get_hosts (uri);
+   assert (hosts);
+   ASSERT_CMPSTR (hosts->host, "crazyhostname");
+   mongoc_uri_destroy (uri);
+
    uri = mongoc_uri_new("mongodb://localhost/?");
    ASSERT(uri);
    mongoc_uri_destroy(uri);


### PR DESCRIPTION
@hanumantmk and @ajdavis if you get a minute today, would you please review?  Note that this only canonicalizes hostnames within URIs.  Once it's merged in the SDAM branch will need a bit more work to complete the task.