### PR TITLE
no braces in debian install script

### DIFF
--- a/debian/libmongoc-dev.install
+++ b/debian/libmongoc-dev.install
@@ -1,4 +1,6 @@
-usr/include/*/*.{h,def,defs}
+usr/include/*/*.h
+usr/include/*/*.def
+usr/include/*/*.defs
 usr/lib/*/libmongoc-[0-9]*.so
 usr/lib/*/pkgconfig/libmongoc-[0-9]*
 usr/lib/*/pkgconfig/libmongoc-ssl-[0-9]*


### PR DESCRIPTION
Resolves lintian warning brace-expansion-in-debhelper-config-file, "This
debhelper config file appears to use shell brace expansion. This happens
to work due to an accident of implementation but is not a supported
feature."