### PR TITLE
CDRIVER-3535 streamable ismaster

### DIFF
--- a/.evergreen/compile-unix.sh
+++ b/.evergreen/compile-unix.sh
@@ -256,6 +256,8 @@ else
    }
 fi
 
+export MONGOC_TEST_SERVER_LOG=stdout
+
 # Write stderr to error.log and to console. Turn off tracing to avoid spurious
 # log messages that CHECK_LOG considers failures.
 mkfifo pipe || true

--- a/.evergreen/compile-windows.sh
+++ b/.evergreen/compile-windows.sh
@@ -132,4 +132,6 @@ if [ "$SKIP_MOCK_TESTS" = "ON" ]; then
    exit 0
 fi
 
+export MONGOC_TEST_SERVER_LOG=stdout
+
 "$TEST_PATH" --no-fork -d -F test-results.json

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -726,6 +726,8 @@ post:
 - func: upload mo artifacts
 - func: upload test results
 - func: cleanup
+timeout:
+- func: backtrace
 tasks:
 - name: check-headers
   commands:

--- a/.evergreen/debug-core-evergreen.sh
+++ b/.evergreen/debug-core-evergreen.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+
+case "$OS" in
+   cygwin*)
+      echo "debug-core-evergreen.sh is not supported on Windows"
+      exit 0
+   ;;
+esac
+
 echo "Debugging core files"
 
 shopt -s nullglob
@@ -7,3 +16,12 @@ for i in *.core; do
    echo $i
    echo "backtrace full" | gdb -q ./src/libmongoc/test-libmongoc $i
 done
+
+# If there is still a test-libmongoc process running (perhaps due to
+# deadlock, or very slow test) attach a debugger and print stacks.
+TEST_LIBMONGOC_PID="$(pgrep test-libmongoc)"
+if [ -n "$TEST_LIBMONGOC_PID" ]; then
+   echo "test-libmongoc processes still running with PID=$TEST_LIBMONGOC_PID"
+   echo "backtrace full" | gdb -q -p $TEST_LIBMONGOC_PID
+   kill $TEST_LIBMONGOC_PID
+fi

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -87,6 +87,8 @@ check_mongocryptd() {
    fi
 }
 
+export MONGOC_TEST_MONITORING_VERBOSE=on
+
 case "$OS" in
    cygwin*)
       export PATH=$PATH:/cygdrive/c/mongodb/bin:/cygdrive/c/libmongocrypt/bin

--- a/build/generate-evergreen-config.py
+++ b/build/generate-evergreen-config.py
@@ -61,6 +61,9 @@ config = OD([
         OD([('func', 'upload test results')]),
         OD([('func', 'cleanup')]),
     ]),
