### PR TITLE
clarify lifecycle of sd

### DIFF
--- a/src/libmongoc/doc/mongoc_server_description_t.rst
+++ b/src/libmongoc/doc/mongoc_server_description_t.rst
@@ -18,7 +18,10 @@ Synopsis
 Lifecycle
 ---------
 
-Clean up with :symbol:`mongoc_server_description_destroy()`.
+Clean up a ``mongoc_server_description_t`` with :symbol:`mongoc_server_description_destroy()` when necessary.
+
+Applications receive a temporary reference to a ``mongoc_server_description_t`` as a parameter to an SDAM Monitoring callback that must not be destroyed.
+:doc:`Introduction to Application Performance Monitoring <application-performance-monitoring>`.
 
 .. only:: html
 

--- a/src/libmongoc/doc/mongoc_server_description_t.rst
+++ b/src/libmongoc/doc/mongoc_server_description_t.rst
@@ -20,7 +20,7 @@ Lifecycle
 
 Clean up a ``mongoc_server_description_t`` with :symbol:`mongoc_server_description_destroy()` when necessary.
 
-Applications receive a temporary reference to a ``mongoc_server_description_t`` as a parameter to an SDAM Monitoring callback that must not be destroyed.
+Applications receive a temporary reference to a ``mongoc_server_description_t`` as a parameter to an SDAM Monitoring callback that must not be destroyed. See
 :doc:`Introduction to Application Performance Monitoring <application-performance-monitoring>`.
 
 .. only:: html


### PR DESCRIPTION
Adds a note to the docs for `mongoc_server_description_t` to note it is temporary when obtained through APM callbacks.

This is similar to the existing note for `mongoc_topology_description_t`. Though users do need to destroy a `mongoc_server_description_t` when obtained through `mongoc_client_select_server`.