### PR TITLE
allow to skip online tests

### DIFF
--- a/tests/test-libmongoc.c
+++ b/tests/test-libmongoc.c
@@ -1209,6 +1209,12 @@ int test_framework_skip_if_max_version_version_less_than_4 (void)
 }
 
 
+int test_framework_skip_if_offline (void)
+{
+   return getenv("MONGOC_TEST_OFFLINE") ? 0 : 1;
+}
+
+
 int
 main (int   argc,
       char *argv[])

--- a/tests/test-libmongoc.h
+++ b/tests/test-libmongoc.h
@@ -61,6 +61,7 @@ int test_framework_skip_if_windows (void);
 int test_framework_skip_if_not_mongos  (void);
 int test_framework_skip_if_not_replset (void);
 int test_framework_skip_if_not_single  (void);
+int test_framework_skip_if_offline  (void);
 
 typedef struct _debug_stream_stats_t {
    mongoc_client_t *client;

--- a/tests/test-mongoc-topology.c
+++ b/tests/test-mongoc-topology.c
@@ -750,7 +750,7 @@ test_connect_timeout_try_once_false(void)
 
 
 static void
-test_multiple_selection_errors (void)
+test_multiple_selection_errors (void *context)
 {
    const char *uri = "mongodb://doesntexist,example.com:2/?replicaSet=rs"
       "&connectTimeoutMS=100";
@@ -811,6 +811,6 @@ test_topology_install (TestSuite *suite)
    TestSuite_Add (suite, "/Topology/connect_timeout/pooled", test_connect_timeout_pooled);
    TestSuite_Add (suite, "/Topology/connect_timeout/single/try_once", test_connect_timeout_single);
    TestSuite_Add (suite, "/Topology/connect_timeout/single/try_once_false", test_connect_timeout_try_once_false);
-   TestSuite_Add (suite, "/Topology/multiple_selection_errors", test_multiple_selection_errors);
+   TestSuite_AddFull (suite, "/Topology/multiple_selection_errors", test_multiple_selection_errors, NULL, NULL, test_framework_skip_if_offline);
    TestSuite_Add (suite, "/Topology/invalid_server_id", test_invalid_server_id);
 }


### PR DESCRIPTION
In Fedora infrastructure, builder don't have internet access.
So test suite fails, see https://kojipkgs.fedoraproject.org//work/tasks/7900/13177900/build.log

    FAIL
    Assert Failure: "No suitable servers found (`serverselectiontryonce` set): [Failed to resolve 'doesntexist'] [Failed to resolve 'example.com']" does not contain "[connection error calling ismaster on 'example.com:2']"

This small enhancement allow to define SKIP_INLINE env. var. before running to skip such test (for now there is only 1)
