### PR TITLE
Fix :Error parsing URI: Invalid host string in URI

### DIFF
--- a/examples/example-gridfs.c
+++ b/examples/example-gridfs.c
@@ -36,7 +36,7 @@ main (int argc, char *argv[])
 
    /* connect to localhost client */
    client =
-      mongoc_client_new ("mongodb://127.0.0.1:27017?appname=gridfs-example");
+      mongoc_client_new ("mongodb://127.0.0.1:27017/?appname=gridfs-example");
    assert (client);
    mongoc_client_set_error_api (client, 2);
 


### PR DESCRIPTION
Fixes issue : 
mongoc: A '/' is required between the host list and any options.
mongoc: Error parsing URI: 'Invalid host string in URI'

mongoc_uri_parse_hosts in mongoc/mongoc-uri.c  expects '/' between host list and options.