### PR TITLE
CDRIVER-3786 clean up OCSP docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ Security Vulnerabilities
 
 If you’ve identified a security vulnerability in a driver or any other
 MongoDB project, please report it according to the `instructions here
-<http://docs.mongodb.org/manual/tutorial/create-a-vulnerability-report>`_.
+<https://docs.mongodb.org/manual/tutorial/create-a-vulnerability-report>`_.
 
 
 Installation

--- a/src/libbson/doc/bson_oid_t.rst
+++ b/src/libbson/doc/bson_oid_t.rst
@@ -19,7 +19,7 @@ Synopsis
 Description
 -----------
 
-The :symbol:`bson_oid_t` structure contains the 12-byte ObjectId notation defined by the `BSON ObjectID specification <http://docs.mongodb.org/manual/reference/object-id/>`_.
+The :symbol:`bson_oid_t` structure contains the 12-byte ObjectId notation defined by the `BSON ObjectID specification <https://docs.mongodb.org/manual/reference/object-id/>`_.
 
 ObjectId is a 12-byte BSON type, constructed using:
 

--- a/src/libmongoc/doc/advanced-connections.rst
+++ b/src/libmongoc/doc/advanced-connections.rst
@@ -10,7 +10,7 @@ For an example of connecting to a simple standalone server, see the :ref:`Tutori
 Connecting to a Replica Set
 ---------------------------
 
-Connecting to a `replica set <http://docs.mongodb.org/manual/replication/>`_ is much like connecting to a standalone MongoDB server. Simply specify the replica set name using the ``?replicaSet=myreplset`` URI option.
+Connecting to a `replica set <https://docs.mongodb.org/manual/replication/>`_ is much like connecting to a standalone MongoDB server. Simply specify the replica set name using the ``?replicaSet=myreplset`` URI option.
 
 .. code-block:: c
 
@@ -47,7 +47,7 @@ Connecting to a `replica set <http://docs.mongodb.org/manual/replication/>`_ is 
 Connecting to a Sharded Cluster
 -------------------------------
 
-To connect to a `sharded cluster <http://docs.mongodb.org/manual/sharding/>`_, specify the ``mongos`` nodes the client should connect to. The C Driver will automatically detect that it has connected to a ``mongos`` sharding server.
+To connect to a `sharded cluster <https://docs.mongodb.org/manual/sharding/>`_, specify the ``mongos`` nodes the client should connect to. The C Driver will automatically detect that it has connected to a ``mongos`` sharding server.
 
 If more than one hostname is specified, a seed list will be created to attempt failover between the ``mongos`` instances.
 

--- a/src/libmongoc/doc/mongoc_client_set_read_prefs.rst
+++ b/src/libmongoc/doc/mongoc_client_set_read_prefs.rst
@@ -18,7 +18,7 @@ The global default is to read from the replica set primary.
 
 It is a programming error to call this function on a client from a :symbol:`mongoc_client_pool_t`. For pooled clients, set the read preferences with the :ref:`MongoDB URI <mongoc_uri_t_read_prefs_options>` instead.
 
-Please see the MongoDB website for a description of `Read Preferences <http://docs.mongodb.org/manual/core/read-preference/>`_.
+Please see the MongoDB website for a description of `Read Preferences <https://docs.mongodb.org/manual/core/read-preference/>`_.
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_collection_aggregate.rst
+++ b/src/libmongoc/doc/mongoc_collection_aggregate.rst
@@ -29,7 +29,7 @@ Parameters
 
 .. include:: includes/aggregate-opts.txt
 
-For a list of all options, see `the MongoDB Manual entry on the aggregate command <http://docs.mongodb.org/manual/reference/command/aggregate/>`_.
+For a list of all options, see `the MongoDB Manual entry on the aggregate command <https://docs.mongodb.org/manual/reference/command/aggregate/>`_.
 
 
 .. include:: includes/retryable-read-aggregate.txt
@@ -37,7 +37,7 @@ For a list of all options, see `the MongoDB Manual entry on the aggregate comman
 Description
 -----------
 
-This function creates a cursor which sends the aggregate command on the underlying collection upon the first call to :symbol:`mongoc_cursor_next()`. For more information on building aggregation pipelines, see `the MongoDB Manual entry on the aggregate command <http://docs.mongodb.org/manual/reference/command/aggregate/>`_.
+This function creates a cursor which sends the aggregate command on the underlying collection upon the first call to :symbol:`mongoc_cursor_next()`. For more information on building aggregation pipelines, see `the MongoDB Manual entry on the aggregate command <https://docs.mongodb.org/manual/reference/command/aggregate/>`_.
 
 Read preferences, read and write concern, and collation can be overridden by various sources. The highest-priority sources for these options are listed first in the following table. In a transaction, read concern and write concern are prohibited in ``opts`` and the read preference must be primary or NULL. Write concern is applied from ``opts``, or if ``opts`` has no write concern and the aggregation pipeline includes "$out", the write concern is applied from ``collection``. The write concern is omitted for MongoDB before 3.4.
 

