### PR TITLE
B-0 fixed bugs in GridFSFile related to seeking and flushing current page

### DIFF
--- a/src/mongoc/mongoc-gridfs-file-private.h
+++ b/src/mongoc/mongoc-gridfs-file-private.h
@@ -59,6 +59,7 @@ struct _mongoc_gridfs_file_t
    const char                *bson_content_type;
    bson_t                     bson_aliases;
    bson_t                     bson_metadata;
+   bool                       pos_after_read_write;
 };
 
 

--- a/src/mongoc/mongoc-gridfs-file.c
+++ b/src/mongoc/mongoc-gridfs-file.c
@@ -598,7 +598,7 @@ _mongoc_gridfs_file_refresh_page (mongoc_gridfs_file_t *file)
       /* if we have a cursor, but the cursor doesn't have the chunk we're going
        * to need, destroy it (we'll grab a new one immediately there after) */
       if (file->cursor &&
-          !(file->cursor_range[0] >= n && file->cursor_range[1] <= n)) {
+          !(file->cursor_range[0] <= n && file->cursor_range[1] >= n)) {
          mongoc_cursor_destroy (file->cursor);
          file->cursor = NULL;
       }

--- a/src/mongoc/mongoc-gridfs-file.c
+++ b/src/mongoc/mongoc-gridfs-file.c
@@ -533,7 +533,7 @@ _mongoc_gridfs_file_flush_page (mongoc_gridfs_file_t *file)
    bson_append_value (selector, "files_id", -1, &file->files_id);
    /** Note when calculating page number:
     *
-    * Our file pointer *could* be  on the next byte to be read or written after a read or write operation,
+    * Our file pointer *could* be on the next byte to be read or written after a read or write operation,
     * that in fact could be the next page when we cross the chunk_size boundary.
     * So we will push it back by one byte when calculating "n" if pos_after_read_write is true
     * to really flush the previous page.

--- a/src/mongoc/mongoc-gridfs-file.c
+++ b/src/mongoc/mongoc-gridfs-file.c
@@ -539,7 +539,7 @@ _mongoc_gridfs_file_flush_page (mongoc_gridfs_file_t *file)
 
    update = bson_sized_new (file->chunk_size + 100);
 
-   bson_append_value (update, "files_id", -1, &file->files_id);  
+   bson_append_value (update, "files_id", -1, &file->files_id);
    bson_append_int32 (update, "n", -1, n);
    bson_append_binary (update, "data", -1, BSON_SUBTYPE_BINARY, buf, len);
 

--- a/src/mongoc/mongoc-gridfs-file.c
+++ b/src/mongoc/mongoc-gridfs-file.c
@@ -197,6 +197,7 @@ _mongoc_gridfs_file_new_from_bson (mongoc_gridfs_t *gridfs,
    file = bson_malloc0 (sizeof *file);
 
    file->gridfs = gridfs;
+   file->pos_after_read_write = false;
    bson_copy_to (data, &file->bson);
 
    bson_iter_init (&iter, &file->bson);
@@ -295,6 +296,7 @@ _mongoc_gridfs_file_new (mongoc_gridfs_t          *gridfs,
 
    file->gridfs = gridfs;
    file->is_dirty = 1;
+   file->pos_after_read_write = false;
 
    if (opt->chunk_size) {
       file->chunk_size = opt->chunk_size;
@@ -430,6 +432,7 @@ mongoc_gridfs_file_readv (mongoc_gridfs_file_t *file,
 
          iov_pos += r;
          file->pos += r;
+         file->pos_after_read_write = true;
          bytes_read += r;
 
          if (iov_pos == iov[i].iov_len) {
@@ -488,6 +491,7 @@ mongoc_gridfs_file_writev (mongoc_gridfs_file_t *file,
 
          iov_pos += r;
          file->pos += r;
+         file->pos_after_read_write = true;
          bytes_written += r;
 
          file->length = BSON_MAX (file->length, (int64_t)file->pos);
@@ -535,7 +539,7 @@ _mongoc_gridfs_file_flush_page (mongoc_gridfs_file_t *file)
     * This is a little hacky and has been moved function mongoc_gridfs_file_writev(),
     * the "else" section of statement "if (iov_pos == iov[i].iov_len)"
     */
-   bson_append_int32 (selector, "n", -1, n = (int32_t)((file->pos - (file->pos == file->length ? 1 : 0)) / file->chunk_size));
+   bson_append_int32 (selector, "n", -1, n = (int32_t)((file->pos - (file->pos_after_read_write ? 1 : 0)) / file->chunk_size));
 
    update = bson_sized_new (file->chunk_size + 100);
 
@@ -739,6 +743,7 @@ mongoc_gridfs_file_seek (mongoc_gridfs_file_t *file,
    }
 
    file->pos = offset;
+   file->pos_after_read_write = false;
 
    return 0;
 }

--- a/src/mongoc/mongoc-gridfs-file.c
+++ b/src/mongoc/mongoc-gridfs-file.c
@@ -530,12 +530,12 @@ _mongoc_gridfs_file_flush_page (mongoc_gridfs_file_t *file)
    /** when flushing the buffer
     *
     * Our file pointer is on the next byte to be written, that could be the next page, 
-    * so push it back one when calculating "n" so
+    * so push it back one when calculating "n" if we are past the end of file so
     * that flush knows to flush the old page rather than a potentially new one.
     * This is a little hacky and has been moved function mongoc_gridfs_file_writev(),
     * the "else" section of statement "if (iov_pos == iov[i].iov_len)"
     */
-   bson_append_int32 (selector, "n", -1, n = (int32_t)((file->pos - 1) / file->chunk_size));
+   bson_append_int32 (selector, "n", -1, n = (int32_t)((file->pos - (file->pos == file->length ? 1 : 0)) / file->chunk_size));
 
    update = bson_sized_new (file->chunk_size + 100);
 


### PR DESCRIPTION
Fixed bug when seeking into a  page has been deleted, and the page is not available in cursor. Signs used to compare if page is available were reversed in the comparison.
Also fixed problem flushing page when positioned one byte after the end of the page