### PR TITLE
CDRIVER-693 Replace mongoc_collection_delete() with mongoc_collection_remove() in mongo-c-driver/doc/deleting-document.page

### DIFF
--- a/doc/deleting-document.page
+++ b/doc/deleting-document.page
@@ -67,7 +67,7 @@ main (int   argc,
     doc = bson_new ();
     BSON_APPEND_OID (doc, "_id", &oid);
 
-    if (!mongoc_collection_delete (collection, MONGOC_DELETE_SINGLE_REMOVE, doc, NULL, &error)) {
+    if (!mongoc_collection_remove (collection, MONGOC_DELETE_SINGLE_REMOVE, doc, NULL, &error)) {
         printf ("Delete failed: %s\n", error.message);
     }
 


### PR DESCRIPTION
As ```mongoc_collection_delete ()``` is deprecated and should not be used in new code.
The document could be updated as well.