### PR TITLE
CDRIVER-3619 reject bad setname for single topology

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-trace-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-trace-private.h
@@ -89,6 +89,23 @@ BSON_BEGIN_DECLS
                   (int) _l);                              \
       mongoc_log_trace_bytes (MONGOC_LOG_DOMAIN, _b, _l); \
    } while (0)
+#define DUMP_BSON(_bson)                                            \
+   do {                                                             \
+      char *_bson_str;                                              \
+      if (_bson) {                                                  \
+         _bson_str = bson_as_canonical_extended_json (_bson, NULL); \
+      } else {                                                      \
+         _bson_str = bson_strdup ("<NULL>");                        \
+      }                                                             \
+      mongoc_log (MONGOC_LOG_LEVEL_TRACE,                           \
+                  MONGOC_LOG_DOMAIN,                                \
+                  "TRACE: %s():%d %s = %s",                         \
+                  BSON_FUNC,                                        \
+                  __LINE__,                                         \
+                  #_bson,                                           \
+                  _bson_str);                                       \
+      bson_free (_bson_str);                                        \
+   } while (0)
 #define DUMP_IOVEC(_n, _iov, _iovcnt)                            \
    do {                                                          \
       mongoc_log (MONGOC_LOG_LEVEL_TRACE,                        \
@@ -109,6 +126,7 @@ BSON_BEGIN_DECLS
 #define GOTO(label) goto label
 #define DUMP_BYTES(_n, _b, _l)
 #define DUMP_IOVEC(_n, _iov, _iovcnt)
+#define DUMP_BSON(_bson)
 #endif
 
 

--- a/src/libmongoc/tests/json/server_discovery_and_monitoring/single/direct_connection_wrong_set_name.json
+++ b/src/libmongoc/tests/json/server_discovery_and_monitoring/single/direct_connection_wrong_set_name.json
@@ -1,7 +1,35 @@
 {
   "description": "Direct connection to RSPrimary with wrong set name",
-  "uri": "mongodb://a/?directConnection=true&replicaSet=wrong",
+  "uri": "mongodb://a/?directConnection=true&replicaSet=rs",
   "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "wrong",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown"
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
     {
       "responses": [
         [
@@ -28,7 +56,7 @@
         },
         "topologyType": "Single",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "wrong"
+        "setName": "rs"
       }
     }
   ]


### PR DESCRIPTION
For a topology type single, if the user specified a setName in the URI, the server should be marked Unknown if it reports a different setName.