### PR TITLE
allow driver to use mongoc-log-private

### DIFF
--- a/src/mongoc/mongoc-log-private.h
+++ b/src/mongoc/mongoc-log-private.h
@@ -17,7 +17,7 @@
 #ifndef MONGOC_LOG_PRIVATE_H
 #define MONGOC_LOG_PRIVATE_H
 
-#if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION)
+#if !defined (MONGOC_INSIDE) && !defined (MONGOC_COMPILATION) && !defined (MONGOC_I_AM_A_DRIVER)
 # error "Only <mongoc.h> can be included directly."
 #endif
 


### PR DESCRIPTION
the mongo-php-driver-prototype (pecl ext mongodb 1.0.0alpha2) needs this.