+    ('timeout', [
+        OD([('func', 'backtrace')])
+    ]),
     ('tasks', all_tasks),
     ('buildvariants', all_variants),
 ])

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -531,6 +531,7 @@ set (SOURCES ${SOURCES}
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-server-description.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-server-stream.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-client-session.c
+   ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-server-monitor.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-set.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-socket.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-stream-buffered.c

--- a/src/libmongoc/doc/mongoc_client_pool_set_apm_callbacks.rst
+++ b/src/libmongoc/doc/mongoc_client_pool_set_apm_callbacks.rst
@@ -15,7 +15,7 @@ Synopsis
 
 Register a set of callbacks to receive Application Performance Monitoring events.
 
-The callbacks are copied by the pool and may be destroyed at any time after.
+The ``callbacks`` are copied by the pool and may be destroyed at any time after.  If a ``context`` is passed, it is the application's responsibility to ensure ``context`` remains valid for the lifetime of the pool.
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_client_set_apm_callbacks.rst
+++ b/src/libmongoc/doc/mongoc_client_set_apm_callbacks.rst
@@ -15,7 +15,7 @@ Synopsis
 
 Register a set of callbacks to receive Application Performance Monitoring events.
 
-The callbacks are copied by the client and may be destroyed at any time after.
+The ``callbacks`` are copied by the client and may be destroyed at any time after. If a ``context`` is passed, it is the application's responsibility to ensure ``context`` remains valid for the lifetime of the client.
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_client_set_stream_initiator.rst
+++ b/src/libmongoc/doc/mongoc_client_set_stream_initiator.rst
@@ -15,6 +15,8 @@ Synopsis
 
 The :symbol:`mongoc_client_set_stream_initiator()` function shall associate a given :symbol:`mongoc_client_t` with a new stream initiator. This will completely replace the default transport (buffered TCP, possibly with TLS). The ``initiator`` should fulfill the :symbol:`mongoc_stream_t` contract. ``user_data`` is passed through to the ``initiator`` callback and may be used for whatever run time customization is necessary.
 
+If ``user_data`` is passed, it is the application's responsibility to ensure ``user_data`` remains valid for the lifetime of the client.
+
 Parameters
 ----------
 

--- a/src/libmongoc/src/mongoc/CMakeLists.txt
+++ b/src/libmongoc/src/mongoc/CMakeLists.txt
@@ -105,6 +105,7 @@ set (src_libmongoc_src_mongoc_DIST_noinst_hs
    mongoc-errno-private.h
    mongoc-error-private.h
    mongoc-find-and-modify-private.h
+   mongoc-flags-private.h
    mongoc-gridfs-bucket-file-private.h
    mongoc-gridfs-bucket-private.h
    mongoc-gridfs-file-list-private.h
@@ -140,6 +141,7 @@ set (src_libmongoc_src_mongoc_DIST_noinst_hs
    mongoc-secure-transport-private.h
    mongoc-server-description-private.h
    mongoc-server-stream-private.h
+   mongoc-server-monitor-private.h
    mongoc-set-private.h
    mongoc-socket-private.h
    mongoc-ssl-private.h
@@ -227,6 +229,7 @@ set (src_libmongoc_src_mongoc_DIST_cs
    mongoc-server-stream.c
    mongoc-client-session.c
    mongoc-set.c
+   mongoc-server-monitor.c
    mongoc-socket.c
    mongoc-stream.c
    mongoc-stream-buffered.c

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -957,13 +957,8 @@ _mongoc_client_recv (mongoc_client_t *client,
    BSON_ASSERT (buffer);
    BSON_ASSERT (server_stream);
 
-   if (!mongoc_cluster_try_recv (
-          &client->cluster, rpc, buffer, server_stream, error)) {
-      mongoc_topology_invalidate_server (
-         client->topology, server_stream->sd->id, error);
-      return false;
-   }
-   return true;
+   return mongoc_cluster_try_recv (
+      &client->cluster, rpc, buffer, server_stream, error);
 }
 
 

--- a/src/libmongoc/src/mongoc/mongoc-error-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-error-private.h
@@ -24,7 +24,7 @@ BSON_BEGIN_DECLS
 typedef enum {
    MONGOC_READ_ERR_NONE,
    MONGOC_READ_ERR_OTHER,
-   MONGOC_READ_ERR_RETRY,
+   MONGOC_READ_ERR_RETRY
 } mongoc_read_err_type_t;
 
 /* Server error codes libmongoc cares about. Compare with:

--- a/src/libmongoc/src/mongoc/mongoc-error.c
+++ b/src/libmongoc/src/mongoc/mongoc-error.c
@@ -243,7 +243,7 @@ _mongoc_error_copy_labels_and_upsert (const bson_t *src,
 bool
 _mongoc_error_is_shutdown (bson_error_t *error)
 {
-   if (!_mongoc_error_is_server(error)) {
+   if (!_mongoc_error_is_server (error)) {
       return false;
    }
    switch (error->code) {
@@ -258,7 +258,7 @@ _mongoc_error_is_shutdown (bson_error_t *error)
 bool
 _mongoc_error_is_not_master (bson_error_t *error)
 {
-   if (!_mongoc_error_is_server(error)) {
+   if (!_mongoc_error_is_server (error)) {
       return false;
    }
 
@@ -277,7 +277,7 @@ _mongoc_error_is_not_master (bson_error_t *error)
 bool
 _mongoc_error_is_recovering (bson_error_t *error)
 {
-   if (!_mongoc_error_is_server(error)) {
+   if (!_mongoc_error_is_server (error)) {
       return false;
    }
    switch (error->code) {

--- a/src/libmongoc/src/mongoc/mongoc-flags-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-flags-private.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mongoc-prelude.h"
+
+#ifndef MONGOC_FLAGS_PRIVATE_H
+#define MONGOC_FLAGS_PRIVATE_H
+
+#include <bson/bson.h>
+
+BSON_BEGIN_DECLS
+
+/**
+ * mongoc_op_msg_flags_t:
+ * @MONGOC_MSG_CHECKSUM_PRESENT: The message ends with 4 bytes containing a
+ * CRC-32C checksum.
+ * @MONGOC_MSG_MORE_TO_COME: If set to 0, wait for a server response. If set to
+ * 1, do not expect a server response.
+ * @MONGOC_MSG_EXHAUST_ALLOWED: If set, allows multiple replies to this request
+ * using the moreToCome bit.
+ */
+typedef enum {
+   MONGOC_MSG_NONE = 0,
+   MONGOC_MSG_CHECKSUM_PRESENT = 1 << 0,
+   MONGOC_MSG_MORE_TO_COME = 1 << 1,
+   MONGOC_MSG_EXHAUST_ALLOWED = 1 << 16,
+} mongoc_op_msg_flags_t;
+
+
+BSON_END_DECLS
+
+
+#endif /* MONGOC_FLAGS_PRIVATE_H */

--- a/src/libmongoc/src/mongoc/mongoc-flags.h
+++ b/src/libmongoc/src/mongoc/mongoc-flags.h
@@ -142,7 +142,6 @@ typedef enum {
 
 #define MONGOC_UPDATE_NO_VALIDATE (1U << 31)
 
-
 BSON_END_DECLS
 
 

--- a/src/libmongoc/src/mongoc/mongoc-rpc-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-rpc-private.h
@@ -176,6 +176,11 @@ _mongoc_rpc_compress (struct _mongoc_cluster_t *cluster,
                       mongoc_rpc_t *rpc_le,
                       bson_error_t *error);
 
+bool
+_mongoc_rpc_decompress_if_necessary (mongoc_rpc_t *rpc,
+                                     mongoc_buffer_t *buffer,
+                                     bson_error_t *error);
+
 BSON_END_DECLS
 
 

--- a/src/libmongoc/src/mongoc/mongoc-rpc.c
+++ b/src/libmongoc/src/mongoc/mongoc-rpc.c
@@ -1330,3 +1330,42 @@ _mongoc_rpc_check_ok (mongoc_rpc_t *rpc,
 
    RETURN (true);
 }
+
+/* If rpc is OP_COMPRESSED, decompress it into buffer.
+ *
+ * Assumes rpc is still in network little-endian representation (i.e.
+ * _mongoc_rpc_swab_to_le has not been called).
+ * Returns true if rpc is not OP_COMPRESSED (and is a no-op) or if decompression
+ * succeeds.
+ * Return false and sets error otherwise.
+ */
+bool
+_mongoc_rpc_decompress_if_necessary (mongoc_rpc_t *rpc,
+                                     mongoc_buffer_t *buffer /* IN/OUT */,
+                                     bson_error_t *error /* OUT */)
+{
+   uint8_t *buf = NULL;
+   size_t len;
+
+   if (BSON_UINT32_FROM_LE (rpc->header.opcode) != MONGOC_OPCODE_COMPRESSED) {
+      return true;
+   }
+
+   len = BSON_UINT32_FROM_LE (rpc->compressed.uncompressed_size) +
+         sizeof (mongoc_rpc_header_t);
+
+   buf = bson_malloc0 (len);
+   if (!_mongoc_rpc_decompress (rpc, buf, len)) {
+      bson_free (buf);
+      bson_set_error (error,
+                      MONGOC_ERROR_PROTOCOL,
+                      MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
+                      "Could not decompress server reply");
+      return false;
+   }
+
+   _mongoc_buffer_destroy (buffer);
+   _mongoc_buffer_init (buffer, buf, len, NULL, NULL);
+
+   return true;
+}

--- a/src/libmongoc/src/mongoc/mongoc-server-description-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-server-description-private.h
@@ -42,6 +42,8 @@
 /* represent a server or topology with no replica set config version */
 #define MONGOC_NO_SET_VERSION -1
 
+#define MONGOC_RTT_UNSET -1
+
 typedef enum {
    MONGOC_SERVER_UNKNOWN,
    MONGOC_SERVER_STANDALONE,

--- a/src/libmongoc/src/mongoc/mongoc-server-monitor-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-server-monitor-private.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mongoc-prelude.h"
+
+#ifndef MONGOC_SERVER_MONITOR_PRIVATE_H
+#define MONGOC_SERVER_MONITOR_PRIVATE_H
+
+#include "mongoc.h"
+#include "mongoc-server-description-private.h"
+#include "mongoc-topology-private.h"
+
+/* For background monitoring of a single server. */
+
+typedef struct _mongoc_server_monitor_t mongoc_server_monitor_t;
+
+mongoc_server_monitor_t *
+mongoc_server_monitor_new (mongoc_topology_t *topology,
+                           mongoc_server_description_t *init_description);
+
+mongoc_server_description_t *
+mongoc_server_monitor_check_server (
+   mongoc_server_monitor_t *server_monitor,
+   const mongoc_server_description_t *previous_description,
+   bool *cancelled);
+
+void
+mongoc_server_monitor_request_cancel (mongoc_server_monitor_t *server_monitor);
+
+void
+mongoc_server_monitor_request_scan (mongoc_server_monitor_t *server_monitor);
+
+bool
+mongoc_server_monitor_request_shutdown (
+   mongoc_server_monitor_t *server_monitor);
+
+void
+mongoc_server_monitor_wait_for_shutdown (
+   mongoc_server_monitor_t *server_monitor);
+
+void
+mongoc_server_monitor_destroy (mongoc_server_monitor_t *server_monitor);
+
+void
+mongoc_server_monitor_run (mongoc_server_monitor_t *server_monitor);
+
+void
+mongoc_server_monitor_run_as_rtt (mongoc_server_monitor_t *server_monitor);
+
+#endif /* MONGOC_SERVER_MONITOR_PRIVATE_H */

--- a/src/libmongoc/src/mongoc/mongoc-server-monitor.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-monitor.c
@@ -1,0 +1,1267 @@
+/*
+ * Copyright 2020-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "common-thread-private.h"
+#include "mongoc-server-monitor-private.h"
+
+#include "mongoc/mongoc-client-private.h"
+#include "mongoc/mongoc-error-private.h"
+#include "mongoc/mongoc-flags-private.h"
+#include "mongoc/mongoc-ssl-private.h"
+#include "mongoc/mongoc-stream-private.h"
+#include "mongoc/mongoc-topology-background-monitoring-private.h"
+#include "mongoc/mongoc-topology-private.h"
+#include "mongoc/mongoc-trace-private.h"
+
+#undef MONGOC_LOG_DOMAIN
+#define MONGOC_LOG_DOMAIN "monitor"
+
+typedef enum {
+   MONGOC_THREAD_OFF = 0,
+   MONGOC_THREAD_RUNNING,
+   MONGOC_THREAD_SHUTTING_DOWN,
+   MONGOC_THREAD_JOINABLE
+} thread_state_t;
+
+/* Use a signed and wide return type for timeouts as long as you can. Cast only
+ * when you know what you're doing with it. */
+static int64_t
+_now_us (void)
+{
+   return bson_get_monotonic_time ();
+}
+
+static int64_t
+_now_ms (void)
+{
+   return _now_us () / 1000;
+}
+
+struct _mongoc_server_monitor_t {
+   mongoc_topology_t *topology;
+   bson_thread_t thread;
+
+   /* State accessed from multiple threads. */
+   struct {
+      bson_mutex_t mutex;
+      mongoc_cond_t cond;
+      thread_state_t state;
+      bool scan_requested;
+      bool cancel_requested;
+   } shared;
+
+   /* Default time to sleep between ismaster checks (reduced when a scan is
+    * requested) */
+   uint64_t heartbeat_frequency_ms;
+   /* The minimum time to sleep between ismaster checks. */
+   uint64_t min_heartbeat_frequency_ms;
+   int64_t connect_timeout_ms;
+   bool use_tls;
+#ifdef MONGOC_ENABLE_SSL
+   mongoc_ssl_opt_t *ssl_opts;
+#endif
+   mongoc_uri_t *uri;
+   /* A custom initiator may be set if a user provides overrides to create a
+    * stream. */
+   mongoc_stream_initiator_t initiator;
+   void *initiator_context;
+   int64_t request_id;
+   mongoc_apm_callbacks_t apm_callbacks;
+   void *apm_context;
+
+   mongoc_stream_t *stream;
+   bool more_to_come;
+   mongoc_server_description_t *description;
+   uint32_t server_id;
+   bool is_rtt;
+};
+
+static BSON_GNUC_PRINTF (3, 4) void _server_monitor_log (
+   mongoc_server_monitor_t *server_monitor,
+   mongoc_log_level_t level,
+   const char *format,
+   ...)
+{
+   va_list ap;
+   char *msg;
+
+   va_start (ap, format);
+   msg = bson_strdupv_printf (format, ap);
+   va_end (ap);
+
+   mongoc_log (level,
+               MONGOC_LOG_DOMAIN,
+               "[%s%s] %s",
+               server_monitor->description->host.host_and_port,
+               server_monitor->is_rtt ? "-RTT" : "",
+               msg);
+   bson_free (msg);
+}
+
+#ifdef MONGOC_TRACE
+#define MONITOR_LOG(sm, ...) \
+   _server_monitor_log (sm, MONGOC_LOG_LEVEL_TRACE, __VA_ARGS__)
+#else
+#define MONITOR_LOG(sm, ...) (void) 0
+#endif
+
+/* TODO CDRIVER-3710 use MONGOC_LOG_LEVEL_ERROR */
+#define MONITOR_LOG_ERROR(sm, ...) \
+   _server_monitor_log (sm, MONGOC_LOG_LEVEL_DEBUG, __VA_ARGS__)
+/* TODO CDRIVER-3710 use MONGOC_LOG_LEVEL_WARNING */
+#define MONITOR_LOG_WARNING(sm, ...) \
+   _server_monitor_log (sm, MONGOC_LOG_LEVEL_DEBUG, __VA_ARGS__)
+
+/* Called only from server monitor thread.
+ * Caller must hold no locks (user's callback may lock topology mutex).
+ * Locks APM mutex.
+ */
+static void
+_server_monitor_heartbeat_started (mongoc_server_monitor_t *server_monitor,
+                                   bool awaited)
+{
+   mongoc_apm_server_heartbeat_started_t event;
+
+   if (!server_monitor->apm_callbacks.server_heartbeat_started) {
+      return;
+   }
+
+   event.host = &server_monitor->description->host;
+   event.context = server_monitor->apm_context;
+   MONITOR_LOG (server_monitor,
+                "%s heartbeat started",
+                awaited ? "awaitable" : "regular");
+   event.awaited = awaited;
+   bson_mutex_lock (&server_monitor->topology->apm_mutex);
+   server_monitor->apm_callbacks.server_heartbeat_started (&event);
+   bson_mutex_unlock (&server_monitor->topology->apm_mutex);
+}
+
+/* Called only from server monitor thread.
+ * Caller must hold no locks (user's callback may lock topology mutex).
+ * Locks APM mutex.
+ */
+static void
+_server_monitor_heartbeat_succeeded (mongoc_server_monitor_t *server_monitor,
+                                     const bson_t *reply,
+                                     int64_t duration_usec,
+                                     bool awaited)
+{
+   mongoc_apm_server_heartbeat_succeeded_t event;
+
+   if (!server_monitor->apm_callbacks.server_heartbeat_succeeded) {
+      return;
+   }
+
+   event.host = &server_monitor->description->host;
+   event.context = server_monitor->apm_context;
+   event.reply = reply;
+   event.duration_usec = duration_usec;
+   MONITOR_LOG (server_monitor,
+                "%s heartbeat succeeded",
+                awaited ? "awaitable" : "regular");
+   event.awaited = awaited;
+   bson_mutex_lock (&server_monitor->topology->apm_mutex);
+   server_monitor->apm_callbacks.server_heartbeat_succeeded (&event);
+   bson_mutex_unlock (&server_monitor->topology->apm_mutex);
+}
+
+/* Called only from server monitor thread.
+ * Caller must hold no locks (user's callback may lock topology mutex).
+ * Locks APM mutex.
+ */
+static void
+_server_monitor_heartbeat_failed (mongoc_server_monitor_t *server_monitor,
+                                  const bson_error_t *error,
+                                  int64_t duration_usec,
+                                  bool awaited)
+{
+   mongoc_apm_server_heartbeat_failed_t event;
+
+   if (!server_monitor->apm_callbacks.server_heartbeat_failed) {
+      return;
+   }
+
+   event.host = &server_monitor->description->host;
+   event.context = server_monitor->apm_context;
+   event.error = error;
+   event.duration_usec = duration_usec;
+   MONITOR_LOG (
+      server_monitor, "%s heartbeat failed", awaited ? "awaitable" : "regular");
+   event.awaited = awaited;
+   bson_mutex_lock (&server_monitor->topology->apm_mutex);
+   server_monitor->apm_callbacks.server_heartbeat_failed (&event);
+   bson_mutex_unlock (&server_monitor->topology->apm_mutex);
+}
+
+static void
+_server_monitor_append_cluster_time (mongoc_server_monitor_t *server_monitor,
+                                     bson_t *cmd)
+{
+   mongoc_topology_t *topology;
+
+   topology = server_monitor->topology;
+   /* Cluster time is updated on every reply. */
+   bson_mutex_lock (&topology->mutex);
+   if (!bson_empty (&topology->description.cluster_time)) {
+      bson_append_document (
+         cmd, "$clusterTime", 12, &topology->description.cluster_time);
+   }
+   bson_mutex_unlock (&topology->mutex);
+}
+
+static bool
+_server_monitor_send_and_recv_opquery (mongoc_server_monitor_t *server_monitor,
+                                       const bson_t *cmd,
+                                       bson_t *reply,
+                                       bson_error_t *error)
+{
+   mongoc_rpc_t rpc;
+   mongoc_array_t array_to_write;
+   mongoc_iovec_t *iovec;
+   int niovec;
+   mongoc_buffer_t buffer;
+   uint32_t reply_len;
+   bson_t temp_reply;
+   bool ret = false;
+
+   rpc.header.msg_len = 0;
+   rpc.header.request_id = server_monitor->request_id++;
+   rpc.header.response_to = 0;
+   rpc.header.opcode = MONGOC_OPCODE_QUERY;
+   rpc.query.flags = MONGOC_QUERY_SLAVE_OK;
+   rpc.query.collection = "admin.$cmd";
+   rpc.query.skip = 0;
+   rpc.query.n_return = -1;
+   rpc.query.query = bson_get_data (cmd);
+   rpc.query.fields = NULL;
+
+   _mongoc_buffer_init (&buffer, NULL, 0, NULL, NULL);
+   _mongoc_array_init (&array_to_write, sizeof (mongoc_iovec_t));
+   _mongoc_rpc_gather (&rpc, &array_to_write);
+   iovec = (mongoc_iovec_t *) array_to_write.data;
+   niovec = array_to_write.len;
+   _mongoc_rpc_swab_to_le (&rpc);
+
+   if (!_mongoc_stream_writev_full (server_monitor->stream,
+                                    iovec,
+                                    niovec,
+                                    server_monitor->connect_timeout_ms,
+                                    error)) {
+      GOTO (fail);
+   }
+
+   if (!_mongoc_buffer_append_from_stream (&buffer,
+                                           server_monitor->stream,
+                                           4,
+                                           server_monitor->connect_timeout_ms,
+                                           error)) {
+      GOTO (fail);
+   }
+
+   memcpy (&reply_len, buffer.data, 4);
+   reply_len = BSON_UINT32_FROM_LE (reply_len);
+
+   if (!_mongoc_buffer_append_from_stream (&buffer,
+                                           server_monitor->stream,
+                                           reply_len - buffer.len,
+                                           server_monitor->connect_timeout_ms,
+                                           error)) {
+      GOTO (fail);
+   }
+
+   if (!_mongoc_rpc_scatter (&rpc, buffer.data, buffer.len)) {
+      bson_set_error (error,
+                      MONGOC_ERROR_PROTOCOL,
+                      MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
+                      "Invalid reply from server.");
+
+      GOTO (fail);
+   }
+
+   if (!_mongoc_rpc_decompress_if_necessary (&rpc, &buffer, error)) {
+      GOTO (fail);
+   }
+   _mongoc_rpc_swab_from_le (&rpc);
+
+   if (!_mongoc_rpc_get_first_document (&rpc, &temp_reply)) {
+      bson_set_error (error,
+                      MONGOC_ERROR_PROTOCOL,
+                      MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
+                      "Invalid reply from server");
+      GOTO (fail);
+   }
+   bson_copy_to (&temp_reply, reply);
+
+   ret = true;
+fail:
+   if (!ret) {
+      bson_init (reply);
+   }
+   _mongoc_array_destroy (&array_to_write);
+   _mongoc_buffer_destroy (&buffer);
+   return ret;
+}
+
+static bool
+_server_monitor_polling_ismaster (mongoc_server_monitor_t *server_monitor,
+                                  bson_t *ismaster_reply,
+                                  bson_error_t *error)
+{
+   bson_t cmd;
+   bool ret;
+
+   bson_init (&cmd);
+   bson_append_int32 (&cmd, "isMaster", 8, 1);
+   _server_monitor_append_cluster_time (server_monitor, &cmd);
+   ret = _server_monitor_send_and_recv_opquery (
+      server_monitor, &cmd, ismaster_reply, error);
+   bson_destroy (&cmd);
+   return ret;
+}
+
+static bool
+_server_monitor_awaitable_ismaster_send (
+   mongoc_server_monitor_t *server_monitor, bson_t *cmd, bson_error_t *error)
+{
+   mongoc_rpc_t rpc = {0};
+   mongoc_array_t array_to_write;
+   mongoc_iovec_t *iovec;
+   int niovec;
+
+   rpc.header.msg_len = 0;
+   rpc.header.request_id = server_monitor->request_id++;
+   rpc.header.response_to = 0;
+   rpc.header.opcode = MONGOC_OPCODE_MSG;
+   rpc.msg.flags = MONGOC_MSG_EXHAUST_ALLOWED;
+   rpc.msg.n_sections = 1;
+   rpc.msg.sections[0].payload_type = 0;
+   rpc.msg.sections[0].payload.bson_document = bson_get_data (cmd);
+
+   _mongoc_array_init (&array_to_write, sizeof (mongoc_iovec_t));
+   _mongoc_rpc_gather (&rpc, &array_to_write);
+
+   iovec = (mongoc_iovec_t *) array_to_write.data;
+   niovec = array_to_write.len;
+   _mongoc_rpc_swab_to_le (&rpc);
+
+   MONITOR_LOG (server_monitor,
+                "sending with timeout %" PRId64,
+                server_monitor->connect_timeout_ms);
+
+   if (!_mongoc_stream_writev_full (server_monitor->stream,
+                                    iovec,
+                                    niovec,
+                                    server_monitor->connect_timeout_ms,
+                                    error)) {
+      MONITOR_LOG_ERROR (server_monitor,
+                         "failed to write awaitable ismaster: %s",
+                         error->message);
+      _mongoc_array_destroy (&array_to_write);
+      return false;
+   }
+   _mongoc_array_destroy (&array_to_write);
+   return true;
+}
+
+/* Poll the server monitor stream for reading. Allows cancellation.
+ *
+ * Called only from server monitor thread.
+ * Locks server monitor mutex.
+ * Returns true if stream is readable. False on error or cancellation.
+ * On cancellation, no error is set, but cancelled is set to true.
+ */
+static bool
+_server_monitor_poll_with_interrupt (mongoc_server_monitor_t *server_monitor,
+                                     int64_t expire_at_ms,
+                                     bool *cancelled,
+                                     bson_error_t *error)
+{
+   /* How many milliseconds we should poll for on each tick.
+    * On every tick, check whether the awaitable ismaster was cancelled. */
+   const int32_t monitor_tick_ms = 500;
+   int64_t timeleft_ms;
+
+   MONITOR_LOG (server_monitor,
+                "_server_monitor_poll_with_interrupt expire_at_ms: %" PRIu64,
+                expire_at_ms);
+   while ((timeleft_ms = expire_at_ms - _now_ms ()) > 0) {
+      ssize_t ret;
+      mongoc_stream_poll_t poller[1];
+
+      poller[0].stream = server_monitor->stream;
+      poller[0].events =
+         POLLIN; /* POLLERR and POLLHUP are added in mongoc_socket_poll. */
+      poller[0].revents = 0;
+
+      MONITOR_LOG (
+         server_monitor,
+         "polling for awaitable ismaster reply with timeleft_ms: %" PRId64,
+         timeleft_ms);
+      ret = mongoc_stream_poll (
+         poller, 1, (int32_t) BSON_MIN (timeleft_ms, monitor_tick_ms));
+      if (ret == -1) {
+         MONITOR_LOG (server_monitor, "mongoc_stream_poll error");
+         bson_set_error (error,
+                         MONGOC_ERROR_STREAM,
+                         MONGOC_ERROR_STREAM_SOCKET,
+                         "poll error");
+         return false;
+      }
+
+      if (poller[0].revents & (POLLERR | POLLHUP)) {
+         bson_set_error (error,
+                         MONGOC_ERROR_STREAM,
+                         MONGOC_ERROR_STREAM_SOCKET,
+                         "connection closed while polling");
+         return false;
+      }
+
+      /* Check for cancellation. */
+      bson_mutex_lock (&server_monitor->shared.mutex);
+      *cancelled = server_monitor->shared.cancel_requested;
+      server_monitor->shared.cancel_requested = false;
+      bson_mutex_unlock (&server_monitor->shared.mutex);
+
+      if (*cancelled) {
+         MONITOR_LOG (server_monitor, "polling cancelled");
+         return false;
+      }
+
+      if (poller[0].revents & POLLIN) {
+         MONITOR_LOG (server_monitor, "mongoc_stream_poll ready to read");
+         return true;
+      }
+   }
+   bson_set_error (error,
+                   MONGOC_ERROR_STREAM,
+                   MONGOC_ERROR_STREAM_SOCKET,
+                   "connection timeout while polling");
+   return false;
+}
+
+/* Calculate the timeout between the current time and an absolute expiration
+ * time in milliseconds.
+ *
+ * Returns 0 and sets error if time expired.
+ */
+int64_t
+_get_timeout_ms (int64_t expire_at_ms, bson_error_t *error)
+{
+   int64_t timeout_ms;
+
+   timeout_ms = expire_at_ms - _now_ms ();
+   if (timeout_ms <= 0) {
+      bson_set_error (error,
+                      MONGOC_ERROR_STREAM,
+                      MONGOC_ERROR_STREAM_SOCKET,
+                      "connection timed out reading message length");
+      return 0;
+   }
+   return timeout_ms;
+}
+
+/* Receive an awaitable ismaster reply.
+ *
+ * May be used to receive additional replies when moreToCome is set.
+ * Called only from server monitor thread.
+ * May lock server monitor mutex in functions that are called.
+ * May block for up to heartbeatFrequencyMS + connectTimeoutMS waiting for
+ * reply.
+ * Returns true if a reply was received. False on error or cancellation.
+ * On cancellation, no error is set, but cancelled is set to true.
+ */
+static bool
+_server_monitor_awaitable_ismaster_recv (
+   mongoc_server_monitor_t *server_monitor,
+   bson_t *ismaster_reply,
+   bool *cancelled,
+   bson_error_t *error)
+{
+   bool ret = false;
+   mongoc_buffer_t buffer;
+   int32_t msg_len;
+   mongoc_rpc_t rpc;
+   bson_t reply_local;
+   int64_t expire_at_ms;
+   int64_t timeout_ms;
+
+   expire_at_ms = _now_ms () + server_monitor->heartbeat_frequency_ms +
+                  server_monitor->connect_timeout_ms;
+   _mongoc_buffer_init (&buffer, NULL, 0, NULL, NULL);
+   if (!_server_monitor_poll_with_interrupt (
+          server_monitor, expire_at_ms, cancelled, error)) {
+      GOTO (fail);
+   }
+
+   timeout_ms = _get_timeout_ms (expire_at_ms, error);
+   if (!timeout_ms) {
+      GOTO (fail);
+   }
+   MONITOR_LOG (server_monitor,
+                "reading first 4 bytes with timeout: %" PRId64,
+                timeout_ms);
+   if (!_mongoc_buffer_append_from_stream (
+          &buffer, server_monitor->stream, 4, (int32_t) timeout_ms, error)) {
+      GOTO (fail);
+   }
+
+   BSON_ASSERT (buffer.len == 4);
+   memcpy (&msg_len, buffer.data, 4);
+   msg_len = BSON_UINT32_FROM_LE (msg_len);
+
+   if ((msg_len < 16) ||
+       (msg_len > server_monitor->description->max_msg_size)) {
+      bson_set_error (
+         error,
+         MONGOC_ERROR_PROTOCOL,
+         MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
+         "Message size %d is not within expected range 16-%d bytes",
+         msg_len,
+         server_monitor->description->max_msg_size);
+      GOTO (fail);
+   }
+
+   timeout_ms = _get_timeout_ms (expire_at_ms, error);
+   if (!timeout_ms) {
+      GOTO (fail);
+   }
+   MONITOR_LOG (server_monitor,
+                "reading remaining %d bytes. Timeout %" PRId64,
+                (int) (msg_len - 4),
+                timeout_ms);
+   if (!_mongoc_buffer_append_from_stream (
+          &buffer, server_monitor->stream, msg_len - 4, timeout_ms, error)) {
+      GOTO (fail);
+   }
+
+   if (!_mongoc_rpc_scatter (&rpc, buffer.data, buffer.len)) {
+      bson_set_error (error,
+                      MONGOC_ERROR_PROTOCOL,
+                      MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
+                      "Malformed message from server");
+      GOTO (fail);
+   }
+
+   if (!_mongoc_rpc_decompress_if_necessary (&rpc, &buffer, error)) {
+      GOTO (fail);
+   }
+
+   _mongoc_rpc_swab_from_le (&rpc);
+   memcpy (&msg_len, rpc.msg.sections[0].payload.bson_document, 4);
+   msg_len = BSON_UINT32_FROM_LE (msg_len);
+   if (!bson_init_static (
+          &reply_local, rpc.msg.sections[0].payload.bson_document, msg_len)) {
+      bson_set_error (error,
+                      MONGOC_ERROR_PROTOCOL,
+                      MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
+                      "Malformed BSON payload from server");
+      GOTO (fail);
+   }
+
+   bson_copy_to (&reply_local, ismaster_reply);
+   server_monitor->more_to_come =
+      (rpc.msg.flags & MONGOC_MSG_MORE_TO_COME) != 0;
+
+   ret = true;
+fail:
+   if (!ret) {
+      bson_init (ismaster_reply);
+   }
+   _mongoc_buffer_destroy (&buffer);
+   return ret;
+}
+
+/* Send and receive an awaitable ismaster.
+ *
+ * Called only from server monitor thread.
+ * May lock server monitor mutex in functions that are called.
+ * May block for up to heartbeatFrequencyMS waiting for reply.
+ */
+static bool
+_server_monitor_awaitable_ismaster (mongoc_server_monitor_t *server_monitor,
+                                    const bson_t *topology_version,
+                                    bson_t *ismaster_reply,
+                                    bool *cancelled,
+                                    bson_error_t *error)
+{
+   bson_t cmd = BSON_INITIALIZER;
+   bool ret = false;
+
+   bson_append_int32 (&cmd, "isMaster", 8, 1);
+   _server_monitor_append_cluster_time (server_monitor, &cmd);
+   bson_append_document (&cmd, "topologyVersion", 15, topology_version);
+   bson_append_int32 (
+      &cmd, "maxAwaitTimeMS", 14, server_monitor->heartbeat_frequency_ms);
+   bson_append_utf8 (&cmd, "$db", 3, "admin", 5);
+
+   if (!_server_monitor_awaitable_ismaster_send (server_monitor, &cmd, error)) {
+      GOTO (fail);
+   }
+
+   if (!_server_monitor_awaitable_ismaster_recv (
+          server_monitor, ismaster_reply, cancelled, error)) {
+      bson_destroy (ismaster_reply);
+      GOTO (fail);
+   }
+
+   ret = true;
+fail:
+   if (!ret) {
+      bson_init (ismaster_reply);
+   }
+   bson_destroy (&cmd);
+   return ret;
+}
+
+/* Update the topology description with a reply or an error.
+ *
+ * Called only from server monitor thread.
+ * Caller must hold no locks.
+ * Locks topology mutex and server monitor mutex.
+ */
+static void
+_server_monitor_update_topology_description (
+   mongoc_server_monitor_t *server_monitor,
+   mongoc_server_description_t *description)
+{
+   mongoc_topology_t *topology;
+   bson_t *ismaster_reply = NULL;
+
+   topology = server_monitor->topology;
+   if (description->has_is_master) {
+      ismaster_reply = &description->last_is_master;
+   }
+
+   if (ismaster_reply) {
+      _mongoc_topology_update_cluster_time (topology, ismaster_reply);
+   }
+
+   bson_mutex_lock (&topology->mutex);
+   if (topology->scanner_state != MONGOC_TOPOLOGY_SCANNER_SHUTTING_DOWN) {
+      /* This is the another case of holding both locks. topology->mutex is
+       * always locked first, then server monitor mutex after. */
+      bson_mutex_lock (&server_monitor->shared.mutex);
+      server_monitor->shared.scan_requested = false;
+      bson_mutex_unlock (&server_monitor->shared.mutex);
+
+      mongoc_topology_description_handle_ismaster (
+         &server_monitor->topology->description,
+         server_monitor->server_id,
+         ismaster_reply,
+         description->round_trip_time_msec,
+         &description->error);
+      /* Reconcile server monitors. */
+      _mongoc_topology_background_monitoring_reconcile (topology);
+   }
+   /* Wake threads performing server selection. */
+   mongoc_cond_broadcast (&server_monitor->topology->cond_client);
+   bson_mutex_unlock (&server_monitor->topology->mutex);
+}
+
+/* Create a new server monitor.
+ *
+ * Called during reconcile.
+ * Caller must hold topology lock.
+ */
+mongoc_server_monitor_t *
+mongoc_server_monitor_new (mongoc_topology_t *topology,
+                           mongoc_server_description_t *init_description)
+{
+   mongoc_server_monitor_t *server_monitor;
+
+   server_monitor = bson_malloc0 (sizeof (*server_monitor));
+   server_monitor->description =
+      mongoc_server_description_new_copy (init_description);
+   server_monitor->server_id = init_description->id;
+   server_monitor->topology = topology;
+   server_monitor->heartbeat_frequency_ms =
+      topology->description.heartbeat_msec;
+   server_monitor->min_heartbeat_frequency_ms =
+      topology->min_heartbeat_frequency_msec;
+   server_monitor->connect_timeout_ms = topology->connect_timeout_msec;
+   server_monitor->uri = mongoc_uri_copy (topology->uri);
+/* TODO CDRIVER-3682: Do not retrieve ssl opts from topology scanner. They
+ * should be stored somewhere else. */
+#ifdef MONGOC_ENABLE_SSL
+   if (topology->scanner->ssl_opts) {
+      server_monitor->ssl_opts = bson_malloc0 (sizeof (mongoc_ssl_opt_t));
+
+      _mongoc_ssl_opts_copy_to (
+         topology->scanner->ssl_opts, server_monitor->ssl_opts, true);
+   }
+#endif
+   memcpy (&server_monitor->apm_callbacks,
+           &topology->description.apm_callbacks,
+           sizeof (mongoc_apm_callbacks_t));
+   server_monitor->apm_context = topology->description.apm_context;
+   server_monitor->initiator = topology->scanner->initiator;
+   server_monitor->initiator_context = topology->scanner->initiator_context;
+   mongoc_cond_init (&server_monitor->shared.cond);
+   bson_mutex_init (&server_monitor->shared.mutex);
+   return server_monitor;
+}
+
+/* Creates a stream and performs the initial ismaster handshake.
+ *
+ * Called only by server monitor thread.
+ * Returns true if both connection and handshake succeeds.
+ * Returns false and sets error otherwise.
+ * ismaster_reply is always initialized.
+ */
+static bool
+_server_monitor_setup_connection (mongoc_server_monitor_t *server_monitor,
+                                  bson_t *ismaster_reply,
+                                  int64_t *start_us,
+                                  bson_error_t *error)
+{
+   bson_t cmd = BSON_INITIALIZER;
+   const bson_t *handshake;
+   bool ret = false;
+
+   ENTRY;
+
+   BSON_ASSERT (!server_monitor->stream);
+   bson_init (ismaster_reply);
+
+   server_monitor->more_to_come = false;
+
+   /* Using an initiator isn't really necessary. Users can't set them on
+    * pools. But it is used for tests. */
+   if (server_monitor->initiator) {
+      server_monitor->stream =
+         server_monitor->initiator (server_monitor->uri,
+                                    &server_monitor->description->host,
+                                    server_monitor->initiator_context,
+                                    error);
+   } else {
+      void *ssl_opts_void = NULL;
+
+#ifdef MONGOC_ENABLE_SSL
+      ssl_opts_void = server_monitor->ssl_opts;
+#endif
+      server_monitor->stream =
+         mongoc_client_connect (false,
+                                ssl_opts_void != NULL,
+                                ssl_opts_void,
+                                server_monitor->uri,
+                                &server_monitor->description->host,
+                                error);
+   }
+
+   if (!server_monitor->stream) {
+      GOTO (fail);
+   }
+
+   /* Update the start time just before the handshake. */
+   *start_us = _now_us ();
+   /* Perform handshake. */
+   handshake = _mongoc_topology_get_ismaster (server_monitor->topology);
+   bson_destroy (&cmd);
+   bson_copy_to (handshake, &cmd);
+   _server_monitor_append_cluster_time (server_monitor, &cmd);
+   bson_destroy (ismaster_reply);
+   if (!_server_monitor_send_and_recv_opquery (
+          server_monitor, &cmd, ismaster_reply, error)) {
+      GOTO (fail);
+   }
+
+   ret = true;
+fail:
+   bson_destroy (&cmd);
+   RETURN (ret);
+}
+
+/* Perform an ismaster check of a server.
+ *
+ * Called only by server monitor thread.
+ * Caller must not hold any locks.
+ * May lock server monitor mutex. May lock topology mutex.
+ * Upon network error, the returned server description will contain the error,
+ * but no ismaster reply.
+ * Upon ismaster cancellation, cancelled will be true, and the returned server
+ * description will not contain an error or ismaster reply.
+ * Upon command error ("ok":0 reply), the returned server description have the
+ * ismaster reply and error set.
+ * Returns a new server description that the caller must destroy.
+ */
+mongoc_server_description_t *
+mongoc_server_monitor_check_server (
+   mongoc_server_monitor_t *server_monitor,
+   const mongoc_server_description_t *previous_description,
+   bool *cancelled)
+{
+   bool ret = false;
+   bson_error_t error;
+   bson_t ismaster_reply;
+   int64_t duration_us;
+   int64_t start_us;
+   bool command_or_network_error = false;
+   bool awaited = false;
+   mongoc_server_description_t *description;
+
+   ENTRY;
+
+   *cancelled = false;
+   memset (&error, 0, sizeof (bson_error_t));
+   description = bson_malloc0 (sizeof (mongoc_server_description_t));
+   mongoc_server_description_init (
+      description,
+      server_monitor->description->connection_address,
+      server_monitor->description->id);
+   start_us = _now_us ();
+
+   if (!server_monitor->stream) {
+      MONITOR_LOG (server_monitor, "setting up connection");
+      awaited = false;
+      _server_monitor_heartbeat_started (server_monitor, awaited);
+      ret = _server_monitor_setup_connection (
+         server_monitor, &ismaster_reply, &start_us, &error);
+      GOTO (exit);
+   }
+
+   if (server_monitor->more_to_come) {
+      awaited = true;
+      /* Publish a heartbeat started for each additional response read. */
+      _server_monitor_heartbeat_started (server_monitor, awaited);
+      MONITOR_LOG (server_monitor, "more to come");
+      ret = _server_monitor_awaitable_ismaster_recv (
+         server_monitor, &ismaster_reply, cancelled, &error);
+      GOTO (exit);
+   }
+
+   if (!bson_empty (&previous_description->topology_version)) {
+      awaited = true;
+      _server_monitor_heartbeat_started (server_monitor, awaited);
+      MONITOR_LOG (server_monitor, "awaitable ismaster");
+      ret = _server_monitor_awaitable_ismaster (
+         server_monitor,
+         &previous_description->topology_version,
+         &ismaster_reply,
+         cancelled,
+         &error);
+      GOTO (exit);
+   }
+
+   MONITOR_LOG (server_monitor, "polling ismaster");
+   awaited = false;
+   _server_monitor_heartbeat_started (server_monitor, awaited);
+   ret = _server_monitor_polling_ismaster (
+      server_monitor, &ismaster_reply, &error);
+
+exit:
+   duration_us = _now_us () - start_us;
+   MONITOR_LOG (
+      server_monitor, "server check duration (us): %" PRId64, duration_us);
+
+   /* If ret is true, we have a reply. Check if "ok": 1. */
+   if (ret && _mongoc_cmd_check_ok (
+                 &ismaster_reply, MONGOC_ERROR_API_VERSION_2, &error)) {
+      int64_t rtt_ms = MONGOC_RTT_UNSET;
+
+      /* rtt remains MONGOC_RTT_UNSET if awaited. */
+      if (!awaited) {
+         rtt_ms = duration_us / 1000;
+      }
+
+      mongoc_server_description_handle_ismaster (
+         description, &ismaster_reply, rtt_ms, NULL);
+      /* If the ismaster reply could not be parsed, consider this a command
+       * error. */
+      if (description->error.code) {
+         MONITOR_LOG_ERROR (server_monitor,
+                            "error parsing server reply: %s",
+                            description->error.message);
+         command_or_network_error = true;
+         _server_monitor_heartbeat_failed (
+            server_monitor, &description->error, duration_us, awaited);
+      } else {
+         _server_monitor_heartbeat_succeeded (
+            server_monitor, &ismaster_reply, duration_us, awaited);
+      }
+   } else if (*cancelled) {
+      MONITOR_LOG (server_monitor, "server monitor cancelled");
+      if (server_monitor->stream) {
+         mongoc_stream_destroy (server_monitor->stream);
+      }
+      server_monitor->stream = NULL;
+      server_monitor->more_to_come = false;
+      _server_monitor_heartbeat_failed (
+         server_monitor, &description->error, duration_us, awaited);
+   } else {
+      /* The ismaster reply had "ok":0 or a network error occurred. */
+      MONITOR_LOG_ERROR (server_monitor,
+                         "command or network error occurred: %s",
+                         error.message);
+      command_or_network_error = true;
+      mongoc_server_description_handle_ismaster (
+         description, NULL, MONGOC_RTT_UNSET, &error);
+      _server_monitor_heartbeat_failed (
+         server_monitor, &description->error, duration_us, awaited);
+   }
+
+   if (command_or_network_error) {
+      if (server_monitor->stream) {
+         mongoc_stream_failed (server_monitor->stream);
+      }
+      server_monitor->stream = NULL;
+      server_monitor->more_to_come = false;
+      bson_mutex_lock (&server_monitor->topology->mutex);
+      _mongoc_topology_clear_connection_pool (server_monitor->topology,
+                                              server_monitor->description->id);
+      bson_mutex_unlock (&server_monitor->topology->mutex);
+   }
+
+   bson_destroy (&ismaster_reply);
+   return description;
+}
+
+/* Request scan of a single server.
+ *
+ * Caller does not need to have topology mutex locked.
+ * Locks server monitor mutex to deliver scan_requested.
+ */
+void
+mongoc_server_monitor_request_scan (mongoc_server_monitor_t *server_monitor)
+{
+   MONITOR_LOG (server_monitor, "requesting scan");
+   bson_mutex_lock (&server_monitor->shared.mutex);
+   server_monitor->shared.scan_requested = true;
+   mongoc_cond_signal (&server_monitor->shared.cond);
+   bson_mutex_unlock (&server_monitor->shared.mutex);
+}
+
+/* Request cancellation of an in progress awaitable ismaster.
+ *
+ * Called from app threads on network errors and during shutdown.
+ * Locks server monitor mutex.
+ */
+void
+mongoc_server_monitor_request_cancel (mongoc_server_monitor_t *server_monitor)
+{
+   MONITOR_LOG (server_monitor, "requesting cancel");
+   bson_mutex_lock (&server_monitor->shared.mutex);
+   server_monitor->shared.cancel_requested = true;
+   mongoc_cond_signal (&server_monitor->shared.cond);
+   bson_mutex_unlock (&server_monitor->shared.mutex);
+}
+
+/* Wait for heartbeatFrequencyMS or minHeartbeatFrequencyMS if a scan is
+ * requested.
+ *
+ * Locks server monitor mutex.
+ */
+void
+mongoc_server_monitor_wait (mongoc_server_monitor_t *server_monitor)
+{
+   int64_t start_ms;
+   int64_t scan_due_ms;
+
+   start_ms = _now_ms ();
+   scan_due_ms = start_ms + server_monitor->heartbeat_frequency_ms;
+
+   bson_mutex_lock (&server_monitor->shared.mutex);
+   while (true) {
+      int64_t sleep_duration_ms;
+      int cond_ret;
+
+      if (server_monitor->shared.state != MONGOC_THREAD_RUNNING) {
+         break;
+      }
+
+      if (server_monitor->shared.scan_requested) {
+         server_monitor->shared.scan_requested = false;
+         scan_due_ms = start_ms + server_monitor->min_heartbeat_frequency_ms;
+      }
+
+      sleep_duration_ms = scan_due_ms - _now_ms ();
+
+      if (sleep_duration_ms <= 0) {
+         break;
+      }
+
+      MONITOR_LOG (server_monitor, "sleeping for %" PRId64, sleep_duration_ms);
+      cond_ret = mongoc_cond_timedwait (&server_monitor->shared.cond,
+                                        &server_monitor->shared.mutex,
+                                        sleep_duration_ms);
+      if (mongo_cond_ret_is_timedout (cond_ret)) {
+         break;
+      }
+   }
+   bson_mutex_unlock (&server_monitor->shared.mutex);
+}
+
+/* The server monitor thread function.
+ *
+ * Server monitor must be in state MONGOC_THREAD_OFF.
+ */
+static BSON_THREAD_FUN (_server_monitor_thread, server_monitor_void)
+{
+   mongoc_server_monitor_t *server_monitor;
+   mongoc_server_description_t *description;
+   mongoc_server_description_t *previous_description;
+
+   server_monitor = (mongoc_server_monitor_t *) server_monitor_void;
+   description =
+      mongoc_server_description_new_copy (server_monitor->description);
+   previous_description = NULL;
+
+   while (true) {
+      bool cancelled = false;
+
+      bson_mutex_lock (&server_monitor->shared.mutex);
+      if (server_monitor->shared.state != MONGOC_THREAD_RUNNING) {
+         bson_mutex_unlock (&server_monitor->shared.mutex);
+         break;
+      }
+      bson_mutex_unlock (&server_monitor->shared.mutex);
+
+      mongoc_server_description_destroy (previous_description);
+      previous_description = mongoc_server_description_new_copy (description);
+      mongoc_server_description_destroy (description);
+      description = mongoc_server_monitor_check_server (
+         server_monitor, previous_description, &cancelled);
+
+      if (cancelled) {
+         mongoc_server_monitor_wait (server_monitor);
+         continue;
+      }
+
+      _server_monitor_update_topology_description (server_monitor, description);
+
+      /* Immediately proceed to the next check if the previous response was
+       * successful and included the topologyVersion field. */
+      if (description->type != MONGOC_SERVER_UNKNOWN &&
+          !bson_empty (&description->topology_version)) {
+         MONITOR_LOG (server_monitor,
+                      "immediately proceeding due to topologyVersion");
+         continue;
+      }
+
+      /* ... or the previous response included the moreToCome flag */
+      if (server_monitor->more_to_come) {
+         MONITOR_LOG (server_monitor,
+                      "immediately proceeding due to moreToCome");
+         continue;
+      }
+
+      /* ... or the server has just transitioned to Unknown due to a network
+       * error. */
+      if (_mongoc_error_is_network (&description->error) &&
+          previous_description->type != MONGOC_SERVER_UNKNOWN) {
+         MONITOR_LOG (server_monitor,
+                      "immediately proceeding due to network error");
+         continue;
+      }
+
+      mongoc_server_monitor_wait (server_monitor);
+   }
+
+   bson_mutex_lock (&server_monitor->shared.mutex);
+   server_monitor->shared.state = MONGOC_THREAD_JOINABLE;
+   bson_mutex_unlock (&server_monitor->shared.mutex);
+   mongoc_server_description_destroy (previous_description);
+   mongoc_server_description_destroy (description);
+   BSON_THREAD_RETURN;
+}
+
+static bool
+_server_monitor_ping_server (mongoc_server_monitor_t *server_monitor,
+                             int64_t *rtt_ms)
+{
+   bool ret = false;
+   int64_t start_us = _now_us ();
+   bson_t ismaster_reply;
+   bson_error_t error;
+
+   *rtt_ms = MONGOC_RTT_UNSET;
+
+   if (!server_monitor->stream) {
+      MONITOR_LOG (server_monitor, "rtt setting up connection");
+      ret = _server_monitor_setup_connection (
+         server_monitor, &ismaster_reply, &start_us, &error);
+      bson_destroy (&ismaster_reply);
+   }
+
+   if (server_monitor->stream) {
+      MONITOR_LOG (server_monitor, "rtt polling ismaster");
+      ret = _server_monitor_polling_ismaster (
+         server_monitor, &ismaster_reply, &error);
+      if (ret) {
+         *rtt_ms = (_now_us () - start_us) / 1000;
+      }
+      bson_destroy (&ismaster_reply);
+   }
+   return ret;
+}
+
+/* The RTT monitor thread function.
+ *
+ * Server monitor must be in state MONGOC_THREAD_OFF.
+ */
+static BSON_THREAD_FUN (_server_monitor_rtt_thread, server_monitor_void)
+{
+   mongoc_server_monitor_t *server_monitor;
+
+   server_monitor = (mongoc_server_monitor_t *) server_monitor_void;
+
+   while (true) {
+      int64_t rtt_ms;
+      bson_error_t error;
+
+      bson_mutex_lock (&server_monitor->shared.mutex);
+      if (server_monitor->shared.state != MONGOC_THREAD_RUNNING) {
+         bson_mutex_unlock (&server_monitor->shared.mutex);
+         break;
+      }
+      bson_mutex_unlock (&server_monitor->shared.mutex);
+
+      _server_monitor_ping_server (server_monitor, &rtt_ms);
+      if (rtt_ms != MONGOC_RTT_UNSET) {
+         mongoc_server_description_t *sd;
+
+         bson_mutex_lock (&server_monitor->topology->mutex);
+         sd = mongoc_topology_description_server_by_id (
+            &server_monitor->topology->description,
+            server_monitor->description->id,
+            &error);
+         if (sd) {
+            /* If the server description has been removed, the RTT thread will
+             * be terminated by background monitoring soon. */
+            mongoc_server_description_update_rtt (sd, rtt_ms);
+         }
+         bson_mutex_unlock (&server_monitor->topology->mutex);
+      }
+      mongoc_server_monitor_wait (server_monitor);
+   }
+
+   bson_mutex_lock (&server_monitor->shared.mutex);
+   server_monitor->shared.state = MONGOC_THREAD_JOINABLE;
+   bson_mutex_unlock (&server_monitor->shared.mutex);
+   BSON_THREAD_RETURN;
+}
+
+void
+mongoc_server_monitor_run (mongoc_server_monitor_t *server_monitor)
+{
+   bson_mutex_lock (&server_monitor->shared.mutex);
+   if (server_monitor->shared.state == MONGOC_THREAD_OFF) {
+      server_monitor->is_rtt = false;
+      server_monitor->shared.state = MONGOC_THREAD_RUNNING;
+      COMMON_PREFIX (thread_create)
+      (&server_monitor->thread, _server_monitor_thread, server_monitor);
+   }
+   bson_mutex_unlock (&server_monitor->shared.mutex);
+}
+
+void
+mongoc_server_monitor_run_as_rtt (mongoc_server_monitor_t *server_monitor)
+{
+   bson_mutex_lock (&server_monitor->shared.mutex);
+   if (server_monitor->shared.state == MONGOC_THREAD_OFF) {
+      server_monitor->is_rtt = true;
+      server_monitor->shared.state = MONGOC_THREAD_RUNNING;
+      COMMON_PREFIX (thread_create)
+      (&server_monitor->thread, _server_monitor_rtt_thread, server_monitor);
+   }
+   bson_mutex_unlock (&server_monitor->shared.mutex);
+}
+
+/* Request thread shutdown.
+ *
+ * Returns true if in state MONGOC_THREAD_OFF and the server monitor can be
+ * safely destroyed.
+ * Called during topology description reconcile.
+ * Caller may hold topology mutex.
+ * Locks server monitor mutex.
+ */
+bool
+mongoc_server_monitor_request_shutdown (mongoc_server_monitor_t *server_monitor)
+{
+   bool off = false;
+
+   bson_mutex_lock (&server_monitor->shared.mutex);
+   if (server_monitor->shared.state == MONGOC_THREAD_RUNNING) {
+      server_monitor->shared.state = MONGOC_THREAD_SHUTTING_DOWN;
+   }
+   if (server_monitor->shared.state == MONGOC_THREAD_JOINABLE) {
+      COMMON_PREFIX (thread_join) (server_monitor->thread);
+      server_monitor->shared.state = MONGOC_THREAD_OFF;
+   }
+   if (server_monitor->shared.state == MONGOC_THREAD_OFF) {
+      off = true;
+   }
+   mongoc_cond_signal (&server_monitor->shared.cond);
+   bson_mutex_unlock (&server_monitor->shared.mutex);
+   /* Cancel an in-progress ismaster check. */
+   if (!off) {
+      mongoc_server_monitor_request_cancel (server_monitor);
+   }
+   return off;
+}
+
+/* Request thread shutdown and block until the server monitor thread terminates.
+ *
+ * Called by one thread.
+ * Caller must not hold topology mutex. Server monitor thread may need to lock
+ * it again in the process of shutting down.
+ * Locks the server monitor mutex.
+ */
+void
+mongoc_server_monitor_wait_for_shutdown (
+   mongoc_server_monitor_t *server_monitor)
+{
+   if (mongoc_server_monitor_request_shutdown (server_monitor)) {
+      return;
+   }
+
+   /* Shutdown requested, but thread is not yet off. Wait. */
+   COMMON_PREFIX (thread_join) (server_monitor->thread);
+   bson_mutex_lock (&server_monitor->shared.mutex);
+   server_monitor->shared.state = MONGOC_THREAD_OFF;
+   bson_mutex_unlock (&server_monitor->shared.mutex);
+}
+
+/* Destroy a server monitor.
+ *
+ * Called only by one thread.
+ * Caller must not hold server monitor lock.
+ * Server monitor thread is in state MONGOC_THREAD_OFF.
+ */
+void
+mongoc_server_monitor_destroy (mongoc_server_monitor_t *server_monitor)
+{
+   if (!server_monitor) {
+      return;
+   }
+
+   /* Locking not necessary since this is only called by one thread, and server
+    * monitor thread is no longer running. */
+   BSON_ASSERT (server_monitor->shared.state == MONGOC_THREAD_OFF);
+
+   mongoc_server_description_destroy (server_monitor->description);
+   mongoc_stream_destroy (server_monitor->stream);
+   mongoc_uri_destroy (server_monitor->uri);
+   mongoc_cond_destroy (&server_monitor->shared.cond);
+   bson_mutex_destroy (&server_monitor->shared.mutex);
+#ifdef MONGOC_ENABLE_SSL
+   if (server_monitor->ssl_opts) {
+      _mongoc_ssl_opts_cleanup (server_monitor->ssl_opts, true);
+      bson_free (server_monitor->ssl_opts);
+   }
+#endif
+   bson_free (server_monitor);
+}

--- a/src/libmongoc/src/mongoc/mongoc-topology-background-monitoring-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-background-monitoring-private.h
@@ -20,24 +20,26 @@
 #ifndef MONGOC_TOPOLOGY_BACKGROUND_MONITORING_PRIVATE_H
 #define MONGOC_TOPOLOGY_BACKGROUND_MONITORING_PRIVATE_H
 
+#include "mongoc.h"
+#include "mongoc-topology-private.h"
+
 /* Methods of mongoc_topology_t for managing background monitoring. */
 
-struct _mongoc_topology_t;
+void
+_mongoc_topology_background_monitoring_start (mongoc_topology_t *topology);
 
 void
-_mongoc_topology_background_monitoring_start (
-   struct _mongoc_topology_t *topology);
-
-void
-_mongoc_topology_background_monitoring_reconcile (
-   struct _mongoc_topology_t *topology);
+_mongoc_topology_background_monitoring_reconcile (mongoc_topology_t *topology);
 
 void
 _mongoc_topology_background_monitoring_request_scan (
-   struct _mongoc_topology_t *topology);
+   mongoc_topology_t *topology);
 
 void
-_mongoc_topology_background_monitoring_stop (
-   struct _mongoc_topology_t *topology);
+_mongoc_topology_background_monitoring_stop (mongoc_topology_t *topology);
+
+void
+_mongoc_topology_background_monitoring_cancel_check (
+   mongoc_topology_t *topology, uint32_t server_id);
 
 #endif /* MONGOC_TOPOLOGY_BACKGROUND_MONITORING_PRIVATE_H */

--- a/src/libmongoc/src/mongoc/mongoc-topology-background-monitoring.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-background-monitoring.c
@@ -18,6 +18,7 @@
 
 #include "mongoc-client-private.h"
 #include "mongoc-log-private.h"
+#include "mongoc-server-monitor-private.h"
 #ifdef MONGOC_ENABLE_SSL
 #include "mongoc-ssl-private.h"
 #endif
@@ -28,7 +29,7 @@
 #include "mongoc-util-private.h"
 
 #undef MONGOC_LOG_DOMAIN
-#define MONGOC_LOG_DOMAIN "bg_monitor"
+#define MONGOC_LOG_DOMAIN "monitor"
 
 static BSON_THREAD_FUN (srv_polling_run, topology_void)
 {
@@ -61,6 +62,9 @@ static BSON_THREAD_FUN (srv_polling_run, topology_void)
                 sleep_duration_ms);
       }
 
+      /* Check for shutdown again here. mongoc_topology_rescan_srv unlocks the
+       * topology mutex for the scan. The topology may have shut down in that
+       * time. */
       if (topology->scanner_state != MONGOC_TOPOLOGY_SCANNER_BG_RUNNING) {
          bson_mutex_unlock (&topology->mutex);
          break;
@@ -71,544 +75,6 @@ static BSON_THREAD_FUN (srv_polling_run, topology_void)
          &topology->srv_polling_cond, &topology->mutex, sleep_duration_ms);
    }
    BSON_THREAD_RETURN;
-}
-
-typedef struct {
-   mongoc_topology_t *topology;
-   bson_thread_t thread;
-
-   /* State accessed from multiple threads. */
-   struct {
-      bson_mutex_t mutex;
-      mongoc_cond_t cond;
-      bool shutting_down;
-      bool is_shutdown;
-      bool scan_requested;
-   } shared;
-
-   /* Time of last scan in milliseconds. */
-   uint64_t last_scan_ms;
-   /* The time of the next scheduled scan. */
-   uint64_t scan_due_ms;
-   /* The server id matching the server description. */
-   uint32_t server_id;
-   /* Default time to sleep between ismaster checks (reduced when a scan is
-    * requested) */
-   uint64_t heartbeat_frequency_ms;
-   /* The minimum time to sleep between ismaster checks. */
-   uint64_t min_heartbeat_frequency_ms;
-   int64_t connect_timeout_ms;
-   bool use_tls;
-#ifdef MONGOC_ENABLE_SSL
-   mongoc_ssl_opt_t *ssl_opts;
-#endif
-   mongoc_uri_t *uri;
-   mongoc_host_list_t host;
-   /* A custom initiator may be set if a user provides overrides to create a
-    * stream. */
-   mongoc_stream_initiator_t initiator;
-   void *initiator_context;
-   mongoc_stream_t *stream;
-   int64_t request_id;
-   mongoc_apm_callbacks_t apm_callbacks;
-   void *apm_context;
-} mongoc_server_monitor_t;
-
-/* Called only from server monitor thread.
- * Caller must hold no locks (user's callback may lock topology mutex).
- * Locks APM mutex.
- */
-static void
-_server_monitor_heartbeat_started (mongoc_server_monitor_t *server_monitor)
-{
-   mongoc_apm_server_heartbeat_started_t event;
-   if (!server_monitor->apm_callbacks.server_heartbeat_started) {
-      return;
-   }
-
-   event.host = &server_monitor->host;
-   event.context = server_monitor->apm_context;
-   event.awaited = false;
-   bson_mutex_lock (&server_monitor->topology->apm_mutex);
-   server_monitor->apm_callbacks.server_heartbeat_started (&event);
-   bson_mutex_unlock (&server_monitor->topology->apm_mutex);
-}
-
-/* Called only from server monitor thread.
- * Caller must hold no locks (user's callback may lock topology mutex).
- * Locks APM mutex.
- */
-static void
-_server_monitor_heartbeat_succeeded (mongoc_server_monitor_t *server_monitor,
-                                     const bson_t *reply,
-                                     int64_t duration_usec)
-{
-   mongoc_apm_server_heartbeat_succeeded_t event;
-
-   if (!server_monitor->apm_callbacks.server_heartbeat_succeeded) {
-      return;
-   }
-   event.host = &server_monitor->host;
-   event.context = server_monitor->apm_context;
-   event.reply = reply;
-   event.duration_usec = duration_usec;
-   event.awaited = false;
-   bson_mutex_lock (&server_monitor->topology->apm_mutex);
-   server_monitor->apm_callbacks.server_heartbeat_succeeded (&event);
-   bson_mutex_unlock (&server_monitor->topology->apm_mutex);
-}
-
-/* Called only from server monitor thread.
- * Caller must hold no locks (user's callback may lock topology mutex).
- * Locks APM mutex.
- */
-static void
-_server_monitor_heartbeat_failed (mongoc_server_monitor_t *server_monitor,
-                                  const bson_error_t *error,
-                                  int64_t duration_usec)
-{
-   mongoc_apm_server_heartbeat_failed_t event;
-
-   if (!server_monitor->apm_callbacks.server_heartbeat_failed) {
-      return;
-   }
-
-   event.host = &server_monitor->host;
-   event.context = server_monitor->apm_context;
-   event.error = error;
-   event.duration_usec = duration_usec;
-   event.awaited = false;
-   bson_mutex_lock (&server_monitor->topology->apm_mutex);
-   server_monitor->apm_callbacks.server_heartbeat_failed (&event);
-   bson_mutex_unlock (&server_monitor->topology->apm_mutex);
-}
-
-static bool
-_server_monitor_cmd_send (mongoc_server_monitor_t *server_monitor,
-                          bson_t *cmd,
-                          bson_t *reply,
-                          bson_error_t *error)
-{
-   mongoc_rpc_t rpc;
-   mongoc_array_t array_to_write;
-   mongoc_iovec_t *iovec;
-   int niovec;
-   mongoc_buffer_t buffer;
-   uint32_t reply_len;
-   bson_t temp_reply;
-
-   rpc.header.msg_len = 0;
-   rpc.header.request_id = server_monitor->request_id++;
-   rpc.header.response_to = 0;
-   rpc.header.opcode = MONGOC_OPCODE_QUERY;
-   rpc.query.flags = MONGOC_QUERY_SLAVE_OK;
-   rpc.query.collection = "admin.$cmd";
-   rpc.query.skip = 0;
-   rpc.query.n_return = -1;
-   rpc.query.query = bson_get_data (cmd);
-   rpc.query.fields = NULL;
-
-   _mongoc_array_init (&array_to_write, sizeof (mongoc_iovec_t));
-   _mongoc_rpc_gather (&rpc, &array_to_write);
-   iovec = (mongoc_iovec_t *) array_to_write.data;
-   niovec = array_to_write.len;
-   _mongoc_rpc_swab_to_le (&rpc);
-
-   if (!_mongoc_stream_writev_full (server_monitor->stream,
-                                    iovec,
-                                    niovec,
-                                    server_monitor->connect_timeout_ms,
-                                    error)) {
-      _mongoc_array_destroy (&array_to_write);
-      bson_init (reply);
-      return false;
-   }
-   _mongoc_array_destroy (&array_to_write);
-
-   _mongoc_buffer_init (&buffer, NULL, 0, NULL, NULL);
-   if (!_mongoc_buffer_append_from_stream (&buffer,
-                                           server_monitor->stream,
-                                           4,
-                                           server_monitor->connect_timeout_ms,
-                                           error)) {
-      _mongoc_buffer_destroy (&buffer);
-      bson_init (reply);
-      return false;
-   }
-
-   memcpy (&reply_len, buffer.data, 4);
-   reply_len = BSON_UINT32_FROM_LE (reply_len);
-
-   if (!_mongoc_buffer_append_from_stream (&buffer,
-                                           server_monitor->stream,
-                                           reply_len - buffer.len,
-                                           server_monitor->connect_timeout_ms,
-                                           error)) {
-      _mongoc_buffer_destroy (&buffer);
-      bson_init (reply);
-      return false;
-   }
-
-   if (!_mongoc_rpc_scatter (&rpc, buffer.data, buffer.len)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_PROTOCOL,
-                      MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
-                      "Invalid reply from server.");
-
-      _mongoc_buffer_destroy (&buffer);
-      bson_init (reply);
-      return false;
-   }
-
-   if (BSON_UINT32_FROM_LE (rpc.header.opcode) == MONGOC_OPCODE_COMPRESSED) {
-      uint8_t *buf = NULL;
-      size_t len = BSON_UINT32_FROM_LE (rpc.compressed.uncompressed_size) +
-                   sizeof (mongoc_rpc_header_t);
-
-      buf = bson_malloc0 (len);
-      if (!_mongoc_rpc_decompress (&rpc, buf, len)) {
-         bson_free (buf);
-         _mongoc_buffer_destroy (&buffer);
-         bson_init (reply);
-         bson_set_error (error,
-                         MONGOC_ERROR_PROTOCOL,
-                         MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
-                         "Could not decompress server reply");
-         return MONGOC_ASYNC_CMD_ERROR;
-      }
-
-      _mongoc_buffer_destroy (&buffer);
-      _mongoc_buffer_init (&buffer, buf, len, NULL, NULL);
-   }
-
-   _mongoc_rpc_swab_from_le (&rpc);
-
-   if (!_mongoc_rpc_get_first_document (&rpc, &temp_reply)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_PROTOCOL,
-                      MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
-                      "Invalid reply from server");
-      _mongoc_buffer_destroy (&buffer);
-      bson_init (reply);
-      return false;
-   }
-   bson_copy_to (&temp_reply, reply);
-   _mongoc_buffer_destroy (&buffer);
-   return true;
-}
-
-/* Update the topology description with a reply or an error.
- *
- * Called only from server monitor thread.
- * Caller must hold no locks.
- * Locks topology mutex.
- */
-static void
-_server_monitor_update_topology_description (
-   mongoc_server_monitor_t *server_monitor,
-   bson_t *reply,
-   uint64_t rtt_us,
-   bson_error_t *error)
-{
-   mongoc_topology_t *topology;
-
-   topology = server_monitor->topology;
-   bson_mutex_lock (&topology->mutex);
-   if (topology->scanner_state != MONGOC_TOPOLOGY_SCANNER_SHUTTING_DOWN) {
-      mongoc_topology_description_handle_ismaster (
-         &server_monitor->topology->description,
-         server_monitor->server_id,
-         reply,
-         rtt_us / 1000,
-         error);
-      /* reconcile server monitors. */
-      _mongoc_topology_background_monitoring_reconcile (topology);
-   }
-   /* Wake threads performing server selection. */
-   mongoc_cond_broadcast (&server_monitor->topology->cond_client);
-   bson_mutex_unlock (&server_monitor->topology->mutex);
-}
-
-/* Send an ismaster command to a server.
- *
- * Called only from server monitor thread.
- * Caller must hold no locks.
- * Locks server_monitor->mutex to reset scan_requested.
- * Locks topology mutex when updating topology description with new ismaster
- * reply (or error).
- */
-static void
-_server_monitor_regular_ismaster (mongoc_server_monitor_t *server_monitor)
-{
-   bson_t cmd;
-   bson_t reply;
-   bool ret;
-   bson_error_t error = {0};
-   int64_t rtt_us;
-   int64_t start_us;
-   int attempt;
-   bool stream_established = false;
-   mongoc_topology_t *topology;
-
-   topology = server_monitor->topology;
-   bson_init (&cmd);
-   bson_init (&reply);
-   rtt_us = 0;
-   attempt = 0;
-   while (true) {
-      /* If the first attempt to send an ismaster failed, see if we can attempt
-       * again.
-       * Server monitoring spec: Once the server is connected, the client MUST
-       * change its type to Unknown only after it has retried the server once.
-      */
-      if (attempt > 0) {
-         mongoc_server_description_t *existing_sd;
-         bool should_retry = false;
-
-         if (attempt > 1 || !stream_established) {
-            /* We've already retried, or we were not able to establish a
-             * connection at all. */
-            should_retry = false;
-         } else {
-            bson_mutex_lock (&topology->mutex);
-            /* If the server description is already Unknown, don't retry. */
-            if (topology->scanner_state !=
-                MONGOC_TOPOLOGY_SCANNER_SHUTTING_DOWN) {
-               existing_sd = mongoc_topology_description_server_by_id (
-                  &topology->description, server_monitor->server_id, NULL);
-               if (existing_sd != NULL &&
-                   existing_sd->type != MONGOC_SERVER_UNKNOWN) {
-                  should_retry = true;
-               }
-            }
-
-            bson_mutex_unlock (&server_monitor->topology->mutex);
-         }
-
-         if (!should_retry) {
-            TRACE ("sm (%d): cannot retry", server_monitor->server_id);
-            /* error was previously set. */
-            _server_monitor_update_topology_description (
-               server_monitor, NULL, -1, &error);
-            break;
-         } else {
-            TRACE ("sm (%d): going to retry", server_monitor->server_id);
-         }
-      }
-      attempt++;
-
-      bson_reinit (&cmd);
-      BCON_APPEND (&cmd, "isMaster", BCON_INT32 (1));
-
-      if (!server_monitor->stream) {
-         /* Using an initiator isn't really necessary. Users can't set them on
-          * pools. But it is used for tests. */
-         if (server_monitor->initiator) {
-            server_monitor->stream =
-               server_monitor->initiator (server_monitor->uri,
-                                          &server_monitor->host,
-                                          server_monitor->initiator_context,
-                                          &error);
-         } else {
-            void *ssl_opts_void = NULL;
-
-#ifdef MONGOC_ENABLE_SSL
-            ssl_opts_void = server_monitor->ssl_opts;
-#endif
-            server_monitor->stream =
-               mongoc_client_connect (false,
-                                      ssl_opts_void != NULL,
-                                      ssl_opts_void,
-                                      server_monitor->uri,
-                                      &server_monitor->host,
-                                      &error);
-         }
-         if (!server_monitor->stream) {
-            TRACE ("sm (%d) failed to connect", server_monitor->server_id);
-            _server_monitor_heartbeat_failed (server_monitor, &error, rtt_us);
-            continue;
-         }
-
-         bson_destroy (&cmd);
-         bson_copy_to (_mongoc_topology_get_ismaster (server_monitor->topology),
-                       &cmd);
-      }
-
-      /* A stream was already established, or we created one successfully. (This
-       * permits a retry). */
-      stream_established = true;
-
-      /* Cluster time is updated on every reply. Don't wait for notifications,
-       * just poll it. */
-      bson_mutex_lock (&server_monitor->topology->mutex);
-      if (!bson_empty (&server_monitor->topology->description.cluster_time)) {
-         bson_append_document (
-            &cmd,
-            "$clusterTime",
-            12,
-            &server_monitor->topology->description.cluster_time);
-      }
-      bson_mutex_unlock (&server_monitor->topology->mutex);
-
-      start_us = bson_get_monotonic_time ();
-      bson_destroy (&reply);
-      _server_monitor_heartbeat_started (server_monitor);
-      ret = _server_monitor_cmd_send (server_monitor, &cmd, &reply, &error);
-      if (!ret) {
-         TRACE ("sm (%d) error = %s", server_monitor->server_id, error.message);
-      }
-      /* Must mark scan_requested as "delivered" before updating the topology
-       * description, not after. Otherwise, we could miss a scan request in
-       * server selection. We need to uphold the invariant: if a scan is
-       * requested, cond_client will be signalled.
-       */
-      bson_mutex_lock (&server_monitor->shared.mutex);
-      server_monitor->shared.scan_requested = false;
-      bson_mutex_unlock (&server_monitor->shared.mutex);
-      rtt_us = (bson_get_monotonic_time () - start_us);
-
-      if (ret) {
-         _server_monitor_update_topology_description (
-            server_monitor, &reply, rtt_us, &error);
-         _server_monitor_heartbeat_succeeded (server_monitor, &reply, rtt_us);
-         break;
-      } else {
-         mongoc_stream_destroy (server_monitor->stream);
-         server_monitor->stream = NULL;
-         _server_monitor_heartbeat_failed (server_monitor, &error, rtt_us);
-         continue;
-      }
-   }
-
-   bson_destroy (&cmd);
-   bson_destroy (&reply);
-}
-
-/* The server monitor thread.
- *
- * Runs continuously and sends ismaster commands. Sleeps until it is time to
- * scan or woken by a change in shared state:
- * - a request for immediate scan
- * - a request for shutdown
- * Locks the server mutex to check shared state.
- * Locks topology mutex to update description.
- */
-static BSON_THREAD_FUN (_server_monitor_run, server_monitor_void)
-{
-   mongoc_server_monitor_t *server_monitor;
-
-   server_monitor = (mongoc_server_monitor_t *) server_monitor_void;
-
-   while (true) {
-      int64_t now_ms;
-      int64_t sleep_duration_ms;
-
-      now_ms = bson_get_monotonic_time () / 1000;
-      if (now_ms >= server_monitor->scan_due_ms) {
-         TRACE ("sm (%d) sending ismaster", server_monitor->server_id);
-         _server_monitor_regular_ismaster (server_monitor);
-         server_monitor->last_scan_ms = bson_get_monotonic_time () / 1000;
-         server_monitor->scan_due_ms = server_monitor->last_scan_ms +
-                                       server_monitor->heartbeat_frequency_ms;
-      }
-
-      bson_mutex_lock (&server_monitor->shared.mutex);
-      if (server_monitor->shared.shutting_down) {
-         server_monitor->shared.is_shutdown = true;
-         bson_mutex_unlock (&server_monitor->shared.mutex);
-         break;
-      }
-
-      if (server_monitor->shared.scan_requested) {
-         server_monitor->scan_due_ms =
-            server_monitor->last_scan_ms +
-            server_monitor->min_heartbeat_frequency_ms;
-      }
-
-      sleep_duration_ms = server_monitor->scan_due_ms - now_ms;
-
-      if (sleep_duration_ms > 0) {
-         TRACE ("sm (%d) sleeping for %" PRId64,
-                server_monitor->server_id,
-                sleep_duration_ms);
-         mongoc_cond_timedwait (&server_monitor->shared.cond,
-                                &server_monitor->shared.mutex,
-                                sleep_duration_ms);
-      }
-      bson_mutex_unlock (&server_monitor->shared.mutex);
-   }
-   BSON_THREAD_RETURN;
-}
-
-/* Free data for a server monitor.
- *
- * Called from any thread during reconcile and during the shutdown procedure.
- * Caller must have topology mutex locked, but not the server monitor mutex.
- */
-static void
-_server_monitor_destroy (mongoc_server_monitor_t *server_monitor)
-{
-   mongoc_stream_destroy (server_monitor->stream);
-   mongoc_uri_destroy (server_monitor->uri);
-   mongoc_cond_destroy (&server_monitor->shared.cond);
-   bson_mutex_destroy (&server_monitor->shared.mutex);
-#ifdef MONGOC_ENABLE_SSL
-   if (server_monitor->ssl_opts) {
-      _mongoc_ssl_opts_cleanup (server_monitor->ssl_opts, true);
-      bson_free (server_monitor->ssl_opts);
-   }
-#endif
-   bson_free (server_monitor);
-}
-
-/* Signal a server monitor to shutdown. If shutdown has already completed, frees
- * server monitor and returns true.
- *
- * Called only during topology description reconcile (from any thread).
- * Caller must hold topology lock.
- */
-static bool
-_server_monitor_try_shutdown_and_destroy (
-   mongoc_server_monitor_t *server_monitor)
-{
-   bool is_shutdown;
-
-   bson_mutex_lock (&server_monitor->shared.mutex);
-   is_shutdown = server_monitor->shared.is_shutdown;
-   server_monitor->shared.shutting_down = true;
-   mongoc_cond_signal (&server_monitor->shared.cond);
-   bson_mutex_unlock (&server_monitor->shared.mutex);
-
-   /* If the server monitor thread has exited, join so the internal thread state
-    * can be freed. Joining can only be done once the server monitor has
-    * completed shutdown. Otherwise, the server monitor may be in the middle of
-    * scanning (and therefore may need to take the topology mutex again).
-    *
-    * Since the topology mutex is locked, we're guaranteed that only one thread
-    * will join.
-    */
-   if (is_shutdown) {
-      TRACE ("sm (%d) try join start", server_monitor->server_id);
-      COMMON_PREFIX (thread_join) (server_monitor->thread);
-      TRACE ("sm (%d) try join end", server_monitor->server_id);
-      _server_monitor_destroy (server_monitor);
-      return true;
-   }
-   return false; /* Still waiting for shutdown. */
-}
-
-/* Request scan of a single server.
- *
- * Caller does not need to have topology mutex locked.
- * Locks server_monitor mutex to deliver scan_requested.
- */
-static void
-_server_monitor_request_scan (mongoc_server_monitor_t *server_monitor)
-{
-   bson_mutex_lock (&server_monitor->shared.mutex);
-   server_monitor->shared.scan_requested = true;
-   mongoc_cond_signal (&server_monitor->shared.cond);
-   bson_mutex_unlock (&server_monitor->shared.mutex);
 }
 
 /* Create a server monitor if necessary.
@@ -626,42 +92,27 @@ _background_monitor_reconcile_server_monitor (mongoc_topology_t *topology,
    server_monitors = topology->server_monitors;
    server_monitor = mongoc_set_get (server_monitors, sd->id);
 
-   if (server_monitor) {
-      return;
+   if (!server_monitor) {
+      /* Add a new server monitor. */
+      server_monitor = mongoc_server_monitor_new (topology, sd);
+      mongoc_server_monitor_run (server_monitor);
+      mongoc_set_add (server_monitors, sd->id, server_monitor);
    }
 
