### PR TITLE
CDRIVER-1415: enable test for wire version 2+ only

### DIFF
--- a/tests/test-mongoc-collection.c
+++ b/tests/test-mongoc-collection.c
@@ -13,9 +13,8 @@
 #include "mock_server/mock-server.h"
 
 
-#ifdef FIXME_CDRIVER_1415
 static void
-test_aggregate_w_write_concern (void) {
+test_aggregate_w_write_concern (void *context) {
    mongoc_cursor_t *cursor;
    mongoc_client_t *client;
    mongoc_collection_t *collection;
@@ -98,7 +97,6 @@ test_aggregate_w_write_concern (void) {
    mongoc_client_destroy (client);
    bson_free (json);
 }
-#endif
 
 
 static void
@@ -3500,11 +3498,10 @@ test_collection_install (TestSuite *suite)
 {
    test_aggregate_install (suite);
 
-#ifdef FIXME_CDRIVER_1415
-   TestSuite_AddLive (suite, "/Collection/aggregate_w_write_concern",
-                      test_aggregate_w_write_concern);
-#endif
-   TestSuite_AddLive (suite, "/Collection/read_prefs_is_valid", 
+   TestSuite_AddFull (suite, "/Collection/aggregate_w_write_concern",
+                      test_aggregate_w_write_concern, NULL, NULL,
+                      test_framework_skip_if_max_version_version_less_than_2);
+   TestSuite_AddLive (suite, "/Collection/read_prefs_is_valid",
                       test_read_prefs_is_valid);
    TestSuite_AddLive (suite, "/Collection/insert_bulk", test_insert_bulk);
    TestSuite_AddLive (suite,


### PR DESCRIPTION
$out pipeline stage is not supported in other versions