### PR TITLE
Use gmtime_s instead of gmtime

### DIFF
--- a/src/libbson/src/bson/bson-iso8601.c
+++ b/src/libbson/src/bson/bson-iso8601.c
@@ -316,7 +316,9 @@ _bson_iso8601_date_format (int64_t msec_since_epoch, bson_string_t *str)
 #else
    {
       /* Windows gmtime is thread-safe */
-      strftime (buf, sizeof buf, "%Y-%m-%dT%H:%M:%S", gmtime (&t));
+      struct tm time_buf;
+      gmtime_s (&time_buf, &t);
+      strftime (buf, sizeof buf, "%Y-%m-%dT%H:%M:%S", &time_buf);
    }
 #endif
 


### PR DESCRIPTION
gmtime_s has security enhancements over gmtime, that is why windows generates a warning when trying to compile using gmtime, for more details:
https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/gmtime-s-gmtime32-s-gmtime64-s