### PR TITLE
CDRIVER-2439 don't gossip cluster time to standalones

### DIFF
--- a/src/mongoc/mongoc-cmd.c
+++ b/src/mongoc/mongoc-cmd.c
@@ -791,7 +791,7 @@ mongoc_cmd_parts_assemble (mongoc_cmd_parts_t *parts,
             _largest_cluster_time (&server_stream->cluster_time, cluster_time);
       }
 
-      if (cluster_time) {
+      if (cluster_time && server_type != MONGOC_SERVER_STANDALONE) {
          _mongoc_cmd_parts_ensure_copied (parts);
          bson_append_document (
             &parts->assembled_body, "$clusterTime", 12, cluster_time);


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-2439

This addresses an edge case where an explicit session's cluster time may have been manually advanced. Under normal usage, sessions used with a standalone will always have an empty cluster time.