### PR TITLE
CDRIVER-870: sane GridFS behavior past end-of-file

### DIFF
--- a/src/mongoc/mongoc-gridfs-file-page-private.h
+++ b/src/mongoc/mongoc-gridfs-file-page-private.h
@@ -51,7 +51,7 @@ int32_t                    _mongoc_gridfs_file_page_read     (mongoc_gridfs_file
 int32_t                    _mongoc_gridfs_file_page_write    (mongoc_gridfs_file_page_t *page,
                                                               const void                *src,
                                                               uint32_t                   len);
-int32_t                    _mongoc_gridfs_file_page_memset0  (mongoc_gridfs_file_page_t *page,
+bool                       _mongoc_gridfs_file_page_memset0  (mongoc_gridfs_file_page_t *page,
                                                               uint32_t                   len);
 uint32_t                   _mongoc_gridfs_file_page_tell     (mongoc_gridfs_file_page_t *page);
 const uint8_t             *_mongoc_gridfs_file_page_get_data (mongoc_gridfs_file_page_t *page);

--- a/src/mongoc/mongoc-gridfs-file-page-private.h
+++ b/src/mongoc/mongoc-gridfs-file-page-private.h
@@ -51,6 +51,8 @@ int32_t                    _mongoc_gridfs_file_page_read     (mongoc_gridfs_file
 int32_t                    _mongoc_gridfs_file_page_write    (mongoc_gridfs_file_page_t *page,
                                                               const void                *src,
                                                               uint32_t                   len);
+int32_t                    _mongoc_gridfs_file_page_memset0  (mongoc_gridfs_file_page_t *page,
+                                                              uint32_t                   len);
 uint32_t                   _mongoc_gridfs_file_page_tell     (mongoc_gridfs_file_page_t *page);
 const uint8_t             *_mongoc_gridfs_file_page_get_data (mongoc_gridfs_file_page_t *page);
 uint32_t                   _mongoc_gridfs_file_page_get_len  (mongoc_gridfs_file_page_t *page);

--- a/src/mongoc/mongoc-gridfs-file-page.c
+++ b/src/mongoc/mongoc-gridfs-file-page.c
@@ -94,11 +94,14 @@ _mongoc_gridfs_file_page_read (mongoc_gridfs_file_page_t *page,
 /**
  * _mongoc_gridfs_file_page_write:
  *
- * writes to a page
+ * Write to a page.
  *
- * writes are copy on write as regards the buf passed during construction.
- * I.e. the first write allocs a buf large enough for the chunk_size, which
- * becomes authoritative from then on.
+ * Writes are copy-on-write with regards to the buffer that was passed to the
+ * mongoc_gridfs_file_page_t during construction. In other words, the first
+ * write allocates a large enough buffer for file->chunk_size, which becomes
+ * authoritative from then on.
+ *
+ * A write of zero bytes will trigger the copy-on-write mechanism.
  */
 int32_t
 _mongoc_gridfs_file_page_write (mongoc_gridfs_file_page_t *page,
@@ -128,6 +131,42 @@ _mongoc_gridfs_file_page_write (mongoc_gridfs_file_page_t *page,
    page->read_buf = page->buf;
 
    RETURN (bytes_written);
+}
+
+
+/**
+ * _mongoc_gridfs_file_page_memset0:
+ *
+ *      Write zeros to a page, starting from the page's current position. Up to
+ *      `len` bytes will be set to zero or until the page is full, whichever
+ *      comes first.
+ *
+ *      Like _mongoc_gridfs_file_page_write, operations are copy-on-write with
+ *      regards to the page buffer.
+ *
+ * Returns:
+ *      The number of bytes actually set to zero.
+ */
+int32_t
+_mongoc_gridfs_file_page_memset0 (mongoc_gridfs_file_page_t *page,
+                                  uint32_t len)
+{
+   int32_t bytes_set;
+
+   ENTRY;
+
+   BSON_ASSERT (page);
+
+   if (!page->buf) {
+      page->buf = (uint8_t *)bson_malloc0 (page->chunk_size);
+      memcpy (page->buf, page->read_buf, BSON_MIN (page->chunk_size, page->len));
+   }
+
+   memset (page->buf + page->offset, '\0', bytes_set);
+   page->offset += bytes_set;
+   page->len = BSON_MAX (page->offset, page->len);
+
+   RETURN (bytes_set);
 }
 
 

--- a/src/mongoc/mongoc-gridfs-file-page.c
+++ b/src/mongoc/mongoc-gridfs-file-page.c
@@ -157,6 +157,8 @@ _mongoc_gridfs_file_page_memset0 (mongoc_gridfs_file_page_t *page,
 
    BSON_ASSERT (page);
 
+   bytes_set = BSON_MIN (page->chunk_size - page->offset, len);
+
    if (!page->buf) {
       page->buf = (uint8_t *)bson_malloc0 (page->chunk_size);
       memcpy (page->buf, page->read_buf, BSON_MIN (page->chunk_size, page->len));

--- a/src/mongoc/mongoc-gridfs-file-page.c
+++ b/src/mongoc/mongoc-gridfs-file-page.c
@@ -145,9 +145,9 @@ _mongoc_gridfs_file_page_write (mongoc_gridfs_file_page_t *page,
  *      regards to the page buffer.
  *
  * Returns:
- *      The number of bytes actually set to zero.
+ *      True on success; false otherwise.
  */
-int32_t
+bool
 _mongoc_gridfs_file_page_memset0 (mongoc_gridfs_file_page_t *page,
                                   uint32_t len)
 {
@@ -168,7 +168,7 @@ _mongoc_gridfs_file_page_memset0 (mongoc_gridfs_file_page_t *page,
    page->offset += bytes_set;
    page->len = BSON_MAX (page->offset, page->len);
 
-   RETURN (bytes_set);
+   RETURN (true);
 }
 
 

--- a/src/mongoc/mongoc-gridfs-file.c
+++ b/src/mongoc/mongoc-gridfs-file.c
@@ -487,7 +487,7 @@ mongoc_gridfs_file_writev (mongoc_gridfs_file_t *file,
 
    /* Pull in the correct page */
    if (!file->page && !_mongoc_gridfs_file_refresh_page (file)) {
-         return -1;
+      return -1;
    }
 
    /* When writing past the end-of-file, fill the gap with zeros */

--- a/src/mongoc/mongoc-gridfs-file.c
+++ b/src/mongoc/mongoc-gridfs-file.c
@@ -418,6 +418,12 @@ mongoc_gridfs_file_readv (mongoc_gridfs_file_t *file,
 
    /* TODO: we should probably do something about timeout_msec here */
 
+   /* Reading when positioned past the end does nothing */
+   if (file->pos >= file->length) {
+      return -1;
+   }
+
+   /* Try to get the current chunk */
    if (!file->page && !_mongoc_gridfs_file_refresh_page (file)) {
          return -1;
    }

--- a/src/mongoc/mongoc-gridfs-file.c
+++ b/src/mongoc/mongoc-gridfs-file.c
@@ -534,7 +534,7 @@ mongoc_gridfs_file_writev (mongoc_gridfs_file_t *file,
 /**
  * _mongoc_gridfs_file_extend:
  *
- *      Extend a GridFS file to the current position pointer. Zero bytes will be
+ *      Extend a GridFS file to the current position pointer. Zeros will be
  *      appended to the end of the file until file->length is even with file->pos.
  *
  *      If file->length >= file-> pos, the function exits successfully with no
@@ -577,7 +577,7 @@ _mongoc_gridfs_file_extend (mongoc_gridfs_file_t *file)
          /* We're done */
          break;
       } else if (!_mongoc_gridfs_file_flush_page (file)) {
-         /* Buffer must be full, so flush it */
+         /* We tried to flush a full buffer, but an error occurred */
          RETURN (-1);
       }
    }

--- a/src/mongoc/mongoc-gridfs-file.c
+++ b/src/mongoc/mongoc-gridfs-file.c
@@ -537,7 +537,7 @@ mongoc_gridfs_file_writev (mongoc_gridfs_file_t *file,
  *      Extend a GridFS file to the current position pointer. Zeros will be
  *      appended to the end of the file until file->length is even with file->pos.
  *
- *      If file->length >= file-> pos, the function exits successfully with no
+ *      If file->length >= file->pos, the function exits successfully with no
  *      operation performed.
  *
  * Parameters:

--- a/src/mongoc/mongoc-gridfs-file.c
+++ b/src/mongoc/mongoc-gridfs-file.c
@@ -491,11 +491,8 @@ mongoc_gridfs_file_writev (mongoc_gridfs_file_t *file,
    }
 
    /* When writing past the end-of-file, fill the gap with zeros */
-   if (file->pos > file->length) {
-      bytes_written = _mongoc_gridfs_file_extend (file);
-      if (bytes_written == -1) {
-         return -1;
-      }
+   if (file->pos > file->length && !_mongoc_gridfs_file_extend (file)) {
+      return -1;
    }
 
    for (i = 0; i < iovcnt; i++) {

--- a/src/mongoc/mongoc-gridfs-file.c
+++ b/src/mongoc/mongoc-gridfs-file.c
@@ -423,7 +423,7 @@ mongoc_gridfs_file_readv (mongoc_gridfs_file_t *file,
 
    /* Reading when positioned past the end does nothing */
    if (file->pos >= file->length) {
-      return -1;
+      return 0;
    }
 
    /* Try to get the current chunk */

--- a/tests/test-mongoc-gridfs-file-page.c
+++ b/tests/test-mongoc-gridfs-file-page.c
@@ -182,7 +182,7 @@ test_write (void)
 
 
 static void
-test_memset (void)
+test_memset0 (void)
 {
    uint8_t buf[] = "wxyz";
    uint32_t len = sizeof buf;
@@ -224,5 +224,5 @@ test_gridfs_file_page_install (TestSuite *suite)
    TestSuite_Add (suite, "/GridFS/File/Page/read", test_read);
    TestSuite_Add (suite, "/GridFS/File/Page/seek", test_seek);
    TestSuite_Add (suite, "/GridFS/File/Page/write", test_write);
-   TestSuite_Add (suite, "/GridFS/File/Page/memset", test_memset);
+   TestSuite_Add (suite, "/GridFS/File/Page/memset0", test_memset0);
 }

--- a/tests/test-mongoc-gridfs-file-page.c
+++ b/tests/test-mongoc-gridfs-file-page.c
@@ -186,7 +186,6 @@ test_memset0 (void)
 {
    uint8_t buf[] = "wxyz";
    uint32_t len = sizeof buf;
-   int32_t r;
    mongoc_gridfs_file_page_t *page;
 
    page = _mongoc_gridfs_file_page_new (buf, len, 5);
@@ -195,20 +194,17 @@ test_memset0 (void)
    ASSERT (page->len == len);
    ASSERT (!page->buf);
 
-   r = _mongoc_gridfs_file_page_memset0 (page, 1);
-   ASSERT (r == 1);
+   ASSERT (_mongoc_gridfs_file_page_memset0 (page, 1));
    ASSERT (page->buf);
    ASSERT (memcmp (page->buf, "\0xyz", 4) == 0);
    ASSERT (page->offset == 1);
 
-   r = _mongoc_gridfs_file_page_memset0 (page, 10);
-   ASSERT (r == 4);
+   ASSERT (_mongoc_gridfs_file_page_memset0 (page, 10));
    ASSERT (page->buf);
    ASSERT (memcmp (page->buf, "\0\0\0\0\0", 5) == 0);
    ASSERT (page->offset == 5);
 
-   r = _mongoc_gridfs_file_page_memset0 (page, 10);
-   ASSERT (r == 0);
+   ASSERT (_mongoc_gridfs_file_page_memset0 (page, 10));
 
    _mongoc_gridfs_file_page_destroy (page);
 }

--- a/tests/test-mongoc-gridfs-file-page.c
+++ b/tests/test-mongoc-gridfs-file-page.c
@@ -181,6 +181,39 @@ test_write (void)
 }
 
 
+static void
+test_memset (void)
+{
+   uint8_t buf[] = "wxyz";
+   uint32_t len = sizeof buf;
+   int32_t r;
+   mongoc_gridfs_file_page_t *page;
+
+   page = _mongoc_gridfs_file_page_new (buf, len, 5);
+
+   ASSERT (page);
+   ASSERT (page->len == len);
+   ASSERT (!page->buf);
+
+   r = _mongoc_gridfs_file_page_memset0 (page, 1);
+   ASSERT (r == 1);
+   ASSERT (page->buf);
+   ASSERT (memcmp (page->buf, "\0xyz", 4) == 0);
+   ASSERT (page->offset == 1);
+
+   r = _mongoc_gridfs_file_page_memset0 (page, 10);
+   ASSERT (r == 4);
+   ASSERT (page->buf);
+   ASSERT (memcmp (page->buf, "\0\0\0\0\0", 5) == 0);
+   ASSERT (page->offset == 5);
+
+   r = _mongoc_gridfs_file_page_memset0 (page, 10);
+   ASSERT (r == 0);
+
+   _mongoc_gridfs_file_page_destroy (page);
+}
+
+
 void
 test_gridfs_file_page_install (TestSuite *suite)
 {
@@ -191,4 +224,5 @@ test_gridfs_file_page_install (TestSuite *suite)
    TestSuite_Add (suite, "/GridFS/File/Page/read", test_read);
    TestSuite_Add (suite, "/GridFS/File/Page/seek", test_seek);
    TestSuite_Add (suite, "/GridFS/File/Page/write", test_write);
+   TestSuite_Add (suite, "/GridFS/File/Page/memset", test_memset);
 }

--- a/tests/test-mongoc-gridfs.c
+++ b/tests/test-mongoc-gridfs.c
@@ -354,6 +354,12 @@ test_read (void)
    ASSERT_CMPINT (memcmp (iov[0].iov_base, "turducken ", 10), ==, 0);
    ASSERT_CMPINT (memcmp (iov[1].iov_base, "spare ribs", 10), ==, 0);
 
+   assert (mongoc_gridfs_file_seek (file, 20, SEEK_END) == 0);
+   r = mongoc_gridfs_file_readv (file, iov, 2, 20, 0);
+
+   assert (r == 0);
+   assert (mongoc_gridfs_file_tell (file) == file->length + 20);
+
    mongoc_gridfs_file_destroy (file);
 
    drop_collections (gridfs, &error);

--- a/tests/test-mongoc-gridfs.c
+++ b/tests/test-mongoc-gridfs.c
@@ -314,6 +314,7 @@ test_read (void)
    ssize_t r;
    char buf[10], buf2[10];
    mongoc_iovec_t iov[2];
+   int previous_errno;
 
    iov[0].iov_base = buf;
    iov[0].iov_len = 10;
@@ -355,8 +356,10 @@ test_read (void)
    ASSERT_CMPINT (memcmp (iov[1].iov_base, "spare ribs", 10), ==, 0);
 
    assert (mongoc_gridfs_file_seek (file, 20, SEEK_END) == 0);
+   previous_errno = errno;
    r = mongoc_gridfs_file_readv (file, iov, 2, 20, 0);
 
+   assert (errno == previous_errno);
    assert (r == 0);
    assert (mongoc_gridfs_file_tell (file) == file->length + 20);
 
@@ -435,8 +438,8 @@ test_write (void)
    assert (mongoc_gridfs_file_tell (file) == file->length + 5);
 
    r = mongoc_gridfs_file_writev (file, iov, 2, 0);
-   assert (r == len + 5);
-   assert (mongoc_gridfs_file_tell (file) == len*2 + 5);
+   assert (r == len);
+   assert (mongoc_gridfs_file_tell (file) == 2*len + 5);
    assert (file->length == 2*len + 5);
    assert (mongoc_gridfs_file_save (file));
 


### PR DESCRIPTION
There are two big fixes in this pull request:

- Attempting to read after calling a seek past the end of file results in an error.
- Performing a write after seeking past the end of a file extends the file, filling in the "gap space" between the old end-of-file and the new write with zeros.