### PR TITLE
CDRIVER-3535 add awaited to heartbeat events

### DIFF
--- a/src/libmongoc/doc/mongoc_apm_server_heartbeat_failed_get_awaited.rst
+++ b/src/libmongoc/doc/mongoc_apm_server_heartbeat_failed_get_awaited.rst
@@ -1,0 +1,31 @@
+:man_page: mongoc_apm_server_heartbeat_failed_get_awaited
+
+mongoc_apm_server_heartbeat_failed_get_awaited()
+================================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  bool
+  mongoc_apm_server_heartbeat_failed_get_awaited (
+     const mongoc_apm_server_heartbeat_failed_t *event);
+
+Returns whether this event came from an awaitable isMaster.
+
+Parameters
+----------
+
+* ``event``: A :symbol:`mongoc_apm_server_heartbeat_failed_t`.
+
+Returns
+-------
+
+The pointer passed with :symbol:`mongoc_client_set_apm_callbacks` or :symbol:`mongoc_client_pool_set_apm_callbacks`.
+
+See Also
+--------
+
+:doc:`Introduction to Application Performance Monitoring <application-performance-monitoring>`
+

--- a/src/libmongoc/doc/mongoc_apm_server_heartbeat_failed_get_awaited.rst
+++ b/src/libmongoc/doc/mongoc_apm_server_heartbeat_failed_get_awaited.rst
@@ -22,7 +22,7 @@ Parameters
 Returns
 -------
 
-The pointer passed with :symbol:`mongoc_client_set_apm_callbacks` or :symbol:`mongoc_client_pool_set_apm_callbacks`.
+A bool indicating whether the heartbeat event came from an awaitable isMaster.
 
 See Also
 --------

--- a/src/libmongoc/doc/mongoc_apm_server_heartbeat_failed_t.rst
+++ b/src/libmongoc/doc/mongoc_apm_server_heartbeat_failed_t.rst
@@ -24,6 +24,7 @@ See Also
     :titlesonly:
     :maxdepth: 1
 
+    mongoc_apm_server_heartbeat_failed_get_awaited
     mongoc_apm_server_heartbeat_failed_get_context
     mongoc_apm_server_heartbeat_failed_get_duration
     mongoc_apm_server_heartbeat_failed_get_error

--- a/src/libmongoc/doc/mongoc_apm_server_heartbeat_started_get_awaited.rst
+++ b/src/libmongoc/doc/mongoc_apm_server_heartbeat_started_get_awaited.rst
@@ -22,7 +22,7 @@ Parameters
 Returns
 -------
 
-The pointer passed with :symbol:`mongoc_client_set_apm_callbacks` or :symbol:`mongoc_client_pool_set_apm_callbacks`.
+A bool indicating whether the heartbeat event came from an awaitable isMaster.
 
 See Also
 --------

--- a/src/libmongoc/doc/mongoc_apm_server_heartbeat_started_get_awaited.rst
+++ b/src/libmongoc/doc/mongoc_apm_server_heartbeat_started_get_awaited.rst
@@ -1,0 +1,31 @@
+:man_page: mongoc_apm_server_heartbeat_started_get_awaited
+
+mongoc_apm_server_heartbeat_started_get_awaited()
+=================================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  bool
+  mongoc_apm_server_heartbeat_started_get_awaited (
+     const mongoc_apm_server_heartbeat_started_t *event);
+
+Returns whether this event came from an awaitable isMaster.
+
+Parameters
+----------
+
+* ``event``: A :symbol:`mongoc_apm_server_heartbeat_started_t`.
+
+Returns
+-------
+
+The pointer passed with :symbol:`mongoc_client_set_apm_callbacks` or :symbol:`mongoc_client_pool_set_apm_callbacks`.
+
+See Also
+--------
+
+:doc:`Introduction to Application Performance Monitoring <application-performance-monitoring>`
+