--- a/src/libmongoc/doc/mongoc_collection_count.rst
+++ b/src/libmongoc/doc/mongoc_collection_count.rst
@@ -47,7 +47,7 @@ Description
 
 This function shall execute a count query on the underlying 'collection'. The bson 'query' is not validated, simply passed along as appropriate to the server.  As such, compatibility and errors should be validated in the appropriate server documentation.
 
-For more information, see the `query reference <http://docs.mongodb.org/manual/reference/operator/query/>`_ at the MongoDB website.
+For more information, see the `query reference <https://docs.mongodb.org/manual/reference/operator/query/>`_ at the MongoDB website.
 
 The :symbol:`mongoc_read_concern_t` specified on the :symbol:`mongoc_collection_t` will be used, if any. If ``read_prefs`` is NULL, the collection's read preferences are used.
 

--- a/src/libmongoc/doc/mongoc_collection_count_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_collection_count_with_opts.rst
@@ -55,7 +55,7 @@ The :symbol:`mongoc_read_concern_t` specified on the :symbol:`mongoc_collection_
 
 In addition to the standard functionality available from mongoc_collection_count, this function allows the user to add arbitrary extra keys to the count.  This pass through enables features such as hinting for counts.
 
-For more information, see the `query reference <http://docs.mongodb.org/manual/reference/operator/query/>`_ at the MongoDB website.
+For more information, see the `query reference <https://docs.mongodb.org/manual/reference/operator/query/>`_ at the MongoDB website.
 
 .. include:: includes/retryable-read.txt
 

--- a/src/libmongoc/doc/mongoc_collection_set_read_prefs.rst
+++ b/src/libmongoc/doc/mongoc_collection_set_read_prefs.rst
@@ -25,5 +25,5 @@ Sets the default read preferences to use for operations on ``collection`` not sp
 
 The global default is MONGOC_READ_PRIMARY: if the client is connected to a replica set it reads from the primary, otherwise it reads from the current MongoDB server.
 
-Please see the MongoDB website for a description of `Read Preferences <http://docs.mongodb.org/manual/core/read-preference/>`_.
+Please see the MongoDB website for a description of `Read Preferences <https://docs.mongodb.org/manual/core/read-preference/>`_.
 

--- a/src/libmongoc/doc/mongoc_database_aggregate.rst
+++ b/src/libmongoc/doc/mongoc_database_aggregate.rst
@@ -27,12 +27,12 @@ Parameters
 
 .. include:: includes/aggregate-opts.txt
 
-For a list of all options, see `the MongoDB Manual entry on the aggregate command <http://docs.mongodb.org/manual/reference/command/aggregate/>`_.
+For a list of all options, see `the MongoDB Manual entry on the aggregate command <https://docs.mongodb.org/manual/reference/command/aggregate/>`_.
 
 Description
 -----------
 
-This function creates a cursor which sends the aggregate command on the underlying database upon the first call to :symbol:`mongoc_cursor_next()`. For more information on building aggregation pipelines, see `the MongoDB Manual entry on the aggregate command <http://docs.mongodb.org/manual/reference/command/aggregate/>`_. Note that the pipeline must start with a compatible stage that does not require an underlying collection (e.g. "$currentOp", "$listLocalSessions").
+This function creates a cursor which sends the aggregate command on the underlying database upon the first call to :symbol:`mongoc_cursor_next()`. For more information on building aggregation pipelines, see `the MongoDB Manual entry on the aggregate command <https://docs.mongodb.org/manual/reference/command/aggregate/>`_. Note that the pipeline must start with a compatible stage that does not require an underlying collection (e.g. "$currentOp", "$listLocalSessions").
 
 Read preferences, read and write concern, and collation can be overridden by various sources. The highest-priority sources for these options are listed first in the following table. In a transaction, read concern and write concern are prohibited in ``opts`` and the read preference must be primary or NULL. Write concern is applied from ``opts``, or if ``opts`` has no write concern and the aggregation pipeline includes "$out", the write concern is applied from ``database``.
 

--- a/src/libmongoc/doc/mongoc_database_find_collections_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_database_find_collections_with_opts.rst
@@ -28,7 +28,7 @@ Parameters
 
 .. include:: includes/generic-opts.txt
 
