### PR TITLE
CDRIVER-2658 Save minidump files if mongodb crashes during test

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -302,6 +302,43 @@ functions:
         permissions: public-read
         content_type: ${content_type|text/plain}
         display_name: "orchestration.log"
+    # Gather and archive mongo coredumps.
+    - command: shell.exec
+      params:
+        working_dir: "mongoc"
+        script: |
+          # Find all core files from mongodb in orchestration and move to mongoc
+          DIR=MO
+          MDMP_DIR=$DIR
+          [ -d "/cygdrive/c/data/mo" ] && DIR="/cygdrive/c/data/mo"
+          [ -d "/cygdrive/c/mongodb" ] && MDMP_DIR="/cygdrive/c/mongodb"
+          core_files=$(/usr/bin/find -H $MO $MDMP_DIR \( -name "*.core" -o -name "*.mdmp" \) 2> /dev/null)
+          for core_file in $core_files
+          do
+            base_name=$(echo $core_file | sed "s/.*\///")
+            # Move file if it does not already exist
+            if [ ! -f $base_name ]; then
+              mv $core_file .
+            fi
+          done
+    - command: archive.targz_pack
+      params:
+        target: "mongo-coredumps.tgz"
+        source_dir: "mongoc"
+        include:
+          - "./**.core"
+          - "./**.mdmp" # Windows: minidumps
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: mongo-coredumps.tgz
+        remote_file: mongo-c-driver/${build_variant}/${revision}/${version_id}/${build_id}/coredumps/${task_id}-${execution}-coredumps.log
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${content_type|application/x-gzip}
+        display_name: Core Dumps - Execution ${execution}
+        optional: true
 
   "backtrace":
     - command: shell.exec


### PR DESCRIPTION
This was already reviewed by @kevinAlbs but I do not have push permission I needed to open a pull request. 

Description from earlier CR:
There is a rare crash on Windows SSL with MongoDB that I would like to get a dump for. As such, I have migrated the Server's evergreen support for collecting crash dumps to the C Driver.

MDMP
Mongo Orchestration is running mongodb from c:\mongodb. Example is from the log in SERVER-35125

2018-05-21T16:23:22.131+0000 I CONTROL [conn9] writing minidump diagnostic file c:\mongodb\bin\mongod.2018-05-21T16-23-22.mdmp

Linux
MongoDB Evergreen hosts generate crashdumps with .core