### PR TITLE
CDRIVER-3780 add client_session_get_dirty

### DIFF
--- a/src/libmongoc/doc/mongoc_client_session_get_dirty.rst
+++ b/src/libmongoc/doc/mongoc_client_session_get_dirty.rst
@@ -1,0 +1,33 @@
+:man_page: mongoc_client_session_get_dirty
+
+mongoc_client_session_get_dirty()
+=================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  bool
+  mongoc_client_session_get_dirty (const mongoc_client_session_t *session);
+
+Indicates whether ``session`` has been marked "dirty" as defined in the `driver sessions specification <https://github.com/mongodb/specifications/blob/master/source/sessions/driver-sessions.rst>`_.
+
+Parameters
+----------
+
+* ``session``: A const :symbol:`mongoc_client_session_t`.
+
+Description
+-----------
+
+This function is intended for use by drivers that wrap libmongoc. It is not useful in client applications.
+
+Returns
+-------
+
+A boolean indicating whether the session has been marked "dirty".
+
+.. only:: html
+
+  .. include:: includes/seealso/session.txt

--- a/src/libmongoc/doc/mongoc_client_session_t.rst
+++ b/src/libmongoc/doc/mongoc_client_session_t.rst
@@ -38,6 +38,7 @@ Example
     mongoc_client_session_append
     mongoc_client_session_get_client
     mongoc_client_session_get_cluster_time
+    mongoc_client_session_get_dirty
     mongoc_client_session_get_operation_time
     mongoc_client_session_get_opts
     mongoc_client_session_get_lsid

--- a/src/libmongoc/src/mongoc/mongoc-client-session.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-session.c
@@ -1613,3 +1613,11 @@ _mongoc_client_session_pin (mongoc_client_session_t *session,
 
    session->server_id = server_id;
 }
+
+bool
+mongoc_client_session_get_dirty (mongoc_client_session_t *session)
+{
+   BSON_ASSERT_PARAM (session);
+
+   return session->server_session->dirty;
+}

--- a/src/libmongoc/src/mongoc/mongoc-client-session.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-session.c
@@ -724,6 +724,7 @@ _mongoc_client_session_new (mongoc_client_t *client,
    ENTRY;
 
    BSON_ASSERT (client);
+   BSON_ASSERT (server_session);
 
    session = bson_malloc0 (sizeof (mongoc_client_session_t));
    session->client = client;

--- a/src/libmongoc/src/mongoc/mongoc-client-session.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-session.h
@@ -183,6 +183,9 @@ mongoc_client_session_append (const mongoc_client_session_t *client_session,
 MONGOC_EXPORT (void)
 mongoc_client_session_destroy (mongoc_client_session_t *session);
 
+MONGOC_EXPORT (bool)
+mongoc_client_session_get_dirty (mongoc_client_session_t *session);
+
 BSON_END_DECLS
 
 


### PR DESCRIPTION
Unified test format (and driver sessions tests) make assertions on whether a session has been marked dirty. This adds a getter to `mongoc_client_session_t` so wrapping drivers can easily implement those assertions.