### PR TITLE
CDRIVER-3751 document NULL for set_compressors

### DIFF
--- a/src/libmongoc/doc/mongoc_uri_set_compressors.rst
+++ b/src/libmongoc/doc/mongoc_uri_set_compressors.rst
@@ -15,7 +15,7 @@ Parameters
 ----------
 
 * ``uri``: A :symbol:`mongoc_uri_t`.
-* ``compressors``: One or more comma (,) separated compressors.
+* ``compressors``: A string consisting of one or more comma (,) separated compressors (e.g. "snappy,zlib") or ``NULL``. Passing ``NULL`` clears any existing compressors set on ``uri``.
 
 Description
 -----------


### PR DESCRIPTION
There is already a test that asserts this behavior:

https://github.com/mongodb/mongo-c-driver/blob/1.16.2/src/libmongoc/tests/test-mongoc-uri.c/#L1039-L1043