### PR TITLE
CDRIVER-3775: Implement standardised logging POC

### DIFF
--- a/src/libbson/src/bson/bson-types.h
+++ b/src/libbson/src/bson/bson-types.h
@@ -519,6 +519,40 @@ typedef struct _bson_error_t {
 } bson_error_t BSON_ALIGNED_END (8);
 
 
+/**
+ * BSON_MAX_LEN_UNLIMITED
+ *
+ * Denotes unlimited length limit when converting BSON to JSON.
+ */
+#define BSON_MAX_LEN_UNLIMITED -1
+
+/**
+ * bson_json_mode_t:
+ *
+ * This enumeration contains the different modes to serialize BSON into extended
+ * JSON.
+ */
+typedef enum {
+   BSON_JSON_MODE_LEGACY,
+   BSON_JSON_MODE_CANONICAL,
+   BSON_JSON_MODE_RELAXED,
+} bson_json_mode_t;
+
+/**
+ * bson_json_opts_t:
+ *
+ * This structure is used to pass options for serializing BSON into extended
+ * JSON to the respective serialization methods.
+ *
+ * max_len can be either a non-negative integer, or BSON_MAX_LEN_UNLIMITED to
+ * set no limit for serialization length.
+ */
+typedef struct {
+   bson_json_mode_t mode;
+   int32_t max_len;
+} bson_json_opts_t;
+
+
 BSON_STATIC_ASSERT2 (error_t, sizeof (bson_error_t) == 512);
 
 

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -44,13 +44,6 @@ typedef enum {
 } bson_validate_phase_t;
 
 
-typedef enum {
-   BSON_JSON_MODE_LEGACY,
-   BSON_JSON_MODE_CANONICAL,
-   BSON_JSON_MODE_RELAXED,
-} bson_json_mode_t;
-
-
 /*
  * Structures.
  */
@@ -69,6 +62,8 @@ typedef struct {
    uint32_t depth;
    bson_string_t *str;
    bson_json_mode_t mode;
+   int32_t max_len;
+   bool max_len_reached;
 } bson_json_state_t;
 
 
@@ -88,7 +83,8 @@ _bson_as_json_visit_document (const bson_iter_t *iter,
 static char *
 _bson_as_json_visit_all (const bson_t *bson,
                          size_t *length,
-                         bson_json_mode_t mode);
+                         bson_json_mode_t mode,
+                         int32_t max_len);
 
 /*
  * Globals.
@@ -2583,7 +2579,7 @@ _bson_as_json_visit_int64 (const bson_iter_t *iter,
 
    if (state->mode == BSON_JSON_MODE_CANONICAL) {
       bson_string_append_printf (
-         state->str, "{ \"$numberLong\" : \"%" PRId64 "\"}", v_int64);
+         state->str, "{ \"$numberLong\" : \"%" PRId64 "\" }", v_int64);
    } else {
       bson_string_append_printf (state->str, "%" PRId64, v_int64);
    }
@@ -2715,8 +2711,8 @@ _bson_as_json_visit_binary (const bson_iter_t *iter,
 
    b64_len = COMMON_PREFIX (bson_b64_ntop_calculate_target_size (v_binary_len));
    b64 = bson_malloc0 (b64_len);
-   BSON_ASSERT (
-      COMMON_PREFIX (bson_b64_ntop (v_binary, v_binary_len, b64, b64_len) != -1));
+   BSON_ASSERT (COMMON_PREFIX (
+      bson_b64_ntop (v_binary, v_binary_len, b64, b64_len) != -1));
 
    if (state->mode == BSON_JSON_MODE_CANONICAL ||
        state->mode == BSON_JSON_MODE_RELAXED) {
@@ -2922,6 +2918,10 @@ _bson_as_json_visit_before (const bson_iter_t *iter,
    bson_json_state_t *state = data;
    char *escaped;
 
+   if (state->max_len_reached) {
+      return true;
+   }
+
    if (state->count) {
       bson_string_append (state->str, ", ");
    }
@@ -2939,6 +2939,30 @@ _bson_as_json_visit_before (const bson_iter_t *iter,
    }
 
    state->count++;
+
+   return false;
+}
+
+
+static bool
+_bson_as_json_visit_after (const bson_iter_t *iter, const char *key, void *data)
+{
+   bson_json_state_t *state = data;
+
+   if (state->max_len == BSON_MAX_LEN_UNLIMITED) {
+      return false;
+   }
+
+   if (state->str->len >= state->max_len) {
+      state->max_len_reached = true;
+
+      if (state->str->len > state->max_len) {
+         /* Truncate string to maximum length */
+         bson_string_truncate (state->str, state->max_len);
+      }
+
+      return true;
+   }
 
    return false;
 }
