### PR TITLE
CDRIVER-1414: parse writeConcernErrors in command helper

### DIFF
--- a/src/mongoc/mongoc-cursor.c
+++ b/src/mongoc/mongoc-cursor.c
@@ -770,6 +770,18 @@ _mongoc_cursor_run_command (mongoc_cursor_t *cursor,
       reply,
       &cursor->error);
 
+   /* Read and Write Concern Spec: "Drivers SHOULD parse server replies for a
+    * "writeConcernError" field and report the error only in command-specific
+    * helper methods that take a separate write concern parameter or an options
+    * parameter that may contain a write concern option.
+    *
+    * Only command helpers with names like "_with_write_concern" can create
+    * cursors with a non-NULL write_concern field.
+    */
+   if (ret && cursor->write_concern) {
+      ret = !_mongoc_parse_wc_err (reply, &cursor->error);
+   }
+
 done:
    apply_read_prefs_result_cleanup (&read_prefs_result);
    mongoc_server_stream_cleanup (server_stream);

--- a/src/mongoc/mongoc-write-concern.c
+++ b/src/mongoc/mongoc-write-concern.c
@@ -71,6 +71,7 @@ mongoc_write_concern_copy (const mongoc_write_concern_t *write_concern)
       ret->wtimeout = write_concern->wtimeout;
       ret->frozen = false;
       ret->wtag = bson_strdup (write_concern->wtag);
+      ret->is_default = write_concern->is_default;
    }
 
    return ret;

--- a/tests/test-mongoc-collection.c
+++ b/tests/test-mongoc-collection.c
@@ -13,7 +13,6 @@
 #include "mock_server/mock-server.h"
 
 
-#ifdef TODO_CDRIVER_1322
 static void
 test_aggregate_w_write_concern (void *context) {
    mongoc_cursor_t *cursor;
@@ -82,7 +81,9 @@ test_aggregate_w_write_concern (void *context) {
 
       if (wire_version_5) {
          if (test_framework_is_replset ()) { /* replica set */
-            ASSERT_OR_PRINT (!mongoc_cursor_error (cursor, &error), error);
+            ASSERT_OR_PRINT (mongoc_cursor_error (cursor, &error), error);
+            ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_WRITE_CONCERN,
+                                   100, "Write Concern error:");
          } else { /* standalone */
             ASSERT_CMPINT (cursor->error.domain, ==, MONGOC_ERROR_SERVER);
             ASSERT_CMPINT (cursor->error.code, ==, 2);
@@ -99,7 +100,6 @@ test_aggregate_w_write_concern (void *context) {
    mongoc_client_destroy (client);
    bson_free (json);
 }
-#endif  /* TODO_CDRIVER_1322 */
 
 
 static void
@@ -3554,11 +3554,9 @@ test_collection_install (TestSuite *suite)
 {
    test_aggregate_install (suite);
 
-#ifdef TODO_CDRIVER_1322
    TestSuite_AddFull (suite, "/Collection/aggregate/write_concern",
                       test_aggregate_w_write_concern, NULL, NULL,
                       test_framework_skip_if_max_version_version_less_than_2);
-#endif
    TestSuite_AddLive (suite, "/Collection/read_prefs_is_valid",
                       test_read_prefs_is_valid);
    TestSuite_AddLive (suite, "/Collection/insert_bulk", test_insert_bulk);


### PR DESCRIPTION
add is_default in mongoc_write_concern_copy. if there is a writeConcernError parse it out and return false