### PR TITLE
edits .gitmodules, fixes libbson url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/libbson"]
 	path = src/libbson
-	url = git://github.com/mongodb/libbson.git
+	url = https://github.com/mongodb/libbson.git


### PR DESCRIPTION
was getting socket error timeouts on `git submodule update --init` within `autogen.sh`, this change makes it work as intended.