### PR TITLE
fixed handling of other cursor errors in mongoc_collection_find_indexes

### DIFF
--- a/src/mongoc/mongoc-collection.c
+++ b/src/mongoc/mongoc-collection.c
@@ -1209,6 +1209,9 @@ mongoc_collection_find_indexes (mongoc_collection_t *collection,
             error->code = 0;
             error->domain = 0;
             cursor = _mongoc_collection_find_indexes_legacy (collection, error);
+         } else {
+            /* other error, to be handled by caller */
+            cursor = NULL;
          }
       }
    }


### PR DESCRIPTION
previous behavior: function returned freed cursor if an error different from the two hardcoded error cases occurred. caller then ran into a "use-after-free" issue.

new behavior: functions returns a NULL pointer if an error different from the two hardcoded error cases occurred
