### PR TITLE
TRACE() macro requires var args

### DIFF
--- a/src/mongoc/mongoc-cluster.c
+++ b/src/mongoc/mongoc-cluster.c
@@ -1034,7 +1034,7 @@ _mongoc_cluster_auth_node_x509 (mongoc_cluster_t      *cluster,
          return false;
       }
 
-      TRACE ("X509: got username from certificate");
+      TRACE ("%s", "X509: got username from certificate");
    }
 
    bson_init (&cmd);
@@ -1170,7 +1170,7 @@ _mongoc_cluster_auth_node_scram (mongoc_cluster_t      *cluster,
       bson_destroy (&reply);
    }
 
-   TRACE ("SCRAM: authenticated");
+   TRACE ("%s", "SCRAM: authenticated");
 
    ret = true;
 


### PR DESCRIPTION
This fixes calls introduced in e8f031a6deb7d0fdea10ba2161d9fb5b56fa6e8e.

I noticed this when compiling a recently bumped libmongoc submodule with PHPC, where we utilize stricter build checks. Original error was:

```
In file included from /home/jmikola/workspace/mongodb/phpc/src/libmongoc/src/mongoc/mongoc-cluster.c:50:0:
/home/jmikola/workspace/mongodb/phpc/src/libmongoc/src/mongoc/mongoc-cluster.c: In function ‘_mongoc_cluster_auth_node_x509’:
/home/jmikola/workspace/mongodb/phpc/src/libmongoc/src/mongoc/mongoc-trace.h:34:135: error: expected expression before ‘)’ token
                     do { mongoc_log(MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, "TRACE: %s():%d " msg, BSON_FUNC, __LINE__, __VA_ARGS__); } while (0)
                                                                                                                                       ^
/home/jmikola/workspace/mongodb/phpc/src/libmongoc/src/mongoc/mongoc-cluster.c:1037:7: note: in expansion of macro ‘TRACE’
       TRACE ("X509: got username from certificate");
       ^
/home/jmikola/workspace/mongodb/phpc/src/libmongoc/src/mongoc/mongoc-cluster.c: In function ‘_mongoc_cluster_auth_node_scram’:
/home/jmikola/workspace/mongodb/phpc/src/libmongoc/src/mongoc/mongoc-trace.h:34:135: error: expected expression before ‘)’ token
                     do { mongoc_log(MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, "TRACE: %s():%d " msg, BSON_FUNC, __LINE__, __VA_ARGS__); } while (0)
                                                                                                                                       ^
/home/jmikola/workspace/mongodb/phpc/src/libmongoc/src/mongoc/mongoc-cluster.c:1173:4: note: in expansion of macro ‘TRACE’
    TRACE ("SCRAM: authenticated");
    ^
make: *** [src/libmongoc/src/mongoc/mongoc-cluster.lo] Error 1
make: *** Waiting for unfinished jobs....
```