### PR TITLE
CDRIVER-3701 fix TRACE macro warnings

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1165,6 +1165,7 @@ tasks:
       script: |-
         set -o errexit
         set -o xtrace
+        export CFLAGS="-Werror -Wno-cast-align"
         export DEBUG="ON"
         export TRACING="ON"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh

--- a/build/evergreen_config_lib/tasks.py
+++ b/build/evergreen_config_lib/tasks.py
@@ -251,7 +251,7 @@ all_tasks = [
                           exit 123
                         fi''')]),
     CompileTask('compile-tracing',
-                TRACING='ON'),
+                TRACING='ON', CFLAGS='-Werror -Wno-cast-align'),
     CompileTask('release-compile',
                 config='release',
                 depends_on=OD([('name', 'make-release-archive'),

--- a/src/libmongoc/src/mongoc/mongoc-crypt.c
+++ b/src/libmongoc/src/mongoc/mongoc-crypt.c
@@ -55,6 +55,9 @@ _log_callback (mongocrypt_log_level_t mongocrypt_log_level,
    case MONGOCRYPT_LOG_LEVEL_TRACE:
       log_level = MONGOC_LOG_LEVEL_TRACE;
       break;
+   default:
+      log_level = MONGOC_LOG_LEVEL_CRITICAL;
+      break;
    }
 
    mongoc_log (log_level, MONGOC_LOG_DOMAIN, "%s", message);

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
@@ -107,7 +107,7 @@ _mongoc_stream_tls_secure_channel_destroy (mongoc_stream_t *stream)
     * Shutting Down an Schannel Connection
     */
 
-   TRACE ("shutting down SSL/TLS connection", NULL);
+   TRACE ("%s", "shutting down SSL/TLS connection");
 
    if (secure_channel->cred && secure_channel->ctxt) {
       SecBufferDesc BuffDesc;
@@ -164,7 +164,7 @@ _mongoc_stream_tls_secure_channel_destroy (mongoc_stream_t *stream)
 
    /* free SSPI Schannel API security context handle */
    if (secure_channel->ctxt) {
-      TRACE ("clear security context handle", NULL);
+      TRACE ("%s", "clear security context handle");
       DeleteSecurityContext (&secure_channel->ctxt->ctxt_handle);
       bson_free (secure_channel->ctxt);
    }
@@ -173,7 +173,7 @@ _mongoc_stream_tls_secure_channel_destroy (mongoc_stream_t *stream)
    if (secure_channel->cred) {
       /* decrement the reference counter of the credential/session handle */
       /* if the handle was not cached and the refcount is zero */
-      TRACE ("clear credential handle", NULL);
+      TRACE ("%s", "clear credential handle");
       FreeCredentialsHandle (&secure_channel->cred->cred_handle);
       bson_free (secure_channel->cred);
    }
@@ -371,7 +371,7 @@ _mongoc_stream_tls_secure_channel_writev (mongoc_stream_t *stream,
    BSON_ASSERT (secure_channel);
    ENTRY;
 
-   TRACE ("Trying to write to the server", NULL);
+   TRACE ("%s", "Trying to write to the server");
    tls->timeout_msec = timeout_msec;
 
    TRACE ("count: %d, 0th: %lu", iovcnt, iov[0].iov_len);
@@ -587,7 +587,7 @@ _mongoc_stream_tls_secure_channel_decrypt (
 
          /* check if server wants to renegotiate the connection context */
          if (sspi_status == SEC_I_RENEGOTIATE) {
-            TRACE ("remote party requests renegotiation", NULL);
+            TRACE ("%s", "remote party requests renegotiation");
          }
          /* check if the server closed the connection */
          else if (sspi_status == SEC_I_CONTEXT_EXPIRED) {
@@ -597,11 +597,11 @@ _mongoc_stream_tls_secure_channel_decrypt (
 
             if (!secure_channel->recv_connection_closed) {
                secure_channel->recv_connection_closed = true;
-               TRACE ("server closed the connection", NULL);
+               TRACE ("%s", "server closed the connection");
             }
          }
       } else if (sspi_status == SEC_E_INCOMPLETE_MESSAGE) {
-         TRACE ("failed to decrypt data, need more data", NULL);
+         TRACE ("%s", "failed to decrypt data, need more data");
       } else {
          TRACE ("failed to read data from server: %d", sspi_status);
          secure_channel->recv_unrecoverable_err = true;
@@ -639,7 +639,7 @@ _mongoc_stream_tls_secure_channel_read (mongoc_stream_t *stream,
     */
 
    if (secure_channel->decdata_offset) {
-      TRACE ("decrypted data is already available", NULL);
+      TRACE ("%s", "decrypted data is already available");
       return _mongoc_stream_tls_secure_channel_debuf (secure_channel, buf, len);
    }
 
@@ -654,17 +654,17 @@ _mongoc_stream_tls_secure_channel_read (mongoc_stream_t *stream,
 
    /* keep these checks separated, for more detailed tracing */
    if (secure_channel->recv_unrecoverable_err) {
-      TRACE ("an unrecoverable error occurred in a prior call", NULL);
+      TRACE ("%s", "an unrecoverable error occurred in a prior call");
       return -1;
    }
 
    if (secure_channel->recv_sspi_close_notify) {
-      TRACE ("server indicated shutdown in a prior call", NULL);
+      TRACE ("%s", "server indicated shutdown in a prior call");
       return -1;
    }
 
    if (secure_channel->recv_connection_closed) {
-      TRACE ("connection closed", NULL);
+      TRACE ("%s", "connection closed");
       return -1;
    }
 
@@ -679,7 +679,7 @@ _mongoc_stream_tls_secure_channel_read (mongoc_stream_t *stream,
 
    if (!nread) {
       if (MONGOC_ERRNO_IS_AGAIN (errno)) {
-         TRACE ("Try again", NULL);
+         TRACE ("%s", "Try again");
          return 0;
       } else {
          secure_channel->recv_connection_closed = true;
@@ -836,11 +836,11 @@ mongoc_stream_tls_secure_channel_handshake (mongoc_stream_t *stream,
 
 
       if (mongoc_secure_channel_handshake_step_1 (tls, (char *) host)) {
-         TRACE ("Step#1 Worked!\n\n", NULL);
+         TRACE ("%s", "Step#1 Worked!\n\n");
          *events = POLLIN;
          RETURN (false);
       } else {
-         TRACE ("Step#1 FAILED!", NULL);
+         TRACE ("%s", "Step#1 FAILED!");
       }
 
       break;
@@ -857,7 +857,7 @@ mongoc_stream_tls_secure_channel_handshake (mongoc_stream_t *stream,
          }
          RETURN (false);
       } else {
-         TRACE ("Step#2 FAILED!", NULL);
+         TRACE ("%s", "Step#2 FAILED!");
       }
 
       break;
@@ -865,17 +865,17 @@ mongoc_stream_tls_secure_channel_handshake (mongoc_stream_t *stream,
    case ssl_connect_3:
 
       if (mongoc_secure_channel_handshake_step_3 (tls, (char *) host)) {
-         TRACE ("Step#3 Worked!\n\n", NULL);
+         TRACE ("%s", "Step#3 Worked!\n\n");
          *events = POLLIN | POLLOUT;
          RETURN (false);
       } else {
-         TRACE ("Step#3 FAILED!", NULL);
+         TRACE ("%s", "Step#3 FAILED!");
       }
 
       break;
 
    case ssl_connect_done:
-      TRACE ("Connect DONE!", NULL);
+      TRACE ("%s", "Connect DONE!");
       /* reset our connection state machine */
       secure_channel->connecting_state = ssl_connect_1;
       RETURN (true);
@@ -961,7 +961,7 @@ mongoc_stream_tls_secure_channel_new (mongoc_stream_t *base_stream,
    tls->timeout_msec = -1;
    tls->base_stream = base_stream;
 
-   TRACE ("SSL/TLS connection with endpoint AcquireCredentialsHandle", NULL);
+   TRACE ("%s", "SSL/TLS connection with endpoint AcquireCredentialsHandle");
 
    /* setup Schannel API options */
    memset (&schannel_cred, 0, sizeof (schannel_cred));
@@ -978,15 +978,15 @@ mongoc_stream_tls_secure_channel_new (mongoc_stream_t *base_stream,
       schannel_cred.dwFlags |= SCH_CRED_MANUAL_CRED_VALIDATION |
                                SCH_CRED_IGNORE_NO_REVOCATION_CHECK |
                                SCH_CRED_IGNORE_REVOCATION_OFFLINE;
-      TRACE ("disabled server certificate checks", NULL);
+      TRACE ("%s", "disabled server certificate checks");
    } else if (_mongoc_ssl_opts_disable_certificate_revocation_check (opt)) {
       schannel_cred.dwFlags |= SCH_CRED_IGNORE_NO_REVOCATION_CHECK |
                                SCH_CRED_IGNORE_REVOCATION_OFFLINE;
-      TRACE ("disabled server certificate revocation checks", NULL);
+      TRACE ("%s", "disabled server certificate revocation checks");
    } else {
       schannel_cred.dwFlags |=
          SCH_CRED_AUTO_CRED_VALIDATION | SCH_CRED_REVOCATION_CHECK_CHAIN;
-      TRACE ("enabled server certificate checks", NULL);
+      TRACE ("%s", "enabled server certificate checks");
    }
 
    if (opt->allow_invalid_hostname) {

--- a/src/libmongoc/src/mongoc/mongoc-topology-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description.c
@@ -1998,7 +1998,7 @@ mongoc_topology_description_handle_ismaster (
 
       if (wrong_set_name) {
          /* Replace with unknown. */
-         TRACE ("wrong set name", NULL);
+         TRACE ("%s", "wrong set name");
          mongoc_server_description_handle_ismaster (sd, NULL, 0, &set_name_err);
       }
    }

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -637,7 +637,7 @@ mongoc_topology_rescan_srv (mongoc_topology_t *topology)
       return;
    }
 
-   TRACE ("Polling for SRV records", NULL);
+   TRACE ("%s", "Polling for SRV records");
 
    /* Go forth and query... */
    prefixed_service = bson_strdup_printf ("_mongodb._tcp.%s", service);

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -40,7 +40,7 @@ checks_cleanup (checks_t *checks)
 static bool
 checks_cmp (checks_t *checks, const char *metric, char cmp, int expected)
 {
-   int actual;
+   int actual = 0;
 
    bson_mutex_lock (&checks->mutex);
    if (0 == strcmp (metric, "n_started")) {


### PR DESCRIPTION
Fix gcc warnings for `TRACE` macros with a single string argument (and trailing NULL).

clang doesn't warn for this, but I saw the same warnings with gcc 5.4 in a VM.

Also fixes a couple other warnings I observed, and adds `-Werror` to the evergreen task that builds with tracing. That builds with gcc 5.4. It was already logging warnings:
https://evergreen.mongodb.com/task_log_raw/mongo_c_driver_releng_compile_tracing_e0be759b857bbafb7cdfa9b543c927e94ff27871_20_06_03_18_22_13/0?type=T#L505 but was not treating them as build failures.