### PR TITLE
CDRIVER-2902: bitFlags field for OP_MSG does not swap for Big-Endian zSeries system

### DIFF
--- a/src/libmongoc/src/mongoc/op-msg.def
+++ b/src/libmongoc/src/mongoc/op-msg.def
@@ -4,6 +4,6 @@ RPC(
   INT32_FIELD(request_id)
   INT32_FIELD(response_to)
   INT32_FIELD(opcode)
-  UINT32_FIELD(flags)
+  ENUM_FIELD(flags)
   SECTION_ARRAY_FIELD(sections)
 )


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-2902

Sorry it's on the wrong branch, but this was made from a checkout on zSeries with little tools available.