### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/mongoc/mongoc-stream.c
+++ b/src/mongoc/mongoc-stream.c
@@ -307,7 +307,7 @@ mongoc_stream_poll (mongoc_stream_poll_t *streams,
                     size_t                nstreams,
                     int32_t               timeout)
 {
-   mongoc_stream_poll_t * poll = bson_malloc(sizeof(*poll) * nstreams);
+   mongoc_stream_poll_t *poller = bson_malloc(sizeof(*poller) * nstreams);
 
    int i;
    int last_type = 0;
@@ -316,33 +316,33 @@ mongoc_stream_poll (mongoc_stream_poll_t *streams,
    errno = 0;
 
    for (i = 0; i < nstreams; i++) {
-      poll[i].stream = mongoc_stream_get_base_stream(streams[i].stream);
-      poll[i].events = streams[i].events;
-      poll[i].revents = 0;
+      poller[i].stream = mongoc_stream_get_base_stream(streams[i].stream);
+      poller[i].events = streams[i].events;
+      poller[i].revents = 0;
 
       if (i == 0) {
-         last_type = poll[i].stream->type;
-      } else if (last_type != poll[i].stream->type) {
+         last_type = poller[i].stream->type;
+      } else if (last_type != poller[i].stream->type) {
          errno = EINVAL;
          goto CLEANUP;
       }
    }
 
-   if (! poll[0].stream->poll) {
+   if (! poller[0].stream->poll) {
       errno = EINVAL;
       goto CLEANUP;
    }
 
-   rval = poll[0].stream->poll(poll, nstreams, timeout);
+   rval = poller[0].stream->poll(poller, nstreams, timeout);
 
    if (rval > 0) {
       for (i = 0; i < nstreams; i++) {
-         streams[i].revents = poll[i].revents;
+         streams[i].revents = poller[i].revents;
       }
    }
 
 CLEANUP:
-   bson_free(poll);
+   bson_free(poller);
 
    return rval;
 }

--- a/tests/test-bulk.c
+++ b/tests/test-bulk.c
@@ -298,7 +298,7 @@ test_bulk_edge_over_1000 (void)
    mongoc_collection_t *collection;
    mongoc_bulk_operation_t * bulk_op;
    mongoc_write_concern_t * wc = mongoc_write_concern_new();
-   bson_iter_t iter, error_iter, index;
+   bson_iter_t iter, error_iter, indexnum;
    bson_t doc, result;
    bson_error_t error;
    int i;
@@ -343,12 +343,12 @@ test_bulk_edge_over_1000 (void)
    assert(bson_iter_next(&error_iter));
 
    for (i = 0; i < 1010; i+=3) {
-      assert(bson_iter_recurse(&error_iter, &index));
-      assert(bson_iter_find(&index, "index"));
-      if (bson_iter_int32(&index) != i) {
-          fprintf(stderr, "index should be %d, but is %d\n", i, bson_iter_int32(&index));
+      assert(bson_iter_recurse(&error_iter, &indexnum));
+      assert(bson_iter_find(&indexnum, "index"));
+      if (bson_iter_int32(&indexnum) != i) {
+          fprintf(stderr, "index should be %d, but is %d\n", i, bson_iter_int32(&indexnum));
       }
-      assert(bson_iter_int32(&index) == i);
+      assert(bson_iter_int32(&indexnum) == i);
       bson_iter_next(&error_iter);
    }
 


### PR DESCRIPTION
./autogen.sh --enable-tracing --enable-debug-symbols=full --enable-maintainer-flags=yes --enable-debug

src/mongoc/mongoc-async.c:68:26: warning: declaration of 'poll' shadows a global declaration [-Wshadow]
src/mongoc/mongoc-stream.c:310:27: warning: declaration of 'poll' shadows a global declaration [-Wshadow]
tests/test-bulk.c:301:34: warning: declaration of ‘index’ shadows a global declaration [-Wshadow]