### PR TITLE
CDRIVER-920: fix leak in `_mongoc_gridfs_new()`

### DIFF
--- a/src/mongoc/mongoc-gridfs.c
+++ b/src/mongoc/mongoc-gridfs.c
@@ -125,7 +125,10 @@ _mongoc_gridfs_new (mongoc_client_t *client,
 
    r = _mongoc_gridfs_ensure_index (gridfs, error);
 
-   if (!r) { return NULL; }
+   if (!r) {
+      mongoc_gridfs_destroy (gridfs);
+      RETURN (NULL);
+   }
 
    RETURN (gridfs);
 }


### PR DESCRIPTION
Failure to create the GridFS indexes no longer leaks a pointer to a `mongoc_gridfs_t`.