### PR TITLE
CDRIVER-3806 fix DNS result size comparison

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-client-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-private.h
@@ -155,10 +155,12 @@ typedef struct _mongoc_rr_data_t {
    char *txt_record_opts;
 } mongoc_rr_data_t;
 
+#define MONGOC_RR_DEFAULT_BUFFER_SIZE 1024
 bool
 _mongoc_client_get_rr (const char *service,
                        mongoc_rr_type_t rr_type,
                        mongoc_rr_data_t *rr_data,
+                       size_t initial_buffer_size,
                        bson_error_t *error);
 
 mongoc_client_t *

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -411,6 +411,7 @@ static bool
 _mongoc_get_rr_search (const char *service,
                        mongoc_rr_type_t rr_type,
                        mongoc_rr_data_t *rr_data,
+                       size_t initial_buffer_size,
                        bson_error_t *error)
 {
 #ifdef MONGOC_HAVE_RES_NSEARCH
@@ -418,7 +419,7 @@ _mongoc_get_rr_search (const char *service,
 #endif
    int size = 0;
    unsigned char *search_buf = NULL;
-   size_t buffer_size = 1024;
+   size_t buffer_size = initial_buffer_size;
    ns_msg ns_answer;
    int n;
    int i;
@@ -475,7 +476,7 @@ _mongoc_get_rr_search (const char *service,
                     service,
                     strerror (h_errno));
       }
-   } while (size > buffer_size);
+   } while (size >= buffer_size);
 
    if (ns_initparse (search_buf, size, &ns_answer)) {
       DNS_ERROR ("Invalid %s answer for \"%s\"", rr_type_name, service);
@@ -579,6 +580,7 @@ bool
 _mongoc_client_get_rr (const char *service,
                        mongoc_rr_type_t rr_type,
                        mongoc_rr_data_t *rr_data,
+                       size_t initial_buffer_size,
                        bson_error_t *error)
 {
    BSON_ASSERT (rr_data);
@@ -586,7 +588,8 @@ _mongoc_client_get_rr (const char *service,
 #ifdef MONGOC_HAVE_DNSAPI
    return _mongoc_get_rr_dnsapi (service, rr_type, rr_data, error);
 #elif (defined(MONGOC_HAVE_RES_NSEARCH) || defined(MONGOC_HAVE_RES_SEARCH))
-   return _mongoc_get_rr_search (service, rr_type, rr_data, error);
+   return _mongoc_get_rr_search (
+      service, rr_type, rr_data, initial_buffer_size, error);
 #else
    bson_set_error (error,
                    MONGOC_ERROR_STREAM,

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -340,6 +340,7 @@ mongoc_topology_new (const mongoc_uri_t *uri, bool single_threaded)
       if (!_mongoc_client_get_rr (prefixed_service,
                                   MONGOC_RR_SRV,
                                   &rr_data,
+                                  MONGOC_RR_DEFAULT_BUFFER_SIZE,
                                   &topology->scanner->error)) {
          GOTO (srv_fail);
       }
@@ -347,8 +348,11 @@ mongoc_topology_new (const mongoc_uri_t *uri, bool single_threaded)
       /* Failure to find TXT records will not return an error (since it is only
        * for options). But _mongoc_client_get_rr may return an error if
        * there is more than one TXT record returned. */
-      if (!_mongoc_client_get_rr (
-             service, MONGOC_RR_TXT, &rr_data, &topology->scanner->error)) {
+      if (!_mongoc_client_get_rr (service,
+                                  MONGOC_RR_TXT,
+                                  &rr_data,
+                                  MONGOC_RR_DEFAULT_BUFFER_SIZE,
+                                  &topology->scanner->error)) {
          GOTO (srv_fail);
       }
 
@@ -658,8 +662,11 @@ mongoc_topology_rescan_srv (mongoc_topology_t *topology)
    /* Unlock topology mutex during scan so it does not hold up other operations.
     */
    bson_mutex_unlock (&topology->mutex);
-   ret = _mongoc_client_get_rr (
-      prefixed_service, MONGOC_RR_SRV, &rr_data, &topology->scanner->error);
+   ret = _mongoc_client_get_rr (prefixed_service,
+                                MONGOC_RR_SRV,
+                                &rr_data,
+                                MONGOC_RR_DEFAULT_BUFFER_SIZE,
+                                &topology->scanner->error);
    bson_mutex_lock (&topology->mutex);
 
    topology->srv_polling_last_scan_ms = bson_get_monotonic_time () / 1000;

--- a/src/libmongoc/tests/test-mongoc-dns.c
+++ b/src/libmongoc/tests/test-mongoc-dns.c
@@ -497,6 +497,30 @@ test_srv_polling_mocked (void *unused)
    mongoc_uri_destroy (uri);
 }
 
+static void
+test_small_initial_buffer (void *unused)
+{
+   mongoc_rr_type_t rr_type = MONGOC_RR_SRV;
+   mongoc_rr_data_t rr_data;
+   bson_error_t error;
+   /* Size needs to be large enough to fit DNS answer header to not error, but
+    * smaller than SRV response to test. The SRV response is 155 bytes. This can
+    * be determined with: dig -t SRV _mongodb._tcp.test1.test.build.10gen.cc */
+   size_t small_buffer_size = 30;
+
+   memset (&rr_data, 0, sizeof (rr_data));
+   ASSERT_OR_PRINT (
+      _mongoc_client_get_rr ("_mongodb._tcp.test1.test.build.10gen.cc",
+                             rr_type,
+                             &rr_data,
+                             small_buffer_size,
+                             &error),
+      error);
+   ASSERT_CMPINT (rr_data.count, ==, 2);
+   bson_free (rr_data.txt_record_opts);
+   _mongoc_host_list_destroy_all (rr_data.hosts);
+}
+
 void
 test_dns_install (TestSuite *suite)
 {
@@ -509,4 +533,10 @@ test_dns_install (TestSuite *suite)
                       test_framework_skip_if_no_crypto);
    TestSuite_AddFull (
       suite, "/srv_polling/mocked", test_srv_polling_mocked, NULL, NULL, NULL);
+   TestSuite_AddFull (suite,
+                      "/initial_dns_seedlist_discovery/small_initial_buffer",
+                      test_small_initial_buffer,
+                      NULL,
+                      NULL,
+                      test_dns_check);
 }


### PR DESCRIPTION
Includes a test with a small initial buffer size. See the ticket for a description of the issue.