### PR TITLE
CDRIVER-3953 Replace acceptAPIVersion2 with acceptApiVersion2

### DIFF
--- a/orchestration_configs/servers/versioned-api-testing.json
+++ b/orchestration_configs/servers/versioned-api-testing.json
@@ -7,6 +7,9 @@
     "logappend": true,
     "journal": true,
     "port": 27017,
-    "setParameter": {"enableTestCommands": 1, "acceptAPIVersion2":  1}
+    "setParameter": {
+      "enableTestCommands": 1,
+      "acceptApiVersion2": 1
+    }
   }
 }

--- a/src/libmongoc/tests/json/versioned_api/test-commands-deprecation-errors.json
+++ b/src/libmongoc/tests/json/versioned_api/test-commands-deprecation-errors.json
@@ -6,7 +6,7 @@
       "minServerVersion": "4.9",
       "serverParameters": {
         "enableTestCommands": true,
-        "acceptAPIVersion2": true,
+        "acceptApiVersion2": true,
         "requireApiVersion": false
       }
     }


### PR DESCRIPTION
[CDRIVER-3953](https://jira.mongodb.org/browse/CDRIVER-3953)

The server changed the parameter `acceptAPIVersion2` to `acceptApiVersion2`. Updates spec test runOnRequirement of `test-commands-deprecation-errors` and our local copy of the `verioned-api-testing.json` server configuration to reflect this.

Note that the server commit renaming `acceptAPIVersion2` will not be available until we upgrade to Ubuntu 18.04. Until then, there might be a setup failure in versioned API tests (setting `acceptApiVersion2=1` when only `acceptAPIVersion2=1` is accepted).