### PR TITLE
CDRIVER-1393 put metadata and max_staleness behind MONGOC_EXPERIMENTAL_FEATURE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,12 @@ else ()
    set (MONGOC_NO_AUTOMATIC_GLOBALS 1)
 endif ()
 
+if (ENABLE_EXPERIMENTAL_FEATURES)
+   set (MONGOC_EXPERIMENTAL_FEATURES 1)
+else ()
+   set (MONGOC_EXPERIMENTAL_FEATURES 0)
+endif ()
+
 include(CheckIncludeFiles)
 CHECK_INCLUDE_FILES(strings.h HAVE_STRINGS_H)
 

--- a/build/autotools/ReadCommandLineArguments.m4
+++ b/build/autotools/ReadCommandLineArguments.m4
@@ -81,6 +81,10 @@ AC_ARG_ENABLE(experimental-features,
                   [Experimental future BSON and MongoDB features [default=no]]),
    [enable_experimental_features=$enableval])
 
+AS_IF([test "$enable_experimental_features" = "yes"],
+      [AC_SUBST(MONGOC_EXPERIMENTAL_FEATURES, 1)],
+      [AC_SUBST(MONGOC_EXPERIMENTAL_FEATURES, 0)])
+
 # Check if we should use the bundled (git submodule) libbson
 AC_ARG_WITH(libbson,
     AC_HELP_STRING([--with-libbson=@<:@auto/system/bundled@:>@],

--- a/build/cmake/libmongoc-experimental.def
+++ b/build/cmake/libmongoc-experimental.def
@@ -78,10 +78,12 @@ mongoc_client_pool_new
 mongoc_client_pool_pop
 mongoc_client_pool_push
 mongoc_client_pool_set_apm_callbacks
+mongoc_client_pool_set_appname
 mongoc_client_pool_set_error_api
 mongoc_client_pool_try_pop
 mongoc_client_select_server
 mongoc_client_set_apm_callbacks
+mongoc_client_set_appname
 mongoc_client_set_error_api
 mongoc_client_set_read_concern
 mongoc_client_set_read_prefs
@@ -225,6 +227,7 @@ mongoc_log_trace_enable
 mongoc_matcher_destroy
 mongoc_matcher_match
 mongoc_matcher_new
+mongoc_metadata_append
 mongoc_read_concern_copy
 mongoc_read_concern_destroy
 mongoc_read_concern_get_level

--- a/build/cmake/libmongoc-ssl-experimental.def
+++ b/build/cmake/libmongoc-ssl-experimental.def
@@ -78,11 +78,13 @@ mongoc_client_pool_new
 mongoc_client_pool_pop
 mongoc_client_pool_push
 mongoc_client_pool_set_apm_callbacks
+mongoc_client_pool_set_appname
 mongoc_client_pool_set_error_api
 mongoc_client_pool_set_ssl_opts
 mongoc_client_pool_try_pop
 mongoc_client_select_server
 mongoc_client_set_apm_callbacks
+mongoc_client_set_appname
 mongoc_client_set_error_api
 mongoc_client_set_read_concern
 mongoc_client_set_read_prefs
@@ -227,6 +229,7 @@ mongoc_log_trace_enable
 mongoc_matcher_destroy
 mongoc_matcher_match
 mongoc_matcher_new
+mongoc_metadata_append
 mongoc_rand_add
 mongoc_rand_seed
 mongoc_rand_status

--- a/build/cmake/libmongoc-ssl.def
+++ b/build/cmake/libmongoc-ssl.def
@@ -78,13 +78,11 @@ mongoc_client_pool_new
 mongoc_client_pool_pop
 mongoc_client_pool_push
 mongoc_client_pool_set_apm_callbacks
-mongoc_client_pool_set_appname
 mongoc_client_pool_set_error_api
 mongoc_client_pool_set_ssl_opts
 mongoc_client_pool_try_pop
 mongoc_client_select_server
 mongoc_client_set_apm_callbacks
-mongoc_client_set_appname
 mongoc_client_set_error_api
 mongoc_client_set_read_concern
 mongoc_client_set_read_prefs
@@ -229,7 +227,6 @@ mongoc_log_trace_enable
 mongoc_matcher_destroy
 mongoc_matcher_match
 mongoc_matcher_new
-mongoc_metadata_append
 mongoc_rand_add
 mongoc_rand_seed
 mongoc_rand_status

--- a/build/cmake/libmongoc.def
+++ b/build/cmake/libmongoc.def
@@ -78,12 +78,10 @@ mongoc_client_pool_new
 mongoc_client_pool_pop
 mongoc_client_pool_push
 mongoc_client_pool_set_apm_callbacks
-mongoc_client_pool_set_appname
 mongoc_client_pool_set_error_api
 mongoc_client_pool_try_pop
 mongoc_client_select_server
 mongoc_client_set_apm_callbacks
-mongoc_client_set_appname
 mongoc_client_set_error_api
 mongoc_client_set_read_concern
 mongoc_client_set_read_prefs
@@ -227,7 +225,6 @@ mongoc_log_trace_enable
 mongoc_matcher_destroy
 mongoc_matcher_match
 mongoc_matcher_new
-mongoc_metadata_append
 mongoc_read_concern_copy
 mongoc_read_concern_destroy
 mongoc_read_concern_get_level

--- a/src/mongoc/Makefile.am
+++ b/src/mongoc/Makefile.am
@@ -69,8 +69,6 @@ INST_H_FILES = \
 	src/mongoc/mongoc-matcher-private.h \
 	src/mongoc/mongoc-matcher.h \
 	src/mongoc/mongoc-memcmp-private.h \
-	src/mongoc/mongoc-metadata.h \
-	src/mongoc/mongoc-metadata-private.h \
 	src/mongoc/mongoc-opcode.h \
 	src/mongoc/mongoc-opcode-private.h \
 	src/mongoc/mongoc-queue-private.h \
@@ -107,6 +105,12 @@ INST_H_FILES = \
 	src/mongoc/mongoc-write-concern-private.h \
 	src/mongoc/mongoc-write-concern.h \
 	src/mongoc/utlist.h
+
+if ENABLE_EXPERIMENTAL_FEATURES
+INST_H_FILES += \
+	src/mongoc/mongoc-metadata.h \
+	src/mongoc/mongoc-metadata-private.h
+endif
 
 if ENABLE_SSL
 INST_H_FILES += \
@@ -163,7 +167,6 @@ MONGOC_SOURCES_SHARED += \
 	src/mongoc/mongoc-matcher-op.c \
 	src/mongoc/mongoc-matcher.c \
 	src/mongoc/mongoc-memcmp.c \
-	src/mongoc/mongoc-metadata.c \
 	src/mongoc/mongoc-opcode.c \
 	src/mongoc/mongoc-queue.c \
 	src/mongoc/mongoc-read-concern.c \
@@ -207,6 +210,11 @@ MONGOC_SOURCES_SHARED += \
 	src/mongoc/mongoc-crypto-cng.c \
 	src/mongoc/mongoc-rand-cng.c
 endif
+endif
+
+if ENABLE_EXPERIMENTAL_FEATURES
+MONGOC_SOURCES_SHARED += \
+	src/mongoc/mongoc-metadata.c
 endif
 
 if ENABLE_SSL

--- a/src/mongoc/mongoc-client-pool.c
+++ b/src/mongoc/mongoc-client-pool.c
@@ -349,6 +349,7 @@ mongoc_client_pool_set_error_api (mongoc_client_pool_t *pool,
    return true;
 }
 
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
 bool
 mongoc_client_pool_set_appname (mongoc_client_pool_t *pool,
                                 const char           *appname)
@@ -362,3 +363,4 @@ mongoc_client_pool_set_appname (mongoc_client_pool_t *pool,
 
    return ret;
 }
+#endif

--- a/src/mongoc/mongoc-client-pool.h
+++ b/src/mongoc/mongoc-client-pool.h
@@ -57,8 +57,10 @@ bool                  mongoc_client_pool_set_apm_callbacks (mongoc_client_pool_t
                                                             void                   *context);
 bool                  mongoc_client_pool_set_error_api     (mongoc_client_pool_t   *pool,
                                                             int32_t                 version);
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
 bool                  mongoc_client_pool_set_appname       (mongoc_client_pool_t   *pool,
                                                             const char             *appname);
+#endif
 BSON_END_DECLS
 
 

--- a/src/mongoc/mongoc-client.c
+++ b/src/mongoc/mongoc-client.c
@@ -1911,6 +1911,7 @@ mongoc_client_set_error_api (mongoc_client_t *client,
    return true;
 }
 
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
 bool
 mongoc_client_set_appname (mongoc_client_t *client,
                            const char      *appname)
@@ -1922,3 +1923,4 @@ mongoc_client_set_appname (mongoc_client_t *client,
    return _mongoc_topology_set_appname (client->topology,
                                         appname);
 }
+#endif

--- a/src/mongoc/mongoc-client.h
+++ b/src/mongoc/mongoc-client.h
@@ -175,8 +175,10 @@ mongoc_server_description_t   *mongoc_client_select_server                 (mong
                                                                             bson_error_t                 *error);
 bool                           mongoc_client_set_error_api                 (mongoc_client_t              *client,
                                                                             int32_t                       version);
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
 bool                           mongoc_client_set_appname                   (mongoc_client_t              *client,
                                                                             const char                   *appname);
+#endif
 BSON_END_DECLS
 
 

--- a/src/mongoc/mongoc-config.h.in
+++ b/src/mongoc/mongoc-config.h.in
@@ -163,4 +163,13 @@
 #  undef MONGOC_NO_AUTOMATIC_GLOBALS
 #endif
 
+/*
+ * Define to support experimental future mongoc features
+ */
+#define MONGOC_EXPERIMENTAL_FEATURES @MONGOC_EXPERIMENTAL_FEATURES@
+
+#if MONGOC_EXPERIMENTAL_FEATURES != 1
+#  undef MONGOC_EXPERIMENTAL_FEATURES
+#endif
+
 #endif /* MONGOC_CONFIG_H */

--- a/src/mongoc/mongoc-init.c
+++ b/src/mongoc/mongoc-init.c
@@ -20,7 +20,11 @@
 #include "mongoc-config.h"
 #include "mongoc-counters-private.h"
 #include "mongoc-init.h"
+
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
 #include "mongoc-metadata-private.h"
+#endif
+
 #ifdef MONGOC_ENABLE_SSL
 # include "mongoc-scram-private.h"
 # include "mongoc-ssl.h"
@@ -121,7 +125,9 @@ static MONGOC_ONCE_FUN( _mongoc_do_init)
    }
 #endif
 
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
    _mongoc_metadata_init ();
+#endif
 
    MONGOC_ONCE_RETURN;
 }
