### PR TITLE
CDRIVER-3792 Support parsing $uuid as extended JSON

### DIFF
--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -940,7 +940,6 @@ _bson_json_parse_binary_elem (bson_json_reader_t *reader,
       uuid[32] = '\0';
 
       if (nread != 36 || val_w_null[nread] != '\0') {
-         binary_len = 0;
          _bson_json_read_set_error (reader,
                                     "Invalid input string \"%s\", looking for "
                                     "a dash-separated UUID string",
@@ -953,7 +952,7 @@ _bson_json_parse_binary_elem (bson_json_reader_t *reader,
       _bson_json_buf_ensure (&bson->bson_type_buf[0], (size_t) binary_len + 1);
 
       if (!_unhexlify_uuid (
-             &uuid[0], bson->bson_type_buf[0].buf, (size_t) binary_len + 1)) {
+             &uuid[0], bson->bson_type_buf[0].buf, (size_t) binary_len)) {
          _bson_json_read_set_error (reader,
                                     "Invalid input string \"%s\", looking for "
                                     "a dash-separated UUID string",

--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -103,7 +103,8 @@ static const char *read_state_names[] = {FOREACH_READ_STATE (GENERATE_STRING)};
    BS (DECIMAL128)                                                   \
    BS (DBPOINTER)                                                    \
    BS (SYMBOL)                                                       \
-   BS (DBREF)
+   BS (DBREF)                                                        \
+   BS (UUID)
 
 typedef enum {
    FOREACH_BSON_STATE (BSON_STATE_ENUM)
@@ -706,6 +707,7 @@ _bson_json_read_integer (bson_json_reader_t *reader, uint64_t val, int64_t sign)
       case BSON_JSON_LF_OID:
       case BSON_JSON_LF_BINARY:
       case BSON_JSON_LF_TYPE:
+      case BSON_JSON_LF_UUID:
       case BSON_JSON_LF_UNDEFINED:
       case BSON_JSON_LF_DOUBLE:
       case BSON_JSON_LF_DECIMAL128:
@@ -833,8 +835,29 @@ _bson_json_read_int64_or_set_error (bson_json_reader_t *reader, /* IN */
    return true;
 }
 
+static bool
+_unhexlify_uuid (const char *uuid, uint8_t *out, size_t max)
+{
+   unsigned int byte;
+   int x = 0;
+   int i = 0;
 
-/* parse a value for "base64", "subType" or legacy "$binary" or "$type" */
+   BSON_ASSERT (strlen (uuid) == 32);
+
+   while (SSCANF (&uuid[i], "%2x", &byte) == 1) {
+      if (x >= max) {
+         return false;
+      }
+
+      out[x++] = (uint8_t) byte;
+      i += 2;
+   }
+
+   return true;
+}
+
+/* parse a value for "base64", "subType", legacy "$binary" or "$type", or
+ * "$uuid" */
 static void
 _bson_json_parse_binary_elem (bson_json_reader_t *reader,
                               const char *val_w_null,
@@ -894,6 +917,50 @@ _bson_json_parse_binary_elem (bson_json_reader_t *reader,
                               (int) vlen);
          }
       }
+   } else if (bs == BSON_JSON_LF_UUID) {
+      int nread = 0;
+      char uuid[33];
+
+      data->binary.has_binary = true;
+      data->binary.has_subtype = true;
+      data->binary.type = BSON_SUBTYPE_UUID;
+
+      /* Validate the UUID and extract relevant portions */
+      /* We can't use %x here as it allows +, -, and 0x prefixes */
+      SSCANF (val_w_null,
+              "%8[0-9a-fA-F]-%4[0-9a-fA-F]-%4[0-9a-fA-F]-%4[0-9a-fA-F]-%12[0-"
+              "9a-fA-F]%n",
+              &uuid[0],
+              &uuid[8],
+              &uuid[12],
+              &uuid[16],
+              &uuid[20],
+              &nread);
+
+      uuid[32] = '\0';
+
+      if (nread != 36 || val_w_null[nread] != '\0') {
+         binary_len = 0;
+         _bson_json_read_set_error (reader,
+                                    "Invalid input string \"%s\", looking for "
+                                    "a dash-separated UUID string",
+                                    val_w_null);
+
+         return;
+      }
+
+      binary_len = 16;
+      _bson_json_buf_ensure (&bson->bson_type_buf[0], (size_t) binary_len + 1);
+
+      if (!_unhexlify_uuid (
+             &uuid[0], bson->bson_type_buf[0].buf, (size_t) binary_len + 1)) {
+         _bson_json_read_set_error (reader,
+                                    "Invalid input string \"%s\", looking for "
+                                    "a dash-separated UUID string",
+                                    val_w_null);
+      }
+
+      bson->bson_type_buf[0].len = (size_t) binary_len;
    }
 }
 
@@ -967,6 +1034,8 @@ _bson_json_read_string (bson_json_reader_t *reader, /* IN */
       case BSON_JSON_LF_BINARY:
       case BSON_JSON_LF_TYPE:
          bson->bson_type_data.binary.is_legacy = true;
+         /* Break omitted intentionally */
+      case BSON_JSON_LF_UUID:
          _bson_json_parse_binary_elem (reader, val_w_null, vlen);
          break;
       case BSON_JSON_LF_INT32: {
@@ -1123,7 +1192,7 @@ _is_known_key (const char *key, size_t len)
           IS_KEY ("$numberDouble") || IS_KEY ("$numberDecimal") ||
           IS_KEY ("$numberInt") || IS_KEY ("$numberLong") ||
           IS_KEY ("$numberDouble") || IS_KEY ("$numberDecimal") ||
-          IS_KEY ("$dbPointer") || IS_KEY ("$symbol"));
+          IS_KEY ("$dbPointer") || IS_KEY ("$symbol") || IS_KEY ("$uuid"));
 
 #undef IS_KEY
 
@@ -1241,6 +1310,8 @@ _bson_json_read_map_key (bson_json_reader_t *reader, /* IN */
          HANDLE_OPTION ("$binary", BSON_TYPE_BINARY, BSON_JSON_LF_BINARY)
       else if
          HANDLE_OPTION ("$type", BSON_TYPE_BINARY, BSON_JSON_LF_TYPE)
+      else if
+         HANDLE_OPTION ("$uuid", BSON_TYPE_BINARY, BSON_JSON_LF_UUID)
       else if
          HANDLE_OPTION ("$date", BSON_TYPE_DATE_TIME, BSON_JSON_LF_DATE)
       else if

--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -927,29 +927,30 @@ _bson_json_parse_binary_elem (bson_json_reader_t *reader,
 
       /* Validate the UUID and extract relevant portions */
       /* We can't use %x here as it allows +, -, and 0x prefixes */
+#ifdef _MSC_VER
       SSCANF (val_w_null,
               "%8c-%4c-%4c-%4c-%12c%n",
               &uuid[0],
-#ifdef _MSC_VER
               8,
-#endif
               &uuid[8],
-#ifdef _MSC_VER
               4,
-#endif
               &uuid[12],
-#ifdef _MSC_VER
               4,
-#endif
               &uuid[16],
-#ifdef _MSC_VER
               4,
-#endif
               &uuid[20],
-#ifdef _MSC_VER
               12,
-#endif
               &nread);
+#else
+      SSCANF (val_w_null,
+              "%8c-%4c-%4c-%4c-%12c%n",
+              &uuid[0],
+              &uuid[8],
+              &uuid[12],
+              &uuid[16],
+              &uuid[20],
+              &nread);
+#endif
 
       uuid[32] = '\0';
 

--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -853,7 +853,7 @@ _unhexlify_uuid (const char *uuid, uint8_t *out, size_t max)
       i += 2;
    }
 
-   return true;
+   return i == 32;
 }
 
 /* parse a value for "base64", "subType", legacy "$binary" or "$type", or

--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -928,13 +928,27 @@ _bson_json_parse_binary_elem (bson_json_reader_t *reader,
       /* Validate the UUID and extract relevant portions */
       /* We can't use %x here as it allows +, -, and 0x prefixes */
       SSCANF (val_w_null,
-              "%8[0-9a-fA-F]-%4[0-9a-fA-F]-%4[0-9a-fA-F]-%4[0-9a-fA-F]-%12[0-"
-              "9a-fA-F]%n",
+              "%8c-%4c-%4c-%4c-%12c%n",
               &uuid[0],
+#ifdef _MSC_VER
+              8,
+#endif
               &uuid[8],
+#ifdef _MSC_VER
+              4,
+#endif
               &uuid[12],
+#ifdef _MSC_VER
+              4,
+#endif
               &uuid[16],
+#ifdef _MSC_VER
+              4,
+#endif
               &uuid[20],
+#ifdef _MSC_VER
+              12,
+#endif
               &nread);
 
       uuid[32] = '\0';

--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -1048,7 +1048,7 @@ _bson_json_read_string (bson_json_reader_t *reader, /* IN */
       case BSON_JSON_LF_BINARY:
       case BSON_JSON_LF_TYPE:
          bson->bson_type_data.binary.is_legacy = true;
-         /* Break omitted intentionally */
+         /* FALL THROUGH */
       case BSON_JSON_LF_UUID:
          _bson_json_parse_binary_elem (reader, val_w_null, vlen);
          break;

--- a/src/libbson/tests/json/bson_corpus/binary.json
+++ b/src/libbson/tests/json/bson_corpus/binary.json
@@ -40,6 +40,12 @@
             "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"04\"}}}"
         },
         {
+            "description": "subtype 0x04 UUID",
+            "canonical_bson": "1D000000057800100000000473FFD26444B34C6990E8E7D1DFC035D400",
+            "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"04\"}}}",
+            "degenerate_extjson": "{\"x\" : { \"$uuid\" : \"73ffd264-44b3-4c69-90e8-e7d1dfc035d4\"}}"
+        },
+        {
             "description": "subtype 0x05",
             "canonical_bson": "1D000000057800100000000573FFD26444B34C6990E8E7D1DFC035D400",
             "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"05\"}}}"
@@ -80,6 +86,28 @@
         {
             "description": "subtype 0x02 length negative one",
             "bson": "130000000578000600000002FFFFFFFFFFFF00"
+        }
+    ],
+    "parseErrors": [
+        {
+            "description": "$uuid wrong type",
+            "string": "{\"x\" : { \"$uuid\" : { \"data\" : \"73ffd264-44b3-4c69-90e8-e7d1dfc035d4\"}}}"
+        },
+        {
+            "description": "$uuid invalid value--too short",
+            "string": "{\"x\" : { \"$uuid\" : \"73ffd264-44b3-90e8-e7d1dfc035d4\"}}"
+        },
+        {
+            "description": "$uuid invalid value--too long",
+            "string": "{\"x\" : { \"$uuid\" : \"73ffd264-44b3-4c69-90e8-e7d1dfc035d4-789e4\"}}"
+        },
+        {
+            "description": "$uuid invalid value--misplaced hyphens",
+            "string": "{\"x\" : { \"$uuid\" : \"73ff-d26444b-34c6-990e8e-7d1dfc035d4\"}}"
+        },
+        {
+            "description": "$uuid invalid value--too many hyphens",
+            "string": "{\"x\" : { \"$uuid\" : \"----d264-44b3-4--9-90e8-e7d1dfc0----\"}}"
         }
     ]
 }

--- a/src/libbson/tests/test-bson-corpus.c
+++ b/src/libbson/tests/test-bson-corpus.c
@@ -239,6 +239,7 @@ test_bson_corpus_parse_error (test_bson_parse_error_type_t *test)
 
    switch (test->bson_type) {
    case BSON_TYPE_EOD: /* top-level document to be parsed as JSON */
+   case BSON_TYPE_BINARY:
       ASSERT (!bson_new_from_json ((uint8_t *) test->str, test->str_len, NULL));
       break;
    case BSON_TYPE_DECIMAL128: {
@@ -251,7 +252,6 @@ test_bson_corpus_parse_error (test_bson_parse_error_type_t *test)
    case BSON_TYPE_UTF8:
    case BSON_TYPE_DOCUMENT:
    case BSON_TYPE_ARRAY:
-   case BSON_TYPE_BINARY:
    case BSON_TYPE_UNDEFINED:
    case BSON_TYPE_OID:
    case BSON_TYPE_BOOL:


### PR DESCRIPTION
CDRIVER-3792

This adds support for parsing UUIDs from extended JSON into BSON. To avoid using a UUID library, this uses sscanf to first validate the UUID and extract the data skipping hyphens, then decodes the hex values into the format understood by the BSON binary type. Any malformed UUID (e.g. wrong length, wrong position of hyphens, etc.) is rejected.