### PR TITLE
client pool: Fix some missing locking and a deadlock

### DIFF
--- a/src/mongoc/mongoc-client-pool.c
+++ b/src/mongoc/mongoc-client-pool.c
@@ -202,8 +202,10 @@ mongoc_client_pool_push (mongoc_client_pool_t *pool,
    if (pool->size > pool->min_pool_size) {
       mongoc_client_t *old_client;
       old_client = _mongoc_queue_pop_head (&pool->queue);
-      mongoc_client_destroy (old_client);
-      pool->size--;
+      if (old_client) {
+          mongoc_client_destroy (old_client);
+          pool->size--;
+      }
    }
    mongoc_mutex_unlock(&pool->mutex);
 

--- a/src/mongoc/mongoc-client-pool.c
+++ b/src/mongoc/mongoc-client-pool.c
@@ -198,12 +198,14 @@ mongoc_client_pool_push (mongoc_client_pool_t *pool,
    bson_return_if_fail(pool);
    bson_return_if_fail(client);
 
+   mongoc_mutex_lock(&pool->mutex);
    if (pool->size > pool->min_pool_size) {
       mongoc_client_t *old_client;
       old_client = _mongoc_queue_pop_head (&pool->queue);
       mongoc_client_destroy (old_client);
       pool->size--;
    }
+   mongoc_mutex_unlock(&pool->mutex);
 
    if ((client->cluster.state == MONGOC_CLUSTER_STATE_HEALTHY) ||
        (client->cluster.state == MONGOC_CLUSTER_STATE_BORN)) {


### PR DESCRIPTION
client pool: Add some missing locking in _push()

This is adds a missing mongoc_mutex_lock/unlock pair in
mongoc_client_pool_push()

client pool: Prevent a deadlock in mongoc_client_pool_pop()

There is situation a where a client could deadlock in 
mongoc_client_pool_pop() which this fix's.