### PR TITLE
CDRIVER-609: Differenciate between a failed stream, and cleanup/destroy

### DIFF
--- a/build/autotools/versions.ldscript
+++ b/build/autotools/versions.ldscript
@@ -250,5 +250,6 @@ LIBMONGOC_1.2 {
         mongoc_server_description_host;
         mongoc_server_description_id;
         mongoc_server_description_new_copy;
+        mongoc_stream_failed;
         mongoc_uri_get_read_prefs_t;
 } LIBMONGOC_1.1;

--- a/build/cmake/libmongoc-ssl.def
+++ b/build/cmake/libmongoc-ssl.def
@@ -188,6 +188,7 @@ mongoc_stream_buffered_new
 mongoc_stream_check_closed
 mongoc_stream_close
 mongoc_stream_destroy
+mongoc_stream_failed
 mongoc_stream_file_get_fd
 mongoc_stream_file_new
 mongoc_stream_file_new_for_path

--- a/build/cmake/libmongoc.def
+++ b/build/cmake/libmongoc.def
@@ -182,6 +182,7 @@ mongoc_stream_buffered_new
 mongoc_stream_check_closed
 mongoc_stream_close
 mongoc_stream_destroy
+mongoc_stream_failed
 mongoc_stream_file_get_fd
 mongoc_stream_file_new
 mongoc_stream_file_new_for_path

--- a/src/libmongoc.symbols
+++ b/src/libmongoc.symbols
@@ -187,6 +187,7 @@ mongoc_stream_buffered_new
 mongoc_stream_check_closed
 mongoc_stream_close
 mongoc_stream_destroy
+mongoc_stream_failed
 mongoc_stream_file_get_fd
 mongoc_stream_file_new
 mongoc_stream_file_new_for_path

--- a/src/mongoc/mongoc-client.c
+++ b/src/mongoc/mongoc-client.c
@@ -342,7 +342,7 @@ mongoc_client_default_stream_initiator (const mongoc_uri_t       *uri,
                             MONGOC_ERROR_STREAM,
                             MONGOC_ERROR_STREAM_SOCKET,
                             "Failed to handshake and validate TLS certificate.");
-            mongoc_stream_destroy (base_stream);
+            mongoc_stream_failed (base_stream);
             base_stream = NULL;
             return NULL;
          }

--- a/src/mongoc/mongoc-cluster.c
+++ b/src/mongoc/mongoc-cluster.c
@@ -1057,7 +1057,8 @@ mongoc_cluster_disconnect_node (mongoc_cluster_t *cluster, uint32_t server_id)
 static void
 _mongoc_cluster_node_destroy (mongoc_cluster_node_t *node)
 {
-   mongoc_stream_destroy (node->stream);
+   /* Failure, or Replica Set reconfigure without this node */
+   mongoc_stream_failed (node->stream);
 
    bson_free (node);
 }
@@ -1264,7 +1265,7 @@ mongoc_cluster_fetch_stream (mongoc_cluster_t *cluster,
             goto FETCH_FAIL;
          }
 
-         mongoc_stream_destroy (cluster_node->stream);
+         mongoc_stream_failed (cluster_node->stream);
          cluster_node->stream = _mongoc_client_create_stream(cluster->client, &sd->host, error);
          cluster_node->timestamp = bson_get_monotonic_time ();
 

--- a/src/mongoc/mongoc-gridfs.c
+++ b/src/mongoc/mongoc-gridfs.c
@@ -263,7 +263,7 @@ mongoc_gridfs_create_file_from_stream (mongoc_gridfs_t          *gridfs,
       }
    }
 
-   mongoc_stream_destroy (stream);
+   mongoc_stream_failed (stream);
 
    mongoc_gridfs_file_seek (file, 0, SEEK_SET);
 

--- a/src/mongoc/mongoc-stream-buffered.c
+++ b/src/mongoc/mongoc-stream-buffered.c
@@ -76,6 +76,31 @@ mongoc_stream_buffered_destroy (mongoc_stream_t *stream) /* IN */
 /*
  *--------------------------------------------------------------------------
  *
+ * mongoc_stream_buffered_failed --
+ *
+ *       Called when a stream fails. Useful for streams that differnciate
+ *       between failure and cleanup.
+ *       Calls mongoc_stream_buffered_destroy() on the stream.
+ *
+ * Returns:
+ *       None.
+ *
+ * Side effects:
+ *       Everything.
+ *
+ *--------------------------------------------------------------------------
+ */
+
+static void
+mongoc_stream_buffered_failed (mongoc_stream_t *stream) /* IN */
+{
+	mongoc_stream_buffered_destroy (stream);
+}
+
+
+/*
+ *--------------------------------------------------------------------------
+ *
  * mongoc_stream_buffered_close --
  *
  *       Close the underlying stream. The buffered content is still
@@ -287,6 +312,7 @@ mongoc_stream_buffered_new (mongoc_stream_t *base_stream, /* IN */
    stream = bson_malloc0(sizeof *stream);
    stream->stream.type = MONGOC_STREAM_BUFFERED;
    stream->stream.destroy = mongoc_stream_buffered_destroy;