@@ -3018,27 +3042,33 @@ _bson_as_json_visit_codewscope (const bson_iter_t *iter,
    bson_json_state_t *state = data;
    char *code_escaped;
    char *scope;
+   int32_t max_scope_len = BSON_MAX_LEN_UNLIMITED;
 
    code_escaped = bson_utf8_escape_for_json (v_code, v_code_len);
    if (!code_escaped) {
       return true;
    }
 
-   /* Encode scope with the same mode */
-   scope = _bson_as_json_visit_all (v_scope, NULL, state->mode);
-
-   if (!scope) {
-      bson_free (code_escaped);
-      return true;
-   }
-
    bson_string_append (state->str, "{ \"$code\" : \"");
    bson_string_append (state->str, code_escaped);
    bson_string_append (state->str, "\", \"$scope\" : ");
+
+   bson_free (code_escaped);
+
+   /* Encode scope with the same mode */
+   if (state->max_len != BSON_MAX_LEN_UNLIMITED) {
+      max_scope_len = BSON_MAX (0, state->max_len - state->str->len);
+   }
+
+   scope = _bson_as_json_visit_all (v_scope, NULL, state->mode, max_scope_len);
+
+   if (!scope) {
+      return true;
+   }
+
    bson_string_append (state->str, scope);
    bson_string_append (state->str, " }");
 
-   bson_free (code_escaped);
    bson_free (scope);
 
    return false;
@@ -3046,7 +3076,7 @@ _bson_as_json_visit_codewscope (const bson_iter_t *iter,
 
 
 static const bson_visitor_t bson_as_json_visitors = {
-   _bson_as_json_visit_before,     NULL, /* visit_after */
+   _bson_as_json_visit_before,     _bson_as_json_visit_after,
    _bson_as_json_visit_corrupt,    _bson_as_json_visit_double,
    _bson_as_json_visit_utf8,       _bson_as_json_visit_document,
    _bson_as_json_visit_array,      _bson_as_json_visit_binary,
@@ -3081,9 +3111,24 @@ _bson_as_json_visit_document (const bson_iter_t *iter,
       child_state.str = bson_string_new ("{ ");
       child_state.depth = state->depth + 1;
       child_state.mode = state->mode;
+      child_state.max_len = BSON_MAX_LEN_UNLIMITED;
+      if (state->max_len != BSON_MAX_LEN_UNLIMITED) {
+         child_state.max_len = BSON_MAX (0, state->max_len - state->str->len);
+      }
+
+      child_state.max_len_reached = child_state.max_len == 0;
+
       if (bson_iter_visit_all (&child, &bson_as_json_visitors, &child_state)) {
+         if (child_state.max_len_reached) {
+            bson_string_append (state->str, child_state.str->str);
+         }
+
          bson_string_free (child_state.str, true);
-         return true;
+
+         /* If max_len was reached, we return a success state to ensure that
+          * VISIT_AFTER is still called
+          */
+         return !child_state.max_len_reached;
       }
 
       bson_string_append (child_state.str, " }");
@@ -3114,9 +3159,24 @@ _bson_as_json_visit_array (const bson_iter_t *iter,
       child_state.str = bson_string_new ("[ ");
       child_state.depth = state->depth + 1;
       child_state.mode = state->mode;
+      child_state.max_len = BSON_MAX_LEN_UNLIMITED;
+      if (state->max_len != BSON_MAX_LEN_UNLIMITED) {
+         child_state.max_len = BSON_MAX (0, state->max_len - state->str->len);
+      }
+
+      child_state.max_len_reached = child_state.max_len == 0;
+
       if (bson_iter_visit_all (&child, &bson_as_json_visitors, &child_state)) {
+         if (child_state.max_len_reached) {
+            bson_string_append (state->str, child_state.str->str);
+         }
+
          bson_string_free (child_state.str, true);
-         return true;
+
+         /* If max_len was reached, we return a success state to ensure that
+          * VISIT_AFTER is still called
+          */
+         return !child_state.max_len_reached;
       }
 
       bson_string_append (child_state.str, " ]");
@@ -3131,7 +3191,8 @@ _bson_as_json_visit_array (const bson_iter_t *iter,
 static char *
 _bson_as_json_visit_all (const bson_t *bson,
                          size_t *length,
-                         bson_json_mode_t mode)
+                         bson_json_mode_t mode,
+                         int32_t max_len)
 {
    bson_json_state_t state;
    bson_iter_t iter;
@@ -3161,9 +3222,12 @@ _bson_as_json_visit_all (const bson_t *bson,
    state.depth = 0;
    state.err_offset = &err_offset;
    state.mode = mode;
+   state.max_len = max_len;
+   state.max_len_reached = false;
 
-   if (bson_iter_visit_all (&iter, &bson_as_json_visitors, &state) ||
-       err_offset != -1) {
+   if ((bson_iter_visit_all (&iter, &bson_as_json_visitors, &state) ||
+        err_offset != -1) &&
+       !state.max_len_reached) {
       /*
        * We were prematurely exited due to corruption or failed visitor.
        */
@@ -3174,7 +3238,9 @@ _bson_as_json_visit_all (const bson_t *bson,
       return NULL;
    }
 
-   bson_string_append (state.str, " }");
+   if (!state.max_len_reached) {
+      bson_string_append (state.str, " }");
+   }
 
    if (length) {
       *length = state.str->len;
@@ -3185,23 +3251,38 @@ _bson_as_json_visit_all (const bson_t *bson,
 
 
 char *
+bson_as_json_with_opts (const bson_t *bson,
+                        size_t *length,
+                        const bson_json_opts_t *opts)
+{
+   return _bson_as_json_visit_all (bson, length, opts->mode, opts->max_len);
+}
+
+
+char *
 bson_as_canonical_extended_json (const bson_t *bson, size_t *length)
 {
-   return _bson_as_json_visit_all (bson, length, BSON_JSON_MODE_CANONICAL);
+   const bson_json_opts_t opts = {BSON_JSON_MODE_CANONICAL,
+                                  BSON_MAX_LEN_UNLIMITED};
+   return bson_as_json_with_opts (bson, length, &opts);
 }
 
 
 char *
 bson_as_json (const bson_t *bson, size_t *length)
 {
-   return _bson_as_json_visit_all (bson, length, BSON_JSON_MODE_LEGACY);
+   const bson_json_opts_t opts = {BSON_JSON_MODE_LEGACY,
+                                  BSON_MAX_LEN_UNLIMITED};
+   return bson_as_json_with_opts (bson, length, &opts);
 }
 
 
 char *
 bson_as_relaxed_extended_json (const bson_t *bson, size_t *length)
 {
-   return _bson_as_json_visit_all (bson, length, BSON_JSON_MODE_RELAXED);
+   const bson_json_opts_t opts = {BSON_JSON_MODE_RELAXED,
+                                  BSON_MAX_LEN_UNLIMITED};
+   return bson_as_json_with_opts (bson, length, &opts);
 }
 
 
@@ -3236,9 +3317,12 @@ bson_array_as_json (const bson_t *bson, size_t *length)
    state.depth = 0;
    state.err_offset = &err_offset;
    state.mode = BSON_JSON_MODE_LEGACY;
+   state.max_len = BSON_MAX_LEN_UNLIMITED;
+   state.max_len_reached = false;
 
-   if (bson_iter_visit_all (&iter, &bson_as_json_visitors, &state) ||
-       err_offset != -1) {
+   if ((bson_iter_visit_all (&iter, &bson_as_json_visitors, &state) ||
+        err_offset != -1) &&
+       !state.max_len_reached) {
       /*
        * We were prematurely exited due to corruption or failed visitor.
        */
@@ -3249,7 +3333,9 @@ bson_array_as_json (const bson_t *bson, size_t *length)
       return NULL;
    }
 
-   bson_string_append (state.str, " ]");
+   if (!state.max_len_reached) {
+      bson_string_append (state.str, " ]");
+   }
 
    if (length) {
       *length = state.str->len;

--- a/src/libbson/src/bson/bson.h
+++ b/src/libbson/src/bson/bson.h
@@ -493,6 +493,31 @@ bson_validate_with_error (const bson_t *bson,
 
 
 /**
+ * bson_as_json_with_opts:
+ * @bson: A bson_t.
+ * @length: A location for the string length, or NULL.
+ * @opts: A bson_t_json_opts_t defining options for the conversion
+ *
+ * Creates a new string containing @bson in the selected JSON format,
+ * conforming to the MongoDB Extended JSON Spec:
+ *
+ * github.com/mongodb/specifications/blob/master/source/extended-json.rst
+ *
+ * The caller is responsible for freeing the resulting string. If @length is
+ * non-NULL, then the length of the resulting string will be placed in @length.
+ *
+ * See http://docs.mongodb.org/manual/reference/mongodb-extended-json/ for
+ * more information on extended JSON.
+ *
+ * Returns: A newly allocated string that should be freed with bson_free().
+ */
+BSON_EXPORT (char *)
+bson_as_json_with_opts (const bson_t *bson,
+                        size_t *length,
+                        const bson_json_opts_t *opts);
+
+
+/**
  * bson_as_canonical_extended_json:
  * @bson: A bson_t.
  * @length: A location for the string length, or NULL.

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -539,6 +539,7 @@ set (SOURCES ${SOURCES}
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-stream-socket.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-structured-log.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-structured-log-command.c
+   ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-structured-log-connection.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-topology.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-topology-background-monitoring.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-topology-description.c

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -537,6 +537,7 @@ set (SOURCES ${SOURCES}
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-stream-gridfs-download.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-stream-gridfs-upload.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-stream-socket.c
+   ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-structured-log.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-topology.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-topology-background-monitoring.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-topology-description.c
@@ -596,6 +597,7 @@ set (HEADERS
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-stream-file.h
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-stream-gridfs.h
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-stream-socket.h
+   ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-structured-log.h
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-topology-description.h
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-uri.h
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-version-functions.h

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -967,6 +967,7 @@ set (test-libmongoc-sources
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-speculative-auth.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-stream.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-streamable-ismaster.c
+   ${PROJECT_SOURCE_DIR}/tests/test-mongoc-structured-log.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-thread.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-topology-description.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-topology-reconcile.c

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -538,6 +538,7 @@ set (SOURCES ${SOURCES}
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-stream-gridfs-upload.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-stream-socket.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-structured-log.c
+   ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-structured-log-command.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-topology.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-topology-background-monitoring.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-topology-description.c

--- a/src/libmongoc/src/mongoc/CMakeLists.txt
+++ b/src/libmongoc/src/mongoc/CMakeLists.txt
@@ -157,6 +157,7 @@ set (src_libmongoc_src_mongoc_DIST_noinst_hs
    mongoc-stream-gridfs-download-private.h
    mongoc-stream-gridfs-upload-private.h
    mongoc-structured-log-command-private.h
+   mongoc-structured-log-connection-private.h
    mongoc-structured-log-private.h
    mongoc-thread-private.h
    mongoc-topology-description-apm-private.h

--- a/src/libmongoc/src/mongoc/CMakeLists.txt
+++ b/src/libmongoc/src/mongoc/CMakeLists.txt
@@ -156,6 +156,7 @@ set (src_libmongoc_src_mongoc_DIST_noinst_hs
    mongoc-stream-tls-secure-transport-private.h
    mongoc-stream-gridfs-download-private.h
    mongoc-stream-gridfs-upload-private.h
+   mongoc-structured-log-command-private.h
    mongoc-structured-log-private.h
    mongoc-thread-private.h
    mongoc-topology-description-apm-private.h

--- a/src/libmongoc/src/mongoc/CMakeLists.txt
+++ b/src/libmongoc/src/mongoc/CMakeLists.txt
@@ -156,6 +156,7 @@ set (src_libmongoc_src_mongoc_DIST_noinst_hs
    mongoc-stream-tls-secure-transport-private.h
    mongoc-stream-gridfs-download-private.h
    mongoc-stream-gridfs-upload-private.h
+   mongoc-structured-log-private.h
    mongoc-thread-private.h
    mongoc-topology-description-apm-private.h
    mongoc-topology-description-private.h

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -2328,8 +2328,14 @@ _mongoc_client_monitor_op_killcursors (mongoc_cluster_t *cluster,
    _mongoc_client_prepare_killcursors_command (cursor_id, collection, &doc);
 
    /* @todo Provide missing arguments */
-   mongoc_structured_log_command_started (
-      &doc, "killCursors", db, operation_id, cluster->request_id, 0, 0, false);
+   mongoc_structured_log_command_started (&doc,
+                                          "killCursors",
+                                          db,
+                                          operation_id,
+                                          cluster->request_id,
+                                          &server_stream->sd->host,
+                                          0,
+                                          false);
 
    if (!client->apm_callbacks.started) {
       bson_destroy (&doc);
@@ -2384,7 +2390,7 @@ _mongoc_client_monitor_op_killcursors_succeeded (
                                           &doc,
                                           duration,
                                           cluster->request_id,
-                                          0,
+                                          &server_stream->sd->host,
                                           0,
                                           false);
 
@@ -2436,7 +2442,7 @@ _mongoc_client_monitor_op_killcursors_failed (
                                           &doc,
                                           error,
                                           cluster->request_id,
-                                          0,
+                                          &server_stream->sd->host,
                                           0,
                                           false);
 

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -61,14 +61,14 @@
 #include "mongoc-change-stream-private.h"
 #include "mongoc-client-session-private.h"
 #include "mongoc-cursor-private.h"
+#include "mongoc-structured-log-command-private.h"
+#include "mongoc-structured-log-connection-private.h"
 
 #ifdef MONGOC_ENABLE_SSL
 #include "mongoc-stream-tls.h"
 #include "mongoc-ssl-private.h"
 #include "mongoc-cmd-private.h"
 #include "mongoc-opts-private.h"
-#include "mongoc-structured-log-command-private.h"
-#include "mongoc-structured-log-connection-private.h"
 #endif
 
 

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -68,6 +68,7 @@
 #include "mongoc-cmd-private.h"
 #include "mongoc-opts-private.h"
 #include "mongoc-structured-log-command-private.h"
+#include "mongoc-structured-log-connection-private.h"
 #endif
 
 
@@ -1168,6 +1169,8 @@ _mongoc_client_new_from_uri (mongoc_topology_t *topology)
       _mongoc_client_set_internal_tls_opts (client, &internal_tls_opts);
    }
 #endif
+
+   mongoc_structured_log_connection_client_created ();
 
    mongoc_counter_clients_active_inc ();
 

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -2325,7 +2325,8 @@ _mongoc_client_monitor_op_killcursors (mongoc_cluster_t *cluster,
    _mongoc_client_prepare_killcursors_command (cursor_id, collection, &doc);
 
    // @todo Provide missing arguments
-   mongoc_structured_log_command_started (&doc, "killCursors", db, operation_id, cluster->request_id, 0, 0, false);
+   mongoc_structured_log_command_started (
+      &doc, "killCursors", db, operation_id, cluster->request_id, 0, 0, false);
 
    if (!client->apm_callbacks.started) {
       bson_destroy (&doc);
@@ -2375,15 +2376,14 @@ _mongoc_client_monitor_op_killcursors_succeeded (
    bson_append_array_end (&doc, &cursors_unknown);
 
    // @todo Provide missing arguments
-   mongoc_structured_log_command_success (
-      "killCursors",
-      operation_id,
-      &doc,
-      duration,
-      cluster->request_id,
-      0,
-      0,
-      false);
+   mongoc_structured_log_command_success ("killCursors",
+                                          operation_id,
+                                          &doc,
+                                          duration,
+                                          cluster->request_id,
+                                          0,
+                                          0,
+                                          false);
 
    if (!client->apm_callbacks.succeeded) {
       bson_destroy (&doc);
@@ -2428,15 +2428,14 @@ _mongoc_client_monitor_op_killcursors_failed (
    bson_append_int32 (&doc, "ok", 2, 0);
 
    // @todo Provide missing arguments
-   mongoc_structured_log_command_failure (
-      "killCursors",
-      operation_id,
-      &doc,
-      error,
-      cluster->request_id,
-      0,
-      0,
-      false);
+   mongoc_structured_log_command_failure ("killCursors",
+                                          operation_id,
+                                          &doc,
+                                          error,
+                                          cluster->request_id,
+                                          0,
+                                          0,
+                                          false);
 
    if (!client->apm_callbacks.failed) {
       bson_destroy (&doc);

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -2327,7 +2327,7 @@ _mongoc_client_monitor_op_killcursors (mongoc_cluster_t *cluster,
    bson_init (&doc);
    _mongoc_client_prepare_killcursors_command (cursor_id, collection, &doc);
 
-   // @todo Provide missing arguments
+   /* @todo Provide missing arguments */
    mongoc_structured_log_command_started (
       &doc, "killCursors", db, operation_id, cluster->request_id, 0, 0, false);
 
@@ -2378,7 +2378,7 @@ _mongoc_client_monitor_op_killcursors_succeeded (
    bson_append_int64 (&cursors_unknown, "0", 1, cursor_id);
    bson_append_array_end (&doc, &cursors_unknown);
 
-   // @todo Provide missing arguments
+   /* @todo Provide missing arguments */
    mongoc_structured_log_command_success ("killCursors",
                                           operation_id,
                                           &doc,
@@ -2430,7 +2430,7 @@ _mongoc_client_monitor_op_killcursors_failed (
    bson_init (&doc);
    bson_append_int32 (&doc, "ok", 2, 0);
 
-   // @todo Provide missing arguments
+   /* @todo Provide missing arguments */
    mongoc_structured_log_command_failure ("killCursors",
                                           operation_id,
                                           &doc,

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -55,6 +55,7 @@
 #include "mongoc-handshake-private.h"
 #include "mongoc-cluster-aws-private.h"
 #include "mongoc-error-private.h"
+#include "mongoc-structured-log-private.h"
 
 #undef MONGOC_LOG_DOMAIN
 #define MONGOC_LOG_DOMAIN "cluster"
@@ -531,6 +532,9 @@ mongoc_cluster_run_command_monitored (mongoc_cluster_t *cluster,
          goto fail_no_events;
       }
    }
+
+   // @todo Provide explicit session
+   mongoc_structured_log_command_started(cmd, request_id, false);
 
    if (callbacks->started) {
       mongoc_apm_command_started_init_with_cmd (

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -55,7 +55,7 @@
 #include "mongoc-handshake-private.h"
 #include "mongoc-cluster-aws-private.h"
 #include "mongoc-error-private.h"
-#include "mongoc-structured-log-private.h"
+#include "mongoc-structured-log-command-private.h"
 
 #undef MONGOC_LOG_DOMAIN
 #define MONGOC_LOG_DOMAIN "cluster"

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -533,8 +533,8 @@ mongoc_cluster_run_command_monitored (mongoc_cluster_t *cluster,
       }
    }
 
-   // @todo Provide explicit session
-   mongoc_structured_log_command_started(cmd, request_id, false);
+   // @todo Provide explicit session and connection IDs
+   mongoc_structured_log_command_started (cmd, request_id, 0, 0, false);
 
    if (callbacks->started) {
       mongoc_apm_command_started_init_with_cmd (

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -534,11 +534,7 @@ mongoc_cluster_run_command_monitored (mongoc_cluster_t *cluster,
    }
 
    /* @todo Provide missing arguments */
-   mongoc_structured_log_command_started_with_cmd (cmd,
-                                                   request_id,
-                                                   0,
-                                                   0,
-                                                   false);
+   mongoc_structured_log_command_started_with_cmd (cmd, request_id, 0, false);
 
    if (callbacks->started) {
       mongoc_apm_command_started_init_with_cmd (
@@ -587,7 +583,7 @@ mongoc_cluster_run_command_monitored (mongoc_cluster_t *cluster,
                                                                   : &fake_reply,
                                              duration,
                                              request_id,
-                                             0,
+                                             &server_stream->sd->host,
                                              0,
                                              false);
 
@@ -617,7 +613,7 @@ mongoc_cluster_run_command_monitored (mongoc_cluster_t *cluster,
                                              reply,
                                              error,
                                              cluster->request_id,
-                                             0,
+                                             &server_stream->sd->host,
                                              0,
                                              false);
 

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -534,7 +534,14 @@ mongoc_cluster_run_command_monitored (mongoc_cluster_t *cluster,
    }
 
    // @todo Provide missing arguments
-   mongoc_structured_log_command_started (cmd->command, cmd->command_name, cmd->db_name, cmd->operation_id, request_id, 0, 0, false);
+   mongoc_structured_log_command_started (cmd->command,
+                                          cmd->command_name,
+                                          cmd->db_name,
+                                          cmd->operation_id,
+                                          request_id,
+                                          0,
+                                          0,
+                                          false);
 
    if (callbacks->started) {
       mongoc_apm_command_started_init_with_cmd (
@@ -565,7 +572,7 @@ mongoc_cluster_run_command_monitored (mongoc_cluster_t *cluster,
 
    if (retval) {
       bson_t fake_reply = BSON_INITIALIZER;
-      int64_t duration = bson_get_monotonic_time() - started;
+      int64_t duration = bson_get_monotonic_time () - started;
 
       /*
        * Unacknowledged writes must provide a CommandSucceededEvent with an
@@ -577,27 +584,27 @@ mongoc_cluster_run_command_monitored (mongoc_cluster_t *cluster,
       }
 
       // @todo Provide missing arguments
-      mongoc_structured_log_command_success (
-         cmd->command_name,
-         cmd->operation_id,
-         cmd->is_acknowledged ? reply : &fake_reply,
-         duration,
-         request_id,
-         0,
-         0,
-         false);
+      mongoc_structured_log_command_success (cmd->command_name,
+                                             cmd->operation_id,
+                                             cmd->is_acknowledged ? reply
+                                                                  : &fake_reply,
+                                             duration,
+                                             request_id,
+                                             0,
+                                             0,
+                                             false);
 
       if (callbacks->succeeded) {
-         mongoc_apm_command_succeeded_init (
-            &succeeded_event,
-            duration,
-            cmd->is_acknowledged ? reply : &fake_reply,
-            cmd->command_name,
-            request_id,
-            cmd->operation_id,
-            &server_stream->sd->host,
-            server_id,
-            cluster->client->apm_context);
+         mongoc_apm_command_succeeded_init (&succeeded_event,
+                                            duration,
+                                            cmd->is_acknowledged ? reply
+                                                                 : &fake_reply,
+                                            cmd->command_name,
+                                            request_id,
+                                            cmd->operation_id,
+                                            &server_stream->sd->host,
+                                            server_id,
+                                            cluster->client->apm_context);
 
          callbacks->succeeded (&succeeded_event);
          mongoc_apm_command_succeeded_cleanup (&succeeded_event);
@@ -605,18 +612,17 @@ mongoc_cluster_run_command_monitored (mongoc_cluster_t *cluster,
 
       bson_destroy (&fake_reply);
    } else {
-      int64_t duration = bson_get_monotonic_time() - started;
+      int64_t duration = bson_get_monotonic_time () - started;
 
       // @todo Provide missing arguments
-      mongoc_structured_log_command_failure (
-         cmd->command_name,
-         cmd->operation_id,
-         reply,
-         error,
-         cluster->request_id,
-         0,
-         0,
-         false);
+      mongoc_structured_log_command_failure (cmd->command_name,
+                                             cmd->operation_id,
+                                             reply,
+                                             error,
+                                             cluster->request_id,
+                                             0,
+                                             0,
+                                             false);
 
       if (callbacks->failed) {
          mongoc_apm_command_failed_init (&failed_event,

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -533,7 +533,7 @@ mongoc_cluster_run_command_monitored (mongoc_cluster_t *cluster,
       }
    }
 
-   // @todo Provide missing arguments
+   /* @todo Provide missing arguments */
    mongoc_structured_log_command_started_with_cmd (cmd,
                                                    request_id,
                                                    0,
@@ -580,7 +580,7 @@ mongoc_cluster_run_command_monitored (mongoc_cluster_t *cluster,
          bson_append_int32 (&fake_reply, "ok", 2, 1);
       }
 
-      // @todo Provide missing arguments
+      /* @todo Provide missing arguments */
       mongoc_structured_log_command_success (cmd->command_name,
                                              cmd->operation_id,
                                              cmd->is_acknowledged ? reply
@@ -611,7 +611,7 @@ mongoc_cluster_run_command_monitored (mongoc_cluster_t *cluster,
    } else {
       int64_t duration = bson_get_monotonic_time () - started;
 
-      // @todo Provide missing arguments
+      /* @todo Provide missing arguments */
       mongoc_structured_log_command_failure (cmd->command_name,
                                              cmd->operation_id,
                                              reply,

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -534,14 +534,11 @@ mongoc_cluster_run_command_monitored (mongoc_cluster_t *cluster,
    }
 
    // @todo Provide missing arguments
-   mongoc_structured_log_command_started (cmd->command,
-                                          cmd->command_name,
-                                          cmd->db_name,
-                                          cmd->operation_id,
-                                          request_id,
-                                          0,
-                                          0,
-                                          false);
+   mongoc_structured_log_command_started_with_cmd (cmd,
+                                                   request_id,
+                                                   0,
+                                                   0,
+                                                   false);
 
    if (callbacks->started) {
       mongoc_apm_command_started_init_with_cmd (

--- a/src/libmongoc/src/mongoc/mongoc-cursor-legacy.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor-legacy.c
@@ -51,7 +51,14 @@ _mongoc_cursor_monitor_legacy_get_more (mongoc_cursor_t *cursor,
    db = bson_strndup (cursor->ns, cursor->dblen);
 
    // @todo Provide missing arguments
-   mongoc_structured_log_command_started (&doc, "getMore", db, cursor->operation_id, client->cluster.request_id, 0, 0, false);
+   mongoc_structured_log_command_started (&doc,
+                                          "getMore",
+                                          db,
+                                          cursor->operation_id,
+                                          client->cluster.request_id,
+                                          0,
+                                          0,
+                                          false);
 
    if (!client->apm_callbacks.started) {
       /* successful */

--- a/src/libmongoc/src/mongoc/mongoc-cursor-legacy.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor-legacy.c
@@ -50,7 +50,7 @@ _mongoc_cursor_monitor_legacy_get_more (mongoc_cursor_t *cursor,
    _mongoc_cursor_prepare_getmore_command (cursor, &doc);
    db = bson_strndup (cursor->ns, cursor->dblen);
 
-   // @todo Provide missing arguments
+   /* @todo Provide missing arguments */
    mongoc_structured_log_command_started (&doc,
                                           "getMore",
                                           db,

--- a/src/libmongoc/src/mongoc/mongoc-cursor-legacy.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor-legacy.c
@@ -56,7 +56,7 @@ _mongoc_cursor_monitor_legacy_get_more (mongoc_cursor_t *cursor,
                                           db,
                                           cursor->operation_id,
                                           client->cluster.request_id,
-                                          0,
+                                          &server_stream->sd->host,
                                           0,
                                           false);
 

--- a/src/libmongoc/src/mongoc/mongoc-cursor-legacy.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor-legacy.c
@@ -32,6 +32,7 @@
 #include "mongoc-write-concern-private.h"
 #include "mongoc-read-prefs-private.h"
 #include "mongoc-rpc-private.h"
+#include "mongoc-structured-log-command-private.h"
 
 
 static bool
@@ -46,14 +47,19 @@ _mongoc_cursor_monitor_legacy_get_more (mongoc_cursor_t *cursor,
    ENTRY;
 
    client = cursor->client;
+   _mongoc_cursor_prepare_getmore_command (cursor, &doc);
+   db = bson_strndup (cursor->ns, cursor->dblen);
+
+   // @todo Provide missing arguments
+   mongoc_structured_log_command_started (&doc, "getMore", db, cursor->operation_id, client->cluster.request_id, 0, 0, false);
+
    if (!client->apm_callbacks.started) {
       /* successful */
+      bson_destroy (&doc);
+      bson_free (db);
       RETURN (true);
    }
 
-   _mongoc_cursor_prepare_getmore_command (cursor, &doc);
-
-   db = bson_strndup (cursor->ns, cursor->dblen);
    mongoc_apm_command_started_init (&event,
                                     &doc,
                                     db,
@@ -86,10 +92,6 @@ _mongoc_cursor_monitor_legacy_query (mongoc_cursor_t *cursor,
    ENTRY;
 
    client = cursor->client;
-   if (!client->apm_callbacks.started) {
-      /* successful */
-      RETURN (true);
-   }
 
    bson_init (&doc);
    db = bson_strndup (cursor->ns, cursor->dblen);

--- a/src/libmongoc/src/mongoc/mongoc-cursor-legacy.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor-legacy.c
@@ -92,13 +92,10 @@ _mongoc_cursor_monitor_legacy_query (mongoc_cursor_t *cursor,
                                      mongoc_server_stream_t *server_stream)
 {
    bson_t doc;
-   mongoc_client_t *client;
    char *db;
    bool r;
 
    ENTRY;
-
-   client = cursor->client;
 
    bson_init (&doc);
    db = bson_strndup (cursor->ns, cursor->dblen);

--- a/src/libmongoc/src/mongoc/mongoc-cursor.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor.c
@@ -700,7 +700,14 @@ _mongoc_cursor_monitor_command (mongoc_cursor_t *cursor,
    db = bson_strndup (cursor->ns, cursor->dblen);
 
    // @todo Provide missing arguments
-   mongoc_structured_log_command_started (cmd, cmd_name, db, cursor->operation_id, client->cluster.request_id, 0, 0, false);
+   mongoc_structured_log_command_started (cmd,
+                                          cmd_name,
+                                          db,
+                                          cursor->operation_id,
+                                          client->cluster.request_id,
+                                          0,
+                                          0,
+                                          false);
 
    if (!client->apm_callbacks.started) {
       /* successful */
@@ -785,15 +792,14 @@ _mongoc_cursor_monitor_succeeded (mongoc_cursor_t *cursor,
    bson_destroy (&docs_array);
 
    // @todo Provide missing arguments
-   mongoc_structured_log_command_success (
-      cmd_name,
-      cursor->operation_id,
-      &reply,
-      duration,
-      client->cluster.request_id,
-      0,
-      0,
-      false);
+   mongoc_structured_log_command_success (cmd_name,
+                                          cursor->operation_id,
+                                          &reply,
+                                          duration,
+                                          client->cluster.request_id,
+                                          0,
+                                          0,
+                                          false);
 
    if (!client->apm_callbacks.succeeded) {
       bson_destroy (&reply);
@@ -840,15 +846,14 @@ _mongoc_cursor_monitor_failed (mongoc_cursor_t *cursor,
    bson_append_int32 (&reply, "ok", 2, 0);
 
    // @todo Provide missing arguments
-   mongoc_structured_log_command_failure (
-      cmd_name,
-      cursor->operation_id,
-      &reply,
-      &cursor->error,
-      client->cluster.request_id,
-      0,
-      0,
-      false);
+   mongoc_structured_log_command_failure (cmd_name,
+                                          cursor->operation_id,
+                                          &reply,
+                                          &cursor->error,
+                                          client->cluster.request_id,
+                                          0,
+                                          0,
+                                          false);
 
    if (!client->apm_callbacks.failed) {
       bson_destroy (&reply);

--- a/src/libmongoc/src/mongoc/mongoc-cursor.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor.c
@@ -705,7 +705,7 @@ _mongoc_cursor_monitor_command (mongoc_cursor_t *cursor,
                                           db,
                                           cursor->operation_id,
                                           client->cluster.request_id,
-                                          0,
+                                          &server_stream->sd->host,
                                           0,
                                           false);
 
@@ -797,7 +797,7 @@ _mongoc_cursor_monitor_succeeded (mongoc_cursor_t *cursor,
                                           &reply,
                                           duration,
                                           client->cluster.request_id,
-                                          0,
+                                          &stream->sd->host,
                                           0,
                                           false);
 
@@ -851,7 +851,7 @@ _mongoc_cursor_monitor_failed (mongoc_cursor_t *cursor,
                                           &reply,
                                           &cursor->error,
                                           client->cluster.request_id,
-                                          0,
+                                          &stream->sd->host,
                                           0,
                                           false);
 

--- a/src/libmongoc/src/mongoc/mongoc-cursor.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor.c
@@ -699,7 +699,7 @@ _mongoc_cursor_monitor_command (mongoc_cursor_t *cursor,
    client = cursor->client;
    db = bson_strndup (cursor->ns, cursor->dblen);
 
-   // @todo Provide missing arguments
+   /* @todo Provide missing arguments */
    mongoc_structured_log_command_started (cmd,
                                           cmd_name,
                                           db,
@@ -791,7 +791,7 @@ _mongoc_cursor_monitor_succeeded (mongoc_cursor_t *cursor,
    bson_append_document_end (&reply, &reply_cursor);
    bson_destroy (&docs_array);
 
-   // @todo Provide missing arguments
+   /* @todo Provide missing arguments */
    mongoc_structured_log_command_success (cmd_name,
                                           cursor->operation_id,
                                           &reply,
@@ -845,7 +845,7 @@ _mongoc_cursor_monitor_failed (mongoc_cursor_t *cursor,
    bson_init (&reply);
    bson_append_int32 (&reply, "ok", 2, 0);
 
-   // @todo Provide missing arguments
+   /* @todo Provide missing arguments */
    mongoc_structured_log_command_failure (cmd_name,
                                           cursor->operation_id,
                                           &reply,

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-command-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-command-private.h
@@ -47,6 +47,13 @@ mongoc_structured_log_command_started (const bson_t *command,
                                        bool explicit_session);
 
 void
+mongoc_structured_log_command_started_with_cmd (const mongoc_cmd_t *cmd,
+                                                uint32_t request_id,
+                                                uint32_t driver_connection_id,
+                                                uint32_t server_connection_id,
+                                                bool explicit_session);
+
+void
 mongoc_structured_log_command_success (const char *command_name,
                                        int64_t operation_id,
                                        const bson_t *reply,

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-command-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-command-private.h
@@ -23,17 +23,24 @@
 #include "mongoc-cmd-private.h"
 
 typedef struct {
-   const char *command_name;
-   const char *db_name;
-   const bson_t *command;
-   const bson_t *reply;
-   const bson_error_t *error;
-   int64_t duration;
-   int64_t operation_id;
-   uint32_t request_id;
-   uint32_t driver_connection_id;
-   uint32_t server_connection_id;
-   bool explicit_session;
+   /* Needed for:                       - Started
+    *                                 /   - Succeeded
+    *                                 | /   - Failed
+    *                                 | | /
+    *                                 | | | */
+   const char *command_name;       /* x x x */
+   const char *db_name;            /* x - - */
+   const bson_t *command;          /* x - - */
+   const bson_t *reply;            /* - x x */
+   const bson_error_t *error;      /* - - x */
+   int64_t duration;               /* - x x */
+   int64_t operation_id;           /* x x x */
+   uint32_t request_id;            /* x x x */
+   const mongoc_host_list_t *host; /* x x x */
+   char *server_resolved_ip;       /* x x x */
+   uint16_t client_port;           /* x x x */
+   uint32_t server_connection_id;  /* x x x */
+   bool explicit_session;          /* x x x */
 } _mongoc_structured_log_command_t;
 
 void
@@ -42,14 +49,13 @@ mongoc_structured_log_command_started (const bson_t *command,
                                        const char *db_name,
                                        int64_t operation_id,
                                        uint32_t request_id,
-                                       uint32_t driver_connection_id,
+                                       const mongoc_host_list_t *host,
                                        uint32_t server_connection_id,
                                        bool explicit_session);
 
 void
 mongoc_structured_log_command_started_with_cmd (const mongoc_cmd_t *cmd,
                                                 uint32_t request_id,
-                                                uint32_t driver_connection_id,
                                                 uint32_t server_connection_id,
                                                 bool explicit_session);
 
@@ -59,7 +65,7 @@ mongoc_structured_log_command_success (const char *command_name,
                                        const bson_t *reply,
                                        uint64_t duration,
                                        uint32_t request_id,
-                                       uint32_t driver_connection_id,
+                                       const mongoc_host_list_t *host,
                                        uint32_t server_connection_id,
                                        bool explicit_session);
 
@@ -69,7 +75,7 @@ mongoc_structured_log_command_failure (const char *command_name,
                                        const bson_t *reply,
                                        const bson_error_t *error,
                                        uint32_t request_id,
-                                       uint32_t driver_connection_id,
+                                       const mongoc_host_list_t *host,
                                        uint32_t server_connection_id,
                                        bool explicit_session);
 

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-command-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-command-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MongoDB, Inc.
+ * Copyright 2020 MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-command-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-command-private.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mongoc-prelude.h"
+#include "mongoc-structured-log.h"
+#include "mongoc-cmd-private.h"
+
+#ifndef MONGOC_STRUCTRURED_LOG_COMMAND_PRIVATE_H
+#define MONGOC_STRUCTRURED_LOG_COMMAND_PRIVATE_H
+
+typedef struct {
+   const mongoc_cmd_t *cmd;
+   const bson_t *reply;
+   const bson_error_t *error;
+   int64_t duration;
+   uint32_t request_id;
+   uint32_t driver_connection_id;
+   uint32_t server_connection_id;
+   bool explicit_session;
+} _mongoc_structured_log_command_t;
+
+void
+mongoc_structured_log_command_started (const mongoc_cmd_t *cmd,
+                                       uint32_t request_id,
+                                       uint32_t driver_connection_id,
+                                       uint32_t server_connection_id,
+                                       bool explicit_session);
+
+void
+mongoc_structured_log_command_success (const mongoc_cmd_t *cmd,
+                                       const bson_t *reply,
+                                       uint64_t duration,
+                                       uint32_t request_id,
+                                       uint32_t driver_connection_id,
+                                       uint32_t server_connection_id,
+                                       bool explicit_session);
+
+#endif /* MONGOC_STRUCTURED_LOG_COMMAND_PRIVATE_H */

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-command-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-command-private.h
@@ -15,11 +15,12 @@
  */
 
 #include "mongoc-prelude.h"
+
+#ifndef MONGOC_STRUCTURED_LOG_COMMAND_PRIVATE_H
+#define MONGOC_STRUCTURED_LOG_COMMAND_PRIVATE_H
+
 #include "mongoc-structured-log.h"
 #include "mongoc-cmd-private.h"
-
-#ifndef MONGOC_STRUCTRURED_LOG_COMMAND_PRIVATE_H
-#define MONGOC_STRUCTRURED_LOG_COMMAND_PRIVATE_H
 
 typedef struct {
    const char *command_name;

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-command-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-command-private.h
@@ -22,10 +22,13 @@
 #define MONGOC_STRUCTRURED_LOG_COMMAND_PRIVATE_H
 
 typedef struct {
-   const mongoc_cmd_t *cmd;
+   const char *command_name;
+   const char *db_name;
+   const bson_t *command;
    const bson_t *reply;
    const bson_error_t *error;
    int64_t duration;
+   int64_t operation_id;
    uint32_t request_id;
    uint32_t driver_connection_id;
    uint32_t server_connection_id;
@@ -33,16 +36,30 @@ typedef struct {
 } _mongoc_structured_log_command_t;
 
 void
-mongoc_structured_log_command_started (const mongoc_cmd_t *cmd,
+mongoc_structured_log_command_started (const bson_t *command,
+                                       const char *command_name,
+                                       const char *db_name,
+                                       int64_t operation_id,
                                        uint32_t request_id,
                                        uint32_t driver_connection_id,
                                        uint32_t server_connection_id,
                                        bool explicit_session);
 
 void
-mongoc_structured_log_command_success (const mongoc_cmd_t *cmd,
+mongoc_structured_log_command_success (const char *command_name,
+                                       int64_t operation_id,
                                        const bson_t *reply,
                                        uint64_t duration,
+                                       uint32_t request_id,
+                                       uint32_t driver_connection_id,
+                                       uint32_t server_connection_id,
+                                       bool explicit_session);
+
+void
+mongoc_structured_log_command_failure (const char *command_name,
+                                       int64_t operation_id,
+                                       const bson_t *reply,
+                                       const bson_error_t *error,
                                        uint32_t request_id,
                                        uint32_t driver_connection_id,
                                        uint32_t server_connection_id,

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-command.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-command.c
@@ -198,7 +198,7 @@ mongoc_structured_log_command_failure (const char *command_name,
 
    mongoc_structured_log (MONGOC_STRUCTURED_LOG_LEVEL_INFO,
                           MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
-                          "Command succeeded",
+                          "Command failed",
                           mongoc_log_structured_build_command_failed_message,
                           &command_log);
 }

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-command.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-command.c
@@ -152,6 +152,38 @@ mongoc_structured_log_command_started (const bson_t *command,
 }
 
 void
+mongoc_structured_log_command_started_with_cmd (const mongoc_cmd_t *cmd,
+                                                uint32_t request_id,
+                                                uint32_t driver_connection_id,
+                                                uint32_t server_connection_id,
+                                                bool explicit_session)
+{
+   // Discard const modifier, we promise we won't modify this
+   bson_t *command = (bson_t *) cmd->command;
+   bool command_owned = false;
+
+   if (cmd->payload && !cmd->payload_size) {
+      command = bson_copy (cmd->command);
+      command_owned = true;
+
+      _mongoc_cmd_append_payload_as_array (cmd, command);
+   }
+
+   mongoc_structured_log_command_started (command,
+                                          cmd->command_name,
+                                          cmd->db_name,
+                                          cmd->operation_id,
+                                          request_id,
+                                          driver_connection_id,
+                                          server_connection_id,
+                                          explicit_session);
+
+   if (command_owned) {
+      bson_destroy (command);
+   }
+}
+
+void
 mongoc_structured_log_command_success (const char *command_name,
                                        int64_t operation_id,
                                        const bson_t *reply,

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-command.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-command.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2020 MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-command.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-command.c
@@ -31,31 +31,31 @@
 #include "mongoc-structured-log-command-private.h"
 
 static void
-_mongoc_log_structured_append_command_data (mongoc_structured_log_entry_t *entry)
+_mongoc_log_structured_append_command_data (
+   mongoc_structured_log_entry_t *entry)
 {
    _mongoc_structured_log_command_t *log_command = entry->command;
 
-   BCON_APPEND (
-      entry->structured_message,
-      "commandName",
-      BCON_UTF8 (log_command->command_name),
-      "requestId",
-      BCON_INT32 (log_command->request_id),
-      "operationId",
-      BCON_INT64 (log_command->operation_id),
-      "driverConnectionId",
-      BCON_INT32 (log_command->driver_connection_id),
-      "serverConnectionId",
-      BCON_INT32 (log_command->server_connection_id),
-      "explicitSession",
-      BCON_BOOL (log_command->explicit_session)
-   );
+   BCON_APPEND (entry->structured_message,
+                "commandName",
+                BCON_UTF8 (log_command->command_name),
+                "requestId",
+                BCON_INT32 (log_command->request_id),
+                "operationId",
+                BCON_INT64 (log_command->operation_id),
+                "driverConnectionId",
+                BCON_INT32 (log_command->driver_connection_id),
+                "serverConnectionId",
+                BCON_INT32 (log_command->server_connection_id),
+                "explicitSession",
+                BCON_BOOL (log_command->explicit_session));
 }
 
 static void
-mongoc_log_structured_build_command_started_message (mongoc_structured_log_entry_t *entry)
+mongoc_log_structured_build_command_started_message (
+   mongoc_structured_log_entry_t *entry)
 {
-   char* cmd_json;
+   char *cmd_json;
    _mongoc_structured_log_command_t *log_command = entry->command;
 
    BSON_ASSERT (entry->component == MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND);
@@ -64,21 +64,20 @@ mongoc_log_structured_build_command_started_message (mongoc_structured_log_entry
 
    _mongoc_log_structured_append_command_data (entry);
 
-   BCON_APPEND (
-      entry->structured_message,
-      "databaseName",
-      BCON_UTF8 (log_command->db_name),
-      "command",
-      BCON_UTF8 (cmd_json)
-   );
+   BCON_APPEND (entry->structured_message,
+                "databaseName",
+                BCON_UTF8 (log_command->db_name),
+                "command",
+                BCON_UTF8 (cmd_json));
 
    bson_free (cmd_json);
 }
 
 static void
-mongoc_log_structured_build_command_succeeded_message (mongoc_structured_log_entry_t *entry)
+mongoc_log_structured_build_command_succeeded_message (
+   mongoc_structured_log_entry_t *entry)
 {
-   char* reply_json;
+   char *reply_json;
    _mongoc_structured_log_command_t *log_command = entry->command;
 
    BSON_ASSERT (entry->component == MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND);
@@ -87,21 +86,20 @@ mongoc_log_structured_build_command_succeeded_message (mongoc_structured_log_ent
 
    _mongoc_log_structured_append_command_data (entry);
 
-   BCON_APPEND (
-      entry->structured_message,
-      "duration",
-      BCON_INT64 (log_command->duration),
-      "reply",
-      BCON_UTF8 (reply_json)
-      );
+   BCON_APPEND (entry->structured_message,
+                "duration",
+                BCON_INT64 (log_command->duration),
+                "reply",
+                BCON_UTF8 (reply_json));
 
    bson_free (reply_json);
 }
 
 static void
-mongoc_log_structured_build_command_failed_message (mongoc_structured_log_entry_t *entry)
+mongoc_log_structured_build_command_failed_message (
+   mongoc_structured_log_entry_t *entry)
 {
-   char* reply_json;
+   char *reply_json;
    _mongoc_structured_log_command_t *log_command = entry->command;
 
    BSON_ASSERT (entry->component == MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND);
@@ -110,16 +108,12 @@ mongoc_log_structured_build_command_failed_message (mongoc_structured_log_entry_
 
    _mongoc_log_structured_append_command_data (entry);
 
-   BCON_APPEND (
-      entry->structured_message,
-      "reply",
-      BCON_UTF8 (reply_json));
+   BCON_APPEND (entry->structured_message, "reply", BCON_UTF8 (reply_json));
 
    if (log_command->error) {
-      BCON_APPEND (
-         entry->structured_message,
-         "failure",
-         BCON_UTF8 (log_command->error->message));
+      BCON_APPEND (entry->structured_message,
+                   "failure",
+                   BCON_UTF8 (log_command->error->message));
    }
 
    bson_free (reply_json);
@@ -146,13 +140,11 @@ mongoc_structured_log_command_started (const bson_t *command,
       .explicit_session = explicit_session,
    };
 
-   mongoc_structured_log (
-      MONGOC_STRUCTURED_LOG_LEVEL_INFO,
-      MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
-      "Command started",
-      mongoc_log_structured_build_command_started_message,
-      &command_log
-   );
+   mongoc_structured_log (MONGOC_STRUCTURED_LOG_LEVEL_INFO,
+                          MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
+                          "Command started",
+                          mongoc_log_structured_build_command_started_message,
+                          &command_log);
 }
 
 void
@@ -176,13 +168,11 @@ mongoc_structured_log_command_success (const char *command_name,
       .explicit_session = explicit_session,
    };
 
-   mongoc_structured_log (
-      MONGOC_STRUCTURED_LOG_LEVEL_INFO,
-      MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
-      "Command succeeded",
-      mongoc_log_structured_build_command_succeeded_message,
-      &command_log
-   );
+   mongoc_structured_log (MONGOC_STRUCTURED_LOG_LEVEL_INFO,
+                          MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
+                          "Command succeeded",
+                          mongoc_log_structured_build_command_succeeded_message,
+                          &command_log);
 }
 
 void
@@ -206,11 +196,9 @@ mongoc_structured_log_command_failure (const char *command_name,
       .explicit_session = explicit_session,
    };
 
-   mongoc_structured_log (
-      MONGOC_STRUCTURED_LOG_LEVEL_INFO,
-      MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
-      "Command succeeded",
-      mongoc_log_structured_build_command_failed_message,
-      &command_log
-   );
+   mongoc_structured_log (MONGOC_STRUCTURED_LOG_LEVEL_INFO,
+                          MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
+                          "Command succeeded",
+                          mongoc_log_structured_build_command_failed_message,
+                          &command_log);
 }

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-command.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-command.c
@@ -20,11 +20,12 @@
 
 static void
 _mongoc_log_structured_append_command_data (
-   mongoc_structured_log_entry_t *entry)
+   void *structured_log_data, bson_t *structured_message /* OUT */)
 {
-   _mongoc_structured_log_command_t *log_command = entry->command;
+   _mongoc_structured_log_command_t *log_command =
+      (_mongoc_structured_log_command_t *) structured_log_data;
 
-   BCON_APPEND (entry->structured_message,
+   BCON_APPEND (structured_message,
                 "commandName",
                 BCON_UTF8 (log_command->command_name),
                 "requestId",
@@ -41,18 +42,22 @@ _mongoc_log_structured_append_command_data (
 
 static void
 mongoc_log_structured_build_command_started_message (
-   mongoc_structured_log_entry_t *entry)
+   mongoc_structured_log_component_t component,
+   void *structured_log_data,
+   bson_t *structured_message /* OUT */)
 {
    char *cmd_json;
-   _mongoc_structured_log_command_t *log_command = entry->command;
+   _mongoc_structured_log_command_t *log_command =
+      (_mongoc_structured_log_command_t *) structured_log_data;
 
-   BSON_ASSERT (entry->component == MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND);
+   BSON_ASSERT (component == MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND);
 
    cmd_json = bson_as_canonical_extended_json (log_command->command, NULL);
 
-   _mongoc_log_structured_append_command_data (entry);
+   _mongoc_log_structured_append_command_data (structured_log_data,
+                                               structured_message);
 
-   BCON_APPEND (entry->structured_message,
+   BCON_APPEND (structured_message,
                 "databaseName",
                 BCON_UTF8 (log_command->db_name),
                 "command",
@@ -63,18 +68,22 @@ mongoc_log_structured_build_command_started_message (
 
 static void
 mongoc_log_structured_build_command_succeeded_message (
-   mongoc_structured_log_entry_t *entry)
+   mongoc_structured_log_component_t component,
+   void *structured_log_data,
+   bson_t *structured_message /* OUT */)
 {
    char *reply_json;
-   _mongoc_structured_log_command_t *log_command = entry->command;
+   _mongoc_structured_log_command_t *log_command =
+      (_mongoc_structured_log_command_t *) structured_log_data;
 
-   BSON_ASSERT (entry->component == MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND);
+   BSON_ASSERT (component == MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND);
 
    reply_json = bson_as_canonical_extended_json (log_command->reply, NULL);
 
-   _mongoc_log_structured_append_command_data (entry);
+   _mongoc_log_structured_append_command_data (structured_log_data,
+                                               structured_message);
 
-   BCON_APPEND (entry->structured_message,
+   BCON_APPEND (structured_message,
                 "duration",
                 BCON_INT64 (log_command->duration),
                 "reply",
@@ -85,21 +94,25 @@ mongoc_log_structured_build_command_succeeded_message (
 
 static void
 mongoc_log_structured_build_command_failed_message (
-   mongoc_structured_log_entry_t *entry)
+   mongoc_structured_log_component_t component,
+   void *structured_log_data,
+   bson_t *structured_message /* OUT */)
 {
    char *reply_json;
-   _mongoc_structured_log_command_t *log_command = entry->command;
+   _mongoc_structured_log_command_t *log_command =
+      (_mongoc_structured_log_command_t *) structured_log_data;
 
-   BSON_ASSERT (entry->component == MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND);
+   BSON_ASSERT (component == MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND);
 
    reply_json = bson_as_canonical_extended_json (log_command->reply, NULL);
 
-   _mongoc_log_structured_append_command_data (entry);
+   _mongoc_log_structured_append_command_data (structured_log_data,
+                                               structured_message);
 
-   BCON_APPEND (entry->structured_message, "reply", BCON_UTF8 (reply_json));
+   BCON_APPEND (structured_message, "reply", BCON_UTF8 (reply_json));
 
    if (log_command->error) {
-      BCON_APPEND (entry->structured_message,
+      BCON_APPEND (structured_message,
                    "failure",
                    BCON_UTF8 (log_command->error->message));
    }

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-command.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-command.c
@@ -158,7 +158,7 @@ mongoc_structured_log_command_started_with_cmd (const mongoc_cmd_t *cmd,
                                                 uint32_t server_connection_id,
                                                 bool explicit_session)
 {
-   // Discard const modifier, we promise we won't modify this
+   /* Discard const modifier, we promise we won't modify this */
    bson_t *command = (bson_t *) cmd->command;
    bool command_owned = false;
 

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-command.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-command.c
@@ -14,18 +14,6 @@
  * limitations under the License.
  */
 
-
-#if defined(__linux__)
-#include <sys/syscall.h>
-#elif defined(_WIN32)
-#include <process.h>
-#elif defined(__FreeBSD__)
-#include <sys/thr.h>
-#else
-#include <unistd.h>
-#endif
-#include <time.h>
-
 #include "mongoc-structured-log.h"
 #include "mongoc-structured-log-private.h"
 #include "mongoc-structured-log-command-private.h"
@@ -130,14 +118,17 @@ mongoc_structured_log_command_started (const bson_t *command,
                                        bool explicit_session)
 {
    _mongoc_structured_log_command_t command_log = {
-      .command = command,
-      .command_name = command_name,
-      .db_name = db_name,
-      .operation_id = operation_id,
-      .request_id = request_id,
-      .driver_connection_id = driver_connection_id,
-      .server_connection_id = server_connection_id,
-      .explicit_session = explicit_session,
+      command_name,
+      db_name,
+      command,
+      NULL,
+      NULL,
+      0,
+      operation_id,
+      request_id,
+      driver_connection_id,
+      server_connection_id,
+      explicit_session,
    };
 
    mongoc_structured_log (MONGOC_STRUCTURED_LOG_LEVEL_INFO,
@@ -158,14 +149,17 @@ mongoc_structured_log_command_success (const char *command_name,
                                        bool explicit_session)
 {
    _mongoc_structured_log_command_t command_log = {
-      .command_name = command_name,
-      .operation_id = operation_id,
-      .reply = reply,
-      .duration = duration,
-      .request_id = request_id,
-      .driver_connection_id = driver_connection_id,
-      .server_connection_id = server_connection_id,
-      .explicit_session = explicit_session,
+      command_name,
+      NULL,
+      NULL,
+      reply,
+      NULL,
+      duration,
+      operation_id,
+      request_id,
+      driver_connection_id,
+      server_connection_id,
+      explicit_session,
    };
 
    mongoc_structured_log (MONGOC_STRUCTURED_LOG_LEVEL_INFO,
@@ -186,14 +180,17 @@ mongoc_structured_log_command_failure (const char *command_name,
                                        bool explicit_session)
 {
    _mongoc_structured_log_command_t command_log = {
-      .command_name = command_name,
-      .operation_id = operation_id,
-      .reply = reply,
-      .error = error,
-      .request_id = request_id,
-      .driver_connection_id = driver_connection_id,
-      .server_connection_id = server_connection_id,
-      .explicit_session = explicit_session,
+      command_name,
+      NULL,
+      NULL,
+      reply,
+      error,
+      0,
+      operation_id,
+      request_id,
+      driver_connection_id,
+      server_connection_id,
+      explicit_session,
    };
 
    mongoc_structured_log (MONGOC_STRUCTURED_LOG_LEVEL_INFO,

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-command.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-command.c
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2013 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#if defined(__linux__)
+#include <sys/syscall.h>
+#elif defined(_WIN32)
+#include <process.h>
+#elif defined(__FreeBSD__)
+#include <sys/thr.h>
+#else
+#include <unistd.h>
+#endif
+#include <time.h>
+
+#include "mongoc-structured-log.h"
+#include "mongoc-structured-log-private.h"
+#include "mongoc-structured-log-command-private.h"
+
+static void
+mongoc_log_structured_build_command_started_message (mongoc_structured_log_entry_t *entry)
+{
+   char* cmd_json;
+   _mongoc_structured_log_command_t *log_command = entry->command;
+
+   BSON_ASSERT (entry->component == MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND);
+
+   cmd_json = bson_as_canonical_extended_json (log_command->cmd->command, NULL);
+
+   BCON_APPEND (
+      entry->structured_message,
+      "command",
+      BCON_UTF8 (cmd_json),
+      "databaseName",
+      BCON_UTF8 (log_command->cmd->db_name),
+      "commandName",
+      BCON_UTF8 (log_command->cmd->command_name),
+      "requestId",
+      BCON_INT32 (log_command->request_id),
+      "operationId",
+      BCON_INT64 (log_command->cmd->operation_id),
+      "driverConnectionId",
+      BCON_INT32 (log_command->driver_connection_id),
+      "serverConnectionId",
+      BCON_INT32 (log_command->server_connection_id),
+      "explicitSession",
+      BCON_BOOL (log_command->explicit_session)
+   );
+
+   bson_free (cmd_json);
+}
+
+static void
+mongoc_log_structured_build_command_succeeded_message (mongoc_structured_log_entry_t *entry)
+{
+   char* reply_json;
+   _mongoc_structured_log_command_t *log_command = entry->command;
+
+   BSON_ASSERT (entry->component == MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND);
+
+   reply_json = bson_as_canonical_extended_json (log_command->reply, NULL);
+
+   BCON_APPEND (
+      entry->structured_message,
+      "reply",
+      BCON_UTF8 (reply_json),
+      "duration",
+      BCON_INT64 (log_command->duration),
+      "databaseName",
+      BCON_UTF8 (log_command->cmd->db_name),
+      "commandName",
+      BCON_UTF8 (log_command->cmd->command_name),
+      "requestId",
+      BCON_INT32 (log_command->request_id),
+      "operationId",
+      BCON_INT64 (log_command->cmd->operation_id),
+      "driverConnectionId",
+      BCON_INT32 (log_command->driver_connection_id),
+      "serverConnectionId",
+      BCON_INT32 (log_command->server_connection_id),
+      "explicitSession",
+      BCON_BOOL (log_command->explicit_session)
+   );
+
+   bson_free (reply_json);
+}
+
+void
+mongoc_structured_log_command_started (const mongoc_cmd_t *cmd,
+                                       uint32_t request_id,
+                                       uint32_t driver_connection_id,
+                                       uint32_t server_connection_id,
+                                       bool explicit_session)
+{
+   _mongoc_structured_log_command_t command_log = {
+      .cmd = cmd,
+      .request_id = request_id,
+      .driver_connection_id = driver_connection_id,
+      .server_connection_id = server_connection_id,
+      .explicit_session = explicit_session,
+   };
+
+   mongoc_structured_log (
+      MONGOC_STRUCTURED_LOG_LEVEL_INFO,
+      MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
+      "Command started",
+      mongoc_log_structured_build_command_started_message,
+      &command_log
+   );
+}
+
+void
+mongoc_structured_log_command_success (const mongoc_cmd_t *cmd,
+                                       const bson_t *reply,
+                                       uint64_t duration,
+                                       uint32_t request_id,
+                                       uint32_t driver_connection_id,
+                                       uint32_t server_connection_id,
+                                       bool explicit_session)
+{
+   _mongoc_structured_log_command_t command_log = {
+      .cmd = cmd,
+      .reply = reply,
+      .duration = duration,
+      .request_id = request_id,
+      .driver_connection_id = driver_connection_id,
+      .server_connection_id = server_connection_id,
+      .explicit_session = explicit_session,
+   };
+
+   mongoc_structured_log (
+      MONGOC_STRUCTURED_LOG_LEVEL_INFO,
+      MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
+      "Command succeeded",
+      mongoc_log_structured_build_command_succeeded_message,
+      &command_log
+   );
+}
+
+void
+mongoc_structured_log_command_failure (const mongoc_cmd_t *cmd,
+                                       const bson_t *reply,
+                                       const bson_error_t *error,
+                                       uint32_t request_id,
+                                       uint32_t driver_connection_id,
+                                       uint32_t server_connection_id,
+                                       bool explicit_session)
+{
+   _mongoc_structured_log_command_t command_log = {
+      .cmd = cmd,
+      .reply = reply,
+      .error = error,
+      .request_id = request_id,
+      .driver_connection_id = driver_connection_id,
+      .server_connection_id = server_connection_id,
+      .explicit_session = explicit_session,
+   };
+
+   mongoc_structured_log (
+      MONGOC_STRUCTURED_LOG_LEVEL_INFO,
+      MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
+      "Command succeeded",
+      mongoc_log_structured_build_command_succeeded_message,
+      &command_log
+   );
+}

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-command.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-command.c
@@ -65,8 +65,7 @@ mongoc_log_structured_build_command_started_message (
 
    BSON_ASSERT (component == MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND);
 
-   /* @todo Use MONGODB_MAX_DOCUMENT_LENGTH */
-   cmd_json = bson_as_canonical_extended_json (log_command->command, NULL);
+   cmd_json = mongoc_structured_log_document_to_json (log_command->command);
 
    _mongoc_log_structured_append_command_data (structured_log_data,
                                                structured_message);
@@ -92,8 +91,7 @@ mongoc_log_structured_build_command_succeeded_message (
 
    BSON_ASSERT (component == MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND);
 
-   /* @todo Use MONGODB_MAX_DOCUMENT_LENGTH */
-   reply_json = bson_as_canonical_extended_json (log_command->reply, NULL);
+   reply_json = mongoc_structured_log_document_to_json (log_command->reply);
 
    _mongoc_log_structured_append_command_data (structured_log_data,
                                                structured_message);
@@ -119,8 +117,7 @@ mongoc_log_structured_build_command_failed_message (
 
    BSON_ASSERT (component == MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND);
 
-   /* @todo Use MONGODB_MAX_DOCUMENT_LENGTH */
-   reply_json = bson_as_canonical_extended_json (log_command->reply, NULL);
+   reply_json = mongoc_structured_log_document_to_json (log_command->reply);
 
    _mongoc_log_structured_append_command_data (structured_log_data,
                                                structured_message);

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-command.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-command.c
@@ -39,7 +39,7 @@ _mongoc_log_structured_append_command_data (
                 "serverPort",
                 BCON_INT32 (log_command->host->port));
 
-   // Append client port only if it was provided
+   /* Append client port only if it was provided */
    if (log_command->client_port) {
       BCON_APPEND (structured_message,
                    "clientPort",

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-connection-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-connection-private.h
@@ -15,13 +15,14 @@
  */
 
 #include "mongoc-prelude.h"
+
+#ifndef MONGOC_STRUCTURED_LOG_CONNECTION_PRIVATE_H
+#define MONGOC_STRUCTURED_LOG_CONNECTION_PRIVATE_H
+
 #include "mongoc-structured-log.h"
 #include "mongoc-cmd-private.h"
 
-#ifndef MONGOC_STRUCTRURED_LOG_CONNECTION_PRIVATE_H
-#define MONGOC_STRUCTRURED_LOG_CONNECTION_PRIVATE_H
-
 void
-mongoc_structured_log_connection_client_created ();
+mongoc_structured_log_connection_client_created (void);
 
 #endif /* MONGOC_STRUCTURED_LOG_COMMAND_PRIVATE_H */

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-connection-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-connection-private.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mongoc-prelude.h"
+#include "mongoc-structured-log.h"
+#include "mongoc-cmd-private.h"
+
+#ifndef MONGOC_STRUCTRURED_LOG_CONNECTION_PRIVATE_H
+#define MONGOC_STRUCTRURED_LOG_CONNECTION_PRIVATE_H
+
+void
+mongoc_structured_log_connection_client_created ();
+
+#endif /* MONGOC_STRUCTURED_LOG_COMMAND_PRIVATE_H */

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-connection.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-connection.c
@@ -24,5 +24,4 @@ mongoc_structured_log_connection_client_created (void)
                           "Client created",
                           NULL,
                           NULL);
-
 }

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-connection.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-connection.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#if defined(__linux__)
+#include <sys/syscall.h>
+#elif defined(_WIN32)
+#include <process.h>
+#elif defined(__FreeBSD__)
+#include <sys/thr.h>
+#else
+#include <unistd.h>
+#endif
+#include <time.h>
+
+#include "mongoc-structured-log-private.h"
+
+void
+mongoc_structured_log_connection_client_created ()
+{
+   mongoc_structured_log (MONGOC_STRUCTURED_LOG_LEVEL_DEBUG,
+                          MONGOC_STRUCTURED_LOG_COMPONENT_CONNECTION,
+                          "Client created",
+                          NULL,
+                          NULL);
+
+}

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-connection.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-connection.c
@@ -14,22 +14,10 @@
  * limitations under the License.
  */
 
-
-#if defined(__linux__)
-#include <sys/syscall.h>
-#elif defined(_WIN32)
-#include <process.h>
-#elif defined(__FreeBSD__)
-#include <sys/thr.h>
-#else
-#include <unistd.h>
-#endif
-#include <time.h>
-
 #include "mongoc-structured-log-private.h"
 
 void
-mongoc_structured_log_connection_client_created ()
+mongoc_structured_log_connection_client_created (void)
 {
    mongoc_structured_log (MONGOC_STRUCTURED_LOG_LEVEL_DEBUG,
                           MONGOC_STRUCTURED_LOG_COMPONENT_CONNECTION,

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-private.h
@@ -26,7 +26,9 @@
 #define MONGOC_STRUCTURED_LOG_DEFAULT_LEVEL MONGOC_STRUCTURED_LOG_LEVEL_WARNING;
 
 typedef void (*mongoc_structured_log_build_message_t) (
-   mongoc_structured_log_entry_t *entry);
+   mongoc_structured_log_component_t component,
+   void *structured_log_data,
+   bson_t *structured_message /* OUT */);
 
 struct _mongoc_structured_log_entry_t {
    mongoc_structured_log_level_t level;
@@ -34,9 +36,7 @@ struct _mongoc_structured_log_entry_t {
    const char *message;
    bson_t *structured_message;
    mongoc_structured_log_build_message_t build_message_func;
-   union {
-      _mongoc_structured_log_command_t *command;
-   };
+   void *structured_log_data;
 };
 
 void

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MongoDB, Inc.
+ * Copyright 2020 MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-private.h
@@ -22,12 +22,13 @@
 #ifndef MONGOC_STRUCTRURED_LOG_PRIVATE_H
 #define MONGOC_STRUCTRURED_LOG_PRIVATE_H
 
-typedef void (*mongoc_structured_log_build_message_t) (mongoc_structured_log_entry_t *entry);
+typedef void (*mongoc_structured_log_build_message_t) (
+   mongoc_structured_log_entry_t *entry);
 
 struct _mongoc_structured_log_entry_t {
    mongoc_structured_log_level_t level;
    mongoc_structured_log_component_t component;
-   const char* message;
+   const char *message;
    bson_t *structured_message;
    mongoc_structured_log_build_message_t build_message_func;
    union {
@@ -43,6 +44,7 @@ mongoc_structured_log (mongoc_structured_log_level_t level,
                        void *structured_message_data);
 
 void
-_mongoc_structured_log_get_handler (mongoc_structured_log_func_t *log_func, void **user_data);
+_mongoc_structured_log_get_handler (mongoc_structured_log_func_t *log_func,
+                                    void **user_data);
 
 #endif /* MONGOC_STRUCTURED_LOG_PRIVATE_H */

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-private.h
@@ -15,12 +15,13 @@
  */
 
 #include "mongoc-prelude.h"
+
+#ifndef MONGOC_STRUCTURED_LOG_PRIVATE_H
+#define MONGOC_STRUCTURED_LOG_PRIVATE_H
+
 #include "mongoc-structured-log.h"
 #include "mongoc-cmd-private.h"
 #include "mongoc-structured-log-command-private.h"
-
-#ifndef MONGOC_STRUCTRURED_LOG_PRIVATE_H
-#define MONGOC_STRUCTRURED_LOG_PRIVATE_H
 
 #define MONGOC_STRUCTURED_LOG_DEFAULT_LEVEL MONGOC_STRUCTURED_LOG_LEVEL_WARNING;
 

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-private.h
@@ -22,6 +22,8 @@
 #ifndef MONGOC_STRUCTRURED_LOG_PRIVATE_H
 #define MONGOC_STRUCTRURED_LOG_PRIVATE_H
 
+#define MONGOC_STRUCTURED_LOG_DEFAULT_LEVEL MONGOC_STRUCTURED_LOG_LEVEL_WARNING;
+
 typedef void (*mongoc_structured_log_build_message_t) (
    mongoc_structured_log_entry_t *entry);
 

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-private.h
@@ -21,19 +21,30 @@
 #ifndef MONGOC_STRUCTRURED_LOG_PRIVATE_H
 #define MONGOC_STRUCTRURED_LOG_PRIVATE_H
 
-// @todo Decide if we want a log entry structure
+typedef void (*mongoc_structured_log_build_context_t) (bson_t *context, va_list *context_data);
+
 struct _mongoc_structured_log_entry_t {
    mongoc_structured_log_level_t level;
    mongoc_structured_log_component_t component;
-   char* message;
-   bson_t* context;
+   const char* message;
+   mongoc_structured_log_build_context_t build_context;
+   va_list *context_data;
+   bson_t *context;
 };
 
-void mongoc_structured_log_command_started(mongoc_cmd_t *cmd,
-                                           uint32_t request_id,
-                                           // Driver connection ID
-                                           // Server connection Id
-                                           bool explicit_session);
+void
+mongoc_structured_log (mongoc_structured_log_level_t level,
+                       mongoc_structured_log_component_t component,
+                       const char *message,
+                       mongoc_structured_log_build_context_t build_context,
+                       ...);
+
+void
+mongoc_structured_log_command_started (mongoc_cmd_t *cmd,
+                                       uint32_t request_id,
+                                       uint32_t driver_connection_id,
+                                       uint32_t server_connection_id,
+                                       bool explicit_session);
 
 #define MONGOC_STRUCTURED_LOG_COMMAND_STARTED()
 

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-private.h
@@ -42,4 +42,7 @@ mongoc_structured_log (mongoc_structured_log_level_t level,
                        mongoc_structured_log_build_message_t build_message_func,
                        void *structured_message_data);
 
+void
+_mongoc_structured_log_get_handler (mongoc_structured_log_func_t *log_func, void **user_data);
+
 #endif /* MONGOC_STRUCTURED_LOG_PRIVATE_H */

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-private.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mongoc-prelude.h"
+#include "mongoc-structured-log.h"
+#include "mongoc-cmd-private.h"
+
+#ifndef MONGOC_STRUCTRURED_LOG_PRIVATE_H
+#define MONGOC_STRUCTRURED_LOG_PRIVATE_H
+
+// @todo Decide if we want a log entry structure
+struct _mongoc_structured_log_entry_t {
+   mongoc_structured_log_level_t level;
+   mongoc_structured_log_component_t component;
+   char* message;
+   bson_t* context;
+};
+
+void mongoc_structured_log_command_started(mongoc_cmd_t *cmd,
+                                           uint32_t request_id,
+                                           // Driver connection ID
+                                           // Server connection Id
+                                           bool explicit_session);
+
+#define MONGOC_STRUCTURED_LOG_COMMAND_STARTED()
+
+#endif /* MONGOC_STRUCTURED_LOG_PRIVATE_H */

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-private.h
@@ -24,6 +24,7 @@
 #include "mongoc-structured-log-command-private.h"
 
 #define MONGOC_STRUCTURED_LOG_DEFAULT_LEVEL MONGOC_STRUCTURED_LOG_LEVEL_WARNING;
+#define MONGOC_STRUCTURED_LOG_DEFAULT_MAX_DOCUMENT_LENGTH 1000;
 
 typedef void (*mongoc_structured_log_build_message_t) (
    mongoc_structured_log_component_t component,

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-private.h
@@ -30,6 +30,7 @@ struct _mongoc_structured_log_entry_t {
    mongoc_structured_log_build_context_t build_context;
    va_list *context_data;
    bson_t *context;
+   bool context_built;
 };
 
 void

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-private.h
@@ -17,36 +17,29 @@
 #include "mongoc-prelude.h"
 #include "mongoc-structured-log.h"
 #include "mongoc-cmd-private.h"
+#include "mongoc-structured-log-command-private.h"
 
 #ifndef MONGOC_STRUCTRURED_LOG_PRIVATE_H
 #define MONGOC_STRUCTRURED_LOG_PRIVATE_H
 
-typedef void (*mongoc_structured_log_build_context_t) (bson_t *context, va_list *context_data);
+typedef void (*mongoc_structured_log_build_message_t) (mongoc_structured_log_entry_t *entry);
 
 struct _mongoc_structured_log_entry_t {
    mongoc_structured_log_level_t level;
    mongoc_structured_log_component_t component;
    const char* message;
-   mongoc_structured_log_build_context_t build_context;
-   va_list *context_data;
-   bson_t *context;
-   bool context_built;
+   bson_t *structured_message;
+   mongoc_structured_log_build_message_t build_message_func;
+   union {
+      _mongoc_structured_log_command_t *command;
+   };
 };
 
 void
 mongoc_structured_log (mongoc_structured_log_level_t level,
                        mongoc_structured_log_component_t component,
                        const char *message,
-                       mongoc_structured_log_build_context_t build_context,
-                       ...);
-
-void
-mongoc_structured_log_command_started (mongoc_cmd_t *cmd,
-                                       uint32_t request_id,
-                                       uint32_t driver_connection_id,
-                                       uint32_t server_connection_id,
-                                       bool explicit_session);
-
-#define MONGOC_STRUCTURED_LOG_COMMAND_STARTED()
+                       mongoc_structured_log_build_message_t build_message_func,
+                       void *structured_message_data);
 
 #endif /* MONGOC_STRUCTURED_LOG_PRIVATE_H */

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.c
@@ -121,7 +121,7 @@ mongoc_structured_log_default_handler (mongoc_structured_log_entry_t *entry, voi
    char *message = bson_as_json (mongoc_structured_log_entry_get_context (entry), NULL);
 
    fprintf (stderr,
-            "Structured log: %d, %d, %s",
+            "Structured log: %d, %d, %s\n",
             mongoc_structured_log_entry_get_level (entry),
             mongoc_structured_log_entry_get_component (entry),
             message);

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.c
@@ -131,3 +131,11 @@ mongoc_structured_log_default_handler (mongoc_structured_log_entry_t *entry, voi
 
    bson_free (message);
 }
+
+/* just for testing */
+void
+_mongoc_structured_log_get_handler (mongoc_structured_log_func_t *log_func, void **user_data)
+{
+   *log_func = gStructuredLogger;
+   *user_data = gStructuredLoggerData;
+}

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.c
@@ -53,7 +53,9 @@ mongoc_structured_log_entry_get_message (mongoc_structured_log_entry_t *entry)
          BCON_NEW ("message", BCON_UTF8 (entry->message));
 
       if (entry->build_message_func) {
-         entry->build_message_func (entry);
+         entry->build_message_func (entry->component,
+                                    entry->structured_log_data,
+                                    entry->structured_message);
       }
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.c
@@ -222,6 +222,30 @@ mongoc_structured_log_default_handler (mongoc_structured_log_entry_t *entry,
    bson_free (message);
 }
 
+static int32_t
+mongoc_structured_log_get_max_length (void)
+{
+   const char *max_length_str = getenv ("MONGODB_LOGGING_MAX_DOCUMENT_LENGTH");
+
+   if (!max_length_str) {
+      return MONGOC_STRUCTURED_LOG_DEFAULT_MAX_DOCUMENT_LENGTH;
+   }
+
+   if (!strcmp (max_length_str, "unlimited")) {
+      return BSON_MAX_LEN_UNLIMITED;
+   }
+
+   return strtoul (max_length_str, NULL, 10);
+}
+
+char *
+mongoc_structured_log_document_to_json (const bson_t *document)
+{
+   bson_json_opts_t opts = {BSON_JSON_MODE_CANONICAL, mongoc_structured_log_get_max_length ()};
+
+   return bson_as_json_with_opts (document, NULL, &opts);
+}
+
 /* just for testing */
 void
 _mongoc_structured_log_get_handler (mongoc_structured_log_func_t *log_func,

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.c
@@ -201,6 +201,7 @@ static void
 mongoc_structured_log_default_handler (mongoc_structured_log_entry_t *entry,
                                        void *user_data)
 {
+   char *message;
    mongoc_structured_log_level_t log_level =
       _mongoc_structured_log_get_log_level (
          mongoc_structured_log_entry_get_component (entry));
@@ -209,7 +210,7 @@ mongoc_structured_log_default_handler (mongoc_structured_log_entry_t *entry,
       return;
    }
 
-   char *message =
+   message =
       bson_as_json (mongoc_structured_log_entry_get_message (entry), NULL);
 
    fprintf (_mongoc_structured_log_get_stream (),

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.c
@@ -67,7 +67,7 @@ mongoc_structured_log_entry_destroy (mongoc_structured_log_entry_t *entry)
    }
 }
 
-bson_t*
+const bson_t*
 mongoc_structured_log_entry_get_context (mongoc_structured_log_entry_t *entry)
 {
    if (entry->context) {
@@ -87,13 +87,13 @@ mongoc_structured_log_entry_get_context (mongoc_structured_log_entry_t *entry)
 }
 
 mongoc_structured_log_level_t
-mongoc_structured_log_entry_get_level (mongoc_structured_log_entry_t *entry)
+mongoc_structured_log_entry_get_level (const mongoc_structured_log_entry_t *entry)
 {
    return entry->level;
 }
 
 mongoc_structured_log_component_t
-mongoc_structured_log_entry_get_component (mongoc_structured_log_entry_t *entry)
+mongoc_structured_log_entry_get_component (const mongoc_structured_log_entry_t *entry)
 {
    return entry->component;
 }

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.c
@@ -56,7 +56,7 @@ mongoc_structured_log_entry_init (mongoc_structured_log_entry_t *entry,
    entry->message = message;
    entry->build_context = build_context;
    entry->context_data = context_data;
-   entry->context = BCON_NEW("message", BCON_UTF8 (message));
+   entry->context = BCON_NEW ("message", BCON_UTF8 (message));
    entry->context_built = false;
 }
 
@@ -70,7 +70,7 @@ const bson_t*
 mongoc_structured_log_entry_get_context (mongoc_structured_log_entry_t *entry)
 {
    if (!entry->context_built && entry->build_context) {
-      entry->build_context(entry->context, entry->context_data);
+      entry->build_context (entry->context, entry->context_data);
       entry->context_built = true;
    }
 
@@ -126,7 +126,7 @@ mongoc_structured_log (mongoc_structured_log_level_t level,
 }
 
 static void
-mongoc_log_structured_build_command_context(bson_t *context, va_list *context_data)
+mongoc_log_structured_build_command_context (bson_t *context, va_list *context_data)
 {
    mongoc_cmd_t *cmd = va_arg (*context_data, mongoc_cmd_t*);
    uint32_t request_id = va_arg (*context_data, uint32_t);
@@ -134,26 +134,26 @@ mongoc_log_structured_build_command_context(bson_t *context, va_list *context_da
    uint32_t server_connection_id = va_arg (*context_data, uint32_t);
    bool explicit_session = !!va_arg (*context_data, int);
 
-   char* cmd_json = bson_as_canonical_extended_json(cmd->command, NULL);
+   char* cmd_json = bson_as_canonical_extended_json (cmd->command, NULL);
 
-   BCON_APPEND(
+   BCON_APPEND (
       context,
       "command",
-      BCON_UTF8(cmd_json),
+      BCON_UTF8 (cmd_json),
       "databaseName",
-      BCON_UTF8(cmd->db_name),
+      BCON_UTF8 (cmd->db_name),
       "commandName",
-      BCON_UTF8(cmd->command_name),
+      BCON_UTF8 (cmd->command_name),
       "requestId",
       BCON_INT32 (request_id),
       "operationId",
-      BCON_INT64(cmd->operation_id),
+      BCON_INT64 (cmd->operation_id),
       "driverConnectionId",
       BCON_INT32 (driver_connection_id),
       "serverConnectionId",
       BCON_INT32 (server_connection_id),
       "explicitSession",
-      BCON_BOOL(explicit_session)
+      BCON_BOOL (explicit_session)
    );
 
    bson_free (cmd_json);

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.c
@@ -32,11 +32,13 @@
 #include "mongoc-thread-private.h"
 
 static void
-mongoc_structured_log_default_handler (mongoc_structured_log_entry_t *entry, void *user_data);
+mongoc_structured_log_default_handler (mongoc_structured_log_entry_t *entry,
+                                       void *user_data);
 
 static bson_once_t once = BSON_ONCE_INIT;
 static bson_mutex_t gStructuredLogMutex;
-static mongoc_structured_log_func_t gStructuredLogger = mongoc_structured_log_default_handler;
+static mongoc_structured_log_func_t gStructuredLogger =
+   mongoc_structured_log_default_handler;
 static void *gStructuredLoggerData;
 
 static BSON_ONCE_FUN (_mongoc_ensure_mutex_once)
@@ -54,11 +56,12 @@ mongoc_structured_log_entry_destroy (mongoc_structured_log_entry_t *entry)
    }
 }
 
-const bson_t*
+const bson_t *
 mongoc_structured_log_entry_get_message (mongoc_structured_log_entry_t *entry)
 {
    if (!entry->structured_message) {
-      entry->structured_message = BCON_NEW ("message", BCON_UTF8 (entry->message));
+      entry->structured_message =
+         BCON_NEW ("message", BCON_UTF8 (entry->message));
 
       if (entry->build_message_func) {
          entry->build_message_func (entry);
@@ -69,19 +72,22 @@ mongoc_structured_log_entry_get_message (mongoc_structured_log_entry_t *entry)
 }
 
 mongoc_structured_log_level_t
-mongoc_structured_log_entry_get_level (const mongoc_structured_log_entry_t *entry)
+mongoc_structured_log_entry_get_level (
+   const mongoc_structured_log_entry_t *entry)
 {
    return entry->level;
 }
 
 mongoc_structured_log_component_t
-mongoc_structured_log_entry_get_component (const mongoc_structured_log_entry_t *entry)
+mongoc_structured_log_entry_get_component (
+   const mongoc_structured_log_entry_t *entry)
 {
    return entry->component;
 }
 
 void
-mongoc_structured_log_set_handler (mongoc_structured_log_func_t log_func, void *user_data)
+mongoc_structured_log_set_handler (mongoc_structured_log_func_t log_func,
+                                   void *user_data)
 {
    bson_once (&once, &_mongoc_ensure_mutex_once);
 
@@ -119,9 +125,11 @@ mongoc_structured_log (mongoc_structured_log_level_t level,
 }
 
 static void
-mongoc_structured_log_default_handler (mongoc_structured_log_entry_t *entry, void *user_data)
+mongoc_structured_log_default_handler (mongoc_structured_log_entry_t *entry,
+                                       void *user_data)
 {
-   char *message = bson_as_json (mongoc_structured_log_entry_get_message (entry), NULL);
+   char *message =
+      bson_as_json (mongoc_structured_log_entry_get_message (entry), NULL);
 
    fprintf (stderr,
             "Structured log: %d, %d, %s\n",
@@ -134,7 +142,8 @@ mongoc_structured_log_default_handler (mongoc_structured_log_entry_t *entry, voi
 
 /* just for testing */
 void
-_mongoc_structured_log_get_handler (mongoc_structured_log_func_t *log_func, void **user_data)
+_mongoc_structured_log_get_handler (mongoc_structured_log_func_t *log_func,
+                                    void **user_data)
 {
    *log_func = gStructuredLogger;
    *user_data = gStructuredLoggerData;

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2020 MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.c
@@ -56,31 +56,22 @@ mongoc_structured_log_entry_init (mongoc_structured_log_entry_t *entry,
    entry->message = message;
    entry->build_context = build_context;
    entry->context_data = context_data;
-   entry->context = NULL;
+   entry->context = BCON_NEW("message", BCON_UTF8 (message));
+   entry->context_built = false;
 }
 
 static void
 mongoc_structured_log_entry_destroy (mongoc_structured_log_entry_t *entry)
 {
-   if (entry->context) {
-      bson_free (entry->context);
-   }
+   bson_free (entry->context);
 }
 
 const bson_t*
 mongoc_structured_log_entry_get_context (mongoc_structured_log_entry_t *entry)
 {
-   if (entry->context) {
-      return entry->context;
-   }
-
-   entry->context = BCON_NEW(
-      "message",
-      BCON_UTF8(entry->message)
-   );
-
-   if (entry->build_context) {
+   if (!entry->context_built && entry->build_context) {
       entry->build_context(entry->context, entry->context_data);
+      entry->context_built = true;
    }
 
    return entry->context;

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.c
@@ -55,7 +55,7 @@ mongoc_structured_log_entry_destroy (mongoc_structured_log_entry_t *entry)
 }
 
 const bson_t*
-mongoc_structured_log_entry_get_context (mongoc_structured_log_entry_t *entry)
+mongoc_structured_log_entry_get_message (mongoc_structured_log_entry_t *entry)
 {
    if (!entry->structured_message) {
       entry->structured_message = BCON_NEW ("message", BCON_UTF8 (entry->message));
@@ -121,7 +121,7 @@ mongoc_structured_log (mongoc_structured_log_level_t level,
 static void
 mongoc_structured_log_default_handler (mongoc_structured_log_entry_t *entry, void *user_data)
 {
-   char *message = bson_as_json (mongoc_structured_log_entry_get_context (entry), NULL);
+   char *message = bson_as_json (mongoc_structured_log_entry_get_message (entry), NULL);
 
    fprintf (stderr,
             "Structured log: %d, %d, %s\n",

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.c
@@ -26,7 +26,6 @@
 #endif
 #include <stdarg.h>
 #include <time.h>
-#include <syslog.h>
 
 #include "mongoc-structured-log.h"
 #include "mongoc-structured-log-private.h"
@@ -191,47 +190,16 @@ mongoc_structured_log_command_started (mongoc_cmd_t *cmd,
    );
 }
 
-static int
-_mongoc_structured_log_convert_level (mongoc_structured_log_level_t level)
-{
-   switch (level)
-   {
-   case MONGOC_STRUCTURED_LOG_LEVEL_TRACE:
-   case MONGOC_STRUCTURED_LOG_LEVEL_DEBUG:
-      return LOG_DEBUG;
-
-   case MONGOC_STRUCTURED_LOG_LEVEL_INFO:
-      return LOG_INFO;
-
-   case MONGOC_STRUCTURED_LOG_LEVEL_NOTICE:
-      return LOG_NOTICE;
-
-   case MONGOC_STRUCTURED_LOG_LEVEL_WARNING:
-      return LOG_WARNING;
-
-   case MONGOC_STRUCTURED_LOG_LEVEL_ERROR:
-      return LOG_ERR;
-
-   case MONGOC_STRUCTURED_LOG_LEVEL_CRITICAL:
-      return LOG_CRIT;
-
-   case MONGOC_STRUCTURED_LOG_LEVEL_ALERT:
-      return LOG_ALERT;
-
-   case MONGOC_STRUCTURED_LOG_LEVEL_EMERGENCY:
-      return LOG_EMERG;
-
-   default:
-      return LOG_ERR;
-   }
-}
-
 void
 mongoc_structured_log_default_handler (mongoc_structured_log_entry_t *entry, void *user_data)
 {
    char *message = bson_as_json (mongoc_structured_log_entry_get_context (entry), NULL);
 
-   syslog (_mongoc_structured_log_convert_level (mongoc_structured_log_entry_get_level (entry)), "%s", message);
+   fprintf (stderr,
+            "Structured log: %d, %d, %s",
+            mongoc_structured_log_entry_get_level (entry),
+            mongoc_structured_log_entry_get_component (entry),
+            message);
 
    bson_free (message);
 }

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.c
@@ -128,7 +128,7 @@ mongoc_structured_log (mongoc_structured_log_level_t level,
 static mongoc_structured_log_level_t
 _mongoc_structured_log_get_log_level_from_env (const char *variable)
 {
-   const char* level = getenv (variable);
+   const char *level = getenv (variable);
 
    if (!level) {
       return MONGOC_STRUCTURED_LOG_DEFAULT_LEVEL;
@@ -151,25 +151,32 @@ _mongoc_structured_log_get_log_level_from_env (const char *variable)
    } else if (!strcasecmp (level, "emergency")) {
       return MONGOC_STRUCTURED_LOG_LEVEL_EMERGENCY;
    } else {
-      MONGOC_ERROR ("Invalid log level %s read for variable %s", level, variable);
+      MONGOC_ERROR (
+         "Invalid log level %s read for variable %s", level, variable);
       exit (EXIT_FAILURE);
    }
 }
 
 static mongoc_structured_log_level_t
-_mongoc_structured_log_get_log_level (mongoc_structured_log_component_t component)
+_mongoc_structured_log_get_log_level (
+   mongoc_structured_log_component_t component)
 {
    switch (component) {
    case MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND:
-      return _mongoc_structured_log_get_log_level_from_env ("MONGODB_LOGGING_COMMAND");
+      return _mongoc_structured_log_get_log_level_from_env (
+         "MONGODB_LOGGING_COMMAND");
    case MONGOC_STRUCTURED_LOG_COMPONENT_CONNECTION:
-      return _mongoc_structured_log_get_log_level_from_env ("MONGODB_LOGGING_CONNECTION");
+      return _mongoc_structured_log_get_log_level_from_env (
+         "MONGODB_LOGGING_CONNECTION");
    case MONGOC_STRUCTURED_LOG_COMPONENT_SDAM:
-      return _mongoc_structured_log_get_log_level_from_env ("MONGODB_LOGGING_SDAM");
+      return _mongoc_structured_log_get_log_level_from_env (
+         "MONGODB_LOGGING_SDAM");
    case MONGOC_STRUCTURED_LOG_COMPONENT_SERVER_SELECTION:
-      return _mongoc_structured_log_get_log_level_from_env ("MONGODB_LOGGING_SERVER_SELECTION");
+      return _mongoc_structured_log_get_log_level_from_env (
+         "MONGODB_LOGGING_SERVER_SELECTION");
    default:
-      MONGOC_ERROR ("Requesting log level for unsupported component %d", component);
+      MONGOC_ERROR ("Requesting log level for unsupported component %d",
+                    component);
       exit (EXIT_FAILURE);
    }
 }
@@ -177,7 +184,7 @@ _mongoc_structured_log_get_log_level (mongoc_structured_log_component_t componen
 static void
 _mongoc_structured_log_initialize_stream ()
 {
-   const char* log_target = getenv("MONGODB_LOGGING_PATH");
+   const char *log_target = getenv ("MONGODB_LOGGING_PATH");
    bool log_to_stderr = !log_target || !strcmp (log_target, "stderr");
 
    log_stream = log_to_stderr ? stderr : fopen (log_target, "a");
@@ -187,7 +194,7 @@ _mongoc_structured_log_initialize_stream ()
    }
 }
 
-static FILE*
+static FILE *
 _mongoc_structured_log_get_stream ()
 {
    if (!log_stream) {
@@ -201,7 +208,9 @@ static void
 mongoc_structured_log_default_handler (mongoc_structured_log_entry_t *entry,
                                        void *user_data)
 {
-   mongoc_structured_log_level_t log_level = _mongoc_structured_log_get_log_level (mongoc_structured_log_entry_get_component (entry));
+   mongoc_structured_log_level_t log_level =
+      _mongoc_structured_log_get_log_level (
+         mongoc_structured_log_entry_get_component (entry));
 
    if (log_level < mongoc_structured_log_entry_get_level (entry)) {
       return;

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.c
@@ -83,8 +83,6 @@ mongoc_structured_log_entry_get_context (mongoc_structured_log_entry_t *entry)
       entry->build_context(entry->context, entry->context_data);
    }
 
-   entry->context_data = NULL;
-
    return entry->context;
 }
 

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2013 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#if defined(__linux__)
+#include <sys/syscall.h>
+#elif defined(_WIN32)
+#include <process.h>
+#elif defined(__FreeBSD__)
+#include <sys/thr.h>
+#else
+#include <unistd.h>
+#endif
+#include <stdarg.h>
+#include <time.h>
+
+#include "mongoc-structured-log.h"
+#include "mongoc-structured-log-private.h"
+#include "mongoc-thread-private.h"
+
+static bson_once_t once = BSON_ONCE_INIT;
+static bson_mutex_t gStructuredLogMutex;
+static mongoc_structured_log_func_t gStructuredLogger = NULL;
+static void *gStructuredLoggerData;
+
+static BSON_ONCE_FUN (_mongoc_ensure_mutex_once)
+{
+   bson_mutex_init (&gStructuredLogMutex);
+
+   BSON_ONCE_RETURN;
+}
+
+static bson_t* mongoc_log_structured_create_context(const char *message, va_list *ap)
+{
+   bson_t  *context;
+   bcon_append_ctx_t ctx;
+
+   context = BCON_NEW ("message", *message);
+
+   bcon_append_ctx_init (&ctx);
+   bcon_append_ctx_va (context, &ctx, ap);
+
+   return context;
+}
+
+void
+mongoc_structured_log_set_handler (mongoc_structured_log_func_t log_func, void *user_data)
+{
+   bson_once (&once, &_mongoc_ensure_mutex_once);
+
+   bson_mutex_lock (&gStructuredLogMutex);
+   gStructuredLogger = log_func;
+   gStructuredLoggerData = user_data;
+   bson_mutex_unlock (&gStructuredLogMutex);
+}
+
+void mongoc_log_structured (mongoc_structured_log_level_t level,
+                            mongoc_structured_log_component_t component,
+                            const char *message,
+                            ...)
+{
+   va_list ap;
+   bson_t *context;
+
+   if (!gStructuredLogger) {
+      return;
+   }
+
+   va_start (ap, message);
+   context = mongoc_log_structured_create_context(message, &ap);
+   va_end (ap);
+
+   bson_mutex_lock (&gStructuredLogMutex);
+   gStructuredLogger (level, component, message, context, gStructuredLoggerData);
+   bson_mutex_unlock (&gStructuredLogMutex);
+
+   bson_destroy(context);
+}
+
+void mongoc_structured_log_command_started(mongoc_cmd_t *cmd,
+                                           uint32_t request_id,
+                                           // Driver connection ID
+                                           // Server connection Id
+                                           bool explicit_session)
+{
+   mongoc_log_structured(
+      MONGOC_STRUCTURED_LOG_LEVEL_INFO,
+      MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
+      "Command started",
+      "command",
+      BCON_DOCUMENT (cmd->command), // @todo Convert to canonical extJson here?
+      "databaseName",
+      cmd->db_name,
+      "commandName",
+      cmd->command_name,
+      "requestId",
+      BCON_INT32 (request_id),
+      "operationId",
+      cmd->operation_id,
+      "driverConnectionId",
+      BCON_INT32 (0), // @todo Provide driverConnectionId
+      "serverConnectionId",
+      BCON_INT32 (0), // @todo Provide serverConnectionId
+      "explicitSession",
+      explicit_session
+   );
+}

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.c
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.c
@@ -31,6 +31,9 @@
 #include "mongoc-structured-log-private.h"
 #include "mongoc-thread-private.h"
 
+static void
+mongoc_structured_log_default_handler (mongoc_structured_log_entry_t *entry, void *user_data);
+
 static bson_once_t once = BSON_ONCE_INIT;
 static bson_mutex_t gStructuredLogMutex;
 static mongoc_structured_log_func_t gStructuredLogger = mongoc_structured_log_default_handler;
@@ -115,7 +118,7 @@ mongoc_structured_log (mongoc_structured_log_level_t level,
    mongoc_structured_log_entry_destroy (&entry);
 }
 
-void
+static void
 mongoc_structured_log_default_handler (mongoc_structured_log_entry_t *entry, void *user_data)
 {
    char *message = bson_as_json (mongoc_structured_log_entry_get_context (entry), NULL);

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2013 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mongoc-prelude.h"
+
+#ifndef MONGOC_STRUCTURED_LOG_H
+#define MONGOC_STRUCTURED_LOG_H
+
+#include <bson/bson.h>
+
+#include "mongoc-macros.h"
+
+BSON_BEGIN_DECLS
+
+typedef enum {
+   MONGOC_STRUCTURED_LOG_LEVEL_EMERGENCY = 0,
+   MONGOC_STRUCTURED_LOG_LEVEL_ALERT = 1,
+   MONGOC_STRUCTURED_LOG_LEVEL_CRITICAL = 2,
+   MONGOC_STRUCTURED_LOG_LEVEL_ERROR = 3,
+   MONGOC_STRUCTURED_LOG_LEVEL_WARNING = 4,
+   MONGOC_STRUCTURED_LOG_LEVEL_NOTICE = 5,
+   MONGOC_STRUCTURED_LOG_LEVEL_INFO = 6,
+   MONGOC_STRUCTURED_LOG_LEVEL_DEBUG = 7,
+   MONGOC_STRUCTURED_LOG_LEVEL_TRACE = 8,
+} mongoc_structured_log_level_t;
+
+typedef enum {
+   MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
+   MONGOC_STRUCTURED_LOG_COMPONENT_SDAM,
+   MONGOC_STRUCTURED_LOG_COMPONENT_SERVER_SELECTION,
+   MONGOC_STRUCTURED_LOG_COMPONENT_CONNECTION,
+} mongoc_structured_log_component_t;
+
+typedef struct _mongoc_structured_log_entry_t mongoc_structured_log_entry_t;
+
+typedef void (*mongoc_structured_log_func_t) (mongoc_structured_log_level_t level,
+                                   mongoc_structured_log_component_t component,
+                                   const char *message,
+                                   bson_t *context,
+                                   void *user_data);
+MONGOC_EXPORT (void)
+mongoc_structured_log_set_handler (mongoc_structured_log_func_t log_func, void *user_data);
+
+MONGOC_EXPORT (void)
+mongoc_log_structured (mongoc_structured_log_level_t level,
+                       mongoc_structured_log_component_t component,
+                       const char *message,
+                       ...);
+
+BSON_END_DECLS
+
+
+#endif /* MONGOC_STRUCTURED_LOG_H */

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.h
@@ -49,17 +49,47 @@ typedef struct _mongoc_structured_log_entry_t mongoc_structured_log_entry_t;
 typedef void (*mongoc_structured_log_func_t) (
    mongoc_structured_log_entry_t *entry, void *user_data);
 
+/**
+ * mongoc_structured_log_set_handler:
+ * @log_func: A function to handle structured messages.
+ * @user_data: User data for @log_func.
+ *
+ * Sets the function to be called to handle structured log messages.
+ */
 MONGOC_EXPORT (void)
 mongoc_structured_log_set_handler (mongoc_structured_log_func_t log_func,
                                    void *user_data);
 
+/**
+ * mongoc_structured_log_entry_get_message:
+ * @entry: A log entry to extract the message from
+ *
+ * Returns the structured message as a bson_t pointer.
+ *
+ * When this function is called, the message is lazily generated if it hasn't
+ * already been generated. Note that it is not safe to call this method outside
+ * of a log handler, as the data needed to assemble the message may have been
+ * freed already.
+ */
 MONGOC_EXPORT (const bson_t *)
 mongoc_structured_log_entry_get_message (mongoc_structured_log_entry_t *entry);
 
+/**
+ * mongoc_structured_log_entry_get_level:
+ * @entry: A log entry to read the level from
+ *
+ * Returns the severity level of the structured log entry
+ */
 MONGOC_EXPORT (mongoc_structured_log_level_t)
 mongoc_structured_log_entry_get_level (
    const mongoc_structured_log_entry_t *entry);
 
+/**
+ * mongoc_structured_log_entry_get_component:
+ * @entry: A log entry to read the component from
+ *
+ * Returns the component of the structured log entry
+ */
 MONGOC_EXPORT (mongoc_structured_log_component_t)
 mongoc_structured_log_entry_get_component (
    const mongoc_structured_log_entry_t *entry);

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MongoDB, Inc.
+ * Copyright 2020 MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.h
@@ -52,11 +52,14 @@ typedef void (*mongoc_structured_log_func_t) (mongoc_structured_log_entry_t *ent
 MONGOC_EXPORT (void)
 mongoc_structured_log_set_handler (mongoc_structured_log_func_t log_func, void *user_data);
 
+MONGOC_EXPORT (const bson_t*)
+mongoc_structured_log_entry_get_context (mongoc_structured_log_entry_t *entry);
+
 MONGOC_EXPORT (mongoc_structured_log_level_t)
-mongoc_structured_log_entry_get_level (mongoc_structured_log_entry_t *entry);
+mongoc_structured_log_entry_get_level (const mongoc_structured_log_entry_t *entry);
 
 MONGOC_EXPORT (mongoc_structured_log_component_t)
-mongoc_structured_log_entry_get_component (mongoc_structured_log_entry_t *entry);
+mongoc_structured_log_entry_get_component (const mongoc_structured_log_entry_t *entry);
 
 MONGOC_EXPORT (void)
 mongoc_structured_log_default_handler (mongoc_structured_log_entry_t *entry, void *user_data);

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.h
@@ -46,20 +46,23 @@ typedef enum {
 
 typedef struct _mongoc_structured_log_entry_t mongoc_structured_log_entry_t;
 
-typedef void (*mongoc_structured_log_func_t) (mongoc_structured_log_entry_t *entry,
-                                              void *user_data);
+typedef void (*mongoc_structured_log_func_t) (
+   mongoc_structured_log_entry_t *entry, void *user_data);
 
 MONGOC_EXPORT (void)
-mongoc_structured_log_set_handler (mongoc_structured_log_func_t log_func, void *user_data);
+mongoc_structured_log_set_handler (mongoc_structured_log_func_t log_func,
+                                   void *user_data);
 
-MONGOC_EXPORT (const bson_t*)
+MONGOC_EXPORT (const bson_t *)
 mongoc_structured_log_entry_get_message (mongoc_structured_log_entry_t *entry);
 
 MONGOC_EXPORT (mongoc_structured_log_level_t)
-mongoc_structured_log_entry_get_level (const mongoc_structured_log_entry_t *entry);
+mongoc_structured_log_entry_get_level (
+   const mongoc_structured_log_entry_t *entry);
 
 MONGOC_EXPORT (mongoc_structured_log_component_t)
-mongoc_structured_log_entry_get_component (const mongoc_structured_log_entry_t *entry);
+mongoc_structured_log_entry_get_component (
+   const mongoc_structured_log_entry_t *entry);
 
 BSON_END_DECLS
 

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.h
@@ -53,7 +53,7 @@ MONGOC_EXPORT (void)
 mongoc_structured_log_set_handler (mongoc_structured_log_func_t log_func, void *user_data);
 
 MONGOC_EXPORT (const bson_t*)
-mongoc_structured_log_entry_get_context (mongoc_structured_log_entry_t *entry);
+mongoc_structured_log_entry_get_message (mongoc_structured_log_entry_t *entry);
 
 MONGOC_EXPORT (mongoc_structured_log_level_t)
 mongoc_structured_log_entry_get_level (const mongoc_structured_log_entry_t *entry);

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.h
@@ -61,9 +61,6 @@ mongoc_structured_log_entry_get_level (const mongoc_structured_log_entry_t *entr
 MONGOC_EXPORT (mongoc_structured_log_component_t)
 mongoc_structured_log_entry_get_component (const mongoc_structured_log_entry_t *entry);
 
-MONGOC_EXPORT (void)
-mongoc_structured_log_default_handler (mongoc_structured_log_entry_t *entry, void *user_data);
-
 BSON_END_DECLS
 
 #endif /* MONGOC_STRUCTURED_LOG_H */

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.h
@@ -46,21 +46,21 @@ typedef enum {
 
 typedef struct _mongoc_structured_log_entry_t mongoc_structured_log_entry_t;
 
-typedef void (*mongoc_structured_log_func_t) (mongoc_structured_log_level_t level,
-                                   mongoc_structured_log_component_t component,
-                                   const char *message,
-                                   bson_t *context,
-                                   void *user_data);
+typedef void (*mongoc_structured_log_func_t) (mongoc_structured_log_entry_t *entry,
+                                              void *user_data);
+
 MONGOC_EXPORT (void)
 mongoc_structured_log_set_handler (mongoc_structured_log_func_t log_func, void *user_data);
 
+MONGOC_EXPORT (mongoc_structured_log_level_t)
+mongoc_structured_log_entry_get_level (mongoc_structured_log_entry_t *entry);
+
+MONGOC_EXPORT (mongoc_structured_log_component_t)
+mongoc_structured_log_entry_get_component (mongoc_structured_log_entry_t *entry);
+
 MONGOC_EXPORT (void)
-mongoc_log_structured (mongoc_structured_log_level_t level,
-                       mongoc_structured_log_component_t component,
-                       const char *message,
-                       ...);
+mongoc_structured_log_default_handler (mongoc_structured_log_entry_t *entry, void *user_data);
 
 BSON_END_DECLS
-
 
 #endif /* MONGOC_STRUCTURED_LOG_H */

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.h
@@ -94,6 +94,16 @@ MONGOC_EXPORT (mongoc_structured_log_component_t)
 mongoc_structured_log_entry_get_component (
    const mongoc_structured_log_entry_t *entry);
 
+/**
+ * mongoc_structured_log_document_to_json:
+ * @document: A BSON document to be serialized
+ *
+ * Returns the extended JSON representation of the given BSON document,
+ * respecting maximum logging length settings.
+ */
+MONGOC_EXPORT (char *)
+mongoc_structured_log_document_to_json (const bson_t *document);
+
 BSON_END_DECLS
 
 #endif /* MONGOC_STRUCTURED_LOG_H */

--- a/src/libmongoc/src/mongoc/mongoc-write-command-legacy.c
+++ b/src/libmongoc/src/mongoc/mongoc-write-command-legacy.c
@@ -50,7 +50,7 @@ _mongoc_monitor_legacy_write (mongoc_client_t *client,
       db,
       command->operation_id,
       request_id,
-      0,
+      &stream->sd->host,
       0,
       false);
 
@@ -111,7 +111,7 @@ _mongoc_monitor_legacy_write_succeeded (mongoc_client_t *client,
       &doc,
       duration,
       request_id,
-      0,
+      &stream->sd->host,
       0,
       false);
 

--- a/src/libmongoc/src/mongoc/mongoc-write-command-legacy.c
+++ b/src/libmongoc/src/mongoc/mongoc-write-command-legacy.c
@@ -43,7 +43,7 @@ _mongoc_monitor_legacy_write (mongoc_client_t *client,
 
    _append_array_from_command (command, &doc);
 
-   // @todo Provide missing arguments
+   /* @todo Provide missing arguments */
    mongoc_structured_log_command_started (
       &doc,
       _mongoc_command_type_to_name (command->type),
@@ -104,7 +104,7 @@ _mongoc_monitor_legacy_write_succeeded (mongoc_client_t *client,
    bson_append_int32 (&doc, "ok", 2, 1);
    bson_append_int32 (&doc, "n", 1, (int32_t) command->n_documents);
 
-   // @todo Provide missing arguments
+   /* @todo Provide missing arguments */
    mongoc_structured_log_command_success (
       _mongoc_command_type_to_name (command->type),
       command->operation_id,

--- a/src/libmongoc/src/mongoc/mongoc.h
+++ b/src/libmongoc/src/mongoc/mongoc.h
@@ -54,6 +54,7 @@
 #include "mongoc-stream-file.h"
 #include "mongoc-stream-gridfs.h"
 #include "mongoc-stream-socket.h"
+#include "mongoc-structured-log.h"
 #include "mongoc-uri.h"
 #include "mongoc-write-concern.h"
 #include "mongoc-version.h"

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -147,6 +147,8 @@ test_list_install (TestSuite *suite);
 extern void
 test_log_install (TestSuite *suite);
 extern void
+test_structured_log_install (TestSuite *suite);
+extern void
 test_matcher_install (TestSuite *suite);
 extern void
 test_mongos_pinning_install (TestSuite *suite);
@@ -2603,6 +2605,7 @@ main (int argc, char *argv[])
    test_linux_distro_scanner_install (&suite);
    test_list_install (&suite);
    test_log_install (&suite);
+   test_structured_log_install (&suite);
    test_long_namespace_install (&suite);
    test_matcher_install (&suite);
    test_mongos_pinning_install (&suite);

--- a/src/libmongoc/tests/test-mongoc-structured-log.c
+++ b/src/libmongoc/tests/test-mongoc-structured-log.c
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <mongoc/mongoc.h>
+
+#include "mongoc/mongoc-structured-log-private.h"
+#include "TestSuite.h"
+
+struct log_assumption {
+   mongoc_structured_log_entry_t expected_entry;
+   int expected_calls;
+   int calls;
+};
+
+struct structured_log_state {
+   mongoc_structured_log_func_t handler;
+   void *data;
+};
+
+static void
+save_state (struct structured_log_state *state)
+{
+   _mongoc_structured_log_get_handler (&state->handler, &state->data);
+}
+
+static void
+restore_state (const struct structured_log_state *state)
+{
+   mongoc_structured_log_set_handler (state->handler, state->data);
+}
+
+static void
+structured_log_func (mongoc_structured_log_entry_t *entry, void *user_data)
+{
+   struct log_assumption *assumption = (struct log_assumption*) user_data;
+
+   assumption->calls++;
+
+   ASSERT_CMPINT (assumption->calls, <=, assumption->expected_calls);
+
+   ASSERT_CMPINT (entry->level, ==, assumption->expected_entry.level);
+   ASSERT_CMPINT (entry->component, ==, assumption->expected_entry.component);
+   ASSERT (bson_equal (mongoc_structured_log_entry_get_message (entry), assumption->expected_entry.structured_message));
+}
+
+void
+test_plain_log_entry ()
+{
+   struct structured_log_state old_state;
+   struct log_assumption assumption = {
+      .expected_entry = {
+         .level = MONGOC_STRUCTURED_LOG_LEVEL_WARNING,
+         .component = MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
+         .message = "Plain log entry",
+         .structured_message = BCON_NEW ("message", BCON_UTF8 ("Plain log entry")),
+      },
+      .expected_calls = 1,
+      .calls = 0,
+   };
+
+   save_state (&old_state);
+
+   mongoc_structured_log_set_handler (structured_log_func, &assumption);
+
+   mongoc_structured_log (
+      MONGOC_STRUCTURED_LOG_LEVEL_WARNING,
+      MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
+      "Plain log entry",
+      NULL,
+      NULL);
+
+   ASSERT_CMPINT (assumption.calls, =, 1);
+
+   restore_state (&old_state);
+}
+
+void
+_test_append_extra_data (mongoc_structured_log_entry_t *entry)
+{
+   BCON_APPEND (entry->structured_message, "extra", BCON_INT32 (1));
+}
+
+void
+test_log_entry_with_extra_data ()
+{
+   struct structured_log_state old_state;
+   struct log_assumption assumption = {
+      .expected_entry = {
+         .level = MONGOC_STRUCTURED_LOG_LEVEL_WARNING,
+         .component = MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
+         .message = "Plain log entry",
+         .structured_message = BCON_NEW (
+            "message", BCON_UTF8 ("Plain log entry"),
+            "extra", BCON_INT32 (1)
+         ),
+      },
+      .expected_calls = 1,
+      .calls = 0,
+   };
+
+   save_state (&old_state);
+
+   mongoc_structured_log_set_handler (structured_log_func, &assumption);
+
+   mongoc_structured_log (
+      MONGOC_STRUCTURED_LOG_LEVEL_WARNING,
+      MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
+      "Plain log entry",
+      _test_append_extra_data,
+      NULL);
+
+   ASSERT_CMPINT (assumption.calls, =, 1);
+
+   restore_state (&old_state);
+}
+
+void
+test_structured_log_install (TestSuite *suite)
+{
+   TestSuite_Add (suite, "/Structured_Log/plain", test_plain_log_entry);
+   TestSuite_Add (suite, "/Structured_Log/with_extra_data", test_log_entry_with_extra_data);
+}

--- a/src/libmongoc/tests/test-mongoc-structured-log.c
+++ b/src/libmongoc/tests/test-mongoc-structured-log.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MongoDB, Inc.
+ * Copyright 2020 MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/libmongoc/tests/test-mongoc-structured-log.c
+++ b/src/libmongoc/tests/test-mongoc-structured-log.c
@@ -85,6 +85,8 @@ test_plain_log_entry ()
    ASSERT_CMPINT (assumption.calls, =, 1);
 
    restore_state (&old_state);
+
+   bson_destroy (assumption.expected_entry.structured_message);
 }
 
 void
@@ -124,6 +126,8 @@ test_log_entry_with_extra_data ()
    ASSERT_CMPINT (assumption.calls, =, 1);
 
    restore_state (&old_state);
+
+   bson_destroy (assumption.expected_entry.structured_message);
 }
 
 void

--- a/src/libmongoc/tests/test-mongoc-structured-log.c
+++ b/src/libmongoc/tests/test-mongoc-structured-log.c
@@ -62,16 +62,14 @@ test_plain_log_entry ()
 {
    struct structured_log_state old_state;
    struct log_assumption assumption = {
-      .expected_entry =
-         {
-            .level = MONGOC_STRUCTURED_LOG_LEVEL_WARNING,
-            .component = MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
-            .message = "Plain log entry",
-            .structured_message =
-               BCON_NEW ("message", BCON_UTF8 ("Plain log entry")),
-         },
-      .expected_calls = 1,
-      .calls = 0,
+      {
+         MONGOC_STRUCTURED_LOG_LEVEL_WARNING,
+         MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
+         "Plain log entry",
+         BCON_NEW ("message", BCON_UTF8 ("Plain log entry")),
+      },
+      1,
+      0,
    };
 
    save_state (&old_state);
@@ -90,9 +88,9 @@ test_plain_log_entry ()
 }
 
 void
-_test_append_extra_data (mongoc_structured_log_entry_t *entry)
+_test_append_extra_data (mongoc_structured_log_component_t component, void *structured_log_data, bson_t *structured_message /* OUT */)
 {
-   BCON_APPEND (entry->structured_message, "extra", BCON_INT32 (1));
+   BCON_APPEND (structured_message, "extra", BCON_INT32 (1));
 }
 
 void
@@ -100,18 +98,17 @@ test_log_entry_with_extra_data ()
 {
    struct structured_log_state old_state;
    struct log_assumption assumption = {
-      .expected_entry =
-         {
-            .level = MONGOC_STRUCTURED_LOG_LEVEL_WARNING,
-            .component = MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
-            .message = "Plain log entry",
-            .structured_message = BCON_NEW ("message",
-                                            BCON_UTF8 ("Plain log entry"),
-                                            "extra",
-                                            BCON_INT32 (1)),
-         },
-      .expected_calls = 1,
-      .calls = 0,
+      {
+         MONGOC_STRUCTURED_LOG_LEVEL_WARNING,
+         MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
+         "Plain log entry",
+         BCON_NEW ("message",
+                   BCON_UTF8 ("Plain log entry"),
+                   "extra",
+                   BCON_INT32 (1)),
+      },
+      1,
+      0,
    };
 
    save_state (&old_state);

--- a/src/libmongoc/tests/test-mongoc-structured-log.c
+++ b/src/libmongoc/tests/test-mongoc-structured-log.c
@@ -129,7 +129,7 @@ test_log_entry_with_extra_data ()
 void
 test_structured_log_install (TestSuite *suite)
 {
-   TestSuite_Add (suite, "/Structured_Log/plain", test_plain_log_entry);
+   TestSuite_Add (suite, "/structured_log/plain", test_plain_log_entry);
    TestSuite_Add (
-      suite, "/Structured_Log/with_extra_data", test_log_entry_with_extra_data);
+      suite, "/structured_log/with_extra_data", test_log_entry_with_extra_data);
 }

--- a/src/libmongoc/tests/test-mongoc-structured-log.c
+++ b/src/libmongoc/tests/test-mongoc-structured-log.c
@@ -45,7 +45,7 @@ restore_state (const struct structured_log_state *state)
 static void
 structured_log_func (mongoc_structured_log_entry_t *entry, void *user_data)
 {
-   struct log_assumption *assumption = (struct log_assumption*) user_data;
+   struct log_assumption *assumption = (struct log_assumption *) user_data;
 
    assumption->calls++;
 
@@ -53,7 +53,8 @@ structured_log_func (mongoc_structured_log_entry_t *entry, void *user_data)
 
    ASSERT_CMPINT (entry->level, ==, assumption->expected_entry.level);
    ASSERT_CMPINT (entry->component, ==, assumption->expected_entry.component);
-   ASSERT (bson_equal (mongoc_structured_log_entry_get_message (entry), assumption->expected_entry.structured_message));
+   ASSERT (bson_equal (mongoc_structured_log_entry_get_message (entry),
+                       assumption->expected_entry.structured_message));
 }
 
 void
@@ -61,12 +62,14 @@ test_plain_log_entry ()
 {
    struct structured_log_state old_state;
    struct log_assumption assumption = {
-      .expected_entry = {
-         .level = MONGOC_STRUCTURED_LOG_LEVEL_WARNING,
-         .component = MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
-         .message = "Plain log entry",
-         .structured_message = BCON_NEW ("message", BCON_UTF8 ("Plain log entry")),
-      },
+      .expected_entry =
+         {
+            .level = MONGOC_STRUCTURED_LOG_LEVEL_WARNING,
+            .component = MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
+            .message = "Plain log entry",
+            .structured_message =
+               BCON_NEW ("message", BCON_UTF8 ("Plain log entry")),
+         },
       .expected_calls = 1,
       .calls = 0,
    };
@@ -75,12 +78,11 @@ test_plain_log_entry ()
 
    mongoc_structured_log_set_handler (structured_log_func, &assumption);
 
-   mongoc_structured_log (
-      MONGOC_STRUCTURED_LOG_LEVEL_WARNING,
-      MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
-      "Plain log entry",
-      NULL,
-      NULL);
+   mongoc_structured_log (MONGOC_STRUCTURED_LOG_LEVEL_WARNING,
+                          MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
+                          "Plain log entry",
+                          NULL,
+                          NULL);
 
    ASSERT_CMPINT (assumption.calls, =, 1);
 
@@ -98,15 +100,16 @@ test_log_entry_with_extra_data ()
 {
    struct structured_log_state old_state;
    struct log_assumption assumption = {
-      .expected_entry = {
-         .level = MONGOC_STRUCTURED_LOG_LEVEL_WARNING,
-         .component = MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
-         .message = "Plain log entry",
-         .structured_message = BCON_NEW (
-            "message", BCON_UTF8 ("Plain log entry"),
-            "extra", BCON_INT32 (1)
-         ),
-      },
+      .expected_entry =
+         {
+            .level = MONGOC_STRUCTURED_LOG_LEVEL_WARNING,
+            .component = MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
+            .message = "Plain log entry",
+            .structured_message = BCON_NEW ("message",
+                                            BCON_UTF8 ("Plain log entry"),
+                                            "extra",
+                                            BCON_INT32 (1)),
+         },
       .expected_calls = 1,
       .calls = 0,
    };
@@ -115,12 +118,11 @@ test_log_entry_with_extra_data ()
 
    mongoc_structured_log_set_handler (structured_log_func, &assumption);
 
-   mongoc_structured_log (
-      MONGOC_STRUCTURED_LOG_LEVEL_WARNING,
-      MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
-      "Plain log entry",
-      _test_append_extra_data,
-      NULL);
+   mongoc_structured_log (MONGOC_STRUCTURED_LOG_LEVEL_WARNING,
+                          MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND,
+                          "Plain log entry",
+                          _test_append_extra_data,
+                          NULL);
 
    ASSERT_CMPINT (assumption.calls, =, 1);
 
@@ -131,5 +133,6 @@ void
 test_structured_log_install (TestSuite *suite)
 {
    TestSuite_Add (suite, "/Structured_Log/plain", test_plain_log_entry);
-   TestSuite_Add (suite, "/Structured_Log/with_extra_data", test_log_entry_with_extra_data);
+   TestSuite_Add (
+      suite, "/Structured_Log/with_extra_data", test_log_entry_with_extra_data);
 }


### PR DESCRIPTION
### Summary

CDRIVER-3775

This PR serves as a starting point for discussion. Parallel to the current mongoc_log implementation, we add a new mongoc_structured_log implementation, which is private and not available to wrapping libraries. To allow for testing, we currently log some data from the command logging portion of the logging spec. The current state of the POC allows for testing in wrapping drivers, but does not yet implement a spec-compliant logger itself.

What's working:
- [x] Command start, success, and failures are logged to the structured logger
- [x] A rudimentary default handler logs all messages to stderr
- [x] The log message is constructed lazily. This helps reduce memory and runtime impact when a log message is not consumed (e.g. based on severity)
- [x] Wrapping libraries can override the default handler and handle log messages themselves (necessary for integration in PHP, Swift, and C++ drivers)
- [x] Implement a spec-compliant default logger. This logger is expected to read environment variables to configure logger behaviour (e.g. levels and target)

Next steps:
- [x] Remove memory leaks - my calls to `BCON_APPEND` seem to leak memory, but I haven't invested much time in figuring out those leaks yet.
- [x] Fix Windows builds: structured logging currently produces some ugly segmentation faults due to access violations whenever we invoke the default logger. This works fine on Ubuntu (apart from the leaks mentioned above).
- [ ] Finalise logging calls to add missing information. We're only logging information we already have. The `driver_connection_id`, `server_connection_id`, and `explicit_session` values of the structured log messages are not yet logged as the data is not always available where we can log.
- [ ] Integrate with existing log implementation: this is not necessarily required or even possible, as we should try to avoid BC breaks here. For example, PHP relies on the existing logging mechanism to put trace logs into a special file using the `mongodb.debug` INI switch.
- [ ] Run `clang-format` on the whole PR

---

### Implementation details

The log implementation is loosely based on `mongoc_log()`, with a few notable exceptions. Since the logging spec defines what can be logged using the structured logger, the entire API is private and not available outside of this implementation. We only provide APIs necessary to consume and handle log messages. This is a notable change from `mongoc_log`, which can be called from the outside.

A significant detail is the handling of additional data for structured logging. Every log message consists of a component, severity level, and a message portion (e.g. "Command started"). Optionally, a method to build the structured message can be passed, along with a struct to contain additional data. For the time being, this only allows to add command information to the log entry, but this will be changed once other log messages are implemented. The structured message is only built if the log message is consumed. While this makes data handling a bit more fragile (e.g. it's not possible to store a `mongoc_structured_log_entry_t` somewhere for later processing), it does significantly reduce the memory impact of the logger when logging is not required. For example, the current logging implementation serialises a the command and reply documents encountered during command execution to the message. Doing this when the message is not consumed but ignored (which would be the default case for this message), makes this problematic. For this reason, assembly of the structured message is deferred until the message is extracted from the `mongoc_structured_log_entry_t` using `mongoc_structured_log_entry_get_message`. From then on, it is stored in the original entry so that it does not need to be re-assembled.