### PR TITLE
CDRIVER-2296 pass bson_validate_flags_t to update/insert functions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+Next Release
+============
+
+New features:
+
+  * Add bson_validate_flags_t to opt for update/insert functions.
+
+
 mongo-c-driver 1.9.0
 ====================
 

--- a/doc/includes/crud-opts.txt
+++ b/doc/includes/crud-opts.txt
@@ -3,7 +3,9 @@
 * ``readConcern``: Construct a :symbol:`mongoc_read_concern_t` and use :symbol:`mongoc_read_concern_append` to add the read concern to ``opts``. See the example code for :symbol:`mongoc_client_read_command_with_opts`.
 * ``writeConcern``: Construct a :symbol:`mongoc_write_concern_t` and use :symbol:`mongoc_write_concern_append` to add the write concern to ``opts``. See the example code for :symbol:`mongoc_client_write_command_with_opts`.
 * ``sessionId``: Construct a :symbol:`mongoc_client_session_t` with :symbol:`mongoc_client_start_session` and use :symbol:`mongoc_client_session_append` to add the session to ``opts``. See the example code for :symbol:`mongoc_client_session_t`.
-* ``validate``: Set to ``false`` to skip client-side validation of the provided BSON documents.
+* ``validate``: Construct a bitwise-or of all desired
+  `bson_validate_flags_t
+  <http://mongoc.org/libbson/current/bson_validate_with_error.html>`_. Set to ``0`` to skip client-side validation of the provided BSON documents.
 * ``bypassDocumentValidation``: Set to ``true`` to skip server-side schema validation of the provided BSON documents.
 * ``collation``: Configure textual comparisons. See :ref:`Setting Collation Order <setting_collation_order>`, and `the MongoDB Manual entry on Collation <https://docs.mongodb.com/manual/reference/collation/>`_.
 * ``serverId``: To target a specific server, include an int32 "serverId" field. Obtain the id by calling :symbol:`mongoc_client_select_server`, then :symbol:`mongoc_server_description_id` on its return value.