-   /* Add a new server monitor. */
-   server_monitor = bson_malloc0 (sizeof (*server_monitor));
-   server_monitor->server_id = sd->id;
-   memcpy (&server_monitor->host, &sd->host, sizeof (mongoc_host_list_t));
-   server_monitor->topology = topology;
-   server_monitor->heartbeat_frequency_ms =
-      topology->description.heartbeat_msec;
-   server_monitor->min_heartbeat_frequency_ms =
-      topology->min_heartbeat_frequency_msec;
-   server_monitor->connect_timeout_ms = topology->connect_timeout_msec;
-   server_monitor->uri = mongoc_uri_copy (topology->uri);
-/* TODO: CDRIVER-3682 Do not retrieve ssl opts from topology scanner. They
- * should be stored somewhere else. */
-#ifdef MONGOC_ENABLE_SSL
-   if (topology->scanner->ssl_opts) {
-      server_monitor->ssl_opts = bson_malloc0 (sizeof (mongoc_ssl_opt_t));
+   /* Check if an RTT monitor is needed. */
+   if (!bson_empty (&sd->topology_version)) {
+      mongoc_set_t *rtt_monitors;
+      mongoc_server_monitor_t *rtt_monitor;
 
-      _mongoc_ssl_opts_copy_to (
-         topology->scanner->ssl_opts, server_monitor->ssl_opts, true);
+      rtt_monitors = topology->rtt_monitors;
+      rtt_monitor = mongoc_set_get (rtt_monitors, sd->id);
+      if (!rtt_monitor) {
+         rtt_monitor = mongoc_server_monitor_new (topology, sd);
+         mongoc_server_monitor_run_as_rtt (rtt_monitor);
+         mongoc_set_add (rtt_monitors, sd->id, rtt_monitor);
+      }
    }
-#endif
-   memcpy (&server_monitor->apm_callbacks,
-           &topology->description.apm_callbacks,
-           sizeof (mongoc_apm_callbacks_t));
-   server_monitor->apm_context = topology->description.apm_context;
-   server_monitor->initiator = topology->scanner->initiator;
-   server_monitor->initiator_context = topology->scanner->initiator_context;
-   mongoc_cond_init (&server_monitor->shared.cond);
-   bson_mutex_init (&server_monitor->shared.mutex);
-   COMMON_PREFIX (thread_create)
-   (&server_monitor->thread, _server_monitor_run, server_monitor);
-   mongoc_set_add (server_monitors, server_monitor->server_id, server_monitor);
+   return;
 }
 
 /* Start background monitoring.
@@ -679,6 +130,8 @@ _mongoc_topology_background_monitoring_start (mongoc_topology_t *topology)
       return;
    }
 
+   TRACE ("%s", "background monitoring starting");
+
    BSON_ASSERT (topology->scanner_state == MONGOC_TOPOLOGY_SCANNER_OFF);
 
    topology->scanner_state = MONGOC_TOPOLOGY_SCANNER_BG_RUNNING;
@@ -695,6 +148,45 @@ _mongoc_topology_background_monitoring_start (mongoc_topology_t *topology)
    }
 }
 
+/* Remove server monitors that are no longer in the set of server descriptions.
+ *
+ * Called by monitor threads and application threads when reconciling the
+ * topology description. Caller must have topology mutex locked.
+ */
+static void
+_remove_orphaned_server_monitors (mongoc_set_t *server_monitors,
+                                  mongoc_set_t *server_descriptions)
+{
+   uint32_t *server_monitor_ids_to_remove;
+   uint32_t n_server_monitor_ids_to_remove = 0;
+   int i;
+
+   /* Signal shutdown to server monitors no longer in the topology description.
+    */
+   server_monitor_ids_to_remove =
+      bson_malloc0 (sizeof (uint32_t) * server_monitors->items_len);
+   for (i = 0; i < server_monitors->items_len; i++) {
+      mongoc_server_monitor_t *server_monitor;
+      uint32_t id;
+
+      server_monitor = mongoc_set_get_item_and_id (server_monitors, i, &id);
+      if (!mongoc_set_get (server_descriptions, id)) {
+         if (mongoc_server_monitor_request_shutdown (server_monitor)) {
+            mongoc_server_monitor_wait_for_shutdown (server_monitor);
+            mongoc_server_monitor_destroy (server_monitor);
+            server_monitor_ids_to_remove[n_server_monitor_ids_to_remove] = id;
+            n_server_monitor_ids_to_remove++;
+         }
+      }
+   }
+
+   /* Remove freed server monitors that have completed shutdown. */
+   for (i = 0; i < n_server_monitor_ids_to_remove; i++) {
+      mongoc_set_rm (server_monitors, server_monitor_ids_to_remove[i]);
+   }
+   bson_free (server_monitor_ids_to_remove);
+}
+
 /* Reconcile the topology description with the set of server monitors.
  *
  * Called when the topology description is updated (via handshake, monitoring,
@@ -709,14 +201,10 @@ _mongoc_topology_background_monitoring_reconcile (mongoc_topology_t *topology)
 {
    mongoc_topology_description_t *td;
    mongoc_set_t *server_descriptions;
-   mongoc_set_t *server_monitors;
-   uint32_t *server_monitor_ids_to_remove;
-   uint32_t n_server_monitor_ids_to_remove = 0;
    int i;
 
    td = &topology->description;
    server_descriptions = td->servers;
-   server_monitors = topology->server_monitors;
 
    BSON_ASSERT (!topology->single_threaded);
 
@@ -732,28 +220,10 @@ _mongoc_topology_background_monitoring_reconcile (mongoc_topology_t *topology)
       _background_monitor_reconcile_server_monitor (topology, sd);
    }
 
-   /* Signal shutdown to server monitors no longer in the topology description.
-    */
-   server_monitor_ids_to_remove =
-      bson_malloc0 (sizeof (uint32_t) * server_monitors->items_len);
-   for (i = 0; i < server_monitors->items_len; i++) {
-      mongoc_server_monitor_t *server_monitor;
-      uint32_t id;
-
-      server_monitor = mongoc_set_get_item_and_id (server_monitors, i, &id);
-      if (!mongoc_set_get (server_descriptions, id)) {
-         if (_server_monitor_try_shutdown_and_destroy (server_monitor)) {
-            server_monitor_ids_to_remove[n_server_monitor_ids_to_remove] = id;
-            n_server_monitor_ids_to_remove++;
-         }
-      }
-   }
-
-   /* Remove freed server monitors that have completed shutdown. */
-   for (i = 0; i < n_server_monitor_ids_to_remove; i++) {
-      mongoc_set_rm (server_monitors, server_monitor_ids_to_remove[i]);
-   }
-   bson_free (server_monitor_ids_to_remove);
+   _remove_orphaned_server_monitors (topology->server_monitors,
+                                     server_descriptions);
+   _remove_orphaned_server_monitors (topology->rtt_monitors,
+                                     server_descriptions);
 }
 
 /* Request all server monitors to scan.
@@ -782,7 +252,7 @@ _mongoc_topology_background_monitoring_request_scan (
       uint32_t id;
 
       server_monitor = mongoc_set_get_item_and_id (server_monitors, i, &id);
-      _server_monitor_request_scan (server_monitor);
+      mongoc_server_monitor_request_scan (server_monitor);
    }
 }
 
@@ -809,6 +279,7 @@ _mongoc_topology_background_monitoring_stop (mongoc_topology_t *topology)
    }
 
    topology->scanner_state = MONGOC_TOPOLOGY_SCANNER_SHUTTING_DOWN;
+   TRACE ("%s", "background monitoring stopping");
 
    is_srv_polling = NULL != mongoc_uri_get_service (topology->uri);
    /* Signal SRV polling to shut down (if it is started). */
