### PR TITLE
Skip over documents that are too large to upload to MongoDB

### DIFF
--- a/src/mongoc/mongoc-write-command.c
+++ b/src/mongoc/mongoc-write-command.c
@@ -1375,6 +1375,11 @@ again:
       too_large_error (error, i, len, max_bson_obj_size, NULL);
       result->failed = true;
       ret = false;
+
+      /* The current document is too large for MongoDB.  Continue to the next. */
+      if (!bson_iter_next (&iter)) {
+         GOTO (cleanup);
+      }
    } else {
       ret = mongoc_cluster_run_command_monitored (&client->cluster,
                                                   server_stream,
@@ -1405,6 +1410,7 @@ again:
       GOTO (again);
    }
 
+cleanup:
    bson_destroy (&cmd);
    EXIT;
 }


### PR DESCRIPTION
I discovered, when working with some code written on top of mongo-cxx, that, if I attempted to upload a document that was larger than 16mb, the driver would go into an infinite loop and hang.

The infinite loop occurs in the function that I've edited with this patch, in the underlying mongo-c driver.  The driver detects that the document is too long.  It looks to me like the intent of the driver is to flag an error for that document and continue to the next.  It does flag the error; it does not continue to the next.  So it just spins forever, repeatedly failing to send the too-large document.

I imagine this wants a unit test.  I have a local test, but it uses mongo-cxx and bson-cxx because I'm not very familiar with the C API, so it would be hard to include it in your test suite...  I figured I ought to at least post this code, though.