### PR TITLE
CDRIVER-3929 Include apiVersion in handshake commands

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-client-pool.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-pool.c
@@ -245,6 +245,7 @@ _initialize_new_client (mongoc_client_pool_t *pool, mongoc_client_t *client)
       client, &pool->apm_callbacks, pool->apm_context);
 
    client->api = mongoc_server_api_copy (pool->api);
+   client->api_set = true;
 
 #ifdef MONGOC_ENABLE_SSL
    if (pool->ssl_opts_set) {
@@ -525,6 +526,14 @@ mongoc_client_pool_set_server_api (mongoc_client_pool_t *pool,
                       MONGOC_ERROR_POOL,
                       MONGOC_ERROR_POOL_API_ALREADY_SET,
                       "Cannot set server api more than once per pool");
+      return false;
+   }
+
+   if (mongoc_client_pool_get_size (pool)) {
+      bson_set_error (error,
+                      MONGOC_ERROR_POOL,
+                      MONGOC_ERROR_POOL_API_TOO_LATE,
+                      "Cannot set server api after a client has been created");
       return false;
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-client-pool.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-pool.c
@@ -529,5 +529,6 @@ mongoc_client_pool_set_server_api (mongoc_client_pool_t *pool,
    }
 
    pool->api = mongoc_server_api_copy (api);
+   _mongoc_topology_scanner_set_server_api (pool->topology->scanner, api);
    return true;
 }

