### PR TITLE
CDRIVER-3819 collation is not an option for collection rename

### DIFF
--- a/src/libmongoc/doc/mongoc_collection_rename_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_collection_rename_with_opts.rst
@@ -27,7 +27,11 @@ Parameters
 
 .. |opts-source| replace:: ``collection``
 
-.. include:: includes/write-opts.txt
+``opts`` may be NULL or a BSON document with additional command options:
+
+* ``writeConcern``: Construct a :symbol:`mongoc_write_concern_t` and use :symbol:`mongoc_write_concern_append` to add the write concern to ``opts``. See the example code for :symbol:`mongoc_client_write_command_with_opts`.
+* ``sessionId``: First, construct a :symbol:`mongoc_client_session_t` with :symbol:`mongoc_client_start_session`. You can begin a transaction with :symbol:`mongoc_client_session_start_transaction`, optionally with a :symbol:`mongoc_transaction_opt_t` that overrides the options inherited from |opts-source|, and use :symbol:`mongoc_client_session_append` to add the session to ``opts``. See the example code for :symbol:`mongoc_client_session_t`.
+* ``serverId``: To target a specific server, include an int32 "serverId" field. Obtain the id by calling :symbol:`mongoc_client_select_server`, then :symbol:`mongoc_server_description_id` on its return value.
 
 Description
 -----------


### PR DESCRIPTION
Note that while this accomplishes the objective of not listing `collation` in an instance where it is not a valid option, it results in duplicating part of the generated `opts` documentation.  If the `opts` change in a way that should be reflected here, then it is not clear how to ensure that change is not overlooked.  That said, this change is probably better than documenting something as valid that is not actually valid.