### PR TITLE
CDRIVER-867: Errors for GridFS seek

### DIFF
--- a/doc/mongoc_gridfs_file_seek.page
+++ b/doc/mongoc_gridfs_file_seek.page
@@ -44,7 +44,6 @@ mongoc_gridfs_file_seek (mongoc_gridfs_file_t *file,
     <table>
       <tr><td><p><code>EINVAL</code></p></td><td><p><code>whence</code> is not one of SEEK_SET, SEEK_CUR or SEEK_END.</p></td></tr>
       <tr><td><p><code>EINVAL</code></p></td><td><p>The resulting file position would be negative.</p></td></tr>
-      <tr><td><p><code>EBADF</code></p></td><td><p>The given file is not seekable.</p></td></tr>
     </table>
   </section>
 

--- a/doc/mongoc_gridfs_file_seek.page
+++ b/doc/mongoc_gridfs_file_seek.page
@@ -23,18 +23,33 @@ mongoc_gridfs_file_seek (mongoc_gridfs_file_t *file,
     <title>Parameters</title>
     <table>
       <tr><td><p>file</p></td><td><p>A <code xref="mongoc_gridfs_file_t">mongoc_gridfs_file_t</code>.</p></td></tr>
-      <tr><td><p>delta</p></td><td><p>The relative offset to <code>whence</code>.</p></td></tr>
-      <tr><td><p>whence</p></td><td><p>A fseek() style whence such as SEEK_SET, SEEK_CUR, or SEEK_END.</p></td></tr>
+      <tr><td><p>delta</p></td><td><p>The amount to move the file position. May be positive or negative.</p></td></tr>
+      <tr><td><p>whence</p></td><td><p>One of SEEK_SET, SEEK_CUR or SEEK_END.</p></td></tr>
     </table>
   </section>
 
   <section id="description">
     <title>Description</title>
-    <p>This function seeks within the underlying file by mimicing <code>fseek()</code>.</p>
+    <p>Adjust the file position pointer in the given file by <code>delta</code>, starting from the position <code>whence</code>. The <code>whence</code> argument is interpreted as in <code>fseek(2)</code>:</p>
+    <table>
+      <tr><td><p><code>SEEK_SET</code></p></td><td><p>Set the position relative to the start of the file.</p></td></tr>
+      <tr><td><p><code>SEEK_CUR</code></p></td><td><p>Move <code>delta</code> relative to the current file position.</p></td></tr>
+      <tr><td><p><code>SEEK_END</code></p></td><td><p>Move <code>delta</code> relative to the end of the file.</p></td></tr>
+    </table>
+    <p>On success, the file's underlying position pointer is set appropriately. On failure, the file position is NOT changed and errno is set to indicate the error.</p>
+  </section>
+
+  <section id="errors">
+    <title>Errors</title>
+    <table>
+      <tr><td><p><code>EINVAL</code></p></td><td><p><code>whence</code> is not one of SEEK_SET, SEEK_CUR or SEEK_END.</p></td></tr>
+      <tr><td><p><code>EINVAL</code></p></td><td><p>The resulting file position would be negative.</p></td></tr>
+      <tr><td><p><code>EBADF</code></p></td><td><p>The given file is not seekable.</p></td></tr>
+    </table>
   </section>
 
   <section id="return">
     <title>Returns</title>
-    <p>Returns 0 if successful, otherwise -1 and errno is set.</p>
+    <p>Returns 0 if successful; otherwise -1 and errno is set.</p>
   </section>
 </page>

--- a/src/mongoc/mongoc-gridfs-file.c
+++ b/src/mongoc/mongoc-gridfs-file.c
@@ -736,7 +736,6 @@ _mongoc_gridfs_file_refresh_page (mongoc_gridfs_file_t *file)
  *
  *    [EINVAL] `whence` is not one of SEEK_SET, SEEK_CUR or SEEK_END.
  *    [EINVAL] Resulting file position would be negative.
- *    [EBADF]  The given file is not seekable (e.g. NULL).
  *
  * Side Effects:
  *
@@ -755,10 +754,7 @@ mongoc_gridfs_file_seek (mongoc_gridfs_file_t *file,
 {
    int64_t offset;
 
-   if (file == NULL) {
-      errno = EBADF;
-      return -1;
-   }
+   BSON_ASSERT (file);
 
    switch (whence) {
    case SEEK_SET:

--- a/src/mongoc/mongoc-gridfs-file.c
+++ b/src/mongoc/mongoc-gridfs-file.c
@@ -734,10 +734,9 @@ _mongoc_gridfs_file_refresh_page (mongoc_gridfs_file_t *file)
  *
  * Errors:
  *
- *    [EINVAL]    `whence` is not one of SEEK_SET, SEEK_CUR or SEEK_END.
- *    [EINVAL]    Resulting file position would be negative.
- *    [EBADF]     The given file is not seekable (e.g. NULL).
- *    [EOVERFLOW] Resulting file offset would overflow.
+ *    [EINVAL] `whence` is not one of SEEK_SET, SEEK_CUR or SEEK_END.
+ *    [EINVAL] Resulting file position would be negative.
+ *    [EBADF]  The given file is not seekable (e.g. NULL).
  *
  * Side Effects:
  *
@@ -747,7 +746,7 @@ _mongoc_gridfs_file_refresh_page (mongoc_gridfs_file_t *file)
  * Returns:
  *
  *    0 on success.
- *    -1 on error, and errno set to the appropriate value.
+ *    -1 on error, and errno set to indicate the error.
  */
 int
 mongoc_gridfs_file_seek (mongoc_gridfs_file_t *file,


### PR DESCRIPTION
`mongoc_gridfs_file_seek()` detects a few more errors. Importantly, it now prohibits seeks to a negative offset (before the start of a file).