@@ -819,10 +290,13 @@ _mongoc_topology_background_monitoring_stop (mongoc_topology_t *topology)
    /* Signal all server monitors to shut down. */
    for (i = 0; i < topology->server_monitors->items_len; i++) {
       server_monitor = mongoc_set_get_item (topology->server_monitors, i);
-      bson_mutex_lock (&server_monitor->shared.mutex);
-      server_monitor->shared.shutting_down = true;
-      mongoc_cond_signal (&server_monitor->shared.cond);
-      bson_mutex_unlock (&server_monitor->shared.mutex);
+      mongoc_server_monitor_request_shutdown (server_monitor);
+   }
+
+   /* Signal all RTT monitors to shut down. */
+   for (i = 0; i < topology->rtt_monitors->items_len; i++) {
+      server_monitor = mongoc_set_get_item (topology->rtt_monitors, i);
+      mongoc_server_monitor_request_shutdown (server_monitor);
    }
 
    /* Some mongoc_server_monitor_t may be waiting for topology mutex. Unlock so
@@ -834,10 +308,15 @@ _mongoc_topology_background_monitoring_stop (mongoc_topology_t *topology)
    for (i = 0; i < topology->server_monitors->items_len; i++) {
       /* Wait for the thread to shutdown. */
       server_monitor = mongoc_set_get_item (topology->server_monitors, i);
