### PR TITLE
libbson fuzzer for OSS-Fuzz integration.

### DIFF
--- a/src/libbson/fuzz/fuzz_test_libbson.c
+++ b/src/libbson/fuzz/fuzz_test_libbson.c
@@ -1,0 +1,19 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <bson/bson.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+        char *nt = malloc(size+1);
+        memcpy(nt, data, size);
+        nt[size] = '\0';
+        bson_error_t error;
+
+        bson_t b;
+        if (bson_init_from_json(&b, nt, -1, &error)) {
+                bson_destroy(&b);
+        }
+
+        free(nt);
+        return 0;
+}

--- a/src/libbson/fuzz/fuzz_test_libbson.c
+++ b/src/libbson/fuzz/fuzz_test_libbson.c
@@ -4,16 +4,16 @@
 #include <bson/bson.h>
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-        char *nt = malloc(size+1);
-        memcpy(nt, data, size);
-        nt[size] = '\0';
-        bson_error_t error;
+    char *nt = malloc(size+1);
+    memcpy(nt, data, size);
+    nt[size] = '\0';
+    bson_error_t error;
 
-        bson_t b;
-        if (bson_init_from_json(&b, nt, -1, &error)) {
-                bson_destroy(&b);
-        }
+    bson_t b;
+    if (bson_init_from_json(&b, nt, -1, &error)) {
+        bson_destroy(&b);
+    }
 
-        free(nt);
-        return 0;
+    free(nt);
+    return 0;
 }


### PR DESCRIPTION
Hi

I have integrated fuzzing into libbson and was thinking that it would be nice to set up continuous fuzzing by way of OSS-Fuzz. In this PR: https://github.com/google/oss-fuzz/pull/4808 I have done exactly that, namely created the necessary logic from an OSS-Fuzz perspective to integrate. In that PR you also see the fuzzer attached, but it would be nicer to have the fuzzer integrated into the upstream project itself rather than keeping it in OSS-Fuzz - so if this PR gets merged I will remove it from OSS-Fuzz

Essentially, OSS-Fuzz is a free service run by Google that performs continuous fuzzing of important open source projects. The only expectation of integrating into OSS-Fuzz is that bugs will be fixed. This is not a "hard" requirement in that no one enforces this and the main point is if bugs are not fixed then it is a waste of resources to run the fuzzers, which we would like to avoid.

If you would like to integrate, could I please have an email(s) that will get access to the data produced by OSS-Fuzz, such as bug reports, coverage reports and more stats. Notice the emails affiliated with the project will be public in the OSS-Fuzz repo, as they will be part of a configuration file and they also need to be linked with a Google account to get the detailed reports. 

David