### PR TITLE
CDRIVER-3722 update docs for bg scanning

### DIFF
--- a/src/libmongoc/doc/connection-pooling.rst
+++ b/src/libmongoc/doc/connection-pooling.rst
@@ -3,7 +3,7 @@
 Connection Pooling
 ==================
 
-The MongoDB C driver has two connection modes: single-threaded and pooled. Single-threaded mode is optimized for embedding the driver within languages like PHP. Multi-threaded programs should use pooled mode: this mode minimizes the total connection count, and in pooled mode a background thread monitors the MongoDB server topology, so the program need not block to scan it.
+The MongoDB C driver has two connection modes: single-threaded and pooled. Single-threaded mode is optimized for embedding the driver within languages like PHP. Multi-threaded programs should use pooled mode: this mode minimizes the total connection count, and in pooled mode background threads monitor the MongoDB server topology, so the program need not block to scan it.
 
 Single Mode
 -----------
@@ -33,7 +33,7 @@ To activate pooled mode, create a :symbol:`mongoc_client_pool_t`:
 
   mongoc_client_pool_t *pool = mongoc_client_pool_new (uri);
 
-When your program first calls :symbol:`mongoc_client_pool_pop`, the pool launches a background thread for monitoring. The thread fans out and connects to all servers in the connection string, using non-blocking sockets and a simple event loop. As it receives ismaster responses from the servers, it updates its view of the server topology. Each time the thread discovers a new server it begins connecting to it, and adds the new socket to the list of non-blocking sockets in the event loop.
+When your program first calls :symbol:`mongoc_client_pool_pop`, the pool launches monitoring threads in the background. Monitoring threads independently connect to all servers in the connection string. As monitoring threads receive ismaster responses from the servers, they update the shared view of the server topology. Additional monitoring threads and connections are created as new servers are discovered. Monitoring threads are terminated when servers are removed from the shared view of the server topology.
 
 Each thread that executes MongoDB operations must check out a client from the pool:
 
@@ -49,7 +49,7 @@ The :symbol:`mongoc_client_t` object is not thread-safe, only the :symbol:`mongo
 
 When the driver is in pooled mode, your program's operations are unblocked as soon as monitoring discovers a usable server. For example, if a thread in your program is waiting to execute an "insert" on the primary, it is unblocked as soon as the primary is discovered, rather than waiting for all secondaries to be checked as well.
 
-The pool opens one connection per server for monitoring, and each client opens its own connection to each server it uses for application operations. The background thread re-scans the server topology roughly every 10 seconds. This interval is configurable with ``heartbeatFrequencyMS`` in the connection string. (See :symbol:`mongoc_uri_t`.)
+The pool opens one connection per server for monitoring, and each client opens its own connection to each server it uses for application operations. Background monitoring threads re-scan servers independently roughly every 10 seconds. This interval is configurable with ``heartbeatFrequencyMS`` in the connection string. (See :symbol:`mongoc_uri_t`.)
 
 The connection string can also specify ``waitQueueTimeoutMS`` to limit the time that :symbol:`mongoc_client_pool_pop` will wait for a client from the pool.  (See :symbol:`mongoc_uri_t`.)  If ``waitQueueTimeoutMS`` is specified, then it is necessary to confirm that a client was actually returned:
 


### PR DESCRIPTION
Multi-threaded monitoring now creates separate threads per server (up
to two per server after CDRIVER-3535).