### PR TITLE
CDRIVER-3808 fix srv polling thread from spinning

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-topology-background-monitoring.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-background-monitoring.c
@@ -150,7 +150,7 @@ _mongoc_topology_background_monitoring_start (mongoc_topology_t *topology)
    /* Reconcile to create the first server monitors. */
    _mongoc_topology_background_monitoring_reconcile (topology);
    /* Start SRV polling thread. */
-   if (mongoc_uri_get_service (topology->uri)) {
+   if (mongoc_topology_should_rescan_srv (topology)) {
       COMMON_PREFIX (thread_create)
       (&topology->srv_polling_thread, srv_polling_run, topology);
    }

--- a/src/libmongoc/src/mongoc/mongoc-topology-background-monitoring.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-background-monitoring.c
@@ -48,6 +48,12 @@ static BSON_THREAD_FUN (srv_polling_run, topology_void)
       }
 
       /* This will check if a scan is due. */
+      if (!mongoc_topology_should_rescan_srv (topology)) {
+         TRACE ("%s\n", "topology ineligible for SRV polling, stopping");
+         bson_mutex_unlock (&topology->mutex);
+         break;
+      }
+
       mongoc_topology_rescan_srv (topology);
 
       /* Unlock and sleep until next scan is due, or until shutdown signalled.

--- a/src/libmongoc/src/mongoc/mongoc-topology-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-private.h
@@ -225,4 +225,7 @@ _mongoc_topology_clear_connection_pool (mongoc_topology_t *topology,
 
 void
 mongoc_topology_rescan_srv (mongoc_topology_t *topology);
+
+bool
+mongoc_topology_should_rescan_srv (mongoc_topology_t *topology);
 #endif

--- a/src/libmongoc/src/mongoc/mongoc-topology-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-private.h
@@ -84,6 +84,7 @@ typedef struct _mongoc_topology_t {
 
    /* Is client side encryption enabled? */
    bool cse_enabled;
+   bool is_srv_polling;
 
 #ifdef MONGOC_ENABLE_CLIENT_SIDE_ENCRYPTION
    _mongoc_crypt_t *crypt;

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -616,9 +616,49 @@ mongoc_topology_apply_scanned_srv_hosts (mongoc_uri_t *uri,
 /*
  *--------------------------------------------------------------------------
  *
+ * mongoc_topology_should_rescan_srv --
+ * 
+ *      Checks whether it is valid to rescan SRV records on the topology.
+ *      Namely, that the topology type is Sharded or Unknown, and that
+ *      the topology URI was configured with SRV.
+ * 
+ *      If this returns false, caller can stop scanning SRV records
+ *      and does not need to try again in the future.
+ * 
+ *      NOTE: this method expects @topology's mutex to be locked on entry.
+ *
+ * --------------------------------------------------------------------------
+ */
+bool
+mongoc_topology_should_rescan_srv (mongoc_topology_t *topology) {
+   const char *service;
+
+   MONGOC_DEBUG_ASSERT (COMMON_PREFIX (mutex_is_locked) (&topology->mutex));
+
+   service = mongoc_uri_get_service (topology->uri);
+   if (!service) {
+      /* Only rescan if we have a mongodb+srv:// URI. */
+      return false;
+   }
+
+   if ((topology->description.type != MONGOC_TOPOLOGY_SHARDED) &&
+       (topology->description.type != MONGOC_TOPOLOGY_UNKNOWN)) {
+      /* Only perform rescan for sharded topology. */
+      return false;
+   }
+
+   return true;
+}
+
+/*
+ *--------------------------------------------------------------------------
+ *
  * mongoc_topology_rescan_srv --
  *
  *      Queries SRV records for new hosts in a mongos cluster.
+ *      Caller must call mongoc_topology_should_rescan_srv before calling
+ *      to ensure preconditions are met (while holding @topology's mutex
+ *      for the duration of both calls).
  *
  *      NOTE: this method expects @topology's mutex to be locked on entry.
  *
@@ -634,19 +674,9 @@ mongoc_topology_rescan_srv (mongoc_topology_t *topology)
    bool ret;
 
    MONGOC_DEBUG_ASSERT (COMMON_PREFIX (mutex_is_locked) (&topology->mutex));
-
-   if ((topology->description.type != MONGOC_TOPOLOGY_SHARDED) &&
-       (topology->description.type != MONGOC_TOPOLOGY_UNKNOWN)) {
-      /* Only perform rescan for sharded topology. */
-      return;
-   }
+   BSON_ASSERT (mongoc_topology_should_rescan_srv (topology));
 
    service = mongoc_uri_get_service (topology->uri);
-   if (!service) {
-      /* Only rescan if we have a mongodb+srv:// URI. */
-      return;
-   }
-
    scan_time_ms = topology->srv_polling_last_scan_ms +
                   topology->srv_polling_rescan_interval_ms;
    if (bson_get_monotonic_time () / 1000 < scan_time_ms) {
@@ -727,8 +757,10 @@ mongoc_topology_scan_once (mongoc_topology_t *topology, bool obey_cooldown)
 {
    MONGOC_DEBUG_ASSERT (COMMON_PREFIX (mutex_is_locked) (&topology->mutex));
 
-   /* Prior to scanning hosts, update the list of SRV hosts, if applicable. */
-   mongoc_topology_rescan_srv (topology);
+   if (mongoc_topology_should_rescan_srv (topology)) {
+      /* Prior to scanning hosts, update the list of SRV hosts, if applicable. */
+      mongoc_topology_rescan_srv (topology);
+   }
 
    /* since the last scan, members may be added or removed from the topology
     * description based on ismaster responses in connection handshakes, see


### PR DESCRIPTION
If an SRV URI is used to connect to a deployment other than a sharded cluster
the SRV polling thread spins since it bypasses the poll due to the topology
type being ineligible. This change terminates the thread when the topology
type is discovered to be ineligible.

I reran SRV polling tests described in [the spec](https://github.com/mongodb/specifications/tree/master/source/polling-srv-records-for-mongos-discovery/tests) using the steps outlined in https://github.com/kevinAlbs/SRVPollingTesting.