### PR TITLE
CDRIVER-3595 adds tests, removes extraneous check

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-cmd.c
@@ -881,7 +881,8 @@ mongoc_cmd_parts_assemble (mongoc_cmd_parts_t *parts,
       }
 
       if (cs && _mongoc_client_session_in_txn (cs)) {
-         if (!IS_PREF_PRIMARY (cs->txn.opts.read_prefs) && !parts->is_write_command) {
+         if (!IS_PREF_PRIMARY (cs->txn.opts.read_prefs) &&
+             !parts->is_write_command) {
             bson_set_error (error,
                             MONGOC_ERROR_TRANSACTION,
                             MONGOC_ERROR_TRANSACTION_INVALID_STATE,
@@ -988,6 +989,7 @@ mongoc_cmd_parts_assemble (mongoc_cmd_parts_t *parts,
          }
       }
 
+      /* if transaction is in progress do not inherit write concern */
       if (parts->assembled.is_txn_finish ||
           !_mongoc_client_session_in_txn (cs)) {
          _mongoc_cmd_parts_add_write_concern (parts);

--- a/src/libmongoc/src/mongoc/mongoc-collection.c
+++ b/src/libmongoc/src/mongoc/mongoc-collection.c
@@ -3278,8 +3278,9 @@ mongoc_collection_find_and_modify_with_opts (
       }
 
       write_concern = appended_opts.writeConcern;
-   } else if (!write_concern) {
-      if (server_stream->sd->max_wire_version >=
+   }
+   /* inherit write concern from collection if not in transaction */
+   else if (server_stream->sd->max_wire_version >=
              WIRE_VERSION_FAM_WRITE_CONCERN &&
           !_mongoc_client_session_in_txn (parts.assembled.session)) {
          if (!mongoc_write_concern_is_valid (collection->write_concern)) {
@@ -3291,7 +3292,7 @@ mongoc_collection_find_and_modify_with_opts (
          }
 
          write_concern = collection->write_concern;
-      }
+
    }
 
    if (appended_opts.hint.value_type) {

--- a/src/libmongoc/src/mongoc/mongoc-collection.c
+++ b/src/libmongoc/src/mongoc/mongoc-collection.c
@@ -3278,13 +3278,10 @@ mongoc_collection_find_and_modify_with_opts (
       }
 
       write_concern = appended_opts.writeConcern;
-   }
-
-   if (!write_concern) {
+   } else if (!write_concern) {
       if (server_stream->sd->max_wire_version >=
              WIRE_VERSION_FAM_WRITE_CONCERN &&
-          (mongoc_write_concern_is_acknowledged (collection->write_concern) ||
-           !_mongoc_client_session_in_txn (parts.assembled.session))) {
+          !_mongoc_client_session_in_txn (parts.assembled.session)) {
          if (!mongoc_write_concern_is_valid (collection->write_concern)) {
             bson_set_error (error,
                             MONGOC_ERROR_COMMAND,

--- a/src/libmongoc/tests/test-mongoc-write-concern.c
+++ b/src/libmongoc/tests/test-mongoc-write-concern.c
@@ -621,7 +621,7 @@ write_concern_count (const mongoc_apm_command_started_t *event)
 /* tests that unacknowledged write concerns are inherited from the
  * collection in fam with options.  Addresses concerns from CDRIVER-3595 */
 void
-test_write_concern_inheritance_fam (void)
+test_write_concern_inheritance_fam (void *context)
 {
    mongoc_find_and_modify_opts_t *opts;
    bson_t *update;
@@ -771,13 +771,17 @@ test_write_concern_install (TestSuite *suite)
       suite, "/WriteConcern/prohibited", test_write_concern_prohibited);
    TestSuite_AddLive (
       suite, "/WriteConcern/unacknowledged", test_write_concern_unacknowledged);
-   TestSuite_AddLive (
-      suite, "/WriteConcern/inherited_fam", test_write_concern_inheritance_fam);
+   TestSuite_AddFull (suite,
+                      "/WriteConcern/inherited_fam",
+                      test_write_concern_inheritance_fam,
+                      NULL,
+                      NULL,
+                      test_framework_skip_if_max_wire_version_less_than_4);
    TestSuite_AddFull (suite,
                       "/WriteConcern/inherited_fam_txn",
                       test_write_concern_inheritance_fam_txn,
-                      NULL /* dtor */,
-                      NULL /* ctx */,
+                      NULL,
+                      NULL,
                       test_framework_skip_if_no_sessions,
                       test_framework_skip_if_no_txns);
 }

--- a/src/libmongoc/tests/test-mongoc-write-concern.c
+++ b/src/libmongoc/tests/test-mongoc-write-concern.c
@@ -662,12 +662,14 @@ test_write_concern_inheritance_fam_txn (bool in_session, bool in_txn)
    if (in_session) {
       session = mongoc_client_start_session (client, NULL, &error);
       ASSERT_OR_PRINT (session, error);
-      mongoc_client_session_append (session, session_id, &error);
+      success = mongoc_client_session_append (session, session_id, &error);
+      ASSERT_OR_PRINT (success, error);
       mongoc_find_and_modify_opts_append (opts, session_id);
    }
    if (in_txn) {
       BSON_ASSERT (in_session);
-      mongoc_client_session_start_transaction (session, NULL, &error);
+      success = mongoc_client_session_start_transaction (session, NULL, &error);
+      ASSERT_OR_PRINT (success, error);
    }
 
    mongoc_find_and_modify_opts_set_update (opts, update);
@@ -696,8 +698,8 @@ test_write_concern_inheritance_fam_txn (bool in_session, bool in_txn)
    if (in_txn) {
       /* check that the sent write concern is not inherited */
       BSON_ASSERT (sent_w == MONGOC_WRITE_CONCERN_W_DEFAULT);
-      success = mongoc_client_session_commit_transaction (session, NULL, NULL);
-      BSON_ASSERT (success);
+      success = mongoc_client_session_commit_transaction (session, NULL, &error);
+      ASSERT_OR_PRINT (success, error);
    } else if (!in_session) {
       /* assert that write concern is inherited */
       BSON_ASSERT (success);
@@ -722,19 +724,19 @@ test_write_concern_inheritance_fam_txn (bool in_session, bool in_txn)
 }
 
 static void
-test_fam_no_session_no_txn ()
+test_fam_no_session_no_txn (void *unused)
 {
    test_write_concern_inheritance_fam_txn (false, false);
 }
 
 static void
-test_fam_session_no_txn ()
+test_fam_session_no_txn (void *unused)
 {
    test_write_concern_inheritance_fam_txn (true, false);
 }
 
 static void
-test_fam_session_txn ()
+test_fam_session_txn (void *unused)
 {
    test_write_concern_inheritance_fam_txn (true, true);
 }

--- a/src/libmongoc/tests/test-mongoc-write-concern.c
+++ b/src/libmongoc/tests/test-mongoc-write-concern.c
@@ -677,7 +677,7 @@ test_write_concern_inheritance_fam_txn (void *context)
       BSON_ASSERT (success);
    } else {
       /* assert that write concern is inherited. In this case the lsid
-       * is not passed. This failure case is tested later. */
+       * is not passed. */
       ASSERT_OR_PRINT (success, error);
       BSON_ASSERT (success);
       BSON_ASSERT (sent_w == 2);


### PR DESCRIPTION
The bugs mentioned in CDRIVER-3595 don't seem to be observable, as demonstrated in the test cases that this PR adds to test-mongoc-write-concern.c.  The only real change that this PR makes is in mongoc-collection.c.