### PR TITLE
Move mongoc_cursor_cursorid_t typedef into private header

### DIFF
--- a/src/mongoc/mongoc-cursor-cursorid-private.h
+++ b/src/mongoc/mongoc-cursor-cursorid-private.h
@@ -29,6 +29,15 @@
 BSON_BEGIN_DECLS
 
 
+typedef struct
+{
+   bool        has_cursor;
+   bool        in_first_batch;
+   bson_iter_t first_batch_iter;
+   bson_t      first_batch_inline;
+} mongoc_cursor_cursorid_t;
+
+
 bool _mongoc_cursor_cursorid_prime (mongoc_cursor_t *cursor);
 void _mongoc_cursor_cursorid_init (mongoc_cursor_t *cursor);
 

--- a/src/mongoc/mongoc-cursor-cursorid.c
+++ b/src/mongoc/mongoc-cursor-cursorid.c
@@ -30,15 +30,6 @@
 #define MONGOC_LOG_DOMAIN "cursor-cursorid"
 
 
-typedef struct
-{
-   bool        has_cursor;
-   bool        in_first_batch;
-   bson_iter_t first_batch_iter;
-   bson_t      first_batch_inline;
-} mongoc_cursor_cursorid_t;
-
-
 static void *
 _mongoc_cursor_cursorid_new (void)
 {


### PR DESCRIPTION
The PHP driver needs access to this structure, since it reimplements some of the logic within `_mongoc_cursor_cursorid_prime()`.