### PR TITLE
Implement BSON to JSON encoder that limits encoded string length

### DIFF
--- a/src/libbson/doc/bson_as_json_with_opts.rst
+++ b/src/libbson/doc/bson_as_json_with_opts.rst
@@ -1,0 +1,54 @@
+:man_page: bson_as_json_with_opts
+
+bson_as_json_with_opts()
+========================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  char *
+  bson_as_json_with_opts (const bson_t *bson, size_t *length, const bson_json_opts_t *opts);
+
+Parameters
+----------
+
+* ``bson``: A :symbol:`bson_t`.
+* ``length``: An optional location for the length of the resulting string.
+* ``opts``: A :symbol:`bson_json_opts_t`.
+
+Description
+-----------
+
+The :symbol:`bson_as_json_with_opts()` encodes ``bson`` as a UTF-8 string in the `MongoDB Extended JSON format`_.
+
+The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
+
+If non-NULL, ``length`` will be set to the length of the result in bytes.
+
+The ``opts`` structure is used to pass options for the encoding process. Please refer to the documentation of :symbol:`bson_json_opts_t` for more details.
+
+Returns
+-------
+
+If successful, a newly allocated UTF-8 encoded string and ``length`` is set.
+
+Upon failure, NULL is returned.
+
+Example
+-------
+
+.. code-block:: c
+
+  bson_json_opts_t opts = { BSON_JSON_MODE_CANONICAL, BSON_MAX_LEN_UNLIMITED };
+  char *str = bson_as_json_with_opts (doc, NULL, &opts);
+  printf ("%s\n", str);
+  bson_free (str);
+
+
+.. only:: html
+
+  .. include:: includes/seealso/bson-as-json.txt
+
+.. _MongoDB Extended JSON format: https://github.com/mongodb/specifications/blob/master/source/extended-json.rst

--- a/src/libbson/doc/bson_as_json_with_opts.rst
+++ b/src/libbson/doc/bson_as_json_with_opts.rst
@@ -41,10 +41,11 @@ Example
 
 .. code-block:: c
 
-  bson_json_opts_t opts = { BSON_JSON_MODE_CANONICAL, BSON_MAX_LEN_UNLIMITED };
-  char *str = bson_as_json_with_opts (doc, NULL, &opts);
+  bson_json_opts_t *opts = bson_json_opts_new (BSON_JSON_MODE_CANONICAL, BSON_MAX_LEN_UNLIMITED);
+  char *str = bson_as_json_with_opts (doc, NULL, opts);
   printf ("%s\n", str);
   bson_free (str);
+  bson_json_opts_destroy (opts);
 
 
 .. only:: html

--- a/src/libbson/doc/bson_json_mode_t.rst
+++ b/src/libbson/doc/bson_json_mode_t.rst
@@ -1,0 +1,30 @@
+:man_page: bson_json_mode_t
+
+bson_json_mode_t
+================
+
+BSON JSON encoding mode enumeration
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  #include <bson/bson.h>
+
+  typedef enum {
+     BSON_JSON_MODE_LEGACY,
+     BSON_JSON_MODE_CANONICAL,
+     BSON_JSON_MODE_RELAXED,
+  } bson_json_mode_t;
+
+Description
+-----------
+
+The :symbol:`bson_json_mode_t` enumeration contains all available modes for encoding BSON into `MongoDB Extended JSON`_.
+
+.. seealso::
+
+  | :symbol:`bson_as_json_with_opts()`
+
+.. _MongoDB Extended JSON: https://github.com/mongodb/specifications/blob/master/source/extended-json.rst

--- a/src/libbson/doc/bson_json_opts_destroy.rst
+++ b/src/libbson/doc/bson_json_opts_destroy.rst
@@ -1,0 +1,22 @@
+:man_page: bson_json_opts_destroy
+
+bson_json_opts_destroy()
+========================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  void
+  bson_json_opts_destroy (bson_json_opts_t *opts);
+
+Parameters
+----------
+
+* ``opts``: A :symbol:`bson_json_opts_t`.
+
+Description
+-----------
+
+Destroys and releases all resources associated with ``opts``. Does nothing if ``opts`` is NULL.

