### PR TITLE
CDRIVER-3779 resync change stream tests

### DIFF
--- a/src/libmongoc/tests/json-test.c
+++ b/src/libmongoc/tests/json-test.c
@@ -1194,11 +1194,17 @@ execute_test (const json_test_config_t *config,
 
    if (bson_has_field (test, "expectations")) {
       bson_t expectations;
+      bson_iter_t iter;
 
-      bson_lookup_doc (test, "expectations", &expectations);
-      check_json_apm_events (&ctx, &expectations);
-      if (config->events_check_cb) {
-         config->events_check_cb (&ctx.events);
+      if (bson_iter_init_find (&iter, test, "expectations")) {
+         /* If 'expectations' is explicitly null, skip the check. */
+         if (!BSON_ITER_HOLDS_NULL (&iter)) {
+            bson_iter_bson (&iter, &expectations);
+            check_json_apm_events (&ctx, &expectations);
+            if (config->events_check_cb) {
+               config->events_check_cb (&ctx.events);
+            }
+         }
       }
    }
 

--- a/src/libmongoc/tests/json/change_streams/change-streams-errors.json
+++ b/src/libmongoc/tests/json/change_streams/change-streams-errors.json
@@ -14,7 +14,7 @@
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
       "operations": [],
-      "expectations": [],
+      "expectations": null,
       "result": {
         "error": {
           "code": 40573

--- a/src/libmongoc/tests/json/change_streams/change-streams.json
+++ b/src/libmongoc/tests/json/change_streams/change-streams.json
@@ -82,7 +82,7 @@
           }
         }
       ],
-      "expectations": [],
+      "expectations": null,
       "result": {
         "success": [
           {


### PR DESCRIPTION
Note, the `cse` tasks on evergreen are failing due to a compiler warning from libmongocrypt. That is independent of this change.