### PR TITLE
CDRIVER-903: Hinted cursors should still apply read prefs

### DIFF
--- a/src/mongoc/mongoc-client-private.h
+++ b/src/mongoc/mongoc-client-private.h
@@ -115,6 +115,7 @@ _mongoc_client_command_simple_with_hint (mongoc_client_t           *client,
                                          const char                *db_name,
                                          const bson_t              *command,
                                          const mongoc_read_prefs_t *read_prefs,
+                                         bool                       is_write_command,
                                          bson_t                    *reply,
                                          uint32_t                   hint,
                                          bson_error_t              *error);

--- a/src/mongoc/mongoc-client.c
+++ b/src/mongoc/mongoc-client.c
@@ -1159,7 +1159,7 @@ mongoc_client_command_simple (mongoc_client_t           *client,
                               bson_error_t              *error)
 {
    return _mongoc_client_command_simple_with_hint (client, db_name, command,
-                                                   read_prefs, reply, 0, error);
+                                                   read_prefs, false, reply, 0, error);
 }
 
 bool
@@ -1167,6 +1167,7 @@ _mongoc_client_command_simple_with_hint (mongoc_client_t           *client,
                                          const char                *db_name,
                                          const bson_t              *command,
                                          const mongoc_read_prefs_t *read_prefs,
+                                         bool                       is_write_command,
                                          bson_t                    *reply,
                                          uint32_t                   hint,
                                          bson_error_t              *error)
@@ -1183,6 +1184,7 @@ _mongoc_client_command_simple_with_hint (mongoc_client_t           *client,
                                    command, NULL, read_prefs);
 
    cursor->hint = hint;
+   cursor->is_write_command = true;
 
    ret = mongoc_cursor_next (cursor, &doc);
 

--- a/src/mongoc/mongoc-cursor-private.h
+++ b/src/mongoc/mongoc-cursor-private.h
@@ -55,14 +55,15 @@ struct _mongoc_cursor_t
    uint32_t                   hint;
    uint32_t                   stamp;
 
-   unsigned                   is_command   : 1;
-   unsigned                   sent         : 1;
-   unsigned                   done         : 1;
-   unsigned                   failed       : 1;
-   unsigned                   end_of_event : 1;
-   unsigned                   in_exhaust   : 1;
-   unsigned                   redir_primary: 1;
-   unsigned                   has_fields   : 1;
+   unsigned                   is_command      : 1;
+   unsigned                   sent            : 1;
+   unsigned                   done            : 1;
+   unsigned                   failed          : 1;
+   unsigned                   end_of_event    : 1;
+   unsigned                   in_exhaust      : 1;
+   unsigned                   redir_primary   : 1;
+   unsigned                   has_fields      : 1;
+   unsigned                   is_write_command: 1;
 
    bson_t                     query;
    bson_t                     fields;

--- a/src/mongoc/mongoc-cursor.c
+++ b/src/mongoc/mongoc-cursor.c
@@ -166,6 +166,7 @@ _mongoc_cursor_new (mongoc_client_t           *client,
    cursor->batch_size = batch_size;
    cursor->is_command = is_command;
    cursor->has_fields = !!fields;
+   cursor->is_write_command = false;
 
 #define MARK_FAILED(c) \
    do { \
@@ -598,11 +599,11 @@ _mongoc_cursor_query (mongoc_cursor_t *cursor)
       rpc.query.fields = NULL;
    }
 
-   if (cursor->hint) {
-      rpc.query.query = bson_get_data (&cursor->query);
-   } else {
-      topology = cursor->client->topology;
+   topology = cursor->client->topology;
 
+   if (cursor->hint) {
+      sd = mongoc_topology_server_by_id(topology, cursor->hint);
+   } else {
       if (!cursor->read_prefs) {
          local_read_prefs = mongoc_read_prefs_new (MONGOC_READ_PRIMARY);
       }
@@ -616,20 +617,28 @@ _mongoc_cursor_query (mongoc_cursor_t *cursor)
       if (local_read_prefs) {
          mongoc_read_prefs_destroy (local_read_prefs);
       }
+   }
 
-      if (!sd) {
-         GOTO (failure);
-      }
+   if (!sd) {
+      GOTO (failure);
+   }
 
+   if (!cursor->hint) {
       cursor->hint = sd->id;
+   }
+
+   if (!cursor->is_write_command) {
       _apply_read_preferences (cursor->read_prefs,
                                topology->description.type,
                                sd->type,
                                &cursor->query,
                                &rpc.query);
-
-      mongoc_server_description_destroy (sd);
+   } else {
+      /* we haven't called _apply_read_preferences, must set query */
+      rpc.query.query = bson_get_data (&cursor->query);
    }
+
+   mongoc_server_description_destroy (sd);
 
    if (!mongoc_cluster_sendv_to_server (&cursor->client->cluster,
                                         &rpc, 1, cursor->hint,

--- a/src/mongoc/mongoc-write-command.c
+++ b/src/mongoc/mongoc-write-command.c
@@ -887,7 +887,7 @@ again:
       ret = false;
    } else {
       ret = _mongoc_client_command_simple_with_hint (client, database, &cmd, NULL,
-                                          &reply, hint, error);
+                                                     true, &reply, hint, error);
 
       if (!ret) {
          result->failed = true;

--- a/tests/test-mongoc-collection.c
+++ b/tests/test-mongoc-collection.c
@@ -1451,7 +1451,7 @@ test_aggregate_legacy (void *data)
 
    /* no "cursor" argument */
    request = mock_server_receives_command (
-      server, "db", MONGOC_QUERY_NONE,
+      server, "db", MONGOC_QUERY_SLAVE_OK,
       "{'aggregate': 'collection',"
       " 'pipeline': [{'a': 1}]},"
       " 'cursor': {'$exists': false} %s",
@@ -1500,7 +1500,7 @@ test_aggregate_modern (void *data)
 
    /* "cursor" argument always sent if wire version >= 1 */
    request = mock_server_receives_command (
-      server, "db", MONGOC_QUERY_NONE,
+      server, "db", MONGOC_QUERY_SLAVE_OK,
       "{'aggregate': 'collection',"
       " 'pipeline': [{'a': 1}],"
       " 'cursor': %s %s}",
@@ -1799,7 +1799,7 @@ BEGIN_IGNORE_DEPRECATIONS;
 
 END_IGNORE_DEPRECATIONS;
 
-   cursor = mongoc_collection_find (collection, MONGOC_QUERY_NONE, 0, 0, 6000,
+   cursor = mongoc_collection_find (collection, MONGOC_QUERY_SLAVE_OK, 0, 0, 6000,
                                     &query, NULL, NULL);
    assert (cursor);
    bson_destroy (&query);
@@ -1841,7 +1841,7 @@ test_command_fq (void *context)
 
    cmd = tmp_bson ("{ 'dbstats': 1}");
 
-   cursor = mongoc_client_command (client, "sometest.$cmd", MONGOC_QUERY_NONE,
+   cursor = mongoc_client_command (client, "sometest.$cmd", MONGOC_QUERY_SLAVE_OK,
                                  0, -1, 0, cmd, NULL, NULL);
    r = mongoc_cursor_next (cursor, &doc);
    assert (r);


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-903

Note: you may want to double-check that the test adjustments. I'm not too familiar with how the request mocking works with respect to topology types, but I assumed that it was mainly using standalone connections, where slaveOk would be injected. 