### PR TITLE
CDRIVER-3322 warning log with destroying unused session in pooled mode

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-buffer.c
+++ b/src/libmongoc/src/mongoc/mongoc-buffer.c
@@ -136,16 +136,10 @@ _mongoc_buffer_append (mongoc_buffer_t *buffer,
    BSON_ASSERT (buffer->datalen);
 
    if (!SPACE_FOR (buffer, data_size)) {
-      if (buffer->len) {
-         memmove (&buffer->data[0], buffer->data, buffer->len);
-      }
-
-      if (!SPACE_FOR (buffer, data_size)) {
-         BSON_ASSERT ((buffer->datalen + data_size) < INT_MAX);
-         buffer->datalen = bson_next_power_of_two (data_size + buffer->len);
-         buffer->data = (uint8_t *) buffer->realloc_func (
-            buffer->data, buffer->datalen, NULL);
-      }
+      BSON_ASSERT ((buffer->datalen + data_size) < INT_MAX);
+      buffer->datalen = bson_next_power_of_two (data_size + buffer->len);
+      buffer->data =
+         (uint8_t *) buffer->realloc_func (buffer->data, buffer->datalen, NULL);
    }
 
    buf = &buffer->data[buffer->len];
@@ -193,16 +187,10 @@ _mongoc_buffer_append_from_stream (mongoc_buffer_t *buffer,
    BSON_ASSERT (buffer->datalen);
 
    if (!SPACE_FOR (buffer, size)) {
-      if (buffer->len) {
-         memmove (&buffer->data[0], buffer->data, buffer->len);
-      }
-
-      if (!SPACE_FOR (buffer, size)) {
-         BSON_ASSERT ((buffer->datalen + size) < INT_MAX);
-         buffer->datalen = bson_next_power_of_two (size + buffer->len);
-         buffer->data = (uint8_t *) buffer->realloc_func (
-            buffer->data, buffer->datalen, NULL);
-      }
+      BSON_ASSERT ((buffer->datalen + size) < INT_MAX);
+      buffer->datalen = bson_next_power_of_two (size + buffer->len);
+      buffer->data =
+         (uint8_t *) buffer->realloc_func (buffer->data, buffer->datalen, NULL);
    }
 
    buf = &buffer->data[buffer->len];
@@ -260,10 +248,6 @@ _mongoc_buffer_fill (mongoc_buffer_t *buffer,
    }
 
    min_bytes -= buffer->len;
-
-   if (buffer->len) {
-      memmove (&buffer->data[0], buffer->data, buffer->len);
-   }
 
    if (!SPACE_FOR (buffer, min_bytes)) {
       buffer->datalen = bson_next_power_of_two (buffer->len + min_bytes);

--- a/src/libmongoc/src/mongoc/mongoc-client-session-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-session-private.h
@@ -27,6 +27,7 @@
 #define UNKNOWN_COMMIT_RESULT "UnknownTransactionCommitResult"
 #define MAX_TIME_MS_EXPIRED "MaxTimeMSExpired"
 #define DEFAULT_MAX_COMMIT_TIME_MS 0
+#define SESSION_NEVER_USED (-1)
 
 #define MONGOC_DEFAULT_WTIMEOUT_FOR_COMMIT_RETRY 10000
 

--- a/src/libmongoc/src/mongoc/mongoc-client-session.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-session.c
@@ -24,8 +24,6 @@
 #include "mongoc-read-prefs-private.h"
 #include "mongoc-error-private.h"
 
-#define SESSION_NEVER_USED (-1)
-
 #define WITH_TXN_TIMEOUT_MS (120 * 1000)
 
 static void

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -34,8 +34,6 @@
 
 #include "utlist.h"
 
-#define SESSION_NEVER_USED (-1)
-
 static void
 _topology_collect_errors (mongoc_topology_t *topology, bson_error_t *error_out);
 

--- a/src/libmongoc/tests/test-mongoc-client-pool.c
+++ b/src/libmongoc/tests/test-mongoc-client-pool.c
@@ -363,7 +363,7 @@ test_client_pool_destroy_without_pushing (void)
 
 /* tests that creating and destroying session is ok */
 static void
-test_mongoc_client_pool_create_unused_session (void)
+test_client_pool_create_unused_session (void)
 {
    mongoc_client_t *client;
    mongoc_client_pool_t *pool;
@@ -383,7 +383,9 @@ test_mongoc_client_pool_create_unused_session (void)
    ASSERT_NO_CAPTURED_LOGS (error.message);
 
    mongoc_client_session_destroy (session);
+   ASSERT_NO_CAPTURED_LOGS (error.message);
    mongoc_client_pool_push (pool, client);
+   ASSERT_NO_CAPTURED_LOGS (error.message);
    mongoc_client_pool_destroy (pool);
    ASSERT_NO_CAPTURED_LOGS (error.message);
 }
@@ -411,8 +413,8 @@ test_client_pool_install (TestSuite *suite)
       suite, "/ClientPool/handshake", test_mongoc_client_pool_handshake);
 
    TestSuite_Add (suite,
-                  "/ClientPool/create_unused_session",
-                  test_mongoc_client_pool_create_unused_session);
+                  "/ClientPool/create_client_pool_unused_session",
+                  test_client_pool_create_unused_session);
 #ifndef MONGOC_ENABLE_SSL
    TestSuite_Add (
       suite, "/ClientPool/ssl_disabled", test_mongoc_client_pool_ssl_disabled);

--- a/src/libmongoc/tests/test-mongoc-client-pool.c
+++ b/src/libmongoc/tests/test-mongoc-client-pool.c
@@ -378,7 +378,7 @@ command_started_cb (const mongoc_apm_command_started_t *event)
 /* tests that creating and destroying an unused session
  * in pooled mode does not result in an error log */
 static void
-test_client_pool_create_unused_session (void)
+test_client_pool_create_unused_session (void *context)
 {
    mongoc_client_t *client;
    mongoc_client_pool_t *pool;
@@ -427,9 +427,12 @@ test_client_pool_install (TestSuite *suite)
    TestSuite_Add (
       suite, "/ClientPool/handshake", test_mongoc_client_pool_handshake);
 
-   TestSuite_Add (suite,
-                  "/ClientPool/create_client_pool_unused_session",
-                  test_client_pool_create_unused_session);
+   TestSuite_AddFull (suite,
+                      "/ClientPool/create_client_pool_unused_session",
+                      test_client_pool_create_unused_session,
+                      NULL /* dtor */,
+                      NULL /* ctx */,
+                      test_framework_skip_if_no_sessions);
 #ifndef MONGOC_ENABLE_SSL
    TestSuite_Add (
       suite, "/ClientPool/ssl_disabled", test_mongoc_client_pool_ssl_disabled);

--- a/src/libmongoc/tests/test-mongoc-client-session.c
+++ b/src/libmongoc/tests/test-mongoc-client-session.c
@@ -762,19 +762,24 @@ static void
 send_ping (mongoc_client_t *client, mongoc_client_session_t *client_session)
 {
    bson_t ping_cmd = BSON_INITIALIZER;
+   bson_t opts = BSON_INITIALIZER;
    bson_error_t error;
    bool ret;
 
    BCON_APPEND (&ping_cmd, "ping", BCON_INT32 (1));
 
+   ret = mongoc_client_session_append (client_session, &opts, &error);
+   ASSERT_OR_PRINT(ret, error);
+
    ret = mongoc_client_command_with_opts (client,
                                           "admin",
                                           &ping_cmd,
                                           NULL,
-                                          &client_session->server_session->lsid,
+                                          &opts,
                                           NULL,
                                           &error);
    ASSERT_OR_PRINT (ret, error);
+   bson_destroy(&opts);
    bson_destroy (&ping_cmd);
 }
 
@@ -820,7 +825,7 @@ _test_end_sessions_many (bool pooled)
    endsessions_test_get_ended_lsids (&test, 0, &ended_lsids);
    ASSERT_CMPINT (bson_count_keys (&ended_lsids), ==, 10000);
    endsessions_test_get_ended_lsids (&test, 1, &ended_lsids);
-   ASSERT_CMPINT (bson_count_keys (&ended_lsids), ==, 2);
+   ASSERT_CMPINT (bson_count_keys (&ended_lsids), ==, 1);
 
    endsessions_test_cleanup (&test);
 }


### PR DESCRIPTION
When in pooling mode, destroying a session that had never been used produced a warning log.  Fixed by not pushing unused sessions to session_pool for being reused because server is unaware of the existence of the session.