### PR TITLE
hp-ux port

### DIFF
--- a/src/mongoc/mongoc-client.c
+++ b/src/mongoc/mongoc-client.c
@@ -151,7 +151,7 @@ mongoc_client_connect_tcp (const mongoc_uri_t       *uri,
       expire_at = bson_get_monotonic_time () + (connecttimeoutms * 1000L);
       if (0 != mongoc_socket_connect (sock,
                                       rp->ai_addr,
-                                      (socklen_t)rp->ai_addrlen,
+                                      (mongoc_socklen_t)rp->ai_addrlen,
                                       expire_at)) {
          char *errmsg;
          char errmsg_buf[BSON_ERROR_BUFFER_SIZE];

--- a/src/mongoc/mongoc-counters-private.h
+++ b/src/mongoc/mongoc-counters-private.h
@@ -35,6 +35,9 @@
 # include <sys/param.h>
 #endif
 
+#ifdef __hpux__
+#include <sys/pstat.h>
+#endif
 
 BSON_BEGIN_DECLS
 
@@ -48,6 +51,13 @@ _mongoc_get_cpu_count (void)
 {
 #if defined(__linux__)
    return get_nprocs ();
+#elif defined(__hpux__)
+  struct pst_dynamic psd;
+  if (pstat_getdynamic (&psd, sizeof (psd), (size_t) 1, 0) != -1) {
+     return psd.psd_max_proc_cnt;
+  }
+
+  return 1;
 #elif defined(__FreeBSD__) || \
       defined(__NetBSD__) || \
       defined(__DragonFly__) || \

--- a/src/mongoc/mongoc-cursor-private.h
+++ b/src/mongoc/mongoc-cursor-private.h
@@ -46,13 +46,7 @@ struct _mongoc_cursor_interface_t
    void             (*get_host) (mongoc_cursor_t        *cursor,
                                  mongoc_host_list_t     *host);
 };
-#ifdef MIN
-#undef MIN
-#endif
 
-#ifdef MAX
-#undef MAX
-#endif
 #define ALLOW_PARTIAL_RESULTS "allowPartialResults"
 #define ALLOW_PARTIAL_RESULTS_LEN 19
 #define AWAIT_DATA "awaitData"
@@ -73,16 +67,16 @@ struct _mongoc_cursor_interface_t
 #define HINT_LEN 4
 #define LIMIT "limit"
 #define LIMIT_LEN 5
-#define MAX "max"
-#define MAX_LEN 3
+#define MAX_STRING "max"
+#define MAX_STRING_LEN 3
 #define MAX_AWAIT_TIME_MS "maxAwaitTimeMS"
 #define MAX_AWAIT_TIME_MS_LEN 14
 #define MAX_SCAN "maxScan"
 #define MAX_SCAN_LEN 7
 #define MAX_TIME_MS "maxTimeMS"
 #define MAX_TIME_MS_LEN 9
-#define MIN "min"
-#define MIN_LEN 3
+#define MIN_STRING "min"
+#define MIN_STRING_LEN 3
 #define NO_CURSOR_TIMEOUT "noCursorTimeout"
 #define NO_CURSOR_TIMEOUT_LEN 15
 #define OPLOG_REPLAY "oplogReplay"

--- a/src/mongoc/mongoc-cursor-private.h
+++ b/src/mongoc/mongoc-cursor-private.h
@@ -46,7 +46,13 @@ struct _mongoc_cursor_interface_t
    void             (*get_host) (mongoc_cursor_t        *cursor,
                                  mongoc_host_list_t     *host);
 };
+#ifdef MIN
+#undef MIN
+#endif
 
+#ifdef MAX
+#undef MAX
+#endif
 #define ALLOW_PARTIAL_RESULTS "allowPartialResults"
 #define ALLOW_PARTIAL_RESULTS_LEN 19
 #define AWAIT_DATA "awaitData"

--- a/src/mongoc/mongoc-cursor.c
+++ b/src/mongoc/mongoc-cursor.c
@@ -1013,7 +1013,7 @@ _mongoc_cursor_parse_opts_for_op_query (mongoc_cursor_t        *cursor,
          } else {
             OPT_ERR ("Wrong type for 'hint' field in 'opts'.");
          }
-      } else if (!strcmp (key, MAX)) {
+      } else if (!strcmp (key, MAX_STRING)) {
          PUSH_DOLLAR_QUERY ();
          OPT_SUBDOCUMENT (max, max);
       } else if (!strcmp (key, MAX_SCAN)) {
@@ -1024,7 +1024,7 @@ _mongoc_cursor_parse_opts_for_op_query (mongoc_cursor_t        *cursor,
          OPT_CHECK_INT ();
          PUSH_DOLLAR_QUERY ();
          BSON_APPEND_INT64 (query, "$maxTimeMS", bson_iter_as_int64 (&iter));
-      } else if (!strcmp (key, MIN)) {
+      } else if (!strcmp (key, MIN_STRING)) {
          PUSH_DOLLAR_QUERY ();
          OPT_SUBDOCUMENT (min, min);
       } else if (!strcmp (key, READ_CONCERN)) {
@@ -1351,12 +1351,12 @@ _translate_query_opt (const char *query_field,
    } else if (!strcmp (MAX_TIME_MS, query_field)) {
       *cmd_field = MAX_TIME_MS;
       *len = MAX_TIME_MS_LEN;
-   } else if (!strcmp (MAX, query_field)) {
-      *cmd_field = MAX;
-      *len = MAX_LEN;
-   } else if (!strcmp (MIN, query_field)) {
-      *cmd_field = MIN;
-      *len = MIN_LEN;
+   } else if (!strcmp (MAX_STRING, query_field)) {
+      *cmd_field = MAX_STRING;
+      *len = MAX_STRING_LEN;
+   } else if (!strcmp (MIN_STRING, query_field)) {
+      *cmd_field = MIN_STRING;
+      *len = MIN_STRING_LEN;
    } else if (!strcmp (RETURN_KEY, query_field)) {
       *cmd_field = RETURN_KEY;
       *len = RETURN_KEY_LEN;

--- a/src/mongoc/mongoc-socket.c
+++ b/src/mongoc/mongoc-socket.c
@@ -333,7 +333,7 @@ _mongoc_socket_capture_errno (mongoc_socket_t *sock) /* IN */
 #else
    sock->errno_ = errno;
 #endif
-   TRACE("setting errno: %d", sock->errno_);
+   TRACE("setting errno: %d %s", sock->errno_, strerror(sock->errno_));
 }
 
 
@@ -412,7 +412,7 @@ mongoc_socket_accept_ex (mongoc_socket_t *sock,      /* IN */
 {
    mongoc_socket_t *client;
    struct sockaddr_in addr = { 0 };
-   socklen_t addrlen = sizeof addr;
+   mongoc_socklen_t addrlen = sizeof addr;
    bool try_again = false;
    bool failed = false;
 #ifdef _WIN32
@@ -487,7 +487,7 @@ again:
 int
 mongoc_socket_bind (mongoc_socket_t       *sock,    /* IN */
                     const struct sockaddr *addr,    /* IN */
-                    socklen_t              addrlen) /* IN */
+                    mongoc_socklen_t       addrlen) /* IN */
 {
    int ret;
 
@@ -578,14 +578,14 @@ mongoc_socket_close (mongoc_socket_t *sock) /* IN */
 int
 mongoc_socket_connect (mongoc_socket_t       *sock,      /* IN */
                        const struct sockaddr *addr,      /* IN */
-                       socklen_t              addrlen,   /* IN */
+                       mongoc_socklen_t       addrlen,   /* IN */
                        int64_t                expire_at) /* IN */
 {
    bool try_again = false;
    bool failed = false;
    int ret;
    int optval;
-   socklen_t optlen = sizeof optval;
+   mongoc_socklen_t optlen = sizeof optval;
 
    ENTRY;
 
@@ -844,11 +844,11 @@ again:
  */
 
 int
-mongoc_socket_setsockopt (mongoc_socket_t *sock,    /* IN */
-                          int              level,   /* IN */
-                          int              optname, /* IN */
-                          const void      *optval,  /* IN */
-                          socklen_t        optlen)  /* IN */
+mongoc_socket_setsockopt (mongoc_socket_t  *sock,    /* IN */
+                          int               level,   /* IN */
+                          int               optname, /* IN */
+                          const void       *optval,  /* IN */
+                          mongoc_socklen_t  optlen)  /* IN */
 {
    int ret;
 
@@ -1167,9 +1167,9 @@ CLEANUP:
 
 
 int
-mongoc_socket_getsockname (mongoc_socket_t *sock,    /* IN */
-                           struct sockaddr *addr,    /* OUT */
-                           socklen_t       *addrlen) /* INOUT */
+mongoc_socket_getsockname (mongoc_socket_t  *sock,    /* IN */
+                           struct sockaddr  *addr,    /* OUT */
+                           mongoc_socklen_t *addrlen) /* INOUT */
 {
    int ret;
 
@@ -1189,7 +1189,7 @@ char *
 mongoc_socket_getnameinfo (mongoc_socket_t *sock) /* IN */
 {
    struct sockaddr addr;
-   socklen_t len = sizeof addr;
+   mongoc_socklen_t len = sizeof addr;
    char *ret;
    char host [BSON_HOST_NAME_MAX + 1];
 

--- a/src/mongoc/mongoc-socket.h
+++ b/src/mongoc/mongoc-socket.h
@@ -38,6 +38,12 @@
 # include <sys/un.h>
 #endif
 
+#ifdef __hpux__
+typedef int       mongoc_socklen_t;
+#else
+typedef socklen_t mongoc_socklen_t;
+#endif
+
 #include "mongoc-iovec.h"
 
 
@@ -59,13 +65,13 @@ mongoc_socket_t *mongoc_socket_accept     (mongoc_socket_t       *sock,
 BSON_API
 int              mongoc_socket_bind       (mongoc_socket_t       *sock,
                                            const struct sockaddr *addr,
-                                           socklen_t              addrlen);
+                                           mongoc_socklen_t       addrlen);
 BSON_API
 int              mongoc_socket_close      (mongoc_socket_t       *socket);
 BSON_API
 int              mongoc_socket_connect    (mongoc_socket_t       *sock,
                                            const struct sockaddr *addr,
-                                           socklen_t              addrlen,
+                                           mongoc_socklen_t       addrlen,
                                            int64_t                expire_at);
 BSON_API
 char            *mongoc_socket_getnameinfo(mongoc_socket_t       *sock);
@@ -76,7 +82,7 @@ int              mongoc_socket_errno      (mongoc_socket_t       *sock);
 BSON_API
 int              mongoc_socket_getsockname(mongoc_socket_t       *sock,
                                            struct sockaddr       *addr,
-                                           socklen_t             *addrlen);
+                                           mongoc_socklen_t      *addrlen);
 BSON_API
 int              mongoc_socket_listen     (mongoc_socket_t       *sock,
                                            unsigned int           backlog);
@@ -95,7 +101,7 @@ int              mongoc_socket_setsockopt (mongoc_socket_t       *sock,
                                            int                    level,
                                            int                    optname,
                                            const void            *optval,
-                                           socklen_t              optlen);
+                                           mongoc_socklen_t       optlen);
 BSON_API
 ssize_t          mongoc_socket_send       (mongoc_socket_t       *sock,
                                            const void            *buf,

--- a/src/mongoc/mongoc-stream-socket.c
+++ b/src/mongoc/mongoc-stream-socket.c
@@ -95,11 +95,11 @@ _mongoc_stream_socket_failed (mongoc_stream_t *stream)
 
 
 static int
-_mongoc_stream_socket_setsockopt (mongoc_stream_t *stream,
-                                  int              level,
-                                  int              optname,
-                                  void            *optval,
-                                  socklen_t        optlen)
+_mongoc_stream_socket_setsockopt (mongoc_stream_t   *stream,
+                                  int                level,
+                                  int                optname,
+                                  void              *optval,
+                                  mongoc_socklen_t   optlen)
 {
    mongoc_stream_socket_t *ss = (mongoc_stream_socket_t *)stream;
    int ret;

--- a/src/mongoc/mongoc-stream-tls-libressl.c
+++ b/src/mongoc/mongoc-stream-tls-libressl.c
@@ -356,11 +356,11 @@ _mongoc_stream_tls_libressl_readv (mongoc_stream_t *stream,
 }
 
 static int
-_mongoc_stream_tls_libressl_setsockopt (mongoc_stream_t *stream,
-                                        int              level,
-                                        int              optname,
-                                        void            *optval,
-                                        socklen_t        optlen)
+_mongoc_stream_tls_libressl_setsockopt (mongoc_stream_t  *stream,
+                                        int               level,
+                                        int               optname,
+                                        void             *optval,
+                                        mongoc_socklen_t  optlen)
 {
    mongoc_stream_tls_t *tls = (mongoc_stream_tls_t *)stream;
    mongoc_stream_tls_libressl_t *libressl = (mongoc_stream_tls_libressl_t *) tls->ctx;

--- a/src/mongoc/mongoc-stream-tls-openssl.c
+++ b/src/mongoc/mongoc-stream-tls-openssl.c
@@ -491,11 +491,11 @@ _mongoc_stream_tls_openssl_readv (mongoc_stream_t *stream,
  */
 
 static int
-_mongoc_stream_tls_openssl_setsockopt (mongoc_stream_t *stream,
-                                       int              level,
-                                       int              optname,
-                                       void            *optval,
-                                       socklen_t        optlen)
+_mongoc_stream_tls_openssl_setsockopt (mongoc_stream_t  *stream,
+                                       int               level,
+                                       int               optname,
+                                       void             *optval,
+                                       mongoc_socklen_t  optlen)
 {
    mongoc_stream_tls_t *tls = (mongoc_stream_tls_t *)stream;
 

--- a/src/mongoc/mongoc-stream-tls-secure-channel.c
+++ b/src/mongoc/mongoc-stream-tls-secure-channel.c
@@ -801,11 +801,11 @@ _mongoc_stream_tls_secure_channel_readv (mongoc_stream_t *stream,
 }
 
 static int
-_mongoc_stream_tls_secure_channel_setsockopt (mongoc_stream_t *stream,
-                                              int              level,
-                                              int              optname,
-                                              void            *optval,
-                                              socklen_t        optlen)
+_mongoc_stream_tls_secure_channel_setsockopt (mongoc_stream_t  *stream,
+                                              int               level,
+                                              int               optname,
+                                              void             *optval,
+                                              mongoc_socklen_t  optlen)
 {
    mongoc_stream_tls_t *tls = (mongoc_stream_tls_t *)stream;
    mongoc_stream_tls_secure_channel_t *secure_channel = (mongoc_stream_tls_secure_channel_t *)tls->ctx;

--- a/src/mongoc/mongoc-stream-tls-secure-transport.c
+++ b/src/mongoc/mongoc-stream-tls-secure-transport.c
@@ -346,11 +346,11 @@ _mongoc_stream_tls_secure_transport_readv (mongoc_stream_t *stream,
 }
 
 static int
-_mongoc_stream_tls_secure_transport_setsockopt (mongoc_stream_t *stream,
-                                                int              level,
-                                                int              optname,
-                                                void            *optval,
-                                                socklen_t        optlen)
+_mongoc_stream_tls_secure_transport_setsockopt (mongoc_stream_t  *stream,
+                                                int               level,
+                                                int               optname,
+                                                void             *optval,
+                                                mongoc_socklen_t  optlen)
 {
    mongoc_stream_tls_t *tls = (mongoc_stream_tls_t *)stream;
    mongoc_stream_tls_secure_transport_t *secure_transport = (mongoc_stream_tls_secure_transport_t *) tls->ctx;

--- a/src/mongoc/mongoc-stream.c
+++ b/src/mongoc/mongoc-stream.c
@@ -286,7 +286,7 @@ mongoc_stream_setsockopt (mongoc_stream_t *stream,
                           int              level,
                           int              optname,
                           void            *optval,
-                          socklen_t        optlen)
+                          mongoc_socklen_t        optlen)
 {
    BSON_ASSERT (stream);
 

--- a/src/mongoc/mongoc-stream.h
+++ b/src/mongoc/mongoc-stream.h
@@ -55,7 +55,7 @@ struct _mongoc_stream_t
                                         int              level,
                                         int              optname,
                                         void            *optval,
-                                        socklen_t        optlen);
+                                        mongoc_socklen_t        optlen);
    mongoc_stream_t *(*get_base_stream) (mongoc_stream_t *stream);
    bool             (*check_closed)    (mongoc_stream_t *stream);
    ssize_t          (*poll)            (mongoc_stream_poll_t *streams,
@@ -105,7 +105,7 @@ int              mongoc_stream_setsockopt      (mongoc_stream_t       *stream,
                                                 int                    level,
                                                 int                    optname,
                                                 void                  *optval,
-                                                socklen_t              optlen);
+                                                mongoc_socklen_t              optlen);
 BSON_API
 bool             mongoc_stream_check_closed    (mongoc_stream_t       *stream);
 BSON_API

--- a/src/mongoc/mongoc-topology-scanner.c
+++ b/src/mongoc/mongoc-topology-scanner.c
@@ -467,7 +467,7 @@ mongoc_topology_scanner_node_connect_tcp (mongoc_topology_scanner_node_t *node,
          continue;
       }
 
-      mongoc_socket_connect (sock, rp->ai_addr, (socklen_t)rp->ai_addrlen, 0);
+      mongoc_socket_connect (sock, rp->ai_addr, (mongoc_socklen_t)rp->ai_addrlen, 0);
 
       break;
    }

--- a/tests/TestSuite.c
+++ b/tests/TestSuite.c
@@ -152,6 +152,10 @@ _Clock_GetMonotonic (struct timespec *ts) /* OUT */
 
    /* milliseconds -> microseconds -> nanoseconds*/
    ts->tv_nsec = (ticks % 1000) * 1000 * 1000;
+#elif defined(__hpux__)
+   int64_t usec = gethrtime();
+   ts->tv_sec = (int64_t)(usec / 1e9);
+   ts->tv_nsec = (int32_t)(usec - (double) ts->tv_sec * 1e9);
 #else
 # warning "Monotonic clock is not yet supported on your platform."
 #endif

--- a/tests/debug-stream.c
+++ b/tests/debug-stream.c
@@ -69,7 +69,7 @@ _mongoc_stream_debug_setsockopt (mongoc_stream_t *stream,
                                  int              level,
                                  int              optname,
                                  void            *optval,
-                                 socklen_t        optlen)
+                                 mongoc_socklen_t        optlen)
 {
    return mongoc_stream_setsockopt (((mongoc_stream_debug_t *) stream)->wrapped,
                                     level,

--- a/tests/mock_server/mock-server.c
+++ b/tests/mock_server/mock-server.c
@@ -1429,7 +1429,7 @@ static uint16_t
 get_port (mongoc_socket_t *sock)
 {
    struct sockaddr_in bound_addr = { 0 };
-   socklen_t addr_len = (socklen_t) sizeof bound_addr;
+   mongoc_socklen_t addr_len = (mongoc_socklen_t) sizeof bound_addr;
 
    if (mongoc_socket_getsockname (sock,
                                   (struct sockaddr *) &bound_addr,

--- a/tests/ssl-test.c
+++ b/tests/ssl-test.c
@@ -39,7 +39,7 @@ ssl_test_server (void * ptr)
    mongoc_stream_t *ssl_stream;
    mongoc_socket_t *listen_sock;
    mongoc_socket_t *conn_sock;
-   socklen_t sock_len;
+   mongoc_socklen_t sock_len;
    char buf[4 * NUM_IOVECS];
    ssize_t r;
    bson_error_t error;

--- a/tests/test-mongoc-socket.c
+++ b/tests/test-mongoc-socket.c
@@ -36,7 +36,7 @@ socket_test_server (void *data_)
    mongoc_socket_t *conn_sock;
    mongoc_stream_t *stream;
    mongoc_iovec_t iov;
-   socklen_t sock_len;
+   mongoc_socklen_t sock_len;
    ssize_t r;
    char buf[5];
 
@@ -167,7 +167,7 @@ sendv_test_server (void *data_)
    mongoc_socket_t *conn_sock;
    mongoc_stream_t *stream;
    mongoc_iovec_t iov;
-   socklen_t sock_len;
+   mongoc_socklen_t sock_len;
    int amount = 0;
    ssize_t r;
    char *buf = (char *)bson_malloc (gFourMB);

--- a/tests/test-mongoc-stream-tls-error.c
+++ b/tests/test-mongoc-stream-tls-error.c
@@ -31,7 +31,7 @@ ssl_error_server (void *ptr)
    mongoc_stream_t *ssl_stream;
    mongoc_socket_t *listen_sock;
    mongoc_socket_t *conn_sock;
-   socklen_t sock_len;
+   mongoc_socklen_t sock_len;
    char buf;
    ssize_t r;
    mongoc_iovec_t iov;


### PR DESCRIPTION
Hello!

Following patch allows  the mongo-c driver to work on HP-UX 11.31 ia64 platform.
Note: to work, with this patch, we need a patch to libbson, that PR-ed just now (https://github.com/mongodb/libbson/pull/179). 

To compile on HPUX we need: 

- gcc-4.8.5
- pass -D_REENTRANT -D_INCLUDE_HPUX_SOURCE to CFLAGS
- pass -mlp64 to CFLAGS and LDFLAGS for 64bit version

configure opts: --enable-shm-counters=no -sinse it not ported yet
