### PR TITLE
Remove unused stamp field on _mongoc_cursor_t struct

### DIFF
--- a/src/mongoc/mongoc-cursor-private.h
+++ b/src/mongoc/mongoc-cursor-private.h
@@ -53,7 +53,6 @@ struct _mongoc_cursor_t
    mongoc_client_t           *client;
 
    uint32_t                   server_id;
-   uint32_t                   stamp;
 
    unsigned                   is_command      : 1;
    unsigned                   sent            : 1;


### PR DESCRIPTION
Realized this while researching [PHPC-688](https://jira.mongodb.org/browse/PHPC-688). I'm not sure when libmongoc stopped using the `stamp` field, but I found no reference to it within the project.

Let me know if you'd like a JIRA ticket for this; I found no reference to a "stamp" among CDRIVER tickets. The concept of a cursor stamp dates back to https://github.com/mongodb/mongo-c-driver/commit/d6e191612c84e33bf06ee85b242a115542e7bed3 but that method has been removed for some time. This is likely just cleaning up dead code.