### PR TITLE
Fix for mingw-w64 Windows build

### DIFF
--- a/src/libbson/src/bson/bson-macros.h
+++ b/src/libbson/src/bson/bson-macros.h
@@ -176,7 +176,7 @@
 #define bson_str_empty0(s) (!s || !s[0])
 
 
-#if defined(_WIN32)
+#if defined(_MSC_VER)
 #define BSON_FUNC __FUNCTION__
 #elif defined(__STDC_VERSION__) && __STDC_VERSION__ < 199901L
 #define BSON_FUNC __FUNCTION__


### PR DESCRIPTION
I am not sure why Windows is special cased here, but mingw-w64 / gcc needs the same logic as other systems, otherwise we get compiler warnings about non-standard c99.