+   stream->stream.failed = mongoc_stream_buffered_failed;
    stream->stream.close = mongoc_stream_buffered_close;
    stream->stream.flush = mongoc_stream_buffered_flush;
    stream->stream.writev = mongoc_stream_buffered_writev;

--- a/src/mongoc/mongoc-stream-file.c
+++ b/src/mongoc/mongoc-stream-file.c
@@ -81,6 +81,17 @@ _mongoc_stream_file_destroy (mongoc_stream_t *stream)
 }
 
 
+static void
+_mongoc_stream_file_failed (mongoc_stream_t *stream)
+{
+   ENTRY;
+
+   _mongoc_stream_file_destroy (stream);
+
+   EXIT;
+}
+
+
 static int
 _mongoc_stream_file_flush (mongoc_stream_t *stream) /* IN */
 {
@@ -185,6 +196,7 @@ mongoc_stream_file_new (int fd) /* IN */
    stream->vtable.type = MONGOC_STREAM_FILE;
    stream->vtable.close = _mongoc_stream_file_close;
    stream->vtable.destroy = _mongoc_stream_file_destroy;
+   stream->vtable.failed = _mongoc_stream_file_failed;
    stream->vtable.flush = _mongoc_stream_file_flush;
    stream->vtable.readv = _mongoc_stream_file_readv;
    stream->vtable.writev = _mongoc_stream_file_writev;

--- a/src/mongoc/mongoc-stream-gridfs.c
+++ b/src/mongoc/mongoc-stream-gridfs.c
@@ -55,6 +55,17 @@ _mongoc_stream_gridfs_destroy (mongoc_stream_t *stream)
 }
 
 
+static void
+_mongoc_stream_gridfs_failed (mongoc_stream_t *stream)
+{
+   ENTRY;
+
+   _mongoc_stream_gridfs_destroy (stream);
+
+   EXIT;
+}
+
+
 static int
 _mongoc_stream_gridfs_close (mongoc_stream_t *stream)
 {
@@ -159,6 +170,7 @@ mongoc_stream_gridfs_new (mongoc_gridfs_file_t *file)
    stream->file = file;
    stream->stream.type = MONGOC_STREAM_GRIDFS;
    stream->stream.destroy = _mongoc_stream_gridfs_destroy;
+   stream->stream.failed = _mongoc_stream_gridfs_failed;
    stream->stream.close = _mongoc_stream_gridfs_close;
    stream->stream.flush = _mongoc_stream_gridfs_flush;
    stream->stream.writev = _mongoc_stream_gridfs_writev;

--- a/src/mongoc/mongoc-stream-socket.c
+++ b/src/mongoc/mongoc-stream-socket.c
@@ -83,6 +83,17 @@ _mongoc_stream_socket_destroy (mongoc_stream_t *stream)
 }
 
 
