### PR TITLE
CDRIVER-570: Executing bulk without write concern should inherit from client

### DIFF
--- a/src/mongoc/mongoc-bulk-operation.c
+++ b/src/mongoc/mongoc-bulk-operation.c
@@ -314,10 +314,6 @@ mongoc_bulk_operation_execute (mongoc_bulk_operation_t *bulk,  /* IN */
 
    bson_return_val_if_fail (bulk, false);
 
-   if (!bulk->write_concern) {
-      bulk->write_concern = mongoc_write_concern_new ();
-   }
-
    if (bulk->executed) {
       _mongoc_write_result_destroy (&bulk->result);
    }


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-570

When using mongoc_bulk_operation_new() to construct a bulk operation (not through a collection), one would expect the client's write concern to be used at execution time if an explicit write concern is not set on the bulk operation. That functionality is already handled by _mongoc_write_command_execute(), but it requires we not initialize a new write concern on the bulk operation.