--- a/src/libmongoc/doc/mongoc_apm_server_heartbeat_started_t.rst
+++ b/src/libmongoc/doc/mongoc_apm_server_heartbeat_started_t.rst
@@ -24,6 +24,7 @@ See Also
     :titlesonly:
     :maxdepth: 1
 
+    mongoc_apm_server_heartbeat_started_get_awaited
     mongoc_apm_server_heartbeat_started_get_context
     mongoc_apm_server_heartbeat_started_get_host
 

--- a/src/libmongoc/doc/mongoc_apm_server_heartbeat_succeeded_get_awaited.rst
+++ b/src/libmongoc/doc/mongoc_apm_server_heartbeat_succeeded_get_awaited.rst
@@ -1,0 +1,31 @@
+:man_page: mongoc_apm_server_heartbeat_succeeded_get_awaited
+
+mongoc_apm_server_heartbeat_succeeded_get_awaited()
+===================================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  bool
+  mongoc_apm_server_heartbeat_succeeded_get_awaited (
+     const mongoc_apm_server_heartbeat_succeeded_t *event);
+
+Returns whether this event came from an awaitable isMaster.
+
+Parameters
+----------
+
+* ``event``: A :symbol:`mongoc_apm_server_heartbeat_succeeded_t`.
+
+Returns
+-------
+
+The pointer passed with :symbol:`mongoc_client_set_apm_callbacks` or :symbol:`mongoc_client_pool_set_apm_callbacks`.
+
+See Also
+--------
+
+:doc:`Introduction to Application Performance Monitoring <application-performance-monitoring>`
+

--- a/src/libmongoc/doc/mongoc_apm_server_heartbeat_succeeded_get_awaited.rst
+++ b/src/libmongoc/doc/mongoc_apm_server_heartbeat_succeeded_get_awaited.rst
@@ -22,7 +22,7 @@ Parameters
 Returns
 -------
 
-The pointer passed with :symbol:`mongoc_client_set_apm_callbacks` or :symbol:`mongoc_client_pool_set_apm_callbacks`.
+A bool indicating whether the heartbeat event came from an awaitable isMaster.
 
 See Also
 --------

--- a/src/libmongoc/doc/mongoc_apm_server_heartbeat_succeeded_t.rst
+++ b/src/libmongoc/doc/mongoc_apm_server_heartbeat_succeeded_t.rst
@@ -24,6 +24,7 @@ See Also
     :titlesonly:
     :maxdepth: 1
 
+    mongoc_apm_server_heartbeat_succeeded_get_awaited
     mongoc_apm_server_heartbeat_succeeded_get_context
     mongoc_apm_server_heartbeat_succeeded_get_duration
     mongoc_apm_server_heartbeat_succeeded_get_host

