### PR TITLE
(Debian packaging) CDRIVER-3809 build mongo-c-driver with libmongocrypt

### DIFF
--- a/.evergreen/debian_package_build.sh
+++ b/.evergreen/debian_package_build.sh
@@ -44,7 +44,7 @@ export DEBOOTSTRAP_DIR=`pwd`/debootstrap.git
 sudo -E ./debootstrap.git/debootstrap unstable ./unstable-chroot/ http://cdn-aws.deb.debian.org/debian
 cp -a mongoc ./unstable-chroot/tmp/
 sudo chroot ./unstable-chroot /bin/bash -c "(set -o xtrace && \
-  apt-get install -y build-essential git-buildpackage fakeroot debhelper cmake libssl-dev pkg-config python3-sphinx zlib1g-dev libicu-dev libsasl2-dev libsnappy-dev libzstd-dev && \
+  apt-get install -y build-essential git-buildpackage fakeroot debhelper cmake libssl-dev pkg-config python3-sphinx zlib1g-dev libicu-dev libsasl2-dev libsnappy-dev libzstd-dev libmongocrypt-dev && \
   cd /tmp/mongoc && \
   git clean -fdx && \
   git reset --hard HEAD && \

--- a/debian/README.source
+++ b/debian/README.source
@@ -5,3 +5,25 @@ embedded copy of source code from another package, the upstream source is
 modified to remove the bundled zlib sources.  This is accomplished by using the
 --git-prebuild option of git-buildpackage to handle generation of the upstream
 tarball without the embedded code.  See debian/gbp.conf for details.
+
+================================================================================
+
+With the introduction of libmongocrypt to Debian (#968995), the mongo-c-driver
+package can now build libmongoc with Client-Side Field Level Encryption support.
+However, libmongocrypt requires libbson-dev in order to build.  To prevent an
+unresolvable Build-Depend cycle, the support for libmongocrypt in the
+mongo-c-driver source package can be disabled by building with the
+pkg.mongo-c-driver.no-libmongocrypt build profile.  Note that when this build
+profile is active that only libbson packages are created, as the build profile
+concept requires that "a binary package must contain the exact same content for
+all profiles with which it builds including no activated profile at all".
+(Consult https://wiki.debian.org/BuildProfileSpec for more information on how
+build profiles work in Debian.)
+
+When bootstrapping a new architecture or otherwise starting with a situation
+where neither the mongo-c-driver nor the libmongocrypt source packages have been
+built yet, first use the pkg.mongo-c-driver.no-libmongocrypt build profile to
+build the mongo-c-driver source package.  Once that is done the libmongocrypt
+source package can be built and once the libmongocrypt source package has been
+built then the mongo-c-driver source package can be built with no build profile
+to produce a complete set of libbson and libmongoc packages.

--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,7 @@ Build-Depends: debhelper (>= 11),
                libssl-dev,
                pkg-config,
                python3-sphinx,
+               libmongocrypt-dev <!pkg.mongo-c-driver.no-libmongocrypt>,
                zlib1g-dev,
                libicu-dev,
                libsasl2-dev,
@@ -23,8 +24,10 @@ Vcs-Browser: https://github.com/mongodb/mongo-c-driver/tree/master
 Package: libmongoc-dev
 Section: libdevel
 Architecture: any
+Build-Profiles: <!pkg.mongo-c-driver.no-libmongocrypt>
 Depends: libmongoc-1.0-0 (= ${binary:Version}),
          libbson-dev (= ${binary:Version}),
+         libmongocrypt-dev,
          libssl-dev,
          zlib1g-dev,
          libsnappy-dev,
@@ -40,6 +43,7 @@ Description: MongoDB C client library - dev files
 
 Package: libmongoc-1.0-0
 Architecture: any
+Build-Profiles: <!pkg.mongo-c-driver.no-libmongocrypt>
 Depends: ${misc:Depends},
          ${shlibs:Depends}
 Description: MongoDB C client library - runtime files
@@ -52,6 +56,7 @@ Description: MongoDB C client library - runtime files
 Package: libmongoc-doc
 Section: doc
 Architecture: all
+Build-Profiles: <!pkg.mongo-c-driver.no-libmongocrypt>
 Depends: ${misc:Depends}
 Description: MongoDB C client library - documentation
  libmongoc is the officially supported MongoDB client library for C


### PR DESCRIPTION
Evergreen patch build (to ensure `debian-package-build` task is exercised): https://spruce.mongodb.com/version/5f9de1fd30661537f4dc19ba/tasks

Note that once this PR is approved/merged I will cherry-pick the change on to the `r1.17` branch.  Ideally, this will take place before the pending 1.17.2 release.  Additionally, I will include an entry regarding this change in the next `debian/changelog` update when I prepare the 1.17.2 package.