### PR TITLE
CDRIVER-3725 fix uninitialized read

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-cluster-sspi.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-sspi.c
@@ -266,8 +266,9 @@ _mongoc_cluster_auth_node_sspi (mongoc_cluster_t *cluster,
 
       tmpstr = bson_iter_utf8 (&iter, &buflen);
       bson_free (buf);
-      buf = bson_malloc (sizeof (SEC_CHAR) * buflen);
+      buf = bson_malloc (sizeof (SEC_CHAR) * (buflen + 1));
       memcpy (buf, tmpstr, buflen);
+      buf[buflen] = (SEC_CHAR) 0;
 
       bson_destroy (&reply);
    }


### PR DESCRIPTION
A fix to a bug I introduced in CDRIVER-3486.

There are no tests. AFAICT the uninitialized reads would be happening in the current SSPI authentication tests on evergreen. The uninitialized read shows up in Dr. Memory for me locally, but still succeeds at authenticating with Kerberos.