### PR TITLE
Missing ENTRY in advance_operation_time

### DIFF
--- a/src/mongoc/mongoc-client-session.c
+++ b/src/mongoc/mongoc-client-session.c
@@ -389,6 +389,8 @@ mongoc_client_session_advance_operation_time (mongoc_client_session_t *session,
                                               uint32_t timestamp,
                                               uint32_t increment)
 {
+   ENTRY;
+
    BSON_ASSERT (session);
 
    if (timestamp > session->operation_timestamp ||


### PR DESCRIPTION
I assume anything with `EXIT` should also have an `ENTRY`. Noticed this was imbalanced while looking at some trace logs.