--- a/src/libbson/doc/bson_json_opts_new.rst
+++ b/src/libbson/doc/bson_json_opts_new.rst
@@ -1,0 +1,31 @@
+:man_page: bson_json_opts_new
+
+bson_json_opts_new()
+====================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  bson_json_opts_t *
+  bson_json_opts_new (bson_json_mode_t mode, int32_t max_len);
+
+Parameters
+----------
+
+* ``mode``: A bson_json_mode_t.
+* ``max_len``: An int32_t.
+
+Description
+-----------
+
+The :symbol:`bson_json_opts_new()` function shall create a new :symbol:`bson_json_opts_t` using the mode and length supplied.  The ``mode`` member is a :symbol:`bson_json_mode_t` defining the encoding mode.
+
+The ``max_len`` member holds a maximum length for the resulting JSON string. Encoding will stop once the serialised string has reached this length. To encode the full BSON document, ``BSON_MAX_LEN_UNLIMITED`` can be used.
+
+Returns
+-------
+
+A newly allocated :symbol:`bson_json_opts_t`.
+

--- a/src/libbson/doc/bson_json_opts_t.rst
+++ b/src/libbson/doc/bson_json_opts_t.rst
@@ -12,10 +12,14 @@ Synopsis
 
   #include <bson/bson.h>
 
-  typedef struct {
-     bson_json_mode_t mode;
-     int32_t max_len;
-  } bson_json_opts_t;
+  typedef struct _bson_json_opts_t bson_json_opts_t;
+
+  bson_json_opts_t *
+  bson_json_opts_new (bson_json_mode_t mode, int32_t max_len);
+
+  void
+  bson_json_opts_destroy (bson_json_opts_t *opts);
+
 
 Description
 -----------
@@ -31,3 +35,16 @@ The ``max_len`` member holds a maximum length for the resulting JSON string. Enc
   | :symbol:`bson_as_json_with_opts()`
 
 .. _MongoDB Extended JSON: https://github.com/mongodb/specifications/blob/master/source/extended-json.rst
+
+
+.. only:: html
+
+	  Functions
+	  ---------
+
+	  .. toctree::
+	     :titlesonly:
+	     :maxdepth: 1
+
+	     bson_json_opts_new
+	     bson_json_opts_destroy

--- a/src/libbson/doc/bson_json_opts_t.rst
+++ b/src/libbson/doc/bson_json_opts_t.rst
@@ -1,0 +1,33 @@
+:man_page: bson_json_opts_t
+
+bson_json_opts_t
+================
+
+BSON to JSON encoding options
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  #include <bson/bson.h>
+
+  typedef struct {
+     bson_json_mode_t mode;
+     int32_t max_len;
+  } bson_json_opts_t;
+
+Description
+-----------
+
+The :symbol:`bson_json_opts_t` structure contains options for encoding BSON into `MongoDB Extended JSON`_.
+
+The ``mode`` member is a :symbol:`bson_json_mode_t` defining the encoding mode.
+
+The ``max_len`` member holds a maximum length for the resulting JSON string. Encoding will stop once the serialised string has reached this length. To encode the full BSON document, ``BSON_MAX_LEN_UNLIMITED`` can be used.
+
+.. seealso::
+
+  | :symbol:`bson_as_json_with_opts()`
+
+.. _MongoDB Extended JSON: https://github.com/mongodb/specifications/blob/master/source/extended-json.rst

--- a/src/libbson/doc/bson_t.rst
+++ b/src/libbson/doc/bson_t.rst
@@ -184,6 +184,7 @@ The :symbol:`bson_t` structure attempts to use an inline allocation within the s
     bson_array_as_json
     bson_as_canonical_extended_json
     bson_as_json
