### PR TITLE
Remove extra arg in mongoc_log call

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
@@ -975,7 +975,7 @@ _log_callback (mongocrypt_log_level_t mongocrypt_log_level,
       break;
    }
 
-   mongoc_log (log_level, MONGOC_LOG_DOMAIN, "%s", message, NULL);
+   mongoc_log (log_level, MONGOC_LOG_DOMAIN, "%s", message);
 }
 
 static void


### PR DESCRIPTION
I encountered the following build warning when compiling PHPC with bundled libmongoc and FLE: 

```
/home/jmikola/workspace/mongodb/phpc/src/libmongoc/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c: In function ‘_log_callback’:
/home/jmikola/workspace/mongodb/phpc/src/libmongoc/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c:978:46: warning: too many arguments for format [-Wformat-extra-args]
    mongoc_log (log_level, MONGOC_LOG_DOMAIN, "%s", message, NULL);
```