### PR TITLE
CDRIVER-3668 support OCSP back to OpenSSL 1.0.1

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1831,6 +1831,25 @@ tasks:
         export SSL="OPENSSL"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
   - func: upload build
+- name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: install ssl
+    vars:
+      SSL: openssl-1.0.1u
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        export CFLAGS="-Wno-redundant-decls"
+        export DEBUG="ON"
+        export SASL="OFF"
+        export SSL="OPENSSL"
+        CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
+  - func: upload build
 - name: test-valgrind-latest-server-auth-nosasl-openssl
   tags:
   - latest
@@ -12320,6 +12339,7 @@ tasks:
       script: |-
         set -o errexit
         set -o xtrace
+        export CFLAGS=-Wno-redundant-decls
         DEBUG=ON CC='${CC}' MARCH='${MARCH}' SASL=OFF SSL=AUTO sh .evergreen/compile.sh
   - func: run auth tests
     vars:
@@ -12556,6 +12576,40 @@ tasks:
         set -o errexit
         set -o xtrace
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-1.0.1-test_1-rsa-delegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_1-ecdsa-delegate
   tags:
   - ocsp-openssl
@@ -12565,6 +12619,40 @@ tasks:
   - func: fetch build
     vars:
       BUILD_NAME: debug-compile-nosasl-openssl
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-1.0.1-test_1-ecdsa-delegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -12624,6 +12712,40 @@ tasks:
         set -o errexit
         set -o xtrace
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-1.0.1-test_1-rsa-nodelegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_1-ecdsa-nodelegate
   tags:
   - ocsp-openssl
@@ -12658,6 +12780,312 @@ tasks:
         set -o errexit
         set -o xtrace
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-1.0.1-test_1-ecdsa-nodelegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-test_2-rsa-delegate
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-1.0.1-test_2-rsa-delegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-test_2-ecdsa-delegate
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-1.0.1-test_2-ecdsa-delegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-test_2-rsa-nodelegate
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-1.0.1-test_2-rsa-nodelegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-test_2-ecdsa-nodelegate
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-1.0.1-test_2-ecdsa-nodelegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-rsa-delegate
   tags:
   - ocsp-openssl
@@ -12667,6 +13095,74 @@ tasks:
   - func: fetch build
     vars:
       BUILD_NAME: debug-compile-nosasl-openssl
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-1.0.1-test_3-rsa-delegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-darwinssl-test_3-rsa-delegate
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - command: shell.exec
     type: test
     params:
@@ -12760,6 +13256,40 @@ tasks:
         set -o errexit
         set -o xtrace
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-1.0.1-test_3-ecdsa-delegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-rsa-nodelegate
   tags:
   - ocsp-openssl
@@ -12769,6 +13299,74 @@ tasks:
   - func: fetch build
     vars:
       BUILD_NAME: debug-compile-nosasl-openssl
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-1.0.1-test_3-rsa-nodelegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-darwinssl-test_3-rsa-nodelegate
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - command: shell.exec
     type: test
     params:
@@ -12862,6 +13460,142 @@ tasks:
         set -o errexit
         set -o xtrace
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-1.0.1-test_3-ecdsa-nodelegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-test_4-rsa-delegate
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-1.0.1-test_4-rsa-delegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-darwinssl-test_4-rsa-delegate
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-test_4-rsa-delegate
   tags:
   - ocsp-winssl
@@ -12880,6 +13614,176 @@ tasks:
         set -o errexit
         set -o xtrace
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-test_4-ecdsa-delegate
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-1.0.1-test_4-ecdsa-delegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-test_4-rsa-nodelegate
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-1.0.1-test_4-rsa-nodelegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-darwinssl-test_4-rsa-nodelegate
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
     vars:
       OCSP: 'on'
@@ -12930,6 +13834,74 @@ tasks:
         set -o errexit
         set -o xtrace
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-test_4-ecdsa-nodelegate
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-1.0.1-test_4-ecdsa-nodelegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-soft_fail_test-rsa-nodelegate
   tags:
   - ocsp-openssl
@@ -12939,6 +13911,74 @@ tasks:
   - func: fetch build
     vars:
       BUILD_NAME: debug-compile-nosasl-openssl
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-1.0.1-soft_fail_test-rsa-nodelegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-darwinssl-soft_fail_test-rsa-nodelegate
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - command: shell.exec
     type: test
     params:
@@ -13032,6 +14072,142 @@ tasks:
         set -o errexit
         set -o xtrace
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-1.0.1-soft_fail_test-ecdsa-nodelegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-malicious_server_test_1-rsa-delegate
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-1.0.1-malicious_server_test_1-rsa-delegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-darwinssl-malicious_server_test_1-rsa-delegate
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-malicious_server_test_1-rsa-delegate
   tags:
   - ocsp-winssl
