### PR TITLE
CDRIVER-1946 SEGFAULT with fast performance counters on NUMA

### DIFF
--- a/src/mongoc/mongoc-counters-private.h
+++ b/src/mongoc/mongoc-counters-private.h
@@ -89,9 +89,12 @@ _mongoc_get_cpu_count (void)
  static BSON_INLINE unsigned
  _mongoc_sched_getcpu (void)
  {
-    volatile uint32_t rax, rdx, aux;
-    __asm__ volatile ("rdtscp\n" : "=a" (rax), "=d" (rdx), "=c" (aux) : : );
-    return aux;
+    volatile uint32_t rax, rdx, rcx;
+    __asm__ volatile ("rdtscp\n" : "=a" (rax), "=d" (rdx), "=c" (rcx) : : );
+    unsigned node_id, core_id;
+    // node_id = (rcx & 0xFFF000)>>12;  // node_id is unused
+    core_id = rcx & 0xFFF;
+    return core_id;
  }
 #elif defined(HAVE_SCHED_GETCPU)
 # define _mongoc_sched_getcpu sched_getcpu


### PR DESCRIPTION
When using the `RDTSCP` instruction, the register `rcx` contains the value of the low-order 32-bits of `IA32_TSC_AUX MSR`, which is loaded for each processor by the Linux kernel to contain the processor number in the `11:0` bits and the node number in the `31:12` bits. So for machines with only one node, or when the process is running on the 0th node, the previous implementation of the code worked. However, when the node ID is not 0, the code would return the entire result of register `rcx`, which could be an invalid number because it would be a combination of the core number plus and number. E.g., on a machine with 2 nodes, if the thread is running on CPU core 61 located on node 1, the previous implementation would return a value of 4157 (61 + 4096), where 4096 comes from the 12th bit of `rcx`. In this case, SEGFAULT occurs due to using the result of `_mongoc_sched_getcpu()` as an index into `__mongoc_counter_##ident.cpus[_mongoc_sched_getcpu()]`.