### PR TITLE
CDRIVER-3917 Run versioned API tests in Evergreen

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -695,8 +695,13 @@ functions:
       working_dir: mongoc
       background: true
       shell: bash
-      script: "set -o errexit\nset -o xtrace\nset -o xtrace\ncd drivers-evergreen-tools\
-        \ \nexport DRIVERS_TOOLS=$(pwd)\nsh .evergreen/atlas_data_lake/run-mongohouse-local.sh"
+      script: |-
+        set -o errexit
+        set -o xtrace
+        set -o xtrace
+        cd drivers-evergreen-tools
+        export DRIVERS_TOOLS=$(pwd)
+        sh .evergreen/atlas_data_lake/run-mongohouse-local.sh
   test mongohouse:
   - command: shell.exec
     type: test
@@ -17496,6 +17501,52 @@ tasks:
   - func: run auth tests
     vars:
       valgrind: 'true'
+- name: test-versioned-api
+  tags:
+  - versioned-api
+  depends_on:
+    name: debug-compile-nosasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      REQUIRE_API_VERSION: 'true'
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - func: test versioned api
+    vars:
+      AUTH: auth
+      SSL: ssl
+- name: test-versioned-api-accept-version-two
+  tags:
+  - versioned-api
+  depends_on:
+    name: debug-compile-nosasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      ORCHESTRATION_FILE: versioned-api-testing
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+  - func: test versioned api
+    vars:
+      AUTH: auth
+      SSL: ssl
 - name: build-and-run-authentication-tests-openssl-0.9.8
   commands:
   - func: install ssl
@@ -22469,46 +22520,6 @@ tasks:
         set -o errexit
         set -o xtrace
         CERT_TYPE=ecdsa .evergreen/run-ocsp-cache-test.sh
-- name: test-versioned-api
-  tags:
-    - versioned-api
-  depends_on:
-    name: debug-compile-nosasl-openssl
-  commands:
-  - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
-  - func: bootstrap mongo-orchestration
-    vars:
-      TOPOLOGY: server
-      AUTH: auth
-      SSL: ssl
-      VERSION: latest
-      REQUIRE_API_VERSION: true
-  - func: test versioned api
-    vars:
-      AUTH: auth
-      SSL: ssl
-- name: test-versioned-api-accept-version-two
-  tags:
-    - versioned-api
-  depends_on:
-    name: debug-compile-nosasl-openssl
-  commands:
-  - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
-  - func: bootstrap mongo-orchestration
-    vars:
-      TOPOLOGY: server
-      AUTH: auth
-      SSL: ssl
-      VERSION: latest
-      ORCHESTRATION_FILE: 'versioned-api-testing'
-  - func: test versioned api
-    vars:
-      AUTH: auth
-      SSL: ssl
 buildvariants:
 - name: releng
   display_name: '**Release Archive Creator'

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -742,6 +742,7 @@ functions:
         export DNS=${DNS}
         export ASAN=${ASAN}
         export MONGODB_API_VERSION=1
