### PR TITLE
CDRIVER-3825 remove BSON_ASSERT for server_id

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -2299,7 +2299,6 @@ mongoc_cluster_stream_for_server (mongoc_cluster_t *cluster,
    ENTRY;
 
    BSON_ASSERT (cluster);
-   BSON_ASSERT (server_id);
 
    if (cs && cs->server_id && cs->server_id != server_id) {
       _mongoc_bson_init_if_set (reply);


### PR DESCRIPTION
I simply removed this assert.  The logic right below should compare for server_id 0 and fail with a nice error.