### PR TITLE
CDRIVER-3918 expose server api options as mongoc_optional_t

### DIFF
--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -528,6 +528,7 @@ set (SOURCES ${SOURCES}
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-matcher-op.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-memcmp.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-cmd.c
+   ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-optional.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-opts-helpers.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-opts.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-queue.c

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -596,6 +596,7 @@ set (HEADERS
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-macros.h
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-matcher.h
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-opcode.h
+   ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-optional.h
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-prelude.h
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-read-concern.h
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-read-prefs.h

--- a/src/libmongoc/src/mongoc/CMakeLists.txt
+++ b/src/libmongoc/src/mongoc/CMakeLists.txt
@@ -41,6 +41,7 @@ set (src_libmongoc_src_mongoc_DIST_hs
    mongoc-macros.h
    mongoc-matcher.h
    mongoc-opcode.h
+   mongoc-optional.h
    mongoc-prelude.h
    mongoc-rand.h
    mongoc-read-concern.h

--- a/src/libmongoc/src/mongoc/CMakeLists.txt
+++ b/src/libmongoc/src/mongoc/CMakeLists.txt
@@ -225,6 +225,7 @@ set (src_libmongoc_src_mongoc_DIST_cs
    mongoc-memcmp.c
    mongoc-cmd.c
    mongoc-ocsp-cache.c
+   mongoc-optional.c
    mongoc-opts.c
    mongoc-opts-helpers.c
    mongoc-queue.c

--- a/src/libmongoc/src/mongoc/mongoc-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-cmd.c
@@ -1000,16 +1000,16 @@ mongoc_cmd_parts_assemble (mongoc_cmd_parts_t *parts,
             bson_append_utf8 (
                &parts->assembled_body, "apiVersion", -1, string_version, -1);
 
-            if (api->strict_set) {
+            if (api->strict.is_set) {
                bson_append_bool (
-                  &parts->assembled_body, "apiStrict", -1, api->strict);
+				 &parts->assembled_body, "apiStrict", -1, api->strict.value);
             }
 
-            if (api->deprecation_errors_set) {
+            if (api->deprecation_errors.is_set) {
                bson_append_bool (&parts->assembled_body,
                                  "apiDeprecationErrors",
                                  -1,
-                                 api->deprecation_errors);
+                                 api->deprecation_errors.value);
             }
          }
       }

--- a/src/libmongoc/src/mongoc/mongoc-optional.c
+++ b/src/libmongoc/src/mongoc/mongoc-optional.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mongoc-optional.h"
+
+void
+mongoc_optional_init (mongoc_optional_t *opt)
+{
+   opt->is_set = false;
+   opt->value = false;
+}
+
+bool
+mongoc_optional_set (mongoc_optional_t *opt)
+{
+   BSON_ASSERT (opt);
+   return opt->is_set;
+}
+
+bool
+mongoc_optional_value (mongoc_optional_t *opt)
+{
+   BSON_ASSERT (opt);
+   return opt->value;
+}
+
+void
+mongoc_optional_set_value (mongoc_optional_t *opt, bool val)
+{
+   BSON_ASSERT (opt);
+   opt->value = val;
+   opt->is_set = true;
+}
+
+void
+mongoc_optional_copy (const mongoc_optional_t *source, mongoc_optional_t *copy) {
+   copy->value = source->value;
+   copy->is_set = source->is_set;
+}

--- a/src/libmongoc/src/mongoc/mongoc-optional.c
+++ b/src/libmongoc/src/mongoc/mongoc-optional.c
@@ -24,7 +24,7 @@ mongoc_optional_init (mongoc_optional_t *opt)
 }
 
 bool
-mongoc_optional_set (mongoc_optional_t *opt)
+mongoc_optional_is_set (mongoc_optional_t *opt)
 {
    BSON_ASSERT (opt);
    return opt->is_set;
@@ -46,7 +46,8 @@ mongoc_optional_set_value (mongoc_optional_t *opt, bool val)
 }
 
 void
-mongoc_optional_copy (const mongoc_optional_t *source, mongoc_optional_t *copy) {
+mongoc_optional_copy (const mongoc_optional_t *source, mongoc_optional_t *copy)
+{
    copy->value = source->value;
    copy->is_set = source->is_set;
 }

--- a/src/libmongoc/src/mongoc/mongoc-optional.h
+++ b/src/libmongoc/src/mongoc/mongoc-optional.h
@@ -26,15 +26,15 @@
 BSON_BEGIN_DECLS
 
 typedef struct {
-    bool value;
-    bool is_set;
+   bool value;
+   bool is_set;
 } mongoc_optional_t;
 
 MONGOC_EXPORT (void)
 mongoc_optional_init (mongoc_optional_t *opt);
 
 MONGOC_EXPORT (bool)
-mongoc_optional_set (mongoc_optional_t *opt);
+mongoc_optional_is_set (mongoc_optional_t *opt);
 
 MONGOC_EXPORT (bool)
 mongoc_optional_value (mongoc_optional_t *opt);

--- a/src/libmongoc/src/mongoc/mongoc-optional.h
+++ b/src/libmongoc/src/mongoc/mongoc-optional.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mongoc-prelude.h"
+
+#ifndef MONGOC_OPTIONAL_H
+#define MONGOC_OPTIONAL_H
+
+#include <bson/bson.h>
+
+#include "mongoc-macros.h"
+
+BSON_BEGIN_DECLS
+
+typedef struct {
+    bool value;
+    bool is_set;
+} mongoc_optional_t;
+
+MONGOC_EXPORT (void)
+mongoc_optional_init (mongoc_optional_t *opt);
+
+MONGOC_EXPORT (bool)
+mongoc_optional_set (mongoc_optional_t *opt);
+
+MONGOC_EXPORT (bool)
+mongoc_optional_value (mongoc_optional_t *opt);
+
+MONGOC_EXPORT (void)
+mongoc_optional_set_value (mongoc_optional_t *opt, bool val);
+
+MONGOC_EXPORT (void)
+mongoc_optional_copy (const mongoc_optional_t *source, mongoc_optional_t *copy);
+
+BSON_END_DECLS
+
+#endif /* MONGOC_OPTIONAL_H */

--- a/src/libmongoc/src/mongoc/mongoc-server-api-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-server-api-private.h
@@ -23,8 +23,8 @@
 
 struct _mongoc_server_api_t {
    mongoc_server_api_version_t version;
-   mongoc_optional_t *strict;
-   mongoc_optional_t *deprecation_errors;
+   mongoc_optional_t strict;
+   mongoc_optional_t deprecation_errors;
 };
 
 #endif /* MONGOC_SERVER_API_PRIVATE_H */

--- a/src/libmongoc/src/mongoc/mongoc-server-api-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-server-api-private.h
@@ -23,10 +23,8 @@
 
 struct _mongoc_server_api_t {
    mongoc_server_api_version_t version;
-   bool strict;
-   bool strict_set;
-   bool deprecation_errors;
-   bool deprecation_errors_set;
+   mongoc_optional_t *strict;
+   mongoc_optional_t *deprecation_errors;
 };
 
 #endif /* MONGOC_SERVER_API_PRIVATE_H */

--- a/src/libmongoc/src/mongoc/mongoc-server-api.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-api.c
@@ -48,6 +48,8 @@ mongoc_server_api_new (mongoc_server_api_version_t version)
 
    api = (mongoc_server_api_t *) bson_malloc0 (sizeof (mongoc_server_api_t));
    api->version = version;
+   api->strict = mongoc_optional_new ();
+   api->deprecation_errors = mongoc_optional_new ();
 
    return api;
 }
@@ -63,10 +65,8 @@ mongoc_server_api_copy (const mongoc_server_api_t *api)
 
    copy = (mongoc_server_api_t *) bson_malloc0 (sizeof (mongoc_server_api_t));
    copy->version = api->version;
-   copy->strict_set = api->strict_set;
-   copy->strict = api->strict;
-   copy->deprecation_errors_set = api->deprecation_errors_set;
-   copy->deprecation_errors = api->deprecation_errors;
+   copy->strict = mongoc_optional_copy (api->strict);
+   copy->deprecation_errors = mongoc_optional_copy (api->deprecation_errors);
 
    return copy;
 }
@@ -85,8 +85,7 @@ void
 mongoc_server_api_strict (mongoc_server_api_t *api, bool strict)
 {
    BSON_ASSERT (api);
-   api->strict = strict;
-   api->strict_set = true;
+   mongoc_optional_set_value (api->strict, strict);
 }
 
 void
@@ -94,6 +93,19 @@ mongoc_server_api_deprecation_errors (mongoc_server_api_t *api,
                                       bool deprecation_errors)
 {
    BSON_ASSERT (api);
-   api->deprecation_errors = deprecation_errors;
-   api->deprecation_errors_set = true;
+   mongoc_optional_set_value (api->deprecation_errors, deprecation_errors);
+}
+
+const mongoc_optional_t *
+mongoc_server_api_get_deprecation_errors (mongoc_server_api_t *api)
+{
+   BSON_ASSERT (api);
+   return api->deprecation_errors;
+}
+
+const mongoc_optional_t *
+mongo_server_api_get_strict (mongoc_server_api_t *api)
+{
+   BSON_ASSERT (api);
+   return api->strict;
 }

--- a/src/libmongoc/src/mongoc/mongoc-server-api.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-api.c
@@ -48,8 +48,8 @@ mongoc_server_api_new (mongoc_server_api_version_t version)
 
    api = (mongoc_server_api_t *) bson_malloc0 (sizeof (mongoc_server_api_t));
    api->version = version;
-   api->strict = mongoc_optional_new ();
-   api->deprecation_errors = mongoc_optional_new ();
+   mongoc_optional_init (&api->strict);
+   mongoc_optional_init (&api->deprecation_errors);
 
    return api;
 }
