### PR TITLE
Fix two warnings when using mongoc.h with the Visual Studio compiler

### DIFF
--- a/src/libbson/src/bson/bson-compat.h
+++ b/src/libbson/src/bson/bson-compat.h
@@ -85,7 +85,9 @@
 
 BSON_BEGIN_DECLS
 
-
+#if !defined(_MSC_VER) || (_MSC_VER >= 1800)
+#include <inttypes.h>
+#endif
 #ifdef _MSC_VER
 #ifndef __cplusplus
 /* benign redefinition of type */
@@ -129,8 +131,6 @@ typedef SSIZE_T ssize_t;
 #ifndef PRIu64
 #define PRIu64 "I64u"
 #endif
-#else
-#include <inttypes.h>
 #endif
 
 #if defined(__MINGW32__) && !defined(INIT_ONCE_STATIC_INIT)

--- a/src/libmongoc/src/mongoc/mongoc-iovec.h
+++ b/src/libmongoc/src/mongoc/mongoc-iovec.h
@@ -32,7 +32,7 @@ BSON_BEGIN_DECLS
 
 #ifdef _WIN32
 typedef struct {
-   u_long iov_len;
+   size_t iov_len;
    char *iov_base;
 } mongoc_iovec_t;
 
@@ -40,10 +40,10 @@ BSON_STATIC_ASSERT2 (sizeof_iovect_t,
                      sizeof (mongoc_iovec_t) == sizeof (WSABUF));
 BSON_STATIC_ASSERT2 (offsetof_iovec_base,
                      offsetof (mongoc_iovec_t, iov_base) ==
-                     offsetof (WSABUF, buf));
+                        offsetof (WSABUF, buf));
 BSON_STATIC_ASSERT2 (offsetof_iovec_len,
                      offsetof (mongoc_iovec_t, iov_len) ==
-                     offsetof (WSABUF, len));
+                        offsetof (WSABUF, len));
 
 #else
 typedef struct iovec mongoc_iovec_t;


### PR DESCRIPTION
Fix macro redefinition warning when including <inttypes.h> after mongoc.h using Visual Studio 2013 or newer.
Fix iov_len in mongoc_iovec_t on Windows to be size_t like on Linux