+    bson_as_json_with_opts
     bson_as_relaxed_extended_json
     bson_compare
     bson_concat
@@ -201,6 +202,8 @@ The :symbol:`bson_t` structure attempts to use an inline allocation within the s
     bson_init
     bson_init_from_json
     bson_init_static
+    bson_json_mode_t
+    bson_json_opts_t
     bson_new
     bson_new_from_buffer
     bson_new_from_data

--- a/src/libbson/doc/includes/seealso/bson-as-json.txt
+++ b/src/libbson/doc/includes/seealso/bson-as-json.txt
@@ -6,4 +6,6 @@
 
   | :symbol:`bson_as_json()`
 
+  | :symbol:`bson_as_json_with_opts()`
+
   | :symbol:`bson_as_relaxed_extended_json()`

--- a/src/libbson/src/bson/CMakeLists.txt
+++ b/src/libbson/src/bson/CMakeLists.txt
@@ -27,6 +27,7 @@ set (src_libbson_src_bson_DIST_hs
    bson-iso8601-private.h
    bson-context-private.h
    bson-timegm-private.h
+   bson-json-private.h
    forwarding/bson.h
 )
 extra_dist_generated (

--- a/src/libbson/src/bson/bson-json-private.h
+++ b/src/libbson/src/bson/bson-json-private.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bson-prelude.h"
+
+#ifndef BSON_JSON_PRIVATE_H
+#define BSON_JSON_PRIVATE_H
+
+
+struct _bson_json_opts_t {
+   bson_json_mode_t mode;
+   int32_t max_len;
+};
+
+
+#endif /* BSON_JSON_PRIVATE_H */

--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -23,6 +23,7 @@
 #include "bson.h"
 #include "bson-config.h"
 #include "bson-json.h"
+#include "bson-json-private.h"
 #include "bson-iso8601-private.h"
 
 #include "common-b64-private.h"
@@ -391,6 +392,25 @@ _noop (void)
       bson->bson_state = (_state);                                             \
    }
 
+
+
+bson_json_opts_t *
+bson_json_opts_new (bson_json_mode_t mode, int32_t max_len)
+{
+   bson_json_opts_t *opts;
+
+   opts = (bson_json_opts_t *) bson_malloc (sizeof *opts);
+   opts->mode = mode;
+   opts->max_len = max_len;
+
+   return opts;
+}
+
+void
+bson_json_opts_destroy (bson_json_opts_t *opts)
+{
+   bson_free (opts);
+}
 
 static void
 _bson_json_read_set_error (bson_json_reader_t *reader, const char *fmt, ...)

--- a/src/libbson/src/bson/bson-json.h
+++ b/src/libbson/src/bson/bson-json.h
@@ -37,6 +37,32 @@ typedef enum {
 } bson_json_error_code_t;
 
 
+/**
+ * BSON_MAX_LEN_UNLIMITED
+ *
+ * Denotes unlimited length limit when converting BSON to JSON.
+ */
+#define BSON_MAX_LEN_UNLIMITED -1
+
+/**
+ * bson_json_mode_t:
+ *
+ * This enumeration contains the different modes to serialize BSON into extended
+ * JSON.
+ */
+typedef enum {
+   BSON_JSON_MODE_LEGACY,
+   BSON_JSON_MODE_CANONICAL,
+   BSON_JSON_MODE_RELAXED,
+} bson_json_mode_t;
+
+
+BSON_EXPORT (bson_json_opts_t *)
+bson_json_opts_new (bson_json_mode_t mode, int32_t max_len);
+BSON_EXPORT (void)
+bson_json_opts_destroy (bson_json_opts_t *opts);
+
+
 typedef ssize_t (*bson_json_reader_cb) (void *handle,
                                         uint8_t *buf,
                                         size_t count);