@@ -65,8 +65,8 @@ mongoc_server_api_copy (const mongoc_server_api_t *api)
 
    copy = (mongoc_server_api_t *) bson_malloc0 (sizeof (mongoc_server_api_t));
    copy->version = api->version;
-   copy->strict = mongoc_optional_copy (api->strict);
-   copy->deprecation_errors = mongoc_optional_copy (api->deprecation_errors);
+   mongoc_optional_copy (&api->strict, &copy->strict);
+   mongoc_optional_copy (&api->deprecation_errors, &copy->deprecation_errors);
 
    return copy;
 }
@@ -85,7 +85,7 @@ void
 mongoc_server_api_strict (mongoc_server_api_t *api, bool strict)
 {
    BSON_ASSERT (api);
-   mongoc_optional_set_value (api->strict, strict);
+   mongoc_optional_set_value (&api->strict, strict);
 }
 
 void
@@ -93,19 +93,19 @@ mongoc_server_api_deprecation_errors (mongoc_server_api_t *api,
                                       bool deprecation_errors)
 {
    BSON_ASSERT (api);
-   mongoc_optional_set_value (api->deprecation_errors, deprecation_errors);
+   mongoc_optional_set_value (&api->deprecation_errors, deprecation_errors);
 }
 
 const mongoc_optional_t *
 mongoc_server_api_get_deprecation_errors (mongoc_server_api_t *api)
 {
    BSON_ASSERT (api);
-   return api->deprecation_errors;
+   return &api->deprecation_errors;
 }
 
 const mongoc_optional_t *
 mongo_server_api_get_strict (mongoc_server_api_t *api)
 {
    BSON_ASSERT (api);
-   return api->strict;
+   return &api->strict;
 }