--- a/src/libmongoc/src/mongoc/mongoc-client-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-private.h
@@ -97,6 +97,7 @@ struct _mongoc_client_t {
    mongoc_uri_t *uri;
    mongoc_cluster_t cluster;
    bool in_exhaust;
+   bool is_pooled;
 
    mongoc_stream_initiator_t initiator;
    void *initiator_data;
@@ -119,7 +120,6 @@ struct _mongoc_client_t {
    bool error_api_set;
 
    mongoc_server_api_t *api;
-   bool api_set;
 
    /* mongoc_client_session_t's in use, to look up lsids and clusterTimes */
    mongoc_set_t *client_sessions;

--- a/src/libmongoc/src/mongoc/mongoc-client-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-private.h
@@ -119,6 +119,7 @@ struct _mongoc_client_t {
    bool error_api_set;
 
    mongoc_server_api_t *api;
+   bool api_set;
 
    /* mongoc_client_session_t's in use, to look up lsids and clusterTimes */
    mongoc_set_t *client_sessions;

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -3105,7 +3105,7 @@ mongoc_client_set_server_api (mongoc_client_t *client,
    BSON_ASSERT_PARAM (client);
    BSON_ASSERT_PARAM (api);
 
-   if (client->api) {
+   if (client->api_set) {
       bson_set_error (error,
                       MONGOC_ERROR_CLIENT,
                       MONGOC_ERROR_CLIENT_API_ALREADY_SET,
@@ -3114,6 +3114,7 @@ mongoc_client_set_server_api (mongoc_client_t *client,
    }
 
    client->api = mongoc_server_api_copy (api);
+   client->api_set = true;
    _mongoc_topology_scanner_set_server_api (client->topology->scanner, api);
    return true;
 }

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -3105,7 +3105,15 @@ mongoc_client_set_server_api (mongoc_client_t *client,
    BSON_ASSERT_PARAM (client);
    BSON_ASSERT_PARAM (api);
 
-   if (client->api_set) {
+   if (client->is_pooled) {
+      bson_set_error (error,
+                      MONGOC_ERROR_CLIENT,
+                      MONGOC_ERROR_CLIENT_API_FROM_POOL,
+                      "Cannot set server api on a client checked out from a pool");
+      return false;
+   }
+
+   if (client->api) {
       bson_set_error (error,
                       MONGOC_ERROR_CLIENT,
                       MONGOC_ERROR_CLIENT_API_ALREADY_SET,
@@ -3114,7 +3122,6 @@ mongoc_client_set_server_api (mongoc_client_t *client,
    }
 
    client->api = mongoc_server_api_copy (api);
-   client->api_set = true;
    _mongoc_topology_scanner_set_server_api (client->topology->scanner, api);
    return true;
 }

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -3114,5 +3114,6 @@ mongoc_client_set_server_api (mongoc_client_t *client,
    }
 
    client->api = mongoc_server_api_copy (api);
+   _mongoc_topology_scanner_set_server_api (client->topology->scanner, api);
    return true;
 }

--- a/src/libmongoc/src/mongoc/mongoc-cmd-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-cmd-private.h
@@ -146,6 +146,10 @@ _is_retryable_read (const mongoc_cmd_parts_t *parts,
 void
 _mongoc_cmd_append_payload_as_array (const mongoc_cmd_t *cmd, bson_t *out);
 
+void
+_mongoc_cmd_append_server_api (bson_t *command_body,
+                               const mongoc_server_api_t *api);
+
 BSON_END_DECLS
 
 

--- a/src/libmongoc/src/mongoc/mongoc-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-cmd.c
@@ -796,8 +796,8 @@ _txn_in_progress (mongoc_cmd_parts_t *parts)
    }
 
    return (_mongoc_client_session_txn_in_progress (cs)
-	   /* commitTransaction and abortTransaction count as in progress, too. */
-	   || parts->assembled.is_txn_finish);
+      /* commitTransaction and abortTransaction count as in progress, too. */
+      || parts->assembled.is_txn_finish);
 }
 
 

--- a/src/libmongoc/src/mongoc/mongoc-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-cmd.c
@@ -1150,6 +1150,7 @@ _mongoc_cmd_append_payload_as_array (const mongoc_cmd_t *cmd, bson_t *out)
  *
  * Pre-conditions:
  *    - @api is initialized.
+ *    - @command_body is initialised
  *
  *--------------------------------------------------------------------------
  */
@@ -1159,6 +1160,7 @@ _mongoc_cmd_append_server_api (bson_t *command_body,
 {
    const char *string_version;
 
+   BSON_ASSERT (command_body);
    BSON_ASSERT (api);
 
    string_version = mongoc_server_api_version_to_string (api->version);

--- a/src/libmongoc/src/mongoc/mongoc-error.h
+++ b/src/libmongoc/src/mongoc/mongoc-error.h
@@ -130,6 +130,7 @@ typedef enum {
 
    /* An error related to server version api */
    MONGOC_ERROR_CLIENT_API_ALREADY_SET,
+   MONGOC_ERROR_CLIENT_API_FROM_POOL,
    MONGOC_ERROR_POOL_API_ALREADY_SET,
    MONGOC_ERROR_POOL_API_TOO_LATE
 } mongoc_error_code_t;

--- a/src/libmongoc/src/mongoc/mongoc-error.h
+++ b/src/libmongoc/src/mongoc/mongoc-error.h
@@ -130,7 +130,8 @@ typedef enum {
 
    /* An error related to server version api */
    MONGOC_ERROR_CLIENT_API_ALREADY_SET,
-   MONGOC_ERROR_POOL_API_ALREADY_SET
+   MONGOC_ERROR_POOL_API_ALREADY_SET,
+   MONGOC_ERROR_POOL_API_TOO_LATE
 } mongoc_error_code_t;
 
 MONGOC_EXPORT (bool)

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner-private.h
@@ -109,6 +109,8 @@ typedef struct mongoc_topology_scanner {
    bool negotiate_sasl_supported_mechs;
    bool bypass_cooldown;
    bool speculative_authentication;
+
+   mongoc_server_api_t *api;
 } mongoc_topology_scanner_t;
 
 mongoc_topology_scanner_t *
@@ -222,6 +224,10 @@ mongoc_topology_scanner_set_ssl_opts (mongoc_topology_scanner_t *ts,
 bool
 mongoc_topology_scanner_node_in_cooldown (mongoc_topology_scanner_node_t *node,
                                           int64_t when);
+
+void
+_mongoc_topology_scanner_set_server_api (mongoc_topology_scanner_t *ts,
+                                         const mongoc_server_api_t *api);
 
 /* for testing. */
 mongoc_stream_t *

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
@@ -419,10 +419,7 @@ mongoc_topology_scanner_destroy (mongoc_topology_scanner_t *ts)
    bson_destroy (&ts->ismaster_cmd);
    bson_destroy (&ts->ismaster_cmd_with_handshake);
    bson_destroy (&ts->cluster_time);
-
-   if (ts->api) {
-      mongoc_server_api_destroy (ts->api);
-   }
+   mongoc_server_api_destroy (ts->api);
 
    /* This field can be set by a mongoc_client */
    bson_free ((char *) ts->appname);
@@ -1354,15 +1351,10 @@ void
 _mongoc_topology_scanner_set_server_api (mongoc_topology_scanner_t *ts,
                                          const mongoc_server_api_t *api)
 {
-   mongoc_server_api_t *prev_api;
-
+   BSON_ASSERT (ts);
    BSON_ASSERT (api);
 
-   prev_api = ts->api;
+   mongoc_server_api_destroy (ts->api);
    ts->api = mongoc_server_api_copy (api);
    _reset_ismaster (ts);
-
-   if (prev_api) {
-      mongoc_server_api_destroy (prev_api);
-   }
 }

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
@@ -114,12 +114,22 @@ _add_ismaster (bson_t *cmd, const mongoc_server_api_t *api)
 }
 
 static void
-_reset_ismaster (mongoc_topology_scanner_t *ts)
+_init_ismaster (mongoc_topology_scanner_t *ts)
 {
    bson_init (&ts->ismaster_cmd);
-   _add_ismaster (&ts->ismaster_cmd, ts->api);
    bson_init (&ts->ismaster_cmd_with_handshake);
    bson_init (&ts->cluster_time);
+
+   _add_ismaster (&ts->ismaster_cmd, ts->api);
+}
+
+static void
+_reset_ismaster (mongoc_topology_scanner_t *ts)
+{
+   bson_reinit (&ts->ismaster_cmd);
+   bson_reinit (&ts->ismaster_cmd_with_handshake);
+
+   _add_ismaster (&ts->ismaster_cmd, ts->api);
 }
 
 const char *
@@ -370,7 +380,7 @@ mongoc_topology_scanner_new (
    /* may be overridden for testing. */
    ts->dns_cache_timeout_ms = DNS_CACHE_TIMEOUT_MS;
 
-   _reset_ismaster (ts);
+   _init_ismaster (ts);
 
    return ts;
 }

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -3,6 +3,7 @@
 #include <mongoc/mongoc-client-pool-private.h>
 
 #include "mongoc/mongoc-client-private.h"
+#include "mongoc/mongoc-server-api-private.h"
 #include "mongoc/mongoc-util-private.h"
 #include "mongoc/mongoc-topology-background-monitoring-private.h"
 #include "TestSuite.h"
@@ -2198,6 +2199,94 @@ test_slow_server_pooled (void)
    mock_server_destroy (primary);
    checks_cleanup (&checks);
 }
+
+static void
+_test_ismaster_versioned_api (bool pooled)
+{
+   mock_server_t *server;
+   mongoc_uri_t *uri;
+   mongoc_client_pool_t *pool;
+   mongoc_client_t *client;
+   char *ismaster;
+   future_t *future;
+   request_t *request;
+   bson_error_t error;
+   mongoc_server_api_version_t version;
+   mongoc_server_api_t *api;
+
+   server = mock_server_new ();
+   mock_server_run (server);
+   uri = mongoc_uri_copy (mock_server_get_uri (server));
+
+   mongoc_server_api_version_from_string ("1", &version);
+   api = mongoc_server_api_new (version);
+
+   if (pooled) {
+      pool = mongoc_client_pool_new (uri);
+      ASSERT_OR_PRINT (mongoc_client_pool_set_server_api (pool, api, &error),
+                       error);
+
+      client = mongoc_client_pool_pop (pool);
+   } else {
+      client = mongoc_client_new_from_uri (uri);
+      ASSERT_OR_PRINT (mongoc_client_set_server_api (client, api, &error),
+                       error);
+   }
+
+   ismaster = bson_strdup_printf ("{'ok': 1,"
+                                  " 'ismaster': true,"
+                                  " 'setName': 'rs',"
+                                  "  'minWireVersion': 2,"
+                                  "  'maxWireVersion': 5,"
+                                  " 'hosts': ['%s']}",
+                                  mock_server_get_host_and_port (server));
+
+   /* For client pools, the first handshake happens when the client is popped.
+    * For non-pooled clients, send a ping command to trigger a handshake. */
+   if (!pooled) {
+      future = future_client_command_simple (
+         client, "admin", tmp_bson ("{'ping': 1}"), NULL, NULL, &error);
+   }
+
+   request = mock_server_receives_ismaster (server);
+   BSON_ASSERT (request);
+   BSON_ASSERT (bson_has_field (request_get_doc (request, 0), "apiVersion"));
+   mock_server_replies_simple (request, ismaster);
+   request_destroy (request);
+
+   if (!pooled) {
+      request = mock_server_receives_command (
+         server, "admin", MONGOC_QUERY_SLAVE_OK, "{'ping': 1}");
+      mock_server_replies_ok_and_destroys (request);
+      BSON_ASSERT (future_get_bool (future));
+      future_destroy (future);
+   }
+
+   if (pooled) {
+      mongoc_client_pool_push (pool, client);
+      mongoc_client_pool_destroy (pool);
+   } else {
+      mongoc_client_destroy (client);
+   }
+
+   mongoc_server_api_destroy (api);
+   mongoc_uri_destroy (uri);
+   mock_server_destroy (server);
+   bson_free (ismaster);
+}
+
+static void
+test_ismaster_versioned_api_single ()
+{
+   _test_ismaster_versioned_api (false);
+}
+
+static void
+test_ismaster_versioned_api_pooled ()
+{
+   _test_ismaster_versioned_api (true);
+}
+
 void
 test_topology_install (TestSuite *suite)
 {
@@ -2352,4 +2441,11 @@ test_topology_install (TestSuite *suite)
                                 test_last_server_removed_warning);
    TestSuite_AddMockServerTest (
       suite, "/Topology/slow_server/pooled", test_slow_server_pooled);
+
+   TestSuite_AddMockServerTest (suite,
+                                "/Topology/ismaster/versioned_api/single",
+                                test_ismaster_versioned_api_single);
+   TestSuite_AddMockServerTest (suite,
+                                "/Topology/ismaster/versioned_api/pooled",
+                                test_ismaster_versioned_api_pooled);
 }

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -963,8 +963,8 @@ _test_select_succeed (bool try_once)
                               "{'ok': 1,"
                               " 'ismaster': true,"
                               " 'setName': 'rs',"
-                              "  'minWireVersion': 2,"
-                              "  'maxWireVersion': 5,"
+                              " 'minWireVersion': 2,"
+                              " 'maxWireVersion': 5,"
                               " 'hosts': ['127.0.0.1:%hu', '127.0.0.1:%hu']}",
                               mock_server_get_port (primary),
                               mock_server_get_port (secondary));
@@ -1110,8 +1110,8 @@ _test_server_removed_during_handshake (bool pooled)
                               "{'ok': 1,"
                               " 'ismaster': true,"
                               " 'setName': 'rs',"
-                              "  'minWireVersion': 2,"
-                              "  'maxWireVersion': 5,"
+                              " 'minWireVersion': 2,"
+                              " 'maxWireVersion': 5,"
                               " 'hosts': ['%s']}",
                               mock_server_get_host_and_port (server));
 
@@ -1145,8 +1145,8 @@ _test_server_removed_during_handshake (bool pooled)
                               "{'ok': 1,"
                               " 'ismaster': true,"
                               " 'setName': 'BAD NAME',"
-                              "  'minWireVersion': 2,"
-                              "  'maxWireVersion': 5,"
+                              " 'minWireVersion': 2,"
+                              " 'maxWireVersion': 5,"
                               " 'hosts': ['%s']}",
                               mock_server_get_host_and_port (server));
 
@@ -1293,8 +1293,8 @@ test_add_and_scan_failure (void)
                               "{'ok': 1,"
                               " 'ismaster': true,"
                               " 'setName': 'rs',"
-                              "  'minWireVersion': 2,"
-                              "  'maxWireVersion': 5,"
+                              " 'minWireVersion': 2,"
+                              " 'maxWireVersion': 5,"
                               " 'hosts': ['%s', 'fake:1']}",
                               mock_server_get_host_and_port (server));
 
@@ -1395,8 +1395,8 @@ _test_ismaster_retry_single (bool hangup, int n_failures)
    ismaster = bson_strdup_printf ("{'ok': 1,"
                                   " 'ismaster': true,"
                                   " 'setName': 'rs',"
-                                  "  'minWireVersion': 2,"
-                                  "  'maxWireVersion': 5,"
+                                  " 'minWireVersion': 2,"
+                                  " 'maxWireVersion': 5,"
                                   " 'hosts': ['%s']}",
                                   mock_server_get_host_and_port (server));
 
@@ -1491,8 +1491,8 @@ _test_ismaster_retry_pooled (bool hangup, int n_failures)
    ismaster = bson_strdup_printf ("{'ok': 1,"
                                   " 'ismaster': true,"
                                   " 'setName': 'rs',"
-                                  "  'minWireVersion': 2,"
-                                  "  'maxWireVersion': 5,"
+                                  " 'minWireVersion': 2,"
+                                  " 'maxWireVersion': 5,"
                                   " 'hosts': ['%s']}",
                                   mock_server_get_host_and_port (server));
 
@@ -1986,8 +1986,8 @@ test_last_server_removed_warning (void)
                               "{'ok': 1,"
                               " 'ismaster': true,"
                               " 'setName': 'rs',"
-                              "  'minWireVersion': 2,"
-                              "  'maxWireVersion': 5,"
+                              " 'minWireVersion': 2,"
+                              " 'maxWireVersion': 5,"
                               " 'hosts': ['127.0.0.1:%hu']}",
                               mock_server_get_port (server));
 
@@ -2236,8 +2236,8 @@ _test_ismaster_versioned_api (bool pooled)
    ismaster = bson_strdup_printf ("{'ok': 1,"
                                   " 'ismaster': true,"
                                   " 'setName': 'rs',"
-                                  "  'minWireVersion': 2,"
-                                  "  'maxWireVersion': 5,"
+                                  " 'minWireVersion': 2,"
+                                  " 'maxWireVersion': 5,"
                                   " 'hosts': ['%s']}",
                                   mock_server_get_host_and_port (server));
 

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -2218,7 +2218,7 @@ _test_ismaster_versioned_api (bool pooled)
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));
 
