### PR TITLE
CDRIVER-529: Spurious "unstable version" warning from configure.

### DIFF
--- a/build/autotools/PrintBuildConfiguration.m4
+++ b/build/autotools/PrintBuildConfiguration.m4
@@ -1,6 +1,6 @@
 AC_OUTPUT
 
-if test $(( ${MONGOC_MINOR_VERSION} % 2 )) -eq 1; then
+if test $(( ${MONGOC_MICRO_VERSION} % 2 )) -eq 1; then
 cat << EOF
  *** IMPORTANT *** 
 


### PR DESCRIPTION
We set an odd micro version (1.1.1, 1.1.3, etc.) between releases to mark the
code unstable, but the configure script was checking the minor version, not the
micro, to decide whether to warn.