--- a/src/libbson/src/bson/bson-types.h
+++ b/src/libbson/src/bson/bson-types.h
@@ -519,6 +519,40 @@ typedef struct _bson_error_t {
 } bson_error_t BSON_ALIGNED_END (8);
 
 
+/**
+ * BSON_MAX_LEN_UNLIMITED
+ *
+ * Denotes unlimited length limit when converting BSON to JSON.
+ */
+#define BSON_MAX_LEN_UNLIMITED -1
+
+/**
+ * bson_json_mode_t:
+ *
+ * This enumeration contains the different modes to serialize BSON into extended
+ * JSON.
+ */
+typedef enum {
+   BSON_JSON_MODE_LEGACY,
+   BSON_JSON_MODE_CANONICAL,
+   BSON_JSON_MODE_RELAXED,
+} bson_json_mode_t;
+
+/**
+ * bson_json_opts_t:
+ *
+ * This structure is used to pass options for serializing BSON into extended
+ * JSON to the respective serialization methods.
+ *
+ * max_len can be either a non-negative integer, or BSON_MAX_LEN_UNLIMITED to
+ * set no limit for serialization length.
+ */
+typedef struct {
+   bson_json_mode_t mode;
+   int32_t max_len;
+} bson_json_opts_t;
+
+
 BSON_STATIC_ASSERT2 (error_t, sizeof (bson_error_t) == 512);
 
 

