### PR TITLE
Silence CMake 3.0+ warning on Mac OS X.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,10 @@ if (UNIX AND NOT APPLE)
    set(LIBS ${LIBS} rt)
 endif()
 
+if (APPLE)
+   cmake_policy(SET CMP0042 OLD)
+endif()
+
 add_definitions(-D_GNU_SOURCE)
 add_definitions(-D_BSD_SOURCE)
 add_definitions("-DBINARY_DIR=\"${SOURCE_DIR}/tests/binary\"")


### PR DESCRIPTION
Silence this warning:

```
CMake Warning (dev):
  Policy CMP0042 is not set: MACOSX_RPATH is enabled by default.  Run "cmake
  --help-policy CMP0042" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  MACOSX_RPATH is not specified for the following targets:

   mongoc_shared
```

Details are here:

http://www.cmake.org/cmake/help/v3.0/policy/CMP0042.html
http://www.cmake.org/Wiki/CMake_RPATH_handling

There may be advantages to configuring rpath properly when building with CMake on Mac, but until further research proves so, we can simply silence the warning and stick to the old CMake behavior.