### PR TITLE
CDRIVER-1096: Use const for mongoc_client_select_server() read prefs

### DIFF
--- a/doc/mongoc_client_select_server.page
+++ b/doc/mongoc_client_select_server.page
@@ -16,10 +16,10 @@
   <section id="synopsis">
     <title>Synopsis</title>
     <synopsis><code mime="text/x-csrc"><![CDATA[mongoc_server_description_t *
-mongoc_client_select_server (mongoc_client_t     *client,
-                             bool                 for_writes,
-                             mongoc_read_prefs_t *prefs,
-                             bson_error_t        *error);
+mongoc_client_select_server (mongoc_client_t           *client,
+                             bool                       for_writes,
+                             const mongoc_read_prefs_t *prefs,
+                             bson_error_t              *error);
 ]]></code></synopsis>
     <p>Choose a server for an operation, according to the logic described in the Server Selection Spec.</p>
     <p>Use this function only for building a language driver that wraps the C Driver. When writing applications in C, higher-level functions automatically select a suitable server.</p>

--- a/src/mongoc/mongoc-client.c
+++ b/src/mongoc/mongoc-client.c
@@ -1839,10 +1839,10 @@ mongoc_server_descriptions_destroy_all (mongoc_server_description_t **sds,
 
 
 mongoc_server_description_t *
-mongoc_client_select_server (mongoc_client_t     *client,
-                             bool                 for_writes,
-                             mongoc_read_prefs_t *prefs,
-                             bson_error_t        *error)
+mongoc_client_select_server (mongoc_client_t           *client,
+                             bool                       for_writes,
+                             const mongoc_read_prefs_t *prefs,
+                             bson_error_t              *error)
 {
    if (for_writes && prefs) {
       bson_set_error(error,

--- a/src/mongoc/mongoc-client.h
+++ b/src/mongoc/mongoc-client.h
@@ -171,7 +171,7 @@ void                           mongoc_server_descriptions_destroy_all      (mong
                                                                             size_t                        n);
 mongoc_server_description_t   *mongoc_client_select_server                 (mongoc_client_t              *client,
                                                                             bool                          for_writes,
-                                                                            mongoc_read_prefs_t          *prefs,
+                                                                            const mongoc_read_prefs_t    *prefs,
                                                                             bson_error_t                 *error);
 BSON_END_DECLS
 


### PR DESCRIPTION
Noticed while implementing [PHPC-607](https://jira.mongodb.org/browse/PHPC-607). This seemed like an oversight compared to the private `mongoc_topology_select()` function and other client functions that accept a read preference.

Related to: https://github.com/mongodb/mongo-c-driver/commit/929e8590a0ff49979ff83cc8175844d8aa992890