### PR TITLE
Lock topology mutex before setting server API

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-client-pool.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-pool.c
@@ -540,6 +540,8 @@ mongoc_client_pool_set_server_api (mongoc_client_pool_t *pool,
    }
 
    pool->api = mongoc_server_api_copy (api);
+   bson_mutex_lock (&pool->topology->mutex);
    _mongoc_topology_scanner_set_server_api (pool->topology->scanner, api);
+   bson_mutex_unlock (&pool->topology->mutex);
    return true;
 }

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -3121,6 +3121,8 @@ mongoc_client_set_server_api (mongoc_client_t *client,
    }
 
    client->api = mongoc_server_api_copy (api);
+   bson_mutex_lock (&client->topology->mutex);
    _mongoc_topology_scanner_set_server_api (client->topology->scanner, api);
+   bson_mutex_unlock (&client->topology->mutex);
    return true;
 }

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
@@ -1347,6 +1347,7 @@ _jumpstart_other_acmds (mongoc_topology_scanner_node_t *node,
    }
 }
 
+/* Caller must lock topology->mutex to protect ismaster_cmd_with_handshake. */
 void
 _mongoc_topology_scanner_set_server_api (mongoc_topology_scanner_t *ts,
                                          const mongoc_server_api_t *api)


### PR DESCRIPTION
Calling `_mongoc_topology_scanner_set_server_api` resets `ismaster_cmd_with_handshake`, which requires obtaining a lock on the topology.