### PR TITLE
CDRIVER-2577 add missing docs for setting SDAM monitoring callbacks

### DIFF
--- a/doc/mongoc_apm_callbacks_t.rst
+++ b/doc/mongoc_apm_callbacks_t.rst
@@ -31,4 +31,13 @@ See Also
     mongoc_apm_set_command_failed_cb
     mongoc_apm_set_command_started_cb
     mongoc_apm_set_command_succeeded_cb
+    mongoc_apm_set_server_changed_cb
+    mongoc_apm_set_server_closed_cb
+    mongoc_apm_set_server_heartbeat_failed_cb
+    mongoc_apm_set_server_heartbeat_started_cb
+    mongoc_apm_set_server_heartbeat_succeeded_cb
+    mongoc_apm_set_server_opening_cb
+    mongoc_apm_set_topology_changed_cb
+    mongoc_apm_set_topology_closed_cb
+    mongoc_apm_set_topology_opening_cb
 

--- a/doc/mongoc_apm_set_server_changed_cb.rst
+++ b/doc/mongoc_apm_set_server_changed_cb.rst
@@ -1,0 +1,30 @@
+:man_page: mongoc_apm_set_server_changed_cb
+
+mongoc_apm_set_server_changed_cb()
+==================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  typedef void (*mongoc_apm_server_changed_cb_t) (
+     const mongoc_apm_server_changed_t *event);
+
+  void
+  mongoc_apm_set_server_changed_cb (mongoc_apm_callbacks_t *callbacks,
+                                       mongoc_apm_server_changed_cb_t cb);
+
+Receive an event notification whenever the driver observes a change in status of a server it is connected to.
+
+Parameters
+----------
+
+* ``callbacks``: A :symbol:`mongoc_apm_callbacks_t`.
+* ``cb``: A function to call with a :symbol:`mongoc_apm_server_changed_t` whenever the driver observes a change in status of a server it is connected to.
+
+See Also
+--------
+
+:doc:`Introduction to Application Performance Monitoring <application-performance-monitoring>`
+

--- a/doc/mongoc_apm_set_server_changed_cb.rst
+++ b/doc/mongoc_apm_set_server_changed_cb.rst
@@ -13,7 +13,7 @@ Synopsis
 
   void
   mongoc_apm_set_server_changed_cb (mongoc_apm_callbacks_t *callbacks,
-                                       mongoc_apm_server_changed_cb_t cb);
+                                    mongoc_apm_server_changed_cb_t cb);
 
 Receive an event notification whenever the driver observes a change in status of a server it is connected to.
 

--- a/doc/mongoc_apm_set_server_closed_cb.rst
+++ b/doc/mongoc_apm_set_server_closed_cb.rst
@@ -13,7 +13,7 @@ Synopsis
 
   void
   mongoc_apm_set_server_closed_cb (mongoc_apm_callbacks_t *callbacks,
-                                       mongoc_apm_server_closed_cb_t cb);
+                                   mongoc_apm_server_closed_cb_t cb);
 
 Receive an event notification whenever the driver stops monitoring a server and removes its :symbol:`mongoc_server_description_t`.
 

--- a/doc/mongoc_apm_set_server_closed_cb.rst
+++ b/doc/mongoc_apm_set_server_closed_cb.rst
@@ -1,0 +1,30 @@
+:man_page: mongoc_apm_set_server_closed_cb
+
+mongoc_apm_set_server_closed_cb()
+=================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  typedef void (*mongoc_apm_server_closed_cb_t) (
+     const mongoc_apm_server_closed_t *event);
+
+  void
+  mongoc_apm_set_server_closed_cb (mongoc_apm_callbacks_t *callbacks,
+                                       mongoc_apm_server_closed_cb_t cb);
+
+Receive an event notification whenever the driver stops monitoring a server and removes its :symbol:`mongoc_server_description_t`.
+
+Parameters
+----------
+
+* ``callbacks``: A :symbol:`mongoc_apm_callbacks_t`.
+* ``cb``: A function to call with a :symbol:`mongoc_apm_server_closed_t` whenever the driver stops monitoring a server and removes its :symbol:`mongoc_server_description_t`.
+
+See Also
+--------
+
+:doc:`Introduction to Application Performance Monitoring <application-performance-monitoring>`
+