--- a/src/libmongoc/src/mongoc/mongoc-server-api.h
+++ b/src/libmongoc/src/mongoc/mongoc-server-api.h
@@ -21,6 +21,7 @@
 
 #include <bson/bson.h>
 
+#include "mongoc-optional.h"
 #include "mongoc-macros.h"
 
 BSON_BEGIN_DECLS
@@ -51,6 +52,12 @@ mongoc_server_api_strict (mongoc_server_api_t *api, bool strict);
 MONGOC_EXPORT (void)
 mongoc_server_api_deprecation_errors (mongoc_server_api_t *api,
                                       bool deprecation_errors);
+
+MONGOC_EXPORT (const mongoc_optional_t *)
+mongoc_server_api_get_deprecation_errors (mongoc_server_api_t *api);
+
+MONGOC_EXPORT (const mongoc_optional_t *)
+mongo_server_api_get_strict (mongoc_server_api_t *api);
 
 BSON_END_DECLS
 

--- a/src/libmongoc/tests/test-mongoc-versioned-api.c
+++ b/src/libmongoc/tests/test-mongoc-versioned-api.c
@@ -33,10 +33,10 @@ _test_mongoc_server_api_copy (void)
    copy = mongoc_server_api_copy (api);
 
    BSON_ASSERT (api->version == copy->version);
