### PR TITLE
CDRIVER-678: Only the first member of seedlist is used

### DIFF
--- a/src/mongoc/mongoc-cluster.c
+++ b/src/mongoc/mongoc-cluster.c
@@ -2071,7 +2071,7 @@ _mongoc_cluster_check_interval (mongoc_cluster_t *cluster,
          }
 
          mongoc_topology_description_handle_ismaster (
-            &topology->description, sd, &reply,
+            &topology->description, topology->scanner, sd, &reply,
             (now - before_ismaster) / 1000,    /* RTT_MS */
             error);
 

--- a/src/mongoc/mongoc-topology-description-private.h
+++ b/src/mongoc/mongoc-topology-description-private.h
@@ -33,11 +33,6 @@ typedef enum
       MONGOC_TOPOLOGY_DESCRIPTION_TYPES
    } mongoc_topology_description_type_t;
 
-typedef struct {
-   void (*add)(const mongoc_server_description_t *);
-   void (*rm)(const mongoc_server_description_t *);
-} mongoc_topology_cb_t;
-
 typedef struct _mongoc_topology_description_t
 {
    mongoc_topology_description_type_t type;
@@ -46,7 +41,6 @@ typedef struct _mongoc_topology_description_t
    bool                               compatible;
    char                              *compatibility_error;
    uint32_t                           max_server_id;
-   mongoc_topology_cb_t               cb;
    bool                               stale;
 } mongoc_topology_description_t;
 
@@ -58,8 +52,7 @@ typedef enum
 
 void
 mongoc_topology_description_init (mongoc_topology_description_t     *description,
-                                  mongoc_topology_description_type_t type,
-                                  mongoc_topology_cb_t              *cb);
+                                  mongoc_topology_description_type_t type);
 
 void
 mongoc_topology_description_destroy (mongoc_topology_description_t *description);

--- a/src/mongoc/mongoc-topology-description-private.h
+++ b/src/mongoc/mongoc-topology-description-private.h
@@ -19,6 +19,7 @@
 
 #include "mongoc-read-prefs-private.h"
 #include "mongoc-server-description.h"
+#include "mongoc-topology-scanner-private.h"
 
 #define MONGOC_SS_DEFAULT_TIMEOUT_MS 30000
 #define MONGOC_SS_DEFAULT_LOCAL_THRESHOLD_MS 15
