### PR TITLE
C Driver SASL fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,7 @@ set(test-libmongoc-sources
    ${SOURCE_DIR}/tests/test-mongoc-topology-scanner.c
    ${SOURCE_DIR}/tests/test-mongoc-uri.c
    ${SOURCE_DIR}/tests/test-mongoc-write-concern.c
+   ${SOURCE_DIR}/tests/test-sasl.c
    ${SOURCE_DIR}/tests/TestSuite.c
    ${SOURCE_DIR}/tests/test-write-commands.c
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ include(InstallRequiredSystemLibraries)
 include(FindOpenSSL)
 
 include(FindBSON REQUIRED)
+include(FindSASL2)
 
 set (SOURCE_DIR "${PROJECT_SOURCE_DIR}/")
 
@@ -30,7 +31,11 @@ else()
    set (MONGOC_ENABLE_SSL 0)
 endif ()
 
-set (MONGOC_ENABLE_SASL 0)
+if (SASL2_FOUND)
+   set (MONGOC_ENABLE_SASL 1)
+else()
+   set (MONGOC_ENABLE_SASL 0)
+endif ()
 
 configure_file (
    "${SOURCE_DIR}/src/mongoc/mongoc-config.h.in"
@@ -161,6 +166,13 @@ if (OPENSSL_FOUND)
    )
    set(LIBS ${LIBS} ${OPENSSL_LIBRARIES})
    include_directories(${OPENSSL_INCLUDE_DIR})
+endif()
+
+if (SASL2_FOUND)
+   set (HEADERS ${HEADERS} ${SOURCE_DIR}/src/mongoc/mongoc-sasl-private.h)
+   set (SOURCES ${SOURCES} ${SOURCE_DIR}/src/mongoc/mongoc-sasl.c)
+   set(LIBS ${LIBS} ${SASL2_LIBRARY})
+   include_directories(${SASL2_INCLUDE_DIR})
 endif()
 
 if (MSVC)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,4 +152,14 @@ If you start `mongod` with SSL, set these variables to configure how
 * `MONGOC_TEST_SSL_WEAK_CERT_VALIDATION`: set to `on` to relax the client's
   validation of the server's certificate.
 
+The SASL / GSSAPI / Kerberos tests are skipped by default. To run them, set up a
+separate `mongod` with Kerberos and set its host and Kerberos principal name
+as environment variables:
+
+* `MONGOC_TEST_GSSAPI_HOST` 
+* `MONGOC_TEST_GSSAPI_USER` 
+
+URI-escape the username, for example write "user@realm" as "user%40realm".
+The user must be authorized to query `test.collection`.
+
 All tests should pass before submitting a patch.

--- a/build/autotools/CheckSasl.m4
+++ b/build/autotools/CheckSasl.m4
@@ -43,17 +43,17 @@ dnl Let mongoc-config.h.in know about SASL status.
 if test "$sasl_mode" != "no" ; then
   AC_SUBST(MONGOC_ENABLE_SASL, 1)
   
-  AC_MSG_CHECKING([for sasl_client_done])
-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <sasl/sasl.h>]],
-                                  [[sasl_client_done ();]])],
-                 [AC_MSG_RESULT(yes)
-                  have_sasl_client_done=yes],
-                 [AC_MSG_RESULT(no)
-                  have_sasl_client_done=no])
-  AS_IF([test "$have_sasl_client_done" = "yes"],
-        [AC_SUBST(MONGOC_HAVE_SASL_CLIENT_DONE, 1)],
-        [AC_SUBST(MONGOC_HAVE_SASL_CLIENT_DONE, 0)])
+  AC_CHECK_LIB([sasl2],[sasl_client_done],
+               [have_sasl_client_done=yes],
+               [have_sasl_client_done=no])
+
+  if test "have_sasl_client_done" = "yes" ; then
+    AC_SUBST(MONGOC_HAVE_SASL_CLIENT_DONE, 1)
+  else
+    AC_SUBST(MONGOC_HAVE_SASL_CLIENT_DONE, 0)
+  fi
 
 else
   AC_SUBST(MONGOC_ENABLE_SASL, 0)
