### PR TITLE
Rewrite comment to avoid -Wcomment warning

### DIFF
--- a/src/mongoc/mongoc-secure-transport.c
+++ b/src/mongoc/mongoc-secure-transport.c
@@ -342,7 +342,7 @@ mongoc_secure_transport_setup_ca (mongoc_stream_tls_secure_transport_t *secure_t
          secure_transport->anchors = CFRetain (items);
       }
 
-      /* This should be SSLSetCertificateAuthorities But the /TLS/* tests fail when it is */
+      /* This should be SSLSetCertificateAuthorities But the /TLS/ tests fail when it is */
       success = !SSLSetTrustedRoots (secure_transport->ssl_ctx_ref, secure_transport->anchors, true);
       MONGOC_DEBUG("Setting certificate authority %s (%s)", success ? "succeeded" : "failed", opt->ca_file);
       return true;


### PR DESCRIPTION
Fixes a compiler warning for "/* within comment"

Feel free to take or leave this, but it seemed trivial to fix without sacrificing the readability of the comment (more so than disabling -Wcomment for the build on PHPC's end).