### PR TITLE
CDRIVER-586 Direct bulk writes to hinted nodes

### DIFF
--- a/src/mongoc/mongoc-client-private.h
+++ b/src/mongoc/mongoc-client-private.h
@@ -117,6 +117,15 @@ mongoc_server_description_t *
 _mongoc_client_get_server_description (mongoc_client_t *client,
                                        uint32_t         server_id);
 
+bool
+_mongoc_client_command_simple_with_hint (mongoc_client_t           *client,
+                                         const char                *db_name,
+                                         const bson_t              *command,
+                                         const mongoc_read_prefs_t *read_prefs,
+                                         bson_t                    *reply,
+                                         uint32_t                   hint,
+                                         bson_error_t              *error);
+
 BSON_END_DECLS
 
 

--- a/src/mongoc/mongoc-client.c
+++ b/src/mongoc/mongoc-client.c
@@ -1256,6 +1256,19 @@ mongoc_client_command_simple (mongoc_client_t           *client,
                               bson_t                    *reply,
                               bson_error_t              *error)
 {
+   return _mongoc_client_command_simple_with_hint (client, db_name, command,
+                                                   read_prefs, reply, 0, error);
+}
+
+bool
+_mongoc_client_command_simple_with_hint (mongoc_client_t           *client,
+                                         const char                *db_name,
+                                         const bson_t              *command,
+                                         const mongoc_read_prefs_t *read_prefs,
+                                         bson_t                    *reply,
+                                         uint32_t                   hint,
+                                         bson_error_t              *error)
+{
    mongoc_cursor_t *cursor;
    const bson_t *doc;
    bool ret;
@@ -1266,6 +1279,8 @@ mongoc_client_command_simple (mongoc_client_t           *client,
 
    cursor = mongoc_client_command (client, db_name, MONGOC_QUERY_NONE, 0, 1, 0,
                                    command, NULL, read_prefs);
+
+   cursor->hint = hint;
 
    ret = mongoc_cursor_next (cursor, &doc);
 

--- a/src/mongoc/mongoc-write-command.c
+++ b/src/mongoc/mongoc-write-command.c
@@ -539,8 +539,8 @@ _mongoc_write_command_delete (mongoc_write_command_t       *command,
    bson_append_document_end (&ar, &child);
    bson_append_array_end (&cmd, &ar);
 
-   ret = mongoc_client_command_simple (client, database, &cmd, NULL,
-                                       &reply, error);
+   ret = _mongoc_client_command_simple_with_hint (client, database, &cmd, NULL,
+                                                  &reply, hint, error);
 
    if (!ret) {
       result->failed = true;
@@ -672,8 +672,8 @@ again:
       bson_append_array_end (&cmd, &ar);
    }
 
-   ret = mongoc_client_command_simple (client, database, &cmd, NULL,
-                                       &reply, error);
+   ret = _mongoc_client_command_simple_with_hint (client, database, &cmd, NULL,
+                                                  &reply, hint, error);
 
    if (!ret) {
       result->failed = true;
@@ -750,8 +750,8 @@ _mongoc_write_command_update (mongoc_write_command_t       *command,
    bson_append_document_end (&ar, &child);
    bson_append_array_end (&cmd, &ar);
 
-   ret = mongoc_client_command_simple (client, database, &cmd, NULL,
-                                       &reply, error);
+   ret = _mongoc_client_command_simple_with_hint (client, database, &cmd, NULL,
+                                                  &reply, hint, error);
 
    if (!ret) {
       result->failed = true;


### PR DESCRIPTION
Bulk writes could have a hint set, which was used for decisions around
legacy op, size of write commands, etc.  After all those checks, we
dispatched to whichever node happened to be the primary though.

Added support for a command_simple_with_hint, which allows for a hint.
This lets us dispatch to a specific node, which will error on a non
master, rather than possibly silently succeeding if we route to a
primary.