### PR TITLE
CDRIVER-701 partial fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,11 @@ mongoc_add_test(test-sharded-cluster FALSE
    ${SOURCE_DIR}/tests/test-sharded-cluster.c
    ${SOURCE_DIR}/tests/mongoc-tests.c
    ${SOURCE_DIR}/tests/ha-test.c)
+mongoc_add_test(test-matcher-cdriver701 FALSE
+        ${SOURCE_DIR}/tests/test-mongoc-matcher_cdriver701.c
+        ${SOURCE_DIR}/tests/mongoc-tests.c
+        ${SOURCE_DIR}/tests/ha-test.c)
+
 
 mongoc_add_test(test-libmongoc FALSE ${test-libmongoc-sources})
 add_test(NAME test-libmongoc COMMAND test-libmongoc -f -p)

--- a/src/mongoc/mongoc-matcher-op.c
+++ b/src/mongoc/mongoc-matcher-op.c
@@ -501,7 +501,29 @@ _mongoc_matcher_iter_eq_match (bson_iter_t *compare_iter, /* IN */
             }
          }
       }
+      case _TYPE_CODE (BSON_TYPE_UTF8, BSON_TYPE_ARRAY):
+      case _TYPE_CODE (BSON_TYPE_OID, BSON_TYPE_ARRAY):
+      case _TYPE_CODE (BSON_TYPE_INT32, BSON_TYPE_ARRAY):
+      case _TYPE_CODE (BSON_TYPE_INT64, BSON_TYPE_ARRAY):
+      case _TYPE_CODE (BSON_TYPE_BOOL, BSON_TYPE_ARRAY):
+      case _TYPE_CODE (BSON_TYPE_DATE_TIME, BSON_TYPE_ARRAY):
+      case _TYPE_CODE (BSON_TYPE_TIMESTAMP, BSON_TYPE_ARRAY):
+      case _TYPE_CODE (BSON_TYPE_DOUBLE, BSON_TYPE_ARRAY):
+      case _TYPE_CODE (BSON_TYPE_BINARY, BSON_TYPE_ARRAY): {
+         bson_iter_t right_array;
+         bson_iter_recurse(iter, &right_array);
+         while (true) {
+            bool right_has_next = bson_iter_next(&right_array);
+            if (!right_has_next) {
+               return false;
+            }
+            if (_mongoc_matcher_iter_eq_match(compare_iter, &right_array)) {
+               return true;
+            }
+         }
+         return false;
 
+      }
    case _TYPE_CODE (BSON_TYPE_DOCUMENT, BSON_TYPE_DOCUMENT):
       {
          uint32_t llen;

--- a/tests/test-mongoc-matcher_cdriver701.c
+++ b/tests/test-mongoc-matcher_cdriver701.c
@@ -1,0 +1,62 @@
+
+
+
+#include "mongoc-tests.h"
+
+#include <bcon.h>
+#include <mongoc.h>
+#include <mongoc-matcher-private.h>
+#include <bson-types.h>
+#include <string.h>
+#include "TestSuite.h"
+
+
+
+
+
+static void
+subdoc_test (void)
+{
+   //this should be true
+   bson_t *doc;
+   bson_t *spec1;
+   bson_t *spec2;
+   bson_error_t error;
+   mongoc_matcher_t *matcher1;
+   mongoc_matcher_t *matcher2;
+
+   bool r;
+   doc  = BCON_NEW("main_doc", "{", "sub_doc", "[","item1", "item2", "item3", "]", "}");
+
+   spec1 = BCON_NEW("main_doc.sub_doc", "item2");
+   spec2 = BCON_NEW("main_doc", "{", "sub_doc", "[","item1", "]", "}");
+
+
+   matcher1 = mongoc_matcher_new (spec1, &error);
+   BSON_ASSERT (matcher1);
+   r = mongoc_matcher_match (matcher1, doc);
+   BSON_ASSERT (r);
+
+   matcher2 = mongoc_matcher_new (spec2, &error);
+   BSON_ASSERT (matcher2);
+   r = mongoc_matcher_match (matcher2, doc);
+   BSON_ASSERT (!r);
+
+
+   bson_destroy (doc);
+   bson_destroy (spec1);
+   mongoc_matcher_destroy (matcher1);
+   bson_destroy (spec2);
+   mongoc_matcher_destroy (matcher2);
+
+}
+
+
+int
+main (int   argc,
+      char *argv[])
+{
+   subdoc_test();
+   return 0;
+
+}


### PR DESCRIPTION
now allows the leaf compare to be more mongo like if right side is an array.  Still returns correctly for previous tests on exact document match. 