### PR TITLE
CDRIVER-3272 Correctly document bson gettimeofday

### DIFF
--- a/src/libbson/doc/bson_get_monotonic_time.rst
+++ b/src/libbson/doc/bson_get_monotonic_time.rst
@@ -13,8 +13,7 @@ Synopsis
   int64_t
   bson_get_monotonic_time (void);
   int
-  bson_gettimeofday (struct timeval *tv,
-                     struct timezone *tz);
+  bson_gettimeofday (struct timeval *tv);
 
 Description
 -----------


### PR DESCRIPTION
[CDRIVER-3272](https://jira.mongodb.org/browse/CDRIVER-3272)

Document `bson_gettimeofday()` correctly. The docs previously listed an incorrect, additional `timezone` param that does not actually exist in [bson-clock.h](https://github.com/mongodb/mongo-c-driver/blob/master/src/libbson/src/bson/bson-clock.h#L35).