### PR TITLE
CDRIVER-2369 remove bundled snappy from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,5 @@ libmongoc-1.0-config-version.cmake
 libmongoc-1.0-config.cmake
 libmongoc-static-1.0-config-version.cmake
 libmongoc-static-1.0-config.cmake
-src/snappy-1.1.3/snappy-stubs-public.h
 src/zlib-1.2.11/zconf.h
 .githooks


### PR DESCRIPTION
This likely should have been removed as part of [CDRIVER-2369](https://jira.mongodb.org/browse/CDRIVER-2369).