### PR TITLE
CDRIVER-3215 Assert transaction state does not change on client-side error

### DIFF
--- a/src/libmongoc/tests/json-test-operations.c
+++ b/src/libmongoc/tests/json-test-operations.c
@@ -2255,6 +2255,49 @@ assert_event_count (json_test_ctx_t *ctx, const bson_t *operation)
    }
 }
 
+static void
+assert_session_transaction_state (json_test_ctx_t *ctx, const bson_t *operation)
+{
+   const char *expected_state;
+   const mongoc_client_session_t *session;
+
+   expected_state = bson_lookup_utf8 (operation, "arguments.state");
+   session = session_from_name (
+      ctx, bson_lookup_utf8 (operation, "arguments.session"));
+
+   if (!strcmp (expected_state, "none")) {
+      if (session->txn.state != MONGOC_INTERNAL_TRANSACTION_NONE) {
+         test_error ("expected session transaction state none, but have %i",
+                     session->txn.state);
+      }
+   } else if (!strcmp (expected_state, "starting")) {
+      if (session->txn.state != MONGOC_INTERNAL_TRANSACTION_STARTING) {
+         test_error ("expected session transaction state starting, but have %i",
+                     session->txn.state);
+      }
+   } else if (!strcmp (expected_state, "in_progress")) {
+      if (session->txn.state != MONGOC_INTERNAL_TRANSACTION_IN_PROGRESS) {
+         test_error (
+            "expected session transaction state in progress, but have %i",
+            session->txn.state);
+      }
+   } else if (!strcmp (expected_state, "committed")) {
+      if (session->txn.state != MONGOC_INTERNAL_TRANSACTION_COMMITTED) {
+         test_error (
+            "expected session transaction state committed, but have %i",
+            session->txn.state);
+      }
+   } else if (!strcmp (expected_state, "aborted")) {
+      if (session->txn.state != MONGOC_INTERNAL_TRANSACTION_ABORTED) {
+         test_error ("expected session transaction state aborted, but have %i",
+                     session->txn.state);
+      }
+   } else {
+      test_error ("unrecognized state %s for assertSessionTransactionState",
+                  expected_state);
+   }
+}
+
 static bool
 op_error (const bson_t *operation)
 {
@@ -2549,6 +2592,8 @@ json_test_operation (json_test_ctx_t *ctx,
          wt = thread_from_name (ctx,
                                 bson_lookup_utf8 (operation, "arguments.name"));
          run_on_thread (wt, &op);
+      } else if (!strcmp (op_name, "assertSessionTransactionState")) {
+         assert_session_transaction_state (ctx, operation);
       } else {
          test_error ("unrecognized testRunner operation name %s", op_name);
       }

--- a/src/libmongoc/tests/json-test-operations.c
+++ b/src/libmongoc/tests/json-test-operations.c
@@ -2260,37 +2260,46 @@ assert_session_transaction_state (json_test_ctx_t *ctx, const bson_t *operation)
 {
    const char *expected_state;
    const mongoc_client_session_t *session;
+   mongoc_transaction_state_t state;
+   char *state_strings[] = {"none",
+                            "starting",
+                            "in progress",
+                            "ending",
+                            "committed",
+                            "committed empty",
+                            "aborted"};
 
    expected_state = bson_lookup_utf8 (operation, "arguments.state");
    session = session_from_name (
       ctx, bson_lookup_utf8 (operation, "arguments.session"));
+   state = mongoc_client_session_get_transaction_state (session);
 
    if (!strcmp (expected_state, "none")) {
-      if (session->txn.state != MONGOC_INTERNAL_TRANSACTION_NONE) {
-         test_error ("expected session transaction state none, but have %i",
-                     session->txn.state);
+      if (state != MONGOC_INTERNAL_TRANSACTION_NONE) {
+         test_error ("expected session transaction state none, but have %s",
+                     state_strings[state]);
       }
    } else if (!strcmp (expected_state, "starting")) {
-      if (session->txn.state != MONGOC_INTERNAL_TRANSACTION_STARTING) {
-         test_error ("expected session transaction state starting, but have %i",
-                     session->txn.state);
+      if (state != MONGOC_INTERNAL_TRANSACTION_STARTING) {
+         test_error ("expected session transaction state starting, but have %s",
+                     state_strings[state]);
       }
    } else if (!strcmp (expected_state, "in_progress")) {
-      if (session->txn.state != MONGOC_INTERNAL_TRANSACTION_IN_PROGRESS) {
+      if (state != MONGOC_INTERNAL_TRANSACTION_IN_PROGRESS) {
          test_error (
-            "expected session transaction state in progress, but have %i",
-            session->txn.state);
+            "expected session transaction state in progress, but have %s",
+            state_strings[state]);
       }
    } else if (!strcmp (expected_state, "committed")) {
-      if (session->txn.state != MONGOC_INTERNAL_TRANSACTION_COMMITTED) {
+      if (state != MONGOC_INTERNAL_TRANSACTION_COMMITTED) {
          test_error (
-            "expected session transaction state committed, but have %i",
-            session->txn.state);
+            "expected session transaction state committed, but have %s",
+            state_strings[state]);
       }
    } else if (!strcmp (expected_state, "aborted")) {
-      if (session->txn.state != MONGOC_INTERNAL_TRANSACTION_ABORTED) {
-         test_error ("expected session transaction state aborted, but have %i",
-                     session->txn.state);
+      if (state != MONGOC_INTERNAL_TRANSACTION_ABORTED) {
+         test_error ("expected session transaction state aborted, but have %s",
+                     state_strings[state]);
       }
    } else {
       test_error ("unrecognized state %s for assertSessionTransactionState",

--- a/src/libmongoc/tests/json-test-operations.c
+++ b/src/libmongoc/tests/json-test-operations.c
@@ -2261,13 +2261,8 @@ assert_session_transaction_state (json_test_ctx_t *ctx, const bson_t *operation)
    const char *expected_state;
    const mongoc_client_session_t *session;
    mongoc_transaction_state_t state;
-   char *state_strings[] = {"none",
-                            "starting",
-                            "in progress",
-                            "ending",
-                            "committed",
-                            "committed empty",
-                            "aborted"};
+   char *state_strings[] = {
+      "none", "starting", "in progress", "committed", "aborted"};
 
    expected_state = bson_lookup_utf8 (operation, "arguments.state");
    session = session_from_name (
@@ -2275,29 +2270,29 @@ assert_session_transaction_state (json_test_ctx_t *ctx, const bson_t *operation)
    state = mongoc_client_session_get_transaction_state (session);
 
    if (!strcmp (expected_state, "none")) {
-      if (state != MONGOC_INTERNAL_TRANSACTION_NONE) {
+      if (state != MONGOC_TRANSACTION_NONE) {
          test_error ("expected session transaction state none, but have %s",
                      state_strings[state]);
       }
    } else if (!strcmp (expected_state, "starting")) {
-      if (state != MONGOC_INTERNAL_TRANSACTION_STARTING) {
+      if (state != MONGOC_TRANSACTION_STARTING) {
          test_error ("expected session transaction state starting, but have %s",
                      state_strings[state]);
       }
    } else if (!strcmp (expected_state, "in_progress")) {
-      if (state != MONGOC_INTERNAL_TRANSACTION_IN_PROGRESS) {
+      if (state != MONGOC_TRANSACTION_IN_PROGRESS) {
          test_error (
             "expected session transaction state in progress, but have %s",
             state_strings[state]);
       }
    } else if (!strcmp (expected_state, "committed")) {
-      if (state != MONGOC_INTERNAL_TRANSACTION_COMMITTED) {
+      if (state != MONGOC_TRANSACTION_COMMITTED) {
          test_error (
             "expected session transaction state committed, but have %s",
             state_strings[state]);
       }
    } else if (!strcmp (expected_state, "aborted")) {
-      if (state != MONGOC_INTERNAL_TRANSACTION_ABORTED) {
+      if (state != MONGOC_TRANSACTION_ABORTED) {
          test_error ("expected session transaction state aborted, but have %s",
                      state_strings[state]);
       }

--- a/src/libmongoc/tests/json/transactions/errors-client.json
+++ b/src/libmongoc/tests/json/transactions/errors-client.json
@@ -1,0 +1,95 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.8",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "transaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "Client side error in command starting transaction",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": {
+                ".": "."
+              }
+            }
+          },
+          "error": true
+        },
+        {
+          "name": "assertSessionTransactionState",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "state": "starting"
+          }
+        }
+      ]
+    },
+    {
+      "description": "Client side error when transaction is in progress",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 4
+            }
+          },
+          "result": {
+            "insertedId": 4
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": {
+                ".": "."
+              }
+            }
+          },
+          "error": true
+        },
+        {
+          "name": "assertSessionTransactionState",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "state": "in_progress"
+          }
+        }
+      ]
+    }
+  ]
+}
+


### PR DESCRIPTION
[CDRIVER-3215](https://jira.mongodb.org/browse/CDRIVER-3215)

Adds new spec test to assert that transaction state does not move from both "starting" or "in progress" when a client-side error is encountered.

Updates test runner to support "assertSessionTransactionState" described [here](https://github.com/mongodb/specifications/blob/master/source/transactions/tests/README.rst#assertsessiontransactionstate).