### PR TITLE
CDRIVER-3917 route all test client and client_pool creation through test framework

### DIFF
--- a/src/libmongoc/tests/json-test.c
+++ b/src/libmongoc/tests/json-test.c
@@ -1051,7 +1051,7 @@ insert_data (const char *db_name,
    bson_t *majority = tmp_bson ("{'writeConcern': {'w': 'majority'}}");
 
    /* use a fresh client to prepare the collection */
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
 
    db = mongoc_client_get_database (client, db_name);
    collection = mongoc_database_get_collection (db, collection_name);
@@ -1210,7 +1210,7 @@ execute_test (const json_test_config_t *config,
 
    if (bson_has_field (test, "outcome.collection")) {
       /* Use a fresh client to check the outcome collection. */
-      outcome_client = test_framework_client_new ();
+      outcome_client = test_framework_new_default_client ();
       if (bson_has_field (test, "outcome.collection.name")) {
          outcome_coll = mongoc_client_get_collection (
             outcome_client,

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -1391,7 +1391,7 @@ test_framework_uri_apply_multi_mongos (mongoc_uri_t *uri,
       goto done;
    }
 
-   /* TODO: Once CDRIVER-3285 is resolved, update this to no longer hardcode the
+   /* TODO Once CDRIVER-3285 is resolved, update this to no longer hardcode the
     * hosts. */
    if (use_multi) {
       if (!mongoc_uri_upsert_host_and_port (uri, "localhost:27017", error)) {
@@ -1497,7 +1497,7 @@ test_framework_replset_member_count (void)
    bson_iter_t iter, array;
    size_t count = 0;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    r = mongoc_client_command_simple (client,
                                      "admin",
                                      tmp_bson ("{'replSetGetStatus': 1}"),
@@ -1623,7 +1623,7 @@ test_framework_set_ssl_opts (mongoc_client_t *client)
 /*
  *--------------------------------------------------------------------------
  *
- * test_framework_client_new --
+ * test_framework_new_default_client --
  *
  *       Get a client connected to the test MongoDB topology.
  *
@@ -1636,7 +1636,7 @@ test_framework_set_ssl_opts (mongoc_client_t *client)
  *--------------------------------------------------------------------------
  */
 mongoc_client_t *
-test_framework_client_new ()
+test_framework_new_default_client ()
 {
    char *test_uri_str = test_framework_get_uri_str ();
    mongoc_client_t *client = mongoc_client_new (test_uri_str);
@@ -1647,6 +1647,20 @@ test_framework_client_new ()
    bson_free (test_uri_str);
 
    return client;
+}
+
+mongoc_client_t *
+test_framework_client_new (const char *uri_str)
+{
+   /* TODO CDRIVER-3917 */
+   return mongoc_client_new (uri_str);
+}
+
+mongoc_client_t *
+test_framework_client_new_from_uri (const mongoc_uri_t *uri)
+{
+   /* TODO CDRIVER-3917 */
+   return mongoc_client_new_from_uri (uri);
 }
 
 
@@ -1711,7 +1725,7 @@ test_framework_set_pool_ssl_opts (mongoc_client_pool_t *pool)
 /*
  *--------------------------------------------------------------------------
  *
- * test_framework_client_pool_new --
+ * test_framework_new_default_client_pool --
  *
  *       Get a client pool connected to the test MongoDB topology.
  *
@@ -1724,7 +1738,7 @@ test_framework_set_pool_ssl_opts (mongoc_client_pool_t *pool)
  *--------------------------------------------------------------------------
  */
 mongoc_client_pool_t *
-test_framework_client_pool_new ()
+test_framework_new_default_client_pool ()
 {
    mongoc_uri_t *test_uri = test_framework_get_uri ();
    mongoc_client_pool_t *pool = mongoc_client_pool_new (test_uri);
@@ -1735,6 +1749,13 @@ test_framework_client_pool_new ()
    mongoc_uri_destroy (test_uri);
    BSON_ASSERT (pool);
    return pool;
+}
+
+mongoc_client_pool_t *
+test_framework_client_pool_new (const mongoc_uri_t *uri)
+{
+   /* TODO CDRIVER-3917 */
+   return mongoc_client_pool_new (uri);
 }
 
 #ifdef MONGOC_ENABLE_SSL
@@ -2116,7 +2137,7 @@ test_framework_get_server_version (void)
    bson_error_t error;
    server_version_t ret = 0;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT_OR_PRINT (
       mongoc_client_command_simple (
          client, "admin", tmp_bson ("{'buildinfo': 1}"), NULL, &reply, &error),
@@ -2367,7 +2388,7 @@ test_framework_skip_if_no_failpoint (void)
       return 0;
    }
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    mongoc_client_set_error_api (client, MONGOC_ERROR_API_VERSION_2);
    ret = mongoc_client_command_simple (
       client,

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -1752,7 +1752,7 @@ test_framework_new_default_client_pool ()
 }
 
 mongoc_client_pool_t *
-test_framework_client_pool_new (const mongoc_uri_t *uri)
+test_framework_client_pool_new_from_uri (const mongoc_uri_t *uri)
 {
    /* TODO CDRIVER-3917 */
    return mongoc_client_pool_new (uri);

--- a/src/libmongoc/tests/test-libmongoc.h
+++ b/src/libmongoc/tests/test-libmongoc.h
@@ -109,7 +109,7 @@ test_framework_client_new_from_uri (const mongoc_uri_t *uri);
 mongoc_client_pool_t *
 test_framework_new_default_client_pool (void);
 mongoc_client_pool_t *
-test_framework_client_pool_new (const mongoc_uri_t *uri);
+test_framework_client_pool_new_from_uri (const mongoc_uri_t *uri);
 
 bool
 test_framework_is_mongos (void);

--- a/src/libmongoc/tests/test-libmongoc.h
+++ b/src/libmongoc/tests/test-libmongoc.h
@@ -98,10 +98,18 @@ void
 test_framework_set_ssl_opts (mongoc_client_t *client);
 void
 test_framework_set_pool_ssl_opts (mongoc_client_pool_t *pool);
+
 mongoc_client_t *
-test_framework_client_new (void);
+test_framework_new_default_client (void);
+mongoc_client_t *
+test_framework_client_new (const char *uri_str);
+mongoc_client_t *
+test_framework_client_new_from_uri (const mongoc_uri_t *uri);
+
 mongoc_client_pool_t *
-test_framework_client_pool_new (void);
+test_framework_new_default_client_pool (void);
+mongoc_client_pool_t *
+test_framework_client_pool_new (const mongoc_uri_t *uri);
 
 bool
 test_framework_is_mongos (void);

--- a/src/libmongoc/tests/test-mongoc-aggregate.c
+++ b/src/libmongoc/tests/test-mongoc-aggregate.c
@@ -21,7 +21,7 @@ _test_query_flag (mongoc_query_flags_t flag, bson_t *opt)
 
    server = mock_server_with_autoismaster (WIRE_VERSION_MAX);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
    cursor = mongoc_collection_aggregate (
       collection, flag, tmp_bson ("{'pipeline': []}"), opt, NULL);

--- a/src/libmongoc/tests/test-mongoc-aggregate.c
+++ b/src/libmongoc/tests/test-mongoc-aggregate.c
@@ -6,6 +6,7 @@
 #include "mock_server/future.h"
 #include "mock_server/future-functions.h"
 #include "test-conveniences.h"
+#include "test-libmongoc.h"
 
 static void
 _test_query_flag (mongoc_query_flags_t flag, bson_t *opt)

--- a/src/libmongoc/tests/test-mongoc-background-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-background-monitoring.c
@@ -225,7 +225,7 @@ tf_new (tf_flags_t flags)
    mongoc_apm_set_server_heartbeat_succeeded_cb (callbacks,
                                                  _heartbeat_succeeded);
    mongoc_apm_set_server_heartbeat_failed_cb (callbacks, _heartbeat_failed);
-   tf->pool = test_framework_client_pool_new (mock_server_get_uri (tf->server));
+   tf->pool = test_framework_client_pool_new_from_uri (mock_server_get_uri (tf->server));
    mongoc_client_pool_set_apm_callbacks (tf->pool, callbacks, tf);
    mongoc_apm_callbacks_destroy (callbacks);
 

--- a/src/libmongoc/tests/test-mongoc-background-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-background-monitoring.c
@@ -225,7 +225,7 @@ tf_new (tf_flags_t flags)
    mongoc_apm_set_server_heartbeat_succeeded_cb (callbacks,
                                                  _heartbeat_succeeded);
    mongoc_apm_set_server_heartbeat_failed_cb (callbacks, _heartbeat_failed);
-   tf->pool = mongoc_client_pool_new (mock_server_get_uri (tf->server));
+   tf->pool = test_framework_client_pool_new (mock_server_get_uri (tf->server));
    mongoc_client_pool_set_apm_callbacks (tf->pool, callbacks, tf);
    mongoc_apm_callbacks_destroy (callbacks);
 

--- a/src/libmongoc/tests/test-mongoc-bulk.c
+++ b/src/libmongoc/tests/test-mongoc-bulk.c
@@ -4156,7 +4156,7 @@ _test_bulk_hint (bool pooled, bool use_primary)
    mock_rs_run (rs);
 
    if (pooled) {
-      pool = test_framework_client_pool_new (mock_rs_get_uri (rs));
+      pool = test_framework_client_pool_new_from_uri (mock_rs_get_uri (rs));
       client = mongoc_client_pool_pop (pool);
    } else {
       client = test_framework_client_new_from_uri (mock_rs_get_uri (rs));

--- a/src/libmongoc/tests/test-mongoc-bulk.c
+++ b/src/libmongoc/tests/test-mongoc-bulk.c
@@ -157,7 +157,7 @@ test_bulk (void)
    bson_t up;
    bson_t doc = BSON_INITIALIZER;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    collection = get_test_collection (client, "test_bulk");
@@ -215,7 +215,7 @@ _test_opt (const char *opts_json, const char *msg)
    mongoc_client_t *client;
    bson_error_t error;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    collection = get_test_collection (client, "test_bulk");
@@ -260,7 +260,8 @@ test_bulk_error (void)
 
    mock_server = mock_server_with_autoismaster (WIRE_VERSION_MIN);
    mock_server_run (mock_server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (mock_server));
+   client =
+      test_framework_client_new_from_uri (mock_server_get_uri (mock_server));
 
    bulk = mongoc_bulk_operation_new (true);
    mongoc_bulk_operation_set_client (bulk, client);
@@ -301,7 +302,7 @@ test_bulk_error_unordered (void)
 
    uri = mongoc_uri_copy (mock_server_get_uri (mock_server));
    mongoc_uri_set_option_as_int32 (uri, "sockettimeoutms", 500);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    mongoc_uri_destroy (uri);
    collection = mongoc_client_get_collection (client, "test", "test");
 
@@ -376,7 +377,7 @@ test_insert (bool ordered)
    mongoc_cursor_t *cursor;
    const bson_t *inserted_doc;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    collection = get_test_collection (client, "test_insert");
@@ -448,7 +449,7 @@ test_insert_check_keys (void)
 
    capture_logs (true);
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
    collection = get_test_collection (client, "test_insert_check_keys");
    BSON_ASSERT (collection);
@@ -522,7 +523,7 @@ test_upsert (bool ordered)
    bson_t *sel;
    bson_t *doc;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    collection = get_test_collection (client, "test_upsert");
@@ -612,7 +613,7 @@ test_upsert_unordered_oversized (void *ctx)
    bson_error_t error;
    bson_t reply;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "upsert_oversized");
    bson_append_bool (&opts, "ordered", 7, false);
    bulk = mongoc_collection_create_bulk_operation_with_opts (collection, &opts);
@@ -662,7 +663,7 @@ test_upserted_index (bool ordered)
    bson_t *inc = tmp_bson ("{'$inc': {'b': 1}}");
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    collection = get_test_collection (client, "test_upserted_index");
@@ -787,7 +788,7 @@ test_update_one (bool ordered)
    bson_t *doc;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    collection = get_test_collection (client, "test_update_one");
@@ -858,7 +859,7 @@ test_update_with_opts_validate (void)
    };
    int i;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_update_with_opts_validate");
 
    for (i = 0; i < 2; i++) {
@@ -947,7 +948,7 @@ test_update_arrayfilters (void *ctx)
    bool ret = false;
    int i;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    collection = get_test_collection (client, "test_update_arrayfilters");
@@ -1032,7 +1033,7 @@ test_update_arrayfilters_unsupported (void *ctx)
       mongoc_bulk_operation_update_many_with_opts,
    };
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_update_arrayfilters_err");
 
    for (i = 0; i < 2; i++) {
@@ -1079,7 +1080,7 @@ test_update_hint_validate (void)
       mongoc_bulk_operation_replace_one_with_opts,
    };
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_update_hint_err");
 
    for (i = 0; i < 3; i++) {
@@ -1126,7 +1127,7 @@ test_delete_hint_validate (void)
       mongoc_bulk_operation_remove_many_with_opts,
    };
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_delete_hint_err");
 
    for (i = 0; i < 2; i++) {
@@ -1166,7 +1167,7 @@ test_replace_one (bool ordered)
    bson_t *doc;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    collection = get_test_collection (client, "test_replace_one");
@@ -1221,7 +1222,7 @@ _test_replace_one_check_keys (bool with_opts)
    bson_t reply;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_replace_one_check_keys");
    bulk = mongoc_collection_create_bulk_operation_with_opts (collection, NULL);
 
@@ -1287,7 +1288,7 @@ test_replace_one_with_opts_validate (void)
    mongoc_bulk_operation_t *bulk;
    bson_error_t error;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_replace_with_opts_validate");
    bulk = mongoc_collection_create_bulk_operation_with_opts (collection, NULL);
 
@@ -1361,7 +1362,7 @@ test_upsert_large (void *ctx)
 
    memset (large_str, 'a', sz);
    large_str[sz - 1] = '\0';
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_upsert_large");
    bulk = mongoc_collection_create_bulk_operation_with_opts (collection, NULL);
 
@@ -1413,7 +1414,7 @@ test_upsert_huge (void *ctx)
    bson_t reply;
    mongoc_cursor_t *cursor;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
    mongoc_client_set_error_api (client, 2);
 
@@ -1494,7 +1495,7 @@ test_update (bool ordered)
    bson_t *bad_update_doc = tmp_bson ("{'foo': 'bar'}");
    bson_t *update_doc;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    collection = get_test_collection (client, "test_update");
@@ -1580,7 +1581,7 @@ _test_update_check_keys (bool many, bool with_opts)
    bson_error_t error;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
    collection = get_test_collection (client, "test_update_check_keys");
    BSON_ASSERT (collection);
@@ -1688,7 +1689,7 @@ _test_update_validate (update_validate_test_t *test)
    bson_error_t error;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
    collection = get_test_collection (client, "test_update_invalid_first");
    BSON_ASSERT (collection);
@@ -1962,7 +1963,7 @@ _test_insert_invalid (bool with_opts, bool invalid_first)
    bool r;
    const char *err = "keys cannot contain \".\": \"a.b\"";
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_insert_validate");
    bulk = mongoc_collection_create_bulk_operation_with_opts (collection, NULL);
    BSON_ASSERT (mongoc_collection_delete_many (
@@ -2080,7 +2081,7 @@ test_insert_with_opts_validate (void)
    mongoc_bulk_operation_t *bulk;
    bson_error_t error;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_insert_with_opts_validate");
    bulk = mongoc_collection_create_bulk_operation_with_opts (collection, NULL);
 
@@ -2152,7 +2153,7 @@ _test_remove_validate (remove_validate_test_t *test)
    bson_error_t error;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
    collection = get_test_collection (client, "test_update_invalid_first");
    BSON_ASSERT (collection);
@@ -2243,7 +2244,7 @@ test_index_offset (void)
    bson_t *doc;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    collection = get_test_collection (client, "test_index_offset");
@@ -2296,7 +2297,7 @@ test_single_ordered_bulk (void)
    bson_t reply;
    bson_error_t error;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    collection = get_test_collection (client, "test_single_ordered_bulk");
@@ -2346,7 +2347,7 @@ test_insert_continue_on_error (void)
    bson_error_t error;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    collection = get_test_collection (client, "test_insert_continue_on_error");
@@ -2395,7 +2396,7 @@ test_update_continue_on_error (void)
    bson_error_t error;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    collection = get_test_collection (client, "test_update_continue_on_error");
@@ -2458,7 +2459,7 @@ test_remove_continue_on_error (void)
    bson_error_t error;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    collection = get_test_collection (client, "test_remove_continue_on_error");
@@ -2509,7 +2510,7 @@ test_single_error_ordered_bulk (void)
    bson_error_t error;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    collection = get_test_collection (client, "test_single_error_ordered_bulk");
@@ -2563,7 +2564,7 @@ test_multiple_error_ordered_bulk (void)
    bson_error_t error;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    collection =
@@ -2626,7 +2627,7 @@ test_single_unordered_bulk (void)
    bson_t reply;
    bson_error_t error;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    collection = get_test_collection (client, "test_single_unordered_bulk");
@@ -2674,7 +2675,7 @@ test_single_error_unordered_bulk (void)
    bson_error_t error;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    collection =
@@ -2732,7 +2733,7 @@ _test_oversized_bulk_op (bool ordered)
    bson_error_t error;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_oversized_bulk");
    mongoc_collection_drop_with_opts (collection, NULL, NULL);
 
@@ -2817,7 +2818,8 @@ _test_write_concern (bool ordered, bool multi_err)
 
    mock_server = mock_server_with_autoismaster (WIRE_VERSION_MIN);
    mock_server_run (mock_server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (mock_server));
+   client =
+      test_framework_client_new_from_uri (mock_server_get_uri (mock_server));
    collection = mongoc_client_get_collection (client, "test", "test");
    wc = mongoc_write_concern_new ();
    mongoc_write_concern_set_w (wc, 2);
@@ -2979,31 +2981,31 @@ test_unordered_bulk_writes_with_error (void)
    /* disable retryable writes, so we move to the next operation on error */
    mongoc_uri_set_option_as_bool (uri, MONGOC_URI_RETRYWRITES, false);
 
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
 
    collection = mongoc_client_get_collection (client, "db", "test");
    /* use an unordered bulk write; we expect to continue on error */
    bulk = mongoc_collection_create_bulk_operation_with_opts (
-      collection, tmp_bson("{'ordered': false}"));
+      collection, tmp_bson ("{'ordered': false}"));
    /* maxWriteBatchSize is set to 1; with 2 inserts we get a batch split */
    for (i = 0; i < 2; i++) {
       mongoc_bulk_operation_insert_with_opts (
-         bulk, tmp_bson("{'_id': %d}", i), NULL, &error);
+         bulk, tmp_bson ("{'_id': %d}", i), NULL, &error);
    }
    future = future_bulk_operation_execute (bulk, &reply, &error);
 
    request = mock_server_receives_request (server);
    BSON_ASSERT (request);
-   mock_server_replies_simple (
-      request, "{ 'errmsg': 'random error', 'ok': 0 }");
+   mock_server_replies_simple (request,
+                               "{ 'errmsg': 'random error', 'ok': 0 }");
    request_destroy (request);
    /* should receive a second request */
    request = mock_server_receives_request (server);
    /* a failure of this assertion means that the client did not continue with
     * the next write operation; it stopped permaturely */
    BSON_ASSERT (request);
-   mock_server_replies_simple (
-      request, "{ 'errmsg': 'random error', 'ok': 0 }");
+   mock_server_replies_simple (request,
+                               "{ 'errmsg': 'random error', 'ok': 0 }");
    request_destroy (request);
    ASSERT (future_wait (future));
 
@@ -3014,7 +3016,6 @@ test_unordered_bulk_writes_with_error (void)
    future_destroy (future);
    mongoc_uri_destroy (uri);
    mock_server_destroy (server);
-
 }
 
 
@@ -3033,7 +3034,8 @@ _test_write_concern_err_api (int32_t error_api_version)
 
    mock_server = mock_server_with_autoismaster (WIRE_VERSION_MIN);
    mock_server_run (mock_server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (mock_server));
+   client =
+      test_framework_client_new_from_uri (mock_server_get_uri (mock_server));
    ASSERT (mongoc_client_set_error_api (client, error_api_version));
    collection = mongoc_client_get_collection (client, "test", "test");
    bulk = mongoc_collection_create_bulk_operation_with_opts (collection, NULL);
@@ -3090,7 +3092,7 @@ test_multiple_error_unordered_bulk (void)
    bson_error_t error;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    collection =
@@ -3165,7 +3167,8 @@ _test_wtimeout_plus_duplicate_key_err (void)
 
    mock_server = mock_server_with_autoismaster (WIRE_VERSION_MIN);
    mock_server_run (mock_server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (mock_server));
+   client =
+      test_framework_client_new_from_uri (mock_server_get_uri (mock_server));
    collection = mongoc_client_get_collection (client, "test", "test");
 
    /* unordered bulk */
@@ -3268,7 +3271,7 @@ test_large_inserts_ordered (void *ctx)
    bson_t query = BSON_INITIALIZER;
    mongoc_cursor_t *cursor;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    huge_doc = BCON_NEW ("a", BCON_INT32 (1));
@@ -3354,7 +3357,7 @@ test_large_inserts_unordered (void *ctx)
    bson_t query = BSON_INITIALIZER;
    mongoc_cursor_t *cursor;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    huge_doc = BCON_NEW ("a", BCON_INT32 (1));
@@ -3485,7 +3488,7 @@ _test_numerous (bool ordered)
 
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
 
 #define TEST_NUMEROUS(_one_write, _doc_format)                                 \
@@ -3549,7 +3552,7 @@ test_bulk_split (void)
    /* ensure we need two batches */
    n_docs = (int) test_framework_max_write_batch_size () + 10;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    collection = get_test_collection (client, "split");
@@ -3642,7 +3645,7 @@ test_bulk_edge_case_372 (bool ordered)
    bson_t *update;
    bson_t reply;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    collection = get_test_collection (client, "CDRIVER_372");
@@ -3760,7 +3763,7 @@ test_bulk_max_msg_size (void)
    mongoc_write_concern_set_w (wc, 1);
    mongoc_write_concern_append (wc, &opts);
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    callbacks = mongoc_apm_callbacks_new ();
    mongoc_apm_set_command_succeeded_cb (callbacks, command_succeeded);
    mongoc_client_set_apm_callbacks (client, callbacks, (void *) &stats);
@@ -3896,7 +3899,7 @@ test_bulk_max_batch_size (void)
    wc = mongoc_write_concern_new ();
    mongoc_write_concern_set_w (wc, 1);
    mongoc_write_concern_append (wc, &opts);
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    callbacks = mongoc_apm_callbacks_new ();
    mongoc_apm_set_command_succeeded_cb (callbacks, command_succeeded);
    mongoc_client_set_apm_callbacks (client, callbacks, (void *) &stats);
@@ -3997,7 +4000,7 @@ test_bulk_new (void)
    bson_t empty = BSON_INITIALIZER;
    uint32_t r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    collection = get_test_collection (client, "bulk_new");
@@ -4065,7 +4068,7 @@ test_bulk_write_concern_split (void)
 
    num_docs = (int) test_framework_max_write_batch_size () + 10;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    write_concern = mongoc_write_concern_new ();
@@ -4153,10 +4156,10 @@ _test_bulk_hint (bool pooled, bool use_primary)
    mock_rs_run (rs);
 
    if (pooled) {
-      pool = mongoc_client_pool_new (mock_rs_get_uri (rs));
+      pool = test_framework_client_pool_new (mock_rs_get_uri (rs));
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (mock_rs_get_uri (rs));
+      client = test_framework_client_new_from_uri (mock_rs_get_uri (rs));
    }
 
    /* warm up the client so its server_id is valid */
@@ -4244,7 +4247,7 @@ test_bulk_reply_w0 (void)
    bson_error_t error;
    bson_t reply;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_insert_w0");
    wc = mongoc_write_concern_new ();
    mongoc_write_concern_set_w (wc, 0);
@@ -4277,7 +4280,7 @@ test_bulk_invalid_write_concern (void)
    bson_error_t error;
    bson_t reply;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_bulk_invalid_write_concern");
    bulk = mongoc_collection_create_bulk_operation_with_opts (
       collection, tmp_bson ("{'writeConcern': {'w': 0, 'j': true}}"));
@@ -4329,7 +4332,8 @@ _test_bulk_collation (int w, int wire_version, bulkop op)
    mock_server = mock_server_with_autoismaster (wire_version);
    mock_server_run (mock_server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (mock_server));
+   client =
+      test_framework_client_new_from_uri (mock_server_get_uri (mock_server));
    collection = mongoc_client_get_collection (client, "test", "test");
 
    bulk = mongoc_collection_create_bulk_operation_with_opts (
@@ -4471,7 +4475,8 @@ _test_bulk_collation_multi (int w, int wire_version)
    mock_server = mock_server_with_autoismaster (wire_version);
    mock_server_run (mock_server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (mock_server));
+   client =
+      test_framework_client_new_from_uri (mock_server_get_uri (mock_server));
    collection = mongoc_client_get_collection (client, "test", "test");
    bulk = mongoc_collection_create_bulk_operation_with_opts (
       collection, tmp_bson ("{'writeConcern': {'w': %d, 'wtimeout': 100}}", w));
@@ -4601,7 +4606,7 @@ test_bulk_update_one_error_message (void)
    mongoc_bulk_operation_t *bulk;
    bson_error_t error;
 
-   client = mongoc_client_new ("mongodb://server");
+   client = test_framework_client_new ("mongodb://server");
    collection = mongoc_client_get_collection (client, "test", "test");
 
    bulk = mongoc_collection_create_bulk_operation_with_opts (collection, NULL);
@@ -4636,7 +4641,7 @@ test_bulk_opts_parse (void)
    bson_error_t error;
    bool r;
 
-   client = mongoc_client_new ("mongodb://server");
+   client = test_framework_client_new ("mongodb://server");
    collection = mongoc_client_get_collection (client, "test", "test");
 
    bulk = mongoc_collection_create_bulk_operation_with_opts (collection, NULL);
@@ -4732,7 +4737,7 @@ test_bulk_bypass_document_validation (void)
    uint32_t i;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "bypass_validation");
 
    /* bypassDocumentValidation can't be passed in opts */
@@ -4972,10 +4977,9 @@ test_bulk_install (TestSuite *suite)
       suite,
       "/BulkOperation/write_concern/write_command/unordered/multi_err",
       test_write_concern_write_command_unordered_multi_err);
-   TestSuite_AddMockServerTest (
-      suite,
-      "/BulkOperation/writes/unordered/error",
-      test_unordered_bulk_writes_with_error);
+   TestSuite_AddMockServerTest (suite,
+                                "/BulkOperation/writes/unordered/error",
+                                test_unordered_bulk_writes_with_error);
    TestSuite_AddMockServerTest (
       suite,
       "/BulkOperation/write_concern/error/write_command/v1",

--- a/src/libmongoc/tests/test-mongoc-cache.c
+++ b/src/libmongoc/tests/test-mongoc-cache.c
@@ -41,7 +41,7 @@ ping ()
 
    uri = bson_strdup_printf ("mongodb://localhost/?tls=true&tlsCAFile=%s",
                              ca_file);
-   ASSERT ((client = test_framework_client_new (uri)));
+   ASSERT ((client = test_framework_client_new_from_uri (uri)));
 
    bson_init (&ping);
    bson_append_int32 (&ping, "ping", 4, 1);

--- a/src/libmongoc/tests/test-mongoc-cache.c
+++ b/src/libmongoc/tests/test-mongoc-cache.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <signal.h>
 #include "TestSuite.h"
+#include "test-libmongoc.h"
 
 #ifndef SIGSTOP
 #define SIGSTOP 19

--- a/src/libmongoc/tests/test-mongoc-cache.c
+++ b/src/libmongoc/tests/test-mongoc-cache.c
@@ -41,7 +41,7 @@ ping ()
 
    uri = bson_strdup_printf ("mongodb://localhost/?tls=true&tlsCAFile=%s",
                              ca_file);
-   ASSERT ((client = mongoc_client_new (uri)));
+   ASSERT ((client = test_framework_client_new (uri)));
 
    bson_init (&ping);
    bson_append_int32 (&ping, "ping", 4, 1);
@@ -86,7 +86,7 @@ main (int argc, char *argv[])
    raise (SIGSTOP);
    ASSERT (ping () == EXIT_FAILURE);
 
-  mongoc_cleanup ();
+   mongoc_cleanup ();
 #endif
    return EXIT_SUCCESS;
 }

--- a/src/libmongoc/tests/test-mongoc-cache.c
+++ b/src/libmongoc/tests/test-mongoc-cache.c
@@ -42,7 +42,7 @@ ping ()
 
    uri = bson_strdup_printf ("mongodb://localhost/?tls=true&tlsCAFile=%s",
                              ca_file);
-   ASSERT ((client = test_framework_client_new_from_uri (uri)));
+   ASSERT ((client = test_framework_client_new (uri)));
 
    bson_init (&ping);
    bson_append_int32 (&ping, "ping", 4, 1);

--- a/src/libmongoc/tests/test-mongoc-change-stream.c
+++ b/src/libmongoc/tests/test-mongoc-change-stream.c
@@ -117,7 +117,7 @@ test_change_stream_pipeline (void)
    server = mock_server_with_autoismaster (5);
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    ASSERT (client);
 
    coll = mongoc_client_get_collection (client, "db", "coll");
@@ -236,7 +236,7 @@ static void
 test_change_stream_live_single_server (void *test_ctx)
 {
    /* Temporarily skip on arm64 until mongod tested against is updated */
-   mongoc_client_t *client = test_framework_client_new ();
+   mongoc_client_t *client = test_framework_new_default_client ();
    mongoc_collection_t *coll;
    bson_error_t error;
    mongoc_change_stream_t *stream;
@@ -332,7 +332,7 @@ test_change_stream_live_track_resume_token (void *test_ctx)
    bson_t doc0_rt, doc1_rt, doc2_rt;
    const bson_t *resume_token;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    callbacks = mongoc_apm_callbacks_new ();
@@ -463,7 +463,7 @@ test_change_stream_live_batch_size (void *test_ctx)
    bson_error_t err;
    uint32_t i;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    callbacks = mongoc_apm_callbacks_new ();
@@ -537,7 +537,7 @@ _test_resume_token_error (const char *id_projection)
    mongoc_write_concern_t *wc = mongoc_write_concern_new ();
    bson_t opts = BSON_INITIALIZER;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
    mongoc_client_set_error_api (client, MONGOC_ERROR_API_VERSION_2);
 
@@ -617,7 +617,7 @@ _test_getmore_error (const char *server_reply,
 
    server = mock_server_with_autoismaster (5);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    coll = mongoc_client_get_collection (client, "db", "coll");
    future = future_collection_watch (coll, tmp_bson ("{}"), NULL);
    request = mock_server_receives_command (
@@ -749,7 +749,7 @@ test_change_stream_resumable_error (void)
 
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_int32 (uri, "socketTimeoutMS", 100);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    mongoc_client_set_error_api (client, MONGOC_ERROR_API_VERSION_2);
    coll = mongoc_client_get_collection (client, "db", "coll");
 
@@ -915,7 +915,7 @@ test_change_stream_options (void)
    server = mock_server_with_autoismaster (5);
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    ASSERT (client);
 
    coll = mongoc_client_get_collection (client, "db", "coll");
@@ -998,7 +998,7 @@ test_change_stream_options (void)
 static void
 test_change_stream_live_watch (void *test_ctx)
 {
-   mongoc_client_t *client = test_framework_client_new ();
+   mongoc_client_t *client = test_framework_new_default_client ();
    bson_t *inserted_doc = tmp_bson ("{ 'x': 'y'}");
    const bson_t *next_doc = NULL;
    mongoc_collection_t *coll;
@@ -1086,7 +1086,7 @@ test_change_stream_live_read_prefs (void *test_ctx)
     */
 
    mongoc_read_prefs_t *prefs;
-   mongoc_client_t *client = test_framework_client_new ();
+   mongoc_client_t *client = test_framework_new_default_client ();
    mongoc_collection_t *coll;
    mongoc_change_stream_t *stream;
    mongoc_cursor_t *raw_cursor;
@@ -1150,7 +1150,8 @@ test_change_stream_server_selection_fails (void)
 {
    const bson_t *bson;
    bson_error_t err;
-   mongoc_client_t *client = mongoc_client_new ("mongodb://localhost:12345/");
+   mongoc_client_t *client =
+      test_framework_client_new ("mongodb://localhost:12345/");
    mongoc_collection_t *coll =
       mongoc_client_get_collection (client, "test", "test");
    mongoc_change_stream_t *cs =
@@ -1172,7 +1173,7 @@ test_change_stream_server_selection_fails (void)
 static void
 test_change_stream_next_after_error (void *test_ctx)
 {
-   mongoc_client_t *client = test_framework_client_new ();
+   mongoc_client_t *client = test_framework_new_default_client ();
    mongoc_collection_t *coll;
    mongoc_change_stream_t *stream;
    const bson_t *bson;
@@ -1217,7 +1218,7 @@ _accepts_array_started (const mongoc_apm_command_started_t *event)
 static void
 test_change_stream_accepts_array (void *test_ctx)
 {
-   mongoc_client_t *client = test_framework_client_new ();
+   mongoc_client_t *client = test_framework_new_default_client ();
    mongoc_apm_callbacks_t *callbacks = mongoc_apm_callbacks_new ();
    array_started_ctx_t ctx = {0};
    mongoc_collection_t *coll;
@@ -1294,7 +1295,7 @@ test_change_stream_accepts_array (void *test_ctx)
 void
 test_change_stream_start_at_operation_time (void *test_ctx)
 {
-   mongoc_client_t *client = test_framework_client_new ();
+   mongoc_client_t *client = test_framework_new_default_client ();
    mongoc_collection_t *coll;
    mongoc_change_stream_t *stream;
    const bson_t *doc;
@@ -1395,7 +1396,7 @@ _resume_at_optime_succeeded (const mongoc_apm_command_succeeded_t *event)
 static void
 test_change_stream_resume_at_optime (void *test_ctx)
 {
-   mongoc_client_t *client = test_framework_client_new ();
+   mongoc_client_t *client = test_framework_new_default_client ();
    mongoc_collection_t *coll;
    mongoc_change_stream_t *stream;
    const bson_t *doc;
@@ -1482,7 +1483,7 @@ _resume_with_post_batch_resume_token_succeeded (
 static void
 test_change_stream_resume_with_post_batch_resume_token (void *test_ctx)
 {
-   mongoc_client_t *client = test_framework_client_new ();
+   mongoc_client_t *client = test_framework_new_default_client ();
    mongoc_collection_t *coll;
    mongoc_change_stream_t *stream;
    const bson_t *doc;
@@ -1517,7 +1518,7 @@ test_change_stream_resume_with_post_batch_resume_token (void *test_ctx)
 void
 test_change_stream_database_watch (void *test_ctx)
 {
-   mongoc_client_t *client = test_framework_client_new ();
+   mongoc_client_t *client = test_framework_new_default_client ();
    mongoc_database_t *db;
    mongoc_collection_t *coll;
    mongoc_change_stream_t *stream;
@@ -1550,7 +1551,7 @@ test_change_stream_database_watch (void *test_ctx)
 void
 test_change_stream_client_watch (void *test_ctx)
 {
-   mongoc_client_t *client = test_framework_client_new ();
+   mongoc_client_t *client = test_framework_new_default_client ();
    mongoc_collection_t *coll;
    mongoc_change_stream_t *stream;
    const bson_t *doc;
@@ -1836,7 +1837,7 @@ _test_resume (const char *opts,
 
    server = mock_server_with_autoismaster (7);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    mongoc_client_set_error_api (client, MONGOC_ERROR_API_VERSION_2);
    coll = mongoc_client_get_collection (client, "db", "coll");
    future = future_collection_watch (coll, tmp_bson ("{}"), tmp_bson (opts));
@@ -2096,7 +2097,7 @@ test_error_null_doc (void *ctx)
    const bson_t *error_doc =
       tmp_bson ("{}"); /* assign to a non-zero address. */
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    stream = mongoc_client_watch (client, tmp_bson ("{}"), NULL);
    /* error_doc starts as non-NULL. */
    BSON_ASSERT (error_doc);
@@ -2134,7 +2135,7 @@ prose_test_11 (void *ctx)
    const bson_t *resume_token;
    _data_change_stream_t *post_batch_expected;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    coll = drop_and_get_coll (client, "db", "coll_resume");
@@ -2196,7 +2197,7 @@ prose_test_12 (void *ctx)
    bson_t expected_token;
    bson_t expected_doc;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    coll = drop_and_get_coll (client, "db", "coll_resume");
@@ -2268,7 +2269,7 @@ prose_test_13 (void *ctx)
    const bson_t *resume_token;
    bson_iter_t iter, child;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    callbacks = mongoc_apm_callbacks_new ();
@@ -2348,7 +2349,7 @@ _save_operation_time_from_agg (const mongoc_apm_command_succeeded_t *event)
 void
 prose_test_14 (void *test_ctx)
 {
-   mongoc_client_t *client = test_framework_client_new ();
+   mongoc_client_t *client = test_framework_new_default_client ();
    mongoc_collection_t *coll;
    mongoc_change_stream_t *stream;
    bson_t opts;
@@ -2443,7 +2444,7 @@ prose_test_17 (void)
 
    server = mock_server_with_autoismaster (WIRE_VERSION_MAX);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
 
    coll = mongoc_client_get_collection (client, "db", "coll");
    /* Pass an arbitrary document as the resume token, like {'x': 1} */
@@ -2519,7 +2520,7 @@ prose_test_18 (void)
 
    server = mock_server_with_autoismaster (WIRE_VERSION_MAX);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
 
    coll = mongoc_client_get_collection (client, "db", "coll");
    /* Pass an arbitrary document as the resume token, like {'x': 1} */

--- a/src/libmongoc/tests/test-mongoc-client-pool.c
+++ b/src/libmongoc/tests/test-mongoc-client-pool.c
@@ -15,7 +15,7 @@ test_mongoc_client_pool_basic (void)
    mongoc_uri_t *uri;
 
    uri = mongoc_uri_new ("mongodb://127.0.0.1/?maxpoolsize=1");
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
    client = mongoc_client_pool_pop (pool);
    BSON_ASSERT (client);
    mongoc_client_pool_push (pool, client);
@@ -32,7 +32,7 @@ test_mongoc_client_pool_try_pop (void)
    mongoc_uri_t *uri;
 
    uri = mongoc_uri_new ("mongodb://127.0.0.1/?maxpoolsize=1");
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
    client = mongoc_client_pool_pop (pool);
    BSON_ASSERT (client);
    BSON_ASSERT (!mongoc_client_pool_try_pop (pool));
@@ -52,7 +52,7 @@ test_mongoc_client_pool_pop_timeout (void)
 
    uri = mongoc_uri_new (
       "mongodb://127.0.0.1/?maxpoolsize=1&waitqueuetimeoutms=2000");
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
    client = mongoc_client_pool_pop (pool);
    BSON_ASSERT (client);
    start = bson_get_monotonic_time ();
@@ -78,7 +78,7 @@ test_mongoc_client_pool_min_size_zero (void)
    mongoc_uri_t *uri;
 
    uri = mongoc_uri_new (NULL);
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
 
    client1 = mongoc_client_pool_pop (pool);
    client2 = mongoc_client_pool_pop (pool);
@@ -109,7 +109,7 @@ test_mongoc_client_pool_min_size_dispose (void)
 
    capture_logs (true);
    uri = mongoc_uri_new ("mongodb://127.0.0.1/?minpoolsize=2");
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
 
    c0 = mongoc_client_pool_pop (pool);
    BSON_ASSERT (c0);
@@ -173,7 +173,7 @@ test_mongoc_client_pool_set_max_size (void)
    _mongoc_array_init (&conns, sizeof client);
 
    uri = mongoc_uri_new ("mongodb://127.0.0.1/?maxpoolsize=10");
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
 
    for (i = 0; i < 5; i++) {
       client = mongoc_client_pool_pop (pool);
@@ -211,7 +211,7 @@ test_mongoc_client_pool_set_min_size (void)
 
    uri = mongoc_uri_new ("mongodb://127.0.0.1/?maxpoolsize=10&minpoolsize=3");
    capture_logs (true);
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
    ASSERT_CAPTURED_LOG (
       "minpoolsize URI option", MONGOC_LOG_LEVEL_WARNING, "is deprecated");
 
@@ -252,7 +252,7 @@ test_mongoc_client_pool_ssl_disabled (void)
 
    ASSERT (uri);
    capture_logs (true);
-   ASSERT (NULL == mongoc_client_pool_new (uri));
+   ASSERT (NULL == test_framework_client_pool_new (uri));
 
    mongoc_uri_destroy (uri);
 }
@@ -266,7 +266,7 @@ test_mongoc_client_pool_handshake (void)
    mongoc_uri_t *uri;
 
    uri = mongoc_uri_new ("mongodb://127.0.0.1/?maxpoolsize=1");
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
 
 
    ASSERT (mongoc_client_pool_set_appname (pool, "some application"));
@@ -281,7 +281,7 @@ test_mongoc_client_pool_handshake (void)
    mongoc_client_pool_destroy (pool);
 
    /* Make sure that after we pop a client we can't set handshake anymore */
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
 
    client = mongoc_client_pool_pop (pool);
 
@@ -321,7 +321,7 @@ test_client_pool_destroy_without_pushing (void)
    bool ret;
 
    cmd = BCON_NEW ("ping", BCON_INT32 (1));
-   pool = test_framework_client_pool_new ();
+   pool = test_framework_new_default_client_pool ();
    client1 = mongoc_client_pool_pop (pool);
    client2 = mongoc_client_pool_pop (pool);
 
@@ -390,7 +390,7 @@ test_client_pool_create_unused_session (void *context)
    capture_logs (true);
 
    callbacks = mongoc_apm_callbacks_new ();
-   pool = test_framework_client_pool_new ();
+   pool = test_framework_new_default_client_pool ();
    client = mongoc_client_pool_pop (pool);
    session = mongoc_client_start_session (client, NULL, &error);
 
@@ -442,7 +442,7 @@ test_client_pool_max_pool_size_exceeded (void)
    int ret;
 
    uri = mongoc_uri_new ("mongodb://127.0.0.1/?maxpoolsize=1");
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
    args->pool = pool;
    args->nleft = 2;
    bson_mutex_init (&args->mutex);

--- a/src/libmongoc/tests/test-mongoc-client-pool.c
+++ b/src/libmongoc/tests/test-mongoc-client-pool.c
@@ -15,7 +15,7 @@ test_mongoc_client_pool_basic (void)
    mongoc_uri_t *uri;
 
    uri = mongoc_uri_new ("mongodb://127.0.0.1/?maxpoolsize=1");
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
    client = mongoc_client_pool_pop (pool);
    BSON_ASSERT (client);
    mongoc_client_pool_push (pool, client);
@@ -32,7 +32,7 @@ test_mongoc_client_pool_try_pop (void)
    mongoc_uri_t *uri;
 
    uri = mongoc_uri_new ("mongodb://127.0.0.1/?maxpoolsize=1");
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
    client = mongoc_client_pool_pop (pool);
    BSON_ASSERT (client);
    BSON_ASSERT (!mongoc_client_pool_try_pop (pool));
@@ -52,7 +52,7 @@ test_mongoc_client_pool_pop_timeout (void)
 
    uri = mongoc_uri_new (
       "mongodb://127.0.0.1/?maxpoolsize=1&waitqueuetimeoutms=2000");
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
    client = mongoc_client_pool_pop (pool);
    BSON_ASSERT (client);
    start = bson_get_monotonic_time ();
@@ -78,7 +78,7 @@ test_mongoc_client_pool_min_size_zero (void)
    mongoc_uri_t *uri;
 
    uri = mongoc_uri_new (NULL);
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
 
    client1 = mongoc_client_pool_pop (pool);
    client2 = mongoc_client_pool_pop (pool);
@@ -109,7 +109,7 @@ test_mongoc_client_pool_min_size_dispose (void)
 
    capture_logs (true);
    uri = mongoc_uri_new ("mongodb://127.0.0.1/?minpoolsize=2");
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
 
    c0 = mongoc_client_pool_pop (pool);
    BSON_ASSERT (c0);
@@ -173,7 +173,7 @@ test_mongoc_client_pool_set_max_size (void)
    _mongoc_array_init (&conns, sizeof client);
 
    uri = mongoc_uri_new ("mongodb://127.0.0.1/?maxpoolsize=10");
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
 
    for (i = 0; i < 5; i++) {
       client = mongoc_client_pool_pop (pool);
@@ -211,7 +211,7 @@ test_mongoc_client_pool_set_min_size (void)
 
    uri = mongoc_uri_new ("mongodb://127.0.0.1/?maxpoolsize=10&minpoolsize=3");
    capture_logs (true);
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
    ASSERT_CAPTURED_LOG (
       "minpoolsize URI option", MONGOC_LOG_LEVEL_WARNING, "is deprecated");
 
@@ -252,7 +252,7 @@ test_mongoc_client_pool_ssl_disabled (void)
 
    ASSERT (uri);
    capture_logs (true);
-   ASSERT (NULL == test_framework_client_pool_new (uri));
+   ASSERT (NULL == test_framework_client_pool_new_from_uri (uri));
 
    mongoc_uri_destroy (uri);
 }
@@ -266,7 +266,7 @@ test_mongoc_client_pool_handshake (void)
    mongoc_uri_t *uri;
 
    uri = mongoc_uri_new ("mongodb://127.0.0.1/?maxpoolsize=1");
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
 
 
    ASSERT (mongoc_client_pool_set_appname (pool, "some application"));
@@ -281,7 +281,7 @@ test_mongoc_client_pool_handshake (void)
    mongoc_client_pool_destroy (pool);
 
    /* Make sure that after we pop a client we can't set handshake anymore */
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
 
    client = mongoc_client_pool_pop (pool);
 
@@ -442,7 +442,7 @@ test_client_pool_max_pool_size_exceeded (void)
    int ret;
 
    uri = mongoc_uri_new ("mongodb://127.0.0.1/?maxpoolsize=1");
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
    args->pool = pool;
    args->nleft = 2;
    bson_mutex_init (&args->mutex);

--- a/src/libmongoc/tests/test-mongoc-client-session.c
+++ b/src/libmongoc/tests/test-mongoc-client-session.c
@@ -446,7 +446,7 @@ _test_mock_end_sessions (bool pooled)
    mock_server_run (server);
 
    if (pooled) {
-      pool = test_framework_client_pool_new (mock_server_get_uri (server));
+      pool = test_framework_client_pool_new_from_uri (mock_server_get_uri (server));
       client = mongoc_client_pool_pop (pool);
    } else {
       client =

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -1716,7 +1716,7 @@ _reset (mongoc_client_pool_t **pool,
       bson_error_t error;
 
       uri = test_framework_get_uri ();
-      *pool = test_framework_client_pool_new (uri);
+      *pool = test_framework_client_pool_new_from_uri (uri);
       test_framework_set_pool_ssl_opts (*pool);
       *singled_threaded_client = test_framework_client_new_from_uri (uri);
       test_framework_set_ssl_opts (*singled_threaded_client);
@@ -1964,7 +1964,7 @@ _test_multi_threaded (bool external_key_vault)
    int i;
 
    uri = test_framework_get_uri ();
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
    test_framework_set_pool_ssl_opts (pool);
    client = test_framework_client_new_from_uri (uri);
    test_framework_set_ssl_opts (client);

--- a/src/libmongoc/tests/test-mongoc-client.c
+++ b/src/libmongoc/tests/test-mongoc-client.c
@@ -50,7 +50,7 @@ test_client_cmd_w_server_id (void)
                                    0 /* arbiters    */);
 
    mock_rs_run (rs);
-   client = mongoc_client_new_from_uri (mock_rs_get_uri (rs));
+   client = test_framework_client_new_from_uri (mock_rs_get_uri (rs));
 
    /* use serverId instead of prefs to select the secondary */
    opts = tmp_bson ("{'serverId': 2, 'readConcern': {'level': 'local'}}");
@@ -95,7 +95,7 @@ test_client_cmd_w_server_id_sharded (void)
 
    server = mock_mongos_new (WIRE_VERSION_MIN);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
 
    opts = tmp_bson ("{'serverId': 1}");
    future = future_client_read_command_with_opts (client,
@@ -132,7 +132,7 @@ test_server_id_option (void *ctx)
    bson_t *cmd;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    cmd = tmp_bson ("{'ping': 1}");
    r = mongoc_client_read_command_with_opts (client,
                                              "test",
@@ -189,7 +189,7 @@ test_client_cmd_w_write_concern (void *ctx)
    bson_error_t error;
 
    opts = bson_new ();
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    mongoc_client_set_error_api (client, 2);
 
    good_wc = mongoc_write_concern_new ();
@@ -263,7 +263,7 @@ test_client_cmd_write_concern (void)
    /* set up client and wire protocol version */
    server = mock_server_with_autoismaster (WIRE_VERSION_MIN);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
 
    /* command with invalid writeConcern */
    cmd = "{'foo' : 1, "
@@ -330,7 +330,7 @@ test_client_cmd_write_concern_fam (void)
 
    server = mock_server_with_autoismaster (WIRE_VERSION_FAM_WRITE_CONCERN - 1);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    wc = mongoc_write_concern_new ();
    mongoc_write_concern_set_w (wc, 2);
    mongoc_client_set_write_concern (client, wc);
@@ -354,7 +354,7 @@ test_client_cmd_write_concern_fam (void)
 
    server = mock_server_with_autoismaster (WIRE_VERSION_FAM_WRITE_CONCERN);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    mongoc_client_set_write_concern (client, wc);
 
    future = future_client_read_write_command_with_opts (
@@ -419,7 +419,7 @@ test_mongoc_client_authenticate (void *context)
    /*
     * Log in as admin.
     */
-   admin_client = test_framework_client_new ();
+   admin_client = test_framework_new_default_client ();
 
    /*
     * Add a user to the test database.
@@ -449,7 +449,7 @@ test_mongoc_client_authenticate (void *context)
    uri_str_no_auth = test_framework_get_uri_str_no_auth ("test");
    uri_str_auth =
       test_framework_add_user_password (uri_str_no_auth, username, "testpass");
-   auth_client = mongoc_client_new (uri_str_auth);
+   auth_client = test_framework_client_new (uri_str_auth);
    test_framework_set_ssl_opts (auth_client);
    collection = mongoc_client_get_collection (auth_client, "test", "test");
    cursor = mongoc_collection_find_with_opts (collection, &q, NULL, NULL);
@@ -499,10 +499,10 @@ test_mongoc_client_authenticate_cached (bool pooled)
    uint32_t server_id;
 
    if (pooled) {
-      pool = test_framework_client_pool_new ();
+      pool = test_framework_new_default_client_pool ();
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = test_framework_client_new ();
+      client = test_framework_new_default_client ();
    }
 
    collection = mongoc_client_get_collection (client, "test", "test");
@@ -593,7 +593,7 @@ test_mongoc_client_authenticate_failure (void *context)
     * Try authenticating with bad user.
     */
    bson_init (&q);
-   client = mongoc_client_new (bad_uri_str);
+   client = test_framework_client_new (bad_uri_str);
    test_framework_set_ssl_opts (client);
 
    collection = mongoc_client_get_collection (client, "test", "test");
@@ -656,7 +656,7 @@ test_mongoc_client_authenticate_timeout (void *context)
    mongoc_uri_set_username (uri, "user");
    mongoc_uri_set_password (uri, "password");
    mongoc_uri_set_option_as_int32 (uri, "socketTimeoutMS", 10);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
 
    future = future_client_command_simple (
       client, "test", tmp_bson ("{'ping': 1}"), NULL, &reply, &error);
@@ -716,7 +716,7 @@ test_wire_version (void)
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_int32 (uri, "heartbeatFrequencyMS", 500);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    collection = mongoc_client_get_collection (client, "test", "test");
 
    cursor = mongoc_collection_find_with_opts (collection, &q, NULL, NULL);
@@ -782,7 +782,7 @@ test_mongoc_client_command (void)
    bool r;
    bson_t cmd = BSON_INITIALIZER;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    bson_append_int32 (&cmd, "ping", 4, 1);
@@ -818,7 +818,7 @@ test_mongoc_client_command_defaults (void)
    read_concern = mongoc_read_concern_new ();
    mongoc_read_concern_set_level (read_concern, "majority");
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    mongoc_client_set_read_prefs (client, read_prefs);
    mongoc_client_set_read_concern (client, read_concern);
 
@@ -861,7 +861,7 @@ test_mongoc_client_command_secondary (void)
 
    capture_logs (true);
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    BSON_APPEND_INT32 (&cmd, "invalid_command_here", 1);
@@ -908,10 +908,10 @@ _test_command_read_prefs (bool simple, bool pooled)
    mongoc_uri_set_read_prefs_t (uri, secondary_pref);
 
    if (pooled) {
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
    }
 
    ASSERT_CMPINT (
@@ -1030,7 +1030,7 @@ test_command_not_found (void)
    bson_error_t error;
    mongoc_cursor_t *cursor;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    cursor = mongoc_client_command (client,
                                    "test",
                                    MONGOC_QUERY_NONE,
@@ -1058,7 +1058,7 @@ test_command_not_found_simple (void)
    bson_t reply;
    bson_error_t error;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (!mongoc_client_command_simple (
       client, "test", tmp_bson ("{'foo': 1}"), NULL, &reply, &error));
 
@@ -1084,7 +1084,7 @@ test_command_with_opts_read_prefs (void)
 
    server = mock_mongos_new (WIRE_VERSION_READ_CONCERN);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    read_prefs = mongoc_read_prefs_new (MONGOC_READ_SECONDARY);
    mongoc_client_set_read_prefs (client, read_prefs);
 
@@ -1160,7 +1160,7 @@ test_read_write_cmd_with_opts (void)
                                    0 /* arbiters */);
 
    mock_rs_run (rs);
-   client = mongoc_client_new_from_uri (mock_rs_get_uri (rs));
+   client = test_framework_client_new_from_uri (mock_rs_get_uri (rs));
    secondary = mongoc_read_prefs_new (MONGOC_READ_SECONDARY);
 
    /* mongoc_client_read_write_command_with_opts must ignore read prefs
@@ -1200,7 +1200,7 @@ test_command_with_opts_legacy (void)
 
    server = mock_mongos_new (WIRE_VERSION_MIN);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
 
    wc = mongoc_write_concern_new ();
    mongoc_write_concern_set_w (wc, 2);
@@ -1270,7 +1270,7 @@ test_read_command_with_opts (void)
 
    server = mock_mongos_new (5);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
 
    /* collation allowed */
    cmd = tmp_bson ("{'create': 'db'}");
@@ -1397,7 +1397,7 @@ test_command_with_opts (void)
    server = mock_mongos_new (5);
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
 
    /* client's write concern, read concern, read prefs are ignored */
    wc = mongoc_write_concern_new ();
@@ -1483,7 +1483,7 @@ test_command_with_opts_op_msg (void)
 
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
 
    /* client's write concern, read concern, read prefs are ignored */
    wc = mongoc_write_concern_new ();
@@ -1553,7 +1553,7 @@ test_command_empty (void)
    bson_error_t error;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    r = mongoc_client_command_simple (
       client, "admin", tmp_bson ("{}"), NULL, NULL, &error);
 
@@ -1602,7 +1602,7 @@ test_command_no_errmsg (void)
 
    server = mock_server_with_autoismaster (WIRE_VERSION_MIN);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    mongoc_client_set_error_api (client, 2);
 
    cmd = tmp_bson ("{'command': 1}");
@@ -1673,7 +1673,7 @@ test_unavailable_seeds (void)
                           mock_server_get_host_and_port (servers[1]));
 
    for (i = 0; i < (sizeof (uri_strs) / sizeof (const char *)); i++) {
-      client = mongoc_client_new (uri_strs[i]);
+      client = test_framework_client_new (uri_strs[i]);
       BSON_ASSERT (client);
 
       collection = mongoc_client_get_collection (client, "test", "test");
@@ -1791,10 +1791,10 @@ test_seed_list (bool rs, connection_option_t connection_option, bool pooled)
    mock_server_autoresponds (server, responder, NULL, NULL);
 
    if (pooled) {
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
    }
 
    topology = client->topology;
@@ -1995,7 +1995,7 @@ test_recovering (void *ctx)
 
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_utf8 (uri, "replicaSet", "rs");
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    prefs = mongoc_read_prefs_new (MONGOC_READ_PRIMARY);
 
    /* recovering member matches no read mode */
@@ -2021,7 +2021,7 @@ test_server_status (void)
    bson_iter_t iter;
    bson_t reply;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    BEGIN_IGNORE_DEPRECATIONS
@@ -2050,7 +2050,7 @@ test_get_database_names (void)
    char **names;
 
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    future = future_client_get_database_names_with_opts (client, NULL, &error);
    request =
       mock_server_receives_command (server,
@@ -2122,7 +2122,7 @@ _test_mongoc_client_ipv6 (bool pooled)
 #endif
 
    if (pooled) {
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
 #if (defined(__APPLE__) || defined(_WIN32)) && defined(MONGOC_ENABLE_SSL)
       mongoc_client_pool_set_ssl_opts (pool, &ssl_opts);
 #else
@@ -2130,7 +2130,7 @@ _test_mongoc_client_ipv6 (bool pooled)
 #endif
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
 #if (defined(__APPLE__) || defined(_WIN32)) && defined(MONGOC_ENABLE_SSL)
       mongoc_client_set_ssl_opts (client, &ssl_opts);
 #else
@@ -2181,7 +2181,7 @@ test_mongoc_client_unix_domain_socket (void *context)
    char *uri_str;
 
    uri_str = test_framework_get_unix_domain_socket_uri_str ();
-   client = mongoc_client_new (uri_str);
+   client = test_framework_client_new (uri_str);
    test_framework_set_ssl_opts (client);
 
    BSON_ASSERT (client);
@@ -2212,7 +2212,7 @@ test_mongoc_client_mismatched_me (void)
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_utf8 (uri, "replicaSet", "rs");
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    prefs = mongoc_read_prefs_new (MONGOC_READ_SECONDARY);
 
    /* any operation should fail with server selection error */
@@ -2286,11 +2286,11 @@ _test_mongoc_client_ssl_opts (bool pooled)
       }
 
       if (pooled) {
-         pool = mongoc_client_pool_new (uri);
+         pool = test_framework_client_pool_new (uri);
          mongoc_client_pool_set_ssl_opts (pool, ssl_opts);
          client = mongoc_client_pool_pop (pool);
       } else {
-         client = mongoc_client_new_from_uri (uri);
+         client = test_framework_client_new_from_uri (uri);
          mongoc_client_set_ssl_opts (client, ssl_opts);
       }
 
@@ -2346,7 +2346,7 @@ test_client_buildinfo_hang (void)
    bson_t command;
    bson_t reply;
 
-   pool = test_framework_client_pool_new ();
+   pool = test_framework_new_default_client_pool ();
    BSON_ASSERT (pool);
    client = mongoc_client_pool_pop (pool);
 
@@ -2372,7 +2372,7 @@ static void
 test_mongoc_client_ssl_disabled (void)
 {
    capture_logs (true);
-   ASSERT (NULL == mongoc_client_new ("mongodb://host/?ssl=true"));
+   ASSERT (NULL == test_framework_client_new ("mongodb://host/?ssl=true"));
 }
 #endif
 
@@ -2390,10 +2390,10 @@ _test_mongoc_client_get_description (bool pooled)
    mongoc_host_list_t host;
 
    if (pooled) {
-      pool = test_framework_client_pool_new ();
+      pool = test_framework_new_default_client_pool ();
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = test_framework_client_new ();
+      client = test_framework_new_default_client ();
    }
 
    /* bad server_id handled correctly */
@@ -2453,7 +2453,7 @@ test_mongoc_client_descriptions_single (void)
    /*
     * single-threaded
     */
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
 
    /* before connecting */
    sds = mongoc_client_get_server_descriptions (client, &n);
@@ -2485,7 +2485,7 @@ test_mongoc_client_descriptions_pooled (void *unused)
    /*
     * pooled
     */
-   pool = test_framework_client_pool_new ();
+   pool = test_framework_new_default_client_pool ();
    client = mongoc_client_pool_pop (pool);
 
    /* wait for background thread to discover all members */
@@ -2522,10 +2522,10 @@ _test_mongoc_client_select_server (bool pooled)
    mongoc_read_prefs_t *prefs;
 
    if (pooled) {
-      pool = test_framework_client_pool_new ();
+      pool = test_framework_new_default_client_pool ();
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = test_framework_client_new ();
+      client = test_framework_new_default_client ();
    }
 
    sd = mongoc_client_select_server (client,
@@ -2620,11 +2620,11 @@ _test_mongoc_client_select_server_error (bool pooled)
    if (pooled) {
       uri = test_framework_get_uri ();
       mongoc_uri_set_option_as_int32 (uri, "serverSelectionTimeoutMS", 3000);
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
       test_framework_set_pool_ssl_opts (pool);
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = test_framework_client_new ();
+      client = test_framework_new_default_client ();
       test_framework_set_ssl_opts (client);
    }
 
@@ -2713,7 +2713,7 @@ _test_mongoc_client_select_server_retry (bool retry_succeeds)
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_utf8 (uri, "replicaSet", "rs");
    mongoc_uri_set_option_as_int32 (uri, "socketCheckIntervalMS", 50);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
 
    /* first selection succeeds */
    future = future_client_select_server (client, true, NULL, &error);
@@ -2792,7 +2792,7 @@ _test_mongoc_client_fetch_stream_retry (bool retry_succeeds)
       "{'ok': 1, 'ismaster': true, 'minWireVersion': 2, 'maxWireVersion': 5}");
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_int32 (uri, "socketCheckIntervalMS", 50);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
 
    /* first time succeeds */
    future = future_client_command_simple (
@@ -2917,11 +2917,12 @@ test_client_set_ssl_copies_args (bool pooled)
 
    if (pooled) {
       capture_logs (true);
-      pool = mongoc_client_pool_new (mock_server_get_uri (server));
+      pool = test_framework_client_pool_new (mock_server_get_uri (server));
       mongoc_client_pool_set_ssl_opts (pool, &client_opts);
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+      client =
+         test_framework_client_new_from_uri (mock_server_get_uri (server));
       mongoc_client_set_ssl_opts (client, &client_opts);
    }
 
@@ -2983,11 +2984,11 @@ _test_ssl_reconnect (bool pooled)
 
    if (pooled) {
       capture_logs (true);
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
       mongoc_client_pool_set_ssl_opts (pool, &client_opts);
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
       mongoc_client_set_ssl_opts (client, &client_opts);
    }
 
@@ -3051,7 +3052,7 @@ test_mongoc_client_application_handshake (void)
    const char *short_string = "hallo thar";
    mongoc_client_t *client;
 
-   client = mongoc_client_new ("mongodb://example");
+   client = test_framework_client_new ("mongodb://example");
 
    memset (big_string, 'a', BUFFER_SIZE - 1);
    big_string[BUFFER_SIZE - 1] = '\0';
@@ -3145,7 +3146,7 @@ test_mongoc_handshake_pool (void)
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    ASSERT (mongoc_uri_set_appname (uri, BSON_FUNC));
 
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
 
    client1 = mongoc_client_pool_pop (pool);
    request1 = mock_server_receives_ismaster (server);
@@ -3200,12 +3201,12 @@ _test_client_sends_handshake (bool pooled)
    mongoc_uri_set_option_as_int32 (uri, "connectTimeoutMS", 100);
 
    if (pooled) {
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
 
       /* Pop a client to trigger the topology scanner */
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
       future = _force_ismaster_with_ping (client, heartbeat_ms);
    }
 
@@ -3318,13 +3319,13 @@ test_client_appname (bool pooled, bool use_uri)
    }
 
    if (pooled) {
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
       if (!use_uri) {
          ASSERT (mongoc_client_pool_set_appname (pool, "testapp"));
       }
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
       if (!use_uri) {
          ASSERT (mongoc_client_set_appname (client, "testapp"));
       }
@@ -3405,10 +3406,10 @@ _test_null_error_pointer (bool pooled)
    mongoc_uri_set_option_as_int32 (uri, "serverSelectionTimeoutMS", 1000);
 
    if (pooled) {
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
    }
 
    /* connect */
@@ -3495,7 +3496,7 @@ test_client_reset_sessions (void)
 
    server = mock_mongos_new (WIRE_VERSION_OP_MSG);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
 
    ASSERT (client->generation == 0);
 
@@ -3566,7 +3567,7 @@ test_client_reset_cursors (void)
 
    server = mock_server_with_autoismaster (WIRE_VERSION_KILLCURSORS_CMD);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
 
    /* Ensure that cursors with an old client generation don't send killCursors.
       This test should timeout and fail if the client does send killCursors. */
@@ -3667,7 +3668,7 @@ test_client_reset_connections (void)
       heartbeat frequency high, so a background scan won't interfere. */
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_int32 (uri, "heartbeatFrequencyMS", 99999);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
 
    database = mongoc_client_get_database (client, "admin");
    future = future_database_command_simple (
@@ -3705,7 +3706,7 @@ test_get_database (void)
    mongoc_read_concern_t *rc;
    mongoc_read_prefs_t *read_prefs;
 
-   client = mongoc_client_new (NULL);
+   client = test_framework_client_new (NULL);
 
    wc = mongoc_write_concern_new ();
    mongoc_write_concern_set_w (wc, 2);
@@ -3739,7 +3740,7 @@ test_invalid_server_id (void)
    bson_error_t error;
    bool ret;
 
-   client = mongoc_client_new ("mongodb://localhost");
+   client = test_framework_client_new ("mongodb://localhost");
    ret = mongoc_client_command_simple_with_server_id (client,
                                                       "admin",
                                                       tmp_bson ("{'ping': 1}"),
@@ -3767,7 +3768,7 @@ test_ssl_opts_override (void)
 
    uri = mongoc_uri_new (
       "mongodb://localhost:27017/?tls=true&tlsDisableOCSPEndpointCheck=true");
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    ssl_opts.allow_invalid_hostname = true;
    mongoc_client_set_ssl_opts (client, &ssl_opts);
    BSON_ASSERT (client->ssl_opts.allow_invalid_hostname);
@@ -3785,7 +3786,7 @@ test_ssl_opts_padding_not_null (void)
 
    ssl_opt.allow_invalid_hostname = true;
    ssl_opt.internal = (void *) 123;
-   client = mongoc_client_new ("mongodb://localhost:27017");
+   client = test_framework_client_new ("mongodb://localhost:27017");
    mongoc_client_set_ssl_opts (client, &ssl_opt);
    BSON_ASSERT (client->ssl_opts.internal == NULL);
    mongoc_client_destroy (client);
@@ -3808,7 +3809,7 @@ test_mongoc_client_recv_network_error (void)
 
    server = mock_server_with_autoismaster (WIRE_VERSION_MAX);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
 
    future = future_client_command_simple (client,
                                           "admin",
@@ -3858,7 +3859,7 @@ test_mongoc_client_timeout_ms (void)
 {
    mongoc_client_t *client;
 
-   client = mongoc_client_new ("mongodb://localhost");
+   client = test_framework_client_new ("mongodb://localhost");
 
    /* no timeout returns -1 */
    BSON_ASSERT (mongoc_client_get_timeout_ms (client) ==

--- a/src/libmongoc/tests/test-mongoc-client.c
+++ b/src/libmongoc/tests/test-mongoc-client.c
@@ -908,7 +908,7 @@ _test_command_read_prefs (bool simple, bool pooled)
    mongoc_uri_set_read_prefs_t (uri, secondary_pref);
 
    if (pooled) {
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
       client = mongoc_client_pool_pop (pool);
    } else {
       client = test_framework_client_new_from_uri (uri);
@@ -1791,7 +1791,7 @@ test_seed_list (bool rs, connection_option_t connection_option, bool pooled)
    mock_server_autoresponds (server, responder, NULL, NULL);
 
    if (pooled) {
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
       client = mongoc_client_pool_pop (pool);
    } else {
       client = test_framework_client_new_from_uri (uri);
@@ -2122,7 +2122,7 @@ _test_mongoc_client_ipv6 (bool pooled)
 #endif
 
    if (pooled) {
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
 #if (defined(__APPLE__) || defined(_WIN32)) && defined(MONGOC_ENABLE_SSL)
       mongoc_client_pool_set_ssl_opts (pool, &ssl_opts);
 #else
@@ -2286,7 +2286,7 @@ _test_mongoc_client_ssl_opts (bool pooled)
       }
 
       if (pooled) {
-         pool = test_framework_client_pool_new (uri);
+         pool = test_framework_client_pool_new_from_uri (uri);
          mongoc_client_pool_set_ssl_opts (pool, ssl_opts);
          client = mongoc_client_pool_pop (pool);
       } else {
@@ -2620,7 +2620,7 @@ _test_mongoc_client_select_server_error (bool pooled)
    if (pooled) {
       uri = test_framework_get_uri ();
       mongoc_uri_set_option_as_int32 (uri, "serverSelectionTimeoutMS", 3000);
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
       test_framework_set_pool_ssl_opts (pool);
       client = mongoc_client_pool_pop (pool);
    } else {
@@ -2917,7 +2917,7 @@ test_client_set_ssl_copies_args (bool pooled)
 
    if (pooled) {
       capture_logs (true);
-      pool = test_framework_client_pool_new (mock_server_get_uri (server));
+      pool = test_framework_client_pool_new_from_uri (mock_server_get_uri (server));
       mongoc_client_pool_set_ssl_opts (pool, &client_opts);
       client = mongoc_client_pool_pop (pool);
    } else {
@@ -2984,7 +2984,7 @@ _test_ssl_reconnect (bool pooled)
 
    if (pooled) {
       capture_logs (true);
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
       mongoc_client_pool_set_ssl_opts (pool, &client_opts);
       client = mongoc_client_pool_pop (pool);
    } else {
@@ -3146,7 +3146,7 @@ test_mongoc_handshake_pool (void)
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    ASSERT (mongoc_uri_set_appname (uri, BSON_FUNC));
 
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
 
    client1 = mongoc_client_pool_pop (pool);
    request1 = mock_server_receives_ismaster (server);
@@ -3201,7 +3201,7 @@ _test_client_sends_handshake (bool pooled)
    mongoc_uri_set_option_as_int32 (uri, "connectTimeoutMS", 100);
 
    if (pooled) {
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
 
       /* Pop a client to trigger the topology scanner */
       client = mongoc_client_pool_pop (pool);
@@ -3319,7 +3319,7 @@ test_client_appname (bool pooled, bool use_uri)
    }
 
    if (pooled) {
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
       if (!use_uri) {
          ASSERT (mongoc_client_pool_set_appname (pool, "testapp"));
       }
@@ -3406,7 +3406,7 @@ _test_null_error_pointer (bool pooled)
    mongoc_uri_set_option_as_int32 (uri, "serverSelectionTimeoutMS", 1000);
 
    if (pooled) {
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
       client = mongoc_client_pool_pop (pool);
    } else {
       client = test_framework_client_new_from_uri (uri);

--- a/src/libmongoc/tests/test-mongoc-cluster.c
+++ b/src/libmongoc/tests/test-mongoc-cluster.c
@@ -170,7 +170,7 @@ _test_cluster_node_disconnect (bool pooled)
    uri = mongoc_uri_copy (mock_server_get_uri (server));
 
    if (pooled) {
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
       client = mongoc_client_pool_pop (pool);
    } else {
       client = test_framework_client_new_from_uri (uri);
@@ -244,7 +244,7 @@ _test_cluster_command_timeout (bool pooled)
    mongoc_uri_set_option_as_int32 (uri, "socketTimeoutMS", 200);
 
    if (pooled) {
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
       client = mongoc_client_pool_pop (pool);
    } else {
       client = test_framework_client_new_from_uri (uri);
@@ -916,7 +916,7 @@ _test_cluster_time_comparison (bool pooled)
    mongoc_uri_set_option_as_int32 (uri, "heartbeatFrequencyMS", 500);
 
    if (pooled) {
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
       client = mongoc_client_pool_pop (pool);
    } else {
       client = test_framework_client_new_from_uri (uri);
@@ -1051,7 +1051,7 @@ _test_not_master (bool pooled,
    mock_server_run (server);
 
    if (pooled) {
-      pool = test_framework_client_pool_new (mock_server_get_uri (server));
+      pool = test_framework_client_pool_new_from_uri (mock_server_get_uri (server));
       client = mongoc_client_pool_pop (pool);
    } else {
       client =
@@ -1453,7 +1453,7 @@ _test_cluster_ismaster_fails (bool hangup)
    uri = mongoc_uri_copy (mock_server_get_uri (mock_server));
    /* increase heartbeatFrequencyMS to prevent background server selection. */
    mongoc_uri_set_option_as_int32 (uri, "heartbeatFrequencyMS", 99999);
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
    mongoc_client_pool_set_error_api (pool, 2);
    mongoc_uri_destroy (uri);
    client = mongoc_client_pool_pop (pool);
@@ -1708,7 +1708,7 @@ _test_ismaster_on_unknown (char *ismaster)
     * The host will get removed on the first failed ismaster. */
    ret = mongoc_uri_upsert_host (uri, "localhost", 12345, &error);
    ASSERT_OR_PRINT (ret, error);
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
 
    client = mongoc_client_pool_pop (pool);
 
@@ -1762,7 +1762,7 @@ _test_cmd_on_unknown_serverid (bool pooled)
    mongoc_uri_set_option_as_int32 (uri, MONGOC_URI_HEARTBEATFREQUENCYMS, 99999);
 
    if (pooled) {
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
       test_framework_set_pool_ssl_opts (pool);
       client = mongoc_client_pool_pop (pool);
    } else {

--- a/src/libmongoc/tests/test-mongoc-cluster.c
+++ b/src/libmongoc/tests/test-mongoc-cluster.c
@@ -47,7 +47,7 @@ test_get_max_bson_obj_size (void)
    uint32_t id;
 
    /* single-threaded */
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    id = server_id_for_reads (&client->cluster);
@@ -60,7 +60,7 @@ test_get_max_bson_obj_size (void)
    mongoc_client_destroy (client);
 
    /* multi-threaded */
-   pool = test_framework_client_pool_new ();
+   pool = test_framework_new_default_client_pool ();
    client = mongoc_client_pool_pop (pool);
 
    id = server_id_for_reads (&client->cluster);
@@ -84,7 +84,7 @@ test_get_max_msg_size (void)
    uint32_t id;
 
    /* single-threaded */
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    id = server_id_for_reads (&client->cluster);
 
    sd = (mongoc_server_description_t *) mongoc_set_get (
@@ -96,7 +96,7 @@ test_get_max_msg_size (void)
    mongoc_client_destroy (client);
 
    /* multi-threaded */
-   pool = test_framework_client_pool_new ();
+   pool = test_framework_new_default_client_pool ();
    client = mongoc_client_pool_pop (pool);
 
    id = server_id_for_reads (&client->cluster);
@@ -170,10 +170,10 @@ _test_cluster_node_disconnect (bool pooled)
    uri = mongoc_uri_copy (mock_server_get_uri (server));
 
    if (pooled) {
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
    }
 
    collection = mongoc_client_get_collection (client, "test", "test");
@@ -244,10 +244,10 @@ _test_cluster_command_timeout (bool pooled)
    mongoc_uri_set_option_as_int32 (uri, "socketTimeoutMS", 200);
 
    if (pooled) {
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
    }
 
    /* server doesn't respond in time */
@@ -335,7 +335,7 @@ _test_write_disconnect (void)
 
    server = mock_server_new ();
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
 
    /*
     * establish connection with an "ismaster" and "ping"
@@ -436,7 +436,7 @@ test_cluster_command_notmaster (void)
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_utf8 (uri, "replicaSet", "rs");
 
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
 
    collection = mongoc_client_get_collection (client, "db", "test");
    /* use an unordered bulk write, so it attempts to continue on error */
@@ -578,7 +578,7 @@ _test_cluster_time (bool pooled, command_fn_t command)
                                         test_cluster_time_cmd_succeeded_cb);
 
    if (pooled) {
-      pool = test_framework_client_pool_new ();
+      pool = test_framework_new_default_client_pool ();
       mongoc_client_pool_set_apm_callbacks (
          pool, callbacks, &cluster_time_test);
       client = mongoc_client_pool_pop (pool);
@@ -586,7 +586,7 @@ _test_cluster_time (bool pooled, command_fn_t command)
        * the test operations. */
       _mongoc_usleep (5000 * 1000); /* 5 s */
    } else {
-      client = test_framework_client_new ();
+      client = test_framework_new_default_client ();
       mongoc_client_set_apm_callbacks (client, callbacks, &cluster_time_test);
    }
 
@@ -916,10 +916,10 @@ _test_cluster_time_comparison (bool pooled)
    mongoc_uri_set_option_as_int32 (uri, "heartbeatFrequencyMS", 500);
 
    if (pooled) {
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
    }
 
    future = future_ping (client, &error);
@@ -1051,10 +1051,11 @@ _test_not_master (bool pooled,
    mock_server_run (server);
 
    if (pooled) {
-      pool = mongoc_client_pool_new (mock_server_get_uri (server));
+      pool = test_framework_client_pool_new (mock_server_get_uri (server));
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+      client =
+         test_framework_client_new_from_uri (mock_server_get_uri (server));
    }
 
    td = &client->topology->description;
@@ -1288,7 +1289,7 @@ _test_dollar_query (void *ctx)
    mock_server_autoresponds (server, auto_ismaster, test, NULL);
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
    if (test->secondary) {
       read_prefs = mongoc_read_prefs_new (MONGOC_READ_SECONDARY);
@@ -1452,7 +1453,7 @@ _test_cluster_ismaster_fails (bool hangup)
    uri = mongoc_uri_copy (mock_server_get_uri (mock_server));
    /* increase heartbeatFrequencyMS to prevent background server selection. */
    mongoc_uri_set_option_as_int32 (uri, "heartbeatFrequencyMS", 99999);
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
    mongoc_client_pool_set_error_api (pool, 2);
    mongoc_uri_destroy (uri);
    client = mongoc_client_pool_pop (pool);
@@ -1520,7 +1521,7 @@ _test_cluster_command_error (bool use_op_msg)
       server = mock_server_with_autoismaster (WIRE_VERSION_OP_MSG - 1);
    }
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    future = future_client_command_simple (client,
                                           "db",
                                           tmp_bson ("{'ping': 1}"),
@@ -1592,7 +1593,7 @@ test_advanced_cluster_time_not_sent_to_standalone (void)
                               " 'maxWireVersion': 6,"
                               " 'logicalSessionTimeoutMinutes': 30}");
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
 
    cs = mongoc_client_start_session (client, NULL, &error);
    ASSERT_OR_PRINT (cs, error);
@@ -1707,7 +1708,7 @@ _test_ismaster_on_unknown (char *ismaster)
     * The host will get removed on the first failed ismaster. */
    ret = mongoc_uri_upsert_host (uri, "localhost", 12345, &error);
    ASSERT_OR_PRINT (ret, error);
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
 
    client = mongoc_client_pool_pop (pool);
 
@@ -1761,12 +1762,12 @@ _test_cmd_on_unknown_serverid (bool pooled)
    mongoc_uri_set_option_as_int32 (uri, MONGOC_URI_HEARTBEATFREQUENCYMS, 99999);
 
    if (pooled) {
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
       test_framework_set_pool_ssl_opts (pool);
       client = mongoc_client_pool_pop (pool);
    } else {
       pool = NULL;
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
       test_framework_set_ssl_opts (client);
    }
 

--- a/src/libmongoc/tests/test-mongoc-cmd.c
+++ b/src/libmongoc/tests/test-mongoc-cmd.c
@@ -43,7 +43,7 @@ test_client_cmd_options (void)
 
    server = mock_server_with_autoismaster (WIRE_VERSION_OP_MSG);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
 
    rc = mongoc_read_concern_new ();
    mongoc_read_concern_set_level (rc, MONGOC_READ_CONCERN_LEVEL_MAJORITY);

--- a/src/libmongoc/tests/test-mongoc-cmd.c
+++ b/src/libmongoc/tests/test-mongoc-cmd.c
@@ -22,6 +22,7 @@
 #include "test-conveniences.h"
 #include "mock_server/mock-server.h"
 #include "mock_server/future-functions.h"
+#include "test-libmongoc.h"
 
 #undef MONGOC_LOG_DOMAIN
 #define MONGOC_LOG_DOMAIN "cmd-test-options"

--- a/src/libmongoc/tests/test-mongoc-collection-find-with-opts.c
+++ b/src/libmongoc/tests/test-mongoc-collection-find-with-opts.c
@@ -60,7 +60,7 @@ _test_collection_op_query_or_find_command (
 
    server = mock_server_with_autoismaster (max_wire_version);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
    cursor = mongoc_collection_find_with_opts (collection,
                                               test_data->filter_bson,
@@ -578,7 +578,7 @@ test_exhaust (void)
 
    server = mock_server_with_autoismaster (WIRE_VERSION_FIND_CMD);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
    cursor = mongoc_collection_find_with_opts (
       collection, tmp_bson (NULL), tmp_bson ("{'exhaust': true}"), NULL);
@@ -631,7 +631,7 @@ test_getmore_cmd_await (void)
     */
    server = mock_server_with_autoismaster (WIRE_VERSION_FIND_CMD);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
    cursor = mongoc_collection_find_with_opts (
       collection, tmp_bson (NULL), opts, NULL);
@@ -708,7 +708,7 @@ test_find_w_server_id (void)
                                    0 /* arbiters     */);
 
    mock_rs_run (rs);
-   client = mongoc_client_new_from_uri (mock_rs_get_uri (rs));
+   client = test_framework_client_new_from_uri (mock_rs_get_uri (rs));
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    /* use serverId instead of prefs to select the secondary */
@@ -752,7 +752,7 @@ test_find_cmd_w_server_id (void)
                                    0 /* arbiters     */);
 
    mock_rs_run (rs);
-   client = mongoc_client_new_from_uri (mock_rs_get_uri (rs));
+   client = test_framework_client_new_from_uri (mock_rs_get_uri (rs));
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    /* use serverId instead of prefs to select the secondary */
@@ -805,7 +805,7 @@ test_find_w_server_id_sharded (void)
 
    server = mock_mongos_new (WIRE_VERSION_MIN);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    opts = tmp_bson ("{'serverId': 1}");
@@ -845,7 +845,7 @@ test_find_cmd_w_server_id_sharded (void)
 
    server = mock_mongos_new (WIRE_VERSION_READ_CONCERN);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    opts = tmp_bson ("{'serverId': 1, 'readConcern': {'level': 'local'}}");
@@ -890,7 +890,7 @@ test_server_id_option (void)
    bson_error_t error;
    mongoc_cursor_t *cursor;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = mongoc_client_get_collection (client, "db", "collection");
    q = tmp_bson (NULL);
    cursor = mongoc_collection_find_with_opts (
@@ -932,7 +932,7 @@ test_find_with_opts_collation_error (void *ctx)
    bson_error_t error;
    mongoc_cursor_t *cursor;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = mongoc_client_get_collection (client, "db", "collection");
    q = tmp_bson (NULL);
    opts = tmp_bson ("{'collation': {'locale': 'is'}}");

--- a/src/libmongoc/tests/test-mongoc-collection-find.c
+++ b/src/libmongoc/tests/test-mongoc-collection-find.c
@@ -111,7 +111,7 @@ _test_collection_find_live (test_collection_find_t *test_data)
    bson_error_t error;
    mongoc_cursor_t *cursor;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    database = mongoc_client_get_database (client, "test");
    collection_name = gen_collection_name ("test");
    collection = mongoc_database_create_collection (
@@ -197,7 +197,7 @@ _test_collection_op_query_or_find_command (test_collection_find_t *test_data,
 
    server = mock_server_with_autoismaster (max_wire_version);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
    cursor = mongoc_collection_find (collection,
                                     test_data->flags,
@@ -811,7 +811,7 @@ test_exhaust (void)
 
    server = mock_server_with_autoismaster (WIRE_VERSION_FIND_CMD);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
    cursor = mongoc_collection_find (
       collection, MONGOC_QUERY_EXHAUST, 0, 0, 0, tmp_bson (NULL), NULL, NULL);
@@ -860,7 +860,7 @@ test_getmore_batch_size (void)
 
    server = mock_server_with_autoismaster (4);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    for (i = 0; i < sizeof (batch_sizes) / sizeof (uint32_t); i++) {
@@ -930,7 +930,7 @@ test_getmore_invalid_reply (void *ctx)
 
    server = mock_server_with_autoismaster (4);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    cursor = mongoc_collection_find (
@@ -1007,7 +1007,7 @@ test_getmore_await (void)
 
    server = mock_server_with_autoismaster (4);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    for (i = 3; i < sizeof (await_tests) / sizeof (await_test_t); i++) {
@@ -1112,10 +1112,10 @@ _test_tailable_timeout (bool pooled)
    capture_logs (true);
 
    if (pooled) {
-      pool = test_framework_client_pool_new ();
+      pool = test_framework_new_default_client_pool ();
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = test_framework_client_new ();
+      client = test_framework_new_default_client ();
    }
 
    database = mongoc_client_get_database (client, "test");

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -38,7 +38,7 @@ test_aggregate_w_write_concern (void *ctx)
    bad_wc = mongoc_write_concern_new ();
    opts = bson_new ();
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
    ASSERT (mongoc_client_set_error_api (client, 2));
 
@@ -102,7 +102,7 @@ test_aggregate_inherit_collection (void)
 
    server = mock_server_with_autoismaster (WIRE_VERSION_MAX_STALENESS);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
 
 
@@ -249,7 +249,8 @@ _batch_size_test (bson_t *pipeline,
    mock_server = mock_server_with_autoismaster (WIRE_VERSION_MAX);
    mock_server_run (mock_server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (mock_server));
+   client =
+      test_framework_client_new_from_uri (mock_server_get_uri (mock_server));
    coll = mongoc_client_get_collection (client, "db", "coll");
 
    cursor = mongoc_collection_aggregate (
@@ -331,7 +332,7 @@ test_read_prefs_is_valid (void *ctx)
    mongoc_read_prefs_t *read_prefs;
    bson_t reply;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    database = get_test_database (client);
@@ -494,7 +495,7 @@ test_copy (void)
    mongoc_collection_t *copy;
    mongoc_client_t *client;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    database = get_test_database (client);
@@ -529,7 +530,7 @@ test_insert (void)
    bson_t b;
 
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    database = get_test_database (client);
@@ -597,7 +598,7 @@ test_insert_null (void)
    bson_iter_t iter;
    uint32_t len;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    collection =
@@ -672,7 +673,7 @@ test_insert_oversize (void *ctx)
    bool r;
    bson_error_t error;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_insert_oversize");
 
    /* two huge strings make the doc too large */
@@ -711,7 +712,7 @@ test_insert_many (void)
    bson_t reply;
    int64_t count;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    database = get_test_database (client);
@@ -836,7 +837,7 @@ test_insert_bulk_empty (void)
    bson_error_t error;
    bson_t *bptr = NULL;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    database = get_test_database (client);
    collection = get_test_collection (client, "test_insert_bulk_empty");
 
@@ -985,7 +986,7 @@ test_insert_command_keys (void)
    server = mock_server_with_autoismaster (WIRE_VERSION_MIN);
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "test", "test");
    bulk = mongoc_collection_create_bulk_operation_with_opts (collection, NULL);
 
@@ -1027,7 +1028,7 @@ test_save (void)
    bson_t b;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    database = get_test_database (client);
@@ -1093,7 +1094,7 @@ test_regex (void)
    bson_t q = BSON_INITIALIZER;
    bson_t *doc;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    database = get_test_database (client);
@@ -1149,7 +1150,7 @@ test_decimal128 (void *ctx)
    bson_decimal128_t read_decimal;
 
    bson_decimal128_from_string ("-123456789.101112E-120", &decimal128);
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    database = get_test_database (client);
@@ -1213,7 +1214,7 @@ test_update (void)
    bson_t u;
    bson_t set;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    database = get_test_database (client);
@@ -1298,7 +1299,7 @@ test_update_pipeline (void *ctx)
    bson_t *replacement;
    bool res;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    database = get_test_database (client);
@@ -1368,7 +1369,7 @@ test_update_oversize (void *ctx)
    bool r;
    bson_error_t error;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_update_oversize");
 
    /* first test oversized selector. two huge strings make the doc too large */
@@ -1420,7 +1421,7 @@ test_remove (void)
    bson_t b;
    int i;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    database = get_test_database (client);
@@ -1472,7 +1473,7 @@ test_remove_oversize (void *ctx)
    bool r;
    bson_error_t error;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_remove_oversize");
 
    /* two huge strings make the doc too large */
@@ -1503,7 +1504,7 @@ test_insert_w0 (void)
    bson_error_t error;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_insert_w0");
    wc = mongoc_write_concern_new ();
    mongoc_write_concern_set_w (wc, 0);
@@ -1529,7 +1530,7 @@ test_update_w0 (void)
    bson_error_t error;
 
    bool r;
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_update_w0");
    wc = mongoc_write_concern_new ();
    mongoc_write_concern_set_w (wc, 0);
@@ -1559,7 +1560,7 @@ test_remove_w0 (void)
    bson_error_t error;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_remove_w0");
    wc = mongoc_write_concern_new ();
    mongoc_write_concern_set_w (wc, 0);
@@ -1587,7 +1588,7 @@ test_insert_twice_w0 (void)
    bson_error_t error;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_insert_twice_w0");
    wc = mongoc_write_concern_new ();
    mongoc_write_concern_set_w (wc, 0);
@@ -1629,7 +1630,7 @@ test_index (void)
    mongoc_index_opt_init (&opt);
    opts = bson_new ();
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
    mongoc_client_set_error_api (client, 2);
 
@@ -1730,7 +1731,7 @@ test_index_w_write_concern ()
    mongoc_index_opt_init (&opt);
    opts = bson_new ();
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    good_wc = mongoc_write_concern_new ();
@@ -1861,7 +1862,7 @@ test_index_compound (void)
 
    mongoc_index_opt_init (&opt);
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    database = get_test_database (client);
@@ -1909,7 +1910,7 @@ test_index_geo (void *unused)
    mongoc_index_opt_init (&opt);
    mongoc_index_opt_geo_init (&geo_opt);
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    database = get_test_database (client);
@@ -2018,7 +2019,7 @@ test_index_storage (void)
    bson_t keys;
    char *engine = NULL;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    /* Skip unless we are on WT */
@@ -2069,7 +2070,7 @@ test_count (void)
    int64_t count;
    bson_t b;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    collection = mongoc_client_get_collection (client, "test", "test");
@@ -2103,7 +2104,7 @@ test_count_read_pref (void)
 
    server = mock_mongos_new (WIRE_VERSION_MIN);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
    prefs = mongoc_read_prefs_new (MONGOC_READ_SECONDARY);
 
@@ -2145,7 +2146,7 @@ test_count_read_concern (void)
    /* wire protocol version 4 */
    server = mock_server_with_autoismaster (WIRE_VERSION_READ_CONCERN);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    ASSERT (client);
 
    collection = mongoc_client_get_collection (client, "test", "test");
@@ -2297,7 +2298,7 @@ _test_count_read_concern_live (bool supports_read_concern)
    bson_t b;
 
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    collection = mongoc_client_get_collection (client, "test", "test");
@@ -2412,7 +2413,7 @@ test_count_with_opts (void)
    /* use a mongos since we don't send SLAVE_OK to mongos by default */
    server = mock_mongos_new (WIRE_VERSION_MIN);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    future = future_collection_count_with_opts (collection,
@@ -2451,7 +2452,7 @@ test_count_with_collation (int wire)
    server = mock_server_with_autoismaster (wire);
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    future = future_collection_count_with_opts (
@@ -2518,7 +2519,7 @@ test_count_documents (void)
 
    server = mock_server_with_autoismaster (WIRE_VERSION_MAX);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "coll");
 
    future =
@@ -2579,7 +2580,7 @@ test_count_documents_live (void)
    bson_error_t error;
    int64_t count;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    collection = mongoc_client_get_collection (client, "test", "test");
@@ -2609,7 +2610,7 @@ test_estimated_document_count (void)
 
    server = mock_server_with_autoismaster (WIRE_VERSION_MAX);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "coll");
 
    future = future_collection_estimated_document_count (
@@ -2650,7 +2651,7 @@ test_estimated_document_count_live (void)
    bson_error_t error;
    int64_t count;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    collection = mongoc_client_get_collection (client, "test", "test");
@@ -2681,7 +2682,7 @@ test_drop (void)
    bson_t *opts = NULL;
 
    opts = bson_new ();
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
    mongoc_client_set_error_api (client, 2);
 
@@ -2774,7 +2775,7 @@ test_aggregate_bypass (void *context)
    int i;
    char *json;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    dbname = gen_collection_name ("dbtest");
@@ -2859,7 +2860,7 @@ test_aggregate (void)
    bson_iter_t iter;
    int i, j;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    database = get_test_database (client);
@@ -3006,7 +3007,7 @@ test_aggregate_large (void)
    bson_t *pipeline;
    const bson_t *doc;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    collection = get_test_collection (client, "test_aggregate_large");
@@ -3088,7 +3089,7 @@ test_aggregate_modern (void *data)
 
    server = mock_server_with_autoismaster (WIRE_VERSION_OP_MSG - 1);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    cursor = mongoc_collection_aggregate (collection,
@@ -3178,7 +3179,7 @@ test_aggregate_w_server_id (void)
                                    0 /* arbiters    */);
 
    mock_rs_run (rs);
-   client = mongoc_client_new_from_uri (mock_rs_get_uri (rs));
+   client = test_framework_client_new_from_uri (mock_rs_get_uri (rs));
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    /* use serverId instead of prefs to select the secondary */
@@ -3225,7 +3226,7 @@ test_aggregate_w_server_id_sharded (void)
 
    server = mock_mongos_new (WIRE_VERSION_MIN);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    opts = tmp_bson ("{'serverId': 1}");
@@ -3268,7 +3269,7 @@ test_aggregate_server_id_option (void *ctx)
    mongoc_cursor_t *cursor;
    const bson_t *doc;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = mongoc_client_get_collection (client, "db", "collection");
    q = tmp_bson (NULL);
    cursor = mongoc_collection_aggregate (
@@ -3313,7 +3314,7 @@ test_aggregate_is_sent_to_primary_w_dollar_out (void *ctx)
 
    capture_logs (true);
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    pipeline = tmp_bson ("{ 'pipeline': [ { '$out' : 'coll2' } ] }");
@@ -3365,7 +3366,7 @@ test_validate (void *ctx)
    const uint32_t expected_err_domain = MONGOC_ERROR_BSON;
    const uint32_t expected_err_code = MONGOC_ERROR_BSON_INVALID;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    collection = get_test_collection (client, "test_validate");
@@ -3438,7 +3439,7 @@ test_rename (void)
    char **names;
    bool found;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
    mongoc_client_set_error_api (client, 2);
    opts = bson_new ();
@@ -3545,7 +3546,7 @@ test_stats (void)
    bson_t stats;
    bson_t doc = BSON_INITIALIZER;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    collection = get_test_collection (client, "test_stats");
@@ -3589,7 +3590,7 @@ test_stats_read_pref (void)
 
    server = mock_mongos_new (WIRE_VERSION_MIN);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
    prefs = mongoc_read_prefs_new (MONGOC_READ_SECONDARY);
    mongoc_collection_set_read_prefs (collection, prefs);
@@ -3630,7 +3631,7 @@ test_find_and_modify_write_concern (int wire_version)
    server = mock_server_new ();
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    ASSERT (client);
 
    collection =
@@ -3713,7 +3714,7 @@ test_find_and_modify (void)
    bson_t doc = BSON_INITIALIZER;
    bson_t reply;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    collection = get_test_collection (client, "test_find_and_modify");
@@ -3779,7 +3780,7 @@ test_large_return (void *ctx)
    char *str;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    collection = get_test_collection (client, "test_large_return");
@@ -3839,7 +3840,7 @@ test_many_return (void)
    bool r;
    int i;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    collection = get_test_collection (client, "test_many_return");
@@ -3929,7 +3930,7 @@ _test_insert_validate (insert_fn_t insert_fn)
    mongoc_collection_t *collection;
    bson_error_t error;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    mongoc_client_set_error_api (client, 2);
    collection = get_test_collection (client, "test_insert_validate");
 
@@ -4011,7 +4012,7 @@ test_insert_bulk_validate (void)
    const bson_t *docs[] = {tmp_bson ("{'a': 1}"), tmp_bson ("{'$': 2}")};
 
    BEGIN_IGNORE_DEPRECATIONS
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    mongoc_client_set_error_api (client, 2);
    collection = get_test_collection (client, "test_insert_validate");
 
@@ -4082,7 +4083,7 @@ test_find_limit (void)
    server = mock_server_with_autoismaster (WIRE_VERSION_MIN);
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "test", "test");
 
    /* test mongoc_collection_find and mongoc_collection_find_with_opts */
@@ -4153,7 +4154,7 @@ test_find_batch_size (void)
    server = mock_server_with_autoismaster (WIRE_VERSION_MIN);
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "test", "test");
 
    /* test mongoc_collection_find and mongoc_collection_find_with_opts */
@@ -4219,7 +4220,7 @@ test_command_fq (void *context)
    bson_t *cmd;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    cmd = tmp_bson ("{ 'dbstats': 1}");
@@ -4279,7 +4280,7 @@ test_get_index_info (void)
    const char *id_idx_name = "_id_";
    int num_idxs = 0;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    collection = get_test_collection (client, "test_get_index_info");
@@ -4435,7 +4436,7 @@ test_find_indexes_err (void)
 
    server = mock_server_with_autoismaster (WIRE_VERSION_MIN);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    mongoc_client_set_error_api (client, 2);
    collection = mongoc_client_get_collection (client, "db", "collection");
 
@@ -4502,7 +4503,7 @@ test_find_read_concern (void)
    server = mock_server_with_autoismaster (WIRE_VERSION_READ_CONCERN);
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "test", "test");
 
    /* No read_concern set - test find and find_with_opts */
@@ -4692,7 +4693,7 @@ test_getmore_read_concern_live (void *ctx)
    bson_error_t error;
    int i = 0;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_read_concern");
 
    rc = mongoc_read_concern_new ();
@@ -4740,7 +4741,7 @@ test_aggregate_secondary (void *ctx)
    mongoc_cursor_t *cursor;
    const bson_t *doc;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "aggregate_secondary");
    pref = mongoc_read_prefs_new (MONGOC_READ_SECONDARY);
    cursor = mongoc_collection_aggregate (
@@ -4777,7 +4778,7 @@ test_aggregate_secondary_sharded (void)
 
    server = mock_mongos_new (WIRE_VERSION_MIN);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
    pref = mongoc_read_prefs_new (MONGOC_READ_SECONDARY);
    cursor = mongoc_collection_aggregate (
@@ -4826,7 +4827,7 @@ test_aggregate_read_concern (void)
 
    server = mock_server_with_autoismaster (WIRE_VERSION_READ_CONCERN);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    /* No readConcern */
@@ -4927,7 +4928,7 @@ test_aggregate_with_collation (int wire)
 
    server = mock_server_with_autoismaster (wire);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    cursor =
@@ -5009,7 +5010,7 @@ test_index_with_collation (int wire)
    /* wire protocol version 0 */
    server = mock_server_with_autoismaster (wire);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    bson_init (&keys);
@@ -5079,7 +5080,7 @@ test_insert_duplicate_key (void)
    mongoc_collection_t *collection;
    bson_error_t error;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_insert_duplicate_key");
    mongoc_collection_insert_one (
       collection, tmp_bson ("{'_id': 1}"), NULL, NULL, NULL);
@@ -5102,8 +5103,8 @@ test_create_index_fail (void *context)
    bson_t reply;
    bson_error_t error;
 
-   client =
-      mongoc_client_new ("mongodb://example.doesntexist/?connectTimeoutMS=10");
+   client = test_framework_client_new (
+      "mongodb://example.doesntexist/?connectTimeoutMS=10");
    collection = mongoc_client_get_collection (client, "test", "test");
    r = mongoc_collection_create_index_with_opts (
       collection, tmp_bson ("{'a': 1}"), NULL, NULL, &reply, &error);
@@ -5185,7 +5186,7 @@ test_insert_one (void)
    bson_t reply;
    bson_t opts_with_wc = BSON_INITIALIZER;
    bool ret;
-   mongoc_client_t *client = test_framework_client_new ();
+   mongoc_client_t *client = test_framework_new_default_client ();
    mongoc_database_t *db = get_test_database (client);
    mongoc_collection_t *coll = mongoc_database_get_collection (db, "coll");
    mongoc_write_concern_t *wc = mongoc_write_concern_new ();
@@ -5326,7 +5327,7 @@ _test_update_and_replace (bool is_replace, bool is_multi)
    bson_t opts_with_wc = BSON_INITIALIZER;
    bson_t opts_with_wc2 = BSON_INITIALIZER;
    bool ret = false;
-   mongoc_client_t *client = test_framework_client_new ();
+   mongoc_client_t *client = test_framework_new_default_client ();
    mongoc_database_t *db = get_test_database (client);
    mongoc_collection_t *coll = mongoc_database_get_collection (db, "coll");
    mongoc_write_concern_t *wc = mongoc_write_concern_new ();
@@ -5630,7 +5631,7 @@ test_array_filters_validate (void)
    bson_error_t error;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    mongoc_client_set_error_api (client, 2);
    collection = get_test_collection (client, "test_array_filters_validation");
    r = mongoc_collection_update_one (collection,
@@ -5677,7 +5678,7 @@ _test_update_validate (update_fn_t update_fn)
    bson_error_t error;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    mongoc_client_set_error_api (client, 2);
    collection = get_test_collection (client, "test_update_validate");
    selector = tmp_bson ("{}");
@@ -5785,7 +5786,7 @@ _test_delete_one_or_many (bool is_multi)
    bson_t reply;
    bson_t opts_with_wc = BSON_INITIALIZER;
    bool ret;
-   mongoc_client_t *client = test_framework_client_new ();
+   mongoc_client_t *client = test_framework_new_default_client ();
    mongoc_database_t *db = get_test_database (client);
    mongoc_collection_t *coll = mongoc_database_get_collection (db, "coll");
    mongoc_write_concern_t *wc = mongoc_write_concern_new ();
@@ -5954,7 +5955,7 @@ _test_delete_collation (int wire, bool is_multi)
    server = mock_server_with_autoismaster (wire);
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
    future = fn (collection,
                 tmp_bson ("{}"),
@@ -6035,7 +6036,7 @@ _test_update_or_replace_with_collation (int wire,
    server = mock_server_with_autoismaster (wire);
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
    future = fn (collection,
                 tmp_bson ("{}"),
@@ -6109,7 +6110,7 @@ _test_update_hint (int wire, bool is_replace, bool is_multi, const char *hint)
    server = mock_server_with_autoismaster (wire);
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
    future = fn (collection,
                 tmp_bson ("{}"),
@@ -6185,7 +6186,7 @@ test_update_hint_validate (void)
    bson_error_t error;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    mongoc_client_set_error_api (client, 2);
    collection = get_test_collection (client, "test_update_hint_validation");
    r = mongoc_collection_update_one (collection,
@@ -6238,7 +6239,7 @@ test_update_multi (void)
    unsigned i;
    bson_t *bptr[10];
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_update_multi");
 
    (void) mongoc_collection_drop (collection, &error);
@@ -6279,7 +6280,7 @@ test_update_upsert (void)
    mongoc_collection_t *collection;
    bson_error_t error;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_update_upsert");
 
    (void) mongoc_collection_drop (collection, &error);
@@ -6312,7 +6313,7 @@ test_remove_multi (void)
    unsigned i;
    bson_t *bptr[10];
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_remove_multi");
 
    (void) mongoc_collection_drop (collection, &error);
@@ -6360,7 +6361,7 @@ test_fam_no_error_on_retry (void *unused)
    bson_t reply;
    mongoc_find_and_modify_opts_t *opts;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ret = mongoc_client_command_simple (
       client,
       "admin",
@@ -6407,7 +6408,8 @@ test_fam_no_error_on_retry (void *unused)
 static void
 test_timeout_ms (void)
 {
-   mongoc_client_t *client = mongoc_client_new ("mongodb://host/db_name");
+   mongoc_client_t *client =
+      test_framework_client_new ("mongodb://host/db_name");
    mongoc_database_t *db = NULL;
    mongoc_collection_t *coll =
       mongoc_client_get_collection (client, "db", "test");

--- a/src/libmongoc/tests/test-mongoc-command-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-command-monitoring.c
@@ -664,7 +664,7 @@ _test_query_operation_id (bool pooled)
    mongoc_apm_set_command_failed_cb (callbacks, test_op_id_failed_cb);
 
    if (pooled) {
-      pool = test_framework_client_pool_new (mock_server_get_uri (server));
+      pool = test_framework_client_pool_new_from_uri (mock_server_get_uri (server));
       ASSERT (mongoc_client_pool_set_apm_callbacks (
          pool, callbacks, (void *) &test));
       client = mongoc_client_pool_pop (pool);

--- a/src/libmongoc/tests/test-mongoc-command-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-command-monitoring.c
@@ -133,7 +133,7 @@ test_get_error (void)
    server = mock_server_with_autoismaster (WIRE_VERSION_MIN);
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    callbacks = mongoc_apm_callbacks_new ();
    mongoc_apm_set_command_failed_cb (callbacks, test_get_error_failed_cb);
    mongoc_client_set_apm_callbacks (client, callbacks, (void *) &error);
@@ -230,7 +230,7 @@ test_change_callbacks (void)
    inc_callbacks = increment_callbacks ();
    dec_callbacks = decrement_callbacks ();
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    mongoc_client_set_apm_callbacks (client, inc_callbacks, &incremented);
 
    collection = get_test_collection (client, "test_change_callbacks");
@@ -281,7 +281,7 @@ test_reset_callbacks (void)
    inc_callbacks = increment_callbacks ();
    dec_callbacks = decrement_callbacks ();
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_reset_apm_callbacks");
 
    /* insert 200 docs so we have a couple batches */
@@ -353,7 +353,7 @@ _test_set_callbacks (bool pooled, bool try_pop)
    mongoc_apm_set_command_started_cb (callbacks, test_set_callbacks_cb);
 
    if (pooled) {
-      pool = test_framework_client_pool_new ();
+      pool = test_framework_new_default_client_pool ();
       ASSERT (mongoc_client_pool_set_apm_callbacks (
          pool, callbacks, (void *) &n_calls));
       if (try_pop) {
@@ -362,7 +362,7 @@ _test_set_callbacks (bool pooled, bool try_pop)
          client = mongoc_client_pool_pop (pool);
       }
    } else {
-      client = test_framework_client_new ();
+      client = test_framework_new_default_client ();
       ASSERT (mongoc_client_set_apm_callbacks (
          client, callbacks, (void *) &n_calls));
    }
@@ -537,12 +537,12 @@ _test_bulk_operation_id (bool pooled, bool use_bulk_operation_new)
    mongoc_apm_set_command_failed_cb (callbacks, test_op_id_failed_cb);
 
    if (pooled) {
-      pool = test_framework_client_pool_new ();
+      pool = test_framework_new_default_client_pool ();
       ASSERT (mongoc_client_pool_set_apm_callbacks (
          pool, callbacks, (void *) &test));
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = test_framework_client_new ();
+      client = test_framework_new_default_client ();
       ASSERT (
          mongoc_client_set_apm_callbacks (client, callbacks, (void *) &test));
    }
@@ -664,12 +664,13 @@ _test_query_operation_id (bool pooled)
    mongoc_apm_set_command_failed_cb (callbacks, test_op_id_failed_cb);
 
    if (pooled) {
-      pool = mongoc_client_pool_new (mock_server_get_uri (server));
+      pool = test_framework_client_pool_new (mock_server_get_uri (server));
       ASSERT (mongoc_client_pool_set_apm_callbacks (
          pool, callbacks, (void *) &test));
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+      client =
+         test_framework_client_new_from_uri (mock_server_get_uri (server));
       ASSERT (
          mongoc_client_set_apm_callbacks (client, callbacks, (void *) &test));
    }
@@ -863,7 +864,7 @@ test_client_cmd (void)
    const bson_t *reply;
 
    cmd_test_init (&test);
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    set_cmd_test_callbacks (client, (void *) &test);
    cursor = mongoc_client_command (client,
                                    "admin",
@@ -920,7 +921,7 @@ test_client_cmd_simple (void)
    bson_error_t error;
 
    cmd_test_init (&test);
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    set_cmd_test_callbacks (client, (void *) &test);
    r = mongoc_client_command_simple (
       client, "admin", tmp_bson ("{'ping': 1}"), NULL, NULL, &error);
@@ -968,7 +969,7 @@ test_client_cmd_op_ids (void)
    mongoc_apm_set_command_succeeded_cb (callbacks, test_op_id_succeeded_cb);
    mongoc_apm_set_command_failed_cb (callbacks, test_op_id_failed_cb);
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    mongoc_client_set_apm_callbacks (client, callbacks, (void *) &test);
 
    r = mongoc_client_command_simple (
@@ -1016,7 +1017,7 @@ test_killcursors_deprecated (void)
    bson_error_t error;
 
    cmd_test_init (&test);
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
 
    /* connect */
    r = mongoc_client_command_simple (
@@ -1097,7 +1098,7 @@ test_command_failed_reply_mock (void)
    mongoc_apm_set_command_failed_cb (callbacks,
                                      command_failed_reply_command_failed_cb);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    ASSERT (mongoc_client_set_apm_callbacks (client, callbacks, (void *) &test));
 
    collection = mongoc_client_get_collection (client, "db", "collection");
@@ -1154,7 +1155,7 @@ test_command_failed_reply_hangup (void)
    mongoc_apm_set_command_failed_cb (callbacks,
                                      command_failed_reply_command_failed_cb);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    ASSERT (mongoc_client_set_apm_callbacks (client, callbacks, (void *) &test));
 
    collection = mongoc_client_get_collection (client, "db", "collection");

--- a/src/libmongoc/tests/test-mongoc-counters.c
+++ b/src/libmongoc/tests/test-mongoc-counters.c
@@ -313,7 +313,7 @@ test_counters_clients (void)
    DIFF_AND_RESET (client_pools_active, ==, 0);
    DIFF_AND_RESET (client_pools_disposed, ==, 0);
    /* check client pools. */
-   client_pool = test_framework_client_pool_new (uri);
+   client_pool = test_framework_client_pool_new_from_uri (uri);
    BSON_ASSERT (client_pool);
    DIFF_AND_RESET (clients_active, ==, 0);
    DIFF_AND_RESET (clients_disposed, ==, 0);

--- a/src/libmongoc/tests/test-mongoc-counters.c
+++ b/src/libmongoc/tests/test-mongoc-counters.c
@@ -78,7 +78,7 @@ _client_new_disable_ss (bool use_compression)
       mongoc_uri_set_option_as_utf8 (uri, MONGOC_URI_COMPRESSORS, compressors);
       bson_free (compressors);
    }
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    test_framework_set_ssl_opts (client);
    sd = mongoc_client_select_server (client, true, NULL, &err);
    ASSERT_OR_PRINT (sd, err);
@@ -301,7 +301,7 @@ test_counters_clients (void)
    mongoc_uri_set_option_as_int32 (
       uri, MONGOC_URI_SOCKETCHECKINTERVALMS, 99999);
    reset_all_counters ();
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    BSON_ASSERT (client);
    DIFF_AND_RESET (clients_active, ==, 1);
    DIFF_AND_RESET (clients_disposed, ==, 0);
@@ -313,7 +313,7 @@ test_counters_clients (void)
    DIFF_AND_RESET (client_pools_active, ==, 0);
    DIFF_AND_RESET (client_pools_disposed, ==, 0);
    /* check client pools. */
-   client_pool = mongoc_client_pool_new (uri);
+   client_pool = test_framework_client_pool_new (uri);
    BSON_ASSERT (client_pool);
    DIFF_AND_RESET (clients_active, ==, 0);
    DIFF_AND_RESET (clients_disposed, ==, 0);
@@ -477,7 +477,7 @@ test_counters_auth (void *ctx)
    mongoc_uri_set_option_as_int32 (
       uri, MONGOC_URI_SOCKETCHECKINTERVALMS, 99999);
    reset_all_counters ();
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    test_framework_set_ssl_opts (client);
    BSON_ASSERT (client);
    ret = mongoc_client_command_simple (
@@ -500,14 +500,14 @@ test_counters_dns (void)
    mongoc_server_description_t *sd;
    bson_error_t err;
    reset_all_counters ();
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    sd = mongoc_client_select_server (client, false, NULL, &err);
    ASSERT_OR_PRINT (sd, err);
    DIFF_AND_RESET (dns_success, >, 0);
    DIFF_AND_RESET (dns_failure, ==, 0);
    mongoc_server_description_destroy (sd);
    mongoc_client_destroy (client);
-   client = mongoc_client_new ("mongodb://invalidhostname/");
+   client = test_framework_client_new ("mongodb://invalidhostname/");
    test_framework_set_ssl_opts (client);
    sd = mongoc_client_select_server (client, false, NULL, &err);
    ASSERT (!sd);
@@ -533,7 +533,7 @@ test_counters_streams_timeout ()
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_int32 (uri, MONGOC_URI_SOCKETTIMEOUTMS, 300);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    mongoc_uri_destroy (uri);
    sd = mongoc_client_select_server (client, true, NULL, &err);
    mongoc_server_description_destroy (sd);

--- a/src/libmongoc/tests/test-mongoc-cursor.c
+++ b/src/libmongoc/tests/test-mongoc-cursor.c
@@ -751,7 +751,7 @@ _test_kill_cursors (bool pooled, bool use_killcursors_cmd)
    mock_rs_run (rs);
 
    if (pooled) {
-      pool = test_framework_client_pool_new (mock_rs_get_uri (rs));
+      pool = test_framework_client_pool_new_from_uri (mock_rs_get_uri (rs));
       client = mongoc_client_pool_pop (pool);
    } else {
       client = test_framework_client_new_from_uri (mock_rs_get_uri (rs));
@@ -1466,7 +1466,7 @@ _test_cursor_hint (bool pooled, bool use_primary)
    mock_rs_run (rs);
 
    if (pooled) {
-      pool = test_framework_client_pool_new (mock_rs_get_uri (rs));
+      pool = test_framework_client_pool_new_from_uri (mock_rs_get_uri (rs));
       client = mongoc_client_pool_pop (pool);
    } else {
       client = test_framework_client_new_from_uri (mock_rs_get_uri (rs));

--- a/src/libmongoc/tests/test-mongoc-cursor.c
+++ b/src/libmongoc/tests/test-mongoc-cursor.c
@@ -27,7 +27,7 @@
    do {                                                             \
       bson_error_t _err;                                            \
       bool _ret;                                                    \
-      client = test_framework_client_new ();                        \
+      client = test_framework_new_default_client ();                \
       coll = mongoc_client_get_collection (client, "test", "test"); \
       /* populate to ensure db and coll exist. */                   \
       _ret = mongoc_collection_insert_one (                         \
@@ -539,7 +539,7 @@ test_limit (void)
    const bson_t *doc = NULL;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_limit");
    bulk = mongoc_collection_create_bulk_operation_with_opts (collection, NULL);
    b = tmp_bson ("{}");
@@ -669,7 +669,7 @@ test_kill_cursor_live (void)
 
    callbacks = mongoc_apm_callbacks_new ();
    mongoc_apm_set_command_succeeded_cb (callbacks, killcursors_succeeded);
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    mongoc_client_set_apm_callbacks (client, callbacks, &ctx);
    collection = get_test_collection (client, "test");
    b = tmp_bson ("{}");
@@ -751,10 +751,10 @@ _test_kill_cursors (bool pooled, bool use_killcursors_cmd)
    mock_rs_run (rs);
 
    if (pooled) {
-      pool = mongoc_client_pool_new (mock_rs_get_uri (rs));
+      pool = test_framework_client_pool_new (mock_rs_get_uri (rs));
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (mock_rs_get_uri (rs));
+      client = test_framework_client_new_from_uri (mock_rs_get_uri (rs));
    }
 
    collection = mongoc_client_get_collection (client, "db", "collection");
@@ -879,7 +879,7 @@ _test_client_kill_cursor (bool has_primary, bool wire_version_4)
                                    1,           /* definitely a secondary */
                                    0);          /* no arbiter */
    mock_rs_run (rs);
-   client = mongoc_client_new_from_uri (mock_rs_get_uri (rs));
+   client = test_framework_client_new_from_uri (mock_rs_get_uri (rs));
    read_prefs = mongoc_read_prefs_new (MONGOC_READ_SECONDARY);
 
    /* make client open a connection - it won't open one to kill a cursor */
@@ -978,7 +978,7 @@ _test_cursor_new_from_command (const char *cmd_json,
    bson_t reply;
    mongoc_cursor_t *cmd_cursor;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = mongoc_client_get_collection (client, "test", collection_name);
    mongoc_collection_delete_many (
       collection, tmp_bson ("{}"), NULL, NULL, NULL);
@@ -1017,7 +1017,7 @@ test_cursor_empty_collection (void)
    const bson_t *doc;
    mongoc_cursor_t *cursor;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = mongoc_client_get_collection (
       client, "test", "test_cursor_empty_collection");
    mongoc_collection_delete_many (
@@ -1087,7 +1087,7 @@ test_cursor_new_invalid (void)
    bson_t b = BSON_INITIALIZER;
    const bson_t *error_doc;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    cursor = mongoc_cursor_new_from_command_reply_with_opts (client, &b, NULL);
    ASSERT (cursor);
    ASSERT (mongoc_cursor_error (cursor, &error));
@@ -1118,7 +1118,7 @@ test_cursor_new_tailable_await (void)
    server = mock_server_with_autoismaster (WIRE_VERSION_FIND_CMD);
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    cursor = mongoc_cursor_new_from_command_reply_with_opts (
       client,
       bson_copy (tmp_bson ("{'ok': 1,"
@@ -1181,7 +1181,7 @@ test_cursor_int64_t_maxtimems (void)
    server = mock_server_with_autoismaster (WIRE_VERSION_FIND_CMD);
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
 
    max_await_time_ms = tmp_bson (NULL);
    bson_append_bool (max_await_time_ms, "tailable", 8, true);
@@ -1245,7 +1245,7 @@ test_cursor_new_ignores_fields (void)
    server = mock_server_with_autoismaster (WIRE_VERSION_FIND_CMD);
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    cursor = mongoc_cursor_new_from_command_reply_with_opts (
       client,
       bson_copy (tmp_bson ("{'ok': 1,"
@@ -1280,7 +1280,7 @@ test_cursor_new_invalid_filter (void)
    bson_error_t error;
    const bson_t *error_doc;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = mongoc_client_get_collection (client, "test", "test");
 
    cursor = mongoc_collection_find_with_opts (
@@ -1311,7 +1311,7 @@ test_cursor_new_invalid_opts (void)
    bson_error_t error;
    const bson_t *error_doc;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = mongoc_client_get_collection (client, "test", "test");
 
    cursor = mongoc_collection_find_with_opts (
@@ -1368,7 +1368,7 @@ test_cursor_new_static (void)
       &bson_static, bson_get_data (bson_alloced), bson_alloced->len));
 
    /* test heap-allocated bson */
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    bson_copied = bson_copy (bson_alloced);
    cursor = mongoc_cursor_new_from_command_reply_with_opts (
       client, bson_copied, NULL);
@@ -1395,7 +1395,7 @@ test_cursor_hint_errors (void)
    mongoc_collection_t *collection;
    mongoc_cursor_t *cursor;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = mongoc_client_get_collection (client, "db", "collection");
    cursor = mongoc_collection_find (
       collection, MONGOC_QUERY_NONE, 0, 0, 0, tmp_bson ("{}"), NULL, NULL);
@@ -1466,10 +1466,10 @@ _test_cursor_hint (bool pooled, bool use_primary)
    mock_rs_run (rs);
 
    if (pooled) {
-      pool = mongoc_client_pool_new (mock_rs_get_uri (rs));
+      pool = test_framework_client_pool_new (mock_rs_get_uri (rs));
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (mock_rs_get_uri (rs));
+      client = test_framework_client_new_from_uri (mock_rs_get_uri (rs));
    }
 
    collection = mongoc_client_get_collection (client, "test", "test");
@@ -1576,7 +1576,7 @@ test_cursor_hint_mongos (void)
 
    server = mock_mongos_new (WIRE_VERSION_MIN);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "test", "test");
 
    for (i = 0; i < sizeof (modes) / sizeof (mongoc_read_mode_t); i++) {
@@ -1622,7 +1622,7 @@ test_cursor_hint_mongos_cmd (void)
 
    server = mock_mongos_new (WIRE_VERSION_FIND_CMD);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "test", "test");
 
    for (i = 0; i < sizeof (modes) / sizeof (mongoc_read_mode_t); i++) {
@@ -1676,10 +1676,10 @@ _test_cursor_hint_no_warmup (bool pooled)
    bson_error_t error;
 
    if (pooled) {
-      pool = test_framework_client_pool_new ();
+      pool = test_framework_new_default_client_pool ();
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = test_framework_client_new ();
+      client = test_framework_new_default_client ();
    }
 
    collection = get_test_collection (client, "test_cursor_hint_no_warmup");
@@ -1729,7 +1729,7 @@ test_tailable_alive (void)
    mongoc_cursor_t *cursor;
    const bson_t *doc;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    database = mongoc_client_get_database (client, "test");
    collection_name = gen_collection_name ("test");
 
@@ -1984,7 +1984,7 @@ _test_cursor_n_return (bool find_with_opts)
 
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "coll");
 
    for (i = 0; i < sizeof (tests) / sizeof (cursor_n_return_test); i++) {
@@ -2060,7 +2060,7 @@ test_empty_final_batch_live (void)
    int i;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    mongoc_client_set_error_api (client, 2);
    collection = get_test_collection (client, "test_empty_final_batch_live");
 
@@ -2107,7 +2107,7 @@ test_empty_final_batch (void)
    server = mock_server_with_autoismaster (WIRE_VERSION_FIND_CMD);
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "coll");
    cursor = mongoc_collection_find_with_opts (
       collection,
@@ -2186,7 +2186,7 @@ test_error_document_query (void)
    const bson_t *doc;
    const bson_t *error_doc;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    mongoc_client_set_error_api (client, 2);
    collection = get_test_collection (client, "test_error_document_query");
    cursor = mongoc_collection_find_with_opts (
@@ -2214,7 +2214,7 @@ test_error_document_command (void)
    const bson_t *doc;
    const bson_t *error_doc;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    mongoc_client_set_error_api (client, 2);
    cursor = mongoc_client_command (client,
                                    "test",
@@ -2251,7 +2251,7 @@ test_error_document_getmore (void)
    const bson_t *doc;
    const bson_t *error_doc;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    mongoc_client_set_error_api (client, 2);
    collection = get_test_collection (client, "test_error_document_getmore");
    mongoc_collection_drop (collection, NULL);
@@ -2304,7 +2304,7 @@ test_find_error_is_alive (void)
    mongoc_cursor_t *cursor;
    bson_error_t err;
    const bson_t *bson;
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    coll = mongoc_client_get_collection (client, "test", "test");
    cursor =
       mongoc_collection_find (coll,

--- a/src/libmongoc/tests/test-mongoc-cyrus.c
+++ b/src/libmongoc/tests/test-mongoc-cyrus.c
@@ -73,7 +73,7 @@ test_sasl_canonicalize_hostname (void *ctx)
    char real_name[BSON_HOST_NAME_MAX + 1] = {'\0'};
    bson_error_t error;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ss = mongoc_cluster_stream_for_reads (
       &client->cluster, NULL, NULL, NULL, &error);
    ASSERT_OR_PRINT (ss, error);

--- a/src/libmongoc/tests/test-mongoc-database.c
+++ b/src/libmongoc/tests/test-mongoc-database.c
@@ -467,7 +467,7 @@ _test_db_command_read_prefs (bool simple, bool pooled)
    mock_server_run (server);
 
    if (pooled) {
-      pool = test_framework_client_pool_new (mock_server_get_uri (server));
+      pool = test_framework_client_pool_new_from_uri (mock_server_get_uri (server));
       client = mongoc_client_pool_pop (pool);
    } else {
       client =

--- a/src/libmongoc/tests/test-mongoc-database.c
+++ b/src/libmongoc/tests/test-mongoc-database.c
@@ -30,7 +30,7 @@ test_aggregate_write_concern (void)
       support aggregate with writeConcern and $out/$merge */
    server = mock_server_with_autoismaster (WIRE_VERSION_READ_CONCERN);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    database = mongoc_client_get_database (client, "agg");
 
    /* If we run an aggregate without a terminal stage,
@@ -98,7 +98,7 @@ test_aggregate_inherit_database (void)
 
    server = mock_server_with_autoismaster (WIRE_VERSION_OP_MSG);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    database = mongoc_client_get_database (client, "admin");
 
    pipeline = BCON_NEW ("pipeline",
@@ -253,7 +253,7 @@ test_create_with_write_concern (void *ctx)
    capture_logs (true);
    opts = bson_new ();
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
    mongoc_client_set_error_api (client, 2);
 
@@ -334,7 +334,7 @@ test_copy (void)
    mongoc_database_t *copy;
    mongoc_client_t *client;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    database = mongoc_client_get_database (client, "test");
@@ -362,7 +362,7 @@ test_has_collection (void)
    bson_oid_t oid;
    bson_t b;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    name = gen_collection_name ("has_collection");
@@ -403,7 +403,7 @@ test_command (void)
    bson_t cmd = BSON_INITIALIZER;
    bson_t reply;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    database = mongoc_client_get_database (client, "admin");
@@ -467,10 +467,11 @@ _test_db_command_read_prefs (bool simple, bool pooled)
    mock_server_run (server);
 
    if (pooled) {
-      pool = mongoc_client_pool_new (mock_server_get_uri (server));
+      pool = test_framework_client_pool_new (mock_server_get_uri (server));
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+      client =
+         test_framework_client_new_from_uri (mock_server_get_uri (server));
    }
 
    db = mongoc_client_get_database (client, "db");
@@ -593,7 +594,7 @@ test_drop (void)
    bool r;
 
    opts = bson_new ();
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
    mongoc_client_set_error_api (client, 2);
 
@@ -682,7 +683,7 @@ test_create_collection (void)
    char *dbname;
    char *name;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    dbname = gen_collection_name ("dbtest");
@@ -739,7 +740,7 @@ test_get_collection_info (void)
    char *capped_name;
    char *noopts_name;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    dbname = gen_collection_name ("dbtest");
@@ -823,7 +824,7 @@ test_get_collection_info_regex (void)
    const bson_t *doc;
    char *dbname;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    dbname = gen_collection_name ("test_get_collection_info_regex");
@@ -879,7 +880,7 @@ test_get_collection_info_with_opts_regex (void)
    const bson_t *doc;
    char *dbname;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    dbname = gen_collection_name ("test_get_collection_info_regex");
@@ -933,7 +934,7 @@ _test_get_collection_info_getmore ()
 
    server = mock_server_with_autoismaster (WIRE_VERSION_FIND_CMD);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    database = mongoc_client_get_database (client, "db");
    future =
       future_database_get_collection_names_with_opts (database, NULL, NULL);
@@ -992,7 +993,7 @@ test_get_collection (void)
    mongoc_read_prefs_t *read_prefs;
    mongoc_collection_t *collection;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    database = mongoc_client_get_database (client, "test");
@@ -1045,7 +1046,7 @@ test_get_collection_names (void)
    char *name5;
    const char *system_prefix = "system.";
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    dbname = gen_collection_name ("dbtest");
@@ -1158,7 +1159,7 @@ test_get_collection_names_error (void)
                               "{'ismaster': true,"
                               " 'maxWireVersion': 3}");
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
 
    database = mongoc_client_get_database (client, "test");
    future =
@@ -1186,7 +1187,8 @@ static void
 test_get_default_database (void)
 {
    /* default database is "db_name" */
-   mongoc_client_t *client = mongoc_client_new ("mongodb://host/db_name");
+   mongoc_client_t *client =
+      test_framework_client_new ("mongodb://host/db_name");
    mongoc_database_t *db = mongoc_client_get_default_database (client);
 
    BSON_ASSERT (!strcmp ("db_name", mongoc_database_get_name (db)));
@@ -1195,7 +1197,7 @@ test_get_default_database (void)
    mongoc_client_destroy (client);
 
    /* no default database */
-   client = mongoc_client_new ("mongodb://host/");
+   client = test_framework_client_new ("mongodb://host/");
    db = mongoc_client_get_default_database (client);
 
    BSON_ASSERT (!db);
@@ -1206,7 +1208,8 @@ test_get_default_database (void)
 static void
 test_timeout_ms (void)
 {
-   mongoc_client_t *client = mongoc_client_new ("mongodb://host/db_name");
+   mongoc_client_t *client =
+      test_framework_client_new ("mongodb://host/db_name");
    mongoc_database_t *db = mongoc_client_get_default_database (client);
    bool res;
    bson_error_t error;

--- a/src/libmongoc/tests/test-mongoc-dns.c
+++ b/src/libmongoc/tests/test-mongoc-dns.c
@@ -217,7 +217,7 @@ _test_dns_maybe_pooled (bson_t *test, bool pooled)
 #endif
 
    if (pooled) {
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
 
       /* before we set SSL on so that we can connect to the test replica set,
        * assert that the URI has SSL on by default, and SSL off if "ssl=false"
@@ -233,7 +233,7 @@ _test_dns_maybe_pooled (bson_t *test, bool pooled)
       mongoc_client_pool_set_apm_callbacks (pool, callbacks, &ctx);
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
       BSON_ASSERT (mongoc_uri_get_tls (client->uri) == expect_ssl);
 #ifdef MONGOC_ENABLE_SSL
       mongoc_client_set_ssl_opts (client, &ssl_opts);
@@ -317,7 +317,7 @@ test_null_error_pointer (void *ctx)
 {
    mongoc_client_t *client;
 
-   client = mongoc_client_new ("mongodb+srv://doesntexist.example.com");
+   client = test_framework_client_new ("mongodb+srv://doesntexist.example.com");
    ASSERT (!mongoc_topology_select_server_id (client->topology,
                                               MONGOC_SS_READ,
                                               NULL /* read prefs */,

--- a/src/libmongoc/tests/test-mongoc-dns.c
+++ b/src/libmongoc/tests/test-mongoc-dns.c
@@ -217,7 +217,7 @@ _test_dns_maybe_pooled (bson_t *test, bool pooled)
 #endif
 
    if (pooled) {
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
 
       /* before we set SSL on so that we can connect to the test replica set,
        * assert that the URI has SSL on by default, and SSL off if "ssl=false"

--- a/src/libmongoc/tests/test-mongoc-error.c
+++ b/src/libmongoc/tests/test-mongoc-error.c
@@ -21,7 +21,7 @@ test_set_error_api_single (void)
    int i;
 
    capture_logs (true);
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
 
    for (i = 0; i < sizeof (unsupported_versions) / sizeof (int32_t); i++) {
       ASSERT (!mongoc_client_set_error_api (client, unsupported_versions[i]));
@@ -43,7 +43,7 @@ test_set_error_api_pooled (void)
    int i;
 
    capture_logs (true);
-   pool = test_framework_client_pool_new ();
+   pool = test_framework_new_default_client_pool ();
 
    for (i = 0; i < sizeof (unsupported_versions) / sizeof (int32_t); i++) {
       ASSERT (
@@ -76,7 +76,7 @@ _test_command_error (int32_t error_api_version)
 
    server = mock_server_with_autoismaster (WIRE_VERSION_MIN);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
 
    if (error_api_version != 0) {
       BSON_ASSERT (mongoc_client_set_error_api (client, error_api_version));

--- a/src/libmongoc/tests/test-mongoc-exhaust.c
+++ b/src/libmongoc/tests/test-mongoc-exhaust.c
@@ -469,7 +469,7 @@ _mock_test_exhaust (bool pooled,
    mock_server_run (server);
 
    if (pooled) {
-      pool = test_framework_client_pool_new (mock_server_get_uri (server));
+      pool = test_framework_client_pool_new_from_uri (mock_server_get_uri (server));
       client = mongoc_client_pool_pop (pool);
    } else {
       client =

--- a/src/libmongoc/tests/test-mongoc-exhaust.c
+++ b/src/libmongoc/tests/test-mongoc-exhaust.c
@@ -58,7 +58,8 @@ get_connection_count (mongoc_client_t *client)
    int conns;
 
    BSON_APPEND_INT32 (&cmd, "serverStatus", 1);
-   res = mongoc_client_command_simple (client, "admin", &cmd, NULL, &reply, &error);
+   res = mongoc_client_command_simple (
+      client, "admin", &cmd, NULL, &reply, &error);
    ASSERT_OR_PRINT (res, error);
 
    conns = bson_lookup_int32 (&reply, "connections.totalCreated");
@@ -93,15 +94,15 @@ test_exhaust_cursor (bool pooled)
 
    can_check_connection_count = test_framework_max_wire_version_at_least (5);
    if (pooled) {
-      pool = test_framework_client_pool_new ();
+      pool = test_framework_new_default_client_pool ();
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = test_framework_client_new ();
+      client = test_framework_new_default_client ();
    }
    BSON_ASSERT (client);
 
    /* Use a separate client to count connections. */
-   audit_client = test_framework_client_new ();
+   audit_client = test_framework_new_default_client ();
 
    collection = get_test_collection (client, "test_exhaust_cursor");
    BSON_ASSERT (collection);
@@ -186,7 +187,8 @@ test_exhaust_cursor (bool pooled)
       ASSERT_CMPINT64 (generation1, ==, get_generation (client, cursor2));
       /* But a new connection was made. */
       if (can_check_connection_count) {
-         ASSERT_CMPINT32 (connection_count1 + 1, ==, get_connection_count (audit_client));
+         ASSERT_CMPINT32 (
+            connection_count1 + 1, ==, get_connection_count (audit_client));
       }
 
       for (i = 0; i < 5; i++) {
@@ -311,7 +313,7 @@ test_exhaust_cursor_multi_batch (void *context)
    mongoc_cursor_t *cursor;
    const bson_t *cursor_doc;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_exhaust_cursor_multi_batch");
 
    ASSERT_OR_PRINT (collection, error);
@@ -355,7 +357,7 @@ test_cursor_set_max_await_time_ms (void)
    mongoc_cursor_t *cursor;
    const bson_t *bson;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection =
       get_test_collection (client, "test_cursor_set_max_await_time_ms");
 
@@ -467,10 +469,11 @@ _mock_test_exhaust (bool pooled,
    mock_server_run (server);
 
    if (pooled) {
-      pool = mongoc_client_pool_new (mock_server_get_uri (server));
+      pool = test_framework_client_pool_new (mock_server_get_uri (server));
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+      client =
+         test_framework_client_new_from_uri (mock_server_get_uri (server));
    }
 
    collection = mongoc_client_get_collection (client, "db", "test");
@@ -588,7 +591,7 @@ test_exhaust_in_child (void)
    uint32_t server_id;
    int child_exit_status;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    coll = get_test_collection (client, "exhaust_in_child");
 
    /* insert some documents, more than one reply's worth. */

--- a/src/libmongoc/tests/test-mongoc-find-and-modify.c
+++ b/src/libmongoc/tests/test-mongoc-find-and-modify.c
@@ -66,7 +66,7 @@ test_find_and_modify_bypass (bool bypass)
    server = mock_server_new ();
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    ASSERT (client);
 
    collection =
@@ -161,7 +161,7 @@ test_find_and_modify_write_concern (int wire_version)
    server = mock_server_new ();
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    ASSERT (client);
 
    collection =
@@ -240,7 +240,7 @@ test_find_and_modify_write_concern_wire_32_failure (void *context)
    bool success;
    mongoc_write_concern_t *wc;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "writeFailure");
    wc = mongoc_write_concern_new ();
 
@@ -309,7 +309,7 @@ test_find_and_modify (void)
    bson_t reply;
    mongoc_find_and_modify_opts_t *opts;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    collection = get_test_collection (client, "test_find_and_modify");
@@ -387,7 +387,7 @@ test_find_and_modify_opts (void)
    server = mock_server_with_autoismaster (WIRE_VERSION_MIN);
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    opts = mongoc_find_and_modify_opts_new ();
@@ -440,7 +440,7 @@ test_find_and_modify_opts_write_concern (void)
    server = mock_server_with_autoismaster (WIRE_VERSION_FAM_WRITE_CONCERN);
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    opts = mongoc_find_and_modify_opts_new ();
@@ -498,7 +498,7 @@ test_find_and_modify_collation (int wire)
    server = mock_server_with_autoismaster (wire);
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
 
 
@@ -569,7 +569,7 @@ test_find_and_modify_hint (void)
    bool ret;
 
    /* Test setting a hint as a string. Should fail on server < 4.2. */
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    mongoc_client_set_error_api (client, MONGOC_ERROR_API_VERSION_2);
    coll = get_test_collection (client, "fam_hint");
    opts = mongoc_find_and_modify_opts_new ();

--- a/src/libmongoc/tests/test-mongoc-gridfs-bucket.c
+++ b/src/libmongoc/tests/test-mongoc-gridfs-bucket.c
@@ -21,7 +21,7 @@ test_create_bucket (void)
    bson_t *opts;
    char *dbname;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    dbname = gen_collection_name ("test");
@@ -103,7 +103,7 @@ _test_upload_and_download (bson_t *create_index_cmd)
 
    str = "This is a test sentence with multiple chunks.";
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
 
    ASSERT (client);
 
@@ -815,7 +815,7 @@ test_gridfs_cb (bson_t *scenario)
 
    /* Make a gridfs on generated db */
    dbname = gen_collection_name ("test");
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    db = mongoc_client_get_database (client, dbname);
    gridfs = mongoc_gridfs_bucket_new (db, NULL, NULL, NULL);
 
@@ -871,7 +871,7 @@ test_upload_error (void *ctx)
    bson_error_t error = {0};
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    db = mongoc_client_get_database (client, "test");
    gridfs = mongoc_gridfs_bucket_new (db, NULL, NULL, NULL);
    source = mongoc_stream_file_new_for_path (
@@ -897,7 +897,7 @@ test_upload_error (void *ctx)
    uri = test_framework_get_uri ();
    mongoc_uri_set_username (uri, "fake_user");
    mongoc_uri_set_password (uri, "password");
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    test_framework_set_ssl_opts (client);
    mongoc_uri_destroy (uri);
 
@@ -930,7 +930,7 @@ test_find_w_session (void *ctx)
    mongoc_client_session_t *session;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    db = mongoc_client_get_database (client, "test");
    gridfs = mongoc_gridfs_bucket_new (db, NULL, NULL, NULL);
    session = mongoc_client_start_session (client, NULL, &error);
@@ -964,7 +964,7 @@ test_gridfs_bucket_opts (void)
    bson_t *opts;
    char *bucket_name;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    db = mongoc_client_get_database (client, "test");
 
    /* check defaults. */

--- a/src/libmongoc/tests/test-mongoc-gridfs.c
+++ b/src/libmongoc/tests/test-mongoc-gridfs.c
@@ -135,7 +135,7 @@ _test_create (bson_t *create_index_cmd)
    mongoc_collection_t *files;
    mongoc_collection_t *chunks;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    files = mongoc_client_get_collection (client, "test", "foo.files");
@@ -222,7 +222,7 @@ test_remove (void)
    bson_error_t error;
    char name[32];
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    ASSERT_OR_PRINT (
@@ -287,7 +287,7 @@ test_list (void)
    char buf[100];
    int i = 0;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    ASSERT_OR_PRINT (gridfs = get_test_gridfs (client, "list", &error), error);
@@ -350,7 +350,7 @@ test_find_with_opts (void)
    bson_error_t error;
    mongoc_gridfs_file_list_t *list;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    mongoc_client_set_error_api (client, 2);
    gridfs = get_test_gridfs (client, "test_find_with_opts", &error);
    ASSERT_OR_PRINT (gridfs, error);
@@ -420,7 +420,7 @@ test_find_one_with_opts_limit (void)
 
    server = mock_server_with_autoismaster (WIRE_VERSION_FIND_CMD);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    mongoc_client_set_error_api (client, 2);
 
    gridfs = _get_gridfs (server, client, MONGOC_QUERY_SLAVE_OK);
@@ -491,7 +491,7 @@ test_properties (void)
    const bson_value_t *file_id;
    const char *alias0, *alias1;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
 
    ASSERT_OR_PRINT (gridfs = get_test_gridfs (client, "list", &error), error);
 
@@ -563,7 +563,7 @@ test_create_from_stream (void)
    mongoc_client_t *client;
    bson_error_t error;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    ASSERT_OR_PRINT ((gridfs = get_test_gridfs (client, "from_stream", &error)),
@@ -608,7 +608,7 @@ test_seek (void)
    mongoc_client_t *client;
    bson_error_t error;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
 
    ASSERT_OR_PRINT (gridfs = get_test_gridfs (client, "seek", &error), error);
 
@@ -662,7 +662,7 @@ test_read (void)
    iov[1].iov_base = buf2;
    iov[1].iov_len = 10;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    ASSERT_OR_PRINT (gridfs = get_test_gridfs (client, "read", &error), error);
@@ -762,7 +762,7 @@ _test_write (bool at_boundary)
 
    opt.chunk_size = 2;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    gridfs = get_test_gridfs (client, "write", &error);
@@ -879,7 +879,7 @@ test_write_past_end (void)
    opt.chunk_size = chunk_sz;
    opt.filename = "foo";
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    gridfs = get_test_gridfs (client, "write_past_end", &error);
@@ -938,7 +938,7 @@ test_empty (void)
    iov[0].iov_base = buf;
    iov[0].iov_len = 2;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
 
    ASSERT_OR_PRINT (gridfs = get_test_gridfs (client, "empty", &error), error);
 
@@ -994,7 +994,7 @@ test_stream (void)
    iov.iov_base = buf;
    iov.iov_len = sizeof buf;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    ASSERT_OR_PRINT (gridfs = get_test_gridfs (client, "fs", &error), error);
@@ -1051,7 +1051,7 @@ test_long_seek (void *ctx)
    iov.iov_len = sizeof (buf);
    memset (iov.iov_base, 0, iov.iov_len);
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    gridfs = get_test_gridfs (client, "long_seek", &error);
    ASSERT_OR_PRINT (gridfs, error);
    file = mongoc_gridfs_create_file (gridfs, &opt);
@@ -1118,7 +1118,7 @@ test_remove_by_filename (void)
    mongoc_client_t *client;
    bson_error_t error;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
 
    ASSERT_OR_PRINT (
@@ -1176,7 +1176,7 @@ test_missing_chunk (void *ctx)
    iov.iov_len = sizeof (buf);
    memset (iov.iov_base, 0, iov.iov_len);
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    gridfs = get_test_gridfs (client, "long_seek", &error);
    ASSERT_OR_PRINT (gridfs, error);
    mongoc_gridfs_drop (gridfs, NULL);
@@ -1239,7 +1239,7 @@ test_oversize (void)
    bson_error_t error;
    bool ret;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
 
    gridfs = get_test_gridfs (client, "test_oversize", &error);
    ASSERT_OR_PRINT (gridfs, error);
@@ -1296,7 +1296,7 @@ test_missing_file (void)
    iov.iov_base = buf;
    iov.iov_len = sizeof buf;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    gridfs =
       mongoc_client_get_gridfs (client, "test_missing_file", NULL, &error);
    ASSERT_OR_PRINT (gridfs, error);
@@ -1351,7 +1351,7 @@ test_set_id (void)
    mongoc_gridfs_file_opt_t opt = {0};
 
    /* create new client and grab gridfs handle */
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ASSERT (client);
    gridfs = mongoc_client_get_gridfs (client, "test", "fs", &error);
    ASSERT_OR_PRINT (gridfs, error);
@@ -1400,7 +1400,7 @@ test_inherit_client_config (void)
    mock_server_run (server);
 
    /* configure read / write concern and read prefs on client */
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
 
    write_concern = mongoc_write_concern_new ();
    mongoc_write_concern_set_w (write_concern, 2);
@@ -1472,7 +1472,7 @@ test_find_one_empty (void)
    mongoc_client_t *client;
    bson_error_t error = {1, 2, "hello"};
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    gridfs = get_test_gridfs (client, "list", &error);
    ASSERT_OR_PRINT (gridfs, error);
    ASSERT (!mongoc_gridfs_find_one (
@@ -1526,7 +1526,7 @@ test_write_failure (void)
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_int32 (uri, "socketTimeoutMS", 100);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    gridfs = mongoc_client_get_gridfs (client, "db", "fs", &error);
    ASSERT_OR_PRINT (gridfs, error);
    stream =

--- a/src/libmongoc/tests/test-mongoc-handshake.c
+++ b/src/libmongoc/tests/test-mongoc-handshake.c
@@ -61,7 +61,7 @@ test_mongoc_handshake_appname_in_uri (void)
    capture_logs (true);
    uri_str = bson_strdup_printf ("mongodb://a/?" MONGOC_URI_APPNAME "=%s",
                                  long_string);
-   ASSERT (!mongoc_client_new (uri_str));
+   ASSERT (!test_framework_client_new (uri_str));
    ASSERT_CAPTURED_LOG ("_mongoc_topology_scanner_set_appname",
                         MONGOC_LOG_LEVEL_WARNING,
                         "Unsupported value");
@@ -92,7 +92,7 @@ test_mongoc_handshake_appname_frozen_single (void)
    mongoc_client_t *client;
    const char *good_uri = "mongodb://host/?" MONGOC_URI_APPNAME "=mongodump";
 
-   client = mongoc_client_new (good_uri);
+   client = test_framework_client_new (good_uri);
 
    /* Shouldn't be able to set appname again */
    capture_logs (true);
@@ -114,7 +114,7 @@ test_mongoc_handshake_appname_frozen_pooled (void)
 
    uri = mongoc_uri_new (good_uri);
 
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
    capture_logs (true);
    ASSERT (!mongoc_client_pool_set_appname (pool, "test"));
    ASSERT_CAPTURED_LOG ("_mongoc_topology_scanner_set_appname",
@@ -189,7 +189,7 @@ test_mongoc_handshake_data_append_success (void)
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_int32 (uri, MONGOC_URI_HEARTBEATFREQUENCYMS, 500);
    mongoc_uri_set_option_as_utf8 (uri, MONGOC_URI_APPNAME, "testapp");
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
 
    /* Force topology scanner to start */
    client = mongoc_client_pool_pop (pool);
@@ -350,7 +350,7 @@ test_mongoc_handshake_data_append_after_cmd (void)
    uri = mongoc_uri_new ("mongodb://127.0.0.1/?" MONGOC_URI_MAXPOOLSIZE "=1");
 
    /* Make sure that after we pop a client we can't set global handshake */
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
 
    client = mongoc_client_pool_pop (pool);
 
@@ -398,7 +398,7 @@ test_mongoc_handshake_too_big (void)
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    /* avoid rare test timeouts */
    mongoc_uri_set_option_as_int32 (uri, MONGOC_URI_CONNECTTIMEOUTMS, 20000);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
 
    ASSERT (mongoc_client_set_appname (client, "my app"));
 
@@ -568,7 +568,7 @@ test_mongoc_handshake_cannot_send (void)
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_int32 (uri, MONGOC_URI_HEARTBEATFREQUENCYMS, 500);
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
 
    /* Pop a client to trigger the topology scanner */
    client = mongoc_client_pool_pop (pool);

--- a/src/libmongoc/tests/test-mongoc-handshake.c
+++ b/src/libmongoc/tests/test-mongoc-handshake.c
@@ -114,7 +114,7 @@ test_mongoc_handshake_appname_frozen_pooled (void)
 
    uri = mongoc_uri_new (good_uri);
 
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
    capture_logs (true);
    ASSERT (!mongoc_client_pool_set_appname (pool, "test"));
    ASSERT_CAPTURED_LOG ("_mongoc_topology_scanner_set_appname",
@@ -189,7 +189,7 @@ test_mongoc_handshake_data_append_success (void)
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_int32 (uri, MONGOC_URI_HEARTBEATFREQUENCYMS, 500);
    mongoc_uri_set_option_as_utf8 (uri, MONGOC_URI_APPNAME, "testapp");
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
 
    /* Force topology scanner to start */
    client = mongoc_client_pool_pop (pool);
@@ -350,7 +350,7 @@ test_mongoc_handshake_data_append_after_cmd (void)
    uri = mongoc_uri_new ("mongodb://127.0.0.1/?" MONGOC_URI_MAXPOOLSIZE "=1");
 
    /* Make sure that after we pop a client we can't set global handshake */
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
 
    client = mongoc_client_pool_pop (pool);
 
@@ -568,7 +568,7 @@ test_mongoc_handshake_cannot_send (void)
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_int32 (uri, MONGOC_URI_HEARTBEATFREQUENCYMS, 500);
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
 
    /* Pop a client to trigger the topology scanner */
    client = mongoc_client_pool_pop (pool);

--- a/src/libmongoc/tests/test-mongoc-hedged-reads.c
+++ b/src/libmongoc/tests/test-mongoc-hedged-reads.c
@@ -21,6 +21,7 @@
 #include "TestSuite.h"
 #include "mock_server/mock-server.h"
 #include "mock_server/future-functions.h"
+#include "test-libmongoc.h"
 
 #undef MONGOC_LOG_DOMAIN
 #define MONGOC_LOG_DOMAIN "client-test-hedged-reads"

--- a/src/libmongoc/tests/test-mongoc-hedged-reads.c
+++ b/src/libmongoc/tests/test-mongoc-hedged-reads.c
@@ -40,7 +40,7 @@ test_mongos_hedged_reads_read_pref (void)
 
    server = mock_mongos_new (5);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    prefs = mongoc_read_prefs_new (MONGOC_READ_SECONDARY_PREFERRED);
@@ -51,12 +51,12 @@ test_mongos_hedged_reads_read_pref (void)
 
    future = future_collection_count (
       collection, MONGOC_QUERY_NONE, NULL, 0, 0, NULL, &error);
-   request = mock_server_receives_command (
-      server,
-      "db",
-      MONGOC_QUERY_SLAVE_OK,
-      "{'$readPreference': { '$exists': false }}",
-      NULL);
+   request =
+      mock_server_receives_command (server,
+                                    "db",
+                                    MONGOC_QUERY_SLAVE_OK,
+                                    "{'$readPreference': { '$exists': false }}",
+                                    NULL);
 
    mock_server_replies_simple (request, "{'ok': 1, 'n': 1}");
    ASSERT_OR_PRINT (1 == future_get_int64_t (future), error);
@@ -98,7 +98,6 @@ test_mongos_hedged_reads_read_pref (void)
 void
 test_client_hedged_reads_install (TestSuite *suite)
 {
-   TestSuite_AddMockServerTest (suite,
-                                "/Client/hedged_reads/mongos",
-                                test_mongos_hedged_reads_read_pref);
+   TestSuite_AddMockServerTest (
+      suite, "/Client/hedged_reads/mongos", test_mongos_hedged_reads_read_pref);
 }

--- a/src/libmongoc/tests/test-mongoc-long-namespace.c
+++ b/src/libmongoc/tests/test-mongoc-long-namespace.c
@@ -89,7 +89,7 @@ test_fixture_init (test_fixture_t *test_fixture,
       bson_strdup_printf ("%s.%s", test_fixture->ns_db, test_fixture->ns_coll);
 
    /* Construct client, database, and collection objects. */
-   test_fixture->client = test_framework_client_new ();
+   test_fixture->client = test_framework_new_default_client ();
    test_framework_set_ssl_opts (test_fixture->client);
    mongoc_client_set_error_api (test_fixture->client,
                                 MONGOC_ERROR_API_VERSION_2);
@@ -486,7 +486,7 @@ collection_rename (test_fixture_t *test_fixture)
    /* Check that source collections do not exist anymore.  Use a separate client
     * so commands
     * don't show up in APM on test fixture's client. */
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    _check_existence (client, test_fixture->ns_db, test_fixture->ns_coll, false);
 
    /* Check that the new collection exists. */
@@ -537,7 +537,7 @@ unsupported_long_coll (void *unused)
    memset (long_coll, 'd', 199);
    long_coll[199] = '\0';
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    mongoc_client_set_error_api (client, MONGOC_ERROR_API_VERSION_2);
    coll = mongoc_client_get_collection (client, "test", long_coll);
    /* Insert. */
@@ -568,7 +568,7 @@ unsupported_long_db (void)
    memset (long_db, 'd', 64);
    long_db[64] = '\0';
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    mongoc_client_set_error_api (client, MONGOC_ERROR_API_VERSION_2);
    coll = mongoc_client_get_collection (client, long_db, "test");
    /* Insert. */

--- a/src/libmongoc/tests/test-mongoc-max-staleness.c
+++ b/src/libmongoc/tests/test-mongoc-max-staleness.c
@@ -228,7 +228,7 @@ _test_last_write_date (bool pooled)
    mongoc_uri_set_option_as_int32 (uri, "heartbeatFrequencyMS", 500);
 
    if (pooled) {
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
       test_framework_set_pool_ssl_opts (pool);
       client = mongoc_client_pool_pop (pool);
    } else {

--- a/src/libmongoc/tests/test-mongoc-max-staleness.c
+++ b/src/libmongoc/tests/test-mongoc-max-staleness.c
@@ -30,35 +30,35 @@ test_mongoc_client_max_staleness (void)
 {
    mongoc_client_t *client;
 
-   client = mongoc_client_new (NULL);
+   client = test_framework_client_new (NULL);
    ASSERT_CMPINT64 (get_max_staleness (client), ==, (int64_t) -1);
    mongoc_client_destroy (client);
 
-   client = mongoc_client_new ("mongodb://a/?" MONGOC_URI_READPREFERENCE
-                               "=secondary");
+   client = test_framework_client_new ("mongodb://a/?" MONGOC_URI_READPREFERENCE
+                                       "=secondary");
    ASSERT_CMPINT64 (get_max_staleness (client), ==, (int64_t) -1);
    mongoc_client_destroy (client);
 
    /* -1 is the default, means "no max staleness" */
-   client =
-      mongoc_client_new ("mongodb://a/?" MONGOC_URI_MAXSTALENESSSECONDS "=-1");
+   client = test_framework_client_new (
+      "mongodb://a/?" MONGOC_URI_MAXSTALENESSSECONDS "=-1");
    ASSERT_CMPINT64 (get_max_staleness (client), ==, (int64_t) -1);
    mongoc_client_destroy (client);
 
-   client =
-      mongoc_client_new ("mongodb://a/?" MONGOC_URI_READPREFERENCE
-                         "=primary&" MONGOC_URI_MAXSTALENESSSECONDS "=-1");
+   client = test_framework_client_new (
+      "mongodb://a/?" MONGOC_URI_READPREFERENCE
+      "=primary&" MONGOC_URI_MAXSTALENESSSECONDS "=-1");
 
    ASSERT_CMPINT64 (get_max_staleness (client), ==, (int64_t) -1);
    mongoc_client_destroy (client);
 
    /* no " MONGOC_URI_MAXSTALENESSSECONDS " with primary mode */
    capture_logs (true);
-   ASSERT (!mongoc_client_new ("mongodb://a/?" MONGOC_URI_MAXSTALENESSSECONDS
-                               "=120"));
-   ASSERT (!mongoc_client_new ("mongodb://a/?" MONGOC_URI_READPREFERENCE
-                               "=primary&" MONGOC_URI_MAXSTALENESSSECONDS
-                               "=120"));
+   ASSERT (!test_framework_client_new (
+      "mongodb://a/?" MONGOC_URI_MAXSTALENESSSECONDS "=120"));
+   ASSERT (!test_framework_client_new (
+      "mongodb://a/?" MONGOC_URI_READPREFERENCE
+      "=primary&" MONGOC_URI_MAXSTALENESSSECONDS "=120"));
    ASSERT_CAPTURED_LOG (MONGOC_URI_MAXSTALENESSSECONDS "=120",
                         MONGOC_LOG_LEVEL_WARNING,
                         "Invalid readPreferences");
@@ -66,8 +66,9 @@ test_mongoc_client_max_staleness (void)
    capture_logs (true);
 
    /* zero is prohibited */
-   client = mongoc_client_new ("mongodb://a/?" MONGOC_URI_READPREFERENCE
-                               "=nearest&" MONGOC_URI_MAXSTALENESSSECONDS "=0");
+   client = test_framework_client_new (
+      "mongodb://a/?" MONGOC_URI_READPREFERENCE
+      "=nearest&" MONGOC_URI_MAXSTALENESSSECONDS "=0");
 
    ASSERT_CAPTURED_LOG (
       MONGOC_URI_MAXSTALENESSSECONDS "=0",
@@ -77,26 +78,27 @@ test_mongoc_client_max_staleness (void)
    ASSERT_CMPINT64 (get_max_staleness (client), ==, (int64_t) -1);
    mongoc_client_destroy (client);
 
-   client = mongoc_client_new ("mongodb://a/?" MONGOC_URI_MAXSTALENESSSECONDS
-                               "=120&" MONGOC_URI_READPREFERENCE "=secondary");
+   client = test_framework_client_new (
+      "mongodb://a/?" MONGOC_URI_MAXSTALENESSSECONDS
+      "=120&" MONGOC_URI_READPREFERENCE "=secondary");
 
    ASSERT_CMPINT64 (get_max_staleness (client), ==, (int64_t) 120);
    mongoc_client_destroy (client);
 
    /* float is ignored */
    capture_logs (true);
-   ASSERT (!mongoc_client_new ("mongodb://a/?" MONGOC_URI_READPREFERENCE
-                               "=secondary&" MONGOC_URI_MAXSTALENESSSECONDS
-                               "=10.5"));
+   ASSERT (!test_framework_client_new (
+      "mongodb://a/?" MONGOC_URI_READPREFERENCE
+      "=secondary&" MONGOC_URI_MAXSTALENESSSECONDS "=10.5"));
 
    ASSERT_CAPTURED_LOG (MONGOC_URI_MAXSTALENESSSECONDS "=10.5",
                         MONGOC_LOG_LEVEL_WARNING,
                         "Invalid " MONGOC_URI_MAXSTALENESSSECONDS);
 
    /* 1 is allowed, it'll be rejected once we begin server selection */
-   client =
-      mongoc_client_new ("mongodb://a/?" MONGOC_URI_READPREFERENCE
-                         "=secondary&" MONGOC_URI_MAXSTALENESSSECONDS "=1");
+   client = test_framework_client_new (
+      "mongodb://a/?" MONGOC_URI_READPREFERENCE
+      "=secondary&" MONGOC_URI_MAXSTALENESSSECONDS "=1");
 
    ASSERT_EQUAL_DOUBLE (get_max_staleness (client), 1);
    mongoc_client_destroy (client);
@@ -116,7 +118,7 @@ test_mongos_max_staleness_read_pref (void)
 
    server = mock_mongos_new (5 /* maxWireVersion */);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    /* count command with mode "secondary", no " MONGOC_URI_MAXSTALENESSSECONDS "
@@ -168,12 +170,12 @@ test_mongos_max_staleness_read_pref (void)
 
    future = future_collection_count (
       collection, MONGOC_QUERY_NONE, NULL, 0, 0, NULL, &error);
-   request = mock_server_receives_command (
-      server,
-      "db",
-      MONGOC_QUERY_SLAVE_OK,
-      "{'$readPreference': {'$exists': false}}",
-      NULL);
+   request =
+      mock_server_receives_command (server,
+                                    "db",
+                                    MONGOC_QUERY_SLAVE_OK,
+                                    "{'$readPreference': {'$exists': false}}",
+                                    NULL);
 
    mock_server_replies_simple (request, "{'ok': 1, 'n': 1}");
    ASSERT_OR_PRINT (1 == future_get_int64_t (future), error);
@@ -226,11 +228,11 @@ _test_last_write_date (bool pooled)
    mongoc_uri_set_option_as_int32 (uri, "heartbeatFrequencyMS", 500);
 
    if (pooled) {
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
       test_framework_set_pool_ssl_opts (pool);
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
       test_framework_set_ssl_opts (client);
    }
    mongoc_uri_destroy (uri);
@@ -241,7 +243,8 @@ _test_last_write_date (bool pooled)
    ASSERT_OR_PRINT (r, error);
 
    _mongoc_usleep (1000 * 1000);
-   s0 = mongoc_topology_select (client->topology, MONGOC_SS_WRITE, NULL, &error);
+   s0 =
+      mongoc_topology_select (client->topology, MONGOC_SS_WRITE, NULL, &error);
    ASSERT_OR_PRINT (s0, error);
 
    _mongoc_usleep (1000 * 1000);
@@ -250,7 +253,8 @@ _test_last_write_date (bool pooled)
    ASSERT_OR_PRINT (r, error);
 
    _mongoc_usleep (1000 * 1000);
-   s1 = mongoc_topology_select (client->topology, MONGOC_SS_WRITE, NULL, &error);
+   s1 =
+      mongoc_topology_select (client->topology, MONGOC_SS_WRITE, NULL, &error);
    ASSERT_OR_PRINT (s1, error);
    ASSERT_CMPINT64 (s1->last_write_date_ms, !=, (int64_t) -1);
 
@@ -297,10 +301,10 @@ _test_last_write_date_absent (bool pooled)
    mongoc_server_description_t *sd;
 
    if (pooled) {
-      pool = test_framework_client_pool_new ();
+      pool = test_framework_new_default_client_pool ();
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = test_framework_client_new ();
+      client = test_framework_new_default_client ();
    }
 
    sd = mongoc_topology_select (client->topology, MONGOC_SS_READ, NULL, &error);

--- a/src/libmongoc/tests/test-mongoc-mongohouse.c
+++ b/src/libmongoc/tests/test-mongoc-mongohouse.c
@@ -208,7 +208,7 @@ test_mongohouse_kill_cursors ()
    const bson_t *doc;
 
    uri = mongoc_uri_new (uri_str);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    BSON_ASSERT (client);
 
    test.cursor_ns = NULL;
@@ -261,7 +261,7 @@ _run_ping_test (const char *connection_string)
    bool res;
 
    uri = mongoc_uri_new (connection_string);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    BSON_ASSERT (client);
 
    res = mongoc_client_command_simple (

--- a/src/libmongoc/tests/test-mongoc-mongos-pinning.c
+++ b/src/libmongoc/tests/test-mongoc-mongos-pinning.c
@@ -53,7 +53,7 @@ test_new_transaction_unpins (void *ctx)
    /* Increase localThresholdMS to avoid false positives. Nodes
       will be discovered with the first call to server selection. */
    mongoc_uri_set_option_as_int32 (uri, MONGOC_URI_LOCALTHRESHOLDMS, 1000);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    test_framework_set_ssl_opts (client);
 
    /* Create a collection. */
@@ -131,7 +131,7 @@ test_non_transaction_unpins (void *ctx)
    /* Increase localThresholdMS to avoid false positives. Nodes
       will be discovered with the first call to server selection. */
    mongoc_uri_set_option_as_int32 (uri, MONGOC_URI_LOCALTHRESHOLDMS, 1000);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    test_framework_set_ssl_opts (client);
 
    /* Create a collection. */

--- a/src/libmongoc/tests/test-mongoc-opts.c
+++ b/src/libmongoc/tests/test-mongoc-opts.c
@@ -805,7 +805,7 @@ test_func_inherits_opts (void *ctx)
       bson_reinit (&cmd);
       bson_reinit (&opts);
 
-      client = mongoc_client_new_from_uri (mock_rs_get_uri (rs));
+      client = test_framework_client_new_from_uri (mock_rs_get_uri (rs));
       if (source_matrix[i] & OPT_SOURCE_CLIENT) {
          set_client_opt (client, test->opt_type);
       }

--- a/src/libmongoc/tests/test-mongoc-primary-stepdown.c
+++ b/src/libmongoc/tests/test-mongoc-primary-stepdown.c
@@ -102,7 +102,7 @@ _run_test_single_and_pooled (_test_fn_t test)
    mongoc_client_destroy (client);
 
    /* Run in pooled mode */
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
    test_framework_set_pool_ssl_opts (pool);
    client = mongoc_client_pool_pop (pool);
    _setup_test_with_client (client);

--- a/src/libmongoc/tests/test-mongoc-primary-stepdown.c
+++ b/src/libmongoc/tests/test-mongoc-primary-stepdown.c
@@ -95,14 +95,14 @@ _run_test_single_and_pooled (_test_fn_t test)
    uri = _get_test_uri ();
 
    /* Run in single-threaded mode */
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    test_framework_set_ssl_opts (client);
    _setup_test_with_client (client);
    test (client);
    mongoc_client_destroy (client);
 
    /* Run in pooled mode */
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
    test_framework_set_pool_ssl_opts (pool);
    client = mongoc_client_pool_pop (pool);
    _setup_test_with_client (client);

--- a/src/libmongoc/tests/test-mongoc-read-concern.c
+++ b/src/libmongoc/tests/test-mongoc-read-concern.c
@@ -137,7 +137,7 @@ _test_read_concern_wire_version (bool allow, bool explicit)
    server = mock_server_with_autoismaster (
       allow ? WIRE_VERSION_READ_CONCERN : WIRE_VERSION_READ_CONCERN - 1);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    if (explicit) {

--- a/src/libmongoc/tests/test-mongoc-read-prefs.c
+++ b/src/libmongoc/tests/test-mongoc-read-prefs.c
@@ -31,7 +31,7 @@ _test_op_query (const mongoc_uri_t *uri,
    future_t *future;
    request_t *request;
 
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    collection = mongoc_client_get_collection (client, "test", "test");
 
    cursor = mongoc_collection_find (collection,
@@ -83,7 +83,7 @@ _test_find_command (const mongoc_uri_t *uri,
    future_t *future;
    request_t *request;
 
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    collection = mongoc_client_get_collection (client, "test", "test");
 
    cursor = mongoc_collection_find (collection,
@@ -138,7 +138,7 @@ _test_op_msg (const mongoc_uri_t *uri,
    future_t *future;
    request_t *request;
 
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    collection = mongoc_client_get_collection (client, "test", "test");
 
    cursor = mongoc_collection_find (collection,
@@ -187,7 +187,7 @@ _test_command (const mongoc_uri_t *uri,
    future_t *future;
    request_t *request;
 
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    collection = mongoc_client_get_collection (client, "test", "test");
    mongoc_collection_set_read_prefs (collection, read_prefs);
 
@@ -236,7 +236,7 @@ _test_command_simple (const mongoc_uri_t *uri,
    future_t *future;
    request_t *request;
 
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    collection = mongoc_client_get_collection (client, "test", "test");
    mongoc_collection_set_read_prefs (collection, read_prefs);
 
@@ -798,7 +798,7 @@ test_read_prefs_mongos_max_staleness (void)
 
    server = mock_mongos_new (WIRE_VERSION_MAX_STALENESS);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "test", "test");
 
    prefs = mongoc_read_prefs_new (MONGOC_READ_SECONDARY_PREFERRED);
@@ -856,7 +856,7 @@ test_read_prefs_mongos_hedged_reads (void)
 
    server = mock_mongos_new (WIRE_VERSION_HEDGED_READS);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "test", "test");
 
    prefs = mongoc_read_prefs_new (MONGOC_READ_SECONDARY_PREFERRED);
@@ -916,7 +916,7 @@ test_mongos_read_concern (void)
 
    server = mock_mongos_new (WIRE_VERSION_READ_CONCERN);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "test", "test");
    prefs = mongoc_read_prefs_new (MONGOC_READ_SECONDARY);
    cursor = mongoc_collection_find_with_opts (
@@ -982,13 +982,13 @@ _test_op_msg_direct_connection (bool is_mongos,
    if (is_mongos) {
       server = mock_mongos_new (WIRE_VERSION_OP_MSG);
    } else {
-      char* ismaster = bson_strdup_printf ("{'ok': 1.0,"
-                                        " 'ismaster': true,"
-                                        " 'setName': 'rs0',"
-                                        " 'secondary': true,"
-                                        " 'minWireVersion': 0,"
-                                        " 'maxWireVersion': %d}",
-                                        WIRE_VERSION_OP_MSG);
+      char *ismaster = bson_strdup_printf ("{'ok': 1.0,"
+                                           " 'ismaster': true,"
+                                           " 'setName': 'rs0',"
+                                           " 'secondary': true,"
+                                           " 'minWireVersion': 0,"
+                                           " 'maxWireVersion': %d}",
+                                           WIRE_VERSION_OP_MSG);
       server = mock_server_new ();
       mock_server_auto_ismaster (server, ismaster);
       bson_free (ismaster);
@@ -997,7 +997,7 @@ _test_op_msg_direct_connection (bool is_mongos,
    mock_server_auto_endsessions (server);
 
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    for (i = 0; i < 2; i++) {

--- a/src/libmongoc/tests/test-mongoc-read-prefs.c
+++ b/src/libmongoc/tests/test-mongoc-read-prefs.c
@@ -7,7 +7,7 @@
 #include "mock_server/mock-server.h"
 #include "mock_server/mock-rs.h"
 #include "test-conveniences.h"
-
+#include "test-libmongoc.h"
 
 static bool
 _can_be_command (const char *query)

--- a/src/libmongoc/tests/test-mongoc-read-write-concern.c
+++ b/src/libmongoc/tests/test-mongoc-read-write-concern.c
@@ -246,7 +246,7 @@ errinfo_propagated (void *unused)
       "clientSupplied'}}}},'mode':{'times':1}}";
 
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    ret = mongoc_client_command_simple (client,
                                        "admin",
                                        tmp_bson (failpoint),

--- a/src/libmongoc/tests/test-mongoc-retryable-reads.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-reads.c
@@ -93,7 +93,7 @@ test_cmd_helpers (void *ctx)
    uri = test_framework_get_uri ();
    mongoc_uri_set_option_as_bool (uri, "retryReads", true);
 
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    mongoc_client_set_error_api (client, MONGOC_ERROR_API_VERSION_2);
    test_framework_set_ssl_opts (client);
    mongoc_uri_destroy (uri);
@@ -240,7 +240,7 @@ test_retry_reads_off (void *ctx)
 
    uri = test_framework_get_uri ();
    mongoc_uri_set_option_as_bool (uri, "retryreads", false);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    test_framework_set_ssl_opts (client);
 
    /* clean up in case a previous test aborted */

--- a/src/libmongoc/tests/test-mongoc-retryable-writes.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-writes.c
@@ -74,7 +74,7 @@ test_rs_failover (void)
    mock_rs_run (rs);
    uri = mongoc_uri_copy (mock_rs_get_uri (rs));
    mongoc_uri_set_option_as_bool (uri, "retryWrites", true);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    collection = mongoc_client_get_collection (client, "db", "collection");
    cs = mongoc_client_start_session (client, NULL, &error);
    ASSERT_OR_PRINT (cs, error);
@@ -99,7 +99,8 @@ test_rs_failover (void)
    request =
       mock_rs_receives_msg (rs, 0, tmp_bson ("{'insert': 'collection'}"), b);
    BSON_ASSERT (mock_rs_request_is_to_secondary (rs, request));
-   mock_server_replies_simple (request, "{'ok': 0, 'code': 10107, 'errmsg': 'not master'}");
+   mock_server_replies_simple (
+      request, "{'ok': 0, 'code': 10107, 'errmsg': 'not master'}");
    request_destroy (request);
 
    request =
@@ -134,7 +135,7 @@ test_command_with_opts (void *ctx)
    uri = test_framework_get_uri ();
    mongoc_uri_set_option_as_bool (uri, "retryWrites", true);
 
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    test_framework_set_ssl_opts (client);
    mongoc_uri_destroy (uri);
 
@@ -205,7 +206,7 @@ test_insert_one_unacknowledged (void)
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_bool (uri, "retryWrites", true);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    wc = mongoc_write_concern_new ();
@@ -253,7 +254,7 @@ test_update_one_unacknowledged (void)
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_bool (uri, "retryWrites", true);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    wc = mongoc_write_concern_new ();
@@ -304,7 +305,7 @@ test_delete_one_unacknowledged (void)
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_bool (uri, "retryWrites", true);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    wc = mongoc_write_concern_new ();
@@ -352,7 +353,7 @@ test_bulk_operation_execute_unacknowledged (void)
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_bool (uri, "retryWrites", true);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    wc = mongoc_write_concern_new ();
@@ -401,7 +402,7 @@ test_remove_unacknowledged (void)
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_bool (uri, "retryWrites", true);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    wc = mongoc_write_concern_new ();
@@ -442,31 +443,34 @@ test_retry_no_crypto (void *ctx)
    /* Test that no warning is logged if retryWrites is disabled. Warning logic
     * is implemented in mongoc_topology_new, but test all public APIs that use
     * the common code path. */
-   client = mongoc_client_new ("mongodb://localhost/?retryWrites=false");
+   client =
+      test_framework_client_new ("mongodb://localhost/?retryWrites=false");
    BSON_ASSERT (client);
-   ASSERT_NO_CAPTURED_LOGS ("mongoc_client_new and retryWrites=false");
+   ASSERT_NO_CAPTURED_LOGS ("test_framework_client_new and retryWrites=false");
    mongoc_client_destroy (client);
 
    uri = mongoc_uri_new ("mongodb://localhost/?retryWrites=false");
    BSON_ASSERT (uri);
 
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    BSON_ASSERT (client);
-   ASSERT_NO_CAPTURED_LOGS ("mongoc_client_new_from_uri and retryWrites=false");
+   ASSERT_NO_CAPTURED_LOGS (
+      "test_framework_client_new_from_uri and retryWrites=false");
    mongoc_client_destroy (client);
 
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
    BSON_ASSERT (pool);
-   ASSERT_NO_CAPTURED_LOGS ("mongoc_client_pool_new and retryWrites=false");
+   ASSERT_NO_CAPTURED_LOGS (
+      "test_framework_client_pool_new and retryWrites=false");
    mongoc_client_pool_destroy (pool);
 
    mongoc_uri_destroy (uri);
 
    /* Test that a warning is logged if retryWrites is enabled. */
-   client = mongoc_client_new ("mongodb://localhost/?retryWrites=true");
+   client = test_framework_client_new ("mongodb://localhost/?retryWrites=true");
    BSON_ASSERT (client);
    ASSERT_CAPTURED_LOG (
-      "mongoc_client_new and retryWrites=true",
+      "test_framework_client_new and retryWrites=true",
       MONGOC_LOG_LEVEL_WARNING,
       "retryWrites not supported without an SSL crypto library");
    mongoc_client_destroy (client);
@@ -476,20 +480,20 @@ test_retry_no_crypto (void *ctx)
    uri = mongoc_uri_new ("mongodb://localhost/?retryWrites=true");
    BSON_ASSERT (uri);
 
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    BSON_ASSERT (client);
    ASSERT_CAPTURED_LOG (
-      "mongoc_client_new_from_uri and retryWrites=true",
+      "test_framework_client_new_from_uri and retryWrites=true",
       MONGOC_LOG_LEVEL_WARNING,
       "retryWrites not supported without an SSL crypto library");
    mongoc_client_destroy (client);
 
    clear_captured_logs ();
 
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
    BSON_ASSERT (pool);
    ASSERT_CAPTURED_LOG (
-      "mongoc_client_pool_new and retryWrites=true",
+      "test_framework_client_pool_new and retryWrites=true",
       MONGOC_LOG_LEVEL_WARNING,
       "retryWrites not supported without an SSL crypto library");
    mongoc_client_pool_destroy (pool);
@@ -515,7 +519,7 @@ test_unsupported_storage_engine_error (void)
 
    rs = mock_rs_with_autoismaster (WIRE_VERSION_RETRY_WRITES, true, 0, 0);
    mock_rs_run (rs);
-   client = mongoc_client_new_from_uri (mock_rs_get_uri (rs));
+   client = test_framework_client_new_from_uri (mock_rs_get_uri (rs));
    session = mongoc_client_start_session (client, NULL, &error);
    ASSERT_OR_PRINT (session, error);
    mongoc_client_set_error_api (client, MONGOC_ERROR_API_VERSION_2);
@@ -614,7 +618,7 @@ test_bulk_retry_tracks_new_server (void *unused)
    callbacks = mongoc_apm_callbacks_new ();
    mongoc_apm_set_command_started_cb (callbacks, _tracks_new_server_cb);
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    mongoc_client_set_apm_callbacks (client, callbacks, &counters);
    collection = get_test_collection (client, "tracks_new_server");
    bulk = mongoc_collection_create_bulk_operation_with_opts (collection, NULL);

--- a/src/libmongoc/tests/test-mongoc-retryable-writes.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-writes.c
@@ -458,10 +458,10 @@ test_retry_no_crypto (void *ctx)
       "test_framework_client_new_from_uri and retryWrites=false");
    mongoc_client_destroy (client);
 
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
    BSON_ASSERT (pool);
    ASSERT_NO_CAPTURED_LOGS (
-      "test_framework_client_pool_new and retryWrites=false");
+      "test_framework_client_pool_new_from_uri and retryWrites=false");
    mongoc_client_pool_destroy (pool);
 
    mongoc_uri_destroy (uri);
@@ -490,10 +490,10 @@ test_retry_no_crypto (void *ctx)
 
    clear_captured_logs ();
 
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
    BSON_ASSERT (pool);
    ASSERT_CAPTURED_LOG (
-      "test_framework_client_pool_new and retryWrites=true",
+      "test_framework_client_pool_new_from_uri and retryWrites=true",
       MONGOC_LOG_LEVEL_WARNING,
       "retryWrites not supported without an SSL crypto library");
    mongoc_client_pool_destroy (pool);

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -2521,7 +2521,7 @@ test_sample_change_stream_command (sample_command_fn_t fn,
        test_framework_skip_if_slow ()) {
 
       /* separate client for the background thread */
-      client = test_framework_client_new ();
+      client = test_framework_new_default_client ();
 
       bson_mutex_init (&ctx.lock);
       ctx.collection = mongoc_client_get_collection (
@@ -3432,7 +3432,7 @@ test_sample_txn_commands (mongoc_client_t *client)
 static mongoc_client_t *
 get_client (void)
 {
-   return test_framework_client_new ();
+   return test_framework_new_default_client ();
 }
 
 static bool
@@ -3464,11 +3464,11 @@ with_transaction_example (bson_error_t *error)
     * members in the URI string; e.g.
     * uri_repl = "mongodb://mongodb0.example.com:27017,mongodb1.example.com:" \
     *    "27017/?replicaSet=myRepl";
-    * client = mongoc_client_new (uri_repl);
+    * client = test_framework_client_new (uri_repl);
     * For a sharded cluster, connect to the mongos instances; e.g.
     * uri_sharded =
     * "mongodb://mongos0.example.com:27017,mongos1.example.com:27017/";
-    * client = mongoc_client_new (uri_sharded);
+    * client = test_framework_client_new (uri_sharded);
     */
 
    client = get_client ();
@@ -3579,7 +3579,7 @@ test_sample_commands (void)
    mongoc_database_t *db;
    mongoc_collection_t *collection;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    db = mongoc_client_get_database (client, "test_sample_command");
    collection = mongoc_database_get_collection (db, "inventory");
    mongoc_collection_drop (collection, NULL);

--- a/src/libmongoc/tests/test-mongoc-scram.c
+++ b/src/libmongoc/tests/test-mongoc-scram.c
@@ -220,7 +220,7 @@ _check_mechanism (bool pooled,
    }
 
    if (pooled) {
-      client_pool = test_framework_client_pool_new (uri);
+      client_pool = test_framework_client_pool_new_from_uri (uri);
       client = mongoc_client_pool_pop (client_pool);
       /* suppress the auth failure logs from pooled clients. */
       capture_logs (true);
@@ -303,7 +303,7 @@ _try_auth_from_uri (bool pooled, mongoc_uri_t *uri, test_error_t expected_error)
    bool res;
 
    if (pooled) {
-      client_pool = test_framework_client_pool_new (uri);
+      client_pool = test_framework_client_pool_new_from_uri (uri);
       test_framework_set_pool_ssl_opts (client_pool);
       mongoc_client_pool_set_error_api (client_pool, 2);
       client = mongoc_client_pool_pop (client_pool);

--- a/src/libmongoc/tests/test-mongoc-scram.c
+++ b/src/libmongoc/tests/test-mongoc-scram.c
@@ -138,7 +138,7 @@ _create_scram_users (void)
    mongoc_client_t *client;
    bool res;
    bson_error_t error;
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    res = mongoc_client_command_simple (
       client,
       "admin",
@@ -176,7 +176,7 @@ _drop_scram_users (void)
    mongoc_database_t *db;
    bool res;
    bson_error_t error;
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    db = mongoc_client_get_database (client, "admin");
    res = mongoc_database_remove_user (db, "sha1", &error);
    ASSERT_OR_PRINT (res, error);
@@ -220,12 +220,12 @@ _check_mechanism (bool pooled,
    }
 
    if (pooled) {
-      client_pool = mongoc_client_pool_new (uri);
+      client_pool = test_framework_client_pool_new (uri);
       client = mongoc_client_pool_pop (client_pool);
       /* suppress the auth failure logs from pooled clients. */
       capture_logs (true);
    } else {
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
    }
    future = future_client_command_simple (client,
                                           "admin",
@@ -303,14 +303,14 @@ _try_auth_from_uri (bool pooled, mongoc_uri_t *uri, test_error_t expected_error)
    bool res;
 
    if (pooled) {
-      client_pool = mongoc_client_pool_new (uri);
+      client_pool = test_framework_client_pool_new (uri);
       test_framework_set_pool_ssl_opts (client_pool);
       mongoc_client_pool_set_error_api (client_pool, 2);
       client = mongoc_client_pool_pop (client_pool);
       /* suppress the auth failure logs from pooled clients. */
       capture_logs (true);
    } else {
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
       mongoc_client_set_error_api (client, 2);
       test_framework_set_ssl_opts (client);
    }
@@ -426,7 +426,7 @@ _skip_if_no_sha256 ()
    bool res;
    bson_error_t error;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
 
    /* Check if SCRAM-SHA-256 is a supported auth mechanism by attempting to
     * create a new user with it. */
@@ -476,7 +476,7 @@ _create_saslprep_users ()
    mongoc_client_t *client;
    bool res;
    bson_error_t error;
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    res = mongoc_client_command_simple (
       client,
       "admin",
@@ -506,7 +506,7 @@ _drop_saslprep_users ()
    mongoc_database_t *db;
    bool res;
    bson_error_t error;
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    db = mongoc_client_get_database (client, "admin");
    res = mongoc_database_remove_user (db, "IX", &error);
    ASSERT_OR_PRINT (res, error);

--- a/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
@@ -476,7 +476,7 @@ test_sdam_monitoring_cb (bson_t *test)
 
    /* parse out the uri and use it to create a client */
    BSON_ASSERT (bson_iter_init_find (&iter, test, "uri"));
-   client = mongoc_client_new (bson_iter_utf8 (&iter, NULL));
+   client = test_framework_client_new (bson_iter_utf8 (&iter, NULL));
    topology = client->topology;
    context_init (&context);
    client_set_topology_event_callbacks (client, &context);
@@ -558,11 +558,11 @@ _test_topology_events (bool pooled)
    context_init (&context);
 
    if (pooled) {
-      pool = test_framework_client_pool_new ();
+      pool = test_framework_new_default_client_pool ();
       pool_set_topology_event_callbacks (pool, &context);
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = test_framework_client_new ();
+      client = test_framework_new_default_client ();
       client_set_topology_event_callbacks (client, &context);
    }
 
@@ -622,7 +622,7 @@ test_topology_events_disabled (void)
 
    context_init (&context);
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    client_set_topology_event_callbacks (client, &context);
 
    r = mongoc_client_command_simple (
@@ -698,11 +698,11 @@ _test_heartbeat_events (bool pooled, bool succeeded)
    start = bson_get_monotonic_time ();
 
    if (pooled) {
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
       pool_set_heartbeat_event_callbacks (pool, &context);
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
       client_set_heartbeat_event_callbacks (client, &context);
    }
 
@@ -835,11 +835,11 @@ _test_heartbeat_fails_dns (bool pooled)
    uri = mongoc_uri_new (
       "mongodb://doesntexist.foobar/?serverSelectionTimeoutMS=3000");
    if (pooled) {
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
       pool_set_heartbeat_event_callbacks (pool, &context);
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
       client_set_heartbeat_event_callbacks (client, &context);
    }
 
@@ -942,7 +942,7 @@ test_no_duplicates (void)
     * from interfering. */
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_int32 (uri, MONGOC_URI_HEARTBEATFREQUENCYMS, 99999);
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
    mongoc_apm_set_server_changed_cb (callbacks, duplicates_server_changed);
    mongoc_apm_set_topology_changed_cb (callbacks, duplicates_topology_changed);
    mongoc_client_pool_set_apm_callbacks (pool, callbacks, &duplicates_counter);

--- a/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
@@ -698,7 +698,7 @@ _test_heartbeat_events (bool pooled, bool succeeded)
    start = bson_get_monotonic_time ();
 
    if (pooled) {
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
       pool_set_heartbeat_event_callbacks (pool, &context);
       client = mongoc_client_pool_pop (pool);
    } else {
@@ -835,7 +835,7 @@ _test_heartbeat_fails_dns (bool pooled)
    uri = mongoc_uri_new (
       "mongodb://doesntexist.foobar/?serverSelectionTimeoutMS=3000");
    if (pooled) {
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
       pool_set_heartbeat_event_callbacks (pool, &context);
       client = mongoc_client_pool_pop (pool);
    } else {
@@ -942,7 +942,7 @@ test_no_duplicates (void)
     * from interfering. */
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_int32 (uri, MONGOC_URI_HEARTBEATFREQUENCYMS, 99999);
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
    mongoc_apm_set_server_changed_cb (callbacks, duplicates_server_changed);
    mongoc_apm_set_topology_changed_cb (callbacks, duplicates_topology_changed);
    mongoc_client_pool_set_apm_callbacks (pool, callbacks, &duplicates_counter);

--- a/src/libmongoc/tests/test-mongoc-sdam.c
+++ b/src/libmongoc/tests/test-mongoc-sdam.c
@@ -121,7 +121,7 @@ test_sdam_cb (bson_t *test)
 
    /* parse out the uri and use it to create a client */
    BSON_ASSERT (bson_iter_init_find (&iter, test, "uri"));
-   client = mongoc_client_new (bson_iter_utf8 (&iter, NULL));
+   client = test_framework_client_new (bson_iter_utf8 (&iter, NULL));
    td = &client->topology->description;
 
    /* for each phase, parse and validate */
@@ -340,11 +340,11 @@ run_one_integration_test (json_test_config_t *config, bson_t *test)
 
    /* SDAM integration tests require streamable ismaster support, which is only
     * available for a client pool. */
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
    mongoc_client_pool_set_error_api (pool, MONGOC_ERROR_API_VERSION_2);
    test_framework_set_pool_ssl_opts (pool);
 
-   setup_client = test_framework_client_new ();
+   setup_client = test_framework_new_default_client ();
    /* Disable failpoints that may have been enabled in a previous test run. */
    deactivate_failpoints_on_all_servers (setup_client);
    mongoc_client_command_simple (setup_client,
@@ -504,7 +504,7 @@ test_topology_discovery (void *ctx)
    replset_name = test_framework_replset_name ();
    uri_str = test_framework_get_uri_str ();
 
-   client = mongoc_client_new (uri_str);
+   client = test_framework_client_new (uri_str);
    test_framework_set_ssl_opts (client);
    prefs = mongoc_read_prefs_new (MONGOC_READ_SECONDARY);
    sd_secondary = mongoc_client_select_server (client,
@@ -526,7 +526,7 @@ test_topology_discovery (void *ctx)
    uri_str_auth = test_framework_add_user_password_from_env (uri_str);
 
    mongoc_client_destroy (client);
-   client = mongoc_client_new (uri_str_auth);
+   client = test_framework_client_new (uri_str_auth);
    test_framework_set_ssl_opts (client);
    collection = get_test_collection (client, "sdam_dc_test");
    BSON_APPEND_UTF8 (&doc, "hello", "world");
@@ -567,7 +567,7 @@ test_direct_connection (void *ctx)
    replset_name = test_framework_replset_name ();
    uri_str = test_framework_get_uri_str ();
 
-   client = mongoc_client_new (uri_str);
+   client = test_framework_client_new (uri_str);
    test_framework_set_ssl_opts (client);
    mongoc_client_set_error_api (client, MONGOC_ERROR_API_VERSION_2);
    prefs = mongoc_read_prefs_new (MONGOC_READ_SECONDARY);
@@ -590,7 +590,7 @@ test_direct_connection (void *ctx)
    uri_str_auth = test_framework_add_user_password_from_env (uri_str);
 
    mongoc_client_destroy (client);
-   client = mongoc_client_new (uri_str_auth);
+   client = test_framework_client_new (uri_str_auth);
    test_framework_set_ssl_opts (client);
    collection = get_test_collection (client, "sdam_dc_test");
    BSON_APPEND_UTF8 (&doc, "hello", "world");
@@ -631,7 +631,7 @@ test_existing_behavior (void *ctx)
    replset_name = test_framework_replset_name ();
    uri_str = test_framework_get_uri_str ();
 
-   client = mongoc_client_new (uri_str);
+   client = test_framework_client_new (uri_str);
    test_framework_set_ssl_opts (client);
    mongoc_client_set_error_api (client, MONGOC_ERROR_API_VERSION_2);
    prefs = mongoc_read_prefs_new (MONGOC_READ_SECONDARY);
@@ -654,7 +654,7 @@ test_existing_behavior (void *ctx)
    uri_str_auth = test_framework_add_user_password_from_env (uri_str);
 
    mongoc_client_destroy (client);
-   client = mongoc_client_new (uri_str_auth);
+   client = test_framework_client_new (uri_str_auth);
    test_framework_set_ssl_opts (client);
    collection = get_test_collection (client, "sdam_dc_test");
    BSON_APPEND_UTF8 (&doc, "hello", "world");
@@ -728,7 +728,7 @@ test_prose_rtt (void *unused)
    callbacks = mongoc_apm_callbacks_new ();
    mongoc_apm_set_server_heartbeat_succeeded_cb (callbacks,
                                                  heartbeat_succeeded);
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
    test_framework_set_pool_ssl_opts (pool);
    memset (&ctx, 0, sizeof (prose_test_ctx_t));
    mongoc_client_pool_set_apm_callbacks (pool, callbacks, &ctx);

--- a/src/libmongoc/tests/test-mongoc-sdam.c
+++ b/src/libmongoc/tests/test-mongoc-sdam.c
@@ -340,7 +340,7 @@ run_one_integration_test (json_test_config_t *config, bson_t *test)
 
    /* SDAM integration tests require streamable ismaster support, which is only
     * available for a client pool. */
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
    mongoc_client_pool_set_error_api (pool, MONGOC_ERROR_API_VERSION_2);
    test_framework_set_pool_ssl_opts (pool);
 
@@ -728,7 +728,7 @@ test_prose_rtt (void *unused)
    callbacks = mongoc_apm_callbacks_new ();
    mongoc_apm_set_server_heartbeat_succeeded_cb (callbacks,
                                                  heartbeat_succeeded);
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
    test_framework_set_pool_ssl_opts (pool);
    memset (&ctx, 0, sizeof (prose_test_ctx_t));
    mongoc_client_pool_set_apm_callbacks (pool, callbacks, &ctx);

--- a/src/libmongoc/tests/test-mongoc-server-selection-errors.c
+++ b/src/libmongoc/tests/test-mongoc-server-selection-errors.c
@@ -42,13 +42,13 @@ server_selection_error_dns (const char *uri_str,
    ASSERT (uri);
 
    if (pooled && expect_success) {
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
       test_framework_set_pool_ssl_opts (pool);
       client = mongoc_client_pool_pop (pool);
    } else if (pooled) {
       /* we expect selection to fail; let the test finish faster */
       mongoc_uri_set_option_as_int32 (uri, "serverSelectionTimeoutMS", 100);
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
       test_framework_set_pool_ssl_opts (pool);
       _mongoc_client_pool_set_stream_initiator (pool, cannot_resolve, NULL);
       client = mongoc_client_pool_pop (pool);
@@ -178,7 +178,7 @@ _test_server_selection_uds_auth_failure (bool pooled)
    ASSERT (uri);
 
    if (pooled) {
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
 #ifdef MONGOC_ENABLE_SSL
       test_framework_set_pool_ssl_opts (pool);
 #endif
@@ -237,7 +237,7 @@ _test_server_selection_uds_not_found (bool pooled)
    mongoc_uri_set_option_as_int32 (uri, "serverSelectionTimeoutMS", 100);
 
    if (pooled) {
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
 #ifdef MONGOC_ENABLE_SSL
       test_framework_set_pool_ssl_opts (pool);
 #endif

--- a/src/libmongoc/tests/test-mongoc-server-selection-errors.c
+++ b/src/libmongoc/tests/test-mongoc-server-selection-errors.c
@@ -42,18 +42,18 @@ server_selection_error_dns (const char *uri_str,
    ASSERT (uri);
 
    if (pooled && expect_success) {
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
       test_framework_set_pool_ssl_opts (pool);
       client = mongoc_client_pool_pop (pool);
    } else if (pooled) {
       /* we expect selection to fail; let the test finish faster */
       mongoc_uri_set_option_as_int32 (uri, "serverSelectionTimeoutMS", 100);
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
       test_framework_set_pool_ssl_opts (pool);
       _mongoc_client_pool_set_stream_initiator (pool, cannot_resolve, NULL);
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
       test_framework_set_ssl_opts (client);
       if (!expect_success) {
          mongoc_client_set_stream_initiator (client, cannot_resolve, NULL);
@@ -178,13 +178,13 @@ _test_server_selection_uds_auth_failure (bool pooled)
    ASSERT (uri);
 
    if (pooled) {
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
 #ifdef MONGOC_ENABLE_SSL
       test_framework_set_pool_ssl_opts (pool);
 #endif
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
 #ifdef MONGOC_ENABLE_SSL
       test_framework_set_ssl_opts (client);
 #endif
@@ -237,13 +237,13 @@ _test_server_selection_uds_not_found (bool pooled)
    mongoc_uri_set_option_as_int32 (uri, "serverSelectionTimeoutMS", 100);
 
    if (pooled) {
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
 #ifdef MONGOC_ENABLE_SSL
       test_framework_set_pool_ssl_opts (pool);
 #endif
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
 #ifdef MONGOC_ENABLE_SSL
       test_framework_set_ssl_opts (client);
 #endif

--- a/src/libmongoc/tests/test-mongoc-speculative-auth.c
+++ b/src/libmongoc/tests/test-mongoc-speculative-auth.c
@@ -154,7 +154,7 @@ _test_mongoc_speculative_auth (bool pooled,
    }
 
    if (pooled) {
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
 
 #ifdef MONGOC_ENABLE_SSL
       if (use_ssl) {

--- a/src/libmongoc/tests/test-mongoc-speculative-auth.c
+++ b/src/libmongoc/tests/test-mongoc-speculative-auth.c
@@ -154,7 +154,7 @@ _test_mongoc_speculative_auth (bool pooled,
    }
 
    if (pooled) {
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
 
 #ifdef MONGOC_ENABLE_SSL
       if (use_ssl) {
@@ -167,7 +167,7 @@ _test_mongoc_speculative_auth (bool pooled,
       /* suppress the auth failure logs from pooled clients. */
       capture_logs (true);
    } else {
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
 
 #ifdef MONGOC_ENABLE_SSL
       if (use_ssl) {

--- a/src/libmongoc/tests/test-mongoc-stream-tls-error.c
+++ b/src/libmongoc/tests/test-mongoc-stream-tls-error.c
@@ -264,7 +264,7 @@ static BSON_THREAD_FUN (handshake_stall_client, ptr)
                                  data->server_port,
                                  connect_timeout_ms);
 
-   client = mongoc_client_new (uri_str);
+   client = test_framework_client_new (uri_str);
    mongoc_client_set_ssl_opts (client, data->client);
 
    /* we should time out after about 200ms */

--- a/src/libmongoc/tests/test-mongoc-stream-tls.c
+++ b/src/libmongoc/tests/test-mongoc-stream-tls.c
@@ -399,7 +399,7 @@ test_mongoc_tls_insecure_nowarning (void)
    }
    uri = test_framework_get_uri ();
    mongoc_uri_set_option_as_bool (uri, MONGOC_URI_TLSINSECURE, true);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
 
    capture_logs (true);
    mongoc_client_command_simple (client,

--- a/src/libmongoc/tests/test-mongoc-streamable-ismaster.c
+++ b/src/libmongoc/tests/test-mongoc-streamable-ismaster.c
@@ -53,7 +53,7 @@ test_topology_version_update (void)
    server = mock_server_new ();
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    /* Override minHeartbeatFrequencyMS so test does not wait for 500ms when a
     * scan is needed. */
    client->topology->min_heartbeat_frequency_msec = 1;

--- a/src/libmongoc/tests/test-mongoc-topology-description.c
+++ b/src/libmongoc/tests/test-mongoc-topology-description.c
@@ -22,11 +22,11 @@ _test_has_readable_writable_server (bool pooled)
    mongoc_topology_t *topology;
 
    if (pooled) {
-      pool = test_framework_client_pool_new ();
+      pool = test_framework_new_default_client_pool ();
       topology = _mongoc_client_pool_get_topology (pool);
       td = &topology->description;
    } else {
-      client = test_framework_client_new ();
+      client = test_framework_new_default_client ();
       td = &client->topology->description;
       topology = client->topology;
    }

--- a/src/libmongoc/tests/test-mongoc-topology-reconcile.c
+++ b/src/libmongoc/tests/test-mongoc-topology-reconcile.c
@@ -118,10 +118,10 @@ _test_topology_reconcile_rs (bool pooled)
    uri = mongoc_uri_new (uri_str);
 
    if (pooled) {
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new (uri_str);
+      client = test_framework_client_new (uri_str);
    }
 
    if (!pooled) {
@@ -236,10 +236,10 @@ _test_topology_reconcile_sharded (bool pooled)
    uri = mongoc_uri_new (uri_str);
 
    if (pooled) {
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new (uri_str);
+      client = test_framework_client_new (uri_str);
    }
 
    primary_read_prefs = mongoc_read_prefs_new (MONGOC_READ_PRIMARY);
@@ -367,7 +367,7 @@ test_topology_reconcile_from_handshake (void *ctx)
       "mongodb://%s/?replicaSet=%s", host_and_port, replset_name);
 
    uri = mongoc_uri_new (uri_str);
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
    mongoc_apm_set_server_opening_cb (callbacks, server_opening);
    mongoc_client_pool_set_apm_callbacks (pool, callbacks, &data);
    test_framework_set_pool_ssl_opts (pool);
@@ -481,7 +481,7 @@ test_topology_reconcile_retire_single (void)
 
    uri = mongoc_uri_new (uri_str);
 
-   client = mongoc_client_new (uri_str);
+   client = test_framework_client_new (uri_str);
    topology = client->topology;
 
 
@@ -601,7 +601,7 @@ test_topology_reconcile_add_single (void)
 
    uri = mongoc_uri_new (uri_str);
 
-   client = mongoc_client_new (uri_str);
+   client = test_framework_client_new (uri_str);
    topology = client->topology;
 
    /* step 1: discover primary */

--- a/src/libmongoc/tests/test-mongoc-topology-reconcile.c
+++ b/src/libmongoc/tests/test-mongoc-topology-reconcile.c
@@ -118,7 +118,7 @@ _test_topology_reconcile_rs (bool pooled)
    uri = mongoc_uri_new (uri_str);
 
    if (pooled) {
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
       client = mongoc_client_pool_pop (pool);
    } else {
       client = test_framework_client_new (uri_str);
@@ -236,7 +236,7 @@ _test_topology_reconcile_sharded (bool pooled)
    uri = mongoc_uri_new (uri_str);
 
    if (pooled) {
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
       client = mongoc_client_pool_pop (pool);
    } else {
       client = test_framework_client_new (uri_str);
@@ -367,7 +367,7 @@ test_topology_reconcile_from_handshake (void *ctx)
       "mongodb://%s/?replicaSet=%s", host_and_port, replset_name);
 
    uri = mongoc_uri_new (uri_str);
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
    mongoc_apm_set_server_opening_cb (callbacks, server_opening);
    mongoc_client_pool_set_apm_callbacks (pool, callbacks, &data);
    test_framework_set_pool_ssl_opts (pool);

--- a/src/libmongoc/tests/test-mongoc-topology-scanner.c
+++ b/src/libmongoc/tests/test-mongoc-topology-scanner.c
@@ -655,7 +655,7 @@ _test_topology_scanner_does_not_renegotiate (bool pooled)
    mongoc_apm_set_server_heartbeat_failed_cb (callbacks, heartbeat_failed);
 
    if (pooled) {
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
       test_framework_set_pool_ssl_opts (pool);
       mongoc_client_pool_set_apm_callbacks (pool, callbacks, &failed);
       client = mongoc_client_pool_pop (pool);

--- a/src/libmongoc/tests/test-mongoc-topology-scanner.c
+++ b/src/libmongoc/tests/test-mongoc-topology-scanner.c
@@ -174,7 +174,7 @@ test_topology_scanner_discovery (void)
 
    uri_str = bson_strdup_printf ("mongodb://%s/?" MONGOC_URI_REPLICASET "=rs",
                                  mock_server_get_host_and_port (primary));
-   client = mongoc_client_new (uri_str);
+   client = test_framework_client_new (uri_str);
    secondary_pref = mongoc_read_prefs_new (MONGOC_READ_SECONDARY_PREFERRED);
 
    future = future_topology_select (
@@ -252,7 +252,7 @@ test_topology_scanner_oscillate (void)
    /* start with server 0 */
    uri_str = bson_strdup_printf ("mongodb://%s/?" MONGOC_URI_REPLICASET "=rs",
                                  mock_server_get_host_and_port (server0));
-   client = mongoc_client_new (uri_str);
+   client = test_framework_client_new (uri_str);
    scanner = client->topology->scanner;
    primary_pref = mongoc_read_prefs_new (MONGOC_READ_PRIMARY);
 
@@ -296,7 +296,7 @@ test_topology_scanner_connection_error (void)
    bson_error_t error;
 
    /* assuming nothing is listening on this port */
-   client = mongoc_client_new ("mongodb://localhost:9876");
+   client = test_framework_client_new ("mongodb://localhost:9876");
 
    ASSERT (!mongoc_client_command_simple (
       client, "db", tmp_bson ("{'foo': 1}"), NULL, NULL, &error));
@@ -325,7 +325,7 @@ test_topology_scanner_socket_timeout (void)
 
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_int32 (uri, MONGOC_URI_CONNECTTIMEOUTMS, 10);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
 
    ASSERT (!mongoc_client_command_simple (
       client, "db", tmp_bson ("{'foo': 1}"), NULL, NULL, &error));
@@ -388,7 +388,7 @@ test_topology_scanner_blocking_initiator (void)
    mock_rs_run (rs);
    uri = mongoc_uri_copy (mock_rs_get_uri (rs));
    mongoc_uri_set_option_as_int32 (uri, MONGOC_URI_CONNECTTIMEOUTMS, 100);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
 
    /* pretend last host in linked list is slow */
    data.slow_port = mongoc_uri_get_hosts (uri)->next->port;
@@ -596,8 +596,8 @@ test_topology_retired_fails_to_initiate (void)
    scanner = mongoc_topology_scanner_new (
       NULL, NULL, &_retired_fails_to_initiate_cb, NULL, TIMEOUT);
 
-   BSON_ASSERT (_mongoc_host_list_from_string (&host_list,
-                                  mock_server_get_host_and_port (server)));
+   BSON_ASSERT (_mongoc_host_list_from_string (
+      &host_list, mock_server_get_host_and_port (server)));
 
    mongoc_topology_scanner_add (scanner, &host_list, 1);
    mongoc_topology_scanner_start (scanner, false);
@@ -655,12 +655,12 @@ _test_topology_scanner_does_not_renegotiate (bool pooled)
    mongoc_apm_set_server_heartbeat_failed_cb (callbacks, heartbeat_failed);
 
    if (pooled) {
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
       test_framework_set_pool_ssl_opts (pool);
       mongoc_client_pool_set_apm_callbacks (pool, callbacks, &failed);
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
       mongoc_client_set_apm_callbacks (client, callbacks, &failed);
       test_framework_set_ssl_opts (client);
    }

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -310,7 +310,7 @@ test_server_selection_try_once_option (void *ctx)
    /* off for pooled clients, can't be enabled */
    for (i = 0; i < sizeof (uri_strings) / sizeof (char *); i++) {
       uri = mongoc_uri_new ("mongodb://a");
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
       client = mongoc_client_pool_pop (pool);
       BSON_ASSERT (!client->topology->server_selection_try_once);
       mongoc_client_pool_push (pool, client);
@@ -480,7 +480,7 @@ _test_topology_invalidate_server (bool pooled)
    callbacks = heartbeat_callbacks ();
 
    if (pooled) {
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
       mongoc_client_pool_set_apm_callbacks (pool, callbacks, &checks);
       test_framework_set_pool_ssl_opts (pool);
       client = mongoc_client_pool_pop (pool);
@@ -1120,7 +1120,7 @@ _test_server_removed_during_handshake (bool pooled)
    mongoc_uri_set_option_as_utf8 (uri, "replicaSet", "rs");
 
    if (pooled) {
-      pool = test_framework_client_pool_new (uri);
+      pool = test_framework_client_pool_new_from_uri (uri);
       client = mongoc_client_pool_pop (pool);
    } else {
       client = test_framework_client_new_from_uri (uri);
@@ -1299,7 +1299,7 @@ test_add_and_scan_failure (void)
 
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_utf8 (uri, "replicaSet", "rs");
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
    client = mongoc_client_pool_pop (pool);
    future = future_client_command_simple (
       client, "db", tmp_bson ("{'ping': 1}"), NULL, NULL, &error);
@@ -1482,7 +1482,7 @@ _test_ismaster_retry_pooled (bool hangup, int n_failures)
       mongoc_uri_set_option_as_int32 (uri, MONGOC_URI_CONNECTTIMEOUTMS, 100);
    }
 
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
    callbacks = heartbeat_callbacks ();
    mongoc_client_pool_set_apm_callbacks (pool, callbacks, &checks);
    client = mongoc_client_pool_pop (pool);
@@ -1739,7 +1739,7 @@ test_cluster_time_updated_during_handshake ()
    mongoc_uri_set_option_as_int32 (uri, "heartbeatFrequencyMS", 99999);
    mongoc_uri_set_option_as_utf8 (uri, "replicaSet", "rs");
 
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
    client = mongoc_client_pool_pop (pool);
 
    /* ensure a topology scan has run, populating the topology description
@@ -1840,7 +1840,7 @@ _test_request_scan_on_error (bool pooled,
 
    if (pooled) {
       mongoc_topology_t *topology;
-      client_pool = test_framework_client_pool_new (uri);
+      client_pool = test_framework_client_pool_new_from_uri (uri);
       topology = _mongoc_client_pool_get_topology (client_pool);
       /* set a small minHeartbeatFrequency, so scans don't block for 500ms. */
       topology->min_heartbeat_frequency_msec = minHBMS;
@@ -2143,7 +2143,7 @@ test_slow_server_pooled (void)
    mongoc_uri_set_option_as_int32 (
       uri, MONGOC_URI_SERVERSELECTIONTIMEOUTMS, 500);
 
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
    callbacks = heartbeat_callbacks ();
    mongoc_client_pool_set_apm_callbacks (pool, callbacks, &checks);
 

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -153,8 +153,8 @@ test_topology_client_creation (void)
    mongoc_uri_set_option_as_int32 (uri, "serverSelectionTimeoutMS", 54321);
 
    /* create two clients directly */
-   client_a = mongoc_client_new_from_uri (uri);
-   client_b = mongoc_client_new_from_uri (uri);
+   client_a = test_framework_client_new_from_uri (uri);
+   client_b = test_framework_client_new_from_uri (uri);
    BSON_ASSERT (client_a);
    BSON_ASSERT (client_b);
 
@@ -213,7 +213,7 @@ test_topology_thread_start_stop (void)
    mongoc_client_pool_t *pool;
    mongoc_topology_t *topology;
 
-   pool = test_framework_client_pool_new ();
+   pool = test_framework_new_default_client_pool ();
    topology = _mongoc_client_pool_get_topology (pool);
 
    /* Test starting up the scanner */
@@ -261,7 +261,7 @@ test_topology_client_pool_creation (void)
    mongoc_topology_t *topology_b;
 
    /* create two clients through a client pool */
-   pool = test_framework_client_pool_new ();
+   pool = test_framework_new_default_client_pool ();
    client_a = mongoc_client_pool_pop (pool);
    client_b = mongoc_client_pool_pop (pool);
    BSON_ASSERT (client_a);
@@ -295,22 +295,22 @@ test_server_selection_try_once_option (void *ctx)
    mongoc_client_pool_t *pool;
 
    /* try_once is on by default for non-pooled, can be turned off */
-   client = mongoc_client_new (uri_strings[0]);
+   client = test_framework_client_new (uri_strings[0]);
    BSON_ASSERT (client->topology->server_selection_try_once);
    mongoc_client_destroy (client);
 
-   client = mongoc_client_new (uri_strings[1]);
+   client = test_framework_client_new (uri_strings[1]);
    BSON_ASSERT (client->topology->server_selection_try_once);
    mongoc_client_destroy (client);
 
-   client = mongoc_client_new (uri_strings[2]);
+   client = test_framework_client_new (uri_strings[2]);
    BSON_ASSERT (!client->topology->server_selection_try_once);
    mongoc_client_destroy (client);
 
    /* off for pooled clients, can't be enabled */
    for (i = 0; i < sizeof (uri_strings) / sizeof (char *); i++) {
       uri = mongoc_uri_new ("mongodb://a");
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
       client = mongoc_client_pool_pop (pool);
       BSON_ASSERT (!client->topology->server_selection_try_once);
       mongoc_client_pool_push (pool, client);
@@ -368,7 +368,7 @@ _test_server_selection (bool try_once)
       mongoc_uri_set_option_as_bool (uri, "serverSelectionTryOnce", false);
    }
 
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    primary_pref = mongoc_read_prefs_new (MONGOC_READ_PRIMARY);
 
    /* no primary, selection fails after one try */
@@ -480,7 +480,7 @@ _test_topology_invalidate_server (bool pooled)
    callbacks = heartbeat_callbacks ();
 
    if (pooled) {
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
       mongoc_client_pool_set_apm_callbacks (pool, callbacks, &checks);
       test_framework_set_pool_ssl_opts (pool);
       client = mongoc_client_pool_pop (pool);
@@ -491,7 +491,7 @@ _test_topology_invalidate_server (bool pooled)
       /* background scanner complains about failed connection */
       capture_logs (true);
    } else {
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
       test_framework_set_ssl_opts (client);
    }
 
@@ -590,7 +590,7 @@ test_invalid_cluster_node (void *ctx)
    mongoc_server_description_t *sd;
 
    /* use client pool, this test is only valid when multi-threaded */
-   pool = test_framework_client_pool_new ();
+   pool = test_framework_new_default_client_pool ();
    client = mongoc_client_pool_pop (pool);
    cluster = &client->cluster;
 
@@ -642,7 +642,7 @@ test_max_wire_version_race_condition (void *ctx)
    bool r;
 
    /* connect directly and add our user, test is only valid with auth */
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    database = mongoc_client_get_database (client, "test");
    (void) mongoc_database_remove_user (database, "pink", &error);
 
@@ -658,7 +658,7 @@ test_max_wire_version_race_condition (void *ctx)
    mongoc_client_destroy (client);
 
    /* use client pool, test is only valid when multi-threaded */
-   pool = test_framework_client_pool_new ();
+   pool = test_framework_new_default_client_pool ();
    client = mongoc_client_pool_pop (pool);
 
    /* load stream into cluster */
@@ -702,7 +702,7 @@ test_cooldown_standalone (void)
 
    server = mock_server_new ();
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    primary_pref = mongoc_read_prefs_new (MONGOC_READ_PRIMARY);
 
    /* first ismaster fails, selection fails */
@@ -791,7 +791,7 @@ test_cooldown_rs (void)
                                  "&connectTimeoutMS=100",
                                  mock_server_get_port (servers[0]));
 
-   client = mongoc_client_new (uri_str);
+   client = test_framework_client_new (uri_str);
    primary_pref = mongoc_read_prefs_new (MONGOC_READ_PRIMARY);
 
    secondary_response = bson_strdup_printf (
@@ -892,7 +892,7 @@ test_cooldown_retry (void)
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_bool (uri, "serverSelectionTryOnce", false);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    primary_pref = mongoc_read_prefs_new (MONGOC_READ_PRIMARY);
 
    future = future_topology_select (
@@ -981,7 +981,7 @@ _test_select_succeed (bool try_once)
       mongoc_uri_set_option_as_bool (uri, "serverSelectionTryOnce", false);
    }
 
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
 
    /* start waiting for a primary (NULL read pref) */
    start = bson_get_monotonic_time ();
@@ -1035,7 +1035,7 @@ test_multiple_selection_errors (void *context)
    bson_t reply;
    bson_error_t error;
 
-   client = mongoc_client_new (uri);
+   client = test_framework_client_new (uri);
    mongoc_client_command_simple (
       client, "test", tmp_bson ("{'ping': 1}"), NULL, &reply, &error);
 
@@ -1063,7 +1063,7 @@ test_invalid_server_id (void)
    mongoc_client_t *client;
    bson_error_t error;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
 
    BSON_ASSERT (
       !mongoc_topology_server_by_id (client->topology, 99999, &error));
@@ -1120,10 +1120,10 @@ _test_server_removed_during_handshake (bool pooled)
    mongoc_uri_set_option_as_utf8 (uri, "replicaSet", "rs");
 
    if (pooled) {
-      pool = mongoc_client_pool_new (uri);
+      pool = test_framework_client_pool_new (uri);
       client = mongoc_client_pool_pop (pool);
    } else {
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
    }
 
    /* initial connection, discover one-node replica set */
@@ -1230,7 +1230,7 @@ test_rtt (void *ctx)
    server = mock_server_new ();
    mock_server_run (server);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    future = future_client_command_simple (
       client, "db", tmp_bson ("{'ping': 1}"), NULL, NULL, &error);
 
@@ -1299,7 +1299,7 @@ test_add_and_scan_failure (void)
 
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_utf8 (uri, "replicaSet", "rs");
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
    client = mongoc_client_pool_pop (pool);
    future = future_client_command_simple (
       client, "db", tmp_bson ("{'ping': 1}"), NULL, NULL, &error);
@@ -1387,7 +1387,7 @@ _test_ismaster_retry_single (bool hangup, int n_failures)
       mongoc_uri_set_option_as_int32 (uri, MONGOC_URI_CONNECTTIMEOUTMS, 100);
    }
 
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    callbacks = heartbeat_callbacks ();
    mongoc_client_set_apm_callbacks (client, callbacks, &checks);
 
@@ -1482,7 +1482,7 @@ _test_ismaster_retry_pooled (bool hangup, int n_failures)
       mongoc_uri_set_option_as_int32 (uri, MONGOC_URI_CONNECTTIMEOUTMS, 100);
    }
 
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
    callbacks = heartbeat_callbacks ();
    mongoc_client_pool_set_apm_callbacks (pool, callbacks, &checks);
    client = mongoc_client_pool_pop (pool);
@@ -1625,7 +1625,7 @@ test_incompatible_error (void)
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_int32 (uri, "heartbeatFrequencyMS", 500);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
 
    /* trigger connection, fails due to incompatibility */
    ASSERT (!mongoc_client_command_simple (
@@ -1677,7 +1677,7 @@ test_compatible_null_error_pointer (void)
    /* incompatible */
    server = mock_server_with_autoismaster (WIRE_VERSION_MIN - 1);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    td = &client->topology->description;
 
    /* trigger connection, fails due to incompatibility */
@@ -1739,7 +1739,7 @@ test_cluster_time_updated_during_handshake ()
    mongoc_uri_set_option_as_int32 (uri, "heartbeatFrequencyMS", 99999);
    mongoc_uri_set_option_as_utf8 (uri, "replicaSet", "rs");
 
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
    client = mongoc_client_pool_pop (pool);
 
    /* ensure a topology scan has run, populating the topology description
@@ -1840,12 +1840,12 @@ _test_request_scan_on_error (bool pooled,
 
    if (pooled) {
       mongoc_topology_t *topology;
-      client_pool = mongoc_client_pool_new (uri);
+      client_pool = test_framework_client_pool_new (uri);
       topology = _mongoc_client_pool_get_topology (client_pool);
       /* set a small minHeartbeatFrequency, so scans don't block for 500ms. */
       topology->min_heartbeat_frequency_msec = minHBMS;
    } else {
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
       /* set a small minHeartbeatFrequency, so scans don't block for 500ms. */
       client->topology->min_heartbeat_frequency_msec = minHBMS;
    }
@@ -1978,7 +1978,7 @@ test_last_server_removed_warning (void)
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_utf8 (uri, "replicaSet", "set");
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    read_prefs = mongoc_read_prefs_new (MONGOC_READ_PRIMARY);
 
    mock_server_auto_ismaster (server,
@@ -2143,7 +2143,7 @@ test_slow_server_pooled (void)
    mongoc_uri_set_option_as_int32 (
       uri, MONGOC_URI_SERVERSELECTIONTIMEOUTMS, 500);
 
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
    callbacks = heartbeat_callbacks ();
    mongoc_client_pool_set_apm_callbacks (pool, callbacks, &checks);
 

--- a/src/libmongoc/tests/test-mongoc-transactions.c
+++ b/src/libmongoc/tests/test-mongoc-transactions.c
@@ -24,7 +24,7 @@ _reset_server (json_test_ctx_t *ctx, const char *host_str)
    mongoc_uri_t *uri = _mongoc_uri_copy_and_replace_host_list (
       ctx->test_framework_uri, host_str);
 
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    test_framework_set_ssl_opts (client);
 
    /* From Transactions tests runner: "Create a MongoClient and call
@@ -79,7 +79,7 @@ _disable_failpoints (json_test_ctx_t *ctx, const char *host_str)
    for (i = 0; i < 7; i++) {
       bool ret;
 
-      client = mongoc_client_new_from_uri (uri);
+      client = test_framework_client_new_from_uri (uri);
       ret = mongoc_client_command_simple (
          client,
          "admin",
@@ -285,7 +285,7 @@ test_transactions_supported (void *ctx)
       return;
    }
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    mongoc_client_set_error_api (client, 2);
    db = mongoc_client_get_database (client, "transaction-tests");
 
@@ -339,7 +339,7 @@ test_in_transaction (void *ctx)
    bson_error_t error;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    mongoc_client_set_error_api (client, 2);
    db = mongoc_client_get_database (client, "transaction-tests");
    /* drop and create collection outside of transaction */
@@ -464,7 +464,7 @@ _test_transient_txn_err (bool hangup)
    rs_response_to_ismaster (
       server, 7, true /* primary */, false /* tags */, server, NULL);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    /* allow fast reconnect */
    client->topology->min_heartbeat_frequency_msec = 0;
    session = mongoc_client_start_session (client, NULL, &error);
@@ -630,7 +630,7 @@ test_unknown_commit_result (void)
    rs_response_to_ismaster (
       server, 7, true /* primary */, false /* tags */, server, NULL);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    /* allow fast reconnect */
    client->topology->min_heartbeat_frequency_msec = 0;
    session = mongoc_client_start_session (client, NULL, &error);
@@ -687,7 +687,7 @@ test_cursor_primary_read_pref (void *ctx)
    bson_error_t error;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_cursor_primary_read_pref");
 
    session = mongoc_client_start_session (client, NULL, &error);
@@ -749,7 +749,7 @@ test_inherit_from_client (void *ctx)
    mongoc_write_concern_set_w (wc, 0);
    mongoc_uri_set_write_concern (uri, wc);
 
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    test_framework_set_ssl_opts (client);
 
    sopt = mongoc_session_opts_new ();
@@ -805,7 +805,7 @@ test_transaction_fails_on_unsupported_version_or_sharded_cluster (void *ctx)
    mongoc_client_t *client;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    session = mongoc_client_start_session (client, NULL, &error);
    ASSERT_OR_PRINT (session, error);
 
@@ -839,7 +839,7 @@ test_transaction_recovery_token_cleared (void *ctx)
    uri = test_framework_get_uri ();
    ASSERT_OR_PRINT (
       mongoc_uri_upsert_host_and_port (uri, "localhost:27018", &error), error);
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    test_framework_set_ssl_opts (client);
    mongoc_uri_destroy (uri);
    session = mongoc_client_start_session (client, NULL, &error);
@@ -926,7 +926,7 @@ test_selected_server_is_pinned_to_mongos (void *ctx)
    ASSERT_OR_PRINT (
       mongoc_uri_upsert_host_and_port (uri, "localhost:27018", &error), error);
 
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    BSON_ASSERT (client);
    test_framework_set_ssl_opts (client);
 
@@ -1040,7 +1040,7 @@ test_get_transaction_opts (void)
    rs_response_to_ismaster (
       server, 7, true /* primary */, false /* tags */, server, NULL);
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    BSON_ASSERT (client);
 
    read_concern = mongoc_read_concern_new ();
@@ -1123,7 +1123,7 @@ test_max_commit_time_ms_is_reset (void *ctx)
    mock_rs_run (rs);
    uri = mongoc_uri_copy (mock_rs_get_uri (rs));
 
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    BSON_ASSERT (client);
 
    txn_opts = mongoc_transaction_opts_new ();

--- a/src/libmongoc/tests/test-mongoc-uri.c
+++ b/src/libmongoc/tests/test-mongoc-uri.c
@@ -542,7 +542,7 @@ test_mongoc_uri_functions (void)
    ASSERT_CMPSTR (mongoc_uri_get_database (uri),
                   "longer database that should work");
 
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    mongoc_uri_destroy (uri);
 
    ASSERT_CMPSTR (mongoc_uri_get_username (client->uri),
@@ -623,7 +623,7 @@ test_mongoc_uri_functions (void)
    /* tls isn't set, return out fallback */
    ASSERT (mongoc_uri_get_option_as_bool (uri, MONGOC_URI_TLS, true));
 
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    mongoc_uri_destroy (uri);
 
    ASSERT (
@@ -668,7 +668,7 @@ test_mongoc_uri_functions (void)
                      uri, MONGOC_URI_SOCKETCHECKINTERVALMS, 0));
 
 
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    ASSERT_CMPINT (2, ==, client->cluster.sockettimeoutms);
    ASSERT_CMPINT (202, ==, client->cluster.socketcheckintervalms);
 
@@ -679,7 +679,7 @@ test_mongoc_uri_functions (void)
    uri = mongoc_uri_new ("mongodb://host/dbname0");
    ASSERT_CMPSTR (mongoc_uri_get_database (uri), "dbname0");
    mongoc_uri_set_database (uri, "dbname1");
-   client = mongoc_client_new_from_uri (uri);
+   client = test_framework_client_new_from_uri (uri);
    db = mongoc_client_get_default_database (client);
    ASSERT_CMPSTR (mongoc_database_get_name (db), "dbname1");
 
@@ -924,11 +924,12 @@ test_mongoc_host_list_from_string (void)
                         "Could not parse address");
 
    capture_logs (true);
-   ASSERT (!_mongoc_host_list_from_string (&host_list, "[::1]extra_chars:27017"));
+   ASSERT (
+      !_mongoc_host_list_from_string (&host_list, "[::1]extra_chars:27017"));
    ASSERT_CAPTURED_LOG ("_mongoc_host_list_from_string",
                         MONGOC_LOG_LEVEL_ERROR,
                         "If present, port should immediately follow the \"]\""
-                           "in an IPv6 address");
+                        "in an IPv6 address");
 
    /* normal parsing, host and port are split, host is downcased */
    ASSERT (_mongoc_host_list_from_string (&host_list, "localHOST:27019"));
@@ -2730,16 +2731,18 @@ test_one_tls_option_enables_tls ()
 static void
 test_casing_options ()
 {
-   mongoc_uri_t* uri;
+   mongoc_uri_t *uri;
    bson_error_t error;
 
-   uri = mongoc_uri_new("mongodb://localhost:27017/");
+   uri = mongoc_uri_new ("mongodb://localhost:27017/");
    mongoc_uri_set_option_as_bool (uri, "TLS", true);
-   mongoc_uri_parse_options(uri, "ssl=false", false, &error);
-   ASSERT_ERROR_CONTAINS(error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG,
+   mongoc_uri_parse_options (uri, "ssl=false", false, &error);
+   ASSERT_ERROR_CONTAINS (error,
+                          MONGOC_ERROR_COMMAND,
+                          MONGOC_ERROR_COMMAND_INVALID_ARG,
                           "conflicts");
 
-   mongoc_uri_destroy(uri);
+   mongoc_uri_destroy (uri);
 }
 
 void
@@ -2775,5 +2778,5 @@ test_uri_install (TestSuite *suite)
    TestSuite_Add (suite,
                   "/Uri/one_tls_option_enables_tls",
                   test_one_tls_option_enables_tls);
-   TestSuite_Add(suite, "/Uri/options_casing", test_casing_options);
+   TestSuite_Add (suite, "/Uri/options_casing", test_casing_options);
 }

--- a/src/libmongoc/tests/test-mongoc-versioned-api.c
+++ b/src/libmongoc/tests/test-mongoc-versioned-api.c
@@ -105,7 +105,7 @@ _test_mongoc_server_api_client_pool (void)
    bson_error_t error;
 
    uri = mongoc_uri_new ("mongodb://localhost");
-   pool = test_framework_client_pool_new (uri);
+   pool = test_framework_client_pool_new_from_uri (uri);
 
    api = mongoc_server_api_new (MONGOC_SERVER_API_V1);
 

--- a/src/libmongoc/tests/test-mongoc-versioned-api.c
+++ b/src/libmongoc/tests/test-mongoc-versioned-api.c
@@ -17,6 +17,7 @@
 #include <mongoc/mongoc.h>
 #include "mongoc-client-private.h"
 #include "mongoc-server-api-private.h"
+#include "test-libmongoc.h"
 
 #include "unified/runner.h"
 
@@ -71,7 +72,7 @@ _test_mongoc_server_api_client (void)
    mongoc_server_api_t *api;
    bson_error_t error;
 
-   client = mongoc_client_new ("mongodb://localhost");
+   client = test_framework_client_new ("mongodb://localhost");
    BSON_ASSERT (!client->api);
 
    api = mongoc_server_api_new (MONGOC_SERVER_API_V1);
@@ -104,7 +105,7 @@ _test_mongoc_server_api_client_pool (void)
    bson_error_t error;
 
    uri = mongoc_uri_new ("mongodb://localhost");
-   pool = mongoc_client_pool_new (uri);
+   pool = test_framework_client_pool_new (uri);
 
    api = mongoc_server_api_new (MONGOC_SERVER_API_V1);
 

--- a/src/libmongoc/tests/test-mongoc-with-transaction.c
+++ b/src/libmongoc/tests/test-mongoc-with-transaction.c
@@ -42,7 +42,7 @@ test_with_transaction_timeout (void *ctx)
    bson_error_t error;
    bool res;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
 
    session = mongoc_client_start_session (client, NULL, &error);
    ASSERT_OR_PRINT (session, error);

--- a/src/libmongoc/tests/test-mongoc-write-commands.c
+++ b/src/libmongoc/tests/test-mongoc-write-commands.c
@@ -31,7 +31,7 @@ test_split_insert (void)
    int i;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    collection = get_test_collection (client, "test_split_insert");
@@ -108,7 +108,7 @@ test_invalid_write_concern (void)
    bson_error_t error;
    bool r;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    collection = get_test_collection (client, "test_invalid_write_concern");
@@ -177,7 +177,7 @@ test_bypass_validation (void *context)
    int r;
    int i;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    dbname = gen_collection_name ("dbtest");
@@ -301,7 +301,7 @@ test_bypass_not_sent ()
    char *collname;
    char *dbname;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
 
    /* set up command monitoring for started commands */
    callbacks = mongoc_apm_callbacks_new ();
@@ -411,7 +411,7 @@ test_split_opquery_with_options (void)
       docs[i] = BCON_NEW ("_id", BCON_INT64 (i));
    }
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    coll = mongoc_client_get_collection (client, "db", "coll");
 
    /* Add a write concern, to ensure that it is taken into account during
@@ -487,7 +487,7 @@ test_opmsg_disconnect_mid_batch_helper (int wire_version)
       docs[i] = BCON_NEW ("_id", BCON_INT64 (i));
    }
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    mongoc_client_set_error_api (client, MONGOC_ERROR_API_VERSION_2);
    coll = mongoc_client_get_collection (client, "db", "coll");
 
@@ -544,7 +544,7 @@ test_w0_legacy_insert_many (void)
    docs[0] = BCON_NEW ("x", BCON_INT32 (1));
    docs[1] = BCON_NEW ("x", BCON_INT32 (2));
 
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    coll = mongoc_client_get_collection (client, "db", "coll");
 
    /* Add unacknowldged write concern */
@@ -602,7 +602,7 @@ _test_invalid_wc_server_error (void *unused)
    bson_t reply;
    bson_error_t error;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    mongoc_client_set_error_api (client, MONGOC_ERROR_API_VERSION_2);
    coll = get_test_collection (client, "server_wc_error");
 

--- a/src/libmongoc/tests/test-mongoc-write-concern.c
+++ b/src/libmongoc/tests/test-mongoc-write-concern.c
@@ -467,7 +467,7 @@ _test_write_concern_wire_version (bool allow)
       allow ? WIRE_VERSION_CMD_WRITE_CONCERN
             : WIRE_VERSION_CMD_WRITE_CONCERN - 1);
    mock_server_run (server);
-   client = mongoc_client_new_from_uri (mock_server_get_uri (server));
+   client = test_framework_client_new_from_uri (mock_server_get_uri (server));
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    /*
@@ -535,7 +535,7 @@ test_write_concern_unacknowledged (void)
    bson_t opts;
    const bson_t **docs;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    coll = mongoc_client_get_collection (client, "db", "coll");
 
    /* w:0 in OP_MSG is indicated by setting the moreToCome flag in OP_MSG. That
@@ -643,7 +643,7 @@ test_write_concern_inheritance_fam_txn (bool in_session, bool in_txn)
    int sent_w = MONGOC_WRITE_CONCERN_W_DEFAULT;
    bool success;
 
-   client = test_framework_client_new ();
+   client = test_framework_new_default_client ();
    collection = mongoc_client_get_collection (client, "db", "collection");
 
    callbacks = mongoc_apm_callbacks_new ();
@@ -698,7 +698,8 @@ test_write_concern_inheritance_fam_txn (bool in_session, bool in_txn)
    if (in_txn) {
       /* check that the sent write concern is not inherited */
       BSON_ASSERT (sent_w == MONGOC_WRITE_CONCERN_W_DEFAULT);
-      success = mongoc_client_session_commit_transaction (session, NULL, &error);
+      success =
+         mongoc_client_session_commit_transaction (session, NULL, &error);
       ASSERT_OR_PRINT (success, error);
    } else if (!in_session) {
       /* assert that write concern is inherited */
@@ -791,5 +792,4 @@ test_write_concern_install (TestSuite *suite)
                       NULL,
                       test_framework_skip_if_no_sessions,
                       test_framework_skip_if_no_txns);
-
 }


### PR DESCRIPTION
This PR renames some of the test framework methods around client and client_pool creation so they match the signatures of the `mongoc_client_new` and `mongoc_client_pool_new` methods.  It also creates new methods in the test framework for client and pool creation, so that all clients and pools in our tests are created through the framework.

The framework stub methods right now have simple pass through to `mongoc_client_new` and `mongoc_client_pool_new`, so these changes should have no behavior changes in our tests.  The next piece of work for CDRIVER-3917 will be to change these stub methods to add in versioned API information to client and pool creation.