### PR TITLE
CDRIVER-1231 Allow to use system crypto policies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ option(ENABLE_SASL "Use Cyrus SASL library for Kerberos." ON)
 option(ENABLE_TESTS "Build MongoDB C Driver tests." ON)
 option(ENABLE_EXAMPLES "Build MongoDB C Driver examples." ON)
 option(ENABLE_AUTOMATIC_INIT_AND_CLEANUP "Enable automatic init and cleanup (GCC only)" ON)
+option(ENABLE_CRYPTO_SYSTEM_PROFILE "Use system crypto profile (OpenSSL only)" OFF)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/build/cmake)
 
@@ -79,6 +80,8 @@ set (MONGOC_ENABLE_CRYPTO_LIBCRYPTO 0)
 set (MONGOC_ENABLE_CRYPTO_COMMON_CRYPTO 0)
 set (MONGOC_ENABLE_CRYPTO_CNG 0)
 
+set (MONGOC_ENABLE_CRYPTO_SYSTEM_PROFILE 0)
+
 if (OPENSSL_FOUND)
    set (MONGOC_ENABLE_SSL 1)
    set (MONGOC_ENABLE_SSL_OPENSSL 1)
@@ -94,6 +97,14 @@ elseif (SECURE_CHANNEL)
    set (MONGOC_ENABLE_SSL_SECURE_CHANNEL 1)
    set (MONGOC_ENABLE_CRYPTO 1)
    set (MONGOC_ENABLE_CRYPTO_CNG 1)
+endif ()
+
+if (ENABLE_CRYPTO_SYSTEM_PROFILE)
+   if (OPENSSL_FOUND)
+      set (MONGOC_ENABLE_CRYPTO_SYSTEM_PROFILE 1)
+   else ()
+      message (FATAL_ERROR "ENABLE_CRYPTO_SYSTEM_PROFILE only available with OpenSSL")
+   endif ()
 endif ()
 
 if (ENABLE_SASL)

--- a/build/autotools/CheckSSL.m4
+++ b/build/autotools/CheckSSL.m4
@@ -6,6 +6,13 @@ AC_ARG_ENABLE([ssl],
               [enable_ssl=auto])
 AC_MSG_RESULT([$enable_ssl])
 
+AC_MSG_CHECKING([whether to use system crypto profile])
+AC_ARG_ENABLE(crypto-system-profile,
+    AC_HELP_STRING([--enable-crypto-system-profile], [use system crypto profile (OpenSSL only) [default=no]]),
+    [],
+    [enable_crypto_system_profile="no"])
+AC_MSG_RESULT([$enable_crypto_system_profile])
+
 AS_IF([test "$enable_ssl" != "no"],[
    AS_IF([test "$enable_ssl" != "darwin"],[
       PKG_CHECK_MODULES(SSL, [openssl], [enable_openssl=auto], [
@@ -84,6 +91,15 @@ else
    AC_SUBST(MONGOC_ENABLE_CRYPTO, 0)
    AC_SUBST(MONGOC_ENABLE_CRYPTO_LIBCRYPTO, 0)
    AC_SUBST(MONGOC_ENABLE_CRYPTO_COMMON_CRYPTO, 0)
+fi
+if test "x$enable_crypto_system_profile" = xyes; then
+   if test "$enable_ssl" = "openssl"; then
+      AC_SUBST(MONGOC_ENABLE_CRYPTO_SYSTEM_PROFILE, 1)
+   else
+      AC_MSG_ERROR([--enable-crypto-system-profile only available with OpenSSL.])
+   fi
+else
+    AC_SUBST(MONGOC_ENABLE_CRYPTO_SYSTEM_PROFILE, 0)
 fi
 
 AM_CONDITIONAL([ENABLE_SSL],                  [test "$enable_ssl" = "darwin" -o "$enable_ssl" = "openssl"])

--- a/src/mongoc/mongoc-config.h.in
+++ b/src/mongoc/mongoc-config.h.in
@@ -108,6 +108,16 @@
 
 
 /*
+ * Use system crypto profile
+ */
+#define MONGOC_ENABLE_CRYPTO_SYSTEM_PROFILE @MONGOC_ENABLE_CRYPTO_SYSTEM_PROFILE@
+
+#if MONGOC_ENABLE_CRYPTO_SYSTEM_PROFILE != 1
+#  undef MONGOC_ENABLE_CRYPTO_SYSTEM_PROFILE
+#endif
+
+
+/*
  * MONGOC_ENABLE_SASL is set from configure to determine if we are
  * compiled with SASL support.
  */
@@ -152,6 +162,5 @@
 #if MONGOC_NO_AUTOMATIC_GLOBALS != 1
 #  undef MONGOC_NO_AUTOMATIC_GLOBALS
 #endif
-
 
 #endif /* MONGOC_CONFIG_H */

--- a/src/mongoc/mongoc-openssl.c
+++ b/src/mongoc/mongoc-openssl.c
@@ -384,11 +384,16 @@ _mongoc_openssl_ctx_new (mongoc_ssl_opt_t *opt)
     * SSL_OP_NO_SSLv2 - Disable SSL v2 support */
    SSL_CTX_set_options (ctx, (SSL_OP_ALL | SSL_OP_NO_SSLv2));
 
+/* only defined in special build, using:
+ * --enable-system-crypto-profile (autotools)
+ * -DENABLE_CRYPTO_SYSTEM_PROFILE:BOOL=ON (cmake)  */
+#ifndef MONGOC_ENABLE_CRYPTO_SYSTEM_PROFILE
    /* HIGH - Enable strong ciphers
     * !EXPORT - Disable export ciphers (40/56 bit)
     * !aNULL - Disable anonymous auth ciphers
     * @STRENGTH - Sort ciphers based on strength */
    SSL_CTX_set_cipher_list (ctx, "HIGH:!EXPORT:!aNULL@STRENGTH");
+#endif
 
    /* If renegotiation is needed, don't return from recv() or send() until it's successful.
     * Note: this is for blocking sockets only. */


### PR DESCRIPTION
See : https://jira.mongodb.org/browse/CDRIVER-1231

* for autotools, add the --enable-system-crypto-profile build option
* for cmake, add the -DENABLE_SYSTEM_CRYPTO_PROFILE:BOOL=ON build option

In both case, default to off, so no change for standard build.