+  AC_SUBST(MONGOC_HAVE_SASL_CLIENT_DONE, 0)
 fi

--- a/build/autotools/CheckSasl.m4
+++ b/build/autotools/CheckSasl.m4
@@ -47,7 +47,7 @@ if test "$sasl_mode" != "no" ; then
                [have_sasl_client_done=yes],
                [have_sasl_client_done=no])
 
-  if test "have_sasl_client_done" = "yes" ; then
+  if test "$have_sasl_client_done" = "yes" ; then
     AC_SUBST(MONGOC_HAVE_SASL_CLIENT_DONE, 1)
   else
     AC_SUBST(MONGOC_HAVE_SASL_CLIENT_DONE, 0)

--- a/build/autotools/CheckSasl.m4
+++ b/build/autotools/CheckSasl.m4
@@ -42,6 +42,18 @@ AC_SUBST(SASL_LIBS)
 dnl Let mongoc-config.h.in know about SASL status.
 if test "$sasl_mode" != "no" ; then
   AC_SUBST(MONGOC_ENABLE_SASL, 1)
+  
+  AC_MSG_CHECKING([for sasl_client_done])
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <sasl/sasl.h>]],
+                                  [[sasl_client_done ();]])],
+                 [AC_MSG_RESULT(yes)
+                  have_sasl_client_done=yes],
+                 [AC_MSG_RESULT(no)
+                  have_sasl_client_done=no])
+  AS_IF([test "$have_sasl_client_done" = "yes"],
+        [AC_SUBST(MONGOC_HAVE_SASL_CLIENT_DONE, 1)],
+        [AC_SUBST(MONGOC_HAVE_SASL_CLIENT_DONE, 0)])
+
 else
   AC_SUBST(MONGOC_ENABLE_SASL, 0)
 fi

--- a/build/cmake/FindSASL2.cmake
+++ b/build/cmake/FindSASL2.cmake
@@ -20,6 +20,17 @@ endif ()
 
 if (SASL2_INCLUDE_DIR AND SASL2_LIBRARY)
     set (SASL2_FOUND 1)
+
+    check_symbol_exists (
+        sasl_client_done
+        ${SASL2_INCLUDE_DIR}/sasl/sasl.h
+        MONGOC_HAVE_SASL_CLIENT_DONE)
+
+    if (MONGOC_HAVE_SASL_CLIENT_DONE)
+        set (MONGOC_HAVE_SASL_CLIENT_DONE 1)
+    else ()
+        set (MONGOC_HAVE_SASL_CLIENT_DONE 0)
+    endif ()
 else ()
     set (SASL2_FOUND 0)
 endif ()

--- a/build/cmake/FindSASL2.cmake
+++ b/build/cmake/FindSASL2.cmake
@@ -1,0 +1,25 @@
+message ("Searching for sasl/sasl.h")
+find_path (
+    SASL2_INCLUDE_DIR NAMES sasl/sasl.h
+    PATHS /include /usr/include /usr/local/include /usr/share/include /opt/include
+    DOC "Searching for sasl/sasl.h")
+
+if (SASL2_INCLUDE_DIR)
+    message (STATUS "  Found in ${SASL2_INCLUDE_DIR}")
+endif ()
+
+message ("Searching for libsasl2")
+find_library(
+    SASL2_LIBRARY NAMES sasl2
+    PATHS /usr/lib /lib /usr/local/lib /usr/share/lib /opt/lib /opt/share/lib /var/lib
+    DOC "Searching for libsasl2")
+
+if (SASL2_LIBRARY)
+    message (STATUS "  Found ${SASL2_LIBRARY}")
+endif ()
+
+if (SASL2_INCLUDE_DIR AND SASL2_LIBRARY)
+    set (SASL2_FOUND 1)
+else ()
+    set (SASL2_FOUND 0)
+endif ()