-      TRACE ("sm (%d) joining thread", server_monitor->server_id);
-      COMMON_PREFIX (thread_join) (server_monitor->thread);
-      TRACE ("sm (%d) thread joined", server_monitor->server_id);
-      _server_monitor_destroy (server_monitor);
+      mongoc_server_monitor_wait_for_shutdown (server_monitor);
+      mongoc_server_monitor_destroy (server_monitor);
+   }
+
+   for (i = 0; i < topology->rtt_monitors->items_len; i++) {
+      /* Wait for the thread to shutdown. */
+      server_monitor = mongoc_set_get_item (topology->rtt_monitors, i);
+      mongoc_server_monitor_wait_for_shutdown (server_monitor);
+      mongoc_server_monitor_destroy (server_monitor);
    }
 
    /* Wait for SRV polling thread. */
@@ -847,7 +326,29 @@ _mongoc_topology_background_monitoring_stop (mongoc_topology_t *topology)
 
    bson_mutex_lock (&topology->mutex);
    mongoc_set_destroy (topology->server_monitors);
+   mongoc_set_destroy (topology->rtt_monitors);
    topology->server_monitors = mongoc_set_new (1, NULL, NULL);
+   topology->rtt_monitors = mongoc_set_new (1, NULL, NULL);
    topology->scanner_state = MONGOC_TOPOLOGY_SCANNER_OFF;
    mongoc_cond_broadcast (&topology->cond_client);
