### PR TITLE
Fix __ss_family build issue on AIX6.1

### DIFF
--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -428,6 +428,11 @@ elseif (NOT ENABLE_CLIENT_SIDE_ENCRYPTION STREQUAL OFF)
 endif ()
 
 CHECK_STRUCT_HAS_MEMBER("struct sockaddr_storage" ss_family "sys/socket.h" MONGOC_HAVE_SS_FAMILY)
+if (NOT MONGOC_HAVE_SS_FAMILY)
+   set (MONGOC_HAVE_SS_FAMILY 0)
+else ()
+   set (MONGOC_HAVE_SS_FAMILY 1)
+endif ()
 
 configure_file (
    "${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-config.h.in"

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -427,6 +427,8 @@ elseif (NOT ENABLE_CLIENT_SIDE_ENCRYPTION STREQUAL OFF)
    endif ()
 endif ()
 
+CHECK_STRUCT_HAS_MEMBER("struct sockaddr_storage" ss_family "sys/socket.h" MONGOC_HAVE_SS_FAMILY)
+
 configure_file (
    "${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-config.h.in"
    "${PROJECT_BINARY_DIR}/src/mongoc/mongoc-config.h"

--- a/src/libmongoc/src/mongoc/mongoc-config.h.in
+++ b/src/libmongoc/src/mongoc/mongoc-config.h.in
@@ -381,6 +381,17 @@
 #  undef MONGOC_ENABLE_CLIENT_SIDE_ENCRYPTION
 #endif
 
+
+/*
+ * Set if struct sockaddr_storage has __ss_family (instead of ss_family)
+ */
+
+#define MONGOC_HAVE_SS_FAMILY @MONGOC_HAVE_SS_FAMILY@
+
+#if MONGOC_HAVE_SS_FAMILY != 1
+#  undef MONGOC_HAVE_SS_FAMILY
+#endif
+
 /*
  * NOTICE:
  * If you're about to update this file and add a config flag, make sure to

--- a/src/libmongoc/src/mongoc/mongoc-socket.h
+++ b/src/libmongoc/src/mongoc/mongoc-socket.h
@@ -38,7 +38,7 @@
 #include <sys/un.h>
 #endif
 
-#if defined(_AIX) && !defined(HAVE_SA_SS_FAMILY)
+#if defined(_AIX) && !defined(MONGOC_HAVE_SS_FAMILY)
 # define ss_family __ss_family
 #endif
 


### PR DESCRIPTION
See issue https://github.com/mongodb/mongo-c-driver/pull/562.
Correct way to find ``ss_family`` on AIX 5+.
Tested on AIX 6.1. It compiles and the whole test suite is OK.