### PR TITLE
Remove unknown fields in isMaster cmd

### DIFF
--- a/src/libmongoc/tests/test-mongoc-async.c
+++ b/src/libmongoc/tests/test-mongoc-async.c
@@ -252,14 +252,13 @@ test_large_ismaster (void *ctx)
    mongoc_ssl_opt_t ssl_opts;
 #endif
 
-   /* Inflate the size of the isMaster message with other fields to ~1MB.
-    * mongod should ignore them, but this tests that CDRIVER-2483 is fixed.
+   /* Inflate the size of the isMaster message to ~1MB. This tests that
+    * CDRIVER-2483 is fixed. Mongod 4.9+ errors on unknown fields (see
+    * SERVER-53150) but appending additional "isMaster" commands seem to be OK.
     */
    BSON_ASSERT (bson_append_int32 (&q, "isMaster", 8, 1));
    while (q.len < 1024 * 1024) {
-      char buf[11];
-      bson_snprintf (buf, sizeof (buf), "key_%06d", i++);
-      BSON_APPEND_INT32 (&q, buf, 0);
+      BSON_APPEND_INT32 (&q, "isMaster", 1);
    }
 
    sock_stream = get_localhost_stream (test_framework_get_port ());

--- a/src/libmongoc/tests/test-mongoc-async.c
+++ b/src/libmongoc/tests/test-mongoc-async.c
@@ -247,7 +247,7 @@ test_large_ismaster (void *ctx)
    mongoc_stream_t *sock_stream;
    int i = 0;
    bson_t q = BSON_INITIALIZER;
-   char buf[size];
+   char buf[1024 * 1024];
 
 #ifdef MONGOC_ENABLE_SSL
    mongoc_ssl_opt_t ssl_opts;

--- a/src/libmongoc/tests/test-mongoc-async.c
+++ b/src/libmongoc/tests/test-mongoc-async.c
@@ -245,7 +245,6 @@ test_large_ismaster (void *ctx)
 {
    mongoc_async_t *async;
    mongoc_stream_t *sock_stream;
-   int i = 0;
    bson_t q = BSON_INITIALIZER;
    char buf[1024 * 1024];
 

--- a/src/libmongoc/tests/test-mongoc-async.c
+++ b/src/libmongoc/tests/test-mongoc-async.c
@@ -235,6 +235,7 @@ test_large_ismaster_helper (mongoc_async_cmd_t *acmd,
    }
    ASSERT_CMPINT (result, ==, MONGOC_ASYNC_CMD_SUCCESS);
 
+   ASSERT_HAS_FIELD(bson, "ismaster");
    BSON_ASSERT (bson_iter_init_find (&iter, bson, "ismaster"));
    BSON_ASSERT (BSON_ITER_HOLDS_BOOL (&iter) && bson_iter_bool (&iter));
 }

--- a/src/libmongoc/tests/test-mongoc-async.c
+++ b/src/libmongoc/tests/test-mongoc-async.c
@@ -258,7 +258,6 @@ test_large_ismaster (void *ctx)
     * fields (see SERVER-53150) we add a ~1MB comment.
     */
    BSON_ASSERT (bson_append_int32 (&q, "isMaster", 8, 1));
-   char buf[1024 * 1024];
    /* size of comment string = (1024 * 1024) - 1 (for null terminator) */
    bson_snprintf(buf, sizeof (buf), "%01048575d", 0);
    BSON_APPEND_UTF8(&q, "comment", buf);

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -2081,10 +2081,18 @@ test_request_scan_on_error ()
                 true /* should_mark_unknown */,
                 "node is recovering");
    /* write concern errors are also checked. */
-   TEST_BOTH ("{'ok': 1, 'writeConcernError': { 'errmsg': 'not master' }}",
-              true, /* should_scan */
-              true /* should_mark_unknown */,
-              "not master");
+   _test_request_scan_on_error (
+      1,
+      "{'ok': 1, 'writeConcernError': { 'errmsg': 'not master' }}",
+      1,
+      1,
+      "not master");
+   _test_request_scan_on_error (
+      0,
+      "{'ok': 1, 'writeConcernError': { 'errmsg': 'not master' }}",
+      1,
+      1,
+      "not master");
    TEST_BOTH ("{'ok': 1, 'writeConcernError': { 'code': 10107 }}",
               true, /* should_scan */
               true /* should_mark_unknown */,


### PR DESCRIPTION
This commit fixes the failing [/Async/ismaster](https://evergreen.mongodb.com/task_log_raw/mongo_c_driver_clang38_i386_test_latest_server_ipv4_client_ipv4_noauth_nosasl_nossl_27f1d6e1be7eb85545ef1ebb14920434ea98d031_21_03_11_22_58_44/0?type=T#L2343) tests in evergreen.

Because of [SERVER-53150](https://jira.mongodb.org/browse/SERVER-53150), the latest server versions fail on isMaster commands with unknown fields. Previously this test inflatted the isMaster to >1MB to address the issue in [CDRIVER-2483](https://jira.mongodb.org/browse/CDRIVER-2483) by adding random-ish fields. Rather than sending an unknown field, this fix adds a >1MB comment.