--- a/src/mongoc/mongoc-bulk-operation.c
+++ b/src/mongoc/mongoc-bulk-operation.c
@@ -355,7 +355,8 @@ mongoc_bulk_operation_insert_with_opts (mongoc_bulk_operation_t *bulk,
 
    BULK_RETURN_IF_PRIOR_ERROR;
 
-   if (!_mongoc_validate_new_document (document, error)) {
+   if (!_mongoc_validate_new_document (
+          document, _mongoc_default_insert_vflags, error)) {
       return false;
    }
 
@@ -400,7 +401,8 @@ _mongoc_bulk_operation_replace_one_with_opts (mongoc_bulk_operation_t *bulk,
    BSON_ASSERT (selector);
    BSON_ASSERT (document);
 
-   if (!_mongoc_validate_replace (document, error)) {
+   if (!_mongoc_validate_replace (
+          document, _mongoc_default_replace_vflags, error)) {
       RETURN (false);
    }
 
@@ -507,7 +509,8 @@ _mongoc_bulk_operation_update_with_opts (mongoc_bulk_operation_t *bulk,
 
    BULK_RETURN_IF_PRIOR_ERROR;
 
-   if (!_mongoc_validate_update (document, error)) {
+   if (!_mongoc_validate_update (
+          document, _mongoc_default_update_vflags, error)) {
       RETURN (false);
    }
 

--- a/src/mongoc/mongoc-collection.c
+++ b/src/mongoc/mongoc-collection.c
@@ -1429,7 +1429,8 @@ mongoc_collection_insert_bulk (mongoc_collection_t *collection,
 
    if (!(flags & MONGOC_INSERT_NO_VALIDATE)) {
       for (i = 0; i < n_documents; i++) {
-         if (!_mongoc_validate_new_document (documents[i], error)) {
+         if (!_mongoc_validate_new_document (
+                documents[i], _mongoc_default_insert_vflags, error)) {
             RETURN (false);
          }
       }
@@ -1477,7 +1478,7 @@ typedef struct {
    mongoc_write_concern_t *write_concern;
    bool write_concern_owned;
    mongoc_client_session_t *client_session;
-   bool client_validation;
+   bson_validate_flags_t validation_flags;
    bson_t copied_opts;
 } mongoc_write_opts_parsed_t;
 
@@ -1486,6 +1487,7 @@ static bool
 _mongoc_write_opts_parse (const bson_t *opts,
                           mongoc_collection_t *collection,
                           mongoc_write_opts_parsed_t *parsed,
+                          bson_validate_flags_t default_vflags,
                           bson_error_t *error)
 {
    mongoc_bulk_write_flags_t default_flags = MONGOC_BULK_WRITE_FLAGS_INIT;
@@ -1498,7 +1500,7 @@ _mongoc_write_opts_parse (const bson_t *opts,
    parsed->write_concern = collection->write_concern;
    parsed->write_concern_owned = false;
    parsed->client_session = NULL;
-   parsed->client_validation = true;
+   parsed->validation_flags = default_vflags;
 
    if (opts) {
       if (!bson_iter_init (&iter, opts)) {
@@ -1538,21 +1540,24 @@ _mongoc_write_opts_parse (const bson_t *opts,
          }
 
          if (!strcmp (bson_iter_key (&iter), "validate")) {
-            parsed->client_validation = bson_iter_as_bool (&iter);
-            if (parsed->client_validation && !BSON_ITER_HOLDS_BOOL (&iter)) {
-               /* reserve truthy values besides boolean "true" for future
-                * fine-grained validation control, see CDRIVER-2296
-                */
-               bson_set_error (
-                  error,
-                  MONGOC_ERROR_COMMAND,
-                  MONGOC_ERROR_COMMAND_INVALID_ARG,
-                  "Invalid type for option \"validate\", \"%s\":"
-                  " \"validate\" must be a boolean.",
-                  _mongoc_bson_type_to_str (bson_iter_type (&iter)));
-               return false;
+            if (BSON_ITER_HOLDS_BOOL (&iter)) {
+               if (!bson_iter_as_bool (&iter)) {
+                  parsed->validation_flags = 0;
+               }
+               continue;
+            } else if (BSON_ITER_HOLDS_INT32 (&iter)) {
+               parsed->validation_flags = bson_iter_int32 (&iter);
+               if (parsed->validation_flags <= 0x1F)
+                  continue;
             }
-            continue;
+            bson_set_error (error,
+                            MONGOC_ERROR_COMMAND,
+                            MONGOC_ERROR_COMMAND_INVALID_ARG,
+                            "Invalid type for option \"validate\", \"%s\":"
+                            " \"validate\" must be a bitwise-or of all desired "
+                            "bson_validate_flags_t.",
+                            _mongoc_bson_type_to_str (bson_iter_type (&iter)));
+            return false;
          }
 
          if (!strcmp (bson_iter_key (&iter), "ordered")) {
@@ -1669,13 +1674,15 @@ mongoc_collection_insert_one (mongoc_collection_t *collection,
 
    _mongoc_bson_init_if_set (reply);
 
-   if (!_mongoc_write_opts_parse (opts, collection, &parsed, error)) {
+   if (!_mongoc_write_opts_parse (
+          opts, collection, &parsed, _mongoc_default_insert_vflags, error)) {
       _mongoc_write_opts_cleanup (&parsed);
       return false;
    }
 
-   if (parsed.client_validation &&
-       !_mongoc_validate_new_document (document, error)) {
+   if (parsed.validation_flags &&
+       !_mongoc_validate_new_document (
+          document, parsed.validation_flags, error)) {
       RETURN (false);
    }
 
@@ -1758,7 +1765,8 @@ mongoc_collection_insert_many (mongoc_collection_t *collection,
 
    _mongoc_bson_init_if_set (reply);
 
-   if (!_mongoc_write_opts_parse (opts, collection, &parsed, error)) {
+   if (!_mongoc_write_opts_parse (
+          opts, collection, &parsed, _mongoc_default_insert_vflags, error)) {
       _mongoc_write_opts_cleanup (&parsed);
       return false;
    }
@@ -1773,8 +1781,9 @@ mongoc_collection_insert_many (mongoc_collection_t *collection,
       false);
 
    for (i = 0; i < n_documents; i++) {
-      if (parsed.client_validation &&
-          !_mongoc_validate_new_document (documents[i], error)) {
+      if (parsed.validation_flags &&
+          !_mongoc_validate_new_document (
+             documents[i], parsed.validation_flags, error)) {
          ret = false;
          GOTO (done);
       }
@@ -1863,11 +1872,13 @@ mongoc_collection_update (mongoc_collection_t *collection,
        bson_iter_init (&iter, update) && bson_iter_next (&iter)) {
       if (bson_iter_key (&iter)[0] == '$') {
          /* update document, all keys must be $-operators */
-         if (!_mongoc_validate_update (update, error)) {
+         if (!_mongoc_validate_update (
+                update, _mongoc_default_update_vflags, error)) {
             return false;
          }
       } else {
-         if (!_mongoc_validate_replace (update, error)) {
+         if (!_mongoc_validate_replace (
+                update, _mongoc_default_replace_vflags, error)) {
             return false;
          }
       }
@@ -1928,18 +1939,25 @@ _mongoc_collection_update_or_replace (mongoc_collection_t *collection,
 
    _mongoc_bson_init_if_set (reply);
 
-   if (!_mongoc_write_opts_parse (opts, collection, &parsed, error)) {
+   if (!_mongoc_write_opts_parse (opts,
+                                  collection,
+                                  &parsed,
+                                  (is_update ? _mongoc_default_update_vflags
+                                             : _mongoc_default_replace_vflags),
+                                  error)) {
       _mongoc_write_opts_cleanup (&parsed);
       return false;
    }
 
-   if (parsed.client_validation) {
+   if (parsed.validation_flags) {
       /* update document, all keys must be $-operators */
       if (is_update) {
-         if (!_mongoc_validate_update (update, error)) {
+         if (!_mongoc_validate_update (
+                update, parsed.validation_flags, error)) {
             return false;
          }
-      } else if (!_mongoc_validate_replace (update, error)) {
+      } else if (!_mongoc_validate_replace (
+                    update, parsed.validation_flags, error)) {
          return false;
       }
    }
@@ -2087,7 +2105,8 @@ mongoc_collection_save (mongoc_collection_t *collection,
    }
 
    /* this document will be inserted, validate same as for inserts */
-   if (!_mongoc_validate_new_document (document, error)) {
+   if (!_mongoc_validate_new_document (
+          document, _mongoc_default_insert_vflags, error)) {
       return false;
    }
 
@@ -2229,7 +2248,7 @@ _mongoc_delete_one_or_many (mongoc_collection_t *collection,
 
    _mongoc_bson_init_if_set (reply);
 
-   if (!_mongoc_write_opts_parse (opts, collection, &parsed, error)) {
+   if (!_mongoc_write_opts_parse (opts, collection, &parsed, 0, error)) {
       _mongoc_write_opts_cleanup (&parsed);
       return false;
    }

--- a/src/mongoc/mongoc-util-private.h
+++ b/src/mongoc/mongoc-util-private.h
@@ -59,6 +59,10 @@
 
 BSON_BEGIN_DECLS
 
+extern const bson_validate_flags_t _mongoc_default_insert_vflags;
+extern const bson_validate_flags_t _mongoc_default_replace_vflags;
+extern const bson_validate_flags_t _mongoc_default_update_vflags;
+
 int
 _mongoc_rand_simple (unsigned int *seed);
 
@@ -100,13 +104,19 @@ _mongoc_get_server_id_from_opts (const bson_t *opts,
                                  bson_error_t *error);
 
 bool
-_mongoc_validate_new_document (const bson_t *insert, bson_error_t *error);
+_mongoc_validate_new_document (const bson_t *insert,
+                               bson_validate_flags_t vflags,
+                               bson_error_t *error);
 
 bool
-_mongoc_validate_replace (const bson_t *insert, bson_error_t *error);
+_mongoc_validate_replace (const bson_t *insert,
+                          bson_validate_flags_t vflags,
+                          bson_error_t *error);
 
 bool
-_mongoc_validate_update (const bson_t *update, bson_error_t *error);
+_mongoc_validate_update (const bson_t *update,
+                         bson_validate_flags_t vflags,
+                         bson_error_t *error);
 
 void
 mongoc_lowercase (const char *src, char *buf /* OUT */);

--- a/src/mongoc/mongoc-util.c
+++ b/src/mongoc/mongoc-util.c
@@ -21,6 +21,19 @@
 #include "mongoc-client.h"
 #include "mongoc-trace-private.h"
 
+const bson_validate_flags_t _mongoc_default_insert_vflags =
+   BSON_VALIDATE_UTF8 | BSON_VALIDATE_UTF8_ALLOW_NULL |
+   BSON_VALIDATE_EMPTY_KEYS | BSON_VALIDATE_DOT_KEYS |
+   BSON_VALIDATE_DOLLAR_KEYS;
+
+const bson_validate_flags_t _mongoc_default_replace_vflags =
+   BSON_VALIDATE_UTF8 | BSON_VALIDATE_UTF8_ALLOW_NULL |
+   BSON_VALIDATE_EMPTY_KEYS | BSON_VALIDATE_DOT_KEYS |
+   BSON_VALIDATE_DOLLAR_KEYS;
+
+const bson_validate_flags_t _mongoc_default_update_vflags =
+   BSON_VALIDATE_UTF8 | BSON_VALIDATE_UTF8_ALLOW_NULL |
+   BSON_VALIDATE_EMPTY_KEYS;
 
 int
 _mongoc_rand_simple (unsigned int *seed)
@@ -289,17 +302,14 @@ _mongoc_get_server_id_from_opts (const bson_t *opts,
 }
 
 
-const bson_validate_flags_t insert_vflags =
-   (bson_validate_flags_t) BSON_VALIDATE_UTF8 | BSON_VALIDATE_UTF8_ALLOW_NULL |
-   BSON_VALIDATE_EMPTY_KEYS | BSON_VALIDATE_DOT_KEYS |
-   BSON_VALIDATE_DOLLAR_KEYS;
-
 bool
-_mongoc_validate_new_document (const bson_t *doc, bson_error_t *error)
+_mongoc_validate_new_document (const bson_t *doc,
+                               const bson_validate_flags_t vflags,
+                               bson_error_t *error)
 {
    bson_error_t validate_err;
 
-   if (!bson_validate_with_error (doc, insert_vflags, &validate_err)) {
+   if (!bson_validate_with_error (doc, vflags, &validate_err)) {
       bson_set_error (error,
                       MONGOC_ERROR_COMMAND,
                       MONGOC_ERROR_COMMAND_INVALID_ARG,
@@ -313,11 +323,13 @@ _mongoc_validate_new_document (const bson_t *doc, bson_error_t *error)
 
 
 bool
-_mongoc_validate_replace (const bson_t *doc, bson_error_t *error)
+_mongoc_validate_replace (const bson_t *doc,
+                          const bson_validate_flags_t vflags,
+                          bson_error_t *error)
 {
    bson_error_t validate_err;
 
-   if (!bson_validate_with_error (doc, insert_vflags, &validate_err)) {
+   if (!bson_validate_with_error (doc, vflags, &validate_err)) {
       bson_set_error (error,
                       MONGOC_ERROR_COMMAND,
                       MONGOC_ERROR_COMMAND_INVALID_ARG,
@@ -331,16 +343,15 @@ _mongoc_validate_replace (const bson_t *doc, bson_error_t *error)
 
 
 bool
-_mongoc_validate_update (const bson_t *update, bson_error_t *error)
+_mongoc_validate_update (const bson_t *update,
+                         const bson_validate_flags_t vflags,
+                         bson_error_t *error)
 {
    bson_error_t validate_err;
    bson_iter_t iter;
    const char *key;
-   int vflags = BSON_VALIDATE_UTF8 | BSON_VALIDATE_UTF8_ALLOW_NULL |
-                BSON_VALIDATE_EMPTY_KEYS;
 
-   if (!bson_validate_with_error (
-          update, (bson_validate_flags_t) vflags, &validate_err)) {
+   if (!bson_validate_with_error (update, vflags, &validate_err)) {
       bson_set_error (error,
                       MONGOC_ERROR_COMMAND,
                       MONGOC_ERROR_COMMAND_INVALID_ARG,


### PR DESCRIPTION
User can now pass bson_validate_flags_t to update/insert functions via "validate" field in the opt.