### PR TITLE
 CDRIVER-3655 handle new 'ns not found' err format

### DIFF
--- a/src/libmongoc/tests/test-mongoc-long-namespace.c
+++ b/src/libmongoc/tests/test-mongoc-long-namespace.c
@@ -115,7 +115,7 @@ test_fixture_init (test_fixture_t *test_fixture,
    /* Drop 'coll'. */
    ret = mongoc_collection_drop (test_fixture->coll, &error);
    /* ignore a 'ns not found' error */
-   if (!ret && 0 != strcmp (error.message, "ns not found")) {
+   if (!ret && NULL == strstr (error.message, "ns not found")) {
       /* unexpected error. */
       test_error ("unexpected error: %s\n", error.message);
    }

--- a/src/libmongoc/tests/test-mongoc-primary-stepdown.c
+++ b/src/libmongoc/tests/test-mongoc-primary-stepdown.c
@@ -37,7 +37,7 @@ _setup_test_with_client (mongoc_client_t *client)
    /* Drop the "step-down.step-down" collection and re-create it */
    coll = mongoc_client_get_collection (client, "step-down", "step-down");
    if (!mongoc_collection_drop (coll, &error)) {
-      if (strcmp (error.message, "ns not found")) {
+      if (NULL == strstr (error.message, "ns not found")) {
          ASSERT_OR_PRINT (false, error);
       }
    }

--- a/src/libmongoc/tests/test-mongoc-retryable-reads.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-reads.c
@@ -97,7 +97,7 @@ test_cmd_helpers (void *ctx)
    database = mongoc_client_get_database (client, "test");
 
    if (!mongoc_collection_drop (collection, &error)) {
-      if (strcmp (error.message, "ns not found")) {
+      if (NULL == strstr (error.message, "ns not found")) {
          /* an error besides ns not found */
          ASSERT_OR_PRINT (false, error);
       }

--- a/src/libmongoc/tests/test-mongoc-retryable-writes.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-writes.c
@@ -147,7 +147,7 @@ test_command_with_opts (void *ctx)
    collection = get_test_collection (client, "retryable_writes");
 
    if (!mongoc_collection_drop (collection, &error)) {
-      if (strcmp (error.message, "ns not found")) {
+      if (NULL == strstr (error.message, "ns not found")) {
          /* an error besides ns not found */
          ASSERT_OR_PRINT (false, error);
       }


### PR DESCRIPTION
The "ns not found" error has changed on the server to include more info. This changes our exact match checks to substring checks. Fixes failing "latest" tests on master.