### PR TITLE
Fix LibreSSL build issue

### DIFF
--- a/src/mongoc/mongoc-stream-tls-openssl.c
+++ b/src/mongoc/mongoc-stream-tls-openssl.c
@@ -651,7 +651,7 @@ mongoc_stream_tls_openssl_new (mongoc_stream_t *base_stream,
       RETURN (NULL);
    }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)
    if (!opt->allow_invalid_hostname) {
       struct in_addr addr;
       X509_VERIFY_PARAM *param = X509_VERIFY_PARAM_new ();


### PR DESCRIPTION
LibreSSL forked from 1.0.1f, this 1.0.2 method is unavailable

In the tree I also see separate sources for LibreSSL but apparently these aren't used. Detection of LibreSSL not going well in configure?