### PR TITLE
CDRIVER-3680 bump valgrind timeout

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1835,7 +1835,7 @@ tasks:
   tags:
   - latest
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -1858,7 +1858,7 @@ tasks:
   tags:
   - latest
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -1881,7 +1881,7 @@ tasks:
   tags:
   - latest
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -1904,7 +1904,7 @@ tasks:
   tags:
   - latest
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -1927,7 +1927,7 @@ tasks:
   tags:
   - latest
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -1950,7 +1950,7 @@ tasks:
   tags:
   - latest
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -1973,7 +1973,7 @@ tasks:
   tags:
   - '4.2'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -1996,7 +1996,7 @@ tasks:
   tags:
   - '4.2'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2019,7 +2019,7 @@ tasks:
   tags:
   - '4.2'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2042,7 +2042,7 @@ tasks:
   tags:
   - '4.2'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2065,7 +2065,7 @@ tasks:
   tags:
   - '4.2'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2088,7 +2088,7 @@ tasks:
   tags:
   - '4.2'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2111,7 +2111,7 @@ tasks:
   tags:
   - '4.0'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2134,7 +2134,7 @@ tasks:
   tags:
   - '4.0'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2157,7 +2157,7 @@ tasks:
   tags:
   - '4.0'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2180,7 +2180,7 @@ tasks:
   tags:
   - '4.0'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2203,7 +2203,7 @@ tasks:
   tags:
   - '4.0'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2226,7 +2226,7 @@ tasks:
   tags:
   - '4.0'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2249,7 +2249,7 @@ tasks:
   tags:
   - '3.6'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2272,7 +2272,7 @@ tasks:
   tags:
   - '3.6'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2295,7 +2295,7 @@ tasks:
   tags:
   - '3.6'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2318,7 +2318,7 @@ tasks:
   tags:
   - '3.6'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2341,7 +2341,7 @@ tasks:
   tags:
   - '3.6'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2364,7 +2364,7 @@ tasks:
   tags:
   - '3.6'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2387,7 +2387,7 @@ tasks:
   tags:
   - '3.4'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2410,7 +2410,7 @@ tasks:
   tags:
   - '3.4'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2433,7 +2433,7 @@ tasks:
   tags:
   - '3.4'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2456,7 +2456,7 @@ tasks:
   tags:
   - '3.4'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2479,7 +2479,7 @@ tasks:
   tags:
   - '3.4'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2502,7 +2502,7 @@ tasks:
   tags:
   - '3.4'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2525,7 +2525,7 @@ tasks:
   tags:
   - '3.2'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2548,7 +2548,7 @@ tasks:
   tags:
   - '3.2'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2571,7 +2571,7 @@ tasks:
   tags:
   - '3.2'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2594,7 +2594,7 @@ tasks:
   tags:
   - '3.2'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2617,7 +2617,7 @@ tasks:
   tags:
   - '3.2'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2640,7 +2640,7 @@ tasks:
   tags:
   - '3.2'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2663,7 +2663,7 @@ tasks:
   tags:
   - '3.0'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2686,7 +2686,7 @@ tasks:
   tags:
   - '3.0'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2709,7 +2709,7 @@ tasks:
   tags:
   - '3.0'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2732,7 +2732,7 @@ tasks:
   tags:
   - '3.0'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2755,7 +2755,7 @@ tasks:
   tags:
   - '3.0'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:
@@ -2778,7 +2778,7 @@ tasks:
   tags:
   - '3.0'
   - test-valgrind
-  exec_timeout_secs: 7200
+  exec_timeout_secs: 14400
   depends_on:
     name: debug-compile-valgrind
   commands:

--- a/build/evergreen_config_lib/tasks.py
+++ b/build/evergreen_config_lib/tasks.py
@@ -429,7 +429,7 @@ class IntegrationTask(MatrixTask):
         if self.valgrind:
             self.add_tags('test-valgrind')
             self.add_tags(self.version)
-            self.options['exec_timeout_secs'] = 7200
+            self.options['exec_timeout_secs'] = 14400
         elif self.coverage:
             self.add_tags('test-coverage')
             self.add_tags(self.version)


### PR DESCRIPTION
From a patch build, it appears they take 3.5 hours to fully execute.

https://evergreen.mongodb.com/version/5ec3d728d1fe073c379213e9