### PR TITLE
Document reply documents for update_one, update_many, replace_one

### DIFF
--- a/src/libmongoc/doc/mongoc_collection_replace_one.rst
+++ b/src/libmongoc/doc/mongoc_collection_replace_one.rst
@@ -34,7 +34,7 @@ Description
 
 This function shall replace documents in ``collection`` that match ``selector`` with ``replacement``.
 
-If you pass a non-NULL ``reply``, it is filled out with fields "modifiedCount" and "matchedCount". If there is a server error then ``reply`` contains either a "writeErrors" array with one subdocument or a "writeConcernErrors" array. The reply must be freed with :symbol:`bson:bson_destroy`.
+If you pass a non-NULL ``reply``, it is filled out with fields "modifiedCount" and "matchedCount", and optionally "upsertedId" if applicable. If there is a server error then ``reply`` contains either a "writeErrors" array with one subdocument or a "writeConcernErrors" array. The reply must be freed with :symbol:`bson:bson_destroy`.
 
 See Also
 --------


### PR DESCRIPTION
@jmikola pointed out in [mongo-swift-driver#104](https://github.com/mongodb/mongo-swift-driver/pull/104) that `upsertedCount` is not mentioned in the docs. It seems that the reply document behavior is identical across all three of these functions, so I've updated the docs to match. 