### PR TITLE
set distinct.query as document

### DIFF
--- a/src/libmongoc/tests/unified/operation.c
+++ b/src/libmongoc/tests/unified/operation.c
@@ -760,7 +760,9 @@ operation_distinct (test_t *test,
                         "key",
                         BCON_UTF8 (field_name),
                         "query",
-                        &filter);
+                        "{",
+                        &filter,
+                        "}");
    bson_concat (distinct, bson_parser_get_extra (parser));
 
    bson_destroy (&op_reply);


### PR DESCRIPTION
This commit fixes the issue from the task **test-latest-server-auth-sasl-openssl-cse on GCC 8.3** [here](https://evergreen.mongodb.com/task_log_raw/mongo_c_driver_gcc83_test_latest_server_auth_sasl_openssl_cse_4184f376b51c64dffb7ba1256dbc7c68a0a7c3b3_21_03_09_16_32_01/0?type=T#L2949). Unfortunately, that task now has another unrelated error.

Here's a patch showing the previously failing tasks succeeding ([link](https://evergreen.mongodb.com/task_log_raw/mongo_c_driver_gcc83_test_latest_server_auth_sasl_openssl_cse_patch_4184f376b51c64dffb7ba1256dbc7c68a0a7c3b3_6047ade19ccd4e2acd95d67f_21_03_09_17_18_28/0?type=T#L2950)). I also verified this locally.