@@ -13050,6 +14226,176 @@ tasks:
         set -o errexit
         set -o xtrace
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-malicious_server_test_1-ecdsa-delegate
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-1.0.1-malicious_server_test_1-ecdsa-delegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-malicious_server_test_1-rsa-nodelegate
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-1.0.1-malicious_server_test_1-rsa-nodelegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-darwinssl-malicious_server_test_1-rsa-nodelegate
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
     vars:
       OCSP: 'on'
@@ -13100,6 +14446,142 @@ tasks:
         set -o errexit
         set -o xtrace
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-malicious_server_test_1-ecdsa-nodelegate
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-1.0.1-malicious_server_test_1-ecdsa-nodelegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-malicious_server_test_2-rsa-nodelegate
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-1.0.1-malicious_server_test_2-rsa-nodelegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-malicious_server_test_2-rsa-nodelegate
   tags:
   - ocsp-winssl
@@ -13134,6 +14616,74 @@ tasks:
         set -o errexit
         set -o xtrace
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-malicious_server_test_2-ecdsa-nodelegate
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
+- name: ocsp-openssl-1.0.1-malicious_server_test_2-ecdsa-nodelegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-cache-rsa-nodelegate
   tags:
   - ocsp-openssl
@@ -13168,6 +14718,40 @@ tasks:
         set -o errexit
         set -o xtrace
         CERT_TYPE=rsa .evergreen/run-ocsp-cache-test.sh
+- name: ocsp-openssl-1.0.1-cache-rsa-nodelegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        CERT_TYPE=rsa .evergreen/run-ocsp-cache-test.sh
 - name: ocsp-openssl-cache-ecdsa-nodelegate
   tags:
   - ocsp-openssl
@@ -13177,6 +14761,40 @@ tasks:
   - func: fetch build
     vars:
       BUILD_NAME: debug-compile-nosasl-openssl
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
+  - func: bootstrap mongo-orchestration
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        CERT_TYPE=ecdsa .evergreen/run-ocsp-cache-test.sh
+- name: ocsp-openssl-1.0.1-cache-ecdsa-nodelegate
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -13830,15 +15448,27 @@ buildvariants:
   - name: debug-compile-nosasl-openssl
     distros:
     - ubuntu1804-test
+  - name: debug-compile-nosasl-darwinssl
+    distros:
+    - macos-1014
   - name: debug-compile-nosasl-winssl
     distros:
     - windows-64-vs2017-test
   - name: .ocsp-openssl
     distros:
     - ubuntu1804-test
+  - name: .ocsp-darwinssl
+    distros:
+    - macos-1014
   - name: .ocsp-winssl
     distros:
     - windows-64-vs2017-test
+  - name: debug-compile-nosasl-openssl-1.0.1
+    distros:
+    - ubuntu1804-test
+  - name: .ocsp-openssl-1.0.1
+    distros:
+    - ubuntu1804-test
   batchtime: 20160
 - name: packaging
   display_name: Linux Distro Packaging

--- a/build/evergreen_config_lib/variants.py
+++ b/build/evergreen_config_lib/variants.py
@@ -573,11 +573,13 @@ all_variants = [
         batchtime=days(1)),
     Variant ('ocsp', 'OCSP tests', 'ubuntu1804-test', [
         OD([('name', 'debug-compile-nosasl-openssl'), ('distros', ['ubuntu1804-test'])]),
-        #OD([('name', 'debug-compile-nosasl-darwinssl'), ('distros', ['macos-1014'])]),
+        OD([('name', 'debug-compile-nosasl-darwinssl'), ('distros', ['macos-1014'])]),
         OD([('name', 'debug-compile-nosasl-winssl'), ('distros', ['windows-64-vs2017-test'])]),
         OD([('name', '.ocsp-openssl'), ('distros', ['ubuntu1804-test'])]),
-        #OD([('name', '.ocsp-darwinssl'), ('distros', ['macos-1014'])]),
-        OD([('name', '.ocsp-winssl'), ('distros', ['windows-64-vs2017-test'])])
+        OD([('name', '.ocsp-darwinssl'), ('distros', ['macos-1014'])]),
+        OD([('name', '.ocsp-winssl'), ('distros', ['windows-64-vs2017-test'])]),
+        OD([('name', 'debug-compile-nosasl-openssl-1.0.1'), ('distros', ['ubuntu1804-test'])]),
+        OD([('name', '.ocsp-openssl-1.0.1'), ('distros', ['ubuntu1804-test'])])
     ], {}, batchtime=days(14)),
     Variant ('packaging', 'Linux Distro Packaging', 'ubuntu1604-test', [
         'debian-package-build',

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -628,10 +628,8 @@ if (NOT ENABLE_SSL STREQUAL OFF)
          ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-stream-tls-openssl.c
          ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-stream-tls-openssl-bio.c
          ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-openssl.c
+         ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-ocsp-cache.c
       )
-      if (OPENSSL_VERSION GREATER 1.1.1 OR OPENSSL_VERSION EQUAL 1.1.1)
-         set (SOURCES ${SOURCES} ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-ocsp-cache.c)
-      endif()
       set (SSL_LIBRARIES ${OPENSSL_LIBRARIES})
       include_directories (${OPENSSL_INCLUDE_DIR})
       if (WIN32)
@@ -948,10 +946,8 @@ if (MONGOC_ENABLE_SSL)
       ${PROJECT_SOURCE_DIR}/tests/test-mongoc-stream-tls-error.c
       ${PROJECT_SOURCE_DIR}/tests/test-mongoc-stream-tls.c
       ${PROJECT_SOURCE_DIR}/tests/test-mongoc-x509.c
+      ${PROJECT_SOURCE_DIR}/tests/test-mongoc-ocsp-cache.c
    )
