### PR TITLE
CDRIVER-2384 Fixed reply not being initialized

### DIFF
--- a/src/mongoc/mongoc-bulk-operation.c
+++ b/src/mongoc/mongoc-bulk-operation.c
@@ -679,6 +679,10 @@ mongoc_bulk_operation_execute (mongoc_bulk_operation_t *bulk, /* IN */
 
    BSON_ASSERT (bulk);
 
+   if (reply) {
+      bson_init (reply);
+   }
+
    if (!bulk->client) {
       bson_set_error (error,
                       MONGOC_ERROR_COMMAND,
@@ -694,10 +698,6 @@ mongoc_bulk_operation_execute (mongoc_bulk_operation_t *bulk, /* IN */
    }
 
    bulk->executed = true;
-
-   if (reply) {
-      bson_init (reply);
-   }
 
    if (!bulk->database) {
       bson_set_error (error,


### PR DESCRIPTION
Fixed monogc_bulk_operation_execute() so that it behaves as documented
and always initializes the reply bson_t before returning.