### PR TITLE
CDRIVER-2072: Always initialize cursor filter and opts

### DIFF
--- a/src/mongoc/mongoc-cursor.c
+++ b/src/mongoc/mongoc-cursor.c
@@ -229,6 +229,9 @@ _mongoc_cursor_new_with_opts (mongoc_client_t *client,
    cursor->client = client;
    cursor->is_command = is_command ? 1 : 0;
 
+   bson_init (&cursor->filter);
+   bson_init (&cursor->opts);
+
    if (filter) {
       if (!bson_validate (filter, BSON_VALIDATE_EMPTY_KEYS, NULL)) {
          MARK_FAILED (cursor);
@@ -239,9 +242,8 @@ _mongoc_cursor_new_with_opts (mongoc_client_t *client,
          GOTO (finish);
       }
 
+      bson_destroy (&cursor->filter);
       bson_copy_to (filter, &cursor->filter);
-   } else {
-      bson_init (&cursor->filter);
    }
 
    if (opts) {
@@ -263,7 +265,6 @@ _mongoc_cursor_new_with_opts (mongoc_client_t *client,
          GOTO (finish);
       }
 
-      bson_init (&cursor->opts);
       bson_copy_to_excluding_noinit (opts, &cursor->opts, "serverId", NULL);
 
       /* true if there's a valid serverId or no serverId, false on err */
@@ -279,8 +280,6 @@ _mongoc_cursor_new_with_opts (mongoc_client_t *client,
       if (server_id) {
          mongoc_cursor_set_hint (cursor, server_id);
       }
-   } else {
-      bson_init (&cursor->opts);
    }
 
    cursor->read_prefs = read_prefs

--- a/tests/test-mongoc-cursor.c
+++ b/tests/test-mongoc-cursor.c
@@ -733,6 +733,74 @@ test_cursor_new_invalid (void)
    mongoc_client_destroy (client);
 }
 
+
+static void
+test_cursor_new_invalid_filter (void)
+{
+   mongoc_client_t *client;
+   mongoc_collection_t *collection;
+   mongoc_cursor_t *cursor;
+   bson_error_t error;
+
+   client = test_framework_client_new ();
+   collection = mongoc_client_get_collection (client, "test", "test");
+
+   cursor = mongoc_collection_find_with_opts (
+      collection, tmp_bson ("{'': 1}"), NULL, NULL);
+
+   ASSERT (cursor);
+   ASSERT (mongoc_cursor_error (cursor, &error));
+   ASSERT_ERROR_CONTAINS (error,
+                          MONGOC_ERROR_CURSOR,
+                          MONGOC_ERROR_CURSOR_INVALID_CURSOR,
+                          "Empty keys are not allowed in 'filter'.");
+
+   mongoc_cursor_destroy (cursor);
+   mongoc_collection_destroy (collection);
+   mongoc_client_destroy (client);
+}
+
+
+static void
+test_cursor_new_invalid_opts (void)
+{
+   mongoc_client_t *client;
+   mongoc_collection_t *collection;
+   mongoc_cursor_t *cursor;
+   bson_error_t error;
+
+   client = test_framework_client_new ();
+   collection = mongoc_client_get_collection (client, "test", "test");
+
+   cursor = mongoc_collection_find_with_opts (
+      collection, tmp_bson (NULL), tmp_bson ("{'projection': {'': 1}}"), NULL);
+
+   ASSERT (cursor);
+   ASSERT (mongoc_cursor_error (cursor, &error));
+   ASSERT_ERROR_CONTAINS (error,
+                          MONGOC_ERROR_CURSOR,
+                          MONGOC_ERROR_CURSOR_INVALID_CURSOR,
+                          "Cannot use empty keys in 'opts'.");
+
+   mongoc_cursor_destroy (cursor);
+
+   cursor = mongoc_collection_find_with_opts (
+      collection, tmp_bson (NULL), tmp_bson ("{'$invalid': 1}"), NULL);
+
+   ASSERT (cursor);
+   ASSERT (mongoc_cursor_error (cursor, &error));
+   ASSERT_ERROR_CONTAINS (error,
+                          MONGOC_ERROR_CURSOR,
+                          MONGOC_ERROR_CURSOR_INVALID_CURSOR,
+                          "Cannot use $-modifiers in 'opts'.");
+
+   mongoc_cursor_destroy (cursor);
+
+   mongoc_collection_destroy (collection);
+   mongoc_client_destroy (client);
+}
+
+
 static void
 test_cursor_new_static (void)
 {
@@ -1592,6 +1660,10 @@ test_cursor_install (TestSuite *suite)
                       NULL,
                       test_framework_skip_if_max_wire_version_less_than_4);
    TestSuite_AddLive (suite, "/Cursor/new_invalid", test_cursor_new_invalid);
+   TestSuite_AddLive (
+      suite, "/Cursor/new_invalid_filter", test_cursor_new_invalid_filter);
+   TestSuite_AddLive (
+      suite, "/Cursor/new_invalid_opts", test_cursor_new_invalid_opts);
    TestSuite_AddLive (suite, "/Cursor/new_static", test_cursor_new_static);
    TestSuite_AddLive (suite, "/Cursor/hint/errors", test_cursor_hint_errors);
    TestSuite_Add (


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-2072

`mongoc_cursor_destroy()` always attempts to destroy these documents, which would previously crash if they were left uninitialized when an error was reported by `_mongoc_cursor_new_with_opts()`.