### PR TITLE
Print leading zeros in datetime ms

### DIFF
--- a/src/libbson/src/bson/bson-iso8601.c
+++ b/src/libbson/src/bson/bson-iso8601.c
@@ -325,7 +325,7 @@ _bson_iso8601_date_format (int64_t msec_since_epoch, bson_string_t *str)
 #endif
 
    if (msecs_part) {
-      bson_string_append_printf (str, "%s.%3" PRId64 "Z", buf, msecs_part);
+      bson_string_append_printf (str, "%s.%03" PRId64 "Z", buf, msecs_part);
    } else {
       bson_string_append (str, buf);
       bson_string_append_c (str, 'Z');


### PR DESCRIPTION
See issue https://github.com/jeroen/mongolite/issues/163

This ensures that leading zero's get included in the ms part of a datetime. Currently dates get printed like this: `1998-11-07T00:00:00. 23Z` (note the blank instead of 0).