### PR TITLE
CDRIVER-3940 Fix missing versioned API options in server monitor

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -770,7 +770,7 @@ _mongoc_stream_run_ismaster (mongoc_cluster_t *cluster,
    BSON_ASSERT (cluster);
    BSON_ASSERT (stream);
 
-   command = _mongoc_topology_get_ismaster (cluster->client->topology);
+   command = _mongoc_topology_get_handshake_cmd (cluster->client->topology);
 
    if (cluster->requires_auth || negotiate_sasl_supported_mechs) {
       copied_command = bson_copy (command);

--- a/src/libmongoc/src/mongoc/mongoc-server-monitor.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-monitor.c
@@ -326,10 +326,12 @@ _server_monitor_polling_ismaster (mongoc_server_monitor_t *server_monitor,
                                   bson_error_t *error)
 {
    bson_t cmd;
+   const bson_t *hello;
    bool ret;
 
-   bson_init (&cmd);
-   bson_append_int32 (&cmd, "isMaster", 8, 1);
+   hello = _mongoc_topology_scanner_get_hello_cmd (server_monitor->topology->scanner);
+   bson_copy_to (hello, &cmd);
+
    _server_monitor_append_cluster_time (server_monitor, &cmd);
    ret = _server_monitor_send_and_recv_opquery (
       server_monitor, &cmd, ismaster_reply, error);
@@ -603,10 +605,13 @@ _server_monitor_awaitable_ismaster (mongoc_server_monitor_t *server_monitor,
                                     bool *cancelled,
                                     bson_error_t *error)
 {
-   bson_t cmd = BSON_INITIALIZER;
+   bson_t cmd;
+   const bson_t *hello;
    bool ret = false;
 
-   bson_append_int32 (&cmd, "isMaster", 8, 1);
+   hello = _mongoc_topology_scanner_get_hello_cmd (server_monitor->topology->scanner);
+   bson_copy_to (hello, &cmd);
+
    _server_monitor_append_cluster_time (server_monitor, &cmd);
    bson_append_document (&cmd, "topologyVersion", 15, topology_version);
    bson_append_int32 (

--- a/src/libmongoc/src/mongoc/mongoc-server-monitor.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-monitor.c
@@ -775,7 +775,7 @@ _server_monitor_setup_connection (mongoc_server_monitor_t *server_monitor,
    /* Update the start time just before the handshake. */
    *start_us = _now_us ();
    /* Perform handshake. */
-   handshake = _mongoc_topology_get_ismaster (server_monitor->topology);
+   handshake = _mongoc_topology_get_handshake_cmd (server_monitor->topology);
    bson_destroy (&cmd);
    bson_copy_to (handshake, &cmd);
    _server_monitor_append_cluster_time (server_monitor, &cmd);

--- a/src/libmongoc/src/mongoc/mongoc-topology-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-private.h
@@ -197,7 +197,7 @@ void
 _mongoc_topology_do_blocking_scan (mongoc_topology_t *topology,
                                    bson_error_t *error);
 const bson_t *
-_mongoc_topology_get_ismaster (mongoc_topology_t *topology);
+_mongoc_topology_get_handshake_cmd (mongoc_topology_t *topology);
 void
 _mongoc_topology_request_scan (mongoc_topology_t *topology);
 

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner-private.h
@@ -194,7 +194,7 @@ _mongoc_topology_scanner_get_speculative_auth_mechanism (
    const mongoc_uri_t *uri);
 
 const bson_t *
-_mongoc_topology_scanner_get_ismaster (mongoc_topology_scanner_t *ts);
+_mongoc_topology_scanner_get_handshake_cmd (mongoc_topology_scanner_t *ts);
 
 bool
 mongoc_topology_scanner_has_node_for_host (mongoc_topology_scanner_t *ts,

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner-private.h
@@ -194,6 +194,9 @@ _mongoc_topology_scanner_get_speculative_auth_mechanism (
    const mongoc_uri_t *uri);
 
 const bson_t *
+_mongoc_topology_scanner_get_hello_cmd (mongoc_topology_scanner_t *ts);
+
+const bson_t *
 _mongoc_topology_scanner_get_handshake_cmd (mongoc_topology_scanner_t *ts);
 
 bool

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
@@ -273,6 +273,12 @@ _build_ismaster_with_handshake (mongoc_topology_scanner_t *ts)
    return res;
 }
 
+const bson_t *
+_mongoc_topology_scanner_get_hello_cmd (mongoc_topology_scanner_t *ts)
+{
+   return &ts->ismaster_cmd;
+}
+
 /* Caller must lock topology->mutex to protect ismaster_cmd_with_handshake. This
  * is called at the start of the scan in _mongoc_topology_run_background, when a
  * node is added in _mongoc_topology_reconcile_add_nodes, or when running an

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
@@ -278,7 +278,7 @@ _build_ismaster_with_handshake (mongoc_topology_scanner_t *ts)
  * node is added in _mongoc_topology_reconcile_add_nodes, or when running an
  * ismaster directly on a node in _mongoc_stream_run_ismaster. */
 const bson_t *
-_mongoc_topology_scanner_get_ismaster (mongoc_topology_scanner_t *ts)
+_mongoc_topology_scanner_get_handshake_cmd (mongoc_topology_scanner_t *ts)
 {
    /* If this is the first time using the node or if it's the first time
     * using it after a failure, build handshake doc */
@@ -311,7 +311,7 @@ _begin_ismaster_cmd (mongoc_topology_scanner_node_t *node,
       /* The node's been used before and not failed recently */
       bson_copy_to (&ts->ismaster_cmd, &cmd);
    } else {
-      bson_copy_to (_mongoc_topology_scanner_get_ismaster (ts), &cmd);
+      bson_copy_to (_mongoc_topology_scanner_get_handshake_cmd (ts), &cmd);
    }
 
    if (node->ts->negotiate_sasl_supported_mechs &&

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -1593,7 +1593,7 @@ _mongoc_topology_get_ismaster (mongoc_topology_t *topology)
 {
    const bson_t *cmd;
    bson_mutex_lock (&topology->mutex);
-   cmd = _mongoc_topology_scanner_get_ismaster (topology->scanner);
+   cmd = _mongoc_topology_scanner_get_handshake_cmd (topology->scanner);
    bson_mutex_unlock (&topology->mutex);
    return cmd;
 }

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -1578,7 +1578,7 @@ _mongoc_topology_end_sessions_cmd (mongoc_topology_t *topology, bson_t *cmd)
 /*
  *--------------------------------------------------------------------------
  *
- * _mongoc_topology_get_ismaster --
+ * _mongoc_topology_get_handshake_cmd --
  *
  *       Locks topology->mutex and retrieves (possibly constructing) the
  *       handshake on the topology scanner.
@@ -1589,7 +1589,7 @@ _mongoc_topology_end_sessions_cmd (mongoc_topology_t *topology, bson_t *cmd)
  *--------------------------------------------------------------------------
  */
 const bson_t *
-_mongoc_topology_get_ismaster (mongoc_topology_t *topology)
+_mongoc_topology_get_handshake_cmd (mongoc_topology_t *topology)
 {
    const bson_t *cmd;
    bson_mutex_lock (&topology->mutex);


### PR DESCRIPTION
CDRIVER-3940

The server monitor assembles its own `isMaster` command without using the topology scanner. This logic was missing the Versioned API fields, causing errors in background monitoring when connected to servers with `requireApiVersion` enabled.

This PR changes the logic to always fetch the hello command from the topology scanner. To make the distinction easier, I renamed `_mongoc_topology_scanner_get_ismaster` to `_mongoc_topology_scanner_get_handshake_cmd` and added a new `_mongoc_topology_scanner_get_hello_cmd` to return the base command without additional handshake data. This contains Versioned API fields, and we append the necessary fields for awaitable hello.

Note that this logic will likely have to change again in the near future, as the server monitor needs to know whether a server supports `hello` or if it needs to revert to `isMaster`. Versioned API will also bring more changes to the handshake process.