### PR TITLE
CDRIVER-3612 do not accept explicit session for collection count

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-collection.c
+++ b/src/libmongoc/src/mongoc/mongoc-collection.c
@@ -810,6 +810,14 @@ mongoc_collection_estimated_document_count (
 
    BSON_ASSERT_PARAM (coll);
 
+   if (opts && bson_has_field (opts, "sessionId")) {
+      bson_set_error (error,
+                      MONGOC_ERROR_COMMAND,
+                      MONGOC_ERROR_COMMAND_INVALID_ARG,
+                      "Collection count must not specify explicit session");
+      GOTO (done);
+   }
+
    reply_ptr = reply ? reply : &reply_local;
    bson_append_utf8 (&cmd, "count", 5, coll->collection, coll->collectionlen);
 
@@ -832,6 +840,7 @@ mongoc_collection_estimated_document_count (
       }
    }
 
+done:
    if (!reply) {
       bson_destroy (&reply_local);
    }

--- a/src/libmongoc/tests/test-mongoc-client-session.c
+++ b/src/libmongoc/tests/test-mongoc-client-session.c
@@ -1598,6 +1598,15 @@ run_session_test_bulk_operation (void *ctx)
 
 
 static void
+run_count_test (session_test_fn_t test_fn)
+{
+   /* CDRIVER-3612: mongoc_collection_estimated_document_count does not support
+    * explicit sessions */
+   _test_implicit_session_lsid (test_fn);
+}
+
+
+static void
 insert_10_docs (session_test_t *test)
 {
    mongoc_bulk_operation_t *bulk;
@@ -2808,7 +2817,13 @@ test_session_install (TestSuite *suite)
    add_session_test (
       suite, "/Session/read_write_cmd", test_read_write_cmd, true);
    add_session_test (suite, "/Session/db_cmd", test_db_cmd, false);
-   add_session_test (suite, "/Session/count", test_count, true);
+   TestSuite_AddFull (suite,
+                      "/Session/count",
+                      (void *) run_count_test,
+                      NULL,
+                      (void *) test_count,
+                      test_framework_skip_if_no_cluster_time,
+                      test_framework_skip_if_no_crypto);
    add_session_test (suite, "/Session/cursor", test_cursor, true);
    add_session_test (suite, "/Session/drop", test_drop, false);
    add_session_test (suite, "/Session/drop_index", test_drop_index, false);

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -2621,6 +2621,18 @@ test_estimated_document_count (void)
    ASSERT_OR_PRINT (123 == future_get_int64_t (future), error);
    ASSERT_MATCH (&reply, server_reply);
 
+   future_destroy (future);
+
+   /* CDRIVER-3612: ensure that an explicit session triggers a client error */
+   future = future_collection_estimated_document_count (
+      collection, tmp_bson ("{'sessionId': 123}"), NULL, &reply, &error);
+
+   ASSERT (-1 == future_get_int64_t (future));
+   ASSERT_ERROR_CONTAINS (error,
+                          MONGOC_ERROR_COMMAND,
+                          MONGOC_ERROR_COMMAND_INVALID_ARG,
+                          "Collection count must not specify explicit session");
+
    bson_destroy (&reply);
    request_destroy (request);
    future_destroy (future);

--- a/src/libmongoc/tests/test-mongoc-retryable-reads.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-reads.c
@@ -16,8 +16,19 @@ retryable_reads_test_run_operation (json_test_ctx_t *ctx,
 {
    bool *explicit_session = (bool *) ctx->config->ctx;
    bson_t reply;
+   bson_iter_t iter;
+   const char *op_name;
+   uint32_t op_len;
    bool res;
 
+   bson_iter_init_find (&iter, operation, "name");
+   op_name = bson_iter_utf8 (&iter, &op_len);
+   if (strcmp (op_name, "estimatedDocumentCount") == 0 ||
+       strcmp (op_name, "count") == 0) {
+      /* CDRIVER-3612: mongoc_collection_estimated_document_count does not
+       * support explicit sessions */
+      *explicit_session = false;
+   }
    res = json_test_operation (ctx,
                               test,
                               operation,


### PR DESCRIPTION
Full patch build: https://spruce.mongodb.com/version/5ef65493d1fe072a882ec1cf/tasks