### PR TITLE
CDRIVER-1347 Add missing BSON_API specifier to mongoc_log_set_handler

### DIFF
--- a/src/mongoc/mongoc-log.h
+++ b/src/mongoc/mongoc-log.h
@@ -76,6 +76,7 @@ typedef void (*mongoc_log_func_t) (mongoc_log_level_t  log_level,
  *
  * Sets the function to be called to handle logging.
  */
+BSON_API
 void mongoc_log_set_handler (mongoc_log_func_t  log_func,
                              void              *user_data);
 


### PR DESCRIPTION
Patch signed off by @bjori in Rietveld; merge at will.  Thanks!