### PR TITLE
CDRIVER-3906 do not add libm on macOS

### DIFF
--- a/src/libbson/CMakeLists.txt
+++ b/src/libbson/CMakeLists.txt
@@ -261,10 +261,17 @@ if (RT_LIBRARY)
    target_link_libraries (bson_shared PRIVATE ${RT_LIBRARY})
 endif ()
 
-find_library (M_LIBRARY m)
-if (M_LIBRARY)
-   target_link_libraries (bson_shared PRIVATE ${M_LIBRARY})
-   set (BSON_LIBRARIES ${BSON_LIBRARIES} ${M_LIBRARY})
+# On macOS Big Sur, libm resolves to the SDK's tbd file, like:
+# /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/libm.tbd
+# Not all consumers can easily link to a tbd file (notably golang will reject a tbd suffix by default)
+# macOS includes libm as part of libSystem (along with libc).
+# It does not need to be explicitly linked.
+if (!APPLE)
+   find_library (M_LIBRARY m)
+   if (M_LIBRARY)
+      target_link_libraries (bson_shared PRIVATE ${M_LIBRARY})
+      set (BSON_LIBRARIES ${BSON_LIBRARIES} ${M_LIBRARY})
+   endif ()
 endif ()
 
 set (THREADS_PREFER_PTHREAD_FLAG 1)


### PR DESCRIPTION
Requiring consumers of libbson-static to link against libm on macOS causes an issue for the Go driver's use of libmongocrypt (error encountered originally in MONGOCRYPT-309, but copying details here).

```
$ pkg-config --libs --cflags libmongocrypt-static
-DMONGOCRYPT_STATIC_DEFINE -DKMS_MSG_STATIC -DBSON_STATIC -I/usr/local/Cellar/libmongocrypt/1.2.0/include/mongocrypt -I/usr/local/Cellar/mongo-c-driver/1.17.4/include/libbson-1.0 -L/usr/local/Cellar/mongo-c-driver/1.17.4/lib /usr/local/Cellar/libmongocrypt/1.2.0/lib/libmongocrypt-static.a /usr/local/Cellar/libmongocrypt/1.2.0/lib/libkms_message-static.a -framework CoreFoundation -framework Security -lbson-static-1.0 /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/libm.tbd
```

The `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/libm.tbd` is a valid input to the macOS linker, and is a [text based stub-library](https://developer.apple.com/forums/thread/4572?answerId=9366022#9366022). By default, Go rejects unrecognized linker inputs. This will be fixed in https://github.com/golang/go/issues/44263 in the `go` command.

Example:
```
// bson.go
package bson

// #cgo pkg-config: libbson-static-1.0
// #include <bson/bson.h>
// #include <stdlib.h>
import "C"
import "fmt"

func RunBson() {
	v := C.bson_get_version()
	fmt.Printf("v=%v\n", v)
}
```

Attempting to build with go results in an error:
```
$ go build -o bson bson.go
go build command-line-arguments: invalid flag in pkg-config --libs: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/libm.tbd
```

Users can work around this by specifying the environment variable `CGO_LDFLAGS_ALLOW='^.*tbd$'`. But, [libm is part of libsystem on macOS](https://learning.oreilly.com/library/view/mac-os-x/0596003560/ch05s02.html). So I do not think it is necessary to explicitly link to libm on macOS.