### PR TITLE
CDRIVER-3708 skip two tests on latest auth replset

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -13464,63 +13464,6 @@ tasks:
       AUTH: noauth
       DNS: 'on'
       SSL: ssl
-- name: test-dns-auth-openssl
-  depends_on:
-    name: debug-compile-sasl-openssl
-  commands:
-  - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
-  - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: ssl
-      TOPOLOGY: replica_set
-      VERSION: latest
-      AUTHSOURCE: thisDB
-  - func: run tests
-    vars:
-      AUTH: auth
-      DNS: dns-auth
-      SSL: ssl
-- name: test-dns-auth-winssl
-  depends_on:
-    name: debug-compile-sspi-winssl
-  commands:
-  - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sspi-winssl
-  - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: ssl
-      TOPOLOGY: replica_set
-      VERSION: latest
-      AUTHSOURCE: thisDB
-  - func: run tests
-    vars:
-      AUTH: auth
-      DNS: dns-auth
-      SSL: ssl
-- name: test-dns-auth-darwinssl
-  depends_on:
-    name: debug-compile-sasl-darwinssl
-  commands:
-  - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
-  - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: ssl
-      TOPOLOGY: replica_set
-      VERSION: latest
-      AUTHSOURCE: thisDB
-  - func: run tests
-    vars:
-      AUTH: auth
-      DNS: dns-auth
-      SSL: ssl
 - name: test-latest-server-compression-zlib
   tags:
   - compression
@@ -16696,7 +16639,6 @@ buildvariants:
   - .4.2 .openssl !.nosasl .server
   - .4.0 .openssl !.nosasl .server
   - test-dns-openssl
-  - test-dns-auth-openssl
 - name: darwin
   display_name: '*Darwin, macOS (Apple LLVM)'
   expansions:
@@ -16723,7 +16665,6 @@ buildvariants:
   - .3.2 .darwinssl !.nosasl .server
   - .3.2 .nossl
   - test-dns-darwinssl
-  - test-dns-auth-darwinssl
   - debug-compile-lto
   - debug-compile-lto-thin
   - debug-compile-aws
@@ -16757,7 +16698,6 @@ buildvariants:
   - .nosasl .latest .nossl
   - .sspi .latest
   - test-dns-winssl
-  - test-dns-auth-winssl
   - debug-compile-aws
   - test-aws-openssl-regular
 - name: windows-2015

--- a/build/evergreen_config_lib/tasks.py
+++ b/build/evergreen_config_lib/tasks.py
@@ -571,7 +571,8 @@ all_tasks = chain(all_tasks, IntegrationTask.matrix())
 
 
 class DNSTask(MatrixTask):
