### PR TITLE
CDRIVER-1921 cursor from static reply

### DIFF
--- a/src/mongoc/mongoc-cursor-cursorid.c
+++ b/src/mongoc/mongoc-cursor-cursorid.c
@@ -373,7 +373,7 @@ _mongoc_cursor_cursorid_init_with_reply (mongoc_cursor_t *cursor,
    BSON_ASSERT (cid);
 
    bson_destroy (&cid->array);
-   bson_steal (&cid->array, reply);
+   bson_steal (&cid->array, reply) || bson_steal(&cid->array, bson_copy(reply));
 
    if (!_mongoc_cursor_cursorid_start_batch (cursor)) {
       bson_set_error (&cursor->error,


### PR DESCRIPTION
Prior to this commit, mongoc_cursor_new_from_command_reply fails if the
reply is read-only.  This commit makes a copy of static bson_t instead of
failing.
