### PR TITLE
Expose mongoc_uri_parse_host() to other drivers

### DIFF
--- a/src/mongoc/mongoc-uri-private.h
+++ b/src/mongoc/mongoc-uri-private.h
@@ -36,6 +36,9 @@ mongoc_uri_append_host           (      mongoc_uri_t *uri,
                                   const char         *host,
                                         uint16_t      port);
 bool
+mongoc_uri_parse_host            (      mongoc_uri_t  *uri,
+                                  const char          *str);
+bool
 mongoc_uri_set_username          (      mongoc_uri_t *uri,
                                   const char         *username);
 bool

--- a/src/mongoc/mongoc-uri.c
+++ b/src/mongoc/mongoc-uri.c
@@ -253,7 +253,7 @@ mongoc_uri_parse_host6 (mongoc_uri_t  *uri,
 }
 
 
-static bool
+bool
 mongoc_uri_parse_host (mongoc_uri_t  *uri,
                        const char    *str)
 {


### PR DESCRIPTION
The PHP driver, for one, relies on this for parsing additional client options (outside of the URI).