### PR TITLE
CDRIVER-3573 hard code version on patches

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -16,9 +16,6 @@ functions:
   - command: git.get_project
     params:
       directory: mongoc
-  - command: git.apply_patch
-    params:
-      directory: mongoc
   - command: shell.exec
     params:
       working_dir: mongoc
@@ -27,7 +24,10 @@ functions:
         set -o errexit
         set -o xtrace
         if [ "${is_patch}" = "true" ]; then
-           VERSION=$(git describe --abbrev=7 --match='1.*')-patch-${version_id}
+           # TODO: CDRIVER-3573 do not hardcode the version for patch builds.
+           VERSION_CURRENT="1.17.0-pre"
+           echo $VERSION_CURRENT > "VERSION_CURRENT"
+           VERSION=$VERSION_CURRENT-patch-${version_id}
         else
            VERSION=latest
         fi

--- a/build/evergreen_config_lib/functions.py
+++ b/build/evergreen_config_lib/functions.py
@@ -26,13 +26,12 @@ all_functions = OD([
             ('params', OD([
                 ('directory', 'mongoc'),
             ]))]),
-        OD([('command', 'git.apply_patch'),
-            ('params', OD([
-                ('directory', 'mongoc'),
-            ]))]),
         shell_mongoc(r'''
         if [ "${is_patch}" = "true" ]; then
-           VERSION=$(git describe --abbrev=7 --match='1.*')-patch-${version_id}
+           # TODO: CDRIVER-3573 do not hardcode the version for patch builds.
+           VERSION_CURRENT="1.17.0-pre"
+           echo $VERSION_CURRENT > "VERSION_CURRENT"
+           VERSION=$VERSION_CURRENT-patch-${version_id}
         else
            VERSION=latest
         fi


### PR DESCRIPTION
Not all evergreen variants have a new enough version of git to run calc_release_version.py on a non-master branch. This fixes patch builds made through GitHub PRs