### PR TITLE
CDRIVER-2256 fix _mongoc_validate_update errmsg

### DIFF
--- a/src/mongoc/mongoc-util.c
+++ b/src/mongoc/mongoc-util.c
@@ -344,7 +344,7 @@ _mongoc_validate_update (const bson_t *update, bson_error_t *error)
       bson_set_error (error,
                       MONGOC_ERROR_COMMAND,
                       MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "invalid selector for update: %s",
+                      "invalid argument for update: %s",
                       validate_err.message);
       return false;
    }


### PR DESCRIPTION
`_mongoc_validate_update()` validates the `newObj` parameter. The selector (i.e. first argument for update and replace) is not validated by these util functions.

This fixes the change introduced in [this commit](https://github.com/mongodb/mongo-c-driver/commit/0c9cc9d26728d3cf4dd84e1fe91e75ca40e9a7fd#diff-305c362b208afd140b9f4230bf871ad4R347).