### PR TITLE
fix dumping io - it should always be done in the stream wrapper

### DIFF
--- a/src/mongoc/mongoc-cluster.c
+++ b/src/mongoc/mongoc-cluster.c
@@ -135,7 +135,6 @@ _mongoc_cluster_run_command (mongoc_cluster_t      *cluster,
    _mongoc_rpc_gather(&rpc, &ar);
    _mongoc_rpc_swab_to_le(&rpc);
 
-   DUMP_IOVEC (((mongoc_iovec_t *)ar.data), ((mongoc_iovec_t *)ar.data), ar.len);
    if (!mongoc_stream_writev(stream, ar.data, ar.len,
                              cluster->sockettimeoutms)) {
       GOTO(failure);
@@ -2277,8 +2276,6 @@ mongoc_cluster_try_recv (mongoc_cluster_t *cluster,
       mongoc_counter_protocol_ingress_error_inc ();
       RETURN (false);
    }
-
-   DUMP_BYTES (buffer, buffer->data + buffer->off, buffer->len);
 
    _mongoc_rpc_swab_from_le (rpc);
 

--- a/src/mongoc/mongoc-socket.c
+++ b/src/mongoc/mongoc-socket.c
@@ -778,8 +778,6 @@ again:
       RETURN (-1);
    }
 
-   DUMP_BYTES (recvbuf, (uint8_t *)buf, ret);
-
    mongoc_counter_streams_ingress_add (ret > 0 ? ret : 0);
 
    RETURN (ret);

--- a/src/mongoc/mongoc-stream.c
+++ b/src/mongoc/mongoc-stream.c
@@ -126,6 +126,7 @@ mongoc_stream_writev (mongoc_stream_t *stream,
       timeout_msec = MONGOC_DEFAULT_TIMEOUT_MSEC;
    }
 
+   DUMP_IOVEC (writev, iov, iovcnt);
    ret = stream->writev(stream, iov, iovcnt, timeout_msec);
 
    RETURN (ret);
@@ -199,6 +200,7 @@ mongoc_stream_readv (mongoc_stream_t *stream,
    BSON_ASSERT (stream->readv);
 
    ret = stream->readv (stream, iov, iovcnt, min_bytes, timeout_msec);
+   DUMP_IOVEC (readv, iov, iovcnt);
 
    RETURN (ret);
 }


### PR DESCRIPTION
otherwise data from other handlers won't be dumped