--- a/src/mongoc/mongoc-config.h.in
+++ b/src/mongoc/mongoc-config.h.in
@@ -41,4 +41,16 @@
 #endif
 
 
+/*
+ * MONGOC_HAVE_SASL_CLIENT_DONE is set from configure to determine if we
+ * have SASL and its version is new enough to use sasl_client_done (),
+ * which supersedes sasl_done ().
+ */
+#define MONGOC_HAVE_SASL_CLIENT_DONE @MONGOC_HAVE_SASL_CLIENT_DONE@
+
+#if MONGOC_HAVE_SASL_CLIENT_DONE != 1
+#  undef MONGOC_HAVE_SASL_CLIENT_DONE
+#endif
+
+
 #endif /* MONGOC_CONFIG_H */

--- a/src/mongoc/mongoc-init.c
+++ b/src/mongoc/mongoc-init.c
@@ -133,11 +133,13 @@ static MONGOC_ONCE_FUN( _mongoc_do_cleanup)
    _mongoc_ssl_cleanup();
 #endif
 
+#ifdef MONGOC_ENABLE_SASL
 #ifdef MONGOC_HAVE_SASL_CLIENT_DONE
    sasl_client_done ();
 #else
    /* fall back to deprecated function */
    sasl_done ();
+#endif
 #endif
 
 #ifdef _WIN32

--- a/src/mongoc/mongoc-init.c
+++ b/src/mongoc/mongoc-init.c
@@ -26,12 +26,77 @@
 # include "mongoc-ssl-private.h"
 #endif
 #include "mongoc-thread-private.h"
+#include "mongoc-trace.h"
+
+
+#ifdef MONGOC_ENABLE_SASL
+#include <sasl/sasl.h>
+
+static void *
+mongoc_sasl_mutex_alloc (void)
+{
+   mongoc_mutex_t *mutex;
+
+   ENTRY;
+
+   mutex = bson_malloc0 (sizeof (mongoc_mutex_t));
+   mongoc_mutex_init (mutex);
+
+   RETURN((void *) mutex);
+}
+
+
+static int
+mongoc_sasl_mutex_lock (void *mutex)
+{
+   ENTRY;
+
+   mongoc_mutex_lock ((mongoc_mutex_t *) mutex);
+
+   RETURN(SASL_OK);
+}
+
+
+static int
+mongoc_sasl_mutex_unlock (void *mutex)
+{
+   ENTRY;
+
+   mongoc_mutex_unlock ((mongoc_mutex_t *) mutex);
+
+   RETURN(SASL_OK);
+}
+
+
+static void
+mongoc_sasl_mutex_free (void *mutex)
+{
+   ENTRY;
+
+   mongoc_mutex_destroy ((mongoc_mutex_t *) mutex);
+   bson_free (mutex);
+
+   EXIT;
+}
+
+#endif//MONGOC_ENABLE_SASL
+
 
 static MONGOC_ONCE_FUN( _mongoc_do_init)
 {
 #ifdef MONGOC_ENABLE_SSL
    _mongoc_ssl_init();
    _mongoc_scram_startup();
+#endif
+
+#ifdef MONGOC_ENABLE_SASL
+   sasl_set_mutex (mongoc_sasl_mutex_alloc,
+                   mongoc_sasl_mutex_lock,
+                   mongoc_sasl_mutex_unlock,
+                   mongoc_sasl_mutex_free);
+
+   /* TODO: logging callback? */
+   sasl_client_init (NULL);
 #endif
 
    _mongoc_counters_init();
@@ -66,6 +131,11 @@ static MONGOC_ONCE_FUN( _mongoc_do_cleanup)
 {
 #ifdef MONGOC_ENABLE_SSL
    _mongoc_ssl_cleanup();
+#endif
+
+   /* apple's libsasl package somehow lacks sasl_client_done before 2.1.24 */
+#if MONGOC_HAVE_SASL_CLIENT_DONE
+      sasl_client_done ();
 #endif
 
 #ifdef _WIN32

--- a/src/mongoc/mongoc-init.c
+++ b/src/mongoc/mongoc-init.c
@@ -133,9 +133,11 @@ static MONGOC_ONCE_FUN( _mongoc_do_cleanup)
    _mongoc_ssl_cleanup();
 #endif
 
-   /* apple's libsasl package somehow lacks sasl_client_done before 2.1.24 */
-#if MONGOC_HAVE_SASL_CLIENT_DONE
-      sasl_client_done ();
+#ifdef MONGOC_HAVE_SASL_CLIENT_DONE
+   sasl_client_done ();
+#else
+   /* fall back to deprecated function */
+   sasl_done ();
 #endif
 
 #ifdef _WIN32

--- a/src/mongoc/mongoc-sasl.c
+++ b/src/mongoc/mongoc-sasl.c
@@ -154,8 +154,6 @@ _mongoc_sasl_init (mongoc_sasl_t *sasl)
    sasl->service_name = NULL;
    sasl->service_host = NULL;
    sasl->interact = NULL;
-
-   sasl_client_init (sasl->callbacks);
 }
 
 
@@ -173,13 +171,6 @@ _mongoc_sasl_destroy (mongoc_sasl_t *sasl)
    free (sasl->mechanism);
    free (sasl->service_name);
    free (sasl->service_host);
-
-#if (SASL_VERSION_MAJOR >= 2) && \
-    (SASL_VERSION_MINOR >= 1) && \
-    (SASL_VERSION_STEP >= 24) && \
-    (!defined(__APPLE__))
-   sasl_client_done ();
-#endif
 }
 
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -116,6 +116,7 @@ test_libmongoc_SOURCES = \
 	tests/test-mongoc-uri.c \
 	tests/test-mongoc-write-concern.c \
 	tests/test-libmongoc.h \
