### PR TITLE
Ignore libtool object files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.gcno
 *.gz
 *.o
+*.lo
 *.pc
 *.so
 *.so.*


### PR DESCRIPTION
These sometimes show up after compiling the libmongoc submodule for PHPC (often after a failed build). I don't believe they have any permanence, so it should be reasonable to ignore them.