--- a/doc/mongoc_apm_set_server_heartbeat_failed_cb.rst
+++ b/doc/mongoc_apm_set_server_heartbeat_failed_cb.rst
@@ -1,0 +1,30 @@
+:man_page: mongoc_apm_set_server_heartbeat_failed_cb
+
+mongoc_apm_set_server_heartbeat_failed_cb()
+===========================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  typedef void (*mongoc_apm_server_heartbeat_failed_cb_t) (
+     const mongoc_apm_server_heartbeat_failed_t *event);
+
+  void
+  mongoc_apm_set_server_heartbeat_failed_cb (mongoc_apm_callbacks_t *callbacks,
+                                       mongoc_apm_server_heartbeat_failed_cb_t cb);
+
+Receive an event notification whenever the driver fails to send an “isMaster” command to check the status of a server.
+
+Parameters
+----------
+
+* ``callbacks``: A :symbol:`mongoc_apm_callbacks_t`.
+* ``cb``: A function to call with a :symbol:`mongoc_apm_server_heartbeat_failed_t` whenever the driver fails to send an “isMaster” command to check the status of a server.
+
+See Also
+--------
+
+:doc:`Introduction to Application Performance Monitoring <application-performance-monitoring>`
+

--- a/doc/mongoc_apm_set_server_heartbeat_failed_cb.rst
+++ b/doc/mongoc_apm_set_server_heartbeat_failed_cb.rst
@@ -13,15 +13,15 @@ Synopsis
 
   void
   mongoc_apm_set_server_heartbeat_failed_cb (mongoc_apm_callbacks_t *callbacks,
-                                       mongoc_apm_server_heartbeat_failed_cb_t cb);
+                                             mongoc_apm_server_heartbeat_failed_cb_t cb);
 
-Receive an event notification whenever the driver fails to send an “isMaster” command to check the status of a server.
+Receive an event notification whenever the driver fails to send an "isMaster" command to check the status of a server.
 
 Parameters
 ----------
 
 * ``callbacks``: A :symbol:`mongoc_apm_callbacks_t`.
-* ``cb``: A function to call with a :symbol:`mongoc_apm_server_heartbeat_failed_t` whenever the driver fails to send an “isMaster” command to check the status of a server.
+* ``cb``: A function to call with a :symbol:`mongoc_apm_server_heartbeat_failed_t` whenever the driver fails to send an "isMaster" command to check the status of a server.
 
 See Also
 --------

--- a/doc/mongoc_apm_set_server_heartbeat_started_cb.rst
+++ b/doc/mongoc_apm_set_server_heartbeat_started_cb.rst
@@ -1,0 +1,30 @@
+:man_page: mongoc_apm_set_server_heartbeat_started_cb
+
+mongoc_apm_set_server_heartbeat_started_cb()
+============================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  typedef void (*mongoc_apm_server_heartbeat_started_cb_t) (
+     const mongoc_apm_server_heartbeat_started_t *event);
+
+  void
+  mongoc_apm_set_server_heartbeat_started_cb (mongoc_apm_callbacks_t *callbacks,
+                                       mongoc_apm_server_heartbeat_started_cb_t cb);
+
+Receive an event notification whenever the driver begins executing an “isMaster” command to check the status of a server.
+
+Parameters
+----------
+
+* ``callbacks``: A :symbol:`mongoc_apm_callbacks_t`.
+* ``cb``: A function to call with a :symbol:`mongoc_apm_server_heartbeat_started_t` whenever the driver begins executing an “isMaster” command to check the status of a server.
+
+See Also
+--------
+
+:doc:`Introduction to Application Performance Monitoring <application-performance-monitoring>`
+

--- a/doc/mongoc_apm_set_server_heartbeat_started_cb.rst
+++ b/doc/mongoc_apm_set_server_heartbeat_started_cb.rst
@@ -13,15 +13,15 @@ Synopsis
 
   void
   mongoc_apm_set_server_heartbeat_started_cb (mongoc_apm_callbacks_t *callbacks,
-                                       mongoc_apm_server_heartbeat_started_cb_t cb);
+                                              mongoc_apm_server_heartbeat_started_cb_t cb);
 
-Receive an event notification whenever the driver begins executing an “isMaster” command to check the status of a server.
+Receive an event notification whenever the driver begins executing an "isMaster" command to check the status of a server.
 
 Parameters
 ----------
 
 * ``callbacks``: A :symbol:`mongoc_apm_callbacks_t`.
-* ``cb``: A function to call with a :symbol:`mongoc_apm_server_heartbeat_started_t` whenever the driver begins executing an “isMaster” command to check the status of a server.
+* ``cb``: A function to call with a :symbol:`mongoc_apm_server_heartbeat_started_t` whenever the driver begins executing an "isMaster" command to check the status of a server.
 
 See Also
 --------

