### PR TITLE
CDRIVER-594 Fix timeout in single-thread selection

### DIFF
--- a/src/mongoc/mongoc-topology.c
+++ b/src/mongoc/mongoc-topology.c
@@ -331,6 +331,12 @@ mongoc_topology_select (mongoc_topology_t         *topology,
 
       /* until we find a server or timeout */
       for (;;) {
+         /* error if we've timed out */
+         now = bson_get_monotonic_time();
+         if (now >= expire_at) {
+            goto TIMEOUT;
+         }
+
          /* attempt to select a server */
          selected_server = mongoc_topology_description_select(&topology->description,
                                                               optype,
@@ -344,12 +350,6 @@ mongoc_topology_select (mongoc_topology_t         *topology,
 
          /* rescan */
          _mongoc_topology_do_blocking_scan(topology);
-
-         /* error if we've timed out */
-         now = bson_get_monotonic_time();
-         if (now > expire_at) {
-            goto TIMEOUT;
-         }
       }
    }
 


### PR DESCRIPTION
Cancel after first blocking scan's timeout, not the second's.

In @bjori's example code for CDRIVER-610, the fix in this PR reduces the total runtime from 90 seconds to the expected 60 seconds on my system.