### PR TITLE
CDRIVER-1384: add symbol to doc, *experimental.def

### DIFF
--- a/build/cmake/libmongoc-experimental.def
+++ b/build/cmake/libmongoc-experimental.def
@@ -324,6 +324,7 @@ mongoc_uri_set_read_prefs_t
 mongoc_uri_set_username
 mongoc_uri_set_write_concern
 mongoc_uri_unescape
+mongoc_write_concern_append
 mongoc_write_concern_copy
 mongoc_write_concern_destroy
 mongoc_write_concern_get_fsync

--- a/build/cmake/libmongoc-ssl-experimental.def
+++ b/build/cmake/libmongoc-ssl-experimental.def
@@ -332,6 +332,7 @@ mongoc_uri_set_read_prefs_t
 mongoc_uri_set_username
 mongoc_uri_set_write_concern
 mongoc_uri_unescape
+mongoc_write_concern_append
 mongoc_write_concern_copy
 mongoc_write_concern_destroy
 mongoc_write_concern_get_fsync

--- a/doc/mongoc_write_concern_append.page
+++ b/doc/mongoc_write_concern_append.page
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>            
+<page xmlns="http://projectmallard.org/1.0/" 
+      type="topic"                          
+      style="function"                     
+      xmlns:api="http://projectmallard.org/experimental/api/" 
+      xmlns:ui="http://projectmallard.org/experimental/ui/"  
+      id="mongoc_write_concern_append">                     
+  <info>                                                   
+    <link type="guide" xref="mongoc_write_concern_t" group="function"/>
+  </info>                                                             
+  <title>mongoc_write_concern_append()</title>                       
+                                                                    
+  <section id="synopsis">                                          
+    <title>Synopsis</title>                                       
+    <synopsis><code mime="text/x-csrc"><![CDATA[bool
+mongoc_write_concern_append (mongoc_write_concern_t *write_concern,
+                             bson_t                 *command);    
+]]></code></synopsis>                                            
+  </section>                                                    
+                                                               
+                                                              
+  <section id="parameters">                                  
+    <title>Parameters</title>                               
+    <table>                                                
+      <tr><td><p>write_concern</p></td><td><p>A pointer to a <code xref="mongoc_write_concern_t">mongoc_write_concern_t</code>.</p></td></tr>
+      <tr><td><p>command</p></td><td><p>A pointer to a <code xref="bson:bson_t">bson_t</code>.</p></td></tr>
+    </table>                                              
+  </section>                                                           
+                                                                      
+  <section id="description">                                         
+    <title>Description</title>                                      
+    <p>This function appends a valid write concern to a command. It is useful for appending a write concern to a command before passing it to a generic command function like <code xref="mongoc_client_command_simple">mongoc_client_command_simple</code>.</p>
+  </section>                                                  
+                                                             
+  <section id="return">                                     
+    <title>Returns</title>                                 
+    <p>Returns true on success, and false otherwise.</p>
+  </section>                                              
+                                                         
+                                                        
+</page> 


### PR DESCRIPTION
Added mongoc_write_concern_append symbol to build/cmake/*-experimental.def files, and added symbol page to documentation. 