### PR TITLE
CDRIVER-802: Mac OS X installation documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -141,6 +141,17 @@ FreeBSD::
 
   $ su -c 'pkg install git gcc automake autoconf libtool'
 
+OS X::
+
+  $ brew install pkg-config
+
+If you don't have Homebrew, you can install it from the `homebrew-website`_. You
+also need Xcode, which is available as a free download in the App Store or on
+the `apple-website`_.
+
+.. _homebrew-website Homebrew website: http://brew.sh
+.. _apple-website Apple Developer website: http://developer.apple.com/xcode
+
 
 Fetch Sources and Build
 -----------------------

--- a/README.rst
+++ b/README.rst
@@ -141,16 +141,13 @@ FreeBSD::
 
   $ su -c 'pkg install git gcc automake autoconf libtool'
 
-OS X::
+OS X:
 
-  $ brew install pkg-config
+The `XCode <https://developer.apple.com/xcode/download/>`_ package is required
+(at least the command-line package). It is recommended to use `Homebrew
+<http://brew.sh/>`_ for other dependencies::
 
-If you don't have Homebrew, you can install it from the `homebrew-website`_. You
-also need Xcode, which is available as a free download in the App Store or on
-the `apple-website`_.
-
-.. _homebrew-website Homebrew website: http://brew.sh
-.. _apple-website Apple Developer website: http://developer.apple.com/xcode
+  $ brew install git automake autoconf libtool pkgconfig
 
 
 Fetch Sources and Build

--- a/doc/installing.page
+++ b/doc/installing.page
@@ -144,6 +144,14 @@ Install man pages                                : yes
 
   </section>
 
+  <section id="mac-os-x">
+    <info><link type="guide" xref="index#installation"/></info>
+    <title>Installing on Mac OS X</title>
+    <p>To build the C Driver on a Mac, install the prerequisites in order to build it from source. It is recommended to use <link href="http://brew.sh">Homebrew</link>:</p>
+    <screen><output style="prompt">$ brew install git automake autoconf libtool pkgconfig</output></screen>
+    <p>Additionally, <link href="http://developer.apple.com/xcode">XCode</link> is required. The driver can then be installed by following the directions for <link xref="installing#build-yourself">building from source</link>.</p>
+  </section>
+
   <section id="building-windows">
     <title>Building on Windows</title>
 


### PR DESCRIPTION
Both the README and the installation page have been updated, though in the future the README should simply point to the online docs for the best and most-detailed explanations.