+}
+
+/* Cancel an in-progress streaming ismaster for a specific server (if
+ * applicable).
+ *
+ * Called from application threads on network errors.
+ * Caller must have topology mutex locked.
+ */
+void
+_mongoc_topology_background_monitoring_cancel_check (
+   mongoc_topology_t *topology, uint32_t server_id)
+{
+   mongoc_server_monitor_t *server_monitor;
+
+   server_monitor = mongoc_set_get (topology->server_monitors, server_id);
+   if (!server_monitor) {
+      /* Already removed. */
+      return;
+   }
+   mongoc_server_monitor_request_cancel (server_monitor);
 }

--- a/src/libmongoc/src/mongoc/mongoc-topology-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description.c
@@ -1132,7 +1132,7 @@ mongoc_topology_description_invalidate_server (
    BSON_ASSERT (error);
 
    /* send NULL ismaster reply */
-   mongoc_topology_description_handle_ismaster (topology, id, NULL, 0, error);
+   mongoc_topology_description_handle_ismaster (topology, id, NULL, MONGOC_RTT_UNSET, error);
 }
 
 /*
@@ -1955,6 +1955,7 @@ mongoc_topology_description_handle_ismaster (
 
       if (mongoc_server_description_topology_version_cmp (
              &sd->topology_version, &incoming_topology_version) == 1) {
+         TRACE ("%s", "topology version is strictly less. Skipping.");
          return;
       }
    }
@@ -1999,7 +2000,8 @@ mongoc_topology_description_handle_ismaster (
       if (wrong_set_name) {
          /* Replace with unknown. */
          TRACE ("%s", "wrong set name");