--- a/src/libbson/src/bson/bson-types.h
+++ b/src/libbson/src/bson/bson-types.h
@@ -97,6 +97,17 @@ typedef enum {
  */
 typedef struct _bson_context_t bson_context_t;
 
+/**
+ * bson_json_opts_t:
+ *
+ * This structure is used to pass options for serializing BSON into extended
+ * JSON to the respective serialization methods.
+ *
+ * max_len can be either a non-negative integer, or BSON_MAX_LEN_UNLIMITED to
+ * set no limit for serialization length.
+ */
+typedef struct _bson_json_opts_t bson_json_opts_t;
+
 
 /**
  * bson_t:
@@ -517,40 +528,6 @@ typedef struct _bson_error_t {
    uint32_t code;
    char message[BSON_ERROR_BUFFER_SIZE];
 } bson_error_t BSON_ALIGNED_END (8);
-
-
-/**
- * BSON_MAX_LEN_UNLIMITED
- *
- * Denotes unlimited length limit when converting BSON to JSON.
- */
-#define BSON_MAX_LEN_UNLIMITED -1
-
-/**
- * bson_json_mode_t:
- *
- * This enumeration contains the different modes to serialize BSON into extended
- * JSON.
- */
-typedef enum {
-   BSON_JSON_MODE_LEGACY,
-   BSON_JSON_MODE_CANONICAL,
-   BSON_JSON_MODE_RELAXED,
-} bson_json_mode_t;
-
-/**
- * bson_json_opts_t:
- *
- * This structure is used to pass options for serializing BSON into extended
- * JSON to the respective serialization methods.
- *
- * max_len can be either a non-negative integer, or BSON_MAX_LEN_UNLIMITED to
- * set no limit for serialization length.
- */
-typedef struct {
-   bson_json_mode_t mode;
-   int32_t max_len;
-} bson_json_opts_t;
 
 
 BSON_STATIC_ASSERT2 (error_t, sizeof (bson_error_t) == 512);

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -3299,7 +3299,6 @@ bson_array_as_json (const bson_t *bson, size_t *length)
    bson_json_state_t state;
    bson_iter_t iter;
    ssize_t err_offset = -1;
-   int32_t remaining;
 
    BSON_ASSERT (bson);
 
@@ -3325,7 +3324,7 @@ bson_array_as_json (const bson_t *bson, size_t *length)
    state.depth = 0;
    state.err_offset = &err_offset;
    state.mode = BSON_JSON_MODE_LEGACY;
-   state.max_len = BSON_MAX_LEN_UNLIMITED; // TODO: how does the limit get here?
+   state.max_len = BSON_MAX_LEN_UNLIMITED;
    state.max_len_reached = false;
 
    if ((bson_iter_visit_all (&iter, &bson_as_json_visitors, &state) ||
@@ -3341,14 +3340,7 @@ bson_array_as_json (const bson_t *bson, size_t *length)
       return NULL;
    }
 
-   /* Append closing space and ] separately, in case we hit the max in between. */
-   remaining = state.max_len - state.str->len;
-   if (state.max_len == BSON_MAX_LEN_UNLIMITED ||
-       remaining > 1) {
-      bson_string_append (state.str, " ]");
-   } else if (remaining == 1) {
-      bson_string_append (state.str, " ");
-   }
+   bson_string_append (state.str, " ]");
 
    if (length) {
       *length = state.str->len;

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -44,13 +44,6 @@ typedef enum {
 } bson_validate_phase_t;
 
 
-typedef enum {
-   BSON_JSON_MODE_LEGACY,
-   BSON_JSON_MODE_CANONICAL,
-   BSON_JSON_MODE_RELAXED,
-} bson_json_mode_t;
-
-
 /*
  * Structures.
  */
@@ -69,6 +62,8 @@ typedef struct {
    uint32_t depth;
    bson_string_t *str;
    bson_json_mode_t mode;
+   int32_t max_len;
+   bool max_len_reached;
 } bson_json_state_t;
 
 
@@ -88,7 +83,8 @@ _bson_as_json_visit_document (const bson_iter_t *iter,
 static char *
 _bson_as_json_visit_all (const bson_t *bson,
                          size_t *length,
-                         bson_json_mode_t mode);
+                         bson_json_mode_t mode,
+                         int32_t max_len);
 
 /*
  * Globals.
@@ -2583,7 +2579,7 @@ _bson_as_json_visit_int64 (const bson_iter_t *iter,
 
    if (state->mode == BSON_JSON_MODE_CANONICAL) {
       bson_string_append_printf (
-         state->str, "{ \"$numberLong\" : \"%" PRId64 "\"}", v_int64);
+         state->str, "{ \"$numberLong\" : \"%" PRId64 "\" }", v_int64);
    } else {
       bson_string_append_printf (state->str, "%" PRId64, v_int64);
    }
@@ -2922,6 +2918,10 @@ _bson_as_json_visit_before (const bson_iter_t *iter,
    bson_json_state_t *state = data;
    char *escaped;
 
+   if (state->max_len_reached) {
+      return true;
+   }
+
    if (state->count) {
       bson_string_append (state->str, ", ");
    }
@@ -2939,6 +2939,30 @@ _bson_as_json_visit_before (const bson_iter_t *iter,
    }
 
    state->count++;
+
+   return false;
+}
+
+
+static bool
+_bson_as_json_visit_after (const bson_iter_t *iter, const char *key, void *data)
+{
+   bson_json_state_t *state = data;
+
+   if (state->max_len == BSON_MAX_LEN_UNLIMITED) {
+      return false;
+   }
+
+   if (state->str->len >= state->max_len) {
+      state->max_len_reached = true;
+
+      if (state->str->len > state->max_len) {
+         /* Truncate string to maximum length */
+         bson_string_truncate (state->str, state->max_len);
+      }
+
+      return true;
+   }
 
    return false;
 }
