### PR TITLE
CDRIVER-1414: add mongoc_write_concern_t to mongoc_cursor_t

### DIFF
--- a/src/mongoc/mongoc-collection.c
+++ b/src/mongoc/mongoc-collection.c
@@ -428,10 +428,8 @@ mongoc_collection_aggregate_with_write_concern (
    }
 
    if (write_concern &&
-       !_mongoc_write_concern_is_default (write_concern) &&
-       selected_server->max_wire_version >= WIRE_VERSION_CMD_WRITE_CONCERN) {
-      bson_append_document (&command, "writeConcern", 12,
-                            _mongoc_write_concern_get_bson (write_concern));
+       !_mongoc_write_concern_is_default (write_concern)) {
+      cursor->write_concern = mongoc_write_concern_copy (write_concern);
    }
 
    if (use_cursor) {

--- a/src/mongoc/mongoc-cursor-private.h
+++ b/src/mongoc/mongoc-cursor-private.h
@@ -67,6 +67,8 @@ struct _mongoc_cursor_t
    mongoc_read_concern_t     *read_concern;
    mongoc_read_prefs_t       *read_prefs;
 
+   mongoc_write_concern_t    *write_concern;
+
    mongoc_query_flags_t       flags;
    uint32_t                   skip;
    int64_t                    limit;


### PR DESCRIPTION
added writeConcern to cursor, and appended writeConcern to command inside _mongoc_cursor_run_command instead of inside mongoc_collection_aggregate_with_write_concern.