### PR TITLE
B-0 fixed seek method. Bad interpretation of seek_end mode. it should…

### DIFF
--- a/src/mongoc/mongoc-gridfs-file.c
+++ b/src/mongoc/mongoc-gridfs-file.c
@@ -709,7 +709,7 @@ mongoc_gridfs_file_seek (mongoc_gridfs_file_t *file,
       offset = file->pos + delta;
       break;
    case SEEK_END:
-      offset = (file->length - 1) + delta;
+      offset = file->length + delta;
       break;
    default:
       errno = EINVAL;


### PR DESCRIPTION
… seek from one byte more than number of bytes written. seek_end with offset zero should put pointer exactly at the end ready to receive more data