-    axes = OD([('auth', [False, True]),
+    # TODO: CDRIVER-3708, change [False] back to [False, True] to test with auth again.
+    axes = OD([('auth', [False]),
                ('ssl', ['openssl', 'winssl', 'darwinssl'])])
 
     name_prefix = 'test-dns'

--- a/build/evergreen_config_lib/variants.py
+++ b/build/evergreen_config_lib/variants.py
@@ -290,8 +290,9 @@ all_variants = [
              'retry-true-latest-server',
              '.4.2 .openssl !.nosasl .server',
              '.4.0 .openssl !.nosasl .server',
-             'test-dns-openssl',
-             'test-dns-auth-openssl'],
+             'test-dns-openssl'
+             # 'test-dns-auth-openssl' TODO CDRIVER-3708 add this back
+             ],
             {'CC': 'gcc'}),
     Variant('darwin',
             '*Darwin, macOS (Apple LLVM)',
@@ -317,7 +318,7 @@ all_variants = [
              '.3.2 .darwinssl !.nosasl .server',
              '.3.2 .nossl',
              'test-dns-darwinssl',
-             'test-dns-auth-darwinssl',
+             # 'test-dns-auth-darwinssl', TODO CDRIVER-3708 add this back
              'debug-compile-lto',
              'debug-compile-lto-thin',
              'debug-compile-aws',
@@ -349,7 +350,7 @@ all_variants = [
              '.nosasl .latest .nossl',
              '.sspi .latest',
              'test-dns-winssl',
-             'test-dns-auth-winssl',
+             # 'test-dns-auth-winssl', TODO CDRIVER-3708 add this back
              'debug-compile-aws',
              'test-aws-openssl-regular'
              ],

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -2400,6 +2400,20 @@ test_framework_skip_if_time_sensitive (void)
 #endif
 }
 
+int
+test_framework_skip_due_to_cdriver3708 (void)
+{
+   if (0 == test_framework_skip_if_auth () &&
+       0 == test_framework_skip_if_replset () &&
+       test_framework_get_server_version () >
+          test_framework_str_to_version ("4.4.0")) {
+      /* If auth is enabled, we're using a replica set, and using a > 4.4
+       * server, skip test. */
+      return 0;
+   }
+   return 1;
+}
+
 static char MONGOC_TEST_UNIQUE[32];
 
 #if defined(_MSC_VER) && defined(_WIN64)

--- a/src/libmongoc/tests/test-libmongoc.h
+++ b/src/libmongoc/tests/test-libmongoc.h
@@ -219,4 +219,7 @@ test_framework_skip_if_no_aws (void);
 int
 test_framework_skip_if_no_setenv (void);
 
+int
+test_framework_skip_due_to_cdriver3708 (void);
+
 #endif

--- a/src/libmongoc/tests/test-mongoc-client.c
+++ b/src/libmongoc/tests/test-mongoc-client.c
@@ -2411,20 +2411,18 @@ test_mongoc_client_get_description_pooled (void)
    _test_mongoc_client_get_description (true);
 }
 
-
 static void
-test_mongoc_client_descriptions (void)
+test_mongoc_client_descriptions_single (void)
 {
    mongoc_client_t *client;
-   mongoc_client_pool_t *pool;
    mongoc_server_description_t **sds;
    size_t n, expected_n;
    bson_error_t error;
    bool r;
    bson_t *ping = tmp_bson ("{'ping': 1}");
-   int64_t start;
 
    expected_n = test_framework_server_count ();
+   n = 0;
 
    /*
     * single-threaded
@@ -2444,6 +2442,19 @@ test_mongoc_client_descriptions (void)
 
    mongoc_server_descriptions_destroy_all (sds, n);
    mongoc_client_destroy (client);
+}
+
+static void
+test_mongoc_client_descriptions_pooled (void *unused)
+{
+   mongoc_client_t *client;
+   mongoc_client_pool_t *pool;
+   mongoc_server_description_t **sds;
+   size_t n, expected_n;
+   int64_t start;
+
+   expected_n = test_framework_server_count ();
+   n = 0;
 
    /*
     * pooled
@@ -3969,8 +3980,16 @@ test_client_install (TestSuite *suite)
    TestSuite_AddLive (suite,
                       "/Client/get_description/pooled",
                       test_mongoc_client_get_description_pooled);
-   TestSuite_AddLive (
-      suite, "/Client/descriptions", test_mongoc_client_descriptions);
+   TestSuite_AddLive (suite,
+                      "/Client/descriptions/single",
+                      test_mongoc_client_descriptions_single);
+   TestSuite_AddFull (suite,
+                      "/Client/descriptions/pooled",
+                      test_mongoc_client_descriptions_pooled,
+                      NULL,
+                      NULL,
+                      TestSuite_CheckLive,
+                      test_framework_skip_due_to_cdriver3708);
    TestSuite_AddLive (suite,
                       "/Client/select_server/single",
                       test_mongoc_client_select_server_single);


### PR DESCRIPTION
Until SERVER-48715 is resolved, skip tests with auth against a >4.4 replica set that rely on arbiters being discovered.

Also skips the test failure described in CDRIVER-3709.

[CDRIVER-3708](https://jira.mongodb.org/browse/CDRIVER-3708) has more context.