-   if (OPENSSL_VERSION GREATER 1.1.1 OR OPENSSL_VERSION EQUAL 1.1.1)
-      set (test-libmongoc-sources ${test-libmongoc-sources} ${PROJECT_SOURCE_DIR}/tests/test-mongoc-ocsp-cache.c)
-   endif()
 endif ()
 
 if (MONGOC_ENABLE_SASL_CYRUS)

--- a/src/libmongoc/doc/configuring_tls.rst
+++ b/src/libmongoc/doc/configuring_tls.rst
@@ -88,9 +88,10 @@ Ensure your system's OpenSSL is a recent version (at least 1.0.1), or install a 
 
 When compiled against OpenSSL, the driver will attempt to load the system default certificate store, as configured by the distribution. That can be overridden by setting the ``tlsCAFile`` URI option or with the fields ``ca_file`` and ``ca_dir`` in the :symbol:`mongoc_ssl_opt_t`.
 
-Setting ``tlsDisableOCSPEndpointCheck`` and ``tlsDisableCertificateRevocationCheck`` has no effect.
+Setting ``tlsDisableCertificateRevocationCheck`` disables OCSP revocation checking.
+Setting ``tlsDisableOCSPEndpointCheck`` disables OCSP responders from being contacted when OCSP revocation checking is enabled, and a server presents a certificate without stapled OCSP response.
 
-The Online Certificate Status Protocol (OCSP) is partially supported (see `RFC 6960 <https://tools.ietf.org/html/rfc6960>`_). Support requires OpenSSL 1.1.0 and has the following behavior:
+The Online Certificate Status Protocol (OCSP) is partially supported (see `RFC 6960 <https://tools.ietf.org/html/rfc6960>`_). Support requires OpenSSL 1.0.1 and has the following behavior:
 
 - Stapled OCSP responses are validated on certificates presented by the server.
 - Server certificates with a Must-Staple extension (see `RFC 7633 <https://tools.ietf.org/html/rfc7633>`_) are required to have stapled responses.

--- a/src/libmongoc/src/mongoc/mongoc-openssl-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-openssl-private.h
@@ -53,6 +53,8 @@ int
 _mongoc_ocsp_tlsext_status (SSL *ssl, mongoc_openssl_ocsp_opt_t *opts);
 #endif
 
+bool
+_mongoc_tlsfeature_has_status_request (const uint8_t *data, int length);
 
 BSON_END_DECLS
 

--- a/src/libmongoc/src/mongoc/mongoc-openssl-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-openssl-private.h
@@ -25,8 +25,9 @@
 #include <openssl/err.h>
 
 #include "mongoc-ssl.h"
+#include "mongoc-stream-tls-openssl-private.h"
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10101000L) && !defined(OPENSSL_NO_OCSP) && \
+#if (OPENSSL_VERSION_NUMBER >= 0x10001000L) && !defined(OPENSSL_NO_OCSP) && \
    !defined(LIBRESSL_VERSION_NUMBER)
 #define MONGOC_ENABLE_OCSP_OPENSSL
 #endif
@@ -35,9 +36,9 @@
 BSON_BEGIN_DECLS
 
 bool
-_mongoc_openssl_check_cert (SSL *ssl,
-                            const char *host,
-                            bool allow_invalid_hostname);
+_mongoc_openssl_check_peer_hostname (SSL *ssl,
+                                     const char *host,
+                                     bool allow_invalid_hostname);
 SSL_CTX *
 _mongoc_openssl_ctx_new (mongoc_ssl_opt_t *opt);
 char *
@@ -49,7 +50,7 @@ _mongoc_openssl_cleanup (void);
 
 #ifdef MONGOC_ENABLE_OCSP_OPENSSL
 int
-_mongoc_ocsp_tlsext_status_cb (SSL *ssl, void *arg);
+_mongoc_ocsp_tlsext_status (SSL *ssl, mongoc_openssl_ocsp_opt_t *opts);
 #endif
 
 

