### PR TITLE
CDRIVER-748 add TSAN tasks

### DIFF
--- a/.evergreen/compile-unix.sh
+++ b/.evergreen/compile-unix.sh
@@ -145,6 +145,7 @@ export UBSAN_OPTIONS="print_stacktrace=1 abort_on_error=1"
 # AddressSanitizer configuration
 export ASAN_OPTIONS="detect_leaks=1 abort_on_error=1 symbolize=1"
 export ASAN_SYMBOLIZER_PATH="/opt/mongodbtoolchain/v3/bin/llvm-symbolizer"
+export TSAN_OPTIONS="suppressions=./.tsan-suppressions"
 
 case "$MARCH" in
    i386)

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1858,6 +1858,26 @@ tasks:
         export SSL="OPENSSL"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
   - func: upload build
+- name: debug-compile-tsan-openssl
+  tags:
+  - special
+  - tsan
+  commands:
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        export CFLAGS="-fsanitize=thread -fno-omit-frame-pointer"
+        export CHECK_LOG="ON"
+        export DEBUG="ON"
+        export EXTRA_CONFIGURE_FLAGS="-DENABLE_EXTRA_ALIGNMENT=OFF -DENABLE_SHM_COUNTERS=OFF"
+        export SSL="OPENSSL"
+        CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
+  - func: upload build
 - name: test-valgrind-latest-server-auth-nosasl-openssl
   tags:
   - latest
@@ -4140,6 +4160,930 @@ tasks:
       ASAN: 'on'
       AUTH: noauth
       SSL: nossl
+      VALGRIND: 'off'
+- name: test-tsan-latest-server-auth-nosasl-openssl
+  tags:
+  - latest
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: latest
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-latest-server-noauth-nosasl-openssl
+  tags:
+  - latest
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: latest
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-latest-replica-set-auth-nosasl-openssl
+  tags:
+  - latest
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: latest
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-latest-replica-set-noauth-nosasl-openssl
+  tags:
+  - latest
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: latest
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-latest-sharded-auth-nosasl-openssl
+  tags:
+  - latest
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-latest-sharded-noauth-nosasl-openssl
+  tags:
+  - latest
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-4.4-server-auth-nosasl-openssl
+  tags:
+  - '4.4'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.4'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-4.4-server-noauth-nosasl-openssl
+  tags:
+  - '4.4'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.4'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-4.4-replica-set-auth-nosasl-openssl
+  tags:
+  - '4.4'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-4.4-replica-set-noauth-nosasl-openssl
+  tags:
+  - '4.4'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-4.4-sharded-auth-nosasl-openssl
+  tags:
+  - '4.4'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-4.4-sharded-noauth-nosasl-openssl
+  tags:
+  - '4.4'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-4.2-server-auth-nosasl-openssl
+  tags:
+  - '4.2'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.2'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-4.2-server-noauth-nosasl-openssl
+  tags:
+  - '4.2'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.2'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-4.2-replica-set-auth-nosasl-openssl
+  tags:
+  - '4.2'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-4.2-replica-set-noauth-nosasl-openssl
+  tags:
+  - '4.2'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-4.2-sharded-auth-nosasl-openssl
+  tags:
+  - '4.2'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-4.2-sharded-noauth-nosasl-openssl
+  tags:
+  - '4.2'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-4.0-server-auth-nosasl-openssl
+  tags:
+  - '4.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-4.0-server-noauth-nosasl-openssl
+  tags:
+  - '4.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-4.0-replica-set-auth-nosasl-openssl
+  tags:
+  - '4.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-4.0-replica-set-noauth-nosasl-openssl
+  tags:
+  - '4.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-4.0-sharded-auth-nosasl-openssl
+  tags:
+  - '4.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-4.0-sharded-noauth-nosasl-openssl
+  tags:
+  - '4.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-3.6-server-auth-nosasl-openssl
+  tags:
+  - '3.6'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '3.6'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-3.6-server-noauth-nosasl-openssl
+  tags:
+  - '3.6'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '3.6'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-3.6-replica-set-auth-nosasl-openssl
+  tags:
+  - '3.6'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-3.6-replica-set-noauth-nosasl-openssl
+  tags:
+  - '3.6'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-3.6-sharded-auth-nosasl-openssl
+  tags:
+  - '3.6'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-3.6-sharded-noauth-nosasl-openssl
+  tags:
+  - '3.6'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-3.4-server-auth-nosasl-openssl
+  tags:
+  - '3.4'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '3.4'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-3.4-server-noauth-nosasl-openssl
+  tags:
+  - '3.4'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '3.4'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-3.4-replica-set-auth-nosasl-openssl
+  tags:
+  - '3.4'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '3.4'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-3.4-replica-set-noauth-nosasl-openssl
+  tags:
+  - '3.4'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '3.4'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-3.4-sharded-auth-nosasl-openssl
+  tags:
+  - '3.4'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.4'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-3.4-sharded-noauth-nosasl-openssl
+  tags:
+  - '3.4'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.4'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-3.2-server-auth-nosasl-openssl
+  tags:
+  - '3.2'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '3.2'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-3.2-server-noauth-nosasl-openssl
+  tags:
+  - '3.2'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '3.2'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-3.2-replica-set-auth-nosasl-openssl
+  tags:
+  - '3.2'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '3.2'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-3.2-replica-set-noauth-nosasl-openssl
+  tags:
+  - '3.2'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '3.2'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-3.2-sharded-auth-nosasl-openssl
+  tags:
+  - '3.2'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.2'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-3.2-sharded-noauth-nosasl-openssl
+  tags:
+  - '3.2'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.2'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
       VALGRIND: 'off'
 - name: test-coverage-latest-server-auth-nosasl-openssl
   tags:
