### PR TITLE
CDRIVER-757: Suppress GCC warning for enum range check

### DIFF
--- a/src/mongoc/mongoc-matcher-op.c
+++ b/src/mongoc/mongoc-matcher-op.c
@@ -162,8 +162,15 @@ _mongoc_matcher_op_compare_new (mongoc_matcher_opcode_t  opcode, /* IN */
 {
    mongoc_matcher_op_t *op;
 
+#if defined(__GNUC__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wtype-limits"
+#endif
    BSON_ASSERT ((opcode >= MONGOC_MATCHER_OPCODE_EQ) &&
                 (opcode <= MONGOC_MATCHER_OPCODE_NIN));
+#if defined(__GNUC__)
+# pragma GCC diagnostic pop
+#endif
    BSON_ASSERT (path);
    BSON_ASSERT (iter);
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-757

If the enum is compiled as an unsigned integer, this could trigger a type-limits warning (which might disrupt a -Werror build).

I only saw this when building on GCC, so I'm not sure if there's an equivalent clang warning we'd like to suppress.