### PR TITLE
CDRIVER-765 fix gridfs flush

### DIFF
--- a/src/mongoc/mongoc-gridfs-file-private.h
+++ b/src/mongoc/mongoc-gridfs-file-private.h
@@ -38,6 +38,7 @@ struct _mongoc_gridfs_file_t
    bson_t                     bson;
    mongoc_gridfs_file_page_t *page;
    uint64_t                   pos;
+   uint32_t                   n;
    bson_error_t               error;
    bool                       failed;
    mongoc_cursor_t           *cursor;

--- a/src/mongoc/mongoc-gridfs-file-private.h
+++ b/src/mongoc/mongoc-gridfs-file-private.h
@@ -38,7 +38,7 @@ struct _mongoc_gridfs_file_t
    bson_t                     bson;
    mongoc_gridfs_file_page_t *page;
    uint64_t                   pos;
-   uint32_t                   n;
+   int32_t                    n;
    bson_error_t               error;
    bool                       failed;
    mongoc_cursor_t           *cursor;

--- a/src/mongoc/mongoc-gridfs-file.c
+++ b/src/mongoc/mongoc-gridfs-file.c
@@ -598,7 +598,7 @@ _mongoc_gridfs_file_refresh_page (mongoc_gridfs_file_t *file)
       /* if we have a cursor, but the cursor doesn't have the chunk we're going
        * to need, destroy it (we'll grab a new one immediately there after) */
       if (file->cursor &&
-          !(file->cursor_range[0] >= n && file->cursor_range[1] <= n)) {
+          (file->n < file->cursor_range[0] || file->n > file->cursor_range[1])) {
          mongoc_cursor_destroy (file->cursor);
          file->cursor = NULL;
       }

--- a/src/mongoc/mongoc-gridfs-file.c
+++ b/src/mongoc/mongoc-gridfs-file.c
@@ -333,6 +333,9 @@ _mongoc_gridfs_file_new (mongoc_gridfs_t          *gridfs,
       bson_copy_to (opt->metadata, &(file->metadata));
    }
 
+   file->pos = 0;
+   file->n = 0;
+
    RETURN (file);
 }
 
@@ -606,7 +609,7 @@ _mongoc_gridfs_file_refresh_page (mongoc_gridfs_file_t *file)
    BSON_ASSERT (file);
    BSON_ASSERT (file->pos >= 0);
 
-   file->n = (uint32_t)(file->pos / file->chunk_size);
+   file->n = (int32_t)(file->pos / file->chunk_size);
 
    if (file->page) {
       _mongoc_gridfs_file_page_destroy (file->page);
@@ -719,7 +722,7 @@ _mongoc_gridfs_file_refresh_page (mongoc_gridfs_file_t *file)
  *    Adjust the file position pointer in `file` by `delta`, starting from the
  *    position `whence`. The `whence` argument is interpreted as in fseek(2):
  *
- *       SEEK_SET    Set the position to the start of the file.
+ *       SEEK_SET    Set the position relative to the start of the file.
  *       SEEK_CUR    Move `delta` from the current file position.
  *       SEEK_END    Move `delta` from the end-of-file.
  *


### PR DESCRIPTION
Fixes an incorrect sign comparison when flushing.

Fixes an incorrect flush when the file's position pointer ends on a chunk boundary when writing to the database.

Added some tests to check the behavior of the driver on chunk boundaries and the like.