@@ -3018,27 +3042,33 @@ _bson_as_json_visit_codewscope (const bson_iter_t *iter,
    bson_json_state_t *state = data;
    char *code_escaped;
    char *scope;
+   int32_t max_scope_len = BSON_MAX_LEN_UNLIMITED;
 
    code_escaped = bson_utf8_escape_for_json (v_code, v_code_len);
    if (!code_escaped) {
       return true;
    }
 
-   /* Encode scope with the same mode */
-   scope = _bson_as_json_visit_all (v_scope, NULL, state->mode);
-
-   if (!scope) {
-      bson_free (code_escaped);
-      return true;
-   }
-
    bson_string_append (state->str, "{ \"$code\" : \"");
    bson_string_append (state->str, code_escaped);
    bson_string_append (state->str, "\", \"$scope\" : ");
+
+   bson_free (code_escaped);
+
+   /* Encode scope with the same mode */
+   if (state->max_len != BSON_MAX_LEN_UNLIMITED) {
+      max_scope_len = BSON_MAX (0, state->max_len - state->str->len);
+   }
+
+   scope = _bson_as_json_visit_all (v_scope, NULL, state->mode, max_scope_len);
+
+   if (!scope) {
+      return true;
+   }
+
    bson_string_append (state->str, scope);
    bson_string_append (state->str, " }");
 
-   bson_free (code_escaped);
    bson_free (scope);
 
    return false;
@@ -3046,7 +3076,7 @@ _bson_as_json_visit_codewscope (const bson_iter_t *iter,
 
 
 static const bson_visitor_t bson_as_json_visitors = {
-   _bson_as_json_visit_before,     NULL, /* visit_after */
+   _bson_as_json_visit_before,     _bson_as_json_visit_after,
    _bson_as_json_visit_corrupt,    _bson_as_json_visit_double,
    _bson_as_json_visit_utf8,       _bson_as_json_visit_document,
    _bson_as_json_visit_array,      _bson_as_json_visit_binary,
@@ -3081,9 +3111,24 @@ _bson_as_json_visit_document (const bson_iter_t *iter,
       child_state.str = bson_string_new ("{ ");
       child_state.depth = state->depth + 1;
       child_state.mode = state->mode;
+      child_state.max_len = BSON_MAX_LEN_UNLIMITED;
+      if (state->max_len != BSON_MAX_LEN_UNLIMITED) {
+         child_state.max_len = BSON_MAX (0, state->max_len - state->str->len);
+      }
+
+      child_state.max_len_reached = child_state.max_len == 0;
+
       if (bson_iter_visit_all (&child, &bson_as_json_visitors, &child_state)) {
+         if (child_state.max_len_reached) {
+            bson_string_append (state->str, child_state.str->str);
+         }
+
          bson_string_free (child_state.str, true);
-         return true;
+
+         /* If max_len was reached, we return a success state to ensure that
+          * VISIT_AFTER is still called
+          */
+         return !child_state.max_len_reached;
       }
 
       bson_string_append (child_state.str, " }");
@@ -3114,9 +3159,24 @@ _bson_as_json_visit_array (const bson_iter_t *iter,
       child_state.str = bson_string_new ("[ ");
       child_state.depth = state->depth + 1;
       child_state.mode = state->mode;
+      child_state.max_len = BSON_MAX_LEN_UNLIMITED;
+      if (state->max_len != BSON_MAX_LEN_UNLIMITED) {
+         child_state.max_len = BSON_MAX (0, state->max_len - state->str->len);
+      }
+
+      child_state.max_len_reached = child_state.max_len == 0;
+
       if (bson_iter_visit_all (&child, &bson_as_json_visitors, &child_state)) {
+         if (child_state.max_len_reached) {
+            bson_string_append (state->str, child_state.str->str);
+         }
+
          bson_string_free (child_state.str, true);
-         return true;
+
+         /* If max_len was reached, we return a success state to ensure that
+          * VISIT_AFTER is still called
+          */
+         return !child_state.max_len_reached;
       }
 
       bson_string_append (child_state.str, " ]");
@@ -3131,7 +3191,8 @@ _bson_as_json_visit_array (const bson_iter_t *iter,
 static char *
 _bson_as_json_visit_all (const bson_t *bson,
                          size_t *length,
-                         bson_json_mode_t mode)
+                         bson_json_mode_t mode,
+                         int32_t max_len)
 {
    bson_json_state_t state;
    bson_iter_t iter;
@@ -3161,9 +3222,12 @@ _bson_as_json_visit_all (const bson_t *bson,
    state.depth = 0;
    state.err_offset = &err_offset;
    state.mode = mode;
+   state.max_len = max_len;
+   state.max_len_reached = false;
 
-   if (bson_iter_visit_all (&iter, &bson_as_json_visitors, &state) ||
-       err_offset != -1) {
+   if ((bson_iter_visit_all (&iter, &bson_as_json_visitors, &state) ||
+        err_offset != -1) &&
+       !state.max_len_reached) {
       /*
        * We were prematurely exited due to corruption or failed visitor.
        */
@@ -3174,7 +3238,9 @@ _bson_as_json_visit_all (const bson_t *bson,
       return NULL;
    }
 
-   bson_string_append (state.str, " }");
+   if (!state.max_len_reached) {
+      bson_string_append (state.str, " }");
+   }
 
    if (length) {
       *length = state.str->len;
@@ -3185,23 +3251,38 @@ _bson_as_json_visit_all (const bson_t *bson,
 
 
 char *
+bson_as_json_with_opts (const bson_t *bson,
+                        size_t *length,
+                        const bson_json_opts_t *opts)
+{
+   return _bson_as_json_visit_all (bson, length, opts->mode, opts->max_len);
+}
+
+
+char *
 bson_as_canonical_extended_json (const bson_t *bson, size_t *length)
 {
-   return _bson_as_json_visit_all (bson, length, BSON_JSON_MODE_CANONICAL);
+   const bson_json_opts_t opts = {BSON_JSON_MODE_CANONICAL,
+                                  BSON_MAX_LEN_UNLIMITED};
+   return bson_as_json_with_opts (bson, length, &opts);
 }
 
 
 char *
 bson_as_json (const bson_t *bson, size_t *length)
 {
-   return _bson_as_json_visit_all (bson, length, BSON_JSON_MODE_LEGACY);
+   const bson_json_opts_t opts = {BSON_JSON_MODE_LEGACY,
+                                  BSON_MAX_LEN_UNLIMITED};
+   return bson_as_json_with_opts (bson, length, &opts);
 }
 
 
 char *
 bson_as_relaxed_extended_json (const bson_t *bson, size_t *length)
 {
-   return _bson_as_json_visit_all (bson, length, BSON_JSON_MODE_RELAXED);
+   const bson_json_opts_t opts = {BSON_JSON_MODE_RELAXED,
+                                  BSON_MAX_LEN_UNLIMITED};
+   return bson_as_json_with_opts (bson, length, &opts);
 }
 
 
@@ -3236,9 +3317,12 @@ bson_array_as_json (const bson_t *bson, size_t *length)
    state.depth = 0;
    state.err_offset = &err_offset;
    state.mode = BSON_JSON_MODE_LEGACY;
+   state.max_len = BSON_MAX_LEN_UNLIMITED;
+   state.max_len_reached = false;
 
-   if (bson_iter_visit_all (&iter, &bson_as_json_visitors, &state) ||
-       err_offset != -1) {
+   if ((bson_iter_visit_all (&iter, &bson_as_json_visitors, &state) ||
+        err_offset != -1) &&
+       !state.max_len_reached) {
       /*
        * We were prematurely exited due to corruption or failed visitor.
        */
@@ -3249,7 +3333,9 @@ bson_array_as_json (const bson_t *bson, size_t *length)
       return NULL;
    }
 
-   bson_string_append (state.str, " ]");
+   if (!state.max_len_reached) {
+      bson_string_append (state.str, " ]");
+   }
 
    if (length) {
       *length = state.str->len;

--- a/src/libbson/src/bson/bson.h
+++ b/src/libbson/src/bson/bson.h
@@ -493,6 +493,31 @@ bson_validate_with_error (const bson_t *bson,
 
 
 /**
+ * bson_as_json_with_opts:
+ * @bson: A bson_t.
+ * @length: A location for the string length, or NULL.
+ * @opts: A bson_t_json_opts_t defining options for the conversion
+ *
+ * Creates a new string containing @bson in the selected JSON format,
+ * conforming to the MongoDB Extended JSON Spec:
+ *
+ * github.com/mongodb/specifications/blob/master/source/extended-json.rst
+ *
+ * The caller is responsible for freeing the resulting string. If @length is
+ * non-NULL, then the length of the resulting string will be placed in @length.
+ *
+ * See http://docs.mongodb.org/manual/reference/mongodb-extended-json/ for
+ * more information on extended JSON.
+ *
+ * Returns: A newly allocated string that should be freed with bson_free().
+ */
+BSON_EXPORT (char *)
+bson_as_json_with_opts (const bson_t *bson,
+                        size_t *length,
+                        const bson_json_opts_t *opts);
+
+
+/**
  * bson_as_canonical_extended_json:
  * @bson: A bson_t.
  * @length: A location for the string length, or NULL.

--- a/src/libbson/tests/test-json.c
+++ b/src/libbson/tests/test-json.c
@@ -3365,6 +3365,12 @@ test_bson_as_json_with_opts_all_types (void)
 
    run_bson_as_json_with_opts_tests (&b, BSON_JSON_MODE_RELAXED, full_relaxed);
    run_bson_as_json_with_opts_tests (&b, BSON_JSON_MODE_CANONICAL, full_canonical);
+
+   bson_free (full_canonical);
+   bson_free (full_relaxed);
+
+   bson_destroy (&b);
+   bson_destroy (&scope);
 }
 
 void

--- a/src/libbson/tests/test-json.c
+++ b/src/libbson/tests/test-json.c
@@ -3322,8 +3322,8 @@ test_bson_as_json_with_opts_decimal128 (void)
 static void
 test_bson_as_json_with_opts_all_types (void)
 {
-   const char *full_canonical;
-   const char *full_relaxed;
+   char *full_canonical;
+   char *full_relaxed;
    bson_oid_t oid;
    bson_decimal128_t decimal128;
    bson_t b;


### PR DESCRIPTION
This commit was extracted from #684, which is the POC for CDRIVER-3775. Since this logic is not entirely related to logging, I figured it was easier to review this separately.

This introduces a new `bson_as_json_with_opts` method, which is used to pass extra options to the encoding process. For now, the opts struct holds a mode (corresponding to the individual `bson_as_json`, `bson_as_canonical_extended_json`, and `bson_as_relaxed_extended_json` functions) and a maximum length, which is required by the new structured logging component.

The goal behind this function is that not all BSON is read and encoded, but that the process ends when the character limit is reached. For the time being, this works by checking the length limit in a `visit_after` visitor. This means that while we won't continue encoding BSON that is essentially dropped later, each field is always encoded in full and the JSON string is truncated later to not exceed the maximum length. This also stops the encoding process.

Example usage:
```c
// Encode up to 1000 characters in canonical extended JSON
bson_json_opts_t opts = { BSON_JSON_MODE_CANONICAL, 1000 };
bson_t b;

char *str = bson_as_json_with_opts (b, NULL, opts);
```

```c
// Encode the entire BSON document as relaxed extended json
bson_json_opts_t opts = { BSON_JSON_MODE_CANONICAL, BSON_MAX_LEN_UNLIMITED };
bson_t b;

char *str = bson_as_json_with_opts (b, NULL, opts);
```

The example above is equivalent to this:
```c
bson_t b;

char *str = bson_as_relaxed_extended_json (b, NULL);
```

While working on this, I noticed that we don't really cover the current logic. I've added tests that encode into both relaxed and canonical extended formats with and without length limits. I've skipped the legacy encoding mode for the time being, but can add test coverage for that as well if desired. I've also included documentation for the new types (including `bson_json_mode_t` which previously was private). Please let me know if I missed something there.