### PR TITLE
CDRIVER-880: aggregation may return destroyed cursor

### DIFF
--- a/src/mongoc/mongoc-collection.c
+++ b/src/mongoc/mongoc-collection.c
@@ -306,7 +306,7 @@ mongoc_collection_aggregate (mongoc_collection_t       *collection, /* IN */
       cursor->limit = 0;
 
       if (! _mongoc_cursor_cursorid_prime (cursor)) {
-         mongoc_cursor_destroy (cursor);
+         ; /* Do nothing, returning the failed cursor. See CDRIVER-880 */
       }
    } else {
       /* for older versions we get an array that we can create a synthetic

--- a/src/mongoc/mongoc-collection.c
+++ b/src/mongoc/mongoc-collection.c
@@ -305,9 +305,8 @@ mongoc_collection_aggregate (mongoc_collection_t       *collection, /* IN */
       _mongoc_cursor_cursorid_init(cursor);
       cursor->limit = 0;
 
-      if (! _mongoc_cursor_cursorid_prime (cursor)) {
-         ; /* Do nothing, returning the failed cursor. See CDRIVER-880 */
-      }
+      /* we always return the cursor, even if it fails; users can detect the failure on performing
+       * a cursor operation. see CDRIVER-880. */
    } else {
       /* for older versions we get an array that we can create a synthetic
        * cursor on top of */

--- a/src/mongoc/mongoc-collection.c
+++ b/src/mongoc/mongoc-collection.c
@@ -307,6 +307,7 @@ mongoc_collection_aggregate (mongoc_collection_t       *collection, /* IN */
 
       /* we always return the cursor, even if it fails; users can detect the failure on performing
        * a cursor operation. see CDRIVER-880. */
+      _mongoc_cursor_cursorid_prime (cursor);
    } else {
       /* for older versions we get an array that we can create a synthetic
        * cursor on top of */


### PR DESCRIPTION
`mongoc_collection_aggregate()` will no longer destroy a failed cursor under certain circumstances. The error can be detected by the user on the next cursor operation.

This also tests an example of a failed aggregation with an incorrect pipeline.