@@ -60,6 +61,7 @@ mongoc_topology_description_destroy (mongoc_topology_description_t *description)
 bool
 mongoc_topology_description_handle_ismaster (
    mongoc_topology_description_t *topology,
+   mongoc_topology_scanner_t     *scanner,
    mongoc_server_description_t   *sd,
    const bson_t                  *reply,
    int64_t                        rtt_msec,
@@ -86,10 +88,12 @@ mongoc_topology_description_suitable_servers (
 
 void
 mongoc_topology_description_invalidate_server (mongoc_topology_description_t *topology,
+                                               mongoc_topology_scanner_t     *scanner,
                                                uint32_t                       id);
 
 bool
 mongoc_topology_description_add_server (mongoc_topology_description_t *topology,
+                                        mongoc_topology_scanner_t     *scanner,
                                         const char                    *server,
                                         uint32_t                      *id /* OUT */);
 

--- a/src/mongoc/mongoc-topology-description.c
+++ b/src/mongoc/mongoc-topology-description.c
@@ -755,6 +755,7 @@ mongoc_topology_description_add_server (mongoc_topology_description_t *topology,
       mongoc_server_description_init(description, server, server_id);
 
       mongoc_set_add(topology->servers, server_id, description);
+      mongoc_topology_scanner_add (scanner, &description->host, server_id);
    }
 
    if (id) {
@@ -772,6 +773,7 @@ _mongoc_topology_description_monitor_new_servers (mongoc_topology_description_t 
 {
    bson_iter_t member_iter;
    const bson_t *rs_members[3];
+   uint32_t id;
    int i;
 
    rs_members[0] = &server->hosts;
@@ -782,7 +784,7 @@ _mongoc_topology_description_monitor_new_servers (mongoc_topology_description_t 
       bson_iter_init (&member_iter, rs_members[i]);
 
       while (bson_iter_next (&member_iter)) {
-         mongoc_topology_description_add_server(topology, scanner, bson_iter_utf8(&member_iter, NULL), NULL);
+         mongoc_topology_description_add_server(topology, scanner, bson_iter_utf8(&member_iter, NULL), &id);
       }
    }
 }

--- a/src/mongoc/mongoc-topology-description.c
+++ b/src/mongoc/mongoc-topology-description.c
@@ -50,8 +50,7 @@ _mongoc_topology_server_dtor (void *server_,
  */
 void
 mongoc_topology_description_init (mongoc_topology_description_t     *description,
-                                  mongoc_topology_description_type_t type,
-                                  mongoc_topology_cb_t              *cb)
+                                  mongoc_topology_description_type_t type)
 {
    ENTRY;
 
@@ -68,10 +67,6 @@ mongoc_topology_description_init (mongoc_topology_description_t     *description
    description->compatible = true;
    description->compatibility_error = NULL;
    description->stale = true;
-
-   if (cb) {
-      memcpy (&description->cb, cb, sizeof (*cb));
-   }
 
    EXIT;
 }
@@ -521,10 +516,6 @@ _mongoc_topology_description_remove_server (mongoc_topology_description_t *descr
    bson_return_if_fail (description);
    bson_return_if_fail (server);
 
-   if (description->cb.rm) {
-      description->cb.rm(server);
-   }
-
    mongoc_set_rm(description->servers, server->id);
 }
 
@@ -759,10 +750,6 @@ mongoc_topology_description_add_server (mongoc_topology_description_t *topology,
       mongoc_server_description_init(description, server, server_id);
 
       mongoc_set_add(topology->servers, server_id, description);
-
-      if (topology->cb.add) {
-         topology->cb.add(description);
-      }
    }
 
    if (id) {

--- a/src/mongoc/mongoc-topology.c
+++ b/src/mongoc/mongoc-topology.c
@@ -84,7 +84,8 @@ _mongoc_topology_scanner_cb (uint32_t      id,
    sd = mongoc_topology_description_server_by_id (&topology->description, id);
 
    if (sd) {
-      r = mongoc_topology_description_handle_ismaster (&topology->description, sd,
+      r = mongoc_topology_description_handle_ismaster (&topology->description,
+                                                       topology->scanner, sd,
                                                        ismaster_response, rtt_msec,
                                                        error);
 
@@ -185,6 +186,7 @@ mongoc_topology_new (const mongoc_uri_t *uri,
 
    for ( hl = mongoc_uri_get_hosts (uri); hl; hl = hl->next) {
       mongoc_topology_description_add_server (&topology->description,
+                                              topology->scanner,
                                               hl->host_and_port,
                                               &id);
       mongoc_topology_scanner_add (topology->scanner, hl, id);
@@ -518,7 +520,8 @@ mongoc_topology_invalidate_server (mongoc_topology_t *topology,
                                    uint32_t           id)
 {
    mongoc_mutex_lock (&topology->mutex);
-   mongoc_topology_description_invalidate_server (&topology->description, id);
+   mongoc_topology_description_invalidate_server (&topology->description,
+           topology->scanner, id);
    mongoc_mutex_unlock (&topology->mutex);
 }
 

--- a/src/mongoc/mongoc-topology.c
+++ b/src/mongoc/mongoc-topology.c
@@ -147,7 +147,7 @@ mongoc_topology_new (const mongoc_uri_t *uri,
       }
    }
 
-   mongoc_topology_description_init(&topology->description, init_type, NULL);
+   mongoc_topology_description_init(&topology->description, init_type);
    topology->description.set_name = bson_strdup(mongoc_uri_get_replica_set(uri));
 
    topology->uri = mongoc_uri_copy (uri);

--- a/src/mongoc/mongoc-topology.c
+++ b/src/mongoc/mongoc-topology.c
@@ -189,7 +189,6 @@ mongoc_topology_new (const mongoc_uri_t *uri,
                                               topology->scanner,
                                               hl->host_and_port,
                                               &id);
-      mongoc_topology_scanner_add (topology->scanner, hl, id);
    }
 
    if (! topology->single_threaded) {

--- a/tests/test-mongoc-sdam.c
+++ b/tests/test-mongoc-sdam.c
@@ -137,6 +137,7 @@ test_sdam_cb (bson_t *test)
 
          /* send ismaster through the topology description's handler */
          mongoc_topology_description_handle_ismaster(&client->topology->description,
+                                                     client->topology->scanner,
                                                      sd,
                                                      &response,
                                                      15,

--- a/tests/test-mongoc-server-selection.c
+++ b/tests/test-mongoc-server-selection.c
@@ -127,9 +127,9 @@ test_server_selection_logic_cb (bson_t *test)
    assert(bson_iter_init_find(&topology_iter, &test_topology, "type"));
    type = bson_iter_utf8(&topology_iter, NULL);
    if (strcmp(type, "Single") == 0) {
-      mongoc_topology_description_init(&topology, MONGOC_TOPOLOGY_SINGLE, NULL);
+      mongoc_topology_description_init(&topology, MONGOC_TOPOLOGY_SINGLE);
    } else {
-      mongoc_topology_description_init(&topology, MONGOC_TOPOLOGY_UNKNOWN, NULL);
+      mongoc_topology_description_init(&topology, MONGOC_TOPOLOGY_UNKNOWN);
       topology.type = topology_type_from_test(bson_iter_utf8(&topology_iter, NULL));
    }
 


### PR DESCRIPTION
Previously we would only add the node (topology description) to the
topology scanner when extracting it from a seedlist.
This resulted in no new nodes were ever added/connected to -- we would
only ever connect to the nodes in the seedlist -- no actual topology
discovery was being done.

Now we make sure we add the node to the scanner when we get a new topology
description, and start monitoring it.
When we have new ismaster results, we add new nodes, and remove old
nodes to/from the scanner.


Also removed weird mongoc_topology_cb_t -- which maybe was originally thought to handle this, but ultimately is not capable of doing so (and wasn't used at all).