### PR TITLE
CDRIVER-3746 skip SDAM int tests on valgrind

### DIFF
--- a/src/libmongoc/tests/test-mongoc-sdam.c
+++ b/src/libmongoc/tests/test-mongoc-sdam.c
@@ -479,7 +479,8 @@ test_all_spec_tests (TestSuite *suite)
                                        resolved,
                                        &test_sdam_integration_cb,
                                        TestSuite_CheckLive,
-                                       test_framework_skip_if_no_crypto);
+                                       test_framework_skip_if_no_crypto,
+                                       test_framework_skip_if_slow);
 }
 
 static void


### PR DESCRIPTION
Some SDAM integration tests make assumptions about thread context switching.

Specifically, the [find-shutdown-error.yml](https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/tests/integration/find-shutdown-error.yml) test starts two threads. Each threads send a `find` command. The server blocks the response to the find command for 500ms before responding with an error (which increments the connection generation). The intent of the 500ms block is so both threads grab a connection from the same generation (i.e. both find commands send the command before either gets an error response).

But the logs for the test running through Valgrind [/server_discovery_and_monitoring/integration/find-shutdown-error](https://evergreen.mongodb.com/task/mongo_c_driver_valgrind_ubuntu_test_valgrind_latest_server_auth_nosasl_openssl_161fb77b8e4a95c5f2d82ceec02ce928430c7f00_20_07_16_16_01_10) show that one thread sends the find and receives a response before the other thread sends a find.

Valgrind only runs one thread at a time: https://www.valgrind.org/docs/manual/manual-core.html#manual-core.pthreads_perf_sched which may be the cause of infrequent context switches. I don't think skipping these tests on Valgrind is a big loss, since ASAN covers all of what Valgrind checks aside from uninitialized reads (and executes much faster).