### PR TITLE
avoid abicheck failure

### DIFF
--- a/tests/abicheck.sh
+++ b/tests/abicheck.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-cpp -P ${cppargs} ${1:-./src/libmongoc.symbols} | sed -e '/^$/d' -e 's/ G_GNUC.*$//' -e 's/ PRIVATE//' -e 's/ DATA//' | sort > expected-abi
+cpp --freestanding -P ${cppargs} ${1:-./src/libmongoc.symbols} | sed -e '/^$/d' -e 's/ G_GNUC.*$//' -e 's/ PRIVATE//' -e 's/ DATA//' | sort > expected-abi
 
 nm -D -g --defined-only .libs/libmongoc-1.0.so | cut -d ' ' -f 3 | egrep -v '^(__bss_start|_edata|_end)' | sort > actual-abi
 diff -u expected-abi actual-abi && rm -f expected-abi actual-abi


### PR DESCRIPTION
We encounter recent failure because of this script.

See: https://bugzilla.redhat.com/1345868
And : https://apps.fedoraproject.org/koschei/package/mongo-c-driver

Build is back to "green" thanks to this minor fix.
