### PR TITLE
Improve error messaging when a NULL parameter is encountered.

### DIFF
--- a/src/libbson/src/bson/bson-macros.h
+++ b/src/libbson/src/bson/bson-macros.h
@@ -196,6 +196,18 @@
          abort ();                                         \
       }                                                    \
    } while (0)
+       
+/* Used for asserting parameters to provide a more precise error message */
+#define BSON_ASSERT_PARAM(param)                                                   \
+   do {                                                                            \
+      if ((BSON_LIKELY (param == NULL))) {                                         \
+         fprintf (stderr,                                                          \
+                  "The parameter: %s, in function %s, cannot be NULL\n", \
+                  #param,                                                          \
+                  BSON_FUNC);                                                      \
+         abort ();                                                                 \
+      }                                                                            \
+   } while (0)      
 
 /* obsolete macros, preserved for compatibility */
 #define BSON_STATIC_ASSERT(s) BSON_STATIC_ASSERT_ (s, __LINE__)

--- a/src/libbson/src/bson/bson-macros.h
+++ b/src/libbson/src/bson/bson-macros.h
@@ -200,7 +200,7 @@
 /* Used for asserting parameters to provide a more precise error message */
 #define BSON_ASSERT_PARAM(param)                                                   \
    do {                                                                            \
-      if ((BSON_UNLIKELY (param == NULL))) {                                         \
+      if ((BSON_UNLIKELY (param == NULL))) {                                       \
          fprintf (stderr,                                                          \
                   "The parameter: %s, in function %s, cannot be NULL\n",           \
                   #param,                                                          \

--- a/src/libbson/src/bson/bson-macros.h
+++ b/src/libbson/src/bson/bson-macros.h
@@ -200,9 +200,9 @@
 /* Used for asserting parameters to provide a more precise error message */
 #define BSON_ASSERT_PARAM(param)                                                   \
    do {                                                                            \
-      if ((BSON_LIKELY (param == NULL))) {                                         \
+      if ((BSON_UNLIKELY (param == NULL))) {                                         \
          fprintf (stderr,                                                          \
-                  "The parameter: %s, in function %s, cannot be NULL\n", \
+                  "The parameter: %s, in function %s, cannot be NULL\n",           \
                   #param,                                                          \
                   BSON_FUNC);                                                      \
          abort ();                                                                 \

--- a/src/libmongoc/src/mongoc/mongoc-buffer.c
+++ b/src/libmongoc/src/mongoc/mongoc-buffer.c
@@ -55,7 +55,7 @@ _mongoc_buffer_init (mongoc_buffer_t *buffer,
                      bson_realloc_func realloc_func,
                      void *realloc_data)
 {
-   BSON_ASSERT (buffer);
+   BSON_ASSERT_PARAM (buffer);
    BSON_ASSERT (buflen || !buf);
 
    if (!realloc_func) {
@@ -89,7 +89,7 @@ _mongoc_buffer_init (mongoc_buffer_t *buffer,
 void
 _mongoc_buffer_destroy (mongoc_buffer_t *buffer)
 {
-   BSON_ASSERT (buffer);
+   BSON_ASSERT_PARAM (buffer);
 
    if (buffer->data && buffer->realloc_func) {
       buffer->realloc_func (buffer->data, 0, buffer->realloc_data);
@@ -111,7 +111,7 @@ _mongoc_buffer_destroy (mongoc_buffer_t *buffer)
 void
 _mongoc_buffer_clear (mongoc_buffer_t *buffer, bool zero)
 {
-   BSON_ASSERT (buffer);
+   BSON_ASSERT_PARAM (buffer);
 
    if (zero) {
       memset (buffer->data, 0, buffer->datalen);
@@ -130,7 +130,7 @@ _mongoc_buffer_append (mongoc_buffer_t *buffer,
 
    ENTRY;
 
-   BSON_ASSERT (buffer);
+   BSON_ASSERT_PARAM (buffer);
    BSON_ASSERT (data_size);
 
    BSON_ASSERT (buffer->datalen);
@@ -186,8 +186,8 @@ _mongoc_buffer_append_from_stream (mongoc_buffer_t *buffer,
 
    ENTRY;
 
-   BSON_ASSERT (buffer);
-   BSON_ASSERT (stream);
+   BSON_ASSERT_PARAM (buffer);
+   BSON_ASSERT_PARAM (stream);
    BSON_ASSERT (size);
 
    BSON_ASSERT (buffer->datalen);
@@ -249,8 +249,8 @@ _mongoc_buffer_fill (mongoc_buffer_t *buffer,
 
    ENTRY;
 
-   BSON_ASSERT (buffer);
-   BSON_ASSERT (stream);
+   BSON_ASSERT_PARAM (buffer);
+   BSON_ASSERT_PARAM (stream);
 
    BSON_ASSERT (buffer->data);
    BSON_ASSERT (buffer->datalen);
@@ -325,8 +325,8 @@ _mongoc_buffer_try_append_from_stream (mongoc_buffer_t *buffer,
 
    ENTRY;
 
-   BSON_ASSERT (buffer);
-   BSON_ASSERT (stream);
+   BSON_ASSERT_PARAM (buffer);
+   BSON_ASSERT_PARAM (stream);
    BSON_ASSERT (size);
 
    BSON_ASSERT (buffer->datalen);

--- a/src/libmongoc/src/mongoc/mongoc-collection.c
+++ b/src/libmongoc/src/mongoc/mongoc-collection.c
@@ -172,9 +172,9 @@ _mongoc_collection_new (mongoc_client_t *client,
 
    ENTRY;
 
-   BSON_ASSERT_PARAM_PARAM (client);
-   BSON_ASSERT_PARAM_PARAM (db);
-   BSON_ASSERT_PARAM_PARAM (collection);
+   BSON_ASSERT_PARAM (client);
+   BSON_ASSERT_PARAM (db);
+   BSON_ASSERT_PARAM (collection);
 
    col = (mongoc_collection_t *) bson_malloc0 (sizeof *col);
    col->client = client;

--- a/src/libmongoc/src/mongoc/mongoc-collection.c
+++ b/src/libmongoc/src/mongoc/mongoc-collection.c
@@ -172,9 +172,9 @@ _mongoc_collection_new (mongoc_client_t *client,
 
    ENTRY;
 
-   BSON_ASSERT (client);
-   BSON_ASSERT (db);
-   BSON_ASSERT (collection);
+   BSON_ASSERT_PARAM_PARAM (client);
+   BSON_ASSERT_PARAM_PARAM (db);
+   BSON_ASSERT_PARAM_PARAM (collection);
 
    col = (mongoc_collection_t *) bson_malloc0 (sizeof *col);
    col->client = client;
@@ -273,7 +273,7 @@ mongoc_collection_copy (mongoc_collection_t *collection) /* IN */
 {
    ENTRY;
 
-   BSON_ASSERT (collection);
+   BSON_ASSERT_PARAM (collection);
 
    RETURN (_mongoc_collection_new (collection->client,
                                    collection->db,
@@ -364,8 +364,8 @@ mongoc_collection_find (mongoc_collection_t *collection,       /* IN */
    bson_t opts;
    bool slave_ok;
    mongoc_cursor_t *cursor;
-   BSON_ASSERT (collection);
-   BSON_ASSERT (query);
+   BSON_ASSERT_PARAM (collection);
+   BSON_ASSERT_PARAM (query);
 
    bson_clear (&collection->gle);
 
@@ -442,8 +442,8 @@ mongoc_collection_find_with_opts (mongoc_collection_t *collection,
                                   const bson_t *opts,
                                   const mongoc_read_prefs_t *read_prefs)
 {
-   BSON_ASSERT (collection);
-   BSON_ASSERT (filter);
+   BSON_ASSERT_PARAM (collection);
+   BSON_ASSERT_PARAM (filter);
 
    bson_clear (&collection->gle);
 
@@ -499,8 +499,8 @@ mongoc_collection_command (mongoc_collection_t *collection,
    char *ns;
    mongoc_cursor_t *cursor;
 
-   BSON_ASSERT (collection);
-   BSON_ASSERT (query);
+   BSON_ASSERT_PARAM (collection);
+   BSON_ASSERT_PARAM (query);
 
    if (!read_prefs) {
       read_prefs = collection->read_prefs;
@@ -537,7 +537,7 @@ mongoc_collection_read_command_with_opts (mongoc_collection_t *collection,
                                           bson_t *reply,
                                           bson_error_t *error)
 {
-   BSON_ASSERT (collection);
+   BSON_ASSERT_PARAM (collection);
 
    return _mongoc_client_command_with_opts (collection->client,
                                             collection->db,
@@ -561,7 +561,7 @@ mongoc_collection_write_command_with_opts (mongoc_collection_t *collection,
                                            bson_t *reply,
                                            bson_error_t *error)
 {
-   BSON_ASSERT (collection);
+   BSON_ASSERT_PARAM (collection);
 
    return _mongoc_client_command_with_opts (collection->client,
                                             collection->db,
@@ -587,7 +587,7 @@ mongoc_collection_read_write_command_with_opts (
    bson_t *reply,
    bson_error_t *error)
 {
-   BSON_ASSERT (collection);
+   BSON_ASSERT_PARAM (collection);
 
    return _mongoc_client_command_with_opts (collection->client,
                                             collection->db,
@@ -612,7 +612,7 @@ mongoc_collection_command_with_opts (mongoc_collection_t *collection,
                                      bson_t *reply,
                                      bson_error_t *error)
 {
-   BSON_ASSERT (collection);
+   BSON_ASSERT_PARAM (collection);
 
    /* Server Selection Spec: "The generic command method has a default read
     * preference of mode 'primary'. The generic command method MUST ignore any
@@ -642,8 +642,8 @@ mongoc_collection_command_simple (mongoc_collection_t *collection,
                                   bson_t *reply,
                                   bson_error_t *error)
 {
-   BSON_ASSERT (collection);
-   BSON_ASSERT (command);
+   BSON_ASSERT_PARAM (collection);
+   BSON_ASSERT_PARAM (command);
 
    bson_clear (&collection->gle);
 
@@ -747,7 +747,7 @@ mongoc_collection_count_with_opts (
 
    ENTRY;
 
-   BSON_ASSERT (collection);
+   BSON_ASSERT_PARAM (collection);
 
    bson_append_utf8 (
       &cmd, "count", 5, collection->collection, collection->collectionlen);
@@ -808,7 +808,7 @@ mongoc_collection_estimated_document_count (
 
    ENTRY;
 
-   BSON_ASSERT (coll);
+   BSON_ASSERT_PARAM (coll);
 
    reply_ptr = reply ? reply : &reply_local;
    bson_append_utf8 (&cmd, "count", 5, coll->collection, coll->collectionlen);
@@ -927,8 +927,8 @@ mongoc_collection_count_documents (mongoc_collection_t *coll,
 
    ENTRY;
 
-   BSON_ASSERT (coll);
-   BSON_ASSERT (filter);
+   BSON_ASSERT_PARAM (coll);
+   BSON_ASSERT_PARAM (filter);
 
    _make_aggregate_for_count (coll, filter, opts, &aggregate_cmd);
    bson_init (&aggregate_opts);
@@ -1009,7 +1009,7 @@ mongoc_collection_drop_with_opts (mongoc_collection_t *collection,
    bool ret;
    bson_t cmd;
 
-   BSON_ASSERT (collection);
+   BSON_ASSERT_PARAM (collection);
 
    bson_init (&cmd);
    bson_append_utf8 (
@@ -1068,8 +1068,8 @@ mongoc_collection_drop_index_with_opts (mongoc_collection_t *collection,
    bool ret;
    bson_t cmd;
 
-   BSON_ASSERT (collection);
-   BSON_ASSERT (index_name);
+   BSON_ASSERT_PARAM (collection);
+   BSON_ASSERT_PARAM (index_name);
 
    bson_init (&cmd);
    bson_append_utf8 (&cmd,
@@ -1105,7 +1105,7 @@ mongoc_collection_keys_to_index_string (const bson_t *keys)
    bson_type_t type;
    int i = 0;
 
-   BSON_ASSERT (keys);
+   BSON_ASSERT_PARAM (keys);
 
    if (!bson_iter_init (&iter, keys)) {
       return NULL;
@@ -1191,8 +1191,8 @@ mongoc_collection_create_index_with_opts (mongoc_collection_t *collection,
 
    ENTRY;
 
-   BSON_ASSERT (collection);
-   BSON_ASSERT (keys);
+   BSON_ASSERT_PARAM (collection);
+   BSON_ASSERT_PARAM (keys);
 
    def_opt = mongoc_index_opt_get_default ();
    opt = opt ? opt : def_opt;
@@ -1419,7 +1419,7 @@ mongoc_collection_find_indexes_with_opts (mongoc_collection_t *collection,
    bson_t child;
    bson_error_t error;
 
-   BSON_ASSERT (collection);
+   BSON_ASSERT_PARAM (collection);
 
    bson_append_utf8 (&cmd,
                      "listIndexes",
@@ -1495,8 +1495,8 @@ mongoc_collection_insert_bulk (mongoc_collection_t *collection,
    uint32_t i;
    bool ret;
 
-   BSON_ASSERT (collection);
-   BSON_ASSERT (documents);
+   BSON_ASSERT_PARAM (collection);
+   BSON_ASSERT_PARAM (documents);
 
    if (!write_concern) {
       write_concern = collection->write_concern;
@@ -1618,8 +1618,8 @@ mongoc_collection_insert_one (mongoc_collection_t *collection,
 
    ENTRY;
 
-   BSON_ASSERT (collection);
-   BSON_ASSERT (document);
+   BSON_ASSERT_PARAM (collection);
+   BSON_ASSERT_PARAM (document);
 
    _mongoc_bson_init_if_set (reply);
 
@@ -1704,8 +1704,8 @@ mongoc_collection_insert_many (mongoc_collection_t *collection,
 
    ENTRY;
 
-   BSON_ASSERT (collection);
-   BSON_ASSERT (documents);
+   BSON_ASSERT_PARAM (collection);
+   BSON_ASSERT_PARAM (documents);
 
    _mongoc_bson_init_if_set (reply);
 
@@ -1798,9 +1798,9 @@ mongoc_collection_update (mongoc_collection_t *collection,
 
    ENTRY;
 
-   BSON_ASSERT (collection);
-   BSON_ASSERT (selector);
-   BSON_ASSERT (update);
+   BSON_ASSERT_PARAM (collection);
+   BSON_ASSERT_PARAM (selector);
+   BSON_ASSERT_PARAM (update);
 
    bson_clear (&collection->gle);
 
@@ -1878,9 +1878,9 @@ _mongoc_collection_update_or_replace (mongoc_collection_t *collection,
 
    ENTRY;
 
-   BSON_ASSERT (collection);
-   BSON_ASSERT (selector);
-   BSON_ASSERT (update);
+   BSON_ASSERT_PARAM (collection);
+   BSON_ASSERT_PARAM (selector);
+   BSON_ASSERT_PARAM (update);
 
    if (update_opts->upsert) {
       bson_append_bool (extra, "upsert", 6, true);
@@ -2015,8 +2015,8 @@ mongoc_collection_update_one (mongoc_collection_t *collection,
 
    ENTRY;
 
-   BSON_ASSERT (collection);
-   BSON_ASSERT (update);
+   BSON_ASSERT_PARAM (collection);
+   BSON_ASSERT_PARAM (update);
 
    if (!_mongoc_update_one_opts_parse (
           collection->client, opts, &update_one_opts, error)) {
@@ -2061,8 +2061,8 @@ mongoc_collection_update_many (mongoc_collection_t *collection,
 
    ENTRY;
 
-   BSON_ASSERT (collection);
-   BSON_ASSERT (update);
+   BSON_ASSERT_PARAM (collection);
+   BSON_ASSERT_PARAM (update);
 
    if (!_mongoc_update_many_opts_parse (
           collection->client, opts, &update_many_opts, error)) {
@@ -2107,8 +2107,8 @@ mongoc_collection_replace_one (mongoc_collection_t *collection,
 
    ENTRY;
 
-   BSON_ASSERT (collection);
-   BSON_ASSERT (replacement);
+   BSON_ASSERT_PARAM (collection);
+   BSON_ASSERT_PARAM (replacement);
 
    if (!_mongoc_replace_one_opts_parse (
           collection->client, opts, &replace_one_opts, error)) {
@@ -2170,8 +2170,8 @@ mongoc_collection_save (mongoc_collection_t *collection,
    bool ret;
    bson_t selector;
 
-   BSON_ASSERT (collection);
-   BSON_ASSERT (document);
+   BSON_ASSERT_PARAM (collection);
+   BSON_ASSERT_PARAM (document);
 
    BEGIN_IGNORE_DEPRECATIONS
    if (!bson_iter_init_find (&iter, document, "_id")) {
@@ -2257,8 +2257,8 @@ mongoc_collection_remove (mongoc_collection_t *collection,
 
    ENTRY;
 
-   BSON_ASSERT (collection);
-   BSON_ASSERT (selector);
+   BSON_ASSERT_PARAM (collection);
+   BSON_ASSERT_PARAM (selector);
 
    bson_clear (&collection->gle);
 
@@ -2330,8 +2330,8 @@ _mongoc_delete_one_or_many (mongoc_collection_t *collection,
 
    ENTRY;
 
-   BSON_ASSERT (collection);
-   BSON_ASSERT (selector);
+   BSON_ASSERT_PARAM (collection);
+   BSON_ASSERT_PARAM (selector);
    BSON_ASSERT (bson_empty0 (reply));
 
    _mongoc_write_result_init (&result);
@@ -2393,8 +2393,8 @@ mongoc_collection_delete_one (mongoc_collection_t *collection,
 
    ENTRY;
 
-   BSON_ASSERT (collection);
-   BSON_ASSERT (selector);
+   BSON_ASSERT_PARAM (collection);
+   BSON_ASSERT_PARAM (selector);
 
    _mongoc_bson_init_if_set (reply);
    if (!_mongoc_delete_one_opts_parse (
@@ -2431,8 +2431,8 @@ mongoc_collection_delete_many (mongoc_collection_t *collection,
 
    ENTRY;
 
-   BSON_ASSERT (collection);
-   BSON_ASSERT (selector);
+   BSON_ASSERT_PARAM (collection);
+   BSON_ASSERT_PARAM (selector);
 
    _mongoc_bson_init_if_set (reply);
    if (!_mongoc_delete_many_opts_parse (
@@ -2476,7 +2476,7 @@ done:
 const mongoc_read_prefs_t *
 mongoc_collection_get_read_prefs (const mongoc_collection_t *collection)
 {
-   BSON_ASSERT (collection);
+   BSON_ASSERT_PARAM (collection);
    return collection->read_prefs;
 }
 
@@ -2501,7 +2501,7 @@ void
 mongoc_collection_set_read_prefs (mongoc_collection_t *collection,
                                   const mongoc_read_prefs_t *read_prefs)
 {
-   BSON_ASSERT (collection);
+   BSON_ASSERT_PARAM (collection);
 
    if (collection->read_prefs) {
       mongoc_read_prefs_destroy (collection->read_prefs);
@@ -2533,7 +2533,7 @@ mongoc_collection_set_read_prefs (mongoc_collection_t *collection,
 const mongoc_read_concern_t *
 mongoc_collection_get_read_concern (const mongoc_collection_t *collection)
 {
-   BSON_ASSERT (collection);
+   BSON_ASSERT_PARAM (collection);
 
    return collection->read_concern;
 }
@@ -2559,7 +2559,7 @@ void
 mongoc_collection_set_read_concern (mongoc_collection_t *collection,
                                     const mongoc_read_concern_t *read_concern)
 {
-   BSON_ASSERT (collection);
+   BSON_ASSERT_PARAM (collection);
 
    if (collection->read_concern) {
       mongoc_read_concern_destroy (collection->read_concern);
@@ -2591,7 +2591,7 @@ mongoc_collection_set_read_concern (mongoc_collection_t *collection,
 const mongoc_write_concern_t *
 mongoc_collection_get_write_concern (const mongoc_collection_t *collection)
 {
-   BSON_ASSERT (collection);
+   BSON_ASSERT_PARAM (collection);
 
    return collection->write_concern;
 }
@@ -2617,7 +2617,7 @@ void
 mongoc_collection_set_write_concern (
    mongoc_collection_t *collection, const mongoc_write_concern_t *write_concern)
 {
-   BSON_ASSERT (collection);
+   BSON_ASSERT_PARAM (collection);
 
    if (collection->write_concern) {
       mongoc_write_concern_destroy (collection->write_concern);
@@ -2649,7 +2649,7 @@ mongoc_collection_set_write_concern (
 const char *
 mongoc_collection_get_name (mongoc_collection_t *collection)
 {
-   BSON_ASSERT (collection);
+   BSON_ASSERT_PARAM (collection);
 
    return collection->collection;
 }
@@ -2678,7 +2678,7 @@ const bson_t *
 mongoc_collection_get_last_error (
    const mongoc_collection_t *collection) /* IN */
 {
-   BSON_ASSERT (collection);
+   BSON_ASSERT_PARAM (collection);
 
    return collection->gle;
 }
@@ -2723,7 +2723,7 @@ mongoc_collection_validate (mongoc_collection_t *collection, /* IN */
    bool ret = false;
    bool reply_initialized = false;
 
-   BSON_ASSERT (collection);
+   BSON_ASSERT_PARAM (collection);
 
    if (options && bson_iter_init_find (&iter, options, "full") &&
        !BSON_ITER_HOLDS_BOOL (&iter)) {
@@ -2802,8 +2802,8 @@ mongoc_collection_rename_with_opts (mongoc_collection_t *collection,
    char *newns;
    bool ret;
 
-   BSON_ASSERT (collection);
-   BSON_ASSERT (new_name);
+   BSON_ASSERT_PARAM (collection);
+   BSON_ASSERT_PARAM (new_name);
 
    if (strchr (new_name, '$')) {
       bson_set_error (error,
@@ -2891,7 +2891,7 @@ mongoc_collection_stats (mongoc_collection_t *collection,
    bson_t cmd = BSON_INITIALIZER;
    bool ret;
 
-   BSON_ASSERT (collection);
+   BSON_ASSERT_PARAM (collection);
 
    if (options && bson_iter_init_find (&iter, options, "scale") &&
        !BSON_ITER_HOLDS_INT32 (&iter)) {
@@ -2961,7 +2961,7 @@ mongoc_collection_create_bulk_operation_with_opts (
    mongoc_bulk_operation_t *bulk;
    bson_error_t err = {0};
 
-   BSON_ASSERT (collection);
+   BSON_ASSERT_PARAM (collection);
 
    (void) _mongoc_bulk_opts_parse (collection->client, opts, &bulk_opts, &err);
    if (!_mongoc_client_session_in_txn (bulk_opts.client_session)) {
@@ -3039,9 +3039,9 @@ mongoc_collection_find_and_modify_with_opts (
 
    ENTRY;
 
-   BSON_ASSERT (collection);
-   BSON_ASSERT (query);
-   BSON_ASSERT (opts);
+   BSON_ASSERT_PARAM (collection);
+   BSON_ASSERT_PARAM (query);
+   BSON_ASSERT_PARAM (opts);
 
    reply_ptr = reply ? reply : &reply_local;
    cluster = &collection->client->cluster;
@@ -3316,8 +3316,8 @@ mongoc_collection_find_and_modify (mongoc_collection_t *collection,
 
    ENTRY;
 
-   BSON_ASSERT (collection);
-   BSON_ASSERT (query);
+   BSON_ASSERT_PARAM (collection);
+   BSON_ASSERT_PARAM (query);
    BSON_ASSERT (update || _remove);
 
 

--- a/src/libmongoc/src/mongoc/mongoc-database.c
+++ b/src/libmongoc/src/mongoc/mongoc-database.c
@@ -65,8 +65,8 @@ _mongoc_database_new (mongoc_client_t *client,
 
    ENTRY;
 
-   BSON_ASSERT (client);
-   BSON_ASSERT (name);
+   BSON_ASSERT_PARAM (client);
+   BSON_ASSERT_PARAM (name);
 
    db = (mongoc_database_t *) bson_malloc0 (sizeof *db);
    db->client = client;
@@ -170,7 +170,7 @@ mongoc_database_copy (mongoc_database_t *database)
 {
    ENTRY;
 
-   BSON_ASSERT (database);
+   BSON_ASSERT_PARAM (database);
 
    RETURN (_mongoc_database_new (database->client,
                                  database->name,
@@ -192,8 +192,8 @@ mongoc_database_command (mongoc_database_t *database,
    char *ns;
    mongoc_cursor_t *cursor;
 
-   BSON_ASSERT (database);
-   BSON_ASSERT (command);
+   BSON_ASSERT_PARAM (database);
+   BSON_ASSERT_PARAM (command);
 
    ns = bson_strdup_printf ("%s.$cmd", database->name);
 
@@ -219,8 +219,8 @@ mongoc_database_command_simple (mongoc_database_t *database,
                                 bson_t *reply,
                                 bson_error_t *error)
 {
-   BSON_ASSERT (database);
-   BSON_ASSERT (command);
+   BSON_ASSERT_PARAM (database);
+   BSON_ASSERT_PARAM (command);
 
    /* Server Selection Spec: "The generic command method has a default read
     * preference of mode 'primary'. The generic command method MUST ignore any
@@ -370,7 +370,7 @@ mongoc_database_drop_with_opts (mongoc_database_t *database,
    bool ret;
    bson_t cmd;
 
-   BSON_ASSERT (database);
+   BSON_ASSERT_PARAM (database);
 
    bson_init (&cmd);
    bson_append_int32 (&cmd, "dropDatabase", 12, 1);
@@ -403,8 +403,8 @@ mongoc_database_remove_user (mongoc_database_t *database,
 
    ENTRY;
 
-   BSON_ASSERT (database);
-   BSON_ASSERT (username);
+   BSON_ASSERT_PARAM (database);
+   BSON_ASSERT_PARAM (username);
 
    bson_init (&cmd);
    BSON_APPEND_UTF8 (&cmd, "dropUser", username);
@@ -424,7 +424,7 @@ mongoc_database_remove_all_users (mongoc_database_t *database,
 
    ENTRY;
 
-   BSON_ASSERT (database);
+   BSON_ASSERT_PARAM (database);
 
    bson_init (&cmd);
    BSON_APPEND_INT32 (&cmd, "dropAllUsersFromDatabase", 1);
@@ -463,8 +463,8 @@ mongoc_database_add_user (mongoc_database_t *database,
 
    ENTRY;
 
-   BSON_ASSERT (database);
-   BSON_ASSERT (username);
+   BSON_ASSERT_PARAM (database);
+   BSON_ASSERT_PARAM (username);
 
    bson_init (&cmd);
    BSON_APPEND_UTF8 (&cmd, "createUser", username);
@@ -507,7 +507,7 @@ mongoc_database_add_user (mongoc_database_t *database,
 const mongoc_read_prefs_t *
 mongoc_database_get_read_prefs (const mongoc_database_t *database) /* IN */
 {
-   BSON_ASSERT (database);
+   BSON_ASSERT_PARAM (database);
    return database->read_prefs;
 }
 
@@ -532,7 +532,7 @@ void
 mongoc_database_set_read_prefs (mongoc_database_t *database,
                                 const mongoc_read_prefs_t *read_prefs)
 {
-   BSON_ASSERT (database);
+   BSON_ASSERT_PARAM (database);
 
    if (database->read_prefs) {
       mongoc_read_prefs_destroy (database->read_prefs);
@@ -564,7 +564,7 @@ mongoc_database_set_read_prefs (mongoc_database_t *database,
 const mongoc_read_concern_t *
 mongoc_database_get_read_concern (const mongoc_database_t *database)
 {
-   BSON_ASSERT (database);
+   BSON_ASSERT_PARAM (database);
 
    return database->read_concern;
 }
@@ -590,7 +590,7 @@ void
 mongoc_database_set_read_concern (mongoc_database_t *database,
                                   const mongoc_read_concern_t *read_concern)
 {
-   BSON_ASSERT (database);
+   BSON_ASSERT_PARAM (database);
 
    if (database->read_concern) {
       mongoc_read_concern_destroy (database->read_concern);
@@ -622,7 +622,7 @@ mongoc_database_set_read_concern (mongoc_database_t *database,
 const mongoc_write_concern_t *
 mongoc_database_get_write_concern (const mongoc_database_t *database)
 {
-   BSON_ASSERT (database);
+   BSON_ASSERT_PARAM (database);
 
    return database->write_concern;
 }
@@ -648,7 +648,7 @@ void
 mongoc_database_set_write_concern (mongoc_database_t *database,
                                    const mongoc_write_concern_t *write_concern)
 {
-   BSON_ASSERT (database);
+   BSON_ASSERT_PARAM (database);
 
    if (database->write_concern) {
       mongoc_write_concern_destroy (database->write_concern);
@@ -693,8 +693,8 @@ mongoc_database_has_collection (mongoc_database_t *database,
 
    ENTRY;
 
-   BSON_ASSERT (database);
-   BSON_ASSERT (name);
+   BSON_ASSERT_PARAM (database);
+   BSON_ASSERT_PARAM (name);
 
    if (error) {
       memset (error, 0, sizeof *error);
@@ -735,7 +735,7 @@ mongoc_database_find_collections (mongoc_database_t *database,
    bson_t opts = BSON_INITIALIZER;
    mongoc_cursor_t *cursor;
 
-   BSON_ASSERT (database);
+   BSON_ASSERT_PARAM (database);
 
    if (filter) {
       if (!BSON_APPEND_DOCUMENT (&opts, "filter", filter)) {
@@ -769,7 +769,7 @@ mongoc_database_find_collections_with_opts (mongoc_database_t *database,
    mongoc_cursor_t *cursor;
    bson_t cmd = BSON_INITIALIZER;
 
-   BSON_ASSERT (database);
+   BSON_ASSERT_PARAM (database);
 
    BSON_APPEND_INT32 (&cmd, "listCollections", 1);
 
@@ -809,7 +809,7 @@ mongoc_database_get_collection_names_with_opts (mongoc_database_t *database,
    const bson_t *doc;
    char **ret;
 
-   BSON_ASSERT (database);
+   BSON_ASSERT_PARAM (database);
 
    if (opts) {
       bson_copy_to (opts, &opts_copy);
@@ -865,8 +865,8 @@ mongoc_database_create_collection (mongoc_database_t *database,
    bson_t cmd;
    bool capped = false;
 
-   BSON_ASSERT (database);
-   BSON_ASSERT (name);
+   BSON_ASSERT_PARAM (database);
+   BSON_ASSERT_PARAM (name);
 
    if (strchr (name, '$')) {
       bson_set_error (error,
@@ -1001,8 +1001,8 @@ mongoc_collection_t *
 mongoc_database_get_collection (mongoc_database_t *database,
                                 const char *collection)
 {
-   BSON_ASSERT (database);
-   BSON_ASSERT (collection);
+   BSON_ASSERT_PARAM (database);
+   BSON_ASSERT_PARAM (collection);
 
    return _mongoc_collection_new (database->client,
                                   database->name,
@@ -1016,7 +1016,7 @@ mongoc_database_get_collection (mongoc_database_t *database,
 const char *
 mongoc_database_get_name (mongoc_database_t *database)
 {
-   BSON_ASSERT (database);
+   BSON_ASSERT_PARAM (database);
 
    return database->name;
 }

--- a/src/libmongoc/src/mongoc/mongoc-stream.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream.c
@@ -54,7 +54,7 @@ mongoc_stream_close (mongoc_stream_t *stream)
 
    ENTRY;
 
-   BSON_ASSERT (stream);
+   BSON_ASSERT_PARAM (stream);
 
    BSON_ASSERT (stream->close);
 
@@ -79,7 +79,7 @@ mongoc_stream_failed (mongoc_stream_t *stream)
 {
    ENTRY;
 
-   BSON_ASSERT (stream);
+   BSON_ASSERT_PARAM (stream);
 
    if (stream->failed) {
       stream->failed (stream);
@@ -126,7 +126,7 @@ mongoc_stream_destroy (mongoc_stream_t *stream)
 int
 mongoc_stream_flush (mongoc_stream_t *stream)
 {
-   BSON_ASSERT (stream);
+   BSON_ASSERT_PARAM (stream);
    return stream->flush (stream);
 }
 
@@ -151,8 +151,8 @@ mongoc_stream_writev (mongoc_stream_t *stream,
 
    ENTRY;
 
-   BSON_ASSERT (stream);
-   BSON_ASSERT (iov);
+   BSON_ASSERT_PARAM (stream);
+   BSON_ASSERT_PARAM (iov);
    BSON_ASSERT (iovcnt);
 
    BSON_ASSERT (stream->writev);
@@ -189,8 +189,8 @@ mongoc_stream_write (mongoc_stream_t *stream,
 
    ENTRY;
 
-   BSON_ASSERT (stream);
-   BSON_ASSERT (buf);
+   BSON_ASSERT_PARAM (stream);
+   BSON_ASSERT_PARAM (buf);
 
    iov.iov_base = buf;
    iov.iov_len = count;
@@ -228,8 +228,8 @@ mongoc_stream_readv (mongoc_stream_t *stream,
 
    ENTRY;
 
-   BSON_ASSERT (stream);
-   BSON_ASSERT (iov);
+   BSON_ASSERT_PARAM (stream);
+   BSON_ASSERT_PARAM (iov);
    BSON_ASSERT (iovcnt);
 
    BSON_ASSERT (stream->readv);
@@ -270,8 +270,8 @@ mongoc_stream_read (mongoc_stream_t *stream,
 
    ENTRY;
 
-   BSON_ASSERT (stream);
-   BSON_ASSERT (buf);
+   BSON_ASSERT_PARAM (stream);
+   BSON_ASSERT_PARAM (buf);
 
    iov.iov_base = buf;
    iov.iov_len = count;
@@ -291,7 +291,7 @@ mongoc_stream_setsockopt (mongoc_stream_t *stream,
                           void *optval,
                           mongoc_socklen_t optlen)
 {
-   BSON_ASSERT (stream);
+   BSON_ASSERT_PARAM (stream);
 
    if (stream->setsockopt) {
       return stream->setsockopt (stream, level, optname, optval, optlen);
@@ -304,7 +304,7 @@ mongoc_stream_setsockopt (mongoc_stream_t *stream,
 mongoc_stream_t *
 mongoc_stream_get_base_stream (mongoc_stream_t *stream) /* IN */
 {
-   BSON_ASSERT (stream);
+   BSON_ASSERT_PARAM (stream);
 
    if (stream->get_base_stream) {
       return stream->get_base_stream (stream);
@@ -317,7 +317,7 @@ mongoc_stream_get_base_stream (mongoc_stream_t *stream) /* IN */
 mongoc_stream_t *
 mongoc_stream_get_root_stream (mongoc_stream_t *stream)
 {
-   BSON_ASSERT (stream);
+   BSON_ASSERT_PARAM (stream);
 
    while (stream->get_base_stream) {
       stream = stream->get_base_stream (stream);
@@ -329,7 +329,7 @@ mongoc_stream_get_root_stream (mongoc_stream_t *stream)
 mongoc_stream_t *
 mongoc_stream_get_tls_stream (mongoc_stream_t *stream) /* IN */
 {
-   BSON_ASSERT (stream);
+   BSON_ASSERT_PARAM (stream);
 
    for (; stream && stream->type != MONGOC_STREAM_TLS;
         stream = stream->get_base_stream (stream))
@@ -405,7 +405,7 @@ mongoc_stream_timed_out (mongoc_stream_t *stream)
 {
    ENTRY;
 
-   BSON_ASSERT (stream);
+   BSON_ASSERT_PARAM (stream);
 
    /* for e.g. a file stream there is no timed_out function */
    RETURN (stream->timed_out && stream->timed_out (stream));
@@ -416,7 +416,7 @@ mongoc_stream_should_retry (mongoc_stream_t *stream)
 {
    ENTRY;
 
-   BSON_ASSERT (stream);
+   BSON_ASSERT_PARAM (stream);
 
    /* for e.g. a file stream there is no should_retry function */
    RETURN (stream->should_retry && stream->should_retry (stream));


### PR DESCRIPTION
## Summary

This pull request makes a change to the way the mongoc driver reports encountering `NULL` in function parameters where a non `NULL` pointer is expected. Currently, a confusing error message is given:

```
mongoc_collection_count_documents(): precondition failed: coll
```

This arises from the  `BSON_ASSERT` macro, defined as:

```c
#define BSON_ASSERT(test)                                  \
   do {                                                    \
      if (!(BSON_LIKELY (test))) {                         \
         fprintf (stderr,                                  \
                  "%s:%d %s(): precondition failed: %s\n", \
                  __FILE__,                                \
                  __LINE__,                                \
                  BSON_FUNC,                               \
                  #test);                                  \
         abort ();                                         \
      }                                                    \
   } while (0)
```

This can work for typical conditions, like `foo != 0`, where the condition is properly transformed into a C-string literal by the preprocessor. However, in the case of NULL values, it just transforms the parameter name, which makes the message confusing. One could think there is something wrong with the parameter, or many different causes, rather than it being NULL.

The solution proposed here is to give a more straight forward message for NULL parameters:

```c
#define BSON_ASSERT_PARAM(param)                                                   \
   do {                                                                            \
      if ((BSON_LIKELY (param == NULL))) {                                         \
         fprintf (stderr,                                                          \
                  "The parameter: %s, in function %s, cannot be NULL\n", \
                  #param,                                                          \
                  BSON_FUNC);                                                      \
         abort ();                                                                 \
      }                                                                            \
   } while (0)   
```

This is much more direct, and accurate way of communicating the error. 

### Notes

As a side note, I don't believe the line number is relevant for these error messages, because that line number does not correspond to where the function is called in a program linking the mongoc driver, it corresponds to the source code of the C driver itself.