### PR TITLE
 CDRIVER-2431 check for empty command before comparing name

### DIFF
--- a/src/mongoc/mongoc-client.c
+++ b/src/mongoc/mongoc-client.c
@@ -1563,9 +1563,8 @@ retry:
     * a new writable stream and retry. If server selection fails or the selected
     * server does not support retryable writes, fall through and allow the
     * original error to be reported. */
-   if (!ret && is_retryable &&
-       (error->domain == MONGOC_ERROR_STREAM ||
-        mongoc_cluster_is_not_master_error (error))) {
+   if (!ret && is_retryable && (error->domain == MONGOC_ERROR_STREAM ||
+                                mongoc_cluster_is_not_master_error (error))) {
       bson_error_t ignored_error;
 
       /* each write command may be retried at most once */
@@ -1578,8 +1577,9 @@ retry:
       retry_server_stream =
          mongoc_cluster_stream_for_writes (&client->cluster, &ignored_error);
 
-      if (retry_server_stream && retry_server_stream->sd->max_wire_version >=
-                                    WIRE_VERSION_RETRY_WRITES) {
+      if (retry_server_stream &&
+          retry_server_stream->sd->max_wire_version >=
+             WIRE_VERSION_RETRY_WRITES) {
          parts->assembled.server_stream = retry_server_stream;
          GOTO (retry);
       }

--- a/tests/test-mongoc-client.c
+++ b/tests/test-mongoc-client.c
@@ -1531,6 +1531,7 @@ static void
 test_command_empty (void)
 {
    mongoc_client_t *client;
+   mongoc_write_concern_t *wc;
    bson_error_t error;
    bool r;
 
@@ -1544,6 +1545,29 @@ test_command_empty (void)
                           MONGOC_ERROR_COMMAND_INVALID_ARG,
                           "Empty command document");
 
+   r = mongoc_client_command_with_opts (
+      client, "admin", tmp_bson ("{}"), NULL, tmp_bson ("{}"), NULL, &error);
+
+   ASSERT (!r);
+   ASSERT_ERROR_CONTAINS (error,
+                          MONGOC_ERROR_COMMAND,
+                          MONGOC_ERROR_COMMAND_INVALID_ARG,
+                          "Empty command document");
+
+   wc = mongoc_write_concern_new ();
+   mongoc_write_concern_set_w (wc, 1);
+   mongoc_client_set_write_concern (client, wc);
+
+   r = mongoc_client_write_command_with_opts (
+      client, "admin", tmp_bson ("{}"), NULL, NULL, &error);
+
+   ASSERT (!r);
+   ASSERT_ERROR_CONTAINS (error,
+                          MONGOC_ERROR_COMMAND,
+                          MONGOC_ERROR_COMMAND_INVALID_ARG,
+                          "Empty command document");
+
+   mongoc_write_concern_destroy (wc);
    mongoc_client_destroy (client);
 }
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-2431

`clang-format` picked up bad formatting in `mongoc-client.c`, which I split off into a separate commit.