### PR TITLE
CDRIVER-942 add copy methods for db and collection

### DIFF
--- a/build/autotools/versions.ldscript
+++ b/build/autotools/versions.ldscript
@@ -270,10 +270,12 @@ LIBMONGOC_1.3 {
         mongoc_collection_find_and_modify_with_opts;
         mongoc_client_get_read_concern;
         mongoc_client_set_read_concern;
+        mongoc_collection_copy;
         mongoc_collection_get_read_concern;
         mongoc_collection_set_read_concern;
         mongoc_cursor_get_max_await_time_ms;
         mongoc_cursor_set_max_await_time_ms;
+        mongoc_database_copy;
         mongoc_database_get_read_concern;
         mongoc_database_set_read_concern;
         mongoc_find_and_modify_opts_destroy;

--- a/build/cmake/libmongoc-ssl.def
+++ b/build/cmake/libmongoc-ssl.def
@@ -55,6 +55,7 @@ mongoc_client_set_write_concern
 mongoc_collection_aggregate
 mongoc_collection_command
 mongoc_collection_command_simple
+mongoc_collection_copy
 mongoc_collection_count
 mongoc_collection_count_with_opts
 mongoc_collection_create_bulk_operation
@@ -102,6 +103,7 @@ mongoc_cursor_set_max_await_time_ms
 mongoc_database_add_user
 mongoc_database_command
 mongoc_database_command_simple
+mongoc_database_copy
 mongoc_database_create_collection
 mongoc_database_destroy
 mongoc_database_drop

--- a/build/cmake/libmongoc.def
+++ b/build/cmake/libmongoc.def
@@ -53,6 +53,7 @@ mongoc_client_set_write_concern
 mongoc_collection_aggregate
 mongoc_collection_command
 mongoc_collection_command_simple
+mongoc_collection_copy
 mongoc_collection_count
 mongoc_collection_count_with_opts
 mongoc_collection_create_bulk_operation
@@ -100,6 +101,7 @@ mongoc_cursor_set_max_await_time_ms
 mongoc_database_add_user
 mongoc_database_command
 mongoc_database_command_simple
+mongoc_database_copy
 mongoc_database_create_collection
 mongoc_database_destroy
 mongoc_database_drop

--- a/src/libmongoc.symbols
+++ b/src/libmongoc.symbols
@@ -58,6 +58,7 @@ mongoc_client_set_write_concern
 mongoc_collection_aggregate
 mongoc_collection_command
 mongoc_collection_command_simple
+mongoc_collection_copy
 mongoc_collection_count
 mongoc_collection_count_with_opts
 mongoc_collection_create_bulk_operation
@@ -105,6 +106,7 @@ mongoc_cursor_set_max_await_time_ms
 mongoc_database_add_user
 mongoc_database_command
 mongoc_database_command_simple
+mongoc_database_copy
 mongoc_database_create_collection
 mongoc_database_destroy
 mongoc_database_drop

--- a/src/mongoc/mongoc-collection.c
+++ b/src/mongoc/mongoc-collection.c
@@ -252,6 +252,37 @@ mongoc_collection_destroy (mongoc_collection_t *collection) /* IN */
 /*
  *--------------------------------------------------------------------------
  *
+ * mongoc_collection_copy --
+ *
+ *       Returns a copy of @collection that needs to be freed by calling
+ *       mongoc_collection_destroy.
+ *
+ * Returns:
+ *       A copy of this collection.
+ *
+ * Side effects:
+ *       None.
+ *
+ *--------------------------------------------------------------------------
+ */
+
+mongoc_collection_t *
+mongoc_collection_copy (mongoc_collection_t *collection) /* IN */
+{
+   ENTRY;
+
+   BSON_ASSERT (collection);
+
+   RETURN(_mongoc_collection_new(collection->client, collection->db,
+                                 collection->collection, collection->read_prefs,
+                                 collection->read_concern,
+                                 collection->write_concern));
+}
+
+
+/*
+ *--------------------------------------------------------------------------
+ *
  * mongoc_collection_aggregate --
  *
  *       Send an "aggregate" command to the MongoDB server.

--- a/src/mongoc/mongoc-collection.h
+++ b/src/mongoc/mongoc-collection.h
@@ -44,6 +44,7 @@ mongoc_cursor_t               *mongoc_collection_aggregate           (mongoc_col
                                                                       const bson_t                  *options,
                                                                       const mongoc_read_prefs_t     *read_prefs) BSON_GNUC_WARN_UNUSED_RESULT;
 void                          mongoc_collection_destroy              (mongoc_collection_t           *collection);
+mongoc_collection_t          *mongoc_collection_copy                 (mongoc_collection_t           *collection);
 mongoc_cursor_t              *mongoc_collection_command              (mongoc_collection_t           *collection,
                                                                       mongoc_query_flags_t           flags,
                                                                       uint32_t                       skip,

--- a/src/mongoc/mongoc-database.c
+++ b/src/mongoc/mongoc-database.c
@@ -130,6 +130,34 @@ mongoc_database_destroy (mongoc_database_t *database)
    EXIT;
 }
 
+/*
+ *--------------------------------------------------------------------------
+ *
+ * mongoc_database_copy --
+ *
+ *       Returns a copy of @database that needs to be freed by calling
+ *       mongoc_database_destroy.
+ *
+ * Returns:
+ *       A copy of this database.
+ *
+ * Side effects:
+ *       None.
+ *
+ *--------------------------------------------------------------------------
+ */
+
+mongoc_database_t *
+mongoc_database_copy (mongoc_database_t *database)
+{
+   ENTRY;
+
+   BSON_ASSERT (database);
+
+   RETURN(_mongoc_database_new(database->client, database->name,
+                               database->read_prefs, database->read_concern,
+                               database->write_concern));
+}
 
 mongoc_cursor_t *
 mongoc_database_command (mongoc_database_t         *database,

--- a/src/mongoc/mongoc-database.h
+++ b/src/mongoc/mongoc-database.h
@@ -49,6 +49,7 @@ bool                          mongoc_database_add_user             (mongoc_datab
                                                                     const bson_t                 *custom_data,
                                                                     bson_error_t                 *error);
 void                          mongoc_database_destroy              (mongoc_database_t            *database);
+mongoc_database_t            *mongoc_database_copy                 (mongoc_database_t            *database);
 mongoc_cursor_t              *mongoc_database_command              (mongoc_database_t            *database,
                                                                     mongoc_query_flags_t          flags,
                                                                     uint32_t                      skip,

--- a/tests/test-mongoc-collection.c
+++ b/tests/test-mongoc-collection.c
@@ -36,6 +36,35 @@ get_test_collection (mongoc_client_t *client,
 
 
 static void
+test_copy (void)
+{
+   mongoc_database_t *database;
+   mongoc_collection_t *collection;
+   mongoc_collection_t *copy;
+   mongoc_client_t *client;
+
+   client = test_framework_client_new ();
+   ASSERT (client);
+
+   database = get_test_database (client);
+   ASSERT (database);
+
+   collection = get_test_collection (client, "test_insert");
+   ASSERT (collection);
+
+   copy = mongoc_collection_copy(collection);
+   ASSERT (copy);
+   ASSERT (copy->client == collection->client);
+   ASSERT (strcmp(copy->ns, collection->ns) == 0);
+
+   mongoc_collection_destroy(copy);
+   mongoc_collection_destroy(collection);
+   mongoc_database_destroy(database);
+   mongoc_client_destroy(client);
+}
+
+
+static void
 test_insert (void)
 {
    mongoc_database_t *database;
@@ -2883,6 +2912,7 @@ test_collection_install (TestSuite *suite)
                   "/Collection/bulk_insert/legacy/oversized_last_continue",
                   test_legacy_bulk_insert_oversized_last_continue);
 
+   TestSuite_Add (suite, "/Collection/copy", test_copy);
    TestSuite_Add (suite, "/Collection/insert", test_insert);
    TestSuite_Add (suite, "/Collection/insert/keys", test_insert_command_keys);
    TestSuite_Add (suite, "/Collection/save", test_save);

--- a/tests/test-mongoc-database.c
+++ b/tests/test-mongoc-database.c
@@ -4,9 +4,33 @@
 #include "test-libmongoc.h"
 #include "mongoc-tests.h"
 #include "mongoc-client-private.h"
+#include "mongoc-database-private.h"
 #include "mock_server/future-functions.h"
 #include "mock_server/mock-server.h"
 
+
+static void
+test_copy (void)
+{
+   mongoc_database_t *database;
+   mongoc_database_t *copy;
+   mongoc_client_t *client;
+
+   client = test_framework_client_new ();
+   ASSERT (client);
+
+   database = mongoc_client_get_database (client, "test");
+   ASSERT (database);
+
+   copy = mongoc_database_copy(database);
+   ASSERT (copy);
+   ASSERT (copy->client == database->client);
+   ASSERT (strcmp(copy->name, database->name) == 0);
+
+   mongoc_database_destroy(copy);
+   mongoc_database_destroy(database);
+   mongoc_client_destroy(client);
+}
 
 static void
 test_has_collection (void)
@@ -450,6 +474,7 @@ test_get_default_database (void)
 void
 test_database_install (TestSuite *suite)
 {
+   TestSuite_Add (suite, "/Database/copy", test_copy);
    TestSuite_Add (suite, "/Database/has_collection", test_has_collection);
    TestSuite_Add (suite, "/Database/command", test_command);
    TestSuite_Add (suite, "/Database/drop", test_drop);


### PR DESCRIPTION
This adds methods for copying `mongoc_database_t`'s and `mongoc_collection_t`'s.

These would be nice to add into the C++11 driver :) Happy to make changes if you have feedback!