### PR TITLE
CDRIVER-1384: added mongoc_write_concern_append

### DIFF
--- a/build/autotools/versions.ldscript
+++ b/build/autotools/versions.ldscript
@@ -366,4 +366,5 @@ LIBMONGOC_1.4 {
         mongoc_uri_set_read_prefs_t;
         mongoc_uri_set_username;
         mongoc_uri_set_write_concern;
+        mongoc_write_concern_append;
 } LIBMONGOC_1.3;

--- a/build/cmake/libmongoc-ssl.def
+++ b/build/cmake/libmongoc-ssl.def
@@ -328,6 +328,7 @@ mongoc_uri_set_read_prefs_t
 mongoc_uri_set_username
 mongoc_uri_set_write_concern
 mongoc_uri_unescape
+mongoc_write_concern_append
 mongoc_write_concern_copy
 mongoc_write_concern_destroy
 mongoc_write_concern_get_fsync

--- a/build/cmake/libmongoc.def
+++ b/build/cmake/libmongoc.def
@@ -319,6 +319,7 @@ mongoc_uri_set_read_prefs_t
 mongoc_uri_set_username
 mongoc_uri_set_write_concern
 mongoc_uri_unescape
+mongoc_write_concern_append
 mongoc_write_concern_copy
 mongoc_write_concern_destroy
 mongoc_write_concern_get_fsync

--- a/src/libmongoc.symbols
+++ b/src/libmongoc.symbols
@@ -335,6 +335,7 @@ mongoc_uri_set_read_prefs_t
 mongoc_uri_set_username
 mongoc_uri_set_write_concern
 mongoc_uri_unescape
+mongoc_write_concern_append
 mongoc_write_concern_copy
 mongoc_write_concern_destroy
 mongoc_write_concern_get_fsync

--- a/src/mongoc/mongoc-write-concern.c
+++ b/src/mongoc/mongoc-write-concern.c
@@ -519,3 +519,32 @@ _mongoc_parse_wc_err (const bson_t *doc, bson_error_t *error) {
    }
    return false;
 }
+
+
+/**
+ * mongoc_write_concern_append:
+ * @write_concern: (in): A mongoc_write_concern_t.
+ * @command: (out): A pointer to a bson document.
+ *
+ * Appends a write_concern document to a command, to send to
+ * a server.
+ *
+ * Returns true on success, false on failure.
+ *
+ */
+bool
+mongoc_write_concern_append (mongoc_write_concern_t *write_concern,
+                             bson_t                 *command)
+{
+   if (!mongoc_write_concern_is_valid (write_concern)) {
+      MONGOC_ERROR ("Invalid writeConcern passed into "
+                    "mongoc_write_concern_append.");
+      return false;
+   }
+   if (!bson_append_document (command, "writeConcern", 12,
+                              _mongoc_write_concern_get_bson (write_concern))) {
+      MONGOC_ERROR ("Could not append writeConcern to command.");
+      return false;
+   }
+   return true;
+}

--- a/src/mongoc/mongoc-write-concern.h
+++ b/src/mongoc/mongoc-write-concern.h
@@ -63,7 +63,8 @@ void                    mongoc_write_concern_set_wmajority   (mongoc_write_conce
                                                               int32_t                       wtimeout_msec);
 bool                    mongoc_write_concern_is_acknowledged (const mongoc_write_concern_t *write_concern);
 bool                    mongoc_write_concern_is_valid        (const mongoc_write_concern_t *write_concern);
-
+bool                    mongoc_write_concern_append          (mongoc_write_concern_t       *write_concern,
+                                                              bson_t                       *doc);
 
 BSON_END_DECLS
 


### PR DESCRIPTION
Function that helps users append writeConcerns to commands before passing them into generic functions.