### PR TITLE
Add .gdbinit file that exposes a 'printbson' function to dump a bson_t*

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,0 +1,242 @@
+define printbson
+	set $bson = $arg0
+	if $bson->flags & BSON_FLAG_INLINE
+		print ((bson_impl_inline_t*) $bson)->data
+		set $data = &(((bson_impl_inline_t*) $bson)->data)
+		printf "INLINE"
+		__printbson $data
+	else
+		set $impl = (bson_impl_alloc_t*) $bson
+		printf "ALLOC [%p + %d]", $impl->buf, $impl->offset
+		__printbson (*$impl->buf) + $impl->data
+	end
+end
+
+define __printbson
+	set $bson = ((uint32_t*)$arg0)
+	printf " (len=%d)\n", $bson[0]
+	printf "{\n"
+	__printelements ($bson+1) 0 1
+	printf "\n}\n"
+end
+
+define __printelements
+	set $data = ((uint8_t*)$arg0)
+	set $isDocument = $arg1
+	set $depth = $arg2
+	set $addComma = 0
+
+	while $data != 0
+		set $type = (uint8_t)($data[0])
+
+		if $type == 0
+			loop_break
+		end
+
+		if $addComma == 1
+			printf ",\n"
+		end
+		set $addComma = 1
+
+		__printSpaces $depth
+		printf "'%s' : ", (char*) ($data+1)
+
+		# skip through C String
+		while $data[0] != '\0'
+			set $data = $data + 1
+		end
+		set $data = $data + 1
+
+	 	if $type == 0x01
+			__printDouble $data
+		end
+	 	if $type == 0x02
+			__printString $data
+		end
+	 	if $type == 0x03
+			__printDocument $data $depth
+		end
+	 	if $type == 0x04
+			__printArray $data $depth
+		end
+	 	if $type == 0x05
+			__printBinary $data
+		end
+	 	if $type == 0x07
+			__printObjectID $data
+		end
+	 	if $type == 0x08
+			__printBool $data
+		end
+	 	if $type == 0x09
+			__printUtcDateTime $data
+		end
+	 	if $type == 0x0a
+			__printNull
+		end
+	 	if $type == 0x0b
+			__printRegex $data
+		end
+	 	if $type == 0x0d
+			__printJavascript $data
+		end
+	 	if $type == 0x0e
+			__printSymbol $data
+		end
+	 	if $type == 0x0f
+			__printJavascriptWScope $data
+		end
+	 	if $type == 0x10
+			__printInt32 $data
+		end
+	 	if $type == 0x11
+			__printTimestamp $data
+		end
+	 	if $type == 0x12
+			__printInt64 $data
+		end
+	end
+end
+
+define __printSpaces
+	set $i = 0
+	while $i < (4 * $arg0)
+		printf " "
+		set $i = $i + 1
+	end
+end
+
+
+define __printDocument
+	set $value = ((uint8_t*) $arg0)
+	set $depth = $arg1
+	printf "{\n"
+	__printElements ($value+4) 1 ($depth+1)
+	printf "\n"
+	__printSpaces ($depth-1)
+	printf "}"
+	set $depth = $depth-1
+	set $data = $data + 1
+end
+
+define __printArray
+	set $value = ((uint8_t*) $arg0)
+	set $depth = $arg1
+	printf "[\n"
+	__printElements ($value+4) (0) ($depth+1)
+	printf "\n"
+	__printSpaces ($depth-1)
+	printf "]"
+	set $depth = $depth-1
+	set $data = $data + 1
+end
+
+
+define __printDouble
+	set $value = ((double*) $arg0)
+	printf "%f", $value[0]
+	set $data = $data + 8
+end
+
+define __printString
+	set $value = ((char*) $arg0) + 4
+	printf "\"%s\"", $value
+	set $data = $data + 4 + ((uint32_t*)$data)[0]
+end
+
+define __printBinary
+	set $value = ((uint8_t*) $arg0)
+	set $length = ((int32_t*) $arg0)[0]
+	printf "Binary(\"%02X\", \"", $value[4]
+	set $i = 4
+	while $i < $length 
+		printf "%02X", $value[$i+5]
+		set $i = $i + 1
+	end
+	printf "\")"
+	set $data = $data + 5 + ((uint32_t*)$data)[0]
+end
+
+define __printObjectID
+	set $value = ((uint8_t*) $arg0)
+	set $i = 0
+	printf "ObjectID(\""
+	while $i < 12
+		printf "%02X", $value[$i]
+		set $i = $i + 1
+	end
+	printf "\")"
+	set $data = $data + 12
+end
+
+define __printBool
+	set $value = ((uint8_t*) $arg0)
+	printf "%s", $value[0] ? "true" : "false"
+	set $data = $data + 1
+end
+
+define __printUtcDateTime
+	set $value = ((uint64_t*) $arg0)
+	printf "UTCDateTime(%ld)", $value[0]
+	set $data = $data + 8
+end
+
+define __printNull
+	printf "null"
+end
+
+define __printRegex
+	printf "Regex(\"%s\", \"", (char*) $data
+
+	# skip through C String
+	while $data[0] != '\0'
+		set $data = $data + 1
+	end
+	set $data = $data + 1
+	
+	printf "%s\")", (char*) $data
+
+	# skip through C String
+	while $data[0] != '\0'
+		set $data = $data + 1
+	end
+	set $data = $data + 1
+end
+
+define __printJavascript
+	set $value = ((char*) $arg0) + 4
+	printf "JavaScript(\"%s\")", $value
+	set $data = $data + 4 + ((uint32_t*)$data)[0]
+end
+
+define __printSymbol
+	set $value = ((char*) $arg0) + 4
+	printf "Symbol(\"%s\")", $value
+	set $data = $data + 4 + ((uint32_t*)$data)[0]
+end
+
+define __printJavascriptWScope
+	set $value = ((char*) $arg0) + 8
+	printf "JavaScript(\"%s\") with scope: ", $value
+	set $data = $data + 8 + ((uint32_t*)$data)[1]
+	__printDocument $data $depth
+end
+
+define __printInt32
+	set $value = ((uint32_t*) $arg0)
+	printf "NumberInt(\"%d\")", $value[0]
+	set $data = $data + 4
+end
+
+define __printTimestamp
+	set $value = ((uint32_t*) $arg0)
+	printf "Timestamp(%u, %u)", $value[0], $value[1]
+	set $data = $data + 8
+end
+
+define __printInt64
+	set $value = ((uint64_t*) $arg0)
+	printf "NumberLong(\"%ld\")", $value[0]
+	set $data = $data + 8
+end
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,4 +215,76 @@ The easiest way to debug a failed tests is to use the `debug` make target:
 $ make debug TEST_ARGS="-l /WriteConcern/bson_omits_defaults"
 ```
 
-This will build all dependencies and leave you in a debugger ready to run the test.
+This will build all dependencies and leave you in a debugger ready to run the
+test.
+
+## GDB Debugging Aids
+
+The repository contains a `.gdbinit` file that contains helper functions to
+aid debugging of data structures. GDB will load this file
+[automatically](https://sourceware.org/gdb/onlinedocs/gdb/Auto_002dloading.html)
+if you have added the directory which contains the `.gdbinit` file to GDB's
+[auto-load safe-path](https://sourceware.org/gdb/onlinedocs/gdb/Auto_002dloading-safe-path.html),
+*and* you start GDB from the directory which holds the `.gdbinit` file.
+
+You can see the safe-path with `show auto-load safe-path` on a GDB prompt. You
+can configure it by setting it in `~/.gdbinit` with:
+
+
+```
+add-auto-load-safe-path /home/<username>/path/to/mongo-c-driver
+```
+
+If you haven't added the path to your auto-load safe-path, or start GDB in
+another directory, you need to run `source path/to/mongo-c-driver/.gdbinit` to
+make the functions available.
+
+Currently, the bundled `.gdbinit` file defines the following function(s):
+
+- `printbson`
+
+  Shows the contents of a `bson_t *` variable. If you have a `bson_t`
+  variable, then you must prefix the variable with a `&`.
+
+  An example GDB session looks like:
+
+  ```
+  (gdb) printbson bson
+  ALLOC [0x555556cd7310 + 0] (len=475)
+  {
+      'bool' : true,
+      'int32' : NumberInt("42"),
+      'int64' : NumberLong("3000000042"),
+      'string' : "Stŕìñg",
+      'objectId' : ObjectID("5A1442F3122D331C3C6757E1"),
+      'utcDateTime' : UTCDateTime(1511277299031),
+      'arrayOfInts' : [
+          '0' : NumberInt("1"),
+          '1' : NumberInt("2")
+      ],
+      'embeddedDocument' : {
+          'arrayOfStrings' : [
+              '0' : "one",
+              '1' : "two"
+          ],
+          'double' : 2.718280,
+          'notherDoc' : {
+              'true' : NumberInt("1"),
+              'false' : false
+          }
+      },
+      'binary' : Binary("02", "3031343532333637"),
+      'regex' : Regex("@[a-z]+@", "im"),
+      'null' : null,
+      'js' : JavaScript("print foo"),
+      'jsws' : JavaScript("print foo") with scope: {
+          'f' : NumberInt("42"),
+          'a' : [
+              '0' : 3.141593,
+              '1' : 2.718282
+          ]
+      },
+      'timestamp' : Timestamp(4294967295, 4294967295),
+      'double' : 3.141593
+  }
+  ```


### PR DESCRIPTION
This PR implements the 'printbson' function in a ``.gdbinit`` file to print ``bson_t*`` values.

An example of an output is:

```
(gdb) printbson bson
ALLOC [0x555556cd7310 + 0] (len=475)
{
    'bool' : true,
    'int32' : NumberInt("42"),
    'int64' : NumberLong("3000000042"),
    'string' : "Stŕìñg",
    'objectId' : ObjectID("5A1442F3122D331C3C6757E1"),
    'utcDateTime' : UTCDateTime(1511277299031),
    'arrayOfInts' : [
        '0' : NumberInt("1"),
        '1' : NumberInt("2"),
        '2' : NumberInt("3"),
        '3' : NumberInt("5"),
        '4' : NumberInt("8"),
        '5' : NumberInt("13"),
        '6' : NumberInt("21"),
        '7' : NumberInt("34")
    ],
    'embeddedDocument' : {
        'arrayOfStrings' : [
            '0' : "one",
            '1' : "two",
            '2' : "three"
        ],
        'double' : 2.718280,
        'notherDoc' : {
            'true' : NumberInt("1"),
            'false' : false
        }
    },
    'binary' : Binary("02", "3031343532333637"),
    'regex' : Regex("@[a-z]+@", "im"),
    'null' : null,
    'js' : JavaScript("print foo"),
    'jsws' : JavaScript("print foo") with scope: {
        'f' : NumberInt("42"),
        'a' : [
            '0' : 3.141593,
            '1' : 2.718282
        ]
    },
    'timestamp' : Timestamp(4294967295, 4294967295),
    'double' : 3.141593
}

```