### PR TITLE
CDRIVER-849 allow seek past end-of-file

### DIFF
--- a/src/mongoc/mongoc-gridfs-file.c
+++ b/src/mongoc/mongoc-gridfs-file.c
@@ -718,8 +718,6 @@ mongoc_gridfs_file_seek (mongoc_gridfs_file_t *file,
       break;
    }
 
-   BSON_ASSERT (file->length > (int64_t)offset);
-
    if (offset / file->chunk_size != file->pos / file->chunk_size) {
       /** no longer on the same page */
 


### PR DESCRIPTION
One should freely be able to seek in a file, even past `EOF`, as long as it isn't before the beginning of a file.