### PR TITLE
CDRIVER-3933 Reinit reply in edc for NamespaceNotFound

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-collection.c
+++ b/src/libmongoc/src/mongoc/mongoc-collection.c
@@ -909,7 +909,9 @@ mongoc_collection_estimated_document_count (
          /* Collection does not exist. From spec: return 0 but no err:
           * https://github.com/mongodb/specifications/blob/master/source/crud/crud.rst#estimateddocumentcount
           */
-         bson_reinit (reply);
+         if (reply) {
+            bson_reinit (reply);
+         }
          memset (error, 0, sizeof *error);
          count = 0;
          GOTO (done);

--- a/src/libmongoc/src/mongoc/mongoc-collection.c
+++ b/src/libmongoc/src/mongoc/mongoc-collection.c
@@ -909,6 +909,7 @@ mongoc_collection_estimated_document_count (
          /* Collection does not exist. From spec: return 0 but no err:
           * https://github.com/mongodb/specifications/blob/master/source/crud/crud.rst#estimateddocumentcount
           */
+         bson_reinit (reply);
          memset (error, 0, sizeof *error);
          count = 0;
          GOTO (done);

--- a/src/libmongoc/tests/unified/operation.c
+++ b/src/libmongoc/tests/unified/operation.c
@@ -817,12 +817,7 @@ operation_estimated_document_count (test_t *test,
       val = bson_val_from_int64 (op_ret);
    }
 
-   /* CDRIVER-3933 Remove special case for 0 count. */
-   if (op_ret == 0) {
-      result_from_val_and_reply (result, val, NULL, &op_error);
-   } else {
-      result_from_val_and_reply (result, val, &op_reply, &op_error);
-   }
+   result_from_val_and_reply (result, val, &op_reply, &op_error);
 
    ret = true;
 done:


### PR DESCRIPTION
[CDRIVER-3933](https://jira.mongodb.org/browse/CDRIVER-3933)

Destroys and re-initializes `reply` in `mongoc_collection_estimated_document_count` in the case of a NamespaceNotFound error caused by an aggregate on a non-existent collection. Also removes the workaround for 3933 in `operation.c`.

Per the spec, drivers are required to swallow a NamespaceNotFound error and return a count of 0. While the `bson_error_t` was being unset, and a count of 0 was being returned, `reply` still housed the error, which is arguably unexpected behavior for the user.