### PR TITLE
Support for ipv6-only hostnames

### DIFF
--- a/src/mongoc/mongoc-uri.c
+++ b/src/mongoc/mongoc-uri.c
@@ -104,7 +104,7 @@ mongoc_uri_append_host (mongoc_uri_t *uri, const char *host, uint16_t port)
                      "%s:%hu",
                      host,
                      port);
-      link_->family = strstr (host, ".sock") ? AF_UNIX : AF_INET;
+      link_->family = strstr (host, ".sock") ? AF_UNIX : AF_UNSPEC;
    }
    link_->host_and_port[sizeof link_->host_and_port - 1] = '\0';
    link_->port = port;


### PR DESCRIPTION
For cases when connection endpoint specified as hostname with ipv6
address only.

We have got this problem when tried to use PHP mongodb driver https://github.com/mongodb/mongo-php-driver with PHP 7. Our mongodb servers have ipv6 addresses only, so we can't rely on AF_INET.