### PR TITLE
Improve docs of cursor returning functions

### DIFF
--- a/src/libmongoc/doc/includes/returns-cursor.txt
+++ b/src/libmongoc/doc/includes/returns-cursor.txt
@@ -1,0 +1,8 @@
+This function returns a newly allocated :symbol:`mongoc_cursor_t` that should be freed with :symbol:`mongoc_cursor_destroy()` when no longer in use. The returned :symbol:`mongoc_cursor_t` is never ``NULL``; if the parameters are invalid, the :symbol:`bson:bson_error_t` in the :symbol:`mongoc_cursor_t` is filled out, and the :symbol:`mongoc_cursor_t` is returned before the server is selected. The user must call :symbol:`mongoc_cursor_next()` on the returned :symbol:`mongoc_cursor_t` to execute the aggregation pipeline.
+
+Cursor errors can be checked with :symbol:`mongoc_cursor_error_document`. It always fills out the :symbol:`bson_error_t` if an error occurred, and optionally includes a server reply document if the error occurred server-side.
+
+.. warning::
+
+  Failure to handle the result of this function is a programming error.
+

--- a/src/libmongoc/doc/includes/returns-cursor.txt
+++ b/src/libmongoc/doc/includes/returns-cursor.txt
@@ -1,8 +1,7 @@
-This function returns a newly allocated :symbol:`mongoc_cursor_t` that should be freed with :symbol:`mongoc_cursor_destroy()` when no longer in use. The returned :symbol:`mongoc_cursor_t` is never ``NULL``; if the parameters are invalid, the :symbol:`bson:bson_error_t` in the :symbol:`mongoc_cursor_t` is filled out, and the :symbol:`mongoc_cursor_t` is returned before the server is selected. The user must call :symbol:`mongoc_cursor_next()` on the returned :symbol:`mongoc_cursor_t` to execute the aggregation pipeline.
+This function returns a newly allocated :symbol:`mongoc_cursor_t` that should be freed with :symbol:`mongoc_cursor_destroy()` when no longer in use. The returned :symbol:`mongoc_cursor_t` is never ``NULL``, even on error. The user must call :symbol:`mongoc_cursor_next()` on the returned :symbol:`mongoc_cursor_t` to execute the initial command.
 
 Cursor errors can be checked with :symbol:`mongoc_cursor_error_document`. It always fills out the :symbol:`bson_error_t` if an error occurred, and optionally includes a server reply document if the error occurred server-side.
 
 .. warning::
 
   Failure to handle the result of this function is a programming error.
-

--- a/src/libmongoc/doc/mongoc_collection_aggregate.rst
+++ b/src/libmongoc/doc/mongoc_collection_aggregate.rst
@@ -54,11 +54,7 @@ Transaction        Transaction    Transaction
 Returns
 -------
 
-This function returns a newly allocated :symbol:`mongoc_cursor_t` that should be freed with :symbol:`mongoc_cursor_destroy()` when no longer in use. The returned :symbol:`mongoc_cursor_t` is never ``NULL``; if the parameters are invalid, the :symbol:`bson:bson_error_t` in the :symbol:`mongoc_cursor_t` is filled out, and the :symbol:`mongoc_cursor_t` is returned before the server is selected. The user must call :symbol:`mongoc_cursor_next()` on the returned :symbol:`mongoc_cursor_t` to execute the aggregation pipeline.
-
-.. warning::
-
-  Failure to handle the result of this function is a programming error.
+.. include:: includes/returns-cursor.txt
 
 Example
 -------

--- a/src/libmongoc/doc/mongoc_collection_command.rst
+++ b/src/libmongoc/doc/mongoc_collection_command.rst
@@ -38,7 +38,4 @@ Parameters
 Returns
 -------
 
-A :symbol:`mongoc_cursor_t`.
-
-The cursor should be freed with :symbol:`mongoc_cursor_destroy()`.
-
+.. include:: includes/returns-cursor.txt

