### PR TITLE
Allow libbson and libmongoc library names to be changed externally

### DIFF
--- a/src/libbson/CMakeLists.txt
+++ b/src/libbson/CMakeLists.txt
@@ -8,6 +8,8 @@ if (ENABLE_TESTS AND NOT ENABLE_STATIC MATCHES "ON|AUTO")
    message (FATAL_ERROR "-DENABLE_STATIC=OFF also requires -DENABLE_TESTS=OFF")
 endif ()
 
+set(BSON_OUTPUT_BASENAME "bson" CACHE STRING "Output bson library base name")
+
 include (CheckFunctionExists)
 include (CheckIncludeFile)
 include (CheckStructHasMember)
@@ -22,7 +24,7 @@ set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/../../build/cm
 include (LoadVersion)
 LoadVersion (${PROJECT_SOURCE_DIR}/../../VERSION_CURRENT BSON)
 
-message ("libbson version (from VERSION_CURRENT file): ${BSON_VERSION}")
+message ("lib${BSON_OUTPUT_BASENAME} version (from VERSION_CURRENT file): ${BSON_VERSION}")
 
 set (BSON_API_VERSION 1.0)
 
@@ -218,16 +220,16 @@ set (CMAKE_CXX_VISIBILITY_PRESET hidden)
 target_compile_definitions (bson_shared PRIVATE BSON_COMPILATION JSONSL_PARSE_NAN)
 target_include_directories (bson_shared INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src> $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>)
 set_target_properties (bson_shared PROPERTIES VERSION 0.0.0 SOVERSION 0)
-set_target_properties (bson_shared PROPERTIES OUTPUT_NAME "bson-${BSON_API_VERSION}" PREFIX "lib")
+set_target_properties (bson_shared PROPERTIES OUTPUT_NAME "${BSON_OUTPUT_BASENAME}-${BSON_API_VERSION}" PREFIX "lib")
 
 if (ENABLE_APPLE_FRAMEWORK)
-   set_target_properties(bson_shared PROPERTIES 
-      FRAMEWORK TRUE 
-      MACOSX_FRAMEWORK_BUNDLE_VERSION ${MONGOC_VERSION} 
+   set_target_properties(bson_shared PROPERTIES
+      FRAMEWORK TRUE
+      MACOSX_FRAMEWORK_BUNDLE_VERSION ${MONGOC_VERSION}
       MACOSX_FRAMEWORK_SHORT_VERSION_STRING ${MONGOC_VERSION}
       MACOSX_FRAMEWORK_IDENTIFIER org.mongodb.bson
-      OUTPUT_NAME "bson"
-      PUBLIC_HEADER "${HEADERS}" 
+      OUTPUT_NAME "${BSON_OUTPUT_BASENAME}"
+      PUBLIC_HEADER "${HEADERS}"
    )
 endif ()
 
@@ -264,7 +266,7 @@ if (ENABLE_STATIC MATCHES "ON|AUTO")
    )
    target_include_directories (bson_static INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src> $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>)
    set_target_properties (bson_static PROPERTIES VERSION 0.0.0)
-   set_target_properties (bson_static PROPERTIES OUTPUT_NAME "bson-static-${BSON_API_VERSION}")
+   set_target_properties (bson_static PROPERTIES OUTPUT_NAME "${BSON_OUTPUT_BASENAME}-static-${BSON_API_VERSION}")
    # We use CMAKE_THREAD_LIBS_INIT rather than Threads::Threads here because the
    # latter fails when building on Mac OS X
    target_link_libraries (bson_static ${CMAKE_THREAD_LIBS_INIT})

--- a/src/libbson/CMakeLists.txt
+++ b/src/libbson/CMakeLists.txt
@@ -8,7 +8,7 @@ if (ENABLE_TESTS AND NOT ENABLE_STATIC MATCHES "ON|AUTO")
    message (FATAL_ERROR "-DENABLE_STATIC=OFF also requires -DENABLE_TESTS=OFF")
 endif ()
 