+static void
+_mongoc_stream_socket_failed (mongoc_stream_t *stream)
+{
+   ENTRY;
+
+   _mongoc_stream_socket_destroy (stream);
+
+   EXIT;
+}
+
+
 static int
 _mongoc_stream_socket_setsockopt (mongoc_stream_t *stream,
                                   int              level,
@@ -296,6 +307,7 @@ mongoc_stream_socket_new (mongoc_socket_t *sock) /* IN */
    stream->vtable.type = MONGOC_STREAM_SOCKET;
    stream->vtable.close = _mongoc_stream_socket_close;
    stream->vtable.destroy = _mongoc_stream_socket_destroy;
+   stream->vtable.failed = _mongoc_stream_socket_failed;
    stream->vtable.flush = _mongoc_stream_socket_flush;
    stream->vtable.readv = _mongoc_stream_socket_readv;
    stream->vtable.writev = _mongoc_stream_socket_writev;

--- a/src/mongoc/mongoc-stream-tls.c
+++ b/src/mongoc/mongoc-stream-tls.c
@@ -394,6 +394,29 @@ _mongoc_stream_tls_destroy (mongoc_stream_t *stream)
 /*
  *--------------------------------------------------------------------------
  *
+ * _mongoc_stream_tls_failed --
+ *
+ *       Called on stream failure. Same as _mongoc_stream_tls_destroy()
+ *
+ * Returns:
+ *       None.
+ *
+ * Side effects:
+ *       None.
+ *
+ *--------------------------------------------------------------------------
+ */
+
+static void
+_mongoc_stream_tls_failed (mongoc_stream_t *stream)
+{
+   _mongoc_stream_tls_destroy (stream);
+}
+
+
+/*
+ *--------------------------------------------------------------------------
+ *
  * _mongoc_stream_tls_close --
  *
  *       Close the underlying socket.
@@ -934,6 +957,7 @@ mongoc_stream_tls_new (mongoc_stream_t  *base_stream,
    tls->base_stream = base_stream;
    tls->parent.type = MONGOC_STREAM_TLS;
    tls->parent.destroy = _mongoc_stream_tls_destroy;
+   tls->parent.failed = _mongoc_stream_tls_failed;
    tls->parent.close = _mongoc_stream_tls_close;
    tls->parent.flush = _mongoc_stream_tls_flush;
    tls->parent.writev = _mongoc_stream_tls_writev;

--- a/src/mongoc/mongoc-stream.c
+++ b/src/mongoc/mongoc-stream.c
@@ -61,6 +61,32 @@ mongoc_stream_close (mongoc_stream_t *stream)
 
 
 /**
+ * mongoc_stream_failed:
+ * @stream: A mongoc_stream_t.
+ *
+ * Frees any resources referenced by @stream, including the memory allocation
+ * for @stream.
+ * This handler is called upon stream failure, such as network errors, invalid replies
+ * or replicaset reconfigures deleteing the stream
+ */
+void
+mongoc_stream_failed (mongoc_stream_t *stream)
+{
+   ENTRY;
+
+   bson_return_if_fail(stream);
+
+   if (stream->failed) {
+	   stream->failed(stream);
+   } else {
+	   stream->destroy(stream);
+   }
+
+   EXIT;
+}
+
+
+/**
  * mongoc_stream_destroy:
  * @stream: A mongoc_stream_t.
  *

--- a/src/mongoc/mongoc-stream.h
+++ b/src/mongoc/mongoc-stream.h
@@ -61,7 +61,7 @@ struct _mongoc_stream_t
    ssize_t          (*poll)            (mongoc_stream_poll_t *streams,
                                         size_t                nstreams,
                                         int32_t               timeout);
-   void             *padding [7];
+   void             *padding [6];
 };
 
 

--- a/src/mongoc/mongoc-stream.h
+++ b/src/mongoc/mongoc-stream.h
@@ -61,13 +61,15 @@ struct _mongoc_stream_t
    ssize_t          (*poll)            (mongoc_stream_poll_t *streams,
                                         size_t                nstreams,
                                         int32_t               timeout);
-   void             *padding [6];
+   void             (*failed)          (mongoc_stream_t *stream);
+   void             *padding [5];
 };
 
 
 mongoc_stream_t *mongoc_stream_get_base_stream (mongoc_stream_t       *stream);
 int              mongoc_stream_close           (mongoc_stream_t       *stream);
 void             mongoc_stream_destroy         (mongoc_stream_t       *stream);
+void             mongoc_stream_failed          (mongoc_stream_t       *stream);
 int              mongoc_stream_flush           (mongoc_stream_t       *stream);
 ssize_t          mongoc_stream_writev          (mongoc_stream_t       *stream,
                                                 mongoc_iovec_t        *iov,

--- a/src/mongoc/mongoc-topology-scanner-private.h
+++ b/src/mongoc/mongoc-topology-scanner-private.h
@@ -88,10 +88,6 @@ mongoc_topology_scanner_add (mongoc_topology_scanner_t *ts,
                              uint32_t                   id);
 
 void
-mongoc_topology_scanner_rm (mongoc_topology_scanner_t *ts,
-                            uint32_t                   id);
-
-void
 mongoc_topology_scanner_start (mongoc_topology_scanner_t *ts,
                                int32_t                    timeout_msec);
 

--- a/src/mongoc/mongoc-topology-scanner.c
+++ b/src/mongoc/mongoc-topology-scanner.c
@@ -163,18 +163,6 @@ mongoc_topology_scanner_get_node (mongoc_topology_scanner_t *ts,
    return NULL;
 }
 
-void
-mongoc_topology_scanner_rm (mongoc_topology_scanner_t *ts,
-                            uint32_t                   id)
-{
-   mongoc_topology_scanner_node_t *ele;
-
-   ele = mongoc_topology_scanner_get_node (ts, id);
-   if (ele) {
-      mongoc_topology_scanner_node_destroy (ele, true);
-   }
-}
-
 /*
  *-----------------------------------------------------------------------
  *


### PR DESCRIPTION
This adds a new `failed` handler to the mongoc_stream_t, along with
mongoc_stream_failed().

The failed handler shall be called when the stream truely needs to be
destroyed (due to errors, removal from topology, etc etc).
The destroy handler shall be called during normal _destroy() routines,
like mongoc_destroy().

By default, for BC, if no failed handler is provided we will fallback
and call the `destroy` handler.