### PR TITLE
fix rpm-package-build task

### DIFF
--- a/.evergreen/spec.patch
+++ b/.evergreen/spec.patch
@@ -1,24 +1,23 @@
---- mongo-c-driver.spec.orig	2020-07-24 11:53:23.689099310 -0400
-+++ mongo-c-driver.spec	2020-07-24 12:57:43.224736974 -0400
-@@ -10,23 +10,20 @@
+--- mongo-c-driver.spec.orig	2020-08-03 17:12:45.829127475 -0400
++++ mongo-c-driver.spec	2020-08-03 17:24:22.415722650 -0400
+@@ -10,14 +10,14 @@
  %global gh_project   mongo-c-driver
  %global libname      libmongoc
  %global libver       1.0
 -%global up_version   1.17.0
--%global up_prever    rc0
 +%global up_version   1.18.0
+ #global up_prever    rc0
  # disabled as require a MongoDB server
  %bcond_with          tests
  
  Name:      mongo-c-driver
  Summary:   Client library written in C for MongoDB
 -Version:   %{up_version}%{?up_prever:~%{up_prever}}
--Release:   2%{?dist}
 +Version:   %{up_version}%{up_prever}
-+Release:   1%{?dist}
+ Release:   1%{?dist}
  # See THIRD_PARTY_NOTICES
  License:   ASL 2.0 and ISC and MIT and zlib
- URL:       https://github.com/%{gh_owner}/%{gh_project}
+@@ -25,8 +25,6 @@
  
  Source0:   https://github.com/%{gh_owner}/%{gh_project}/releases/download/%{up_version}%{?up_prever:-%{up_prever}}/%{gh_project}-%{up_version}%{?up_prever:-%{up_prever}}.tar.gz
  
@@ -27,7 +26,7 @@
  BuildRequires: cmake >= 3.1
  BuildRequires: gcc
  # pkg-config may pull compat-openssl10
-@@ -40,7 +37,6 @@
+@@ -40,7 +38,6 @@
  BuildRequires: mongodb-server
  BuildRequires: openssl
  %endif
@@ -35,7 +34,7 @@
  BuildRequires: perl-interpreter
  # From man pages
  BuildRequires: python3
-@@ -70,7 +66,6 @@
+@@ -70,7 +67,6 @@
  Requires:   pkgconfig
  Requires:   cmake-filesystem
  Requires:   pkgconfig(libzstd)
@@ -43,7 +42,7 @@
  
  %description devel
  This package contains the header files and development libraries
-@@ -107,7 +102,6 @@
+@@ -107,7 +103,6 @@
  
  %prep
  %setup -q -n %{gh_project}-%{up_version}%{?up_prever:-%{up_prever}}
@@ -51,7 +50,7 @@
  
  
  %build
-@@ -130,7 +124,6 @@
+@@ -130,7 +125,6 @@
  %endif
      -DENABLE_EXAMPLES:BOOL=OFF \
      -DENABLE_UNINSTALL:BOOL=OFF \


### PR DESCRIPTION
This updates the spec.patch so that it applies cleanly the latest upstream spec file.

Patch build: https://spruce.mongodb.com/version/5f2880b157e85a6bdd33eea8/tasks