### PR TITLE
CDRIVER-3734 add Host header to OCSP requests

### DIFF
--- a/.evergreen/run-ocsp-test.sh
+++ b/.evergreen/run-ocsp-test.sh
@@ -92,6 +92,7 @@ expect_failure () {
     echo "Should fail:"
     if $MONGOC_PING $MONGODB_URI >output.txt 2>&1; then
         echo "Unexpected - succeeded but it should not have"
+        cat output.txt
         exit 1
     else
         echo "failed as expected"

--- a/src/libmongoc/src/mongoc/mongoc-ocsp-cache.c
+++ b/src/libmongoc/src/mongoc/mongoc-ocsp-cache.c
@@ -174,10 +174,8 @@ _mongoc_ocsp_cache_get_status (OCSP_CERTID *id,
 
    *cert_status = entry->cert_status;
    *reason = entry->reason;
-   *this_update =
-      ASN1_item_dup (ASN1_ITEM_rptr (ASN1_TIME), entry->this_update);
-   *next_update =
-      ASN1_item_dup (ASN1_ITEM_rptr (ASN1_TIME), entry->next_update);
+   *this_update = entry->this_update;
+   *next_update = entry->next_update;
 
    ret = true;
 done:

--- a/src/libmongoc/src/mongoc/mongoc-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-openssl.c
@@ -658,7 +658,7 @@ _contact_ocsp_responder (OCSP_CERTID *id, X509 *peer)
 {
    STACK_OF (OPENSSL_STRING) *url_stack = NULL;
    OPENSSL_STRING url = NULL, host = NULL, path = NULL, port = NULL;
-   OCSP_REQUEST *req;
+   OCSP_REQUEST *req = NULL;
    OCSP_REQ_CTX *sendreq_ctx = NULL;
    OCSP_RESPONSE *resp = NULL;
    BIO *bio = NULL;

--- a/src/libmongoc/src/mongoc/mongoc-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-openssl.c
@@ -874,8 +874,12 @@ _mongoc_ocsp_tlsext_status (SSL *ssl, mongoc_openssl_ocsp_opt_t *opts)
     * 2. Next, the function verifies the signature of the basic response.
     * 3. Finally, the function validates the signer cert, constructing the
     * validation path via the untrusted cert chain.
+    *
+    * cert_chain has already been verified. Use OCSP_TRUSTOTHER so the signer
+    * certificate can be considered verified if it is in cert_chain.
     */
-   if (OCSP_basic_verify (basic, cert_chain, store, 0) != OCSP_VERIFY_SUCCESS) {
+   if (OCSP_basic_verify (basic, cert_chain, store, OCSP_TRUSTOTHER) !=
+       OCSP_VERIFY_SUCCESS) {
       SOFT_FAIL ("OCSP response failed verification: %s", ERR_STR);
       ret = OCSP_CB_ERROR;
       GOTO (done);


### PR DESCRIPTION
Log messages in Evergreen were indicating soft-failures against Amazon KMS servers. In addition to checking responses locally, I inspected the logs of the `-cse` tasks to validate this is no longer failing.

The HTTP header Host is required by KMS servers (and is required by HTTP in general). Related issue in OpenSSL: https://github.com/openssl/openssl/issues/1986

Fixes a leak of `next_time` / `this_time` fields.

Permits verified chain be used to validate OCSP response signature certificate.

