### PR TITLE
Supply description argument to AC_DEFINE

### DIFF
--- a/build/autotools/m4/ax_prototype.m4
+++ b/build/autotools/m4/ax_prototype.m4
@@ -168,7 +168,7 @@ dnl Assumes that function is a macro containing the name of the function in uppe
 dnl and that tag_VAL is a macro containing the value associated to tag.
 dnl
 AC_DEFUN([AX_PROTOTYPE_DEFINES],[ifelse($1,,[],
-	[AC_DEFINE(function[]_$1, $1_VAL)
+	[AC_DEFINE(function[]_$1, $1_VAL, [ ])
 	AC_SUBST(function[]_$1, "$1_VAL")
 	AX_PROTOTYPE_DEFINES(builtin([shift],$@))])])
 


### PR DESCRIPTION
This avoids a possible autoheader warning when calling AC_DEFINE with less than three arguments.

See: https://lists.gnu.org/archive/html/autoconf/2009-04/msg00087.html

This resolves an issue when including this m4 file in the PHP driver:

```
$ phpize
Configuring for:
PHP Api Version:         20131106
Zend Module Api No:      20131226
Zend Extension Api No:   220131226
autoheader: warning: missing template: ACCEPT_ARG2
autoheader: Use AC_DEFINE([ACCEPT_ARG2], [], [Description])
autoheader: warning: missing template: ACCEPT_ARG3
```

If it's relevant, my environment was using autoheader 2.6.9.

Related to: https://github.com/mongodb/mongo-c-driver/commit/63757304e5e97a8beb4f6d1bac18c7723a6f421d