### PR TITLE
CDRIVER-768: Fix build warning for uninitialized value

### DIFF
--- a/tests/test-mongoc-collection.c
+++ b/tests/test-mongoc-collection.c
@@ -419,7 +419,7 @@ _test_legacy_bulk_insert (const bson_t **bsons,
    future_t *future;
    mongoc_insert_flags_t flags;
    int offset;
-   bool has_oversized;
+   bool has_oversized = false;
    int batch_sz;
    const bson_t *gle;
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-768