### PR TITLE
Fix warning: arithmetic on a pointer to void

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-async-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-async-cmd.c
@@ -319,7 +319,7 @@ _mongoc_async_cmd_phase_send (mongoc_async_cmd_t *acmd)
       niovec = acmd->niovec - i;
       iovec = bson_malloc (niovec * sizeof (mongoc_iovec_t));
       memcpy (iovec, acmd->iovec + i, niovec * sizeof (mongoc_iovec_t));
-      iovec[0].iov_base += offset;
+      iovec[0].iov_base = (char *) iovec[0].iov_base + offset;
       iovec[0].iov_len -= offset;
       used_temp_iovec = true;
    }


### PR DESCRIPTION
Arithmetic on a pointer to void is a GNU extension [-Wpointer-arith]