@@ -14025,6 +14969,7 @@ tasks:
         set -o xtrace
         # Compile mongoc-ping. Disable unnecessary dependencies since mongoc-ping is copied to a remote Ubuntu 18.04 ECS cluster for testing, which may not have all dependent libraries.
         . .evergreen/find-cmake.sh
+        export CC=${CC}
         $CMAKE -DENABLE_SASL=OFF -DENABLE_SNAPPY=OFF -DENABLE_ZSTD=OFF -DENABLE_CLIENT_SIDE_ENCRYPTION=OFF .
         $CMAKE --build . --target mongoc-ping
   - func: upload build
@@ -17132,3 +18077,11 @@ buildvariants:
     distros:
     - rhel80-test
   batchtime: 1440
+- name: tsan-ubuntu
+  display_name: Thread Sanitizer (TSAN) Tests (Ubuntu 16.04)
+  expansions:
+    CC: /opt/mongodbtoolchain/v3/bin/clang
+  run_on: ubuntu1604-small
+  tasks:
+  - .tsan
+  batchtime: 10080

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -13,6 +13,7 @@ DNS=${DNS:-nodns}
 # AddressSanitizer configuration
 export ASAN_OPTIONS="detect_leaks=1 abort_on_error=1 symbolize=1"
 export ASAN_SYMBOLIZER_PATH="/opt/mongodbtoolchain/v3/bin/llvm-symbolizer"
+export TSAN_OPTIONS="suppressions=./.tsan-suppressions"
 
 echo "COMPRESSORS='${COMPRESSORS}' CC='${CC}' AUTH=${AUTH} SSL=${SSL} URI=${URI} IPV4_ONLY=${IPV4_ONLY} VALGRIND=${VALGRIND} MONGOC_TEST_URI=${MONGOC_TEST_URI}"
 

--- a/.tsan-suppressions
+++ b/.tsan-suppressions
@@ -1,0 +1,1 @@
+race:mongoc_counter*

--- a/build/evergreen_config_lib/variants.py
+++ b/build/evergreen_config_lib/variants.py
@@ -592,5 +592,11 @@ all_variants = [
     Variant ('packaging', 'Linux Distro Packaging', 'ubuntu1604-test', [
         'debian-package-build',
         OD([('name', 'rpm-package-build'), ('distros', ['rhel80-test'])]),
-    ], {}, batchtime=days(1))
+    ], {}, batchtime=days(1)),
+    Variant('tsan-ubuntu',
+        'Thread Sanitizer (TSAN) Tests (Ubuntu 16.04)',
+        'ubuntu1604-small',
+        ['.tsan'],
+        {'CC': '/opt/mongodbtoolchain/v3/bin/clang'},
+        batchtime=days(7))
 ]

--- a/src/libmongoc/tests/mock_server/mock-server.c
+++ b/src/libmongoc/tests/mock_server/mock-server.c
@@ -72,7 +72,9 @@ struct _autoresponder_handle_t {
    int id;
 };
 
-typedef enum { REPLY, HANGUP, RESET } reply_type_t;
+typedef enum {
+   REPLY, HANGUP, RESET
+} reply_type_t;
 
 
 typedef struct {


### PR DESCRIPTION
Adds thread sanitizer tasks to Evergreen to catch thread races.

[Here's an example failure](https://spruce.mongodb.com/task/mongo_c_driver_tsan_ubuntu_test_tsan_3.4_replica_set_noauth_nosasl_openssl_patch_1763427bff432aca8abf01e753969343095cb496_5efd072b32f41770fe1d220c_20_07_01_21_59_33/logs). TSAN produces stack traces to identify the concurrent reader/writer of shared data.