### PR TITLE
Cdriver 3704

### DIFF
--- a/.evergreen/debian_package_build.sh
+++ b/.evergreen/debian_package_build.sh
@@ -41,10 +41,10 @@ cd ..
 
 git clone https://salsa.debian.org/installer-team/debootstrap.git debootstrap.git
 export DEBOOTSTRAP_DIR=`pwd`/debootstrap.git
-# perl-openssl-defaults is explicitly listed to work around https://bugs.debian.org/907015
-sudo -E ./debootstrap.git/debootstrap --include=build-essential,perl-openssl-defaults,git-buildpackage,fakeroot,debhelper,cmake,libssl-dev,pkg-config,python3-sphinx,zlib1g-dev,libicu-dev,libsasl2-dev,libsnappy-dev,libzstd-dev unstable ./unstable-chroot/ http://cdn-aws.deb.debian.org/debian
+sudo -E ./debootstrap.git/debootstrap unstable ./unstable-chroot/ http://cdn-aws.deb.debian.org/debian
 cp -a mongoc ./unstable-chroot/tmp/
 sudo chroot ./unstable-chroot /bin/bash -c "(set -o xtrace && \
+  apt-get install -y build-essential git-buildpackage fakeroot debhelper cmake libssl-dev pkg-config python3-sphinx zlib1g-dev libicu-dev libsasl2-dev libsnappy-dev libzstd-dev && \
   cd /tmp/mongoc && \
   git clean -fdx && \
   git reset --hard HEAD && \

--- a/debian/rules
+++ b/debian/rules
@@ -18,7 +18,6 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 export DEB_LDFLAGS_MAINT_APPEND := -lpthread
 
 ifneq (,$(findstring nodoc,$(DEB_BUILD_OPTIONS)))
-	echo "Found 'nodoc' in 'DEB_BUILD_OPTIONS'; not building documentation"
 	DOCS=OFF
 else
 	DOCS=ON
@@ -29,6 +28,7 @@ endif
 	dh $@
 
 override_dh_auto_configure:
+	[ "$(DOCS)" = "ON" ] || echo "Found 'nodoc' in 'DEB_BUILD_OPTIONS'; not building documentation"
 	dh_auto_configure -- \
 	-DBUILD_VERSION=$(DEB_VERSION_UPSTREAM) \
 	-DENABLE_MONGOC=ON \


### PR DESCRIPTION
The two commits in this PR:
* address the bug identified in CDRIVER-3704
* fix the persistent failure in the `debian-package-build` task by installing build dependencies from within the chroot environment

Evergreen patch build: https://evergreen.mongodb.com/version/5edc5eb0306615560ebd3eff