### PR TITLE
CDRIVER-2297: Space out parents to avoid unterminated string error

### DIFF
--- a/build/autotools/Versions.m4
+++ b/build/autotools/Versions.m4
@@ -1,9 +1,9 @@
 MONGOC_CURRENT_FILE=${srcdir}/VERSION_CURRENT
 MONGOC_VERSION=$(cat $MONGOC_CURRENT_FILE)
 # Ensure newline for "cut" implementations that need it, e.g. HP-UX.
-MONGOC_MAJOR_VERSION=$((cat $MONGOC_CURRENT_FILE; echo) | cut -d- -f1 | cut -d. -f1)
-MONGOC_MINOR_VERSION=$((cat $MONGOC_CURRENT_FILE; echo) | cut -d- -f1 | cut -d. -f2)
-MONGOC_MICRO_VERSION=$((cat $MONGOC_CURRENT_FILE; echo) | cut -d- -f1 | cut -d. -f3)
+MONGOC_MAJOR_VERSION=$( (cat $MONGOC_CURRENT_FILE; echo) | cut -d- -f1 | cut -d. -f1 )
+MONGOC_MINOR_VERSION=$( (cat $MONGOC_CURRENT_FILE; echo) | cut -d- -f1 | cut -d. -f2 )
+MONGOC_MICRO_VERSION=$( (cat $MONGOC_CURRENT_FILE; echo) | cut -d- -f1 | cut -d. -f3 )
 MONGOC_PRERELEASE_VERSION=$(cut -s -d- -f2 $MONGOC_CURRENT_FILE)
 AC_SUBST(MONGOC_VERSION)
 AC_SUBST(MONGOC_MAJOR_VERSION)


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-2297