-   mongoc_server_api_version_from_string ("1", &version);
+   BSON_ASSERT (mongoc_server_api_version_from_string ("1", &version));
    api = mongoc_server_api_new (version);
 
    if (pooled) {

--- a/src/libmongoc/tests/test-mongoc-versioned-api.c
+++ b/src/libmongoc/tests/test-mongoc-versioned-api.c
@@ -126,8 +126,8 @@ _test_mongoc_server_api_client_pool (void)
    ASSERT (!mongoc_client_set_server_api (client, api, &error));
    ASSERT_ERROR_CONTAINS (error,
                           MONGOC_ERROR_CLIENT,
-                          MONGOC_ERROR_CLIENT_API_ALREADY_SET,
-                          "Cannot set server api more than once");
+                          MONGOC_ERROR_CLIENT_API_FROM_POOL,
+                          "Cannot set server api on a client checked out from a pool");
 
    mongoc_client_pool_push (pool, client);
    mongoc_client_pool_destroy (pool);
@@ -163,8 +163,8 @@ _test_mongoc_server_api_client_pool_once (void)
    ASSERT (!mongoc_client_set_server_api (client, api, &error));
    ASSERT_ERROR_CONTAINS (error,
                           MONGOC_ERROR_CLIENT,
-                          MONGOC_ERROR_CLIENT_API_ALREADY_SET,
-                          "Cannot set server api more than once");
+                          MONGOC_ERROR_CLIENT_API_FROM_POOL,
+                          "Cannot set server api on a client checked out from a pool");
 
    mongoc_client_pool_push (pool, client);
    mongoc_client_pool_destroy (pool);


### PR DESCRIPTION
CDRIVER-3929

This fixes an oversight in the versioned API implementation where the handshake did not send API Version information to the server. This required exposing the API Version to the topology scanner as that's where the actual commands are handled. I've decided to allow changing the API Version multiple times as this part of libmongoc is very much internal.

During testing I discovered a couple of edge cases around setting API Version on a pooled client:
* When no API Version has been set, a user can set it after clients have been popped. This causes an inconsistent state in the pool. Solution is to prevent changing the API Version when the pool size is greater than 0. I understand this can cause an inconsistency when the last client is destroyed where one could once again set the API Version. Let me know if we should also prevent that case.
* When fetching a client from a pool that had no server API set, the api was not locked against modifications, which could once again lead to an inconsistent state in the pool. For clients fetched from a pool, the server API is mutable. This may apply to other properties of the client as well, so we may want to create a follow-up ticket for this.