### PR TITLE
Windows: fix compiler warnings

### DIFF
--- a/src/mongoc/mongoc-cluster-sspi.c
+++ b/src/mongoc/mongoc-cluster-sspi.c
@@ -149,10 +149,8 @@ _mongoc_cluster_auth_node_sspi (mongoc_cluster_t *cluster,
    bson_t cmd;
    int res = MONGOC_SSPI_AUTH_GSS_CONTINUE;
    int step;
-   const bson_t *options;
    mongoc_server_stream_t *server_stream;
 
-   options = mongoc_uri_get_options (cluster->uri);
    state = _mongoc_cluster_sspi_new (cluster->uri, sd->host.host);
 
    if (!state) {

--- a/src/mongoc/mongoc-socket.c
+++ b/src/mongoc/mongoc-socket.c
@@ -26,6 +26,7 @@
 #include "mongoc-trace-private.h"
 #ifdef _WIN32
 #include <Mstcpip.h>
+#include <process.h>
 #endif
 
 #undef MONGOC_LOG_DOMAIN
@@ -351,7 +352,6 @@ mongoc_socket_poll (mongoc_socket_poll_t *sds, /* IN */
 static void
 _mongoc_socket_setkeepalive_windows (SOCKET sd)
 {
-   BOOL optval = 1;
    struct tcp_keepalive keepalive;
    DWORD lpcbBytesReturned = 0;
    HKEY hKey;
@@ -415,9 +415,9 @@ _mongoc_socket_setkeepalive_windows (SOCKET sd)
                  &lpcbBytesReturned,
                  NULL,
                  NULL) == SOCKET_ERROR) {
-      TRACE ("Could not set keepalive values");
+      TRACE ("%s", "Could not set keepalive values");
    } else {
-      TRACE ("KeepAlive values updated");
+      TRACE ("%s", "KeepAlive values updated");
       TRACE ("KeepAliveTime: %d", keepalive.keepalivetime);
       TRACE ("KeepAliveInterval: %d", keepalive.keepaliveinterval);
    }
@@ -1000,7 +1000,11 @@ mongoc_socket_new (int domain,   /* IN */
    sock = (mongoc_socket_t *) bson_malloc0 (sizeof *sock);
    sock->sd = sd;
    sock->domain = domain;
+#ifdef _WIN32
+   sock->pid = (int) _getpid ();
+#else
    sock->pid = (int) getpid ();
+#endif
 
    RETURN (sock);
 


### PR DESCRIPTION
Ran into a few more warnings on mingw-w64. These are (hopefully) the final windows fixes I need.

Fixed two `-Wunused` warnings:

```c
mongoc/mongoc-socket.c:354:9: warning: unused variable 'optval'
mongoc/mongoc-cluster-sspi.c:152:18: warning: variable 'options' set but not used
```

Fixed missing `#include process.h` for `_getpid()`:

```c
mongoc/mongoc-socket.c:775:4: warning: implicit declaration of function '_getpid'
```

And a `-pedantic` warning about variadic args:

```c
mongoc/mongoc-socket.c:419:46: warning: ISO C99 requires rest arguments to be used
mongoc/mongoc-socket.c:421:40: warning: ISO C99 requires rest arguments to be used
```

Thank you for reviewing!