+	tests/test-sasl.c \
 	tests/test-write-commands.c \
 	tests/TestSuite.c \
 	tests/TestSuite.h

--- a/tests/test-libmongoc.c
+++ b/tests/test-libmongoc.c
@@ -44,6 +44,7 @@ extern void test_queue_install             (TestSuite *suite);
 extern void test_read_prefs_install        (TestSuite *suite);
 extern void test_rpc_install               (TestSuite *suite);
 extern void test_sdam_install              (TestSuite *suite);
+extern void test_sasl_install              (TestSuite *suite);
 extern void test_server_selection_install  (TestSuite *suite);
 extern void test_set_install               (TestSuite *suite);
 extern void test_socket_install            (TestSuite *suite);
@@ -135,7 +136,7 @@ gen_collection_name (const char *str)
  *
  *--------------------------------------------------------------------------
  */
-static char *
+char *
 test_framework_getenv (const char *name)
 {
 #ifdef _MSC_VER
@@ -650,6 +651,7 @@ main (int   argc,
    test_queue_install (&suite);
    test_read_prefs_install (&suite);
    test_rpc_install (&suite);
+   test_sasl_install (&suite);
    test_socket_install (&suite);
    test_topology_scanner_install (&suite);
    test_sdam_install (&suite);

--- a/tests/test-libmongoc.h
+++ b/tests/test-libmongoc.h
@@ -26,6 +26,7 @@ void usleep (int64_t usec);
 
 char *gen_collection_name (const char *prefix);
 void suppress_one_message (void);
+char *test_framework_getenv (const char *name);
 char *test_framework_get_host (void);
 uint16_t test_framework_get_port (void);
 bool test_framework_get_ssl (void);

--- a/tests/test-sasl.c
+++ b/tests/test-sasl.c
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <mongoc.h>
+#include <mongoc-thread-private.h>
+
+#include "TestSuite.h"
+#include "test-libmongoc.h"
+
+
+static const char *GSSAPI_HOST = "MONGOC_TEST_GSSAPI_HOST";
+static const char *GSSAPI_USER = "MONGOC_TEST_GSSAPI_USER";
+
+#define NTHREADS 10
+#define NLOOPS 10
+
+
+int
+should_run_gssapi_kerberos (void)
+{
+   char *host = test_framework_getenv (GSSAPI_HOST);
+   char *user = test_framework_getenv (GSSAPI_USER);
+   int ret = (host && user);
+
+   bson_free (host);
+   bson_free (user);
+
+   return ret;
+}
+
+
+struct closure_t
+{
+   mongoc_client_pool_t *pool;
+   int                   finished;
+   mongoc_mutex_t        mutex;
+};
+
+
+static void *
+gssapi_kerberos_worker (void *data)
+{
+   struct closure_t *closure = (struct closure_t *)data;
+   mongoc_client_pool_t *pool = closure->pool;
+   mongoc_client_t *client;
+   mongoc_collection_t *collection;
+   mongoc_cursor_t *cursor;
+   bson_error_t error;
+   const bson_t *doc;
+   bson_t query = BSON_INITIALIZER;
+   int i;
+
+   for (i = 0; i < NLOOPS; i++) {
+      client = mongoc_client_pool_pop (pool);
+      collection = mongoc_client_get_collection (client, "test", "collection");
+      cursor = mongoc_collection_find (collection,
+                                       MONGOC_QUERY_NONE,
+                                       0,
+                                       0,
+                                       0,
+                                       &query,
+                                       NULL,
+                                       NULL);
+
+      if (!mongoc_cursor_next (cursor, &doc) &&
+          mongoc_cursor_error (cursor, &error)) {
+         fprintf (stderr, "Cursor Failure: %s\n", error.message);
+         abort ();
+      }
+
+      mongoc_cursor_destroy (cursor);
+      mongoc_collection_destroy (collection);
+      mongoc_client_pool_push (pool, client);
+   }
+
+   bson_destroy (&query);
+
+   mongoc_mutex_lock (&closure->mutex);
+   closure->finished++;
+   mongoc_mutex_unlock (&closure->mutex);
+
+   return NULL;
+}
+
+
+static void
+test_gssapi_kerberos (void *context)
+{
+   char *host = test_framework_getenv (GSSAPI_HOST);
+   char *user = test_framework_getenv (GSSAPI_USER);
+   char *uri_str;
+   mongoc_uri_t *uri;
+   struct closure_t closure = { 0 };
+   int i;
+   mongoc_thread_t threads[NTHREADS];
+
+   assert (host && user);
+
+   mongoc_mutex_init (&closure.mutex);
+
+   uri_str = bson_strdup_printf (
+      "mongodb://%s@%s/?authMechanism=GSSAPI&serverselectiontimeoutms=1000",
+      user, host);
+
+   uri = mongoc_uri_new (uri_str);
+   closure.pool = mongoc_client_pool_new (uri);
+
+   for (i = 0; i < NTHREADS; i++) {
+      mongoc_thread_create (&threads[i],
+                            gssapi_kerberos_worker,
+                            (void *)&closure);
+   }
+
+   for (i = 0; i < NTHREADS; i++) {
+      mongoc_thread_join (threads[i]);
+   }
+
+   mongoc_mutex_lock (&closure.mutex);
+   ASSERT_CMPINT (NTHREADS, ==, closure.finished);
+   mongoc_mutex_unlock (&closure.mutex);
+
+   mongoc_client_pool_destroy (closure.pool);
+   mongoc_mutex_destroy (&closure.mutex);
+   mongoc_uri_destroy (uri);
+   bson_free (uri_str);
+   bson_free (host);
+   bson_free (user);
+}
+
+
+void
+test_sasl_install (TestSuite *suite)
+{
+   TestSuite_AddFull (suite,
+                      "/SASL/gssapi_kerberos",
+                      test_gssapi_kerberos,
+                      NULL,
+                      NULL,
+                      should_run_gssapi_kerberos);
+}


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-530: SASL version check is wrong

https://jira.mongodb.org/browse/CDRIVER-547: properly use sasl_set_mutex, sasl_client_init, and sasl_client_done

Also, experimental support for building with SASL in CMake.