### PR TITLE
CDRIVER-3303 always apply command options for OP_MSG

### DIFF
--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -871,6 +871,7 @@ set (test-libmongoc-sources
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-client-side-encryption.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-client.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-cluster.c
+   ${PROJECT_SOURCE_DIR}/tests/test-mongoc-cmd.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-collection-find-with-opts.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-collection-find.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-collection.c

--- a/src/libmongoc/src/mongoc/mongoc-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-cmd.c
@@ -894,6 +894,7 @@ mongoc_cmd_parts_assemble (mongoc_cmd_parts_t *parts,
 
       /* If an explicit session was not provided and lsid is not prohibited,
        * attempt to create an implicit session (ignoring any errors). */
+
       if (!cs && !parts->prohibit_lsid && parts->assembled.is_acknowledged) {
          cs = mongoc_client_start_session (parts->client, NULL, NULL);
 
@@ -966,12 +967,14 @@ mongoc_cmd_parts_assemble (mongoc_cmd_parts_t *parts,
 
       if (!is_get_more) {
          if (cs) {
+            _mongoc_cmd_parts_ensure_copied (parts);
             _mongoc_client_session_append_read_concern (
                cs,
                &parts->read_concern_document,
                parts->is_read_command,
                &parts->assembled_body);
          } else if (!bson_empty (&parts->read_concern_document)) {
+            _mongoc_cmd_parts_ensure_copied (parts);
             bson_append_document (&parts->assembled_body,
                                   "readConcern",
                                   11,
@@ -984,6 +987,7 @@ mongoc_cmd_parts_assemble (mongoc_cmd_parts_t *parts,
          _mongoc_cmd_parts_add_write_concern (parts);
       }
 
+      _mongoc_cmd_parts_ensure_copied (parts);
       if (!_mongoc_client_session_append_txn (
              cs, &parts->assembled_body, error)) {
          GOTO (done);

--- a/src/libmongoc/src/mongoc/mongoc-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-cmd.c
@@ -894,7 +894,6 @@ mongoc_cmd_parts_assemble (mongoc_cmd_parts_t *parts,
 
       /* If an explicit session was not provided and lsid is not prohibited,
        * attempt to create an implicit session (ignoring any errors). */
-
       if (!cs && !parts->prohibit_lsid && parts->assembled.is_acknowledged) {
          cs = mongoc_client_start_session (parts->client, NULL, NULL);
 

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -101,6 +101,8 @@ test_client_hedged_reads_install (TestSuite *suite);
 extern void
 test_client_pool_install (TestSuite *suite);
 extern void
+test_client_cmd_install (TestSuite *suite);
+extern void
 test_cluster_install (TestSuite *suite);
 extern void
 test_collection_install (TestSuite *suite);

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -2438,6 +2438,7 @@ main (int argc, char *argv[])
    test_client_max_staleness_install (&suite);
    test_client_hedged_reads_install (&suite);
    test_client_pool_install (&suite);
+   test_client_cmd_install (&suite);
    test_write_command_install (&suite);
    test_bulk_install (&suite);
    test_cluster_install (&suite);

--- a/src/libmongoc/tests/test-mongoc-cmd.c
+++ b/src/libmongoc/tests/test-mongoc-cmd.c
@@ -37,7 +37,6 @@ test_client_cmd_options (void)
    mongoc_client_t *client;
    mongoc_read_concern_t * rc;
    bson_t opts;
-   bson_t* cmd;
    future_t *future;
    request_t *request;
    bson_error_t error;
@@ -51,10 +50,14 @@ test_client_cmd_options (void)
    bson_init (&opts);
    mongoc_read_concern_append (rc, &opts);
 
-   cmd = tmp_bson ("{'ping': 1, '$db': 'db'}");
-
    future = future_client_command_with_opts (
-      client, "db", cmd, NULL, &opts, NULL, &error);
+      client,
+      "db",
+      tmp_bson ("{'ping': 1, '$db': 'db'}"),
+      NULL,
+      &opts,
+      NULL,
+      &error);
 
    request = mock_server_receives_msg (
       server,
@@ -69,7 +72,6 @@ test_client_cmd_options (void)
 
    bson_destroy (&opts);
    mongoc_read_concern_destroy (rc);
-   bson_destroy (cmd);
    mongoc_client_destroy (client);
    mock_server_destroy (server);
 }

--- a/src/libmongoc/tests/test-mongoc-cmd.c
+++ b/src/libmongoc/tests/test-mongoc-cmd.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <mongoc/mongoc.h>
+
+#include "mongoc/mongoc-client-private.h"
+
+#include "TestSuite.h"
+#include "test-conveniences.h"
+#include "mock_server/mock-server.h"
+#include "mock_server/future-functions.h"
+
+#undef MONGOC_LOG_DOMAIN
+#define MONGOC_LOG_DOMAIN "cmd-test-options"
+
+
+/* CDRIVER-3303 - mongoc_cmd_parts_assemble sometimes fails to set options;
+ * the fix was to refactor the code and this test guards against regressions
+ */
+static void
+test_client_cmd_options (void)
+{
+   mock_server_t *server;
+   mongoc_client_t *client;
+   mongoc_read_concern_t * rc;
+   bson_t opts;
+   bson_t* cmd;
+   future_t *future;
+   request_t *request;
+   bson_error_t error;
+
+   server = mock_server_with_autoismaster (WIRE_VERSION_OP_MSG);
+   mock_server_run (server);
+   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+
+   rc = mongoc_read_concern_new ();
+   mongoc_read_concern_set_level (rc, MONGOC_READ_CONCERN_LEVEL_MAJORITY);
+   bson_init (&opts);
+   mongoc_read_concern_append (rc, &opts);
+
+   cmd = tmp_bson ("{'ping': 1, '$db': 'db'}");
+
+   future = future_client_command_with_opts (
+      client, "db", cmd, NULL, &opts, NULL, &error);
+
+   request = mock_server_receives_msg (
+      server,
+      MONGOC_QUERY_NONE,
+      tmp_bson ("{'readConcern': { '$exists': true }}"));
+
+   mock_server_replies_simple (request, "{'ok': 1, 'n': 1}");
+   ASSERT_OR_PRINT (1 == future_get_bool (future), error);
+
+   request_destroy (request);
+   future_destroy (future);
+
+   bson_destroy (&opts);
+   mongoc_read_concern_destroy (rc);
+   bson_destroy (cmd);
+   mongoc_client_destroy (client);
+   mock_server_destroy (server);
+}
+
+
+void
+test_client_cmd_install (TestSuite *suite)
+{
+   TestSuite_AddMockServerTest (suite,
+                                "/Client/cmd/options",
+                                test_client_cmd_options);
+}

--- a/src/libmongoc/tests/test-mongoc-cmd.c
+++ b/src/libmongoc/tests/test-mongoc-cmd.c
@@ -65,7 +65,7 @@ test_client_cmd_options (void)
       tmp_bson ("{'readConcern': { '$exists': true }}"));
 
    mock_server_replies_simple (request, "{'ok': 1, 'n': 1}");
-   ASSERT_OR_PRINT (1 == future_get_bool (future), error);
+   ASSERT_OR_PRINT (future_get_bool (future), error);
 
    request_destroy (request);
    future_destroy (future);


### PR DESCRIPTION
The original plan was to eliminate `_mongoc_cmd_parts_ensure_copied` and refactor so that any changes to options along the way are always captured and never lost.  However, that proved to be more risky because of `mongoc_cmd_parts_append_opts` not being idempotent.  As a result, the approach in this PR was taken instead: to add calls to `_mongoc_cmd_parts_ensure_copied` in places where they were missing.  A separate ticket will be written to consider a more comprehensive solution.