### PR TITLE
Fix crash related to pem_file in optimized build

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
@@ -995,8 +995,9 @@ mongoc_stream_tls_secure_channel_new (mongoc_stream_t *base_stream,
       mongoc_secure_channel_setup_crl (secure_channel, opt);
    }
 
+   PCCERT_CONTEXT cert = NULL;
    if (opt->pem_file) {
-      PCCERT_CONTEXT cert =
+      cert =
          mongoc_secure_channel_setup_certificate (secure_channel, opt);
 
       if (cert) {


### PR DESCRIPTION
PCCERT_CONTEXT cert/paCred pointer goes out of `if` scope in optimized build, leading to crash (this seem to work fine in unoptimized/debug build). VC14 x64