### PR TITLE
CDRIVER-3823 ignore SIGPIPE on osx

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-socket.c
+++ b/src/libmongoc/src/mongoc/mongoc-socket.c
@@ -1020,7 +1020,7 @@ mongoc_socket_new (int domain,   /* IN */
       _mongoc_socket_setkeepalive (sd);
    }
 
-   /* Set SO_NISIGPIPE, to ignore SIGPIPE on writes for platforms where
+   /* Set SO_NOSIGPIPE, to ignore SIGPIPE on writes for platforms where
       setting MSG_NOSIGNAL on writes is not supported (primarily OSX). */
 #ifdef SO_NOSIGPIPE
    setsockopt(sd, SOL_SOCKET, SO_NOSIGPIPE, &on, sizeof(on));

--- a/src/libmongoc/src/mongoc/mongoc-socket.c
+++ b/src/libmongoc/src/mongoc/mongoc-socket.c
@@ -993,6 +993,9 @@ mongoc_socket_new (int domain,   /* IN */
 #else
    int sd;
 #endif
+#ifdef SO_NOSIGPIPE
+   int on = 1;
+#endif
 
    ENTRY;
 
@@ -1016,6 +1019,12 @@ mongoc_socket_new (int domain,   /* IN */
       }
       _mongoc_socket_setkeepalive (sd);
    }
+
+   /* Set SO_NISIGPIPE, to ignore SIGPIPE on writes for platforms where
+      setting MSG_NOSIGNAL on writes is not supported (primarily OSX). */
+#ifdef SO_NOSIGPIPE
+   setsockopt(sd, SOL_SOCKET, SO_NOSIGPIPE, &on, sizeof(on));
+#endif
 
    sock = (mongoc_socket_t *) bson_malloc0 (sizeof *sock);
    sock->sd = sd;


### PR DESCRIPTION
`MSG_NOSIGNAL`, the flag that we currently use to ignore `SIGPIPE` on POSIX systems, is not supported on OSX.  Instead, OSX offers the `SO_NOSIGPIPE` flag that can be set as a socket option before performing writes.

I had asked @kmahar to test a different solution for ignoring `SIGPIPE`:
`signal(SIGPIPE, SIG_IGN);`

Upon further research, this solution isn't ideal, because it ignores `SIGPIPE` for the entire program, including any user code running a level above the C driver.  In the case that a user is interested in `SIGPIPE` for some reason, setting the handler to `SIG_IGN` like this would also capture `SIGPIPE` in user code.  The `SO_NOSIGPIPE` solution is less intrusive for a library like ours.