--- a/src/libmongoc/src/mongoc/mongoc-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-openssl.c
@@ -58,6 +58,8 @@ _mongoc_openssl_thread_cleanup (void);
 #define ASN1_STRING_get0_data ASN1_STRING_data
 #endif
 
+static int tlsfeature_nid;
+
 /**
  * _mongoc_openssl_init:
  *
@@ -83,6 +85,14 @@ _mongoc_openssl_init (void)
    if (!ctx) {
       MONGOC_ERROR ("Failed to initialize OpenSSL.");
    }
+
+#ifdef NID_tlsfeature
+   tlsfeature_nid = NID_tlsfeature;
+#else
+   /* TLS versions before 1.1.0 did not define the TLS Feature extension. */
+   tlsfeature_nid =
+      OBJ_create ("1.3.6.1.5.5.7.1.24", "tlsfeature", "TLS Feature");
+#endif
 
    SSL_CTX_free (ctx);
 }
@@ -183,6 +193,31 @@ _mongoc_openssl_import_cert_stores (SSL_CTX *context)
 }
 #endif
 
+#if OPENSSL_VERSION_NUMBER > 0x10002000L
+bool
+_mongoc_openssl_check_peer_hostname (SSL *ssl,
+                                     const char *host,
+                                     bool allow_invalid_hostname)
+{
+   X509 *peer = NULL;
+
+   if (allow_invalid_hostname) {
+      return true;
+   }
+
+   peer = SSL_get_peer_certificate (ssl);
+   if (peer && (X509_check_host (peer, host, 0, 0, NULL) == 1 ||
+                X509_check_ip_asc (peer, host, 0) == 1)) {
+      X509_free (peer);
+      return true;
+   }
+
+   if (peer) {
+      X509_free (peer);
+   }
+   return false;
+}
+#else
 /** mongoc_openssl_hostcheck
  *
  * rfc 6125 match a given hostname against a given pattern
@@ -250,9 +285,9 @@ _mongoc_openssl_hostcheck (const char *pattern, const char *hostname)
 /** check if a provided cert matches a passed hostname
  */
 bool
-_mongoc_openssl_check_cert (SSL *ssl,
-                            const char *host,
-                            bool allow_invalid_hostname)
+_mongoc_openssl_check_peer_hostname (SSL *ssl,
+                                     const char *host,
+                                     bool allow_invalid_hostname)
 {
    X509 *peer;
    X509_NAME *subject_name;
@@ -392,6 +427,7 @@ _mongoc_openssl_check_cert (SSL *ssl,
    X509_free (peer);
    RETURN (r);
 }
+#endif /* OPENSSL_VERSION_NUMBER */
 
 
 static bool
@@ -477,6 +513,142 @@ _get_issuer (X509 *cert, STACK_OF (X509) * chain)
    RETURN (issuer);
 }
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+/* OpenSSL 1.1.0+ has conveniences that we polyfill in older OpenSSL versions.
+ */
+
+STACK_OF (X509) * _get_verified_chain (SSL *ssl)
+{
+   return SSL_get0_verified_chain (ssl);
+}
+
+void _free_verified_chain (STACK_OF (X509) * verified_chain)
+{
+   /* _get_verified_chain does not return a copy. Do nothing. */
+   return;
+}
+
+const STACK_OF (X509_EXTENSION) * _get_extensions (const X509 *cert)
+{
+   return X509_get0_extensions (cert);
+}
+
+#else
+/* Polyfill functionality for pre 1.1.0 OpenSSL */
+
+STACK_OF (X509) * _get_verified_chain (SSL *ssl)
+{
+   X509_STORE *store = NULL;
+   X509 *peer = NULL;
+   STACK_OF (X509) *peer_chain = NULL;
+   X509_STORE_CTX *store_ctx = NULL;
+   STACK_OF (X509) *verified_chain = NULL;
+
+   /* Get the certificate the server presented. */
+   peer = SSL_get_peer_certificate (ssl);
+   /* Get the chain of certificates the server presented. This is not a verified
+    * chain. */
+   peer_chain = SSL_get_peer_cert_chain (ssl);
+   store = SSL_CTX_get_cert_store (SSL_get_SSL_CTX (ssl));
+   store_ctx = X509_STORE_CTX_new ();
+   if (!X509_STORE_CTX_init (store_ctx, store, peer, peer_chain)) {
+      MONGOC_ERROR ("failed to initialize X509 store");
+      goto fail;
+   }
+
+   if (X509_verify_cert (store_ctx) <= 0) {
+      MONGOC_ERROR ("failed to obtain verified chain");
+      goto fail;
+   }
+
+   verified_chain = X509_STORE_CTX_get1_chain (store_ctx);
+
+fail:
+   X509_free (peer);
+   X509_STORE_CTX_free (store_ctx);
+   return verified_chain;
+}
+
+/* On OpenSSL < 1.1.0, this chain isn't attached to the SSL session, so we need
+ * it to dispose of itself. */
+void _free_verified_chain (STACK_OF (X509) * verified_chain)
+{
+   if (!verified_chain) {
+      return;
+   }
+   sk_X509_pop_free (verified_chain, X509_free);
+}
+
+const STACK_OF (X509_EXTENSION) * _get_extensions (const X509 *cert)
+{
+   return cert->cert_info->extensions;
+}
+#endif /* OPENSSL_VERSION_NUMBER */
+
+
+#define TLSFEATURE_STATUS_REQUEST 5
+
+/* Parse just enough of a DER encoded data to check if a SEQUENCE of INTEGER
+ * contains the status_request extension (5). There are only five tlsfeature
+ * extension types, so this only handles the case that the sequence's length is
+ * representable in one byte, and that each integer is representable in one
+ * byte. */
+static bool
+_sequence_has_status_request (const uint8_t *data, int length)
+{
+   int i;
+
+   /* Expect a sequence type, with a sequence length representable in one byte.
+    */
+   if (length < 3 || data[0] != 0x30 || data[1] >= 127) {
+      MONGOC_ERROR ("malformed tlsfeature extension sequence");
+      return false;
+   }
+
+   for (i = 2; i < length; i += 3) {
+      /* Expect an integer, representable in one byte. */
+      if (length < i + 3 || data[i] != 0x02 || data[i + 1] >= 127) {
+         MONGOC_ERROR ("malformed tlsfeature extension integer");
+         return false;
+      }
+
+      if (data[i + 2] == TLSFEATURE_STATUS_REQUEST) {
+         TRACE ("%s", "found status request in tlsfeature extension");
+         return true;
+      }
+   }
+   return false;
+}
+
+/* Check that the certificate has a tlsfeature extension with status_request. */
+bool
+_get_must_staple (X509 *cert)
+{
+   const STACK_OF (X509_EXTENSION) *exts = NULL;
+   X509_EXTENSION *ext;
+   ASN1_STRING *ext_data;
+   int idx;
+
+   exts = _get_extensions (cert);
+   if (!exts) {
+      TRACE ("%s", "certificate extensions not found");
+      return false;
+   }
+
+   idx = X509v3_get_ext_by_NID (exts, tlsfeature_nid, -1);
+   if (-1 == idx) {
+      TRACE ("%s", "tlsfeature extension not found");
+      return false;
+   }
+
+   ext = sk_X509_EXTENSION_value (exts, idx);
+   ext_data = X509_EXTENSION_get_data (ext);
+
+   /* Data is a DER encoded sequence of integers. */
+   return _sequence_has_status_request (ASN1_STRING_get0_data (ext_data),
+                                        ASN1_STRING_length (ext_data));
+}
+
 #define ERR_STR (ERR_error_string (ERR_get_error (), NULL))
 
 OCSP_RESPONSE *
