### PR TITLE
CDRIVER-3904 move log handler above init in logging example

### DIFF
--- a/src/libmongoc/doc/logging.rst
+++ b/src/libmongoc/doc/logging.rst
@@ -91,8 +91,8 @@ For example, you could register a custom handler to suppress messages at INFO le
   int
   main (int argc, char *argv[])
   {
-     mongoc_init ();
      mongoc_log_set_handler (my_logger, NULL);
+     mongoc_init ();
 
      /* ... your code ...  */
 


### PR DESCRIPTION
This PR moves `mongoc_log_set_handler` above `mongoc_init` in our logging docs example. This clarifies the log handler can be set at any time, even before a call to `mongoc_init`. 