### PR TITLE
Sync Versioned API Tests

### DIFF
--- a/src/libmongoc/tests/json/versioned_api/crud-api-version-1-strict.json
+++ b/src/libmongoc/tests/json/versioned_api/crud-api-version-1-strict.json
@@ -608,7 +608,6 @@
     },
     {
       "description": "estimatedDocumentCount appends declared API version",
-      "skipReason": "DRIVERS-1561 collStats is not in API version 1",
       "operations": [
         {
           "name": "estimatedDocumentCount",

--- a/src/libmongoc/tests/json/versioned_api/crud-api-version-1-strict.json
+++ b/src/libmongoc/tests/json/versioned_api/crud-api-version-1-strict.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.7"
+      "minServerVersion": "4.9"
     }
   ],
   "createEntities": [
@@ -301,6 +301,12 @@
                         "$inc": {
                           "x": 1
                         }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],
@@ -353,7 +359,10 @@
                           "x": 1
                         }
                       },
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "apiVersion": "1",
@@ -396,6 +405,9 @@
                       "u": {
                         "_id": 4,
                         "x": 44
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
                       },
                       "upsert": true
                     }
@@ -597,11 +609,6 @@
     {
       "description": "estimatedDocumentCount appends declared API version",
       "skipReason": "DRIVERS-1561 collStats is not in API version 1",
-      "runOnRequirements": [
-        {
-          "minServerVersion": "4.9.0"
-        }
-      ],
       "operations": [
         {
           "name": "estimatedDocumentCount",
@@ -972,6 +979,9 @@
                         "_id": 4,
                         "x": 44
                       },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
                       "upsert": true
                     }
                   ],
@@ -1027,7 +1037,10 @@
                           "x": 1
                         }
                       },
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "apiVersion": "1",
@@ -1077,6 +1090,12 @@
                         "$inc": {
                           "x": 1
                         }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],

--- a/src/libmongoc/tests/json/versioned_api/crud-api-version-1.json
+++ b/src/libmongoc/tests/json/versioned_api/crud-api-version-1.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.7"
+      "minServerVersion": "4.9"
     }
   ],
   "createEntities": [
@@ -298,6 +298,12 @@
                         "$inc": {
                           "x": 1
                         }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],
@@ -350,7 +356,10 @@
                           "x": 1
                         }
                       },
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "apiVersion": "1",
@@ -393,6 +402,9 @@
                       "u": {
                         "_id": 4,
                         "x": 44
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
                       },
                       "upsert": true
                     }
@@ -587,46 +599,7 @@
       ]
     },
     {
-      "description": "estimatedDocumentCount appends declared API version on less than 4.9.0",
-      "runOnRequirements": [
-        {
-          "maxServerVersion": "4.8.99"
-        }
-      ],
-      "operations": [
-        {
-          "name": "estimatedDocumentCount",
-          "object": "collection",
-          "arguments": {}
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "count": "test",
-                  "apiVersion": "1",
-                  "apiStrict": {
-                    "$$unsetOrMatches": false
-                  },
-                  "apiDeprecationErrors": true
-                }
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "estimatedDocumentCount appends declared API version on 4.9.0 or greater",
-      "runOnRequirements": [
-        {
-          "minServerVersion": "4.9.0"
-        }
-      ],
+      "description": "estimatedDocumentCount appends declared API version",
       "operations": [
         {
           "name": "estimatedDocumentCount",
@@ -997,6 +970,9 @@
                         "_id": 4,
                         "x": 44
                       },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
                       "upsert": true
                     }
                   ],
@@ -1052,7 +1028,10 @@
                           "x": 1
                         }
                       },
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "apiVersion": "1",
@@ -1102,6 +1081,12 @@
                         "$inc": {
                           "x": 1
                         }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],

--- a/src/libmongoc/tests/json/versioned_api/runcommand-helper-no-api-version-declared.json
+++ b/src/libmongoc/tests/json/versioned_api/runcommand-helper-no-api-version-declared.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.7",
+      "minServerVersion": "4.9",
       "serverParameters": {
         "requireApiVersion": false
       }

--- a/src/libmongoc/tests/json/versioned_api/test-commands-deprecation-errors.json
+++ b/src/libmongoc/tests/json/versioned_api/test-commands-deprecation-errors.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.7",
+      "minServerVersion": "4.9",
       "serverParameters": {
         "enableTestCommands": true,
         "acceptAPIVersion2": true,

--- a/src/libmongoc/tests/json/versioned_api/test-commands-strict-mode.json
+++ b/src/libmongoc/tests/json/versioned_api/test-commands-strict-mode.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.7",
+      "minServerVersion": "4.9",
       "serverParameters": {
         "enableTestCommands": true
       }

--- a/src/libmongoc/tests/json/versioned_api/transaction-handling.json
+++ b/src/libmongoc/tests/json/versioned_api/transaction-handling.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.7",
+      "minServerVersion": "4.9",
       "topologies": [
         "replicaset",
         "sharded-replicaset"
@@ -382,7 +382,138 @@
           ]
         }
       ]
+    },
+    {
+      "description": "abortTransaction does not include an API version",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "replicaset",
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session",
+            "document": {
+              "_id": 6,
+              "x": 66
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 6
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session",
+            "document": {
+              "_id": 7,
+              "x": 77
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 7
+              }
+            }
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 6,
+                      "x": 66
+                    }
+                  ],
+                  "lsid": {
+                    "$$sessionLsid": "session"
+                  },
+                  "startTransaction": true,
+                  "apiVersion": "1",
+                  "apiStrict": {
+                    "$$unsetOrMatches": false
+                  },
+                  "apiDeprecationErrors": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 7,
+                      "x": 77
+                    }
+                  ],
+                  "lsid": {
+                    "$$sessionLsid": "session"
+                  },
+                  "apiVersion": {
+                    "$$exists": false
+                  },
+                  "apiStrict": {
+                    "$$exists": false
+                  },
+                  "apiDeprecationErrors": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "abortTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session"
+                  },
+                  "apiVersion": {
+                    "$$exists": false
+                  },
+                  "apiStrict": {
+                    "$$exists": false
+                  },
+                  "apiDeprecationErrors": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }
-


### PR DESCRIPTION
[CDRIVER-3919](https://jira.mongodb.org/browse/CDRIVER-3919)
[CDRIVER-3920](https://jira.mongodb.org/browse/CDRIVER-3920)
[CDRIVER-3932](https://jira.mongodb.org/browse/CDRIVER-3932)

Syncs versioned API spec tests to add a new test for abortTransaction and only run tests on 4.9+. Also removes skipReason on estimatedDocumentCount test.

I will not merge this until PR #753 to include apiVersion in handshakes and heartbeats is merged, and the "latest" server version on Evergreen includes [this commit](https://evergreen.mongodb.com/version/mongodb_mongo_master_075e51fefecc54e219c56e75c3ba08c993b5c187).