-   BSON_ASSERT (!copy->strict);
-   BSON_ASSERT (copy->strict_set);
-   BSON_ASSERT (!copy->deprecation_errors);
-   BSON_ASSERT (!copy->deprecation_errors_set);
+   BSON_ASSERT (!copy->strict.value);
+   BSON_ASSERT (copy->strict.is_set);
+   BSON_ASSERT (!copy->deprecation_errors.value);
+   BSON_ASSERT (!copy->deprecation_errors.is_set);
 
    mongoc_server_api_destroy (api);
    mongoc_server_api_destroy (copy);
@@ -48,18 +48,18 @@ _test_mongoc_server_api_setters (void)
    mongoc_server_api_t *api = mongoc_server_api_new (MONGOC_SERVER_API_V1);
 
    BSON_ASSERT (api->version == MONGOC_SERVER_API_V1);
-   BSON_ASSERT (!api->strict_set);
-   BSON_ASSERT (!api->deprecation_errors_set);
-   BSON_ASSERT (!api->strict);
-   BSON_ASSERT (!api->deprecation_errors);
+   BSON_ASSERT (!api->strict.is_set);
+   BSON_ASSERT (!api->deprecation_errors.is_set);
+   BSON_ASSERT (!api->strict.value);
+   BSON_ASSERT (!api->deprecation_errors.value);
 
    mongoc_server_api_strict (api, true);
-   BSON_ASSERT (api->strict_set);
-   BSON_ASSERT (api->strict);
+   BSON_ASSERT (api->strict.is_set);
+   BSON_ASSERT (api->strict.value);
 
    mongoc_server_api_deprecation_errors (api, false);
-   BSON_ASSERT (api->deprecation_errors_set);
-   BSON_ASSERT (!api->deprecation_errors);
+   BSON_ASSERT (api->deprecation_errors.is_set);
+   BSON_ASSERT (!api->deprecation_errors.value);
 
    mongoc_server_api_destroy (api);
 }


### PR DESCRIPTION
This PR adds a new `mongoc_optional_t` type (which represents an optional bool) and returns that type for boolean options for versioned API.  I thought through a couple of questions when implementing this:

- What about other optional types?  Is it odd that `mongoc_optional_t` is only for bools?
The only other type I could see us wanting to represent this way is an integer.  Everything else can be pointer-based to indicate NULL-ness.  I think we could implement a `mongoc_optional_int_t` later on if we wanted to, and we actually may need specifically named types for int32, int64, etc.  Given that, I decided using `mongoc_optional_t` here would be nicer than `mongoc_optional_bool_t`.

- Is this over-engineered?
Maybe!  We do represent optional booleans in a fair number of places, and I think this little type is a nice way to wrap that up.

- Expose the type, or not?
It's our convention in most places to hide struct definitions and allow users to access them only through getters and setters.  However, we lose a lot of the convenience that a `mongoc_optional_t` offers if we require `opt.value` and `opt.is_set` to be accessed through getters and setters.  I chose to expose the struct and offer getters and setters, but happy to discuss this.