### PR TITLE
CDRIVER-882 update link to c driver manual

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ Building the Driver from Source
 ===============================
 
 Detailed installation instructions are in the manual:
-http://api.mongodb.org/mongo-c-driver/current/installing.html
+http://api.mongodb.org/c/current/installing.html
 
 From a tarball
 --------------


### PR DESCRIPTION
Stumbled across this while installing.
Came in from [CDRIVER-882](https://jira.mongodb.org/browse/CDRIVER-882) and its respective [commit](https://github.com/mongodb/mongo-c-driver/commit/c725c7e44e95c0d3762539caaffd715c66a1d42e).

[http://api.mongodb.org/mongo-c-driver/current/installing.html](http://api.mongodb.org/mongo-c-driver/current/installing.html) will 404; in documentation section for current readme you link to [http://api.mongodb.org/c/current/](http://api.mongodb.org/c/current/).

Feel free to not merge and fix it yourself :).