### PR TITLE
CDRIVER-3739 Add 5 second timeout to OCSP

### DIFF
--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -512,6 +512,7 @@ set (SOURCES ${SOURCES}
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-gridfs-file-list.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-handshake.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-host-list.c
+   ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-http.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-index.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-init.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-interrupt.c
@@ -898,6 +899,7 @@ set (test-libmongoc-sources
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-gridfs.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-handshake.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-hedged-reads.c
+   ${PROJECT_SOURCE_DIR}/tests/test-mongoc-http.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-interrupt.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-linux-distro-scanner.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-list.c

--- a/src/libmongoc/src/mongoc/CMakeLists.txt
+++ b/src/libmongoc/src/mongoc/CMakeLists.txt
@@ -116,6 +116,7 @@ set (src_libmongoc_src_mongoc_DIST_noinst_hs
    mongoc-handshake-os-private.h
    mongoc-handshake-private.h
    mongoc-host-list-private.h
+   mongoc-http-private.h
    mongoc-interrupt-private.h
    mongoc-libressl-private.h
    mongoc-linux-distro-scanner-private.h
@@ -210,6 +211,7 @@ set (src_libmongoc_src_mongoc_DIST_cs
    mongoc-gridfs-file-page.c
    mongoc-gridfs-file-list.c
    mongoc-handshake.c
+   mongoc-http.c
    mongoc-index.c
    mongoc-linux-distro-scanner.c
    mongoc-list.c

--- a/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
@@ -126,7 +126,6 @@ fail:
 }
 
 
-#define MONGOC_AWS_SOCKET_TIMEOUT 10000
 /*
  * Send an HTTP request and get a response.
  * On success, returns true.

--- a/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
@@ -25,6 +25,7 @@
 #include "mongoc-trace-private.h"
 #include "mongoc-uri-private.h"
 #include "mongoc-util-private.h"
+#include "mongoc-http-private.h"
 
 #undef MONGOC_LOG_DOMAIN
 #define MONGOC_LOG_DOMAIN "aws_auth"
@@ -125,6 +126,7 @@ fail:
 }
 
 
+#define MONGOC_AWS_SOCKET_TIMEOUT 10000
 /*
  * Send an HTTP request and get a response.
  * On success, returns true.
@@ -145,88 +147,35 @@ _send_http_request (const char *ip,
                     char **http_response_headers,
                     bson_error_t *error)
 {
-   mongoc_stream_t *stream = NULL;
-   mongoc_host_list_t host_list;
-   bool ret = false;
-   mongoc_iovec_t iovec;
-   uint8_t buf[512];
-   ssize_t bytes_read;
+   mongoc_http_request_t req;
+   mongoc_http_response_t res;
    const int socket_timeout_ms = 10000;
-   char *http_request = NULL;
-   bson_string_t *http_response = NULL;
-   char *ptr;
-   bool need_slash;
+   bool ret;
 
    *http_response_body = NULL;
    *http_response_headers = NULL;
+   _mongoc_http_request_init (&req);
+   _mongoc_http_response_init (&res);
 
-   if (!_mongoc_host_list_from_hostport_with_err (
-          &host_list, ip, port, error)) {
-      goto fail;
+   req.host = ip;
+   req.port = port;
+   req.method = method;
+   req.path = path;
+   req.extra_headers = headers;
+   ret = _mongoc_http_send (&req,
+                            socket_timeout_ms,
+                            false /* use_tls */,
+                            NULL /* ssl_opts */,
+                            &res,
+                            error);
+
+   if (ret) {
+      *http_response_headers = bson_strndup (res.headers, res.headers_len);
+      *http_response_body = (char *) bson_malloc0 (res.body_len + 1);
+      memcpy (*http_response_body, res.body, res.body_len);
    }
 
-   stream = mongoc_client_connect_tcp (socket_timeout_ms, &host_list, error);
-   if (!stream) {
-      goto fail;
-   }
-
-   if (strstr (path, "/") == path) {
-      need_slash = false;
-   } else {
-      need_slash = true;
-   }
-
-   /* Always add 'Host: <domain>' header. */
-   http_request = bson_strdup_printf (
-      "%s %s%s HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n%s\r\n",
-      method,
-      need_slash ? "/" : "",
-      path,
-      ip,
-      headers);
-   iovec.iov_base = http_request;
-   iovec.iov_len = strlen (http_request);
-
-   if (!_mongoc_stream_writev_full (
-          stream, &iovec, 1, socket_timeout_ms, error)) {
-      goto fail;
-   }
-
-   /* If timeout == 0, you'll get EAGAIN errors. */
-   http_response = bson_string_new (NULL);
-   memset (buf, 0, sizeof (buf));
-   /* leave at least one byte out of buffer to leave it null terminated. */
-   while ((bytes_read = mongoc_stream_read (
-              stream, buf, (sizeof buf) - 1, 0, socket_timeout_ms)) > 0) {
-      bson_string_append (http_response, (const char *) buf);
-      memset (buf, 0, sizeof (buf));
-   }
-
-   if (bytes_read < 0) {
-      char errmsg_buf[BSON_ERROR_BUFFER_SIZE];
-      char *errmsg;
-
-      errmsg = bson_strerror_r (errno, errmsg_buf, sizeof errmsg_buf);
-      AUTH_ERROR_AND_FAIL ("error occurred reading stream: %s", errmsg);
-   }
-
-   /* Find the body. */
-   ptr = strstr (http_response->str, "\r\n\r\n");
-   if (NULL == ptr) {
-      AUTH_ERROR_AND_FAIL ("error occurred reading response, body not found");
-   }
-
-   *http_response_headers =
-      bson_strndup (http_response->str, ptr - http_response->str);
-   *http_response_body = bson_strdup (ptr + 4);
-
-   ret = true;
-fail:
-   mongoc_stream_destroy (stream);
-   bson_free (http_request);
-   if (http_response) {
-      bson_string_free (http_response, true);
-   }
+   _mongoc_http_response_cleanup (&res);
    return ret;
 }
 

--- a/src/libmongoc/src/mongoc/mongoc-http-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-http-private.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mongoc.h"
+#include "mongoc-ssl.h"
+
+#include "mongoc-prelude.h"
+
+#ifndef MONGOC_HTTP_PRIVATE_H
+#define MONGOC_HTTP_PRIVATE_H
+
+typedef struct {
+   const char *host;
+   int port;
+   const char *method;
+   const char *path;
+   const char *extra_headers;
+   const char *body;
+   int body_len;
+} mongoc_http_request_t;
+
+typedef struct {
+   int status;
+   char *headers;
+   int headers_len;
+   char *body;
+   int body_len;
+} mongoc_http_response_t;
+
+void
+_mongoc_http_request_init (mongoc_http_request_t *request);
+
+void
+_mongoc_http_response_init (mongoc_http_response_t *response);
+
+void
+_mongoc_http_response_cleanup (mongoc_http_response_t *response);
+
+/*
+ * Send an HTTP request and get a response.
+ * On success, returns true.
+ * On failure, returns false and sets error.
+ * If use_tls is true, then ssl_opts must be set.
+ * Caller must call _mongoc_http_response_cleanup on res.
+ */
+bool
+_mongoc_http_send (mongoc_http_request_t *req,
+                   int timeout_ms,
+                   bool use_tls,
+                   mongoc_ssl_opt_t *ssl_opts,
+                   mongoc_http_response_t *res,
+                   bson_error_t *error);
+
+#endif /* MONGOC_HTTP_PRIVATE */

--- a/src/libmongoc/src/mongoc/mongoc-http.c
+++ b/src/libmongoc/src/mongoc/mongoc-http.c
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2020-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mongoc-http-private.h"
+
+#include "mongoc-client-private.h"
+#include "mongoc-host-list-private.h"
+#include "mongoc-stream-tls.h"
+#include "mongoc-stream-private.h"
+#include "mongoc-buffer-private.h"
+
+void
+_mongoc_http_request_init (mongoc_http_request_t *request)
+{
+   memset (request, 0, sizeof (*request));
+}
+
+void
+_mongoc_http_response_init (mongoc_http_response_t *response)
+{
+   memset (response, 0, sizeof (*response));
+}
+
+void
+_mongoc_http_response_cleanup (mongoc_http_response_t *response)
+{
+   if (!response) {
+      return;
+   }
+   bson_free (response->headers);
+   bson_free (response->body);
+}
+
+bool
+_mongoc_http_send (mongoc_http_request_t *req,
+                   int timeout_ms,
+                   bool use_tls,
+                   mongoc_ssl_opt_t *ssl_opts,
+                   mongoc_http_response_t *res,
+                   bson_error_t *error)
+{
+   mongoc_stream_t *stream = NULL;
+   mongoc_host_list_t host_list;
+   bool ret = false;
+   mongoc_iovec_t iovec;
+   ssize_t bytes_read;
+   char *path = NULL;
+   bson_string_t *http_request = NULL;
+   mongoc_buffer_t http_response_buf;
+   char *http_response_str;
+   char *ptr;
+
+   memset (res, 0, sizeof (*res));
+   _mongoc_buffer_init (&http_response_buf, NULL, 0, NULL, NULL);
+
+   if (!_mongoc_host_list_from_hostport_with_err (
+          &host_list, req->host, (uint16_t) req->port, error)) {
+      goto fail;
+   }
+
+   stream = mongoc_client_connect_tcp (timeout_ms, &host_list, error);
+   if (!stream) {
+      bson_set_error (error,
+                      MONGOC_ERROR_STREAM,
+                      MONGOC_ERROR_STREAM_SOCKET,
+                      "Failed to connect to: %s",
+                      req->host);
+      goto fail;
+   }
+
+#ifndef MONGOC_ENABLE_SSL
+   if (use_tls) {
+      bson_set_error (
+         error,
+         MONGOC_ERROR_STREAM,
+         MONGOC_ERROR_STREAM_SOCKET,
+         "Failed to connect to %s: libmongoc not built with TLS support",
+         req->host);
+      goto fail;
+   }
+#else
+   if (use_tls) {
+      mongoc_stream_t *tls_stream;
+
+      BSON_ASSERT (ssl_opts);
+      tls_stream = mongoc_stream_tls_new_with_hostname (
+         stream, req->host, ssl_opts, true);
+      if (!tls_stream) {
+         bson_set_error (error,
+                         MONGOC_ERROR_STREAM,
+                         MONGOC_ERROR_STREAM_SOCKET,
+                         "Failed create TLS stream to: %s",
+                         req->host);
+         goto fail;
+      }
+
+      stream = tls_stream;
+      if (!mongoc_stream_tls_handshake_block (
+             stream, req->host, timeout_ms, error)) {
+         goto fail;
+      }
+   }
+#endif
+
+   if (!req->path) {
+      path = bson_strdup ("/");
+   } else if (req->path[0] != '/') {
+      path = bson_strdup_printf ("/%s", req->path);
+   } else {
+      path = bson_strdup (req->path);
+   }
+
+   http_request = bson_string_new ("");
+   bson_string_append_printf (
+      http_request, "%s %s HTTP/1.0\r\n", req->method, path);
+   /* Always add Host header. */
+   bson_string_append_printf (http_request, "Host: %s\r\n", req->host);
+   /* Always add Connection: close header to ensure server closes connection. */
+   bson_string_append_printf (http_request, "Connection: close\r\n");
+   /* Add Content-Length if body included. */
+   if (req->body_len) {
+      bson_string_append_printf (
+         http_request, "Content-Length: %d\r\n", req->body_len);
+   }
+   if (req->extra_headers) {
+      bson_string_append (http_request, req->extra_headers);
+   }
+   bson_string_append (http_request, "\r\n");
+
+   iovec.iov_base = http_request->str;
+   iovec.iov_len = http_request->len;
+
+   if (!_mongoc_stream_writev_full (stream, &iovec, 1, timeout_ms, error)) {
+      goto fail;
+   }
+
+   if (req->body) {
+      iovec.iov_base = (void *) req->body;
+      iovec.iov_len = req->body_len;
+      if (!_mongoc_stream_writev_full (stream, &iovec, 1, timeout_ms, error)) {
+         goto fail;
+      }
+   }
+
+   /* Read until connection close. */
+   do {
+      bytes_read = _mongoc_buffer_try_append_from_stream (
+         &http_response_buf, stream, 512, timeout_ms);
+   } while (bytes_read > 0 || mongoc_stream_should_retry (stream));
+
+   if (bytes_read < 0 && mongoc_stream_timed_out (stream)) {
+      bson_set_error (error,
+                      MONGOC_ERROR_STREAM,
+                      MONGOC_ERROR_STREAM_SOCKET,
+                      "Timeout reading from stream");
+      goto fail;
+   }
+
+   if (http_response_buf.len == 0) {
+      bson_set_error (error,
+                      MONGOC_ERROR_STREAM,
+                      MONGOC_ERROR_STREAM_SOCKET,
+                      "No response received");
+      goto fail;
+   }
+
+   http_response_str = (char *) http_response_buf.data;
+
+   /* Find the end of the headers. */
+   ptr = strstr (http_response_str, "\r\n\r\n");
+   if (NULL == ptr) {
+      bson_set_error (
+         error,
+         MONGOC_ERROR_STREAM,
+         MONGOC_ERROR_STREAM_SOCKET,
+         "Error occurred reading response: end of headers not found");
+      goto fail;
+   }
+
+   res->headers_len = ptr - http_response_str;
+   res->headers = bson_strndup (http_response_str, res->headers_len);
+   res->body_len = http_response_buf.len - res->headers_len - 4;
+   /* Add a NULL character in case caller assumes NULL terminated. */
+   res->body = bson_malloc0 (res->body_len + 1);
+   memcpy (res->body, ptr + 4, res->body_len);
+   ret = true;
+
+fail:
+   mongoc_stream_destroy (stream);
+   if (http_request) {
+      bson_string_free (http_request, true);
+   }
+   _mongoc_buffer_destroy (&http_response_buf);
+   bson_free (path);
+   return ret;
+}

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl-private.h
@@ -29,6 +29,9 @@ typedef struct {
    bool allow_invalid_hostname;
    bool weak_cert_validation;
    bool disable_endpoint_check;
+   /* If reaching out to an OCSP responder requires TLS,
+    * use the same TLS options that the user provided. */
+   mongoc_ssl_opt_t ssl_opts;
 } mongoc_openssl_ocsp_opt_t;
 
 void

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl.c
@@ -786,12 +786,13 @@ mongoc_stream_tls_openssl_new (mongoc_stream_t *base_stream,
          RETURN (NULL);
       }
 
-      ocsp_opts = bson_malloc (sizeof (mongoc_openssl_ocsp_opt_t));
+      ocsp_opts = bson_malloc0 (sizeof (mongoc_openssl_ocsp_opt_t));
       ocsp_opts->allow_invalid_hostname = opt->allow_invalid_hostname;
       ocsp_opts->weak_cert_validation = opt->weak_cert_validation;
       ocsp_opts->disable_endpoint_check =
          _mongoc_ssl_opts_disable_ocsp_endpoint_check (opt);
       ocsp_opts->host = bson_strdup (host);
+      _mongoc_ssl_opts_copy_to (opt, &ocsp_opts->ssl_opts, true);
    }
 #endif /* MONGOC_ENABLE_OCSP_OPENSSL */
 
