### PR TITLE
CDRIVER-3573 fix hardcode

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -24,7 +24,7 @@ functions:
         set -o errexit
         set -o xtrace
         # TODO: CDRIVER-3573 do not hardcode the version.
-        if [ "${project}" != "mongoc-c-driver" ]; then
+        if [ "${project}" != "mongo-c-driver" ]; then
            # This is an older branch, like r1.17
            VERSION_CURRENT="1.17.0-pre"
            echo $VERSION_CURRENT > "VERSION_CURRENT"

--- a/build/evergreen_config_lib/functions.py
+++ b/build/evergreen_config_lib/functions.py
@@ -28,7 +28,7 @@ all_functions = OD([
             ]))]),
         shell_mongoc(r'''
         # TODO: CDRIVER-3573 do not hardcode the version.
-        if [ "${project}" != "mongoc-c-driver" ]; then
+        if [ "${project}" != "mongo-c-driver" ]; then
            # This is an older branch, like r1.17
            VERSION_CURRENT="1.17.0-pre"
            echo $VERSION_CURRENT > "VERSION_CURRENT"


### PR DESCRIPTION
https://github.com/mongodb/mongo-c-driver/commit/529a2be72907aeb6823e9ebbf830f9dbe7baa91c had a typo, comparing `mongoc-c-driver` instead of `mongo-c-driver`. This meant that the Evergreen project tracking the master branch was not uploading to the expected location. I noticed this in the C++ driver project, which was fetching the version of libmongoc just before 529a2be72907aeb6823e9ebbf830f9dbe7baa91c.