### PR TITLE
clear convenience temps after each test

### DIFF
--- a/src/libmongoc/tests/TestSuite.c
+++ b/src/libmongoc/tests/TestSuite.c
@@ -38,6 +38,7 @@
 #include <windows.h>
 #endif
 
+#include "test-conveniences.h"
 #include "test-libmongoc.h"
 #include "TestSuite.h"
 
@@ -594,7 +595,9 @@ TestSuite_RunTest (TestSuite *suite, /* IN */
 #endif
 
       srand (test->seed);
+      test_conveniences_init ();
       test->func (test->ctx);
+      test_conveniences_cleanup ();
    } else {
       status = TestSuite_RunFuncInChild (suite, test);
    }

--- a/src/libmongoc/tests/test-conveniences.c
+++ b/src/libmongoc/tests/test-conveniences.c
@@ -43,22 +43,21 @@ static char *gHugeString;
 static size_t gHugeStringLength;
 static char *gFourMBString;
 
-static void
-test_conveniences_cleanup ();
 
-
-static void
+void
 test_conveniences_init ()
 {
    if (!gConveniencesInitialized) {
       _mongoc_array_init (&gTmpBsonArray, sizeof (bson_t *));
       atexit (test_conveniences_cleanup);
       gConveniencesInitialized = true;
+      gHugeString = NULL;
+      gFourMBString = NULL;
    }
 }
 
 
-static void
+void
 test_conveniences_cleanup ()
 {
    int i;
@@ -71,9 +70,11 @@ test_conveniences_cleanup ()
       }
 
       _mongoc_array_destroy (&gTmpBsonArray);
-   }
 
-   bson_free (gHugeString);
+      bson_free (gHugeString);
+      bson_free (gFourMBString);
+      gConveniencesInitialized = false;
+   }
 }
 
 
@@ -1552,6 +1553,8 @@ init_huge_string (mongoc_client_t *client)
 
    BSON_ASSERT (client);
 
+   test_conveniences_init ();
+
    if (!gHugeString) {
       max_bson_size = mongoc_cluster_get_max_bson_obj_size (&client->cluster);
       BSON_ASSERT (max_bson_size > 0);
@@ -1583,6 +1586,8 @@ huge_string_length (mongoc_client_t *client)
 static void
 init_four_mb_string ()
 {
+   test_conveniences_init ();
+
    if (!gFourMBString) {
       gFourMBString = (char *) bson_malloc (FOUR_MB + 1);
       BSON_ASSERT (gFourMBString);

--- a/src/libmongoc/tests/test-conveniences.h
+++ b/src/libmongoc/tests/test-conveniences.h
@@ -23,6 +23,19 @@
 #include "mongoc/mongoc-read-prefs-private.h"
 #include "mongoc/mongoc-client-private.h"
 
+/* Initialize global test convenience structures.
+ * Safe to call repeatedly, or after calling test_conveniences_cleanup().
+ */
+void
+test_conveniences_init ();
+
+/* Tear down global test conveniences.
+ * Safe to call repeatedly.
+ * Called automatically at process exit.
+ */
+void
+test_conveniences_cleanup ();
+
 bson_t *
 tmp_bson (const char *json, ...);
 


### PR DESCRIPTION
Not urgent. I had theorized that temporary objects created in tests (via `tmp_bson()`) were causing slowdown in Valgrind tasks. Clearing it after each test run did not speed up Valgrind, but seemed like a reasonable improvement regardless.