### PR TITLE
CDRIVER-1639 seeds rand for use in selecting servers

### DIFF
--- a/src/mongoc/mongoc-topology-description.c
+++ b/src/mongoc/mongoc-topology-description.c
@@ -56,6 +56,8 @@ mongoc_topology_description_init (mongoc_topology_description_t      *descriptio
                         type == MONGOC_TOPOLOGY_SINGLE ||
                         type == MONGOC_TOPOLOGY_RS_NO_PRIMARY);
 
+   srand(time(0));
+
    memset (description, 0, sizeof (*description));
 
    bson_oid_init (&description->topology_id, NULL);


### PR DESCRIPTION
As per https://jira.mongodb.org/browse/CDRIVER-1639:

The call to rand() used when selecting a server is unseeded (https://github.com/mongodb/mongo-c-driver/blob/a4bcfffa9c7ffa2e541a3351ec26cfad417cbdcf/src/mongoc/mongoc-topology-description.c#L693)

This tends to manifest itself as uneven balancing between nodes in a cluster.

As a specific example: when libmongoc is used as part of, say, the php-driver:

1. A sudden increase in traffic creates new children (e.g. Apache workers)
2. The new workers create new connections to mongo using the php-driver, and therefore libmongoc
3. All workers initially choose the same server from the cluster as the first value from rand() is always the same
4. One mongo node takes the vast majority of the queries - possibly causing it to become overloaded while other nodes in the cluster receive little traffic