### PR TITLE
CDRIVER-1328 reply is always initialized in mongoc_collection_validate

### DIFF
--- a/doc/mongoc_collection_validate.page
+++ b/doc/mongoc_collection_validate.page
@@ -29,7 +29,7 @@ mongoc_collection_validate (mongoc_collection_t *collection,
     <table>
       <tr><td><p>collection</p></td><td><p>A <code xref="mongoc_collection_t">mongoc_collection_t</code>.</p></td></tr>
       <tr><td><p>options</p></td><td><p>A <code xref="bson:bson_t">bson_t</code>.</p></td></tr>
-      <tr><td><p>reply</p></td><td><p>A <code xref="bson:bson_t">bson_t</code>.</p></td></tr>
+      <tr><td><p>reply</p></td><td><p>An optional location for a <code xref="bson:bson_t">bson_t</code>.</p></td></tr>
       <tr><td><p>error</p></td><td><p>An optional location for a <code xref="errors">bson_error_t</code> or <code>NULL</code>.</p></td></tr>
     </table>
   </section>
@@ -50,7 +50,7 @@ mongoc_collection_validate (mongoc_collection_t *collection,
   <section id="return">
     <title>Returns</title>
     <p>true if successful, otherwise false and error is set.</p>
-    <p><code>reply</code> is always initialized and must be destroyed with <code xref="bson:bson_destroy()">bson_destroy()</code>.</p>
+    <p><code>reply</code> is always initialized if it's not <code>NULL</code> and must be destroyed with <code xref="bson:bson_destroy()">bson_destroy()</code>.</p>
   </section>
 
 </page>

--- a/src/mongoc/mongoc-collection.c
+++ b/src/mongoc/mongoc-collection.c
@@ -1898,7 +1898,8 @@ mongoc_collection_validate (mongoc_collection_t *collection, /* IN */
 {
    bson_iter_t iter;
    bson_t cmd = BSON_INITIALIZER;
-   bool ret;
+   bool ret = false;
+   bool reply_initialized = false;
 
    BSON_ASSERT (collection);
 
@@ -1909,7 +1910,7 @@ mongoc_collection_validate (mongoc_collection_t *collection, /* IN */
                       MONGOC_ERROR_BSON,
                       MONGOC_ERROR_BSON_INVALID,
                       "'full' must be a boolean value.");
-      return false;
+      goto cleanup;
    }
 
    bson_append_utf8 (&cmd, "validate", 8,
@@ -1921,8 +1922,14 @@ mongoc_collection_validate (mongoc_collection_t *collection, /* IN */
    }
 
    ret = mongoc_collection_command_simple (collection, &cmd, NULL, reply, error);
+   reply_initialized = true;
 
+cleanup:
    bson_destroy (&cmd);
+
+   if (reply && !reply_initialized) {
+      bson_init (reply);
+   }
 
    return ret;
 }


### PR DESCRIPTION
I guess I forgot to make a pull request for this. Here's the CR link:
https://mongodbcr.appspot.com/79000001/
