### PR TITLE
CDRIVER-903: Hinted cursors should still apply read prefs

### DIFF
--- a/src/mongoc/mongoc-client-private.h
+++ b/src/mongoc/mongoc-client-private.h
@@ -115,6 +115,7 @@ _mongoc_client_command_simple_with_hint (mongoc_client_t           *client,
                                          const char                *db_name,
                                          const bson_t              *command,
                                          const mongoc_read_prefs_t *read_prefs,
+                                         bool                       is_write_command,
                                          bson_t                    *reply,
                                          uint32_t                   hint,
                                          bson_error_t              *error);

--- a/src/mongoc/mongoc-client.c
+++ b/src/mongoc/mongoc-client.c
@@ -1159,7 +1159,7 @@ mongoc_client_command_simple (mongoc_client_t           *client,
                               bson_error_t              *error)
 {
    return _mongoc_client_command_simple_with_hint (client, db_name, command,
-                                                   read_prefs, reply, 0, error);
+                                                   read_prefs, false, reply, 0, error);
 }
 
 bool
@@ -1167,6 +1167,7 @@ _mongoc_client_command_simple_with_hint (mongoc_client_t           *client,
                                          const char                *db_name,
                                          const bson_t              *command,
                                          const mongoc_read_prefs_t *read_prefs,
+                                         bool                       is_write_command,
                                          bson_t                    *reply,
                                          uint32_t                   hint,
                                          bson_error_t              *error)
@@ -1183,6 +1184,7 @@ _mongoc_client_command_simple_with_hint (mongoc_client_t           *client,
                                    command, NULL, read_prefs);
 
    cursor->hint = hint;
+   cursor->is_write_command = true;
 
    ret = mongoc_cursor_next (cursor, &doc);
 

--- a/src/mongoc/mongoc-collection.c
+++ b/src/mongoc/mongoc-collection.c
@@ -1961,7 +1961,7 @@ mongoc_collection_find_and_modify (mongoc_collection_t *collection,
     */
    ret = _mongoc_client_command_simple_with_hint (collection->client,
                                                   collection->db, &command, NULL,
-                                                  reply, selected_server->id, error);
+                                                  true, reply, selected_server->id, error);
 
    /*
     * Cleanup.

--- a/src/mongoc/mongoc-cursor-private.h
+++ b/src/mongoc/mongoc-cursor-private.h
@@ -55,13 +55,14 @@ struct _mongoc_cursor_t
    uint32_t                   hint;
    uint32_t                   stamp;
 
-   unsigned                   is_command   : 1;
-   unsigned                   sent         : 1;
-   unsigned                   done         : 1;
-   unsigned                   failed       : 1;
-   unsigned                   end_of_event : 1;
-   unsigned                   in_exhaust   : 1;
-   unsigned                   has_fields   : 1;
+   unsigned                   is_command      : 1;
+   unsigned                   sent            : 1;
+   unsigned                   done            : 1;
+   unsigned                   failed          : 1;
+   unsigned                   end_of_event    : 1;
+   unsigned                   has_fields      : 1;
+   unsigned                   in_exhaust      : 1;
+   unsigned                   is_write_command: 1;
 
    bson_t                     query;
    bson_t                     fields;

--- a/src/mongoc/mongoc-write-command.c
+++ b/src/mongoc/mongoc-write-command.c
@@ -892,7 +892,7 @@ again:
       ret = false;
    } else {
       ret = _mongoc_client_command_simple_with_hint (client, database, &cmd, NULL,
-                                          &reply, hint, error);
+                                                     true, &reply, hint, error);
 
       if (!ret) {
          result->failed = true;

--- a/tests/test-mongoc-collection.c
+++ b/tests/test-mongoc-collection.c
@@ -1454,7 +1454,7 @@ test_aggregate_legacy (void *data)
 
    /* no "cursor" argument */
    request = mock_server_receives_command (
-      server, "db", MONGOC_QUERY_NONE,
+      server, "db", MONGOC_QUERY_SLAVE_OK,
       "{'aggregate': 'collection',"
       " 'pipeline': [{'a': 1}]},"
       " 'cursor': {'$exists': false} %s",
@@ -1503,7 +1503,7 @@ test_aggregate_modern (void *data)
 
    /* "cursor" argument always sent if wire version >= 1 */
    request = mock_server_receives_command (
-      server, "db", MONGOC_QUERY_NONE,
+      server, "db", MONGOC_QUERY_SLAVE_OK,
       "{'aggregate': 'collection',"
       " 'pipeline': [{'a': 1}],"
       " 'cursor': %s %s}",
@@ -1890,7 +1890,7 @@ BEGIN_IGNORE_DEPRECATIONS;
 
 END_IGNORE_DEPRECATIONS;
 
-   cursor = mongoc_collection_find (collection, MONGOC_QUERY_NONE, 0, 0, 6000,
+   cursor = mongoc_collection_find (collection, MONGOC_QUERY_SLAVE_OK, 0, 0, 6000,
                                     &query, NULL, NULL);
    assert (cursor);
    bson_destroy (&query);
@@ -1932,7 +1932,7 @@ test_command_fq (void *context)
 
    cmd = tmp_bson ("{ 'dbstats': 1}");
 
-   cursor = mongoc_client_command (client, "sometest.$cmd", MONGOC_QUERY_NONE,
+   cursor = mongoc_client_command (client, "sometest.$cmd", MONGOC_QUERY_SLAVE_OK,
                                  0, -1, 0, cmd, NULL, NULL);
    r = mongoc_cursor_next (cursor, &doc);
    assert (r);


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-903 (supersedes #283)

This fixes an issue with the slaveOk bit not being set when using hint to query a secondary directly.

We introduce a new is_write_command property on the cursor (private API change) to avoid setting the slaveOk bit on write commands.