@@ -154,7 +160,9 @@ static MONGOC_ONCE_FUN( _mongoc_do_cleanup)
 
    _mongoc_counters_cleanup ();
 
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
    _mongoc_metadata_cleanup ();
+#endif
 
    MONGOC_ONCE_RETURN;
 }

--- a/src/mongoc/mongoc-read-prefs.c
+++ b/src/mongoc/mongoc-read-prefs.c
@@ -15,6 +15,7 @@
  */
 
 
+#include "mongoc-config.h"
 #include "mongoc-error.h"
 #include "mongoc-read-prefs-private.h"
 #include "mongoc-trace.h"
@@ -97,7 +98,7 @@ mongoc_read_prefs_add_tag (mongoc_read_prefs_t *read_prefs,
 }
 
 
-#ifdef BSON_EXPERIMENTAL_FEATURES
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
 int32_t
 mongoc_read_prefs_get_max_staleness_ms (const mongoc_read_prefs_t *read_prefs)
 {
@@ -197,7 +198,7 @@ _apply_read_preferences_mongos (const mongoc_read_prefs_t *read_prefs,
    const bson_t *tags = NULL;
    bson_t child;
    const char *mode_str;
-#ifdef BSON_EXPERIMENTAL_FEATURES
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
    int64_t max_staleness_ms;
 #endif
 
@@ -255,7 +256,7 @@ _apply_read_preferences_mongos (const mongoc_read_prefs_t *read_prefs,
          bson_append_array (&child, "tags", 4, tags);
       }
 
-#ifdef BSON_EXPERIMENTAL_FEATURES
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
       max_staleness_ms = mongoc_read_prefs_get_max_staleness_ms (read_prefs);
       if (max_staleness_ms > 0) {
          bson_append_int64 (&child, "maxStalenessMS", 14, max_staleness_ms);

--- a/src/mongoc/mongoc-read-prefs.h
+++ b/src/mongoc/mongoc-read-prefs.h
@@ -23,6 +23,7 @@
 
 #include <bson.h>
 
+#include "mongoc-config.h"
 
 BSON_BEGIN_DECLS
 
@@ -51,7 +52,7 @@ void                 mongoc_read_prefs_set_tags             (mongoc_read_prefs_t
                                                              const bson_t              *tags);
 void                 mongoc_read_prefs_add_tag              (mongoc_read_prefs_t       *read_prefs,
                                                              const bson_t              *tag);
-#ifdef BSON_EXPERIMENTAL_FEATURES
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
 int32_t              mongoc_read_prefs_get_max_staleness_ms (const mongoc_read_prefs_t *read_prefs);
 void                 mongoc_read_prefs_set_max_staleness_ms (mongoc_read_prefs_t       *read_prefs,
                                                              int32_t                    max_staleness_ms);

--- a/src/mongoc/mongoc-server-description.c
+++ b/src/mongoc/mongoc-server-description.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "mongoc-config.h"
 #include "mongoc-host-list.h"
 #include "mongoc-host-list-private.h"
 #include "mongoc-read-prefs.h"
@@ -453,7 +454,7 @@ mongoc_server_description_handle_ismaster (
    bson_error_t                  *error)
 {
    bson_iter_t iter;
-#ifdef BSON_EXPERIMENTAL_FEATURES
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
    bson_iter_t child;
 #endif
    bool is_master = false;
@@ -548,7 +549,7 @@ mongoc_server_description_handle_ismaster (
          bson_init_static (&sd->tags, bytes, len);
       } else if (strcmp ("hidden", bson_iter_key (&iter)) == 0) {
          is_hidden = bson_iter_bool (&iter);
-#ifdef BSON_EXPERIMENTAL_FEATURES
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
       } else if (strcmp ("lastWrite", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_DOCUMENT (&iter) ||
              !bson_iter_recurse (&iter, &child) ||
@@ -660,7 +661,7 @@ mongoc_server_description_filter_stale (mongoc_server_description_t **sds,
                                         int64_t                       heartbeat_frequency_ms,
                                         const mongoc_read_prefs_t    *read_prefs)
 {
-#ifdef BSON_EXPERIMENTAL_FEATURES
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
    int64_t max_staleness_ms;
    int64_t max_last_write_date_ms;
    size_t i;

--- a/src/mongoc/mongoc-topology-scanner.c
+++ b/src/mongoc/mongoc-topology-scanner.c
@@ -17,12 +17,16 @@
 #include <bson.h>
 #include <bson-string.h>
 
+#include "mongoc-config.h"
 #include "mongoc-error.h"
-#include "mongoc-metadata.h"
-#include "mongoc-metadata-private.h"
 #include "mongoc-trace.h"
 #include "mongoc-topology-scanner-private.h"
 #include "mongoc-stream-socket.h"
+
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
+#include "mongoc-metadata.h"
+#include "mongoc-metadata-private.h"
+#endif
 
 #ifdef MONGOC_ENABLE_SSL
 #include "mongoc-stream-tls.h"
@@ -49,6 +53,7 @@ _add_ismaster (bson_t *cmd)
    BSON_APPEND_INT32 (cmd, "isMaster", 1);
 }
 
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
 static bool
 _build_ismaster_with_metadata (mongoc_topology_scanner_t *ts)
 {
@@ -66,11 +71,13 @@ _build_ismaster_with_metadata (mongoc_topology_scanner_t *ts)
    /* Return whether the meta doc fit the size limit */
    return res;
 }
+#endif
 
 static bson_t *
 _get_ismaster_doc (mongoc_topology_scanner_t      *ts,
                    mongoc_topology_scanner_node_t *node)
 {
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
    bool ismaster_with_metadata_ok = true;
 
    if (node->last_used != -1 && node->last_failed == -1) {
@@ -92,6 +99,9 @@ _get_ismaster_doc (mongoc_topology_scanner_t      *ts,
    }
 
    return &ts->ismaster_cmd_with_metadata;
+#else
+   return &ts->ismaster_cmd;
+#endif
 }
 
 static void
@@ -746,6 +756,7 @@ mongoc_topology_scanner_reset (mongoc_topology_scanner_t *ts)
    }
 }
 
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
 /*
  * Set a field in the topology scanner.
  */
@@ -765,3 +776,4 @@ _mongoc_topology_scanner_set_appname (mongoc_topology_scanner_t *ts,
    ts->appname = bson_strdup (appname);
    return true;
 }
+#endif

--- a/src/mongoc/mongoc-topology.c
+++ b/src/mongoc/mongoc-topology.c
@@ -14,8 +14,13 @@
  * limitations under the License.
  */
 
+#include "mongoc-config.h"
+
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
 #include "mongoc-metadata.h"
 #include "mongoc-metadata-private.h"
+#endif
+
 #include "mongoc-error.h"
 #include "mongoc-topology-private.h"
 #include "mongoc-client-private.h"
@@ -328,7 +333,10 @@ _mongoc_topology_do_blocking_scan (mongoc_topology_t *topology,
    mongoc_topology_scanner_t *scanner;
 
    topology->scanner_state = MONGOC_TOPOLOGY_SCANNER_SINGLE_THREADED;
+
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
    _mongoc_metadata_freeze ();
+#endif
 
    scanner = topology->scanner;
    mongoc_topology_scanner_start (scanner,
@@ -353,7 +361,7 @@ mongoc_topology_compatible (const mongoc_topology_description_t *td,
                             int64_t                              heartbeat_msec,
                             bson_error_t                        *error)
 {
-#ifdef BSON_EXPERIMENTAL_FEATURES
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
    int32_t max_staleness;
    int32_t max_wire_version;
 
@@ -882,7 +890,10 @@ _mongoc_topology_start_background_scanner (mongoc_topology_t *topology)
    mongoc_mutex_lock (&topology->mutex);
    if (topology->scanner_state == MONGOC_TOPOLOGY_SCANNER_OFF) {
       topology->scanner_state = MONGOC_TOPOLOGY_SCANNER_BG_RUNNING;
+
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
       _mongoc_metadata_freeze ();
+#endif
 
       mongoc_thread_create (&topology->thread, _mongoc_topology_run_background,
                             topology);
@@ -941,6 +952,7 @@ _mongoc_topology_background_thread_stop (mongoc_topology_t *topology)
    }
 }
 
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
 bool
 _mongoc_topology_set_appname (mongoc_topology_t *topology,
                               const char *appname)
@@ -955,3 +967,4 @@ _mongoc_topology_set_appname (mongoc_topology_t *topology,
    mongoc_mutex_unlock (&topology->mutex);
    return ret;
 }
+#endif

--- a/src/mongoc/mongoc-uri.c
+++ b/src/mongoc/mongoc-uri.c
@@ -24,6 +24,7 @@
 /* strcasecmp on windows */
 #include "mongoc-util-private.h"
 
+#include "mongoc-config.h"
 #include "mongoc-host-list.h"
 #include "mongoc-host-list-private.h"
 #include "mongoc-log.h"
@@ -546,7 +547,7 @@ mongoc_uri_option_is_int32 (const char *key)
        !strcasecmp(key, "localthresholdms") ||
        !strcasecmp(key, "maxpoolsize") ||
        !strcasecmp(key, "minpoolsize") ||
-#ifdef BSON_EXPERIMENTAL_FEATURES
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
        !strcasecmp(key, "maxstalenessms") ||
 #endif
        !strcasecmp(key, "maxidletimems") ||
@@ -950,7 +951,7 @@ mongoc_uri_new (const char *uri_string)
    uri->str = bson_strdup(uri_string);
 
    _mongoc_uri_assign_read_prefs_mode(uri);
-#ifdef BSON_EXPERIMENTAL_FEATURES
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
    max_staleness_ms = mongoc_uri_get_option_as_int32 (uri, "maxstalenessms", 0);
    mongoc_read_prefs_set_max_staleness_ms (uri->read_prefs, max_staleness_ms);
 #endif

--- a/src/mongoc/mongoc.h
+++ b/src/mongoc/mongoc.h
@@ -40,7 +40,9 @@
 #include "mongoc-host-list.h"
 #include "mongoc-init.h"
 #include "mongoc-matcher.h"
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
 #include "mongoc-metadata.h"
+#endif
 #include "mongoc-opcode.h"
 #include "mongoc-log.h"
 #include "mongoc-socket.h"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -111,7 +111,6 @@ test_libmongoc_SOURCES = \
 	tests/test-mongoc-log.c \
 	tests/test-mongoc-list.c \
 	tests/test-mongoc-matcher.c \
-	tests/test-mongoc-metadata.c \
 	tests/test-mongoc-queue.c \
 	tests/test-mongoc-read-prefs.c \
 	tests/test-mongoc-rpc.c \
@@ -137,7 +136,8 @@ test_libmongoc_SOURCES = \
 
 if ENABLE_EXPERIMENTAL_FEATURES
 test_libmongoc_SOURCES += \
-	tests/test-mongoc-max-staleness.c
+	tests/test-mongoc-max-staleness.c \
+	tests/test-mongoc-metadata.c
 endif
 
 if ENABLE_SSL

--- a/tests/json-test.c
+++ b/tests/json-test.c
@@ -15,6 +15,7 @@
  */
 
 
+#include "mongoc-config.h"
 #include "mongoc-server-description-private.h"
 #include "mongoc-topology-description-private.h"
 #include "mongoc-topology-private.h"
@@ -275,7 +276,7 @@ test_server_selection_logic_cb (bson_t *test)
       }
    }
 
-#ifdef BSON_EXPERIMENTAL_FEATURES
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
    if (bson_iter_init_find (&read_pref_iter, &test_read_pref,
                             "maxStalenessMS")) {
       mongoc_read_prefs_set_max_staleness_ms (

--- a/tests/test-conveniences.c
+++ b/tests/test-conveniences.c
@@ -824,7 +824,7 @@ bson_type_to_str (bson_type_t t)
    case BSON_TYPE_INT64: return "INT64";
    case BSON_TYPE_MAXKEY: return "MAXKEY";
    case BSON_TYPE_MINKEY: return "MINKEY";
-#ifdef BSON_EXPERIMENTAL_FEATURES
+#if defined (BSON_EXPERIMENTAL_FEATURES) && defined (MONGOC_EXPERIMENTAL_FEATURES)
    case BSON_TYPE_DECIMAL128: return "DECIMAL128";
 #endif
    default: return "Unknown";
@@ -1049,7 +1049,7 @@ match_bson_value (const bson_value_t *doc,
    case BSON_TYPE_DBPOINTER:
       MONGOC_ERROR ("DBPointer comparison not implemented");
       abort ();
-#ifdef BSON_EXPERIMENTAL_FEATURES
+#if defined (BSON_EXPERIMENTAL_FEATURES) && defined (MONGOC_EXPERIMENTAL_FEATURES)
    case BSON_TYPE_DECIMAL128:
       MONGOC_ERROR ("Decimal128 comparison not implemented");
       abort ();

--- a/tests/test-libmongoc.c
+++ b/tests/test-libmongoc.c
@@ -39,7 +39,7 @@ extern void test_async_install                   (TestSuite *suite);
 extern void test_buffer_install                  (TestSuite *suite);
 extern void test_bulk_install                    (TestSuite *suite);
 extern void test_client_install                  (TestSuite *suite);
-#ifdef BSON_EXPERIMENTAL_FEATURES
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
 extern void test_client_max_staleness_install    (TestSuite *suite);
 #endif
 extern void test_client_pool_install             (TestSuite *suite);
@@ -57,7 +57,9 @@ extern void test_gridfs_install                  (TestSuite *suite);
 extern void test_list_install                    (TestSuite *suite);
 extern void test_log_install                     (TestSuite *suite);
 extern void test_matcher_install                 (TestSuite *suite);
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
 extern void test_metadata_install                (TestSuite *suite);
+#endif
 extern void test_queue_install                   (TestSuite *suite);
 extern void test_read_prefs_install              (TestSuite *suite);
 extern void test_rpc_install                     (TestSuite *suite);
@@ -1656,7 +1658,7 @@ main (int   argc,
    test_async_install (&suite);
    test_buffer_install (&suite);
    test_client_install (&suite);
-#ifdef BSON_EXPERIMENTAL_FEATURES
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
    test_client_max_staleness_install (&suite);
 #endif
    test_client_pool_install (&suite);
@@ -1676,7 +1678,9 @@ main (int   argc,
    test_list_install (&suite);
    test_log_install (&suite);
    test_matcher_install (&suite);
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
    test_metadata_install (&suite);
+#endif
    test_queue_install (&suite);
    test_read_prefs_install (&suite);
    test_rpc_install (&suite);

--- a/tests/test-mongoc-client-pool.c
+++ b/tests/test-mongoc-client-pool.c
@@ -210,6 +210,7 @@ test_mongoc_client_pool_ssl_disabled (void)
 }
 #endif
 
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
 static void
 test_mongoc_client_pool_metadata (void)
 {
@@ -243,6 +244,7 @@ test_mongoc_client_pool_metadata (void)
    mongoc_uri_destroy(uri);
    mongoc_client_pool_destroy(pool);
 }
+#endif
 
 void
 test_client_pool_install (TestSuite *suite)
@@ -253,7 +255,10 @@ test_client_pool_install (TestSuite *suite)
    TestSuite_Add (suite, "/ClientPool/min_size_dispose", test_mongoc_client_pool_min_size_dispose);
    TestSuite_Add (suite, "/ClientPool/set_max_size", test_mongoc_client_pool_set_max_size);
    TestSuite_Add (suite, "/ClientPool/set_min_size", test_mongoc_client_pool_set_min_size);
+
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
    TestSuite_Add (suite, "/ClientPool/metadata", test_mongoc_client_pool_metadata);
+#endif
 
 #ifndef MONGOC_ENABLE_SSL
    TestSuite_Add (suite, "/ClientPool/ssl_disabled", test_mongoc_client_pool_ssl_disabled);

--- a/tests/test-mongoc-client.c
+++ b/tests/test-mongoc-client.c
@@ -4,8 +4,11 @@
 
 #include "mongoc-client-private.h"
 #include "mongoc-cursor-private.h"
-#include "mongoc-metadata-private.h"
 #include "mongoc-util-private.h"
+
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
+#include "mongoc-metadata-private.h"
+#endif
 
 #include "TestSuite.h"
 #include "test-conveniences.h"
@@ -1693,6 +1696,7 @@ test_ssl_reconnect_pooled (void)
 
 #endif
 
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
 static void
 test_mongoc_client_application_metadata (void)
 {
@@ -1888,6 +1892,7 @@ test_client_sends_metadata_pooled (void)
 {
    _test_client_sends_metadata (true);
 }
+#endif
 
 void
 test_client_install (TestSuite *suite)
@@ -1935,11 +1940,14 @@ test_client_install (TestSuite *suite)
    TestSuite_Add (suite, "/Client/database_names", test_get_database_names);
    TestSuite_AddFull (suite, "/Client/connect/uds", test_mongoc_client_unix_domain_socket, NULL, NULL, test_framework_skip_if_no_uds);
    TestSuite_Add (suite, "/Client/mismatched_me", test_mongoc_client_mismatched_me);
+
+#ifdef MONGOC_EXPERIMENTAL_FEATURES
    TestSuite_Add (suite, "/Client/application_metadata", test_mongoc_client_application_metadata);
    TestSuite_Add (suite, "/Client/sends_metadata_single",
                   test_client_sends_metadata_single);
    TestSuite_Add (suite, "/Client/sends_metadata_pooled",
                   test_client_sends_metadata_pooled);
+#endif
 
 #ifdef TODO_CDRIVER_689
    TestSuite_Add (suite, "/Client/wire_version", test_wire_version);

--- a/tests/test-mongoc-collection.c
+++ b/tests/test-mongoc-collection.c
@@ -965,7 +965,7 @@ test_regex (void)
 }
 
 
-#ifdef BSON_EXPERIMENTAL_FEATURES
+#if defined (BSON_EXPERIMENTAL_FEATURES) && defined (MONGOC_EXPERIMENTAL_FEATURES)
 static void
 test_decimal128 (void *ctx)
 {
@@ -3453,7 +3453,7 @@ test_collection_install (TestSuite *suite)
    TestSuite_AddLive (suite, "/Collection/index_geo", test_index_geo);
    TestSuite_AddLive (suite, "/Collection/index_storage", test_index_storage);
    TestSuite_AddLive (suite, "/Collection/regex", test_regex);
-#ifdef BSON_EXPERIMENTAL_FEATURES
+#if defined (BSON_EXPERIMENTAL_FEATURES) && defined (MONGOC_EXPERIMENTAL_FEATURES)
    TestSuite_AddFull (suite, "/Collection/decimal128", test_decimal128, NULL, NULL, skip_unless_server_has_decimal128);
 #endif
    TestSuite_AddLive (suite, "/Collection/update", test_update);


### PR DESCRIPTION
Only change I made from the CR was to remove metadata_append, client_set_appname and client_pool_set_appname from libmongoc.def and libmongoc-ssl.def (so now it's only in the "-experimental" files)