### PR TITLE
fix UBSAN problem

### DIFF
--- a/src/mongoc/mongoc-set.c
+++ b/src/mongoc/mongoc-set.c
@@ -167,6 +167,10 @@ mongoc_set_for_each (mongoc_set_t            *set,
 
    items_len = set->items_len;
 
+   // prevent undefined behavior of memcpy(NULL)
+   if(items_len == 0)
+    return;
+
    old_set = (mongoc_set_item_t *)bson_malloc (sizeof (*old_set) * items_len);
    memcpy (old_set, set->items, sizeof (*old_set) * items_len);
 


### PR DESCRIPTION
If `items_len == 0` then `malloc(items_len) == NULL` which results in `memcpy(NULL, ...)` which is undefined behaviour.