--- a/src/libmongoc/src/mongoc/mongoc-apm-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-apm-private.h
@@ -125,6 +125,7 @@ struct _mongoc_apm_topology_closed_t {
 struct _mongoc_apm_server_heartbeat_started_t {
    const mongoc_host_list_t *host;
    void *context;
+   bool awaited;
 };
 
 struct _mongoc_apm_server_heartbeat_succeeded_t {
@@ -132,6 +133,7 @@ struct _mongoc_apm_server_heartbeat_succeeded_t {
    const bson_t *reply;
    const mongoc_host_list_t *host;
    void *context;
+   bool awaited;
 };
 
 struct _mongoc_apm_server_heartbeat_failed_t {
@@ -139,6 +141,7 @@ struct _mongoc_apm_server_heartbeat_failed_t {
    const bson_error_t *error;
    const mongoc_host_list_t *host;
    void *context;
+   bool awaited;
 };
 
 void

--- a/src/libmongoc/src/mongoc/mongoc-apm.c
+++ b/src/libmongoc/src/mongoc/mongoc-apm.c
@@ -570,6 +570,13 @@ mongoc_apm_server_heartbeat_started_get_context (
    return event->context;
 }
 
+bool
+mongoc_apm_server_heartbeat_started_get_awaited (
+   const mongoc_apm_server_heartbeat_started_t *event)
+{
+   return event->awaited;
+}
+
 
 /* heartbeat-succeeded event fields */
 
@@ -602,6 +609,13 @@ mongoc_apm_server_heartbeat_succeeded_get_context (
    const mongoc_apm_server_heartbeat_succeeded_t *event)
 {
    return event->context;
+}
+
+bool
+mongoc_apm_server_heartbeat_succeeded_get_awaited (
+   const mongoc_apm_server_heartbeat_succeeded_t *event)
+{
+   return event->awaited;
 }
 
 
@@ -638,6 +652,12 @@ mongoc_apm_server_heartbeat_failed_get_context (
    return event->context;
 }
 
+bool
+mongoc_apm_server_heartbeat_failed_get_awaited (
+   const mongoc_apm_server_heartbeat_failed_t *event)
+{
+   return event->awaited;
+}
 
 /*
  * registering callbacks

--- a/src/libmongoc/src/mongoc/mongoc-apm.h
+++ b/src/libmongoc/src/mongoc/mongoc-apm.h
@@ -238,6 +238,9 @@ mongoc_apm_server_heartbeat_started_get_host (
 MONGOC_EXPORT (void *)
 mongoc_apm_server_heartbeat_started_get_context (
    const mongoc_apm_server_heartbeat_started_t *event);
+MONGOC_EXPORT (bool)
+mongoc_apm_server_heartbeat_started_get_awaited (
+   const mongoc_apm_server_heartbeat_started_t *event);
 
 /* heartbeat-succeeded event fields */
 
@@ -253,6 +256,9 @@ mongoc_apm_server_heartbeat_succeeded_get_host (
 MONGOC_EXPORT (void *)
 mongoc_apm_server_heartbeat_succeeded_get_context (
    const mongoc_apm_server_heartbeat_succeeded_t *event);
+MONGOC_EXPORT (bool)
+mongoc_apm_server_heartbeat_succeeded_get_awaited (
+   const mongoc_apm_server_heartbeat_succeeded_t *event);
 
 /* heartbeat-failed event fields */
 
@@ -267,6 +273,9 @@ mongoc_apm_server_heartbeat_failed_get_host (
    const mongoc_apm_server_heartbeat_failed_t *event);
 MONGOC_EXPORT (void *)
 mongoc_apm_server_heartbeat_failed_get_context (
+   const mongoc_apm_server_heartbeat_failed_t *event);
+MONGOC_EXPORT (bool)
+mongoc_apm_server_heartbeat_failed_get_awaited (
    const mongoc_apm_server_heartbeat_failed_t *event);
 
 

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
@@ -1205,6 +1205,7 @@ _mongoc_topology_scanner_monitor_heartbeat_started (
       mongoc_apm_server_heartbeat_started_t event;
       event.host = host;
       event.context = ts->apm_context;
+      event.awaited = false;
       ts->apm_callbacks.server_heartbeat_started (&event);
    }
 }
@@ -1229,6 +1230,7 @@ _mongoc_topology_scanner_monitor_heartbeat_succeeded (
       event.context = ts->apm_context;
       event.reply = reply;
       event.duration_usec = duration_usec;
+      event.awaited = false;
       ts->apm_callbacks.server_heartbeat_succeeded (&event);
 
       bson_destroy (&ismaster_redacted);
@@ -1249,6 +1251,7 @@ _mongoc_topology_scanner_monitor_heartbeat_failed (
       event.context = ts->apm_context;
       event.error = error;
       event.duration_usec = duration_usec;
+      event.awaited = false;
       ts->apm_callbacks.server_heartbeat_failed (&event);
    }
 }

--- a/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
@@ -313,12 +313,16 @@ server_heartbeat_started (const mongoc_apm_server_heartbeat_started_t *event)
 
    ctx = (context_t *) mongoc_apm_server_heartbeat_started_get_context (event);
    host = mongoc_apm_server_heartbeat_started_get_host (event);
-   context_append (ctx,
-                   BCON_NEW ("heartbeat_started_event",
-                             "{",
-                             "host",
-                             BCON_UTF8 (host->host_and_port),
-                             "}"));
+   context_append (
+      ctx,
+      BCON_NEW (
+         "heartbeat_started_event",
+         "{",
+         "host",
+         BCON_UTF8 (host->host_and_port),
+         "awaited",
+         BCON_BOOL (mongoc_apm_server_heartbeat_started_get_awaited (event)),
+         "}"));
 }
 
 static void
@@ -332,12 +336,16 @@ server_heartbeat_succeeded (
    ctx =
       (context_t *) mongoc_apm_server_heartbeat_succeeded_get_context (event);
    host = mongoc_apm_server_heartbeat_succeeded_get_host (event);
-   context_append (ctx,
-                   BCON_NEW ("heartbeat_succeeded_event",
-                             "{",
-                             "host",
-                             BCON_UTF8 (host->host_and_port),
-                             "}"));
+   context_append (
+      ctx,
+      BCON_NEW (
+         "heartbeat_succeeded_event",
+         "{",
+         "host",
+         BCON_UTF8 (host->host_and_port),
+         "awaited",
+         BCON_BOOL (mongoc_apm_server_heartbeat_succeeded_get_awaited (event)),
+         "}"));
 
    duration = mongoc_apm_server_heartbeat_succeeded_get_duration (event);
    _mongoc_array_append_val (&ctx->heartbeat_succeeded_durations, duration);
@@ -352,12 +360,16 @@ server_heartbeat_failed (const mongoc_apm_server_heartbeat_failed_t *event)
 
    ctx = (context_t *) mongoc_apm_server_heartbeat_failed_get_context (event);
    host = mongoc_apm_server_heartbeat_failed_get_host (event);
-   context_append (ctx,
-                   BCON_NEW ("heartbeat_failed_event",
-                             "{",
-                             "host",
-                             BCON_UTF8 (host->host_and_port),
-                             "}"));
+   context_append (
+      ctx,
+      BCON_NEW (
+         "heartbeat_failed_event",
+         "{",
+         "host",
+         BCON_UTF8 (host->host_and_port),
+         "awaited",
+         BCON_BOOL (mongoc_apm_server_heartbeat_failed_get_awaited (event)),
+         "}"));
 
    duration = mongoc_apm_server_heartbeat_failed_get_duration (event);
    _mongoc_array_append_val (&ctx->heartbeat_failed_durations, duration);
@@ -746,15 +758,16 @@ _test_heartbeat_events (bool pooled, bool succeeded)
    if (succeeded) {
       durations = &context.heartbeat_succeeded_durations;
       expected_json = bson_strdup_printf (
-         "{'0': {'heartbeat_started_event': {'host': '%s'}},"
-         " '1': {'heartbeat_succeeded_event': {'host': '%s'}}}",
+         "{'0': {'heartbeat_started_event': {'host': '%s', 'awaited': false}},"
+         " '1': {'heartbeat_succeeded_event': {'host': '%s', 'awaited': "
+         "false}}}",
          mock_server_get_host_and_port (server),
          mock_server_get_host_and_port (server));
    } else {
       durations = &context.heartbeat_failed_durations;
       expected_json = bson_strdup_printf (
-         "{'0': {'heartbeat_started_event': {'host': '%s'}},"
-         " '1': {'heartbeat_failed_event': {'host': '%s'}}}",
+         "{'0': {'heartbeat_started_event': {'host': '%s', 'awaited': false}},"
+         " '1': {'heartbeat_failed_event': {'host': '%s', 'awaited': false}}}",
          mock_server_get_host_and_port (server),
          mock_server_get_host_and_port (server));
    }


### PR DESCRIPTION
A small isolated chunk of streamable ismaster to add an `awaited` field to heartbeat started/succeeded/failed events. It was added as part of this spec change: https://github.com/mongodb/specifications/commit/a813663112d2ec67b71925f62b2363c79ce4478a

Currently `awaited` is always false, but after streamable ismaster, it will be true for awaitable isMaster commands.