### PR TITLE
CDRIVER-3773 Remove support for canonical regular expressions with no options

### DIFF
--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -1389,11 +1389,6 @@ _bson_json_read_append_regex (bson_json_reader_t *reader,    /* IN */
                                     "Missing \"$regex\" after \"$options\"");
          return;
       }
-      if (!data->regex.has_options) {
-         _bson_json_read_set_error (reader,
-                                    "Missing \"$options\" after \"$regex\"");
-         return;
-      }
    } else if (!data->regex.has_pattern) {
       _bson_json_read_set_error (
          reader, "Missing \"pattern\" after \"options\" in regular expression");

--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -1389,9 +1389,18 @@ _bson_json_read_append_regex (bson_json_reader_t *reader,    /* IN */
                                     "Missing \"$regex\" after \"$options\"");
          return;
       }
+      if (!data->regex.has_options) {
+         _bson_json_read_set_error (reader,
+                                    "Missing \"$options\" after \"$regex\"");
+         return;
+      }
    } else if (!data->regex.has_pattern) {
       _bson_json_read_set_error (
          reader, "Missing \"pattern\" after \"options\" in regular expression");
+      return;
+   } else if (!data->regex.has_options) {
+      _bson_json_read_set_error (
+         reader, "Missing \"options\" after \"pattern\" in regular expression");
       return;
    }
 

--- a/src/libbson/tests/test-json.c
+++ b/src/libbson/tests/test-json.c
@@ -1075,13 +1075,12 @@ test_bson_json_read_legacy_regex (void)
    bson_destroy (&b);
 
    r = bson_init_from_json (&b, "{\"a\": {\"$regex\": \"abc\"}}", -1, &error);
-   BSON_ASSERT (!r);
-   ASSERT_ERROR_CONTAINS (error,
-                          BSON_ERROR_JSON,
-                          BSON_JSON_ERROR_READ_INVALID_PARAM,
-                          "Missing \"$options\" after \"$regex\"");
+   ASSERT_OR_PRINT (r, error);
+   BCON_EXTRACT (&b, "a", BCONE_REGEX (pattern, flags));
+   ASSERT_CMPSTR (pattern, "abc");
+   ASSERT_CMPSTR (flags, "");
 
-   memset (&error, 0, sizeof error);
+   bson_destroy (&b);
 
    r = bson_init_from_json (&b, "{\"a\": {\"$options\": \"ix\"}}", -1, &error);
    BSON_ASSERT (!r);

--- a/src/libbson/tests/test-json.c
+++ b/src/libbson/tests/test-json.c
@@ -1075,12 +1075,13 @@ test_bson_json_read_legacy_regex (void)
    bson_destroy (&b);
 
    r = bson_init_from_json (&b, "{\"a\": {\"$regex\": \"abc\"}}", -1, &error);
-   ASSERT_OR_PRINT (r, error);
-   BCON_EXTRACT (&b, "a", BCONE_REGEX (pattern, flags));
-   ASSERT_CMPSTR (pattern, "abc");
-   ASSERT_CMPSTR (flags, "");
+   BSON_ASSERT (!r);
+   ASSERT_ERROR_CONTAINS (error,
+                          BSON_ERROR_JSON,
+                          BSON_JSON_ERROR_READ_INVALID_PARAM,
+                          "Missing \"$options\" after \"$regex\"");
 
-   bson_destroy (&b);
+   memset (&error, 0, sizeof error);
 
    r = bson_init_from_json (&b, "{\"a\": {\"$options\": \"ix\"}}", -1, &error);
    BSON_ASSERT (!r);
@@ -1090,24 +1091,6 @@ test_bson_json_read_legacy_regex (void)
                           "Missing \"$regex\" after \"$options\"");
 }
 
-static void
-test_bson_json_read_regex_no_options (void)
-{
-   bson_t b;
-   bson_error_t error;
-   bool r;
-   const char *pattern;
-   const char *flags;
-
-   r = bson_init_from_json (
-      &b, "{\"a\": {\"$regularExpression\": { \"pattern\": \"abc\"}}}", -1, &error);
-   ASSERT_OR_PRINT (r, error);
-   BCON_EXTRACT (&b, "a", BCONE_REGEX (pattern, flags));
-   ASSERT_CMPSTR (pattern, "abc");
-   ASSERT_CMPSTR (flags, "");
-
-   bson_destroy (&b);
-}
 
 static void
 test_bson_json_read_regex_options_order (void)
@@ -3468,8 +3451,6 @@ test_json_install (TestSuite *suite)
       suite, "/bson/json/read/dbpointer", test_bson_json_read_dbpointer);
    TestSuite_Add (
       suite, "/bson/json/read/legacy_regex", test_bson_json_read_legacy_regex);
-   TestSuite_Add (
-      suite, "/bson/json/read/regex_no_options", test_bson_json_read_regex_no_options);
    TestSuite_Add (suite,
                   "/bson/json/read/regex_options_order",
                   test_bson_json_read_regex_options_order);


### PR DESCRIPTION
Reverts mongodb/mongo-c-driver#751.

We cannot support regular expressions with no options without a spec change because of an existing spec [test](https://github.com/mongodb/specifications/blob/master/source/bson-corpus/tests/top.json#L74..L77) that checks for a parse error on a regex with no options.

[CDRIVER-3773](https://jira.mongodb.org/browse/CDRIVER-3773) would require a larger spec change, which I will look into.