-         mongoc_server_description_handle_ismaster (sd, NULL, 0, &set_name_err);
+         mongoc_server_description_handle_ismaster (
+            sd, NULL, MONGOC_RTT_UNSET, &set_name_err);
       }
    }
 
@@ -2220,7 +2222,8 @@ mongoc_topology_description_reconcile (mongoc_topology_description_t *td,
    mongoc_host_list_t *host;
    _remove_if_not_in_host_list_ctx_t ctx;
 
-   LL_FOREACH(host_list, host) {
+   LL_FOREACH (host_list, host)
+   {
       /* "add" is really an "upsert" */
       mongoc_topology_description_add_server (td, host->host_and_port, NULL);
    }

--- a/src/libmongoc/src/mongoc/mongoc-topology-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-private.h
@@ -101,8 +101,8 @@ typedef struct _mongoc_topology_t {
 
    /* For background monitoring. */
    mongoc_set_t *server_monitors;
+   mongoc_set_t *rtt_monitors;
    bson_mutex_t apm_mutex;
-
 } mongoc_topology_t;
 
 mongoc_topology_t *
@@ -146,6 +146,12 @@ _mongoc_topology_host_by_id (mongoc_topology_t *topology,
                              uint32_t id,
                              bson_error_t *error);
 
+/* TODO: Try to remove this function when CDRIVER-3654 is complete.
+ * It is only called when an application thread needs to mark a server Unknown.
+ * But an application error is also tied to other behavior, and should also
+ * consider the connection generation. This logic is captured in
+ * _mongoc_topology_handle_app_error. This should not be called directly
+ */
 void
 mongoc_topology_invalidate_server (mongoc_topology_t *topology,
                                    uint32_t id,

--- a/src/libmongoc/tests/mock_server/mock-server.h
+++ b/src/libmongoc/tests/mock_server/mock-server.h
@@ -19,6 +19,7 @@
 
 #include <bson/bson.h>
 
+#include "mongoc/mongoc-flags-private.h"
 #include "mongoc/mongoc-uri.h"
 
 #ifdef MONGOC_ENABLE_SSL
@@ -198,6 +199,11 @@ mock_server_replies_to_find (request_t *request,
                              const char *ns,
                              const char *reply_json,
                              bool is_command);
+
+void
+mock_server_replies_opmsg (request_t *request,
+                           mongoc_op_msg_flags_t flags,
+                           const bson_t *doc);
 
 void
 mock_server_reply_multi (request_t *request,

--- a/src/libmongoc/tests/test-mongoc-client-session.c
+++ b/src/libmongoc/tests/test-mongoc-client-session.c
@@ -2624,10 +2624,13 @@ _test_session_dirty_helper (bool retry_succeeds)
       ASSERT_OR_PRINT (ret, error);
    } else {
       BSON_ASSERT (!ret);
-      ASSERT_ERROR_CONTAINS (
-         error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "socket error");
+      ASSERT_ERROR_CONTAINS (error,
+                             MONGOC_ERROR_STREAM,
+                             MONGOC_ERROR_STREAM_SOCKET,
+                             "socket error");
    }
-   /* Regardless of whether the retry succeeded, the session should be marked dirty */
+   /* Regardless of whether the retry succeeded, the session should be marked
+    * dirty */
    BSON_ASSERT (session->server_session->dirty);
 
    CDL_COUNT (client->topology->session_pool, next, pooled_session_count_pre);
@@ -2772,14 +2775,16 @@ test_session_install (TestSuite *suite)
                       NULL,
                       NULL,
                       test_framework_skip_if_no_crypto,
-                      test_framework_skip_if_max_wire_version_less_than_6);
+                      test_framework_skip_if_max_wire_version_less_than_6,
+                      test_framework_skip_if_slow);
    TestSuite_AddFull (suite,
                       "/Session/end/many/pooled",
                       test_end_sessions_many_pooled,
                       NULL,
                       NULL,
                       test_framework_skip_if_no_crypto,
-                      test_framework_skip_if_max_wire_version_less_than_6);
+                      test_framework_skip_if_max_wire_version_less_than_6,
+                      test_framework_skip_if_slow);
    TestSuite_AddFull (suite,
                       "/Session/advance_cluster_time",
                       test_session_advance_cluster_time,
@@ -3013,13 +3018,14 @@ test_session_install (TestSuite *suite)
                                        test_sessions_spec_cb,
                                        test_framework_skip_if_no_sessions);
 
