### PR TITLE
Fixing gridfs_file_set_xxx wouldn’t export to module map.

### DIFF
--- a/src/mongoc/mongoc-gridfs-file.h
+++ b/src/mongoc/mongoc-gridfs-file.h
@@ -31,6 +31,7 @@ BSON_BEGIN_DECLS
 #define MONGOC_GRIDFS_FILE_STR_HEADER(name)                                \
    BSON_API                                                                \
    const char *mongoc_gridfs_file_get_##name (mongoc_gridfs_file_t *file); \
+   BSON_API                                                                \
    void mongoc_gridfs_file_set_##name (mongoc_gridfs_file_t *file,         \
                                        const char *str);
 
@@ -38,6 +39,7 @@ BSON_BEGIN_DECLS
 #define MONGOC_GRIDFS_FILE_BSON_HEADER(name)                                 \
    BSON_API                                                                  \
    const bson_t *mongoc_gridfs_file_get_##name (mongoc_gridfs_file_t *file); \
+   BSON_API                                                                  \
    void mongoc_gridfs_file_set_##name (mongoc_gridfs_file_t *file,           \
                                        const bson_t *bson);
 


### PR DESCRIPTION
When using clang to export modules, functions set of
mongo_gridfs_file_set_xxx couldn’t export to destination simply because
only the getting methods were marked with BSON_API. Typical scenario is
a third party exporting, such as c library exporting for Swift
language.
Script test-libmongoc, which includes GridFS, passed.
This issue was found by Kyle Jessup and Rockford Wei,
perfect.org