### PR TITLE
CDRIVER-3902 handle absence of expectResult/expectError

### DIFF
--- a/src/libmongoc/tests/unified/operation.c
+++ b/src/libmongoc/tests/unified/operation.c
@@ -2049,6 +2049,8 @@ operation_with_transaction (test_t *test,
    mongoc_client_session_with_transaction (
       session, with_transaction_cb, topts, &tctx, &op_reply, &op_error);
 
+   result_from_val_and_reply (result, NULL, &op_reply, &op_error);
+
    ret = true;
 done:
    bson_parser_destroy_with_parsed_fields (bp);

--- a/src/libmongoc/tests/unified/result.c
+++ b/src/libmongoc/tests/unified/result.c
@@ -338,8 +338,11 @@ result_check (result_t *result,
    bson_val_t *error_expect_result;
 
    if (!expect_result && !expect_error) {
-      /* TODO: "create index on a non-existing collection" seems to assume no
-       * "expectResult" or "expectError" means no check. */
+      if (!result->ok) {
+         test_set_error (
+            error, "expected success, but got error: %s", result->error.message);
+         goto done;
+      }
       ret = true;
       goto done;
    }

--- a/src/libmongoc/tests/unified/runner.c
+++ b/src/libmongoc/tests/unified/runner.c
@@ -732,6 +732,8 @@ test_setup_initial_data (test_t *test, bson_error_t *error)
             /* This is not a "ns not found" error. Fail the test. */
             goto loopexit;
          }
+         /* Clear an "ns not found" error. */
+         memset (error, 0, sizeof (bson_error_t));
       }
 
       /* Insert documents if specified. */


### PR DESCRIPTION
Not urgent – this is a follow up ticket for unified test format. If an operation in the unified test format does not include `expectResult` or `expectError` it should still check that the operation succeeded.