-   TestSuite_AddFull (suite,
-                      "/Session/dirty",
-                      test_session_dirty,
-                      NULL /* dtor */,
-                      NULL /* ctx */,
-                      test_framework_skip_if_no_sessions,
-                      test_framework_skip_if_no_failpoint,
-                      /* Tests with retryable writes, requires non-standalone. */
-                      test_framework_skip_if_single);
+   TestSuite_AddFull (
+      suite,
+      "/Session/dirty",
+      test_session_dirty,
+      NULL /* dtor */,
+      NULL /* ctx */,
+      test_framework_skip_if_no_sessions,
+      test_framework_skip_if_no_failpoint,
+      /* Tests with retryable writes, requires non-standalone. */
+      test_framework_skip_if_single);
 }

--- a/src/libmongoc/tests/test-mongoc-client.c
+++ b/src/libmongoc/tests/test-mongoc-client.c
@@ -3751,6 +3751,67 @@ test_ssl_opts_padding_not_null (void)
 }
 #endif
 
+static void
+test_mongoc_client_recv_network_error (void)
+{
+   mock_server_t *server;
+   mongoc_client_t *client;
+   future_t *future;
+   request_t *request;
+   bson_error_t error;
+   mongoc_server_description_t *sd;
+   int generation;
+   mongoc_rpc_t rpc;
+   mongoc_buffer_t buffer;
+   mongoc_server_stream_t *stream;
+
+   server = mock_server_with_autoismaster (WIRE_VERSION_MAX);
+   mock_server_run (server);
+   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+
+   future = future_client_command_simple (client,
+                                          "admin",
+                                          tmp_bson ("{'ping': 1}"),
+                                          NULL /* read prefs */,
+                                          NULL /* reply */,
+                                          &error);
+   request = mock_server_receives_request (server);
+   mock_server_replies_ok_and_destroys (request);
+   future_wait (future);
+   future_destroy (future);
+
+   /* The server should be a standalone. */
+   sd = mongoc_topology_server_by_id (client->topology, 1, &error);
+   ASSERT_OR_PRINT (sd, error);
+   generation = sd->generation;
+   BSON_ASSERT (sd->type == MONGOC_SERVER_STANDALONE);
+   mongoc_server_description_destroy (sd);
+   mock_server_destroy (server);
+
+   /* A network error when calling _mongoc_client_recv should mark the server
+    * unknown and increment the generation. */
+   _mongoc_buffer_init (&buffer,
+                        NULL /* initial buffer */,
+                        0 /* initial length */,
+                        NULL /* realloc fn */,
+                        NULL /* realloc ctx */);
+   memset (&rpc, 0, sizeof (mongoc_rpc_t));
+   stream = mongoc_cluster_stream_for_server (
+      &client->cluster, 1, false, NULL, NULL, &error);
+   ASSERT_OR_PRINT (stream, error);
+   BSON_ASSERT (!_mongoc_client_recv (client, &rpc, &buffer, stream, &error));
+
+   sd = mongoc_topology_server_by_id (client->topology, 1, &error);
+   ASSERT_OR_PRINT (sd, error);
+   ASSERT_CMPINT (sd->generation, ==, generation + 1);
+   BSON_ASSERT (sd->type == MONGOC_SERVER_UNKNOWN);
+
+   mongoc_server_description_destroy (sd);
+   mongoc_client_destroy (client);
+   _mongoc_buffer_destroy (&buffer);
+   mongoc_server_stream_cleanup (stream);
+}
+
 void
 test_client_install (TestSuite *suite)
 {
@@ -4028,4 +4089,7 @@ test_client_install (TestSuite *suite)
                       test_framework_skip_if_slow);
    TestSuite_Add (suite, "/Client/get_database", test_get_database);
    TestSuite_Add (suite, "/Client/invalid_server_id", test_invalid_server_id);
+   TestSuite_AddMockServerTest (suite,
+                                "/Client/recv_network_error",
+                                test_mongoc_client_recv_network_error);
 }


### PR DESCRIPTION
Implementation of streamable ismaster. Integration tests and unit tests are on another branch and passing. I left them out of this PR to keep it a little smaller.

The pseudocode in the Server Monitoring spec captures the core logic: https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-monitoring.rst#monitor-thread but I've commented inline pointing to relevant sections. 