@@ -836,6 +837,7 @@ mongoc_openssl_ocsp_opt_destroy (void *ocsp_opt)
    }
    casted = (mongoc_openssl_ocsp_opt_t *) ocsp_opt;
    bson_free (casted->host);
+   _mongoc_ssl_opts_cleanup (&casted->ssl_opts, true);
    bson_free (ocsp_opt);
 }
 

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -256,6 +256,8 @@ extern void
 test_interrupt_install (TestSuite *suite);
 extern void
 test_monitoring_install (TestSuite *suite);
+extern void
+test_http_install (TestSuite *suite);
 
 typedef struct {
    mongoc_log_level_t level;
@@ -2658,6 +2660,7 @@ main (int argc, char *argv[])
 #endif
    test_interrupt_install (&suite);
    test_monitoring_install (&suite);
+   test_http_install (&suite);
 
    ret = TestSuite_Run (&suite);
 

--- a/src/libmongoc/tests/test-mongoc-http.c
+++ b/src/libmongoc/tests/test-mongoc-http.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "TestSuite.h"
+#include "test-libmongoc.h"
+#include "mongoc/mongoc.h"
+#include "mongoc/mongoc-http-private.h"
+
+void
+test_mongoc_http (void *unused)
+{
+   mongoc_http_request_t req;
+   mongoc_http_response_t res;
+   bool r;
+   bson_error_t error;
+
+   _mongoc_http_request_init (&req);
+   _mongoc_http_response_init (&res);
+
+   /* Basic GET request */
+   req.method = "GET";
+   req.host = "example.com";
+   req.port = 80;
+   r = _mongoc_http_send (&req, 10000, false, NULL, &res, &error);
+   ASSERT_OR_PRINT (r, error);
+   _mongoc_http_response_cleanup (&res);
+
+   /* Basic POST request with a body. */
+   req.method = "POST";
+   req.body = "test";
+   req.body_len = 4;
+   req.port = 80;
+   r = _mongoc_http_send (&req, 10000, false, NULL, &res, &error);
+   ASSERT_OR_PRINT (r, error);
+   _mongoc_http_response_cleanup (&res);
+}
+
+void
+test_http_install (TestSuite *suite)
+{
+   TestSuite_AddFull (suite,
+                      "/http",
+                      test_mongoc_http,
+                      NULL /* dtor */,
+                      NULL /* ctx */,
+                      test_framework_skip_if_offline);
+}


### PR DESCRIPTION
- Reuse libmongoc's HTTP function instead of OCSP_sendreq_new
- Support TLS in OCSP endpoint
- Do not log a soft failure if a certificate has no OCSP endpoints