-set(BSON_OUTPUT_BASENAME "bson" CACHE STRING "Output bson library base name")
+set (BSON_OUTPUT_BASENAME "bson" CACHE STRING "Output bson library base name")
 
 include (CheckFunctionExists)
 include (CheckIncludeFile)

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -28,7 +28,7 @@ set (MONGOC_ENABLE_COMPRESSION_SNAPPY 0)
 set (MONGOC_ENABLE_COMPRESSION_ZLIB 0)
 set (MONGOC_ENABLE_COMPRESSION_ZSTD 0)
 
-set(MONGOC_OUTPUT_BASENAME "mongoc" CACHE STRING "Output mongoc library base name")
+set (MONGOC_OUTPUT_BASENAME "mongoc" CACHE STRING "Output mongoc library base name")
 
 if (ENABLE_COVERAGE)
    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g --coverage")

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -28,6 +28,8 @@ set (MONGOC_ENABLE_COMPRESSION_SNAPPY 0)
 set (MONGOC_ENABLE_COMPRESSION_ZLIB 0)
 set (MONGOC_ENABLE_COMPRESSION_ZSTD 0)
 
+set(MONGOC_OUTPUT_BASENAME "mongoc" CACHE STRING "Output mongoc library base name")
+
 if (ENABLE_COVERAGE)
    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g --coverage")
 endif ()
@@ -683,7 +685,7 @@ target_include_directories (mongoc_shared PRIVATE ${PRIVATE_ZLIB_INCLUDES})
 target_compile_definitions (mongoc_shared PRIVATE MONGOC_COMPILATION)
 
 set_target_properties (mongoc_shared PROPERTIES VERSION 0.0.0 SOVERSION 0)
-set_target_properties (mongoc_shared PROPERTIES OUTPUT_NAME "mongoc-${MONGOC_API_VERSION}" PREFIX "lib")
+set_target_properties (mongoc_shared PROPERTIES OUTPUT_NAME "${MONGOC_OUTPUT_BASENAME}-${MONGOC_API_VERSION}" PREFIX "lib")
 
 if (MONGOC_ENABLE_STATIC)
    add_library (mongoc_static STATIC ${SOURCES} ${HEADERS} ${HEADERS_FORWARDING})
@@ -695,17 +697,17 @@ if (MONGOC_ENABLE_STATIC)
       PRIVATE MONGOC_COMPILATION
    )
    set_target_properties (mongoc_static PROPERTIES VERSION 0.0.0)
-   set_target_properties (mongoc_static PROPERTIES OUTPUT_NAME "mongoc-static-${MONGOC_API_VERSION}")
+   set_target_properties (mongoc_static PROPERTIES OUTPUT_NAME "${MONGOC_OUTPUT_BASENAME}-static-${MONGOC_API_VERSION}")
 endif ()
 
 if (ENABLE_APPLE_FRAMEWORK)
-   set_target_properties (mongoc_shared PROPERTIES 
-      FRAMEWORK TRUE 
-      MACOSX_FRAMEWORK_BUNDLE_VERSION ${MONGOC_VERSION} 
+   set_target_properties (mongoc_shared PROPERTIES
+      FRAMEWORK TRUE
+      MACOSX_FRAMEWORK_BUNDLE_VERSION ${MONGOC_VERSION}
       MACOSX_FRAMEWORK_SHORT_VERSION_STRING ${MONGOC_VERSION}
       MACOSX_FRAMEWORK_IDENTIFIER org.mongodb.mongoc
-      OUTPUT_NAME "mongoc"
-      PUBLIC_HEADER "${HEADERS}" 
+      OUTPUT_NAME "${MONGOC_OUTPUT_BASENAME}"
+      PUBLIC_HEADER "${HEADERS}"
    )
 endif ()
 


### PR DESCRIPTION
Internally we rename the libraries we integrate as to avoid interference with the library versions already available on the target systems by giving them a prefix.
This PR allows users to specify, for example:
```
-DBSON_OUTPUT_BASENAME:STRING=MYORG_bson
-DMONGOC_OUTPUT_BASENAME:STRING=MYORG_mongoc
```
I used `BASENAME` as the flavor and/or version are appended later.

Alternatively, it would be also fine for us to add a prefix variable like `OUTPUT_NAME_PREFIX` or so but I was unable to find a good name that cannot be confused the target `PREFIX` property (e.g. `lib`)