### PR TITLE
Removed memory leak in function mongoc_database_has_collection

### DIFF
--- a/src/mongoc/mongoc-database.c
+++ b/src/mongoc/mongoc-database.c
@@ -613,13 +613,15 @@ mongoc_database_has_collection (mongoc_database_t *database,
    BSON_APPEND_UTF8 (&filter, "name", name);
 
    cursor = mongoc_database_find_collections (database, &filter, error);
-
-   if (!cursor ||
-       (error &&
-        ((error->domain != 0) ||
-         (error->code != 0)))) {
-      mongoc_cursor_destroy( cursor );
+   
+   if (!cursor) {
       return ret;
+   }
+   
+   if (error &&
+        ((error->domain != 0) ||
+         (error->code != 0))) {
+      GOTO (cleanup);
    }
 
    while (mongoc_cursor_next (cursor, &doc)) {

--- a/src/mongoc/mongoc-database.c
+++ b/src/mongoc/mongoc-database.c
@@ -618,6 +618,7 @@ mongoc_database_has_collection (mongoc_database_t *database,
        (error &&
         ((error->domain != 0) ||
          (error->code != 0)))) {
+      mongoc_cursor_destroy( cursor );
       return ret;
    }
 


### PR DESCRIPTION
If an invalid namespace is supplied to mongoc_database_has_collection the cursor that is used in this function is not freed causing a memory leak every time the function is called. This leads to a drastic increase in memory consumption if the function is called frequently.