+        # TODO: CDRIVER-3954 Run all integration tests
         ./src/libmongoc/test-libmongoc --no-fork -l /versioned_api/* -d
         unset MONGODB_API_VERSION
   run aws tests:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -416,6 +416,7 @@ functions:
         export SSL=${SSL}
         export ORCHESTRATION_FILE=${ORCHESTRATION_FILE}
         export OCSP=${OCSP}
+        export REQUIRE_API_VERSION=${REQUIRE_API_VERSION}
         sh .evergreen/integration-tests.sh
   run tests:
   - command: shell.exec
@@ -716,6 +717,28 @@ functions:
         export RUN_MONGOHOUSE_TESTS=true
         ./src/libmongoc/test-libmongoc --no-fork -l /mongohouse/* -d
         unset RUN_MONGOHOUSE_TESTS
+  test versioned api:
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o xtrace
+        export COMPRESSORS='${COMPRESSORS}'
+        export CC='${CC}'
+        export AUTH=${AUTH}
+        export SSL=${SSL}
+        export URI=${URI}
+        export IPV4_ONLY=${IPV4_ONLY}
+        export VALGRIND=${VALGRIND}
+        export MONGOC_TEST_URI=${URI}
+        export DNS=${DNS}
+        export ASAN=${ASAN}
+        export MONGODB_API_VERSION=1
+        ./src/libmongoc/test-libmongoc --no-fork -l /versioned_api/* -d
+        unset MONGODB_API_VERSION
   run aws tests:
   - command: shell.exec
     type: test
@@ -22446,6 +22469,46 @@ tasks:
         set -o errexit
         set -o xtrace
         CERT_TYPE=ecdsa .evergreen/run-ocsp-cache-test.sh
+- name: test-versioned-api
+  tags:
+    - versioned-api
+  depends_on:
+    name: debug-compile-nosasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      TOPOLOGY: server
+      AUTH: auth
+      SSL: ssl
+      VERSION: latest
+      REQUIRE_API_VERSION: true
+  - func: test versioned api
+    vars:
+      AUTH: auth
+      SSL: ssl
+- name: test-versioned-api-accept-version-two
+  tags:
+    - versioned-api
+  depends_on:
+    name: debug-compile-nosasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      TOPOLOGY: server
+      AUTH: auth
+      SSL: ssl
+      VERSION: latest
+      ORCHESTRATION_FILE: 'versioned-api-testing'
+  - func: test versioned api
+    vars:
+      AUTH: auth
+      SSL: ssl
 buildvariants:
 - name: releng
   display_name: '**Release Archive Creator'
@@ -23162,3 +23225,9 @@ buildvariants:
   tasks:
   - .tsan
   batchtime: 1440
+- name: versioned-api
+  display_name: Versioned API Tests
+  run_on: ubuntu1804-test
+  tasks:
+  - debug-compile-nosasl-openssl
+  - .versioned-api

--- a/.evergreen/integration-tests.sh
+++ b/.evergreen/integration-tests.sh
@@ -12,6 +12,8 @@
 # ORCHESTRATION_FILE: <file name in orchestration_configs/ without .json>
 #   If this is not set, the file name is constructed from other options.
 # OCSP: off, on
+# REQUIRE_API_VERSION: set to a non-empty string to set the requireApiVersion parameter
+#   This is currently only supported for standalone servers
 #
 # This script may be run locally.
 #
@@ -39,6 +41,7 @@ AUTH=${AUTH:-noauth}
 SSL=${SSL:-nossl}
 TOPOLOGY=${TOPOLOGY:-server}
 OCSP=${OCSP:-off}
+REQUIRE_API_VERSION=${REQUIRE_API_VERSION}
 
 # If caller of script specifies an ORCHESTRATION_FILE, do not attempt to modify it. Otherwise construct it.
 if [ -z "$ORCHESTRATION_FILE" ]; then
@@ -166,3 +169,8 @@ echo $MONGO_SHELL_CONNECTION_FLAGS
 
 `pwd`/mongodb/bin/mongo $MONGO_SHELL_CONNECTION_FLAGS --eval 'printjson(db.serverBuildInfo())' admin
 `pwd`/mongodb/bin/mongo $MONGO_SHELL_CONNECTION_FLAGS --eval 'printjson(db.isMaster())' admin
+
+# Set the requireApiVersion parameter.
+if [ ! -z "$REQUIRE_API_VERSION" ]; then
+  `pwd`/mongodb/bin/mongo $MONGO_SHELL_CONNECTION_FLAGS $DIR/require-api-version.js
+fi

--- a/.evergreen/require-api-version.js
+++ b/.evergreen/require-api-version.js
@@ -1,0 +1,1 @@
+db.adminCommand({ "setParameter": 1, "requireApiVersion": 1 });

--- a/build/evergreen_config_lib/functions.py
+++ b/build/evergreen_config_lib/functions.py
@@ -74,7 +74,7 @@ all_functions = OD([
         . bin/activate
         ./bin/pip install sphinx
         cd ..
-        
+
         set -o xtrace
         export MONGOC_TEST_FUTURE_TIMEOUT_MS=30000
         export MONGOC_TEST_SKIP_LIVE=on
@@ -98,13 +98,13 @@ all_functions = OD([
             ]))]),
         shell_exec(r'''
         mkdir mongoc
-        
+
         if command -v gtar 2>/dev/null; then
            TAR=gtar
         else
            TAR=tar
         fi
-        
+
         $TAR xf build.tar.gz -C mongoc/
         ''', test=False, continue_on_err=True),
     )),
@@ -140,7 +140,7 @@ all_functions = OD([
         make
         cd ..
         mv aha-repo/aha .
-        
+
         sh .evergreen/man-pages-to-html.sh libbson cmake_build/src/libbson/doc/man > bson-man-pages.html
         sh .evergreen/man-pages-to-html.sh libmongoc cmake_build/src/libmongoc/doc/man > mongoc-man-pages.html
         ''', test=False, silent=True, xtrace=False),
@@ -175,7 +175,7 @@ all_functions = OD([
         export AWS_ACCESS_KEY_ID=${aws_key}
         export AWS_SECRET_ACCESS_KEY=${aws_secret}
         aws s3 cp abi-compliance/compat_reports s3://mciuploads/${project}/%s/abi-compliance/compat_reports --recursive --acl public-read --region us-east-1
-        
+
         if [ -e ./abi-compliance/abi-error.txt ]; then
           exit 1
         else
@@ -279,6 +279,7 @@ all_functions = OD([
         export SSL=${SSL}
         export ORCHESTRATION_FILE=${ORCHESTRATION_FILE}
         export OCSP=${OCSP}
+        export REQUIRE_API_VERSION=${REQUIRE_API_VERSION}
         sh .evergreen/integration-tests.sh
         ''', test=False),
     )),
@@ -475,7 +476,7 @@ all_functions = OD([
         shell_mongoc(r'''
         set -o xtrace
 
-        cd drivers-evergreen-tools 
+        cd drivers-evergreen-tools
         export DRIVERS_TOOLS=$(pwd)
 
         sh .evergreen/atlas_data_lake/run-mongohouse-local.sh
@@ -497,6 +498,24 @@ all_functions = OD([
         export RUN_MONGOHOUSE_TESTS=true
         ./src/libmongoc/test-libmongoc --no-fork -l /mongohouse/* -d
         unset RUN_MONGOHOUSE_TESTS
+
+        '''),
+    )),
+    ('test versioned api', Function(
+        shell_mongoc(r'''
+        export COMPRESSORS='${COMPRESSORS}'
+        export CC='${CC}'
+        export AUTH=${AUTH}
+        export SSL=${SSL}
+        export URI=${URI}
+        export IPV4_ONLY=${IPV4_ONLY}
+        export VALGRIND=${VALGRIND}
+        export MONGOC_TEST_URI=${URI}
+        export DNS=${DNS}
+        export ASAN=${ASAN}
+        export MONGODB_API_VERSION=1
+        ./src/libmongoc/test-libmongoc --no-fork -l /versioned_api/* -d
+        unset MONGODB_API_VERSION
 
         '''),
     )),

--- a/build/evergreen_config_lib/functions.py
+++ b/build/evergreen_config_lib/functions.py
@@ -514,6 +514,7 @@ all_functions = OD([
         export DNS=${DNS}
         export ASAN=${ASAN}
         export MONGODB_API_VERSION=1
+        # TODO: CDRIVER-3954 Run all integration tests
         ./src/libmongoc/test-libmongoc --no-fork -l /versioned_api/* -d
         unset MONGODB_API_VERSION
 

--- a/build/evergreen_config_lib/tasks.py
+++ b/build/evergreen_config_lib/tasks.py
@@ -838,6 +838,20 @@ all_tasks = chain(all_tasks, [
                   SSL=OPENSSL CFLAGS='-DBSON_MEMCHECK' sh .evergreen/compile.sh
                 """),
             func('run auth tests', valgrind='true')]),
+    PostCompileTask(
+        'test-versioned-api',
+        tags=['versioned-api'],
+        depends_on='debug-compile-nosasl-openssl',
+        commands=[func('fetch build', BUILD_NAME='debug-compile-nosasl-openssl'),
+                  func('bootstrap mongo-orchestration', TOPOLOGY='server', AUTH='auth', SSL='ssl', VERSION='latest', REQUIRE_API_VERSION='true'),
+                  func('test versioned api', AUTH='auth', SSL='ssl')]),
+    PostCompileTask(
+        'test-versioned-api-accept-version-two',
+        tags=['versioned-api'],
+        depends_on='debug-compile-nosasl-openssl',
+        commands=[func('fetch build', BUILD_NAME='debug-compile-nosasl-openssl'),
+                  func('bootstrap mongo-orchestration', TOPOLOGY='server', AUTH='auth', SSL='ssl', VERSION='latest', ORCHESTRATION_FILE='versioned-api-testing'),
+                  func('test versioned api', AUTH='auth', SSL='ssl')]),
 ])
 
 

--- a/build/evergreen_config_lib/variants.py
+++ b/build/evergreen_config_lib/variants.py
@@ -636,4 +636,10 @@ all_variants = [
         ['.tsan'],
         {'CC': '/opt/mongodbtoolchain/v3/bin/clang'},
         batchtime=days(1))
+    Variant('versioned-api',
+        'Versioned API Tests',
+        'ubuntu1804-test',
+        ['debug-compile-nosasl-openssl',
+         '.versioned-api'],
+        {})
 ]

--- a/orchestration_configs/servers/versioned-api-testing.json
+++ b/orchestration_configs/servers/versioned-api-testing.json
@@ -1,0 +1,12 @@
+{
+  "id": "versioned-api-testing",
+  "name": "mongod",
+  "procParams": {
+    "ipv6": true,
+    "bind_ip": "127.0.0.1,::1",
+    "logappend": true,
+    "journal": true,
+    "port": 27017,
+    "setParameter": {"enableTestCommands": 1, "acceptAPIVersion2":  1}
+  }
+}


### PR DESCRIPTION
[CDRIVER-3917](https://jira.mongodb.org/browse/CDRIVER-3917)

Adds a new Evergreen build variant for versioned API with three tasks. The first is `debug-compile-nosasl-openssl` to compile a `test-libmongoc`. The second is `test-versioned-api` to run versioned API tests against a 4.9.0 server with `requireApiVersion=1`. The third is `test-versioned-api-accept-version-two` to run versioned API tests against a 4.9.0 server with `enableTestCommands=1`, `acceptApiVersion2=1` and `requireApiVersion=0`.

These new tests (see example patch [here](https://spruce.mongodb.com/version/6064b0123066156f51b72d99/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)), will continue to fail until [CDRIVER-3940](https://github.com/mongodb/mongo-c-driver/pull/770) is merged.

We might want to update the C driver project config in Evergreen to run Versioned API tasks on each patch, too.