### PR TITLE
Fix valgrind

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-collection.c
+++ b/src/libmongoc/src/mongoc/mongoc-collection.c
@@ -905,7 +905,7 @@ mongoc_collection_estimated_document_count (
       ret = mongoc_collection_read_command_with_opts (
          coll, &cmd, read_prefs, opts, reply_ptr, error);
 
-      if (error && error->code == MONGOC_ERROR_COLLECTION_DOES_NOT_EXIST) {
+      if (!ret && error->code == MONGOC_ERROR_COLLECTION_DOES_NOT_EXIST) {
          /* Collection does not exist. From spec: return 0 but no err:
           * https://github.com/mongodb/specifications/blob/master/source/crud/crud.rst#estimateddocumentcount
           */


### PR DESCRIPTION
This PR fixes a conditional jump warning in valgrind if an uninitialized `bson_error_t` is passed as the output argument for `mongoc_collection_estimated_document_count`.

This appeared on a C++ [patch build](https://evergreen.mongodb.com/lobster/evergreen/task/cxx_driver_ubuntu1604_debug_valgrind_compile_and_test_with_shared_libs_patch_33416f88f1d59e19eb103fedab59d73399332a7c_6061e9b2d6d80a5ce526e478_21_03_29_14_52_40/0/task#bookmarks=0%2C6962%2C6967%2C7647&l=1) while implementing Azure/GCP support.

There is a test coverage of running `mongoc_collection_estimated_document_count` against a live server and passing an uninitialized `bson_error_t` in [test_estimated_document_count_live](https://github.com/mongodb/mongo-c-driver/blob/a9afdeb0d58dfb5ac60be699442f17fde6f78dd9/src/libmongoc/tests/test-mongoc-collection.c#L2646:L2646).

This run on the waterfall ran it against a 4.9.0 server. There was a [successful run](https://evergreen.mongodb.com/task/mongo_c_driver_valgrind_ubuntu_test_valgrind_latest_server_noauth_nosasl_nossl_203e6b9e26bfce6ca76f1d087470c3840318afdd_21_03_25_17_00_09) after estimated document count was merged. [This is the log line](https://evergreen.mongodb.com/task_log_raw/mongo_c_driver_valgrind_ubuntu_test_valgrind_latest_server_noauth_nosasl_nossl_203e6b9e26bfce6ca76f1d087470c3840318afdd_21_03_25_17_00_09/0?type=T#L3563).

I am not sure why the conditional jump was not caught by valgrind in that task.