### PR TITLE
Improve documentation for CRUD replies

### DIFF
--- a/src/libmongoc/doc/mongoc_collection_insert_many.rst
+++ b/src/libmongoc/doc/mongoc_collection_insert_many.rst
@@ -38,7 +38,7 @@ To insert a single document, see :symbol:`mongoc_collection_insert_one`.
 
 For any document that does not have an "_id" field, a :symbol:`bson:bson_oid_t` will be generated locally and added to the document. If you must know the inserted document's ``_id``, generate it in your code and include it in the ``document``. The ``_id`` you generate can be a :symbol:`bson:bson_oid_t` or any other non-array BSON type.
 
-If you pass a non-NULL ``reply``, it is filled out with an "insertedCount" field. If there is a server error then ``reply`` contains either a "writeErrors" array with one subdocument or a "writeConcernErrors" array. The reply must be freed with :symbol:`bson:bson_destroy`.
+If you pass a non-NULL ``reply``, it is filled out with an "insertedCount" field. If there is a server error then ``reply`` may contain a "writeErrors" array and/or a "writeConcernErrors" array (see :doc:`Bulk Write Operations <bulk>` for examples). The reply must be freed with :symbol:`bson:bson_destroy`.
 
 Errors
 ------

--- a/src/libmongoc/doc/mongoc_collection_update_many.rst
+++ b/src/libmongoc/doc/mongoc_collection_update_many.rst
@@ -36,6 +36,8 @@ This function updates all documents in ``collection`` that match ``selector``.
 
 To update at most one document see :symbol:`mongoc_collection_update_one`.
 
+If you pass a non-NULL ``reply``, it is filled out with fields  ``matchedCount``, ``modifiedCount``, and optionally ``upsertedId`` if applicable. If there is a server error then ``reply`` contains either a "writeErrors" array with one subdocument or a "writeConcernErrors" array. The reply must be freed with :symbol:`bson:bson_destroy`.
+
 See Also
 --------
 
@@ -54,5 +56,3 @@ Returns
 Returns ``true`` if successful. Returns ``false`` and sets ``error`` if there are invalid arguments or a server or network error.
 
 A write concern timeout or write concern error is considered a failure.
-
-If provided, ``reply`` will be initialized and populated with the fields ``matchedCount``, ``modifiedCount``, and optionally ``upsertedId`` if applicable. The reply must be freed with :symbol:`bson:bson_destroy`.

--- a/src/libmongoc/doc/mongoc_collection_update_one.rst
+++ b/src/libmongoc/doc/mongoc_collection_update_one.rst
@@ -36,6 +36,8 @@ This function updates at most one document in ``collection`` that matches ``sele
 
 To update multiple documents see :symbol:`mongoc_collection_update_many`.
 
+If you pass a non-NULL ``reply``, it is filled out with fields  ``matchedCount``, ``modifiedCount``, and optionally ``upsertedId`` if applicable. If there is a server error then ``reply`` contains either a "writeErrors" array with one subdocument or a "writeConcernErrors" array. The reply must be freed with :symbol:`bson:bson_destroy`.
+
 See Also
 --------
 
@@ -56,8 +58,6 @@ Returns
 Returns ``true`` if successful. Returns ``false`` and sets ``error`` if there are invalid arguments or a server or network error.
 
 A write concern timeout or write concern error is considered a failure.
-
-If provided, ``reply`` will be initialized and populated with the fields ``matchedCount``, ``modifiedCount``, and optionally ``upsertedId`` if applicable. The reply must be freed with :symbol:`bson:bson_destroy`.
 
 Example
 -------


### PR DESCRIPTION
`update_one` and `update_many` were inconsistent with other methods.

Since `insert_many` is technically a bulk write, its reply may include multiple `writeErrors` alongside `writeConcernErrors` (with one subdocument). Revise that language and reference the bulk write examples to avoid repetition.