--- a/src/libmongoc/doc/mongoc_collection_find.rst
+++ b/src/libmongoc/doc/mongoc_collection_find.rst
@@ -51,7 +51,12 @@ If no options are necessary, ``query`` can simply contain a query such as ``{a:1
 Returns
 -------
 
-A newly allocated :symbol:`mongoc_cursor_t` that should be freed with :symbol:`mongoc_cursor_destroy()` when no longer in use.
+This function returns a newly allocated :symbol:`mongoc_cursor_t` that should be freed with :symbol:`mongoc_cursor_destroy()` when no longer in use. The returned :symbol:`mongoc_cursor_t` is never ``NULL``; if the parameters are invalid, the :symbol:`bson:bson_error_t` in the :symbol:`mongoc_cursor_t` is filled out, and the :symbol:`mongoc_cursor_t` is returned before the server is selected. The user must call :symbol:`mongoc_cursor_next()` on the returned :symbol:`mongoc_cursor_t` to execute the aggregation pipeline.
+
+.. warning::
+
+  Failure to handle the result of this function is a programming error.
+
 
 Example
 -------

--- a/src/libmongoc/doc/mongoc_collection_find.rst
+++ b/src/libmongoc/doc/mongoc_collection_find.rst
@@ -51,7 +51,7 @@ If no options are necessary, ``query`` can simply contain a query such as ``{a:1
 Returns
 -------
 
-This function returns a newly allocated :symbol:`mongoc_cursor_t` that should be freed with :symbol:`mongoc_cursor_destroy()` when no longer in use. The returned :symbol:`mongoc_cursor_t` is never ``NULL``; if the parameters are invalid, the :symbol:`bson:bson_error_t` in the :symbol:`mongoc_cursor_t` is filled out, and the :symbol:`mongoc_cursor_t` is returned before the server is selected. The user must call :symbol:`mongoc_cursor_next()` on the returned :symbol:`mongoc_cursor_t` to execute the aggregation pipeline.
+This function returns a newly allocated :symbol:`mongoc_cursor_t` that should be freed with :symbol:`mongoc_cursor_destroy()` when no longer in use. The returned :symbol:`mongoc_cursor_t` is never ``NULL``; if the parameters are invalid, the :symbol:`bson:bson_error_t` in the :symbol:`mongoc_cursor_t` is filled out, and the :symbol:`mongoc_cursor_t` is returned before the server is selected. The user must call :symbol:`mongoc_cursor_next()` on the returned :symbol:`mongoc_cursor_t` to execute the query.
 
 .. warning::
 

--- a/src/libmongoc/doc/mongoc_collection_find.rst
+++ b/src/libmongoc/doc/mongoc_collection_find.rst
@@ -51,12 +51,7 @@ If no options are necessary, ``query`` can simply contain a query such as ``{a:1
 Returns
 -------
 
-This function returns a newly allocated :symbol:`mongoc_cursor_t` that should be freed with :symbol:`mongoc_cursor_destroy()` when no longer in use. The returned :symbol:`mongoc_cursor_t` is never ``NULL``; if the parameters are invalid, the :symbol:`bson:bson_error_t` in the :symbol:`mongoc_cursor_t` is filled out, and the :symbol:`mongoc_cursor_t` is returned before the server is selected. The user must call :symbol:`mongoc_cursor_next()` on the returned :symbol:`mongoc_cursor_t` to execute the query.
-
-.. warning::
-
-  Failure to handle the result of this function is a programming error.
-
+.. include:: includes/returns-cursor.txt
 
 Example
 -------

--- a/src/libmongoc/doc/mongoc_collection_find_indexes.rst
+++ b/src/libmongoc/doc/mongoc_collection_find_indexes.rst
@@ -37,4 +37,9 @@ Errors are propagated via the ``error`` parameter.
 Returns
 -------
 
-A cursor where each result corresponds to the server's representation of an index on this collection. If the collection does not exist on the server, the cursor will be empty.
+.. include:: includes/returns-cursor.txt
+
+In the returned cursor each result corresponds to the server's representation of an index on this collection. If the collection does not exist on the server, the cursor will be empty.
+
+The cursor functions :symbol:`mongoc_cursor_set_limit`, :symbol:`mongoc_cursor_set_batch_size`, and :symbol:`mongoc_cursor_set_max_await_time_ms` have no use on the returned cursor.
+

--- a/src/libmongoc/doc/mongoc_collection_find_indexes_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_collection_find_indexes_with_opts.rst
@@ -34,7 +34,9 @@ Use :symbol:`mongoc_cursor_error` on the returned cursor to check for errors.
 Returns
 -------
 
-A cursor where each result corresponds to the server's representation of an index on this collection. If the collection does not exist on the server, the cursor will be empty.
+.. include:: includes/returns-cursor.txt
+
+In the returned cursor each result corresponds to the server's representation of an index on this collection. If the collection does not exist on the server, the cursor will be empty.
 
 The cursor functions :symbol:`mongoc_cursor_set_limit`, :symbol:`mongoc_cursor_set_batch_size`, and :symbol:`mongoc_cursor_set_max_await_time_ms` have no use on the returned cursor.
 

--- a/src/libmongoc/doc/mongoc_collection_find_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_collection_find_with_opts.rst
@@ -39,11 +39,7 @@ To target a specific server, include an integer "serverId" field in ``opts`` wit
 Returns
 -------
 
-This function returns a newly allocated :symbol:`mongoc_cursor_t` that should be freed with :symbol:`mongoc_cursor_destroy()` when no longer in use. The returned :symbol:`mongoc_cursor_t` is never ``NULL``; if the parameters are invalid, the :symbol:`bson:bson_error_t` in the :symbol:`mongoc_cursor_t` is filled out, and the :symbol:`mongoc_cursor_t` is returned before the server is selected. The user must call :symbol:`mongoc_cursor_next()` on the returned :symbol:`mongoc_cursor_t` to execute the query.
-
-.. warning::
-
-  Failure to handle the result of this function is a programming error.
+.. include:: includes/returns-cursor.txt
 
 Examples
 --------

--- a/src/libmongoc/doc/mongoc_collection_find_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_collection_find_with_opts.rst
@@ -39,7 +39,11 @@ To target a specific server, include an integer "serverId" field in ``opts`` wit
 Returns
 -------
 
-A newly allocated :symbol:`mongoc_cursor_t` that must be freed with :symbol:`mongoc_cursor_destroy()`.
+This function returns a newly allocated :symbol:`mongoc_cursor_t` that should be freed with :symbol:`mongoc_cursor_destroy()` when no longer in use. The returned :symbol:`mongoc_cursor_t` is never ``NULL``; if the parameters are invalid, the :symbol:`bson:bson_error_t` in the :symbol:`mongoc_cursor_t` is filled out, and the :symbol:`mongoc_cursor_t` is returned before the server is selected. The user must call :symbol:`mongoc_cursor_next()` on the returned :symbol:`mongoc_cursor_t` to execute the aggregation pipeline.
+
+.. warning::
+
+  Failure to handle the result of this function is a programming error.
 
 Examples
 --------

--- a/src/libmongoc/doc/mongoc_collection_find_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_collection_find_with_opts.rst
@@ -39,7 +39,7 @@ To target a specific server, include an integer "serverId" field in ``opts`` wit
 Returns
 -------
 
-This function returns a newly allocated :symbol:`mongoc_cursor_t` that should be freed with :symbol:`mongoc_cursor_destroy()` when no longer in use. The returned :symbol:`mongoc_cursor_t` is never ``NULL``; if the parameters are invalid, the :symbol:`bson:bson_error_t` in the :symbol:`mongoc_cursor_t` is filled out, and the :symbol:`mongoc_cursor_t` is returned before the server is selected. The user must call :symbol:`mongoc_cursor_next()` on the returned :symbol:`mongoc_cursor_t` to execute the aggregation pipeline.
+This function returns a newly allocated :symbol:`mongoc_cursor_t` that should be freed with :symbol:`mongoc_cursor_destroy()` when no longer in use. The returned :symbol:`mongoc_cursor_t` is never ``NULL``; if the parameters are invalid, the :symbol:`bson:bson_error_t` in the :symbol:`mongoc_cursor_t` is filled out, and the :symbol:`mongoc_cursor_t` is returned before the server is selected. The user must call :symbol:`mongoc_cursor_next()` on the returned :symbol:`mongoc_cursor_t` to execute the query.
 
 .. warning::
 

--- a/src/libmongoc/doc/mongoc_database_aggregate.rst
+++ b/src/libmongoc/doc/mongoc_database_aggregate.rst
@@ -51,11 +51,7 @@ Transaction        Transaction    Transaction
 Returns
 -------
 
-This function returns a newly allocated :symbol:`mongoc_cursor_t` that should be freed with :symbol:`mongoc_cursor_destroy()` when no longer in use. The returned :symbol:`mongoc_cursor_t` is never ``NULL``; if the parameters are invalid, the :symbol:`bson:bson_error_t` in the :symbol:`mongoc_cursor_t` is filled out, and the :symbol:`mongoc_cursor_t` is returned before the server is selected. The user must call :symbol:`mongoc_cursor_next()` on the returned :symbol:`mongoc_cursor_t` to execute the aggregation pipeline.
-
-.. warning::
-
-  Failure to handle the result of this function is a programming error.
+.. include:: includes/returns-cursor.txt
 
 Example
 -------

--- a/src/libmongoc/doc/mongoc_database_command.rst
+++ b/src/libmongoc/doc/mongoc_database_command.rst
@@ -42,7 +42,5 @@ Parameters
 Returns
 -------
 
-A :symbol:`mongoc_cursor_t`.
-
-The cursor should be freed with :symbol:`mongoc_cursor_destroy()`.
+.. include:: includes/returns-cursor.txt
 

--- a/src/libmongoc/doc/mongoc_database_find_collections.rst
+++ b/src/libmongoc/doc/mongoc_database_find_collections.rst
@@ -43,9 +43,8 @@ Errors are propagated via the ``error`` parameter.
 Returns
 -------
 
-.. include:: includes/returns-cursor.txt
+This function returns a newly allocated :symbol:`mongoc_cursor_t` that should be freed with :symbol:`mongoc_cursor_destroy()` when no longer in use, or `NULL` in case of error. The user must call :symbol:`mongoc_cursor_next()` on the returned :symbol:`mongoc_cursor_t` to execute the initial command.
 
 In the returned cursor each result corresponds to the server's representation of a collection in this database.
 
 The cursor functions :symbol:`mongoc_cursor_set_limit`, :symbol:`mongoc_cursor_set_batch_size`, and :symbol:`mongoc_cursor_set_max_await_time_ms` have no use on the returned cursor.
-

--- a/src/libmongoc/doc/mongoc_database_find_collections.rst
+++ b/src/libmongoc/doc/mongoc_database_find_collections.rst
@@ -43,5 +43,9 @@ Errors are propagated via the ``error`` parameter.
 Returns
 -------
 
-A cursor where each result corresponds to the server's representation of a collection in this database.
+.. include:: includes/returns-cursor.txt
+
+In the returned cursor each result corresponds to the server's representation of a collection in this database.
+
+The cursor functions :symbol:`mongoc_cursor_set_limit`, :symbol:`mongoc_cursor_set_batch_size`, and :symbol:`mongoc_cursor_set_max_await_time_ms` have no use on the returned cursor.
 

--- a/src/libmongoc/doc/mongoc_database_find_collections_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_database_find_collections_with_opts.rst
@@ -38,7 +38,9 @@ Use :symbol:`mongoc_cursor_error` on the returned cursor to check for errors.
 Returns
 -------
 
-A cursor where each result corresponds to the server's representation of a collection in this database.
+.. include:: includes/returns-cursor.txt
+
+In the returned cursor each result corresponds to the server's representation of a collection in this database.
 
 The cursor functions :symbol:`mongoc_cursor_set_limit`, :symbol:`mongoc_cursor_set_batch_size`, and :symbol:`mongoc_cursor_set_max_await_time_ms` have no use on the returned cursor.
 


### PR DESCRIPTION
Comparing the "Returns" section in src/libmongoc/doc/mongoc_collection_aggreage.rst with the one in src/libmongoc/doc/mongoc_collection_find.rst and src/libmongoc/doc/mongoc_collection_find_with_options.rst it seems the later ones are missing important information about how errors are reported (related with https://stackoverflow.com/questions/66027858/how-to-get-errors-when-calling-mongoc-collection-find-function).

I'd like to have feedback on this pull request, please. If it is right, please merge to improve the documentation. In addition, if you know any other document (others operations returning mongo_cursor_t*, probably) that may need a similar improvement, I can include it in this PR before merging.

Thanks!