--- a/doc/mongoc_apm_set_server_heartbeat_succeeded_cb.rst
+++ b/doc/mongoc_apm_set_server_heartbeat_succeeded_cb.rst
@@ -1,0 +1,30 @@
+:man_page: mongoc_apm_set_server_heartbeat_succeeded_cb
+
+mongoc_apm_set_server_heartbeat_succeeded_cb()
+==============================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  typedef void (*mongoc_apm_server_heartbeat_succeeded_cb_t) (
+     const mongoc_apm_server_heartbeat_succeeded_t *event);
+
+  void
+  mongoc_apm_set_server_heartbeat_succeeded_cb (mongoc_apm_callbacks_t *callbacks,
+                                       mongoc_apm_server_heartbeat_succeeded_cb_t cb);
+
+Receive an event notification whenever the driver completes an “isMaster” command to check the status of a server.
+
+Parameters
+----------
+
+* ``callbacks``: A :symbol:`mongoc_apm_callbacks_t`.
+* ``cb``: A function to call with a :symbol:`mongoc_apm_server_heartbeat_succeeded_t` whenever the driver completes an “isMaster” command to check the status of a server.
+
+See Also
+--------
+
+:doc:`Introduction to Application Performance Monitoring <application-performance-monitoring>`
+

--- a/doc/mongoc_apm_set_server_heartbeat_succeeded_cb.rst
+++ b/doc/mongoc_apm_set_server_heartbeat_succeeded_cb.rst
@@ -13,15 +13,15 @@ Synopsis
 
   void
   mongoc_apm_set_server_heartbeat_succeeded_cb (mongoc_apm_callbacks_t *callbacks,
-                                       mongoc_apm_server_heartbeat_succeeded_cb_t cb);
+                                                mongoc_apm_server_heartbeat_succeeded_cb_t cb);
 
-Receive an event notification whenever the driver completes an “isMaster” command to check the status of a server.
+Receive an event notification whenever the driver completes an "isMaster" command to check the status of a server.
 
 Parameters
 ----------
 
 * ``callbacks``: A :symbol:`mongoc_apm_callbacks_t`.
-* ``cb``: A function to call with a :symbol:`mongoc_apm_server_heartbeat_succeeded_t` whenever the driver completes an “isMaster” command to check the status of a server.
+* ``cb``: A function to call with a :symbol:`mongoc_apm_server_heartbeat_succeeded_t` whenever the driver completes an "isMaster" command to check the status of a server.
 
 See Also
 --------

--- a/doc/mongoc_apm_set_server_opening_cb.rst
+++ b/doc/mongoc_apm_set_server_opening_cb.rst
@@ -13,7 +13,7 @@ Synopsis
 
   void
   mongoc_apm_set_server_opening_cb (mongoc_apm_callbacks_t *callbacks,
-                                       mongoc_apm_server_opening_cb_t cb);
+                                    mongoc_apm_server_opening_cb_t cb);
 
 Receive an event notification whenever the driver adds a :symbol:`mongoc_server_description_t` for a new server it was not monitoring before.
 

--- a/doc/mongoc_apm_set_server_opening_cb.rst
+++ b/doc/mongoc_apm_set_server_opening_cb.rst
@@ -1,0 +1,30 @@
+:man_page: mongoc_apm_set_server_opening_cb
+
+mongoc_apm_set_server_opening_cb()
+==================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  typedef void (*mongoc_apm_server_opening_cb_t) (
+     const mongoc_apm_server_opening_t *event);
+
+  void
+  mongoc_apm_set_server_opening_cb (mongoc_apm_callbacks_t *callbacks,
+                                       mongoc_apm_server_opening_cb_t cb);
+
+Receive an event notification whenever the driver adds a :symbol:`mongoc_server_description_t` for a new server it was not monitoring before.
+
+Parameters
+----------
+
+* ``callbacks``: A :symbol:`mongoc_apm_callbacks_t`.
+* ``cb``: A function to call with a :symbol:`mongoc_apm_server_opening_t` whenever the driver adds a :symbol:`mongoc_server_description_t` for a new server it was not monitoring before.
+
+See Also
+--------
+
+:doc:`Introduction to Application Performance Monitoring <application-performance-monitoring>`
+

--- a/doc/mongoc_apm_set_topology_changed_cb.rst
+++ b/doc/mongoc_apm_set_topology_changed_cb.rst
@@ -13,7 +13,7 @@ Synopsis
 
   void
   mongoc_apm_set_topology_changed_cb (mongoc_apm_callbacks_t *callbacks,
-                                       mongoc_apm_topology_changed_cb_t cb);
+                                      mongoc_apm_topology_changed_cb_t cb);
 
 Receive an event notification whenever the driver observes a change in any of the servers it is connected to or a change in the overall server topology.
 

