### PR TITLE
CDRIVER-1054: Support negative cursor limit

### DIFF
--- a/src/mongoc/mongoc-cursor-private.h
+++ b/src/mongoc/mongoc-cursor-private.h
@@ -70,7 +70,7 @@ struct _mongoc_cursor_t
 
    mongoc_query_flags_t       flags;
    uint32_t                   skip;
-   uint32_t                   limit;
+   int32_t                    limit;
    uint32_t                   count;
    uint32_t                   batch_size;
    uint32_t                   max_await_time_ms;
@@ -96,7 +96,7 @@ mongoc_cursor_t         * _mongoc_cursor_new          (mongoc_client_t          
                                                        const char                   *db_and_collection,
                                                        mongoc_query_flags_t          flags,
                                                        uint32_t                      skip,
-                                                       uint32_t                      limit,
+                                                       int32_t                       limit,
                                                        uint32_t                      batch_size,
                                                        bool                          is_command,
                                                        const bson_t                 *query,

--- a/src/mongoc/mongoc-cursor.c
+++ b/src/mongoc/mongoc-cursor.c
@@ -47,6 +47,8 @@ _mongoc_n_return (mongoc_cursor_t * cursor)
    if (cursor->is_command) {
       /* commands always have n_return of 1 */
       return 1;
+   } else if (cursor->limit < 0) {
+      return cursor->limit;
    } else if (cursor->limit) {
       int32_t remaining = cursor->limit - cursor->count;
       BSON_ASSERT (remaining > 0);
@@ -67,7 +69,7 @@ _mongoc_cursor_new (mongoc_client_t           *client,
                     const char                *db_and_collection,
                     mongoc_query_flags_t       qflags,
                     uint32_t                   skip,
-                    uint32_t                   limit,
+                    int32_t                    limit,
                     uint32_t                   batch_size,
                     bool                       is_command,
                     const bson_t              *query,
@@ -738,7 +740,11 @@ _mongoc_cursor_prepare_find_command (mongoc_cursor_t *cursor,
    }
 
    if (cursor->limit) {
-      bson_append_int64 (command, "limit", 5, cursor->limit);
+      if (cursor->limit < 0) {
+         bson_append_bool (command, "singleBatch", 11, true);
+      }
+
+      bson_append_int64 (command, "limit", 5, labs(cursor->limit));
    }
 
    if (cursor->batch_size) {
@@ -1035,7 +1041,7 @@ _mongoc_cursor_next (mongoc_cursor_t  *cursor,
     * If we reached our limit, make sure we mark this as done and do not try to
     * make further progress.
     */
-   if (cursor->limit && cursor->count >= cursor->limit) {
+   if (cursor->limit && cursor->count >= labs(cursor->limit)) {
       cursor->done = true;
       RETURN (false);
    }

--- a/tests/test-mongoc-collection-find.c
+++ b/tests/test-mongoc-collection-find.c
@@ -24,11 +24,11 @@ typedef struct
    bson_t               *fields_bson;
    const char           *expected_find_command;
    const char           *expected_op_query;
-   uint32_t              n_return;
+   int32_t               n_return;
    const char           *expected_result;
    bson_t               *expected_result_bson;
    uint32_t              skip;
-   uint32_t              limit;
+   int32_t               limit;
    uint32_t              batch_size;
    mongoc_query_flags_t  flags;
    mongoc_read_prefs_t  *read_prefs;
@@ -688,6 +688,21 @@ test_limit (void)
 
 
 static void
+test_negative_limit (void)
+{
+   test_collection_find_t test_data = TEST_COLLECTION_FIND_INIT;
+   test_data.docs = "[{'_id': 1}, {'_id': 2}, {'_id': 3}]";
+   test_data.limit = -2;
+   test_data.query_input = "{'$query': {}, '$orderby': {'_id': 1}}";
+   test_data.expected_op_query = test_data.query_input;
+   test_data.n_return = -2;
+   test_data.expected_find_command = "{'find': 'collection', 'filter': {}, 'sort': {'_id': 1}, 'singleBatch': true, 'limit': {'$numberLong': '2'}}";
+   test_data.expected_result = "[{'_id': 1}, {'_id': 2}]";
+   _test_collection_find (&test_data);
+}
+
+
+static void
 test_unrecognized_dollar_option (void)
 {
    test_collection_find_t test_data = TEST_COLLECTION_FIND_INIT;
@@ -1016,6 +1031,8 @@ test_collection_find_install (TestSuite *suite)
                   test_batch_size);
    TestSuite_Add (suite, "/Collection/find/limit",
                   test_limit);
+   TestSuite_Add (suite, "/Collection/find/negative_limit",
+                  test_negative_limit);
    TestSuite_Add (suite, "/Collection/find/unrecognized",
                   test_unrecognized_dollar_option);
    TestSuite_Add (suite, "/Collection/find/flags",


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-1054

This adds internal support for specifying a negative cursor limit (i.e. single-batch mode) for both OP_QUERY and find command code paths. Note that this does not change the public API, which will be handled for 2.0 by CDRIVER-1053.