-For a list of all options, see `the MongoDB Manual entry on the listCollections command <http://docs.mongodb.org/manual/reference/command/listCollections/>`_.
+For a list of all options, see `the MongoDB Manual entry on the listCollections command <https://docs.mongodb.org/manual/reference/command/listCollections/>`_.
 
 Errors
 ------

--- a/src/libmongoc/doc/mongoc_database_get_collection_names_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_database_get_collection_names_with_opts.rst
@@ -28,7 +28,7 @@ Parameters
 
 .. include:: includes/generic-opts.txt
 
-For a list of all options, see `the MongoDB Manual entry on the listCollections command <http://docs.mongodb.org/manual/reference/command/listCollections/>`_.
+For a list of all options, see `the MongoDB Manual entry on the listCollections command <https://docs.mongodb.org/manual/reference/command/listCollections/>`_.
 
 Errors
 ------

--- a/src/libmongoc/doc/mongoc_database_set_read_prefs.rst
+++ b/src/libmongoc/doc/mongoc_database_set_read_prefs.rst
@@ -16,7 +16,7 @@ This function sets the default read preferences to use on operations performed w
 
 The global default is MONGOC_READ_PRIMARY: if the client is connected to a replica set it reads from the primary, otherwise it reads from the current MongoDB server.
 
-Please see the MongoDB website for a description of `Read Preferences <http://docs.mongodb.org/manual/core/read-preference/>`_.
+Please see the MongoDB website for a description of `Read Preferences <https://docs.mongodb.org/manual/core/read-preference/>`_.
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_read_mode_t.rst
+++ b/src/libmongoc/doc/mongoc_read_mode_t.rst
@@ -23,5 +23,5 @@ Description
 
 This enum describes how reads should be dispatched. The default is MONGOC_READ_PRIMARY.
 
-Please see the MongoDB website for a description of `Read Preferences <http://docs.mongodb.org/manual/core/read-preference/>`_.
+Please see the MongoDB website for a description of `Read Preferences <https://docs.mongodb.org/manual/core/read-preference/>`_.
 

--- a/src/libmongoc/doc/mongoc_read_prefs_set_mode.rst
+++ b/src/libmongoc/doc/mongoc_read_prefs_set_mode.rst
@@ -21,5 +21,5 @@ Parameters
 Description
 -----------
 
-Sets the read preference mode. See the MongoDB website for more information on `Read Preferences <http://docs.mongodb.org/manual/core/read-preference/>`_.
+Sets the read preference mode. See the MongoDB website for more information on `Read Preferences <https://docs.mongodb.org/manual/core/read-preference/>`_.
 

--- a/src/libmongoc/doc/mongoc_uri_t.rst
+++ b/src/libmongoc/doc/mongoc_uri_t.rst
@@ -15,7 +15,7 @@ Description
 
 ``mongoc_uri_t`` provides an abstraction on top of the MongoDB connection URI format. It provides standardized parsing as well as convenience methods for extracting useful information such as replica hosts or authorization information.
 
-See `Connection String URI Reference <http://docs.mongodb.org/manual/reference/connection-string/>`_ on the MongoDB website for more information.
+See `Connection String URI Reference <https://docs.mongodb.org/manual/reference/connection-string/>`_ on the MongoDB website for more information.
 
 Format
 ------

--- a/src/libmongoc/doc/mongoc_write_concern_t.rst
+++ b/src/libmongoc/doc/mongoc_write_concern_t.rst
@@ -23,7 +23,7 @@ Exceptions to this principle are the generic command functions:
 
 These generic command functions do not automatically apply a write concern, and they do not check the server response for a write concern error or write concern timeout.
 
-See `Write Concern <http://docs.mongodb.org/manual/core/write-concern/>`_ on the MongoDB website for more information.
+See `Write Concern <https://docs.mongodb.org/manual/core/write-concern/>`_ on the MongoDB website for more information.
 
 Write Concern Levels
 --------------------

--- a/src/libmongoc/doc/tutorial.rst
+++ b/src/libmongoc/doc/tutorial.rst
@@ -784,7 +784,7 @@ Executing Commands
 
 The driver provides helper functions for executing MongoDB commands on client, database and collection structures. These functions return :doc:`cursors <mongoc_cursor_t>`; the ``_simple`` variants return booleans indicating success or failure.
 
-This example executes the `collStats <http://docs.mongodb.org/manual/reference/command/collStats/>`_ command against the collection "mycoll" in database "mydb".
+This example executes the `collStats <https://docs.mongodb.org/manual/reference/command/collStats/>`_ command against the collection "mycoll" in database "mydb".
 
 .. code-block:: c
 


### PR DESCRIPTION
- only note OCSP behavior exceptions
- note that crl_file is unsupported with LibreSSL and Secure Transport