@@ -492,7 +664,7 @@ _contact_ocsp_responder (OCSP_CERTID *id, X509 *peer)
    url_stack = X509_get1_ocsp (peer);
    for (i = 0; i < sk_OPENSSL_STRING_num (url_stack) && !resp; i++) {
       url = sk_OPENSSL_STRING_value (url_stack, i);
-      MONGOC_DEBUG ("Contacting OCSP responder '%s'", url);
+      TRACE ("Contacting OCSP responder '%s'", url);
 
       /* splits the given url into its host, port and path components */
       if (!OCSP_parse_url (url, &host, &port, &path, &ssl)) {
@@ -560,7 +732,7 @@ _contact_ocsp_responder (OCSP_CERTID *id, X509 *peer)
 #define OCSP_VERIFY_SUCCESS 1
 
 int
-_mongoc_ocsp_tlsext_status_cb (SSL *ssl, void *arg)
+_mongoc_ocsp_tlsext_status (SSL *ssl, mongoc_openssl_ocsp_opt_t *opts)
 {
    enum { OCSP_CB_ERROR = -1, OCSP_CB_REVOKED, OCSP_CB_SUCCESS } ret;
    bool stapled_response = true;
@@ -570,10 +742,9 @@ _mongoc_ocsp_tlsext_status_cb (SSL *ssl, void *arg)
    X509_STORE *store = NULL;
    X509 *peer = NULL, *issuer = NULL;
    STACK_OF (X509) *cert_chain = NULL;
-   const unsigned char *r = NULL;
+   const unsigned char *resp_data = NULL;
    int cert_status, reason, len, status;
    OCSP_CERTID *id = NULL;
-   mongoc_openssl_ocsp_opt_t *opts = (mongoc_openssl_ocsp_opt_t *) arg;
    ASN1_GENERALIZEDTIME *produced_at = NULL, *this_update = NULL,
                         *next_update = NULL;
 
@@ -589,8 +760,8 @@ _mongoc_ocsp_tlsext_status_cb (SSL *ssl, void *arg)
 
    /* Get a STACK_OF(X509) certs forming the cert chain of the peer, including
     * the peer's cert */
-   if (!(cert_chain = SSL_get0_verified_chain (ssl))) {
-      MONGOC_ERROR ("No certificate was presented by the peer");
+   if (!(cert_chain = _get_verified_chain (ssl))) {
+      MONGOC_ERROR ("Unable to obtain verified chain");
       ret = OCSP_CB_REVOKED;
       GOTO (done);
    }
@@ -613,32 +784,33 @@ _mongoc_ocsp_tlsext_status_cb (SSL *ssl, void *arg)
    }
 
    /* Get the stapled OCSP response returned by the server */
-   len = SSL_get_tlsext_status_ocsp_resp (ssl, &r);
-   stapled_response = !!r;
+   len = SSL_get_tlsext_status_ocsp_resp (ssl, &resp_data);
+   stapled_response = !!resp_data;
    if (stapled_response) {
       /* obtain an OCSP_RESPONSE object from the OCSP response */
-      if (!d2i_OCSP_RESPONSE (&resp, &r, len)) {
+      if (!d2i_OCSP_RESPONSE (&resp, &resp_data, len)) {
          MONGOC_ERROR ("Failed to parse OCSP response");
          ret = OCSP_CB_ERROR;
          GOTO (done);
       }
    } else {
-      MONGOC_DEBUG ("Server does not contain a stapled response");
-      must_staple = X509_get_ext_d2i (peer, NID_tlsfeature, 0, 0) != NULL;
+      TRACE ("%s", "Server does not contain a stapled response");
+      must_staple = _get_must_staple (peer);
       if (must_staple) {
          MONGOC_ERROR ("Server must contain a stapled response");
          ret = OCSP_CB_REVOKED;
          GOTO (done);
       }
 
-      if (!(resp = _contact_ocsp_responder (id, peer))) {
+      if (opts->disable_endpoint_check ||
+          !(resp = _contact_ocsp_responder (id, peer))) {
          MONGOC_DEBUG ("Soft-fail: No OCSP responder could be reached");
          ret = OCSP_CB_SUCCESS;
          GOTO (done);
       }
    }
 
-   MONGOC_DEBUG ("Validating OCSP response");
+   TRACE ("%s", "Validating OCSP response");
    /* Validate the OCSP response status of the OCSP_RESPONSE object */
    status = OCSP_response_status (resp);
    if (status != OCSP_RESPONSE_STATUS_SUCCESSFUL) {
@@ -649,7 +821,7 @@ _mongoc_ocsp_tlsext_status_cb (SSL *ssl, void *arg)
       GOTO (done);
    }
 
-   MONGOC_DEBUG ("OCSP response status successful");
+   TRACE ("%s", "OCSP response status successful");
 
    /* Get the OCSP_BASICRESP structure contained in OCSP_RESPONSE object for the
     * peer cert */
@@ -700,7 +872,7 @@ _mongoc_ocsp_tlsext_status_cb (SSL *ssl, void *arg)
 validate:
    switch (cert_status) {
    case V_OCSP_CERTSTATUS_GOOD:
-      MONGOC_DEBUG ("OCSP Certificate Status: Good");
+      TRACE ("%s", "OCSP Certificate Status: Good");
       _mongoc_ocsp_cache_set_resp (
          id, cert_status, reason, this_update, next_update);
       break;
@@ -719,9 +891,8 @@ validate:
    }
 
    /* Validate hostname matches cert */
-   if (!opts->allow_invalid_hostname &&
-       X509_check_host (peer, opts->host, 0, 0, NULL) != X509_CHECK_SUCCESS &&
-       X509_check_ip_asc (peer, opts->host, 0) != X509_CHECK_SUCCESS) {
+   if (!_mongoc_openssl_check_peer_hostname (
+          ssl, opts->host, opts->allow_invalid_hostname)) {
       ret = OCSP_CB_REVOKED;
       GOTO (done);
    }
@@ -739,9 +910,12 @@ done:
       OCSP_CERTID_free (id);
    if (peer)
       X509_free (peer);
+   if (cert_chain)
+      _free_verified_chain (cert_chain);
    RETURN (ret);
 }
-#endif
+
+#endif /* MONGOC_ENABLE_OCSP_OPENSSL */
 
 /**
  * _mongoc_openssl_ctx_new:

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl-private.h
@@ -28,6 +28,7 @@ typedef struct {
    char *host;
    bool allow_invalid_hostname;
    bool weak_cert_validation;
+   bool disable_endpoint_check;
 } mongoc_openssl_ocsp_opt_t;
 
 void

--- a/src/libmongoc/src/mongoc/mongoc-uri.c
+++ b/src/libmongoc/src/mongoc/mongoc-uri.c
@@ -2414,7 +2414,13 @@ mongoc_uri_get_tls (const mongoc_uri_t *uri) /* IN */
        bson_iter_init_find_case (
           &iter, &uri->options, MONGOC_URI_TLSINSECURE) ||
        bson_iter_init_find_case (
-          &iter, &uri->options, MONGOC_URI_TLSCERTIFICATEKEYFILEPASSWORD)) {
+          &iter, &uri->options, MONGOC_URI_TLSCERTIFICATEKEYFILEPASSWORD) ||
+       bson_iter_init_find_case (
+          &iter, &uri->options, MONGOC_URI_TLSDISABLEOCSPENDPOINTCHECK) ||
+       bson_iter_init_find_case (
+          &iter,
+          &uri->options,
+          MONGOC_URI_TLSDISABLECERTIFICATEREVOCATIONCHECK)) {
       return true;
    }
 
@@ -3050,7 +3056,8 @@ mongoc_uri_init_with_srv_host_list (mongoc_uri_t *uri,
    BSON_ASSERT (uri->is_srv);
    BSON_ASSERT (!uri->hosts);
 
-   LL_FOREACH (host_list, host) {
+   LL_FOREACH (host_list, host)
+   {
       if (!mongoc_uri_upsert_host_and_port (uri, host->host_and_port, error)) {
          return false;
       }

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -38,6 +38,10 @@
 #include <errhandlingapi.h>
 #include <DbgHelp.h>
 #endif
+
+#ifdef MONGOC_ENABLE_SSL_OPENSSL
+#include "mongoc/mongoc-openssl-private.h"
+#endif
 /* libbson */
 
 
@@ -244,7 +248,7 @@ extern void
 test_aws_install (TestSuite *suite);
 extern void
 test_streamable_ismaster_install (TestSuite *suite);
-#ifdef MONGOC_ENABLE_OCSP_OPENSSL
+#if defined(MONGOC_ENABLE_OCSP_OPENSSL) && OPENSSL_VERSION_NUMBER >= 0x10101000L
 extern void
 test_ocsp_cache_install (TestSuite *suite);
 #endif
@@ -2629,7 +2633,7 @@ main (int argc, char *argv[])
    test_server_description_install (&suite);
    test_aws_install (&suite);
    test_streamable_ismaster_install (&suite);
-#ifdef MONGOC_ENABLE_OCSP_OPENSSL
+#if defined(MONGOC_ENABLE_OCSP_OPENSSL) && OPENSSL_VERSION_NUMBER >= 0x10101000L
    test_ocsp_cache_install (&suite);
 #endif
    test_interrupt_install (&suite);

--- a/src/libmongoc/tests/test-mongoc-ocsp-cache.c
+++ b/src/libmongoc/tests/test-mongoc-ocsp-cache.c
@@ -18,7 +18,7 @@
 
 #include "mongoc/mongoc-ocsp-cache-private.h"
 
-#ifdef MONGOC_ENABLE_OCSP_OPENSSL
+#if defined(MONGOC_ENABLE_OCSP_OPENSSL) && OPENSSL_VERSION_NUMBER >= 0x10101000L
 #include <openssl/pem.h>
 
 static OCSP_CERTID *
@@ -187,16 +187,15 @@ test_mongoc_cache_remove_expired_cert (void)
    CLEAR_CACHE;
 }
 
-#endif
-
 void
 test_ocsp_cache_install (TestSuite *suite)
 {
-#ifdef MONGOC_ENABLE_OCSP_OPENSSL
    TestSuite_Add (suite, "/OCSPCache/insert", test_mongoc_cache_insert);
    TestSuite_Add (suite, "/OCSPCache/update", test_mongoc_cache_update);
    TestSuite_Add (suite,
                   "/OCSPCache/remove_expired_cert",
                   test_mongoc_cache_remove_expired_cert);
-#endif
 }
+#else
+extern int no_mongoc_ocsp;
+#endif /* MONGOC_ENABLE_OCSP_OPENSSL */

--- a/src/libmongoc/tests/test-mongoc-uri.c
+++ b/src/libmongoc/tests/test-mongoc-uri.c
@@ -2693,7 +2693,10 @@ test_one_tls_option_enables_tls ()
                          MONGOC_URI_SSLCLIENTCERTIFICATEKEYPASSWORD "=file.pem",
                          MONGOC_URI_SSLCERTIFICATEAUTHORITYFILE "=file.pem",
                          MONGOC_URI_SSLALLOWINVALIDCERTIFICATES "=true",
-                         MONGOC_URI_SSLALLOWINVALIDHOSTNAMES "=true"};
+                         MONGOC_URI_SSLALLOWINVALIDHOSTNAMES "=true",
+                         MONGOC_URI_TLSDISABLEOCSPENDPOINTCHECK "=true",
+                         MONGOC_URI_TLSDISABLECERTIFICATEREVOCATIONCHECK
+                         "=true"};
    int i;
 
    for (i = 0; i < sizeof (opts) / sizeof (opts[0]); i++) {

--- a/src/libmongoc/tests/test-mongoc-x509.c
+++ b/src/libmongoc/tests/test-mongoc-x509.c
@@ -1,7 +1,12 @@
 #include <mongoc/mongoc.h>
 #include "mongoc/mongoc-ssl-private.h"
 
+#ifdef MONGOC_ENABLE_SSL_OPENSSL
+#include "mongoc/mongoc-openssl-private.h"
+#endif
+
 #include "TestSuite.h"
+#include "test-libmongoc.h"
 
 #if defined(MONGOC_ENABLE_SSL) && !defined(MONGOC_ENABLE_SSL_LIBRESSL)
 static void
@@ -22,11 +27,73 @@ test_extract_subject (void)
 }
 #endif
 
+#ifdef MONGOC_ENABLE_SSL_OPENSSL
+/* Test parsing a DER encoded tlsfeature extension contents for the
+ * status_request (value 5). This is a SEQUENCE of INTEGER. libmongoc assumes
+ * this is a sequence of one byte integers. */
+
+static void
+_expect_malformed (const char *data, int32_t len)
+{
+   bool ret;
+
+   ret = _mongoc_tlsfeature_has_status_request ((const uint8_t *) data, len);
+   BSON_ASSERT (!ret);
+   ASSERT_CAPTURED_LOG ("mongoc", MONGOC_LOG_LEVEL_ERROR, "malformed");
+   clear_captured_logs ();
+}
+
+static void
+_expect_no_status_request (const char *data, int32_t len)
+{
+   bool ret;
+   ret = _mongoc_tlsfeature_has_status_request ((const uint8_t *) data, len);
+   BSON_ASSERT (!ret);
+   ASSERT_NO_CAPTURED_LOGS ("mongoc");
+}
+
+static void
+_expect_status_request (const char *data, int32_t len)
+{
+   bool ret;
+   ret = _mongoc_tlsfeature_has_status_request ((const uint8_t *) data, len);
+   BSON_ASSERT (ret);
+   ASSERT_NO_CAPTURED_LOGS ("mongoc");
+}
+
+static void
+test_tlsfeature_parsing (void)
+{
+   capture_logs (true);
+   /* A sequence of one integer = 5. */
+   _expect_status_request ("\x30\x03\x02\x01\x05", 5);
+   /* A sequence of one integer = 6. */
+   _expect_no_status_request ("\x30\x03\x02\x01\x06", 5);
+   /* A sequence of two integers = 5,6. */
+   _expect_status_request ("\x30\x03\x02\x01\x05\x02\x01\x06", 8);
+   /* A sequence of two integers = 6,5. */
+   _expect_status_request ("\x30\x03\x02\x01\x06\x02\x01\x05", 8);
+   /* A sequence containing a non-integer. Parsing fails. */
+   _expect_malformed ("\x30\x03\x03\x01\x05\x02\x01\x06", 8);
+   /* A non-sequence. It will not read past the first byte (despite the >1
+    * length). */
+   _expect_malformed ("\xFF", 2);
+   /* A sequence with a length represented in more than one byte. Parsing fails.
+    */
+   _expect_malformed ("\x30\x82\x04\x48", 4);
+   /* An integer with length > 1. Parsing fails. */
+   _expect_malformed ("\x30\x03\x02\x02\x05\x05", 6);
+}
+#endif
 
 void
 test_x509_install (TestSuite *suite)
 {
 #if defined(MONGOC_ENABLE_SSL) && !defined(MONGOC_ENABLE_SSL_LIBRESSL)
    TestSuite_Add (suite, "/X509/extract_subject", test_extract_subject);
+#endif
+
+#ifdef MONGOC_ENABLE_SSL_OPENSSL
+   TestSuite_Add (suite, "/X509/tlsfeature_parsing", test_tlsfeature_parsing);
 #endif
 }


### PR DESCRIPTION
Adds polyfills and makes a few tweaks to support OpenSSL back to 1.0.1.

Summary of changes:

- change SSL_CTX_set_tlsext_status_type to SSL_set_tlsext_status_type.
- polyfill SSL_get0_verified_chain, NID_tlsfeature, and hostname check.
- check for status_request from the tlsfeature extension when inspecting peer certificate.
- skip time check for older OpenSSL when updating cache entries.
- perform the OCSP check after the handshake, since sometimes the peer certificate is not available in the callback in OpenSSL <= 1.0.2.
- check tlsDisableOCSPEndpointCheck before reaching out to a responder.
- make tlsDisableOCSPEndpointCheck and tlsDisableCertificateRevocationCheck URI options implicitly enable TLS.
- enable OCSP tests on OpenSSL and macOS that were skipped.
- add OCSP tests for OpenSSL 1.0.1.
- update OCSP OpenSSL documentation.
- change OCSP verification logs from MONGOC_DEBUG to TRACE in successful cases.

The first commit has the changes, the second has the config.yml regeneration.

Full evergreen patch build: https://evergreen.mongodb.com/version/5ed03422a4cf471c38658ada