### PR TITLE
CDRIVER-2449 omit lsid from auth and monitoring commands

### DIFF
--- a/src/mongoc/mongoc-cluster.c
+++ b/src/mongoc/mongoc-cluster.c
@@ -857,6 +857,7 @@ _mongoc_cluster_auth_node_cr (mongoc_cluster_t *cluster,
    bson_append_int32 (&command, "getnonce", 8, 1);
    mongoc_cmd_parts_init (
       &parts, cluster->client, auth_source, MONGOC_QUERY_SLAVE_OK, &command);
+   parts.prohibit_lsid = true;
    server_stream = _mongoc_cluster_create_server_stream (
       cluster->client->topology, sd->id, stream, error);
 
@@ -898,6 +899,7 @@ _mongoc_cluster_auth_node_cr (mongoc_cluster_t *cluster,
     */
    mongoc_cmd_parts_init (
       &parts, cluster->client, auth_source, MONGOC_QUERY_SLAVE_OK, &command);
+   parts.prohibit_lsid = true;
    ret = mongoc_cluster_run_command_parts (
       cluster, server_stream, &parts, &reply, error);
 
@@ -983,6 +985,7 @@ _mongoc_cluster_auth_node_plain (mongoc_cluster_t *cluster,
 
    mongoc_cmd_parts_init (
       &parts, cluster->client, "$external", MONGOC_QUERY_SLAVE_OK, &b);
+   parts.prohibit_lsid = true;
    server_stream = _mongoc_cluster_create_server_stream (
       cluster->client->topology, sd->id, stream, error);
    ret = mongoc_cluster_run_command_parts (
@@ -1055,6 +1058,7 @@ _mongoc_cluster_auth_node_x509 (mongoc_cluster_t *cluster,
 
    mongoc_cmd_parts_init (
       &parts, cluster->client, "$external", MONGOC_QUERY_SLAVE_OK, &cmd);
+   parts.prohibit_lsid = true;
    server_stream = _mongoc_cluster_create_server_stream (
       cluster->client->topology, sd->id, stream, error);
    ret = mongoc_cluster_run_command_parts (
@@ -1151,6 +1155,7 @@ _mongoc_cluster_auth_node_scram (mongoc_cluster_t *cluster,
 
       mongoc_cmd_parts_init (
          &parts, cluster->client, auth_source, MONGOC_QUERY_SLAVE_OK, &cmd);
+      parts.prohibit_lsid = true;
       server_stream = _mongoc_cluster_create_server_stream (
          cluster->client->topology, sd->id, stream, error);
       if (!mongoc_cluster_run_command_parts (
@@ -2233,6 +2238,7 @@ mongoc_cluster_check_interval (mongoc_cluster_t *cluster, uint32_t server_id)
       BSON_APPEND_INT32 (&command, "ping", 1);
       mongoc_cmd_parts_init (
          &parts, cluster->client, "admin", MONGOC_QUERY_SLAVE_OK, &command);
+      parts.prohibit_lsid = true;
       server_stream = _mongoc_cluster_create_server_stream (
          cluster->client->topology, server_id, stream, &error);
       r = mongoc_cluster_run_command_parts (


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-2449

Per [exceptions to sending the session ID to the server on all commands](https://github.com/mongodb/specifications/blob/master/source/sessions/driver-sessions.rst#exceptions-to-sending-the-session-id-to-the-server-on-all-commands), we should omit `lsid` from authentication commands and may also do so for monitoring commands. The spec only mentions `isMaster` for monitoring, but libmongoc uses `ping` for that purpose as well.