### PR TITLE
changes assignment to equality check

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-timeout.c
+++ b/src/libmongoc/src/mongoc/mongoc-timeout.c
@@ -20,7 +20,7 @@
 typedef struct _mongoc_timeout_t {
    bool is_set;
    int64_t timeout_ms;
-} mongoc_timeout_t;
+};
 
 int64_t
 mongoc_timeout_get_timeout_ms (const mongoc_timeout_t *timeout)

--- a/src/libmongoc/tests/test-mongoc-versioned-api.c
+++ b/src/libmongoc/tests/test-mongoc-versioned-api.c
@@ -47,7 +47,7 @@ _test_mongoc_server_api_setters (void)
 {
    mongoc_server_api_t *api = mongoc_server_api_new (MONGOC_SERVER_API_V1);
 
-   BSON_ASSERT (api->version = MONGOC_SERVER_API_V1);
+   BSON_ASSERT (api->version == MONGOC_SERVER_API_V1);
    BSON_ASSERT (!api->strict_set);
    BSON_ASSERT (!api->deprecation_errors_set);
    BSON_ASSERT (!api->strict);


### PR DESCRIPTION
removes redefinition of mongoc_timeout_t.