### PR TITLE
Windows: fixes for implicit declaration of functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,12 +250,6 @@ endif ()
 include(CheckIncludeFiles)
 CHECK_INCLUDE_FILES(strings.h HAVE_STRINGS_H)
 
-if (MINGW)
-   # Define _CRT_RAND_S, so that MinGW's stdlib.h declares Microsoft's rand_s().
-   message (" MinGW: define _CRT_RAND_S")
-   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_CRT_RAND_S")
-endif ()
-
 include(CheckTypeSize)
 if (WIN32)
    SET(CMAKE_EXTRA_INCLUDE_FILES "ws2tcpip.h")

--- a/src/mongoc/mongoc-cluster-sspi.c
+++ b/src/mongoc/mongoc-cluster-sspi.c
@@ -140,11 +140,11 @@ _mongoc_cluster_auth_node_sspi (mongoc_cluster_t *cluster,
 {
    mongoc_cmd_parts_t parts;
    mongoc_sspi_client_state_t *state;
-   uint8_t buf[4096] = {0};
+   SEC_CHAR buf[4096] = {0};
    bson_iter_t iter;
    uint32_t buflen;
    bson_t reply;
-   char *tmpstr;
+   const char *tmpstr;
    int conv_id;
    bson_t cmd;
    int res = MONGOC_SSPI_AUTH_GSS_CONTINUE;
@@ -178,7 +178,7 @@ _mongoc_cluster_auth_node_sspi (mongoc_cluster_t *cluster,
          res = _mongoc_sspi_auth_sspi_client_unwrap (state, buf);
          response = bson_strdup (state->response);
          _mongoc_sspi_auth_sspi_client_wrap (
-            state, response, tmp_creds, tmp_creds_len, 0);
+            state, response, (SEC_CHAR*) tmp_creds, tmp_creds_len, 0);
          bson_free (response);
       }
 

--- a/src/mongoc/mongoc-socket.c
+++ b/src/mongoc/mongoc-socket.c
@@ -771,9 +771,9 @@ mongoc_socket_close (mongoc_socket_t *sock) /* IN */
 
    BSON_ASSERT (sock);
 
-   owned = (sock->pid == (int) getpid ());
-
 #ifdef _WIN32
+   owned = (sock->pid == (int) _getpid ());
+
    if (sock->sd != INVALID_SOCKET) {
       if (owned) {
          shutdown (sock->sd, SD_BOTH);
@@ -788,6 +788,8 @@ mongoc_socket_close (mongoc_socket_t *sock) /* IN */
    }
    RETURN (0);
 #else
+   owned = (sock->pid == (int) getpid ());
+
    if (sock->sd != -1) {
       if (owned) {
          shutdown (sock->sd, SHUT_RDWR);

--- a/src/mongoc/mongoc-sspi-private.h
+++ b/src/mongoc/mongoc-sspi-private.h
@@ -47,7 +47,7 @@ typedef struct {
    ULONG flags;
    UCHAR haveCred;
    UCHAR haveCtx;
-   INT qop;
+   ULONG qop;
 } mongoc_sspi_client_state_t;
 
 void

--- a/src/mongoc/mongoc-util.c
+++ b/src/mongoc/mongoc-util.c
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+#ifdef _WIN32
+#define _CRT_RAND_S
+#endif
 
 #include <string.h>
 


### PR DESCRIPTION
This fixes two compiler warnings on mingw-w64:

```c
mongoc/mongoc-socket.c: In function 'mongoc_socket_close':
mongoc/mongoc-socket.c:774:4: warning: implicit declaration of function 'getpid' [-Wimplicit-function-declaration]
    owned = (sock->pid == (int) getpid ());
    ^
```

This PR switched to `_getpid()` on Windows (which is already used elsewhere in the code).

```c
mongoc/mongoc-util.c -o mongoc/mongoc-util.o
mongoc/mongoc-util.c: In function '_mongoc_rand_simple':
mongoc/mongoc-util.c:33:4: warning: implicit declaration of function 'rand_s' [-Wimplicit-function-declaration]
    err = rand_s (&ret);
    ^
```

The [windows documentation](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/rand-s) says:

> The `rand_s` function requires that constant `_CRT_RAND_S` be defined prior to the inclusion statement for the function to be declared.

I confirmed that this fixes the compiler warning.