### PR TITLE
CDRIVER-3756 remove unused MESSAGES_ENABLED

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required (VERSION 3.1)
 
-# Used in MaintainerFlags.cmake to silence errors while testing configs.
-set (MESSAGES_ENABLED 1)
-
 set (ENABLE_SSL AUTO CACHE STRING
    "Enable TLS connections and SCRAM-SHA-1 authentication. Options are
    \"DARWIN\" to use Apple's Secure Transport, \"WINDOWS\" to use Windows


### PR DESCRIPTION
After the `message` override was removed in 5ab86d634e24de99bd1f1b2ca27d69871139ee6d, `MESSAGES_ENABLED` is unused.