### PR TITLE
CDRIVER-3535 integration tests + RTT test

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-server-monitor.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-monitor.c
@@ -395,13 +395,14 @@ _server_monitor_poll_with_interrupt (mongoc_server_monitor_t *server_monitor,
    const int32_t monitor_tick_ms = 500;
    int64_t timeleft_ms;
 
-   MONITOR_LOG (server_monitor,
-                "_server_monitor_poll_with_interrupt expire_at_ms: %" PRIu64,
-                expire_at_ms);
    while ((timeleft_ms = expire_at_ms - _now_ms ()) > 0) {
       ssize_t ret;
       mongoc_stream_poll_t poller[1];
 
+      MONITOR_LOG (server_monitor,
+                   "_server_monitor_poll_with_interrupt expires in: %" PRIu64
+                   "ms",
+                   timeleft_ms);
       poller[0].stream = server_monitor->stream;
       poller[0].events =
          POLLIN; /* POLLERR and POLLHUP are added in mongoc_socket_poll. */

--- a/src/libmongoc/tests/TestSuite.c
+++ b/src/libmongoc/tests/TestSuite.c
@@ -943,6 +943,7 @@ int
 TestSuite_Run (TestSuite *suite) /* IN */
 {
    int failures = 0;
+   int64_t start_us;
 
    if (suite->flags & TEST_HELPTEXT) {
       TestSuite_PrintHelp (suite);
@@ -963,6 +964,7 @@ TestSuite_Run (TestSuite *suite) /* IN */
       }
    }
 
+   start_us = bson_get_monotonic_time ();
    if (suite->tests) {
       if (suite->testname) {
          failures += TestSuite_RunNamed (suite, suite->testname);
@@ -975,6 +977,8 @@ TestSuite_Run (TestSuite *suite) /* IN */
          TestSuite_PrintJsonFooter (suite->outfile);
       }
    }
+   MONGOC_DEBUG ("Duration of all tests (s): %" PRId64,
+                 (bson_get_monotonic_time () - start_us) / (1000 * 1000));
 
    return failures;
 }

--- a/src/libmongoc/tests/json-test-monitoring.h
+++ b/src/libmongoc/tests/json-test-monitoring.h
@@ -31,6 +31,9 @@ void
 set_apm_callbacks (json_test_ctx_t *ctx, mongoc_client_t *client);
 
 void
+set_apm_callbacks_pooled (json_test_ctx_t *ctx, mongoc_client_pool_t *pool);
+
+void
 check_json_apm_events (json_test_ctx_t *ctx, const bson_t *expectations);
 
 #endif

--- a/src/libmongoc/tests/json-test-operations.h
+++ b/src/libmongoc/tests/json-test-operations.h
@@ -19,7 +19,22 @@
 
 struct _json_test_config_t;
 
+#include "mongoc/mongoc-thread-private.h"
+#include "common-thread-private.h"
+#include "mock_server/sync-queue.h"
+
+struct _json_test_ctx_t;
+
 typedef struct {
+   struct _json_test_ctx_t *ctx;
+   bson_thread_t thread;
+   sync_queue_t *queue;
+   bson_mutex_t mutex;
+   mongoc_cond_t cond;
+   bool shutdown_requested;
+} json_test_worker_thread_t;
+
+typedef struct _json_test_ctx_t {
    const struct _json_test_config_t *config;
    uint32_t n_events;
    bson_t events;
@@ -35,6 +50,20 @@ typedef struct {
    mongoc_change_stream_t *change_stream;
    /* Sessions tests check the most recently sent two lsid's */
    bson_t *sent_lsids[2];
+   bson_mutex_t mutex;
+   /* The total number of times a server description was marked unknown. */
+   int64_t total_ServerMarkedUnknownEvent;
+   /* How many were accounted for in the test. */
+   int64_t measured_ServerMarkedUnknownEvent;
+   /* How many connection generation increments were accounted for in the test.
+    */
+   int64_t measured_PoolClearedEvent;
+   mongoc_host_list_t primary_host;
+
+   int64_t total_PrimaryChangedEvent;
+   int64_t measured_PrimaryChangedEvent;
+
+   json_test_worker_thread_t *worker_threads[2];
 } json_test_ctx_t;
 
 mongoc_client_session_t *
@@ -77,5 +106,11 @@ check_result (const bson_t *test,
               bool succeeded,
               const bson_value_t *result,
               const bson_error_t *error);
+
+json_test_worker_thread_t *
+worker_thread_new (json_test_ctx_t *ctx);
+
+void
+worker_thread_destroy (json_test_worker_thread_t *wt);
 
 #endif

--- a/src/libmongoc/tests/json-test.c
+++ b/src/libmongoc/tests/json-test.c
@@ -1099,7 +1099,7 @@ DONE:
 }
 
 
-static void
+void
 check_outcome_collection (mongoc_collection_t *collection, bson_t *test)
 {
    bson_t data;
@@ -1108,6 +1108,7 @@ check_outcome_collection (mongoc_collection_t *collection, bson_t *test)
    mongoc_cursor_t *cursor;
    bson_t query = BSON_INITIALIZER;
    mongoc_read_prefs_t *prefs = mongoc_read_prefs_new (MONGOC_READ_PRIMARY);
+   bson_t opts = BSON_INITIALIZER;
 
    bson_lookup_doc (test, "outcome.collection.data", &data);
    ASSERT (bson_iter_init (&iter, &data));
@@ -1121,7 +1122,9 @@ check_outcome_collection (mongoc_collection_t *collection, bson_t *test)
       mongoc_collection_set_read_concern (collection, rc);
    }
 
-   cursor = mongoc_collection_find_with_opts (collection, &query, NULL, prefs);
+   BCON_APPEND (&opts, "sort", "{", "_id", BCON_INT32 (1), "}");
+   cursor = mongoc_collection_find_with_opts (collection, &query, &opts, prefs);
+   bson_destroy (&opts);
 
    while (bson_iter_next (&iter)) {
       bson_t expected_doc;

--- a/src/libmongoc/tests/json-test.h
+++ b/src/libmongoc/tests/json-test.h
@@ -105,4 +105,18 @@ install_json_test_suite (TestSuite *suite,
 #define install_json_test_suite_with_check(_suite, _dir_path, ...) \
    _install_json_test_suite_with_check (_suite, _dir_path, __VA_ARGS__, NULL)
 
+void
+set_uri_opts_from_bson (mongoc_uri_t *uri, const bson_t *opts);
+
+void
+insert_data (const char *db_name,
+             const char *collection_name,
+             const bson_t *scenario);
+
+bool
+check_scenario_version (const bson_t *scenario);
+
+void
+check_outcome_collection (mongoc_collection_t *collection, bson_t *test);
+
 #endif

--- a/src/libmongoc/tests/json/server_discovery_and_monitoring/integration/cancel-server-check.json
+++ b/src/libmongoc/tests/json/server_discovery_and_monitoring/integration/cancel-server-check.json
@@ -1,0 +1,130 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.2",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "sdam-tests",
+  "collection_name": "cancel-server-check",
+  "data": [],
+  "tests": [
+    {
+      "description": "Cancel server check",
+      "clientOptions": {
+        "retryWrites": true,
+        "heartbeatFrequencyMS": 10000,
+        "serverSelectionTimeoutMS": 5000,
+        "appname": "cancelServerCheckTest"
+      },
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 1
+            }
+          }
+        },
+        {
+          "name": "configureFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 2
+            }
+          },
+          "result": {
+            "insertedId": 2
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/libmongoc/tests/json/server_discovery_and_monitoring/integration/find-network-error.json
+++ b/src/libmongoc/tests/json/server_discovery_and_monitoring/integration/find-network-error.json
@@ -1,0 +1,144 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.4"
+    }
+  ],
+  "database_name": "sdam-tests",
+  "collection_name": "find-network-error",
+  "data": [
+    {
+      "_id": 1
+    },
+    {
+      "_id": 2
+    }
+  ],
+  "tests": [
+    {
+      "description": "Reset server and pool after network error on find",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "find"
+          ],
+          "closeConnection": true,
+          "appName": "findNetworkErrorTest"
+        }
+      },
+      "clientOptions": {
+        "retryWrites": false,
+        "retryReads": false,
+        "appname": "findNetworkErrorTest"
+      },
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            }
+          },
+          "error": true
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 5
+              },
+              {
+                "_id": 6
+              }
+            ]
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "find": "find-network-error"
+            },
+            "command_name": "find",
+            "database_name": "sdam-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "find-network-error",
+              "documents": [
+                {
+                  "_id": 5
+                },
+                {
+                  "_id": 6
+                }
+              ]
+            },
+            "command_name": "insert",
+            "database_name": "sdam-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 5
+            },
+            {
+              "_id": 6
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/libmongoc/tests/json/server_discovery_and_monitoring/integration/find-shutdown-error.json
+++ b/src/libmongoc/tests/json/server_discovery_and_monitoring/integration/find-shutdown-error.json
@@ -1,0 +1,168 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.4"
+    }
+  ],
+  "database_name": "sdam-tests",
+  "collection_name": "find-shutdown-error",
+  "data": [],
+  "tests": [
+    {
+      "description": "Concurrent shutdown error on find",
+      "clientOptions": {
+        "retryWrites": false,
+        "retryReads": false,
+        "heartbeatFrequencyMS": 500,
+        "appname": "shutdownErrorFindTest"
+      },
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 1
+            }
+          }
+        },
+        {
+          "name": "configureFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "appName": "shutdownErrorFindTest",
+                "errorCode": 91,
+                "blockConnection": true,
+                "blockTimeMS": 500
+              }
+            }
+          }
+        },
+        {
+          "name": "startThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread1"
+          }
+        },
+        {
+          "name": "startThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread2"
+          }
+        },
+        {
+          "name": "runOnThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread1",
+            "operation": {
+              "name": "find",
+              "object": "collection",
+              "arguments": {
+                "filter": {
+                  "_id": 1
+                }
+              },
+              "error": true
+            }
+          }
+        },
+        {
+          "name": "runOnThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread2",
+            "operation": {
+              "name": "find",
+              "object": "collection",
+              "arguments": {
+                "filter": {
+                  "_id": 1
+                }
+              },
+              "error": true
+            }
+          }
+        },
+        {
+          "name": "waitForThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread1"
+          }
+        },
+        {
+          "name": "waitForThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread2"
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 4
+            }
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 4
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/libmongoc/tests/json/server_discovery_and_monitoring/integration/insert-network-error.json
+++ b/src/libmongoc/tests/json/server_discovery_and_monitoring/integration/insert-network-error.json
@@ -1,0 +1,156 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.4"
+    }
+  ],
+  "database_name": "sdam-tests",
+  "collection_name": "insert-network-error",
+  "data": [
+    {
+      "_id": 1
+    },
+    {
+      "_id": 2
+    }
+  ],
+  "tests": [
+    {
+      "description": "Reset server and pool after network error on insert",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "insert"
+          ],
+          "closeConnection": true,
+          "appName": "insertNetworkErrorTest"
+        }
+      },
+      "clientOptions": {
+        "retryWrites": false,
+        "appname": "insertNetworkErrorTest"
+      },
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 3
+              },
+              {
+                "_id": 4
+              }
+            ]
+          },
+          "error": true
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 5
+              },
+              {
+                "_id": 6
+              }
+            ]
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "insert-network-error",
+              "documents": [
+                {
+                  "_id": 3
+                },
+                {
+                  "_id": 4
+                }
+              ]
+            },
+            "command_name": "insert",
+            "database_name": "sdam-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "insert-network-error",
+              "documents": [
+                {
+                  "_id": 5
+                },
+                {
+                  "_id": 6
+                }
+              ]
+            },
+            "command_name": "insert",
+            "database_name": "sdam-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 5
+            },
+            {
+              "_id": 6
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/libmongoc/tests/json/server_discovery_and_monitoring/integration/insert-shutdown-error.json
+++ b/src/libmongoc/tests/json/server_discovery_and_monitoring/integration/insert-shutdown-error.json
@@ -1,0 +1,167 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.4"
+    }
+  ],
+  "database_name": "sdam-tests",
+  "collection_name": "insert-shutdown-error",
+  "data": [],
+  "tests": [
+    {
+      "description": "Concurrent shutdown error on insert",
+      "clientOptions": {
+        "retryWrites": false,
+        "heartbeatFrequencyMS": 500,
+        "appname": "shutdownErrorInsertTest"
+      },
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 1
+            }
+          }
+        },
+        {
+          "name": "configureFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "appName": "shutdownErrorInsertTest",
+                "errorCode": 91,
+                "blockConnection": true,
+                "blockTimeMS": 500
+              }
+            }
+          }
+        },
+        {
+          "name": "startThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread1"
+          }
+        },
+        {
+          "name": "startThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread2"
+          }
+        },
+        {
+          "name": "runOnThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread1",
+            "operation": {
+              "name": "insertOne",
+              "object": "collection",
+              "arguments": {
+                "document": {
+                  "_id": 2
+                }
+              },
+              "error": true
+            }
+          }
+        },
+        {
+          "name": "runOnThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread2",
+            "operation": {
+              "name": "insertOne",
+              "object": "collection",
+              "arguments": {
+                "document": {
+                  "_id": 3
+                }
+              },
+              "error": true
+            }
+          }
+        },
+        {
+          "name": "waitForThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread1"
+          }
+        },
+        {
+          "name": "waitForThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread2"
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 4
+            }
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 4
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/libmongoc/tests/json/server_discovery_and_monitoring/integration/isMaster-command-error.json
+++ b/src/libmongoc/tests/json/server_discovery_and_monitoring/integration/isMaster-command-error.json
@@ -1,0 +1,245 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.4"
+    }
+  ],
+  "database_name": "sdam-tests",
+  "collection_name": "isMaster-command-error",
+  "data": [],
+  "tests": [
+    {
+      "description": "Command error on Monitor handshake",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "isMaster"
+          ],
+          "appName": "commandErrorHandshakeTest",
+          "closeConnection": false,
+          "errorCode": 91
+        }
+      },
+      "clientOptions": {
+        "retryWrites": false,
+        "connectTimeoutMS": 250,
+        "heartbeatFrequencyMS": 500,
+        "appname": "commandErrorHandshakeTest"
+      },
+      "operations": [
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1
+              },
+              {
+                "_id": 2
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "isMaster-command-error",
+              "documents": [
+                {
+                  "_id": 1
+                },
+                {
+                  "_id": 2
+                }
+              ]
+            },
+            "command_name": "insert",
+            "database_name": "sdam-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Command error on Monitor check",
+      "clientOptions": {
+        "retryWrites": false,
+        "connectTimeoutMS": 1000,
+        "heartbeatFrequencyMS": 500,
+        "appname": "commandErrorCheckTest"
+      },
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1
+              },
+              {
+                "_id": 2
+              }
+            ]
+          }
+        },
+        {
+          "name": "configureFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "isMaster"
+                ],
+                "appName": "commandErrorCheckTest",
+                "closeConnection": false,
+                "blockConnection": true,
+                "blockTimeMS": 750,
+                "errorCode": 91
+              }
+            }
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 3
+              },
+              {
+                "_id": 4
+              }
+            ]
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "isMaster-command-error",
+              "documents": [
+                {
+                  "_id": 1
+                },
+                {
+                  "_id": 2
+                }
+              ]
+            },
+            "command_name": "insert",
+            "database_name": "sdam-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "isMaster-command-error",
+              "documents": [
+                {
+                  "_id": 3
+                },
+                {
+                  "_id": 4
+                }
+              ]
+            },
+            "command_name": "insert",
+            "database_name": "sdam-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/libmongoc/tests/json/server_discovery_and_monitoring/integration/isMaster-network-error.json
+++ b/src/libmongoc/tests/json/server_discovery_and_monitoring/integration/isMaster-network-error.json
@@ -1,0 +1,225 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.4"
+    }
+  ],
+  "database_name": "sdam-tests",
+  "collection_name": "isMaster-network-error",
+  "data": [],
+  "tests": [
+    {
+      "description": "Network error on Monitor handshake",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "isMaster"
+          ],
+          "appName": "networkErrorHandshakeTest",
+          "closeConnection": true
+        }
+      },
+      "clientOptions": {
+        "retryWrites": false,
+        "connectTimeoutMS": 250,
+        "heartbeatFrequencyMS": 500,
+        "appname": "networkErrorHandshakeTest"
+      },
+      "operations": [
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1
+              },
+              {
+                "_id": 2
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "isMaster-network-error",
+              "documents": [
+                {
+                  "_id": 1
+                },
+                {
+                  "_id": 2
+                }
+              ]
+            },
+            "command_name": "insert",
+            "database_name": "sdam-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Network error on Monitor check",
+      "clientOptions": {
+        "retryWrites": false,
+        "connectTimeoutMS": 250,
+        "heartbeatFrequencyMS": 500,
+        "appname": "networkErrorCheckTest"
+      },
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1
+              },
+              {
+                "_id": 2
+              }
+            ]
+          }
+        },
+        {
+          "name": "configureFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "isMaster"
+                ],
+                "appName": "networkErrorCheckTest",
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 3
+              },
+              {
+                "_id": 4
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "isMaster-network-error",
+              "documents": [
+                {
+                  "_id": 1
+                },
+                {
+                  "_id": 2
+                }
+              ]
+            },
+            "command_name": "insert",
+            "database_name": "sdam-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "isMaster-network-error",
+              "documents": [
+                {
+                  "_id": 3
+                },
+                {
+                  "_id": 4
+                }
+              ]
+            },
+            "command_name": "insert",
+            "database_name": "sdam-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/libmongoc/tests/json/server_discovery_and_monitoring/integration/isMaster-timeout.json
+++ b/src/libmongoc/tests/json/server_discovery_and_monitoring/integration/isMaster-timeout.json
@@ -1,0 +1,359 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.4"
+    }
+  ],
+  "database_name": "sdam-tests",
+  "collection_name": "isMaster-timeout",
+  "data": [],
+  "tests": [
+    {
+      "description": "Network timeout on Monitor handshake",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "isMaster"
+          ],
+          "appName": "timeoutMonitorHandshakeTest",
+          "blockConnection": true,
+          "blockTimeMS": 1000
+        }
+      },
+      "clientOptions": {
+        "retryWrites": false,
+        "connectTimeoutMS": 250,
+        "heartbeatFrequencyMS": 500,
+        "appname": "timeoutMonitorHandshakeTest"
+      },
+      "operations": [
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1
+              },
+              {
+                "_id": 2
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "isMaster-timeout",
+              "documents": [
+                {
+                  "_id": 1
+                },
+                {
+                  "_id": 2
+                }
+              ]
+            },
+            "command_name": "insert",
+            "database_name": "sdam-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Network timeout on Monitor check",
+      "clientOptions": {
+        "retryWrites": false,
+        "connectTimeoutMS": 750,
+        "heartbeatFrequencyMS": 500,
+        "appname": "timeoutMonitorCheckTest"
+      },
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1
+              },
+              {
+                "_id": 2
+              }
+            ]
+          }
+        },
+        {
+          "name": "configureFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "isMaster"
+                ],
+                "appName": "timeoutMonitorCheckTest",
+                "blockConnection": true,
+                "blockTimeMS": 1000
+              }
+            }
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 3
+              },
+              {
+                "_id": 4
+              }
+            ]
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "isMaster-timeout",
+              "documents": [
+                {
+                  "_id": 1
+                },
+                {
+                  "_id": 2
+                }
+              ]
+            },
+            "command_name": "insert",
+            "database_name": "sdam-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "isMaster-timeout",
+              "documents": [
+                {
+                  "_id": 3
+                },
+                {
+                  "_id": 4
+                }
+              ]
+            },
+            "command_name": "insert",
+            "database_name": "sdam-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Driver extends timeout while streaming",
+      "clientOptions": {
+        "retryWrites": false,
+        "connectTimeoutMS": 250,
+        "heartbeatFrequencyMS": 500,
+        "appname": "extendsTimeoutTest"
+      },
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1
+              },
+              {
+                "_id": 2
+              }
+            ]
+          }
+        },
+        {
+          "name": "wait",
+          "object": "testRunner",
+          "arguments": {
+            "ms": 2000
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 3
+              },
+              {
+                "_id": 4
+              }
+            ]
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 0
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "isMaster-timeout",
+              "documents": [
+                {
+                  "_id": 1
+                },
+                {
+                  "_id": 2
+                }
+              ]
+            },
+            "command_name": "insert",
+            "database_name": "sdam-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "isMaster-timeout",
+              "documents": [
+                {
+                  "_id": 3
+                },
+                {
+                  "_id": 4
+                }
+              ]
+            },
+            "command_name": "insert",
+            "database_name": "sdam-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/libmongoc/tests/json/server_discovery_and_monitoring/integration/rediscover-quickly-after-step-down.json
+++ b/src/libmongoc/tests/json/server_discovery_and_monitoring/integration/rediscover-quickly-after-step-down.json
@@ -1,0 +1,152 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.4",
+      "topology": [
+        "replicaset"
+      ]
+    }
+  ],
+  "database_name": "sdam-tests",
+  "collection_name": "test-replSetStepDown",
+  "data": [
+    {
+      "_id": 1
+    },
+    {
+      "_id": 2
+    }
+  ],
+  "tests": [
+    {
+      "description": "Rediscover quickly after replSetStepDown",
+      "clientOptions": {
+        "appname": "replSetStepDownTest",
+        "heartbeatFrequencyMS": 60000,
+        "serverSelectionTimeoutMS": 5000,
+        "w": "majority"
+      },
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 3
+              },
+              {
+                "_id": 4
+              }
+            ]
+          }
+        },
+        {
+          "name": "recordPrimary",
+          "object": "testRunner"
+        },
+        {
+          "name": "runAdminCommand",
+          "object": "testRunner",
+          "command_name": "replSetStepDown",
+          "arguments": {
+            "command": {
+              "replSetStepDown": 1,
+              "secondaryCatchUpPeriodSecs": 1,
+              "force": false
+            }
+          }
+        },
+        {
+          "name": "waitForPrimaryChange",
+          "object": "testRunner",
+          "arguments": {
+            "timeoutMS": 5000
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 5
+              },
+              {
+                "_id": 6
+              }
+            ]
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test-replSetStepDown",
+              "documents": [
+                {
+                  "_id": 3
+                },
+                {
+                  "_id": 4
+                }
+              ]
+            },
+            "command_name": "insert",
+            "database_name": "sdam-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test-replSetStepDown",
+              "documents": [
+                {
+                  "_id": 5
+                },
+                {
+                  "_id": 6
+                }
+              ]
+            },
+            "command_name": "insert",
+            "database_name": "sdam-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            },
+            {
+              "_id": 5
+            },
+            {
+              "_id": 6
+            }
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds support for all SDAM integration tests and the prose RTT test.

This does not include the connectTimeoutMS=0 test introduced in [CDRIVER-3721](https://jira.mongodb.org/browse/CDRIVER-3721). libmongoc does not interpret `connectTimeoutMS=0` as an unlimited timeout, and instead interprets `0` as the option being unset (so it defaults to `10,000`). I'll address that as part of CDRIVER-3721 instead of folding it in here.

The JSON files are on the second commit.