### PR TITLE
CDRIVER-3924 Ignore RCs when comparing test version strings

### DIFF
--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -2096,14 +2096,10 @@ _parse_server_version (const bson_t *buildinfo)
    /* Server returns a 4-part version like [3, 2, 0, 0], or like [3, 2, 0, -49]
     * for an RC. Ignore the 4th part since RCs are equivalent to non-RCs for
     * testing purposes. */
-   i = 0;
-   while (bson_iter_next (&array_iter)) {
-      if (i == N_SERVER_VERSION_PARTS) {
-         break;
-      }
+   for (i = 0; i < N_SERVER_VERSION_PARTS && bson_iter_next (&array_iter);
+        i++) {
       ret *= 1000;
       ret += 100 + bson_iter_as_int64 (&array_iter);
-      i++;
    }
 
    ASSERT_CMPINT (i, ==, N_SERVER_VERSION_PARTS);
@@ -2142,20 +2138,15 @@ test_framework_str_to_version (const char *version_str)
    server_version_t ret = 0;
 
    str_copy = bson_strdup (version_str);
-   i = 0;
    part = strtok (str_copy, ".");
 
    /* Versions can have 4 parts like "3.2.0.0", or like "3.2.0.-49" for an RC.
     * Ignore the 4th part since RCs are equivalent to non-RCs for testing
     * purposes. */
-   while (part) {
-      if (i == N_SERVER_VERSION_PARTS) {
-         break;
-      }
+   for (i = 0; i < N_SERVER_VERSION_PARTS && part; i++) {
       ret *= 1000;
       ret += 100 + bson_ascii_strtoll (part, &end, 10);
       part = strtok (NULL, ".");
-      i++;
    }
 
    /* pad out a short version like "3.0" to three parts */

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -2080,7 +2080,7 @@ test_framework_max_write_batch_size (void)
    return size;
 }
 
-#define N_SERVER_VERSION_PARTS 4
+#define N_SERVER_VERSION_PARTS 3
 
 static server_version_t
 _parse_server_version (const bson_t *buildinfo)
@@ -2098,11 +2098,12 @@ _parse_server_version (const bson_t *buildinfo)
     * testing purposes. */
    i = 0;
    while (bson_iter_next (&array_iter)) {
-      if (++i == N_SERVER_VERSION_PARTS) {
+      if (i == N_SERVER_VERSION_PARTS) {
          break;
       }
       ret *= 1000;
       ret += 100 + bson_iter_as_int64 (&array_iter);
+      i++;
    }
 
    ASSERT_CMPINT (i, ==, N_SERVER_VERSION_PARTS);
@@ -2148,16 +2149,17 @@ test_framework_str_to_version (const char *version_str)
     * Ignore the 4th part since RCs are equivalent to non-RCs for testing
     * purposes. */
    while (part) {
-      if (++i == N_SERVER_VERSION_PARTS) {
+      if (i == N_SERVER_VERSION_PARTS) {
          break;
       }
       ret *= 1000;
       ret += 100 + bson_ascii_strtoll (part, &end, 10);
       part = strtok (NULL, ".");
+      i++;
    }
 
    /* pad out a short version like "3.0" to three parts */
-   for (; i < N_SERVER_VERSION_PARTS - 1; i++) {
+   for (; i < N_SERVER_VERSION_PARTS; i++) {
       ret *= 1000;
       ret += 100;
    }


### PR DESCRIPTION
[CDRIVER-3924](https://jira.mongodb.org/browse/CDRIVER-3924)

Ignores the fourth field of version strings in `_parse_server_version` and `test_framework_str_to_version`. Updates `test_version_cmp` to test this behavior.

According to the unified test format [spec](https://github.com/mongodb/specifications/blob/master/source/unified-test-format/unified-test-format.rst#version-string), we should only consider `major`, `minor` and `patch` when comparing server version strings for testing. Release candidates like `"3.4.0.-49"` should not be distinct from non-rcs like `"3.4.0"`.

I _think_ the changes in this PR will also affect tests outside of the unified test format, so let me know if that seems like a problem.