### PR TITLE
Do not overwrite {SNAPPY,ZLIB}_LIBS for system versions

### DIFF
--- a/build/autotools/CheckSnappy.m4
+++ b/build/autotools/CheckSnappy.m4
@@ -11,6 +11,7 @@ AS_IF([test "x${with_snappy}" = xauto -o "x${with_snappy}" = xsystem], [
       AC_CHECK_LIB([snappy], [snappy_uncompress], [
          AC_CHECK_HEADER([snappy-c.h], [
             found_snappy=yes
+            SNAPPY_LIBS=-lsnappy
          ])
       ])
    ])
@@ -18,7 +19,6 @@ AS_IF([test "x${with_snappy}" = xauto -o "x${with_snappy}" = xsystem], [
 
 AS_IF([test "x${found_snappy}" = xyes], [
    with_snappy=system
-   SNAPPY_LIBS=-lsnappy
 ], [
    # snappy not found
    AS_IF([test "x${with_snappy}" = xsystem], [

--- a/build/autotools/CheckZlib.m4
+++ b/build/autotools/CheckZlib.m4
@@ -3,7 +3,7 @@
 found_zlib=no
 
 AS_IF([test "x${with_zlib}" = xauto -o "x${with_zlib}" = xsystem], [
-   PKG_CHECK_MODULES(zlib, [zlib], [
+   PKG_CHECK_MODULES(ZLIB, [zlib], [
       found_zlib=yes
    ], [
       # If we didn't find zlib with pkgconfig, search manually. If that
@@ -12,6 +12,7 @@ AS_IF([test "x${with_zlib}" = xauto -o "x${with_zlib}" = xsystem], [
       AC_CHECK_LIB([zlib], [compress2], [
          AC_CHECK_HEADER([zlib.h], [
             found_zlib=yes
+            ZLIB_LIBS=-lz
          ])
       ])
    ])
@@ -23,7 +24,6 @@ AS_IF([test "x${with_zlib}" = xauto -o "x${with_zlib}" = xsystem], [
 
 AS_IF([test "x${found_zlib}" = "xyes"], [
    with_zlib=system
-   ZLIB_LIBS=-lz
 ], [
    # zlib not found
    AS_IF([test "x${with_zlib}" = xauto -o "x${with_zlib}" = xbundled], [


### PR DESCRIPTION
*_LIBS often contains library paths (-L) if returned by pkg-config.
Stripping them out causes the snappy and zlib libraries to not be found if they are not installed in a system library path.

This happens with (at least) the libmongoc package in Spack (https://github.com/spack/spack).