--- a/doc/mongoc_apm_set_topology_changed_cb.rst
+++ b/doc/mongoc_apm_set_topology_changed_cb.rst
@@ -1,0 +1,30 @@
+:man_page: mongoc_apm_set_topology_changed_cb
+
+mongoc_apm_set_topology_changed_cb()
+====================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  typedef void (*mongoc_apm_topology_changed_cb_t) (
+     const mongoc_apm_topology_changed_t *event);
+
+  void
+  mongoc_apm_set_topology_changed_cb (mongoc_apm_callbacks_t *callbacks,
+                                       mongoc_apm_topology_changed_cb_t cb);
+
+Receive an event notification whenever the driver observes a change in any of the servers it is connected to or a change in the overall server topology.
+
+Parameters
+----------
+
+* ``callbacks``: A :symbol:`mongoc_apm_callbacks_t`.
+* ``cb``: A function to call with a :symbol:`mongoc_apm_topology_changed_t` whenever the driver observes a change in any of the servers it is connected to or a change in the overall server topology.
+
+See Also
+--------
+
+:doc:`Introduction to Application Performance Monitoring <application-performance-monitoring>`
+

--- a/doc/mongoc_apm_set_topology_closed_cb.rst
+++ b/doc/mongoc_apm_set_topology_closed_cb.rst
@@ -13,7 +13,7 @@ Synopsis
 
   void
   mongoc_apm_set_topology_closed_cb (mongoc_apm_callbacks_t *callbacks,
-                                       mongoc_apm_topology_closed_cb_t cb);
+                                     mongoc_apm_topology_closed_cb_t cb);
 
 Receive an event notification whenever the driver stops monitoring a server topology and destroys its :symbol:`mongoc_topology_description_t`.
 

--- a/doc/mongoc_apm_set_topology_closed_cb.rst
+++ b/doc/mongoc_apm_set_topology_closed_cb.rst
@@ -1,0 +1,30 @@
+:man_page: mongoc_apm_set_topology_closed_cb
+
+mongoc_apm_set_topology_closed_cb()
+===================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  typedef void (*mongoc_apm_topology_closed_cb_t) (
+     const mongoc_apm_topology_closed_t *event);
+
+  void
+  mongoc_apm_set_topology_closed_cb (mongoc_apm_callbacks_t *callbacks,
+                                       mongoc_apm_topology_closed_cb_t cb);
+
+Receive an event notification whenever the driver stops monitoring a server topology and destroys its :symbol:`mongoc_topology_description_t`.
+
+Parameters
+----------
+
+* ``callbacks``: A :symbol:`mongoc_apm_callbacks_t`.
+* ``cb``: A function to call with a :symbol:`mongoc_apm_topology_closed_t` whenever the driver stops monitoring a server topology and destroys its :symbol:`mongoc_topology_description_t`.
+
+See Also
+--------
+
+:doc:`Introduction to Application Performance Monitoring <application-performance-monitoring>`
+

--- a/doc/mongoc_apm_set_topology_opening_cb.rst
+++ b/doc/mongoc_apm_set_topology_opening_cb.rst
@@ -1,0 +1,30 @@
+:man_page: mongoc_apm_set_topology_opening_cb
+
+mongoc_apm_set_topology_opening_cb()
+====================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  typedef void (*mongoc_apm_topology_opening_cb_t) (
+     const mongoc_apm_topology_opening_t *event);
+
+  void
+  mongoc_apm_set_topology_opening_cb (mongoc_apm_callbacks_t *callbacks,
+                                       mongoc_apm_topology_opening_cb_t cb);
+
+Receive an event notification whenever the driver initializes a :symbol:`mongoc_topology_description_t`.
+
+Parameters
+----------
+
+* ``callbacks``: A :symbol:`mongoc_apm_callbacks_t`.
+* ``cb``: A function to call with a :symbol:`mongoc_apm_topology_opening_t` whenever the driver initializes a :symbol:`mongoc_topology_description_t`.
+
+See Also
+--------
+
+:doc:`Introduction to Application Performance Monitoring <application-performance-monitoring>`
+

--- a/doc/mongoc_apm_set_topology_opening_cb.rst
+++ b/doc/mongoc_apm_set_topology_opening_cb.rst
@@ -13,7 +13,7 @@ Synopsis
 
   void
   mongoc_apm_set_topology_opening_cb (mongoc_apm_callbacks_t *callbacks,
-                                       mongoc_apm_topology_opening_cb_t cb);
+                                      mongoc_apm_topology_opening_cb_t cb);
 
 Receive an event notification whenever the driver initializes a :symbol:`mongoc_topology_description_t`.
 


### PR DESCRIPTION
sphinx generated all the HTML files and man pages without complaining. the HTML pages look correct to me in the browser, and I just used `groff -man -Tascii [filename]` to check that the man pages as plaintext looked reasonable/matched the existing ones - is there is some other way I should check those, let me know. 