### PR TITLE
CDRIVER-3947 Use "hello" command when an API version is declared

### DIFF
--- a/src/libmongoc/doc/mongoc_server_description_hello_response.rst
+++ b/src/libmongoc/doc/mongoc_server_description_hello_response.rst
@@ -1,6 +1,6 @@
-:man_page: mongoc_server_description_last_hello_response
+:man_page: mongoc_server_description_hello_response
 
-mongoc_server_description_last_hello_response()
+mongoc_server_description_hello_response()
 ===============================================
 
 Synopsis
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   const bson_t *
-  mongoc_server_description_last_hello_response (
+  mongoc_server_description_hello_response (
      const mongoc_server_description_t *description);
 
 Parameters
@@ -24,7 +24,7 @@ The client or client pool periodically runs a
 `"hello" <https://docs.mongodb.org/manual/reference/command/isMaster/>`_
 command on each server, to update its view of the MongoDB deployment. Use
 :symbol:`mongoc_client_get_server_descriptions()` and
-``mongoc_server_description_last_hello_response()`` to get the most recent "hello"
+``mongoc_server_description_hello_response()`` to get the most recent "hello"
 response.
 
 Returns

--- a/src/libmongoc/doc/mongoc_server_description_hello_response.rst
+++ b/src/libmongoc/doc/mongoc_server_description_hello_response.rst
@@ -1,0 +1,34 @@
+:man_page: mongoc_server_description_hello_response
+
+mongoc_server_description_hello_response()
+==========================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  const bson_t *
+  mongoc_server_description_hello_response (
+     const mongoc_server_description_t *description);
+
+Parameters
+----------
+
+* ``description``: A :symbol:`mongoc_server_description_t`.
+
+Description
+-----------
+
+The client or client pool periodically runs a
+`"hello" <https://docs.mongodb.org/manual/reference/command/isMaster/>`_
+command on each server, to update its view of the MongoDB deployment. Use
+:symbol:`mongoc_client_get_server_descriptions()` and
+``mongoc_server_description_hello_response()`` to get the most recent "hello"
+response.
+
+Returns
+-------
+
+A reference to a BSON document, owned by the server description. The document is empty if the driver is not connected to the server.
+

--- a/src/libmongoc/doc/mongoc_server_description_ismaster.rst
+++ b/src/libmongoc/doc/mongoc_server_description_ismaster.rst
@@ -12,6 +12,15 @@ Synopsis
   mongoc_server_description_ismaster (
      const mongoc_server_description_t *description);
 
+Deprecated
+----------
+
+.. warning::
+
+  This function is deprecated and should not be used in new code.
+
+Please use :doc:`mongoc_server_description_hello_response() <mongoc_server_description_hello_response>` instead.
+
 Parameters
 ----------
 

--- a/src/libmongoc/doc/mongoc_server_description_ismaster.rst
+++ b/src/libmongoc/doc/mongoc_server_description_ismaster.rst
@@ -19,7 +19,7 @@ Deprecated
 
   This function is deprecated and should not be used in new code.
 
-Please use :doc:`mongoc_server_description_hello_response() <mongoc_server_description_hello_response>` instead.
+Please use :doc:`mongoc_server_description_last_hello_response() <mongoc_server_description_last_hello_response>` instead.
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_server_description_ismaster.rst
+++ b/src/libmongoc/doc/mongoc_server_description_ismaster.rst
@@ -19,7 +19,7 @@ Deprecated
 
   This function is deprecated and should not be used in new code.
 
-Please use :doc:`mongoc_server_description_last_hello_response() <mongoc_server_description_last_hello_response>` instead.
+Please use :doc:`mongoc_server_description_hello_response() <mongoc_server_description_hello_response>` instead.
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_server_description_last_hello_response.rst
+++ b/src/libmongoc/doc/mongoc_server_description_last_hello_response.rst
@@ -1,7 +1,7 @@
-:man_page: mongoc_server_description_hello_response
+:man_page: mongoc_server_description_last_hello_response
 
-mongoc_server_description_hello_response()
-==========================================
+mongoc_server_description_last_hello_response()
+===============================================
 
 Synopsis
 --------
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   const bson_t *
-  mongoc_server_description_hello_response (
+  mongoc_server_description_last_hello_response (
      const mongoc_server_description_t *description);
 
 Parameters
@@ -24,7 +24,7 @@ The client or client pool periodically runs a
 `"hello" <https://docs.mongodb.org/manual/reference/command/isMaster/>`_
 command on each server, to update its view of the MongoDB deployment. Use
 :symbol:`mongoc_client_get_server_descriptions()` and
-``mongoc_server_description_hello_response()`` to get the most recent "hello"
+``mongoc_server_description_last_hello_response()`` to get the most recent "hello"
 response.
 
 Returns

--- a/src/libmongoc/doc/mongoc_server_description_t.rst
+++ b/src/libmongoc/doc/mongoc_server_description_t.rst
@@ -33,6 +33,7 @@ Applications receive a temporary reference to a ``mongoc_server_description_t`` 
     :maxdepth: 1
 
     mongoc_server_description_destroy
+    mongoc_server_description_hello_response
     mongoc_server_description_host
     mongoc_server_description_id
     mongoc_server_description_ismaster

--- a/src/libmongoc/doc/mongoc_server_description_t.rst
+++ b/src/libmongoc/doc/mongoc_server_description_t.rst
@@ -33,7 +33,7 @@ Applications receive a temporary reference to a ``mongoc_server_description_t`` 
     :maxdepth: 1
 
     mongoc_server_description_destroy
-    mongoc_server_description_hello_response
+    mongoc_server_description_last_hello_response
     mongoc_server_description_host
     mongoc_server_description_id
     mongoc_server_description_ismaster

--- a/src/libmongoc/doc/mongoc_server_description_t.rst
+++ b/src/libmongoc/doc/mongoc_server_description_t.rst
@@ -33,7 +33,7 @@ Applications receive a temporary reference to a ``mongoc_server_description_t`` 
     :maxdepth: 1
 
     mongoc_server_description_destroy
-    mongoc_server_description_last_hello_response
+    mongoc_server_description_hello_response
     mongoc_server_description_host
     mongoc_server_description_id
     mongoc_server_description_ismaster

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -2107,7 +2107,7 @@ _mongoc_cluster_add_node (mongoc_cluster_t *cluster,
       GOTO (error);
    }
 
-   _mongoc_handshake_parse_sasl_supported_mechs (&sd->last_is_master,
+   _mongoc_handshake_parse_sasl_supported_mechs (&sd->last_hello_response,
                                                  &sasl_supported_mechs);
 
    if (cluster->requires_auth) {

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -731,11 +731,11 @@ mongoc_cluster_run_command_parts (mongoc_cluster_t *cluster,
 /*
  *--------------------------------------------------------------------------
  *
- * _mongoc_stream_run_ismaster --
+ * _mongoc_stream_run_hello --
  *
- *       Run an ismaster command on the given stream. If
+ *       Run a hello command on the given stream. If
  *       @negotiate_sasl_supported_mechs is true, then saslSupportedMechs is
- *       added to the ismaster command.
+ *       added to the hello command.
  *
  * Returns:
  *       A mongoc_server_description_t you must destroy or NULL. If the call
@@ -744,18 +744,18 @@ mongoc_cluster_run_command_parts (mongoc_cluster_t *cluster,
  *--------------------------------------------------------------------------
  */
 static mongoc_server_description_t *
-_mongoc_stream_run_ismaster (mongoc_cluster_t *cluster,
-                             mongoc_stream_t *stream,
-                             const char *address,
-                             uint32_t server_id,
-                             bool negotiate_sasl_supported_mechs,
-                             mongoc_scram_cache_t *scram_cache,
-                             mongoc_scram_t *scram,
-                             bson_t *speculative_auth_response /* OUT */,
-                             bson_error_t *error)
+_mongoc_stream_run_hello (mongoc_cluster_t *cluster,
+                          mongoc_stream_t *stream,
+                          const char *address,
+                          uint32_t server_id,
+                          bool negotiate_sasl_supported_mechs,
+                          mongoc_scram_cache_t *scram_cache,
+                          mongoc_scram_t *scram,
+                          bson_t *speculative_auth_response /* OUT */,
+                          bson_error_t *error)
 {
    const bson_t *command;
-   mongoc_cmd_t ismaster_cmd;
+   mongoc_cmd_t hello_cmd;
    bson_t reply;
    int64_t start;
    int64_t rtt_msec;
@@ -814,15 +814,15 @@ _mongoc_stream_run_ismaster (mongoc_cluster_t *cluster,
     * last known ismaster indicates the server supports a newer wire protocol.
     */
    server_stream->sd->max_wire_version = WIRE_VERSION_MIN;
-   memset (&ismaster_cmd, 0, sizeof (ismaster_cmd));
-   ismaster_cmd.db_name = "admin";
-   ismaster_cmd.command = command;
-   ismaster_cmd.command_name = _mongoc_get_command_name (command);
-   ismaster_cmd.query_flags = MONGOC_QUERY_SLAVE_OK;
-   ismaster_cmd.server_stream = server_stream;
+   memset (&hello_cmd, 0, sizeof (hello_cmd));
+   hello_cmd.db_name = "admin";
+   hello_cmd.command = command;
+   hello_cmd.command_name = _mongoc_get_command_name (command);
+   hello_cmd.query_flags = MONGOC_QUERY_SLAVE_OK;
+   hello_cmd.server_stream = server_stream;
 
    if (!mongoc_cluster_run_command_private (
-          cluster, &ismaster_cmd, &reply, error)) {
+          cluster, &hello_cmd, &reply, error)) {
       if (negotiate_sasl_supported_mechs) {
          if (bson_iter_init_find (&iter, &reply, "ok") &&
              !bson_iter_as_bool (&iter)) {
@@ -846,8 +846,8 @@ _mongoc_stream_run_ismaster (mongoc_cluster_t *cluster,
       sizeof (mongoc_server_description_t));
 
    mongoc_server_description_init (sd, address, server_id);
-   /* send the error from run_command IN to handle_ismaster */
-   mongoc_server_description_handle_ismaster (sd, &reply, rtt_msec, error);
+   /* send the error from run_command IN to handle_hello */
+   mongoc_server_description_handle_hello (sd, &reply, rtt_msec, error);
 
    if (cluster->requires_auth && speculative_auth_response) {
       _mongoc_topology_scanner_parse_speculative_authentication (
@@ -878,9 +878,9 @@ _mongoc_stream_run_ismaster (mongoc_cluster_t *cluster,
 /*
  *--------------------------------------------------------------------------
  *
- * _mongoc_cluster_run_ismaster --
+ * _mongoc_cluster_run_hello --
  *
- *       Run an initial ismaster command for the given node and handle result.
+ *       Run an initial hello command for the given node and handle result.
  *
  * Returns:
  *       mongoc_server_description_t on success, NULL otherwise.
@@ -888,18 +888,18 @@ _mongoc_stream_run_ismaster (mongoc_cluster_t *cluster,
  *
  * Side effects:
  *       Makes a blocking I/O call, updates cluster->topology->description
- *       with ismaster result.
+ *       with hello result.
  *
  *--------------------------------------------------------------------------
  */
 static mongoc_server_description_t *
-_mongoc_cluster_run_ismaster (mongoc_cluster_t *cluster,
-                              mongoc_cluster_node_t *node,
-                              uint32_t server_id,
-                              mongoc_scram_cache_t *scram_cache,
-                              mongoc_scram_t *scram /* OUT */,
-                              bson_t *speculative_auth_response /* OUT */,
-                              bson_error_t *error /* OUT */)
+_mongoc_cluster_run_hello (mongoc_cluster_t *cluster,
+                           mongoc_cluster_node_t *node,
+                           uint32_t server_id,
+                           mongoc_scram_cache_t *scram_cache,
+                           mongoc_scram_t *scram /* OUT */,
+                           bson_t *speculative_auth_response /* OUT */,
+                           bson_error_t *error /* OUT */)
 {
    mongoc_server_description_t *sd;
 
@@ -909,7 +909,7 @@ _mongoc_cluster_run_ismaster (mongoc_cluster_t *cluster,
    BSON_ASSERT (node);
    BSON_ASSERT (node->stream);
 
-   sd = _mongoc_stream_run_ismaster (
+   sd = _mongoc_stream_run_hello (
       cluster,
       node->stream,
       node->connection_address,
@@ -2096,13 +2096,13 @@ _mongoc_cluster_add_node (mongoc_cluster_t *cluster,
    cluster_node =
       _mongoc_cluster_node_new (stream, generation, host->host_and_port);
 
-   sd = _mongoc_cluster_run_ismaster (cluster,
-                                      cluster_node,
-                                      server_id,
-                                      cluster->scram_cache,
-                                      &scram,
-                                      &speculative_auth_response,
-                                      error);
+   sd = _mongoc_cluster_run_hello (cluster,
+                                   cluster_node,
+                                   server_id,
+                                   cluster->scram_cache,
+                                   &scram,
+                                   &speculative_auth_response,
+                                   error);
    if (!sd) {
       GOTO (error);
    }

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -285,10 +285,11 @@ mongoc_cluster_run_command_opquery (mongoc_cluster_t *cluster,
    _mongoc_rpc_gather (&rpc, &cluster->iov);
    _mongoc_rpc_swab_to_le (&rpc);
 
-   if (compressor_id != -1 && IS_NOT_COMMAND ("ismaster") &&
-       IS_NOT_COMMAND ("saslstart") && IS_NOT_COMMAND ("saslcontinue") &&
-       IS_NOT_COMMAND ("getnonce") && IS_NOT_COMMAND ("authenticate") &&
-       IS_NOT_COMMAND ("createuser") && IS_NOT_COMMAND ("updateuser")) {
+   if (compressor_id != -1 && IS_NOT_COMMAND (HANDSHAKE_CMD_LEGACY_HELLO) &&
+       IS_NOT_COMMAND ("hello") && IS_NOT_COMMAND ("saslstart") &&
+       IS_NOT_COMMAND ("saslcontinue") && IS_NOT_COMMAND ("getnonce") &&
+       IS_NOT_COMMAND ("authenticate") && IS_NOT_COMMAND ("createuser") &&
+       IS_NOT_COMMAND ("updateuser")) {
       output = _mongoc_rpc_compress (cluster, compressor_id, &rpc, error);
       if (output == NULL) {
          GOTO (done);

--- a/src/libmongoc/src/mongoc/mongoc-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-cmd.c
@@ -1073,7 +1073,8 @@ mongoc_cmd_is_compressible (mongoc_cmd_t *cmd)
    BSON_ASSERT (cmd);
    BSON_ASSERT (cmd->command_name);
 
-   return !!strcasecmp (cmd->command_name, "ismaster") &&
+   return !!strcasecmp (cmd->command_name, "hello") &&
+          !!strcasecmp (cmd->command_name, HANDSHAKE_CMD_LEGACY_HELLO) &&
           !!strcasecmp (cmd->command_name, "authenticate") &&
           !!strcasecmp (cmd->command_name, "getnonce") &&
           !!strcasecmp (cmd->command_name, "saslstart") &&

--- a/src/libmongoc/src/mongoc/mongoc-handshake-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-handshake-private.h
@@ -35,6 +35,9 @@ BSON_BEGIN_DECLS
 #define HANDSHAKE_OS_ARCHITECTURE_MAX 32
 #define HANDSHAKE_DRIVER_NAME_MAX 64
 #define HANDSHAKE_DRIVER_VERSION_MAX 32
+
+#define HANDSHAKE_CMD_LEGACY_HELLO "isMaster"
+#define HANDSHAKE_RESPONSE_LEGACY_HELLO "ismaster"
 /* platform has no fixed max size. It can just occupy the remaining
  * available space in the document. */
 

--- a/src/libmongoc/src/mongoc/mongoc-handshake.h
+++ b/src/libmongoc/src/mongoc/mongoc-handshake.h
@@ -61,7 +61,7 @@ BSON_BEGIN_DECLS
  * Returns true if the given fields are set successfully. Otherwise, it returns
  * false and logs an error.
  *
- * The default handshake data the driver sends with "isMaster" looks something
+ * The default handshake data the driver sends with "hello" looks something
  * like:
  *  client: {
  *    driver: {

--- a/src/libmongoc/src/mongoc/mongoc-server-description-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-server-description-private.h
@@ -62,8 +62,8 @@ struct _mongoc_server_description_t {
    mongoc_host_list_t host;
    int64_t round_trip_time_msec;
    int64_t last_update_time_usec;
-   bson_t last_is_master;
-   bool has_is_master;
+   bson_t last_hello_response;
+   bool has_hello_response;
    const char *connection_address;
    /* SDAM dictates storing me/hosts/passives/arbiters after being "normalized
     * to lower-case" Instead, they are stored in the casing they are received,

--- a/src/libmongoc/src/mongoc/mongoc-server-description-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-server-description-private.h
@@ -149,10 +149,10 @@ mongoc_server_description_update_rtt (mongoc_server_description_t *server,
                                       int64_t rtt_msec);
 
 void
-mongoc_server_description_handle_ismaster (mongoc_server_description_t *sd,
-                                           const bson_t *reply,
-                                           int64_t rtt_msec,
-                                           const bson_error_t *error /* IN */);
+mongoc_server_description_handle_hello (mongoc_server_description_t *sd,
+                                        const bson_t *hello_response,
+                                        int64_t rtt_msec,
+                                        const bson_error_t *error /* IN */);
 
 void
 mongoc_server_description_filter_stale (mongoc_server_description_t **sds,

--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -564,7 +564,9 @@ mongoc_server_description_handle_ismaster (mongoc_server_description_t *sd,
             sd->error.code = MONGOC_ERROR_CLIENT_AUTHENTICATE;
             goto failure;
          }
-      } else if (strcmp ("ismaster", bson_iter_key (&iter)) == 0) {
+      } else if (strcmp ("isWritablePrimary", bson_iter_key (&iter)) == 0 ||
+                 strcmp (HANDSHAKE_RESPONSE_LEGACY_HELLO,
+                         bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_BOOL (&iter))
             goto failure;
          is_master = bson_iter_bool (&iter);

--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -404,7 +404,7 @@ const bson_t *
 mongoc_server_description_ismaster (
    const mongoc_server_description_t *description)
 {
-   return &description->last_hello_response;
+   return mongoc_server_description_last_hello_response (description);
 }
 
 /*

--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -370,7 +370,7 @@ mongoc_server_description_type (const mongoc_server_description_t *description)
 /*
  *--------------------------------------------------------------------------
  *
- * mongoc_server_description_hello_response --
+ * mongoc_server_description_last_hello_response --
  *
  *      Return this server's most recent "hello" command response.
  *
@@ -381,7 +381,7 @@ mongoc_server_description_type (const mongoc_server_description_t *description)
  */
 
 const bson_t *
-mongoc_server_description_hello_response (
+mongoc_server_description_last_hello_response (
    const mongoc_server_description_t *description)
 {
    return &description->last_hello_response;

--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -370,7 +370,7 @@ mongoc_server_description_type (const mongoc_server_description_t *description)
 /*
  *--------------------------------------------------------------------------
  *
- * mongoc_server_description_last_hello_response --
+ * mongoc_server_description_hello_response --
  *
  *      Return this server's most recent "hello" command response.
  *
@@ -381,7 +381,7 @@ mongoc_server_description_type (const mongoc_server_description_t *description)
  */
 
 const bson_t *
-mongoc_server_description_last_hello_response (
+mongoc_server_description_hello_response (
    const mongoc_server_description_t *description)
 {
    return &description->last_hello_response;
@@ -404,7 +404,7 @@ const bson_t *
 mongoc_server_description_ismaster (
    const mongoc_server_description_t *description)
 {
-   return mongoc_server_description_last_hello_response (description);
+   return mongoc_server_description_hello_response (description);
 }
 
 /*

--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -41,7 +41,7 @@ mongoc_server_description_cleanup (mongoc_server_description_t *sd)
 {
    BSON_ASSERT (sd);
 
-   bson_destroy (&sd->last_is_master);
+   bson_destroy (&sd->last_hello_response);
    bson_destroy (&sd->hosts);
    bson_destroy (&sd->passives);
    bson_destroy (&sd->arbiters);
@@ -69,10 +69,10 @@ mongoc_server_description_reset (mongoc_server_description_t *sd)
    sd->session_timeout_minutes = MONGOC_NO_SESSIONS;
    sd->last_write_date_ms = -1;
 
-   /* always leave last ismaster in an init-ed state until we destroy sd */
-   bson_destroy (&sd->last_is_master);
-   bson_init (&sd->last_is_master);
-   sd->has_is_master = false;
+   /* always leave last hello in an init-ed state until we destroy sd */
+   bson_destroy (&sd->last_hello_response);
+   bson_init (&sd->last_hello_response);
+   sd->has_hello_response = false;
    sd->last_update_time_usec = bson_get_monotonic_time ();
 
    bson_destroy (&sd->hosts);
@@ -128,7 +128,7 @@ mongoc_server_description_init (mongoc_server_description_t *sd,
    }
 
    sd->connection_address = sd->host.host_and_port;
-   bson_init (&sd->last_is_master);
+   bson_init (&sd->last_hello_response);
    bson_init (&sd->hosts);
    bson_init (&sd->passives);
    bson_init (&sd->arbiters);
@@ -309,7 +309,7 @@ mongoc_server_description_last_update_time (
  * mongoc_server_description_round_trip_time --
  *
  *      Get the round trip time of this server, which is the client's
- *      measurement of the duration of an "ismaster" command.
+ *      measurement of the duration of a "hello" command.
  *
  * Returns:
  *      The server's round trip time in milliseconds.
@@ -370,9 +370,29 @@ mongoc_server_description_type (const mongoc_server_description_t *description)
 /*
  *--------------------------------------------------------------------------
  *
+ * mongoc_server_description_hello_response --
+ *
+ *      Return this server's most recent "hello" command response.
+ *
+ * Returns:
+ *      A reference to a BSON document, owned by the server description.
+ *
+ *--------------------------------------------------------------------------
+ */
+
+const bson_t *
+mongoc_server_description_hello_response (
+   const mongoc_server_description_t *description)
+{
+   return &description->last_hello_response;
+}
+
+/*
+ *--------------------------------------------------------------------------
+ *
  * mongoc_server_description_ismaster --
  *
- *      Return this server's most recent "ismaster" command response.
+ *      Return this server's most recent "hello" command response.
  *
  * Returns:
  *      A reference to a BSON document, owned by the server description.
@@ -384,7 +404,7 @@ const bson_t *
 mongoc_server_description_ismaster (
    const mongoc_server_description_t *description)
 {
-   return &description->last_is_master;
+   return &description->last_hello_response;
 }
 
 /*
@@ -487,7 +507,7 @@ _mongoc_server_description_set_error (mongoc_server_description_t *sd,
       bson_set_error (&sd->error,
                       MONGOC_ERROR_STREAM,
                       MONGOC_ERROR_STREAM_CONNECT,
-                      "unknown error calling ismaster");
+                      "unknown error calling hello");
    }
 
    /* Server Discovery and Monitoring Spec: if the server type changes from a
@@ -534,17 +554,19 @@ mongoc_server_description_handle_ismaster (mongoc_server_description_t *sd,
       EXIT;
    }
 
-   bson_destroy (&sd->last_is_master);
-   bson_init (&sd->last_is_master);
-   bson_copy_to_excluding_noinit (
-      ismaster_response, &sd->last_is_master, "speculativeAuthenticate", NULL);
-   sd->has_is_master = true;
+   bson_destroy (&sd->last_hello_response);
+   bson_init (&sd->last_hello_response);
+   bson_copy_to_excluding_noinit (ismaster_response,
+                                  &sd->last_hello_response,
+                                  "speculativeAuthenticate",
+                                  NULL);
+   sd->has_hello_response = true;
 
    /* Only reinitialize the topology version if we have an ismaster response.
     * Resetting a server description should not effect the topology version. */
    bson_reinit (&sd->topology_version);
 
-   BSON_ASSERT (bson_iter_init (&iter, &sd->last_is_master));
+   BSON_ASSERT (bson_iter_init (&iter, &sd->last_hello_response));
 
    while (bson_iter_next (&iter)) {
       num_keys++;
@@ -760,7 +782,7 @@ mongoc_server_description_new_copy (
    copy->round_trip_time_msec = MONGOC_RTT_UNSET;
 
    copy->connection_address = copy->host.host_and_port;
-   bson_init (&copy->last_is_master);
+   bson_init (&copy->last_hello_response);
    bson_init (&copy->hosts);
    bson_init (&copy->passives);
    bson_init (&copy->arbiters);
@@ -768,11 +790,11 @@ mongoc_server_description_new_copy (
    bson_init (&copy->compressors);
    bson_copy_to (&description->topology_version, &copy->topology_version);
 
-   if (description->has_is_master) {
+   if (description->has_hello_response) {
       /* calls mongoc_server_description_reset */
       mongoc_server_description_handle_ismaster (
          copy,
-         &description->last_is_master,
+         &description->last_hello_response,
          description->round_trip_time_msec,
          &description->error);
    } else {

--- a/src/libmongoc/src/mongoc/mongoc-server-description.h
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.h
@@ -54,7 +54,7 @@ MONGOC_EXPORT (const char *)
 mongoc_server_description_type (const mongoc_server_description_t *description);
 
 MONGOC_EXPORT (const bson_t *)
-mongoc_server_description_hello_response (
+mongoc_server_description_last_hello_response (
    const mongoc_server_description_t *description);
 
 MONGOC_EXPORT (const bson_t *)

--- a/src/libmongoc/src/mongoc/mongoc-server-description.h
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.h
@@ -54,8 +54,12 @@ MONGOC_EXPORT (const char *)
 mongoc_server_description_type (const mongoc_server_description_t *description);
 
 MONGOC_EXPORT (const bson_t *)
-mongoc_server_description_ismaster (
+mongoc_server_description_hello_response (
    const mongoc_server_description_t *description);
+
+MONGOC_EXPORT (const bson_t *)
+mongoc_server_description_ismaster (
+   const mongoc_server_description_t *description) BSON_GNUC_DEPRECATED;
 
 MONGOC_EXPORT (int32_t)
 mongoc_server_description_compressor_id (

--- a/src/libmongoc/src/mongoc/mongoc-server-description.h
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.h
@@ -59,7 +59,8 @@ mongoc_server_description_last_hello_response (
 
 MONGOC_EXPORT (const bson_t *)
 mongoc_server_description_ismaster (
-   const mongoc_server_description_t *description) BSON_GNUC_DEPRECATED;
+   const mongoc_server_description_t *description)
+   BSON_GNUC_DEPRECATED_FOR (mongoc_server_description_last_hello_response);
 
 MONGOC_EXPORT (int32_t)
 mongoc_server_description_compressor_id (

--- a/src/libmongoc/src/mongoc/mongoc-server-description.h
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.h
@@ -54,13 +54,13 @@ MONGOC_EXPORT (const char *)
 mongoc_server_description_type (const mongoc_server_description_t *description);
 
 MONGOC_EXPORT (const bson_t *)
-mongoc_server_description_last_hello_response (
+mongoc_server_description_hello_response (
    const mongoc_server_description_t *description);
 
 MONGOC_EXPORT (const bson_t *)
 mongoc_server_description_ismaster (
    const mongoc_server_description_t *description)
-   BSON_GNUC_DEPRECATED_FOR (mongoc_server_description_last_hello_response);
+   BSON_GNUC_DEPRECATED_FOR (mongoc_server_description_hello_response);
 
 MONGOC_EXPORT (int32_t)
 mongoc_server_description_compressor_id (

--- a/src/libmongoc/src/mongoc/mongoc-server-monitor.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-monitor.c
@@ -321,9 +321,9 @@ fail:
 }
 
 static bool
-_server_monitor_polling_ismaster (mongoc_server_monitor_t *server_monitor,
-                                  bson_t *ismaster_reply,
-                                  bson_error_t *error)
+_server_monitor_polling_hello (mongoc_server_monitor_t *server_monitor,
+                               bson_t *hello_response,
+                               bson_error_t *error)
 {
    bson_t cmd;
    const bson_t *hello;
@@ -335,14 +335,15 @@ _server_monitor_polling_ismaster (mongoc_server_monitor_t *server_monitor,
 
    _server_monitor_append_cluster_time (server_monitor, &cmd);
    ret = _server_monitor_send_and_recv_opquery (
-      server_monitor, &cmd, ismaster_reply, error);
+      server_monitor, &cmd, hello_response, error);
    bson_destroy (&cmd);
    return ret;
 }
 
 static bool
-_server_monitor_awaitable_ismaster_send (
-   mongoc_server_monitor_t *server_monitor, bson_t *cmd, bson_error_t *error)
+_server_monitor_awaitable_hello_send (mongoc_server_monitor_t *server_monitor,
+                                      bson_t *cmd,
+                                      bson_error_t *error)
 {
    mongoc_rpc_t rpc = {0};
    mongoc_array_t array_to_write;
@@ -481,7 +482,7 @@ _get_timeout_ms (int64_t expire_at_ms, bson_error_t *error)
    return timeout_ms;
 }
 
-/* Receive an awaitable ismaster reply.
+/* Receive an awaitable hello reply.
  *
  * May be used to receive additional replies when moreToCome is set.
  * Called only from server monitor thread.
@@ -492,11 +493,10 @@ _get_timeout_ms (int64_t expire_at_ms, bson_error_t *error)
  * On cancellation, no error is set, but cancelled is set to true.
  */
 static bool
-_server_monitor_awaitable_ismaster_recv (
-   mongoc_server_monitor_t *server_monitor,
-   bson_t *ismaster_reply,
-   bool *cancelled,
-   bson_error_t *error)
+_server_monitor_awaitable_hello_recv (mongoc_server_monitor_t *server_monitor,
+                                      bson_t *hello_response,
+                                      bool *cancelled,
+                                      bson_error_t *error)
 {
    bool ret = false;
    mongoc_buffer_t buffer;
@@ -579,14 +579,14 @@ _server_monitor_awaitable_ismaster_recv (
       GOTO (fail);
    }
 
-   bson_copy_to (&reply_local, ismaster_reply);
+   bson_copy_to (&reply_local, hello_response);
    server_monitor->more_to_come =
       (rpc.msg.flags & MONGOC_MSG_MORE_TO_COME) != 0;
 
    ret = true;
 fail:
    if (!ret) {
-      bson_init (ismaster_reply);
+      bson_init (hello_response);
    }
    _mongoc_buffer_destroy (&buffer);
    return ret;
@@ -599,11 +599,11 @@ fail:
  * May block for up to heartbeatFrequencyMS waiting for reply.
  */
 static bool
-_server_monitor_awaitable_ismaster (mongoc_server_monitor_t *server_monitor,
-                                    const bson_t *topology_version,
-                                    bson_t *ismaster_reply,
-                                    bool *cancelled,
-                                    bson_error_t *error)
+_server_monitor_awaitable_hello (mongoc_server_monitor_t *server_monitor,
+                                 const bson_t *topology_version,
+                                 bson_t *hello_response,
+                                 bool *cancelled,
+                                 bson_error_t *error)
 {
    bson_t cmd;
    const bson_t *hello;
@@ -619,20 +619,20 @@ _server_monitor_awaitable_ismaster (mongoc_server_monitor_t *server_monitor,
       &cmd, "maxAwaitTimeMS", 14, server_monitor->heartbeat_frequency_ms);
    bson_append_utf8 (&cmd, "$db", 3, "admin", 5);
 
-   if (!_server_monitor_awaitable_ismaster_send (server_monitor, &cmd, error)) {
+   if (!_server_monitor_awaitable_hello_send (server_monitor, &cmd, error)) {
       GOTO (fail);
    }
 
-   if (!_server_monitor_awaitable_ismaster_recv (
-          server_monitor, ismaster_reply, cancelled, error)) {
-      bson_destroy (ismaster_reply);
+   if (!_server_monitor_awaitable_hello_recv (
+          server_monitor, hello_response, cancelled, error)) {
+      bson_destroy (hello_response);
       GOTO (fail);
    }
 
    ret = true;
 fail:
    if (!ret) {
-      bson_init (ismaster_reply);
+      bson_init (hello_response);
    }
    bson_destroy (&cmd);
    return ret;
@@ -650,15 +650,15 @@ _server_monitor_update_topology_description (
    mongoc_server_description_t *description)
 {
    mongoc_topology_t *topology;
-   bson_t *ismaster_reply = NULL;
+   bson_t *hello_response = NULL;
 
    topology = server_monitor->topology;
    if (description->has_hello_response) {
-      ismaster_reply = &description->last_hello_response;
+      hello_response = &description->last_hello_response;
    }
 
-   if (ismaster_reply) {
-      _mongoc_topology_update_cluster_time (topology, ismaster_reply);
+   if (hello_response) {
+      _mongoc_topology_update_cluster_time (topology, hello_response);
    }
 
    bson_mutex_lock (&topology->mutex);
@@ -669,10 +669,10 @@ _server_monitor_update_topology_description (
       server_monitor->shared.scan_requested = false;
       bson_mutex_unlock (&server_monitor->shared.mutex);
 
-      mongoc_topology_description_handle_ismaster (
+      mongoc_topology_description_handle_hello (
          &server_monitor->topology->description,
          server_monitor->server_id,
-         ismaster_reply,
+         hello_response,
          description->round_trip_time_msec,
          &description->error);
       /* Reconcile server monitors. */
@@ -732,11 +732,11 @@ mongoc_server_monitor_new (mongoc_topology_t *topology,
  * Called only by server monitor thread.
  * Returns true if both connection and handshake succeeds.
  * Returns false and sets error otherwise.
- * ismaster_reply is always initialized.
+ * hello_response is always initialized.
  */
 static bool
 _server_monitor_setup_connection (mongoc_server_monitor_t *server_monitor,
-                                  bson_t *ismaster_reply,
+                                  bson_t *hello_response,
                                   int64_t *start_us,
                                   bson_error_t *error)
 {
@@ -747,7 +747,7 @@ _server_monitor_setup_connection (mongoc_server_monitor_t *server_monitor,
    ENTRY;
 
    BSON_ASSERT (!server_monitor->stream);
-   bson_init (ismaster_reply);
+   bson_init (hello_response);
 
    server_monitor->more_to_come = false;
 
@@ -785,9 +785,9 @@ _server_monitor_setup_connection (mongoc_server_monitor_t *server_monitor,
    bson_destroy (&cmd);
    bson_copy_to (handshake, &cmd);
    _server_monitor_append_cluster_time (server_monitor, &cmd);
-   bson_destroy (ismaster_reply);
+   bson_destroy (hello_response);
    if (!_server_monitor_send_and_recv_opquery (
-          server_monitor, &cmd, ismaster_reply, error)) {
+          server_monitor, &cmd, hello_response, error)) {
       GOTO (fail);
    }
 
@@ -818,7 +818,7 @@ mongoc_server_monitor_check_server (
 {
    bool ret = false;
    bson_error_t error;
-   bson_t ismaster_reply;
+   bson_t hello_response;
    int64_t duration_us;
    int64_t start_us;
    bool command_or_network_error = false;
@@ -841,7 +841,7 @@ mongoc_server_monitor_check_server (
       awaited = false;
       _server_monitor_heartbeat_started (server_monitor, awaited);
       ret = _server_monitor_setup_connection (
-         server_monitor, &ismaster_reply, &start_us, &error);
+         server_monitor, &hello_response, &start_us, &error);
       GOTO (exit);
    }
 
@@ -850,8 +850,8 @@ mongoc_server_monitor_check_server (
       /* Publish a heartbeat started for each additional response read. */
       _server_monitor_heartbeat_started (server_monitor, awaited);
       MONITOR_LOG (server_monitor, "more to come");
-      ret = _server_monitor_awaitable_ismaster_recv (
-         server_monitor, &ismaster_reply, cancelled, &error);
+      ret = _server_monitor_awaitable_hello_recv (
+         server_monitor, &hello_response, cancelled, &error);
       GOTO (exit);
    }
 
@@ -859,10 +859,10 @@ mongoc_server_monitor_check_server (
       awaited = true;
       _server_monitor_heartbeat_started (server_monitor, awaited);
       MONITOR_LOG (server_monitor, "awaitable hello");
-      ret = _server_monitor_awaitable_ismaster (
+      ret = _server_monitor_awaitable_hello (
          server_monitor,
          &previous_description->topology_version,
-         &ismaster_reply,
+         &hello_response,
          cancelled,
          &error);
       GOTO (exit);
@@ -871,8 +871,8 @@ mongoc_server_monitor_check_server (
    MONITOR_LOG (server_monitor, "polling hello");
    awaited = false;
    _server_monitor_heartbeat_started (server_monitor, awaited);
-   ret = _server_monitor_polling_ismaster (
-      server_monitor, &ismaster_reply, &error);
+   ret =
+      _server_monitor_polling_hello (server_monitor, &hello_response, &error);
 
 exit:
    duration_us = _now_us () - start_us;
@@ -881,7 +881,7 @@ exit:
 
    /* If ret is true, we have a reply. Check if "ok": 1. */
    if (ret && _mongoc_cmd_check_ok (
-                 &ismaster_reply, MONGOC_ERROR_API_VERSION_2, &error)) {
+                 &hello_response, MONGOC_ERROR_API_VERSION_2, &error)) {
       int64_t rtt_ms = MONGOC_RTT_UNSET;
 
       /* rtt remains MONGOC_RTT_UNSET if awaited. */
@@ -889,8 +889,8 @@ exit:
          rtt_ms = duration_us / 1000;
       }
 
-      mongoc_server_description_handle_ismaster (
-         description, &ismaster_reply, rtt_ms, NULL);
+      mongoc_server_description_handle_hello (
+         description, &hello_response, rtt_ms, NULL);
       /* If the ismaster reply could not be parsed, consider this a command
        * error. */
       if (description->error.code) {
@@ -902,7 +902,7 @@ exit:
             server_monitor, &description->error, duration_us, awaited);
       } else {
          _server_monitor_heartbeat_succeeded (
-            server_monitor, &ismaster_reply, duration_us, awaited);
+            server_monitor, &hello_response, duration_us, awaited);
       }
    } else if (*cancelled) {
       MONITOR_LOG (server_monitor, "server monitor cancelled");
@@ -919,7 +919,7 @@ exit:
                          "command or network error occurred: %s",
                          error.message);
       command_or_network_error = true;
-      mongoc_server_description_handle_ismaster (
+      mongoc_server_description_handle_hello (
          description, NULL, MONGOC_RTT_UNSET, &error);
       _server_monitor_heartbeat_failed (
          server_monitor, &description->error, duration_us, awaited);
@@ -937,7 +937,7 @@ exit:
       bson_mutex_unlock (&server_monitor->topology->mutex);
    }
 
-   bson_destroy (&ismaster_reply);
+   bson_destroy (&hello_response);
    return description;
 }
 
@@ -1096,7 +1096,7 @@ _server_monitor_ping_server (mongoc_server_monitor_t *server_monitor,
 {
    bool ret = false;
    int64_t start_us = _now_us ();
-   bson_t ismaster_reply;
+   bson_t hello_response;
    bson_error_t error;
 
    *rtt_ms = MONGOC_RTT_UNSET;
@@ -1104,18 +1104,18 @@ _server_monitor_ping_server (mongoc_server_monitor_t *server_monitor,
    if (!server_monitor->stream) {
       MONITOR_LOG (server_monitor, "rtt setting up connection");
       ret = _server_monitor_setup_connection (
-         server_monitor, &ismaster_reply, &start_us, &error);
-      bson_destroy (&ismaster_reply);
+         server_monitor, &hello_response, &start_us, &error);
+      bson_destroy (&hello_response);
    }
 
    if (server_monitor->stream) {
       MONITOR_LOG (server_monitor, "rtt polling hello");
-      ret = _server_monitor_polling_ismaster (
-         server_monitor, &ismaster_reply, &error);
+      ret = _server_monitor_polling_hello (
+         server_monitor, &hello_response, &error);
       if (ret) {
          *rtt_ms = (_now_us () - start_us) / 1000;
       }
-      bson_destroy (&ismaster_reply);
+      bson_destroy (&hello_response);
    }
    return ret;
 }

--- a/src/libmongoc/src/mongoc/mongoc-server-monitor.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-monitor.c
@@ -329,7 +329,8 @@ _server_monitor_polling_ismaster (mongoc_server_monitor_t *server_monitor,
    const bson_t *hello;
    bool ret;
 
-   hello = _mongoc_topology_scanner_get_hello_cmd (server_monitor->topology->scanner);
+   hello = _mongoc_topology_scanner_get_hello_cmd (
+      server_monitor->topology->scanner);
    bson_copy_to (hello, &cmd);
 
    _server_monitor_append_cluster_time (server_monitor, &cmd);
@@ -373,9 +374,8 @@ _server_monitor_awaitable_ismaster_send (
                                     niovec,
                                     server_monitor->connect_timeout_ms,
                                     error)) {
-      MONITOR_LOG_ERROR (server_monitor,
-                         "failed to write awaitable ismaster: %s",
-                         error->message);
+      MONITOR_LOG_ERROR (
+         server_monitor, "failed to write awaitable hello: %s", error->message);
       _mongoc_array_destroy (&array_to_write);
       return false;
    }
@@ -416,7 +416,7 @@ _server_monitor_poll_with_interrupt (mongoc_server_monitor_t *server_monitor,
 
       MONITOR_LOG (
          server_monitor,
-         "polling for awaitable ismaster reply with timeleft_ms: %" PRId64,
+         "polling for awaitable hello reply with timeleft_ms: %" PRId64,
          timeleft_ms);
       ret = mongoc_stream_poll (
          poller, 1, (int32_t) BSON_MIN (timeleft_ms, monitor_tick_ms));
@@ -609,7 +609,8 @@ _server_monitor_awaitable_ismaster (mongoc_server_monitor_t *server_monitor,
    const bson_t *hello;
    bool ret = false;
 
-   hello = _mongoc_topology_scanner_get_hello_cmd (server_monitor->topology->scanner);
+   hello = _mongoc_topology_scanner_get_hello_cmd (
+      server_monitor->topology->scanner);
    bson_copy_to (hello, &cmd);
 
    _server_monitor_append_cluster_time (server_monitor, &cmd);
@@ -652,8 +653,8 @@ _server_monitor_update_topology_description (
    bson_t *ismaster_reply = NULL;
 
    topology = server_monitor->topology;
-   if (description->has_is_master) {
-      ismaster_reply = &description->last_is_master;
+   if (description->has_hello_response) {
+      ismaster_reply = &description->last_hello_response;
    }
 
    if (ismaster_reply) {
@@ -857,7 +858,7 @@ mongoc_server_monitor_check_server (
    if (!bson_empty (&previous_description->topology_version)) {
       awaited = true;
       _server_monitor_heartbeat_started (server_monitor, awaited);
-      MONITOR_LOG (server_monitor, "awaitable ismaster");
+      MONITOR_LOG (server_monitor, "awaitable hello");
       ret = _server_monitor_awaitable_ismaster (
          server_monitor,
          &previous_description->topology_version,
@@ -867,7 +868,7 @@ mongoc_server_monitor_check_server (
       GOTO (exit);
    }
 
-   MONITOR_LOG (server_monitor, "polling ismaster");
+   MONITOR_LOG (server_monitor, "polling hello");
    awaited = false;
    _server_monitor_heartbeat_started (server_monitor, awaited);
    ret = _server_monitor_polling_ismaster (
@@ -1108,7 +1109,7 @@ _server_monitor_ping_server (mongoc_server_monitor_t *server_monitor,
    }
 
    if (server_monitor->stream) {
-      MONITOR_LOG (server_monitor, "rtt polling ismaster");
+      MONITOR_LOG (server_monitor, "rtt polling hello");
       ret = _server_monitor_polling_ismaster (
          server_monitor, &ismaster_reply, &error);
       if (ret) {

--- a/src/libmongoc/src/mongoc/mongoc-topology-description-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description-private.h
@@ -76,10 +76,10 @@ mongoc_topology_description_destroy (
    mongoc_topology_description_t *description);
 
 void
-mongoc_topology_description_handle_ismaster (
+mongoc_topology_description_handle_hello (
    mongoc_topology_description_t *topology,
    uint32_t server_id,
-   const bson_t *reply,
+   const bson_t *hello_response,
    int64_t rtt_msec,
    const bson_error_t *error /* IN */);
 

--- a/src/libmongoc/src/mongoc/mongoc-topology-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description.c
@@ -1131,8 +1131,8 @@ mongoc_topology_description_invalidate_server (
 {
    BSON_ASSERT (error);
 
-   /* send NULL ismaster reply */
-   mongoc_topology_description_handle_ismaster (
+   /* send NULL hello reply */
+   mongoc_topology_description_handle_hello (
       topology, id, NULL, MONGOC_RTT_UNSET, error);
 }
 
@@ -1414,7 +1414,7 @@ _mongoc_topology_description_update_rs_from_primary (
       return;
 
    /* If server->set_name was null this function wouldn't be called from
-    * mongoc_server_description_handle_ismaster(). static code analyzers however
+    * mongoc_server_description_handle_hello(). static code analyzers however
     * don't know that so we check for it explicitly. */
    if (server->set_name) {
       /* 'Server' can only be the primary if it has the right rs name  */
@@ -1903,11 +1903,11 @@ _mongoc_topology_description_check_compatible (
 /*
  *--------------------------------------------------------------------------
  *
- * mongoc_topology_description_handle_ismaster --
+ * mongoc_topology_description_handle_hello --
  *
- *      Handle an ismaster. This is called by the background SDAM process,
+ *      Handle a hello. This is called by the background SDAM process,
  *      and by client when performing a handshake or invalidating servers.
- *      If there was an error calling ismaster, pass it in as @error.
+ *      If there was an error calling hello, pass it in as @error.
  *
  *      NOTE: this method should only be called while holding the mutex on
  *      the owning topology object.
@@ -1916,10 +1916,10 @@ _mongoc_topology_description_check_compatible (
  */
 
 void
-mongoc_topology_description_handle_ismaster (
+mongoc_topology_description_handle_hello (
    mongoc_topology_description_t *topology,
    uint32_t server_id,
-   const bson_t *ismaster_response,
+   const bson_t *hello_response,
    int64_t rtt_msec,
    const bson_error_t *error /* IN */)
 {
@@ -1944,8 +1944,8 @@ mongoc_topology_description_handle_ismaster (
       _mongoc_topology_description_copy_to (topology, prev_td);
    }
 
-   if (ismaster_response &&
-       bson_iter_init_find (&iter, ismaster_response, "topologyVersion") &&
+   if (hello_response &&
+       bson_iter_init_find (&iter, hello_response, "topologyVersion") &&
        BSON_ITER_HOLDS_DOCUMENT (&iter)) {
       bson_t incoming_topology_version;
       const uint8_t *bytes;
@@ -1972,11 +1972,10 @@ mongoc_topology_description_handle_ismaster (
       prev_sd = mongoc_server_description_new_copy (sd);
    }
 
-   DUMP_BSON (ismaster_response);
+   DUMP_BSON (hello_response);
    /* pass the current error in */
 
-   mongoc_server_description_handle_ismaster (
-      sd, ismaster_response, rtt_msec, error);
+   mongoc_server_description_handle_hello (sd, hello_response, rtt_msec, error);
 
    /* if the user specified a set_name in the connection string
     * and they are in topology type single, check that the set name
@@ -2005,13 +2004,12 @@ mongoc_topology_description_handle_ismaster (
       if (wrong_set_name) {
          /* Replace with unknown. */
          TRACE ("%s", "wrong set name");
-         mongoc_server_description_handle_ismaster (
+         mongoc_server_description_handle_hello (
             sd, NULL, MONGOC_RTT_UNSET, &set_name_err);
       }
    }
 
-   mongoc_topology_description_update_cluster_time (topology,
-                                                    ismaster_response);
+   mongoc_topology_description_update_cluster_time (topology, hello_response);
 
    if (prev_sd) {
       sd_changed = !_mongoc_server_description_equal (prev_sd, sd);
@@ -2035,7 +2033,7 @@ mongoc_topology_description_handle_ismaster (
    _mongoc_topology_description_update_session_timeout (topology);
 
    /* Don't bother checking wire version compatibility if we already errored */
-   if (ismaster_response && (!error || !error->code)) {
+   if (hello_response && (!error || !error->code)) {
       _mongoc_topology_description_check_compatible (topology);
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-topology-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description.c
@@ -803,7 +803,7 @@ mongoc_topology_description_select (mongoc_topology_description_t *topology,
       sd = (mongoc_server_description_t *) mongoc_set_get_item (
          topology->servers, 0);
 
-      if (sd->has_is_master) {
+      if (sd->has_hello_response) {
          RETURN (sd);
       } else {
          TRACE ("Topology type single, [%s] is down", sd->host.host_and_port);
@@ -1132,7 +1132,8 @@ mongoc_topology_description_invalidate_server (
    BSON_ASSERT (error);
 
    /* send NULL ismaster reply */
-   mongoc_topology_description_handle_ismaster (topology, id, NULL, MONGOC_RTT_UNSET, error);
+   mongoc_topology_description_handle_ismaster (
+      topology, id, NULL, MONGOC_RTT_UNSET, error);
 }
 
 /*

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner-private.h
@@ -83,8 +83,8 @@ typedef struct mongoc_topology_scanner {
    mongoc_async_t *async;
    int64_t connect_timeout_msec;
    mongoc_topology_scanner_node_t *nodes;
-   bson_t ismaster_cmd;
-   bson_t ismaster_cmd_with_handshake;
+   bson_t hello_cmd;
+   bson_t hello_cmd_with_handshake;
    bson_t cluster_time;
    bool handshake_ok_to_send;
    const char *appname;

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
@@ -296,7 +296,7 @@ _mongoc_topology_scanner_get_handshake_cmd (mongoc_topology_scanner_t *ts)
    if (bson_empty (&ts->ismaster_cmd_with_handshake)) {
       ts->handshake_ok_to_send = _build_ismaster_with_handshake (ts);
       if (!ts->handshake_ok_to_send) {
-         MONGOC_WARNING ("Handshake doc too big, not including in isMaster");
+         MONGOC_WARNING ("Handshake doc too big, not including in hello");
       }
    }
 
@@ -697,7 +697,7 @@ _async_error_or_timeout (mongoc_async_cmd_t *acmd,
       bson_set_error (&node->last_error,
                       MONGOC_ERROR_CLIENT,
                       MONGOC_ERROR_STREAM_CONNECT,
-                      "%s calling ismaster on \'%s\'",
+                      "%s calling hello on \'%s\'",
                       message,
                       node->host.host_and_port);
 
@@ -1014,7 +1014,7 @@ mongoc_topology_scanner_node_setup (mongoc_topology_scanner_node_t *node,
  * mongoc_topology_scanner_node_in_cooldown --
  *
  *      Return true if @node has experienced a network error attempting
- *      to call "ismaster" less than 5 seconds before @when, a timestamp in
+ *      to call "hello" less than 5 seconds before @when, a timestamp in
  *      microseconds.
  *
  *      Server Discovery and Monitoring Spec: "After a single-threaded client

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
@@ -113,7 +113,7 @@ _add_ismaster (mongoc_topology_scanner_t *ts)
       BSON_APPEND_INT32 (cmd, "hello", 1);
       _mongoc_cmd_append_server_api (cmd, api);
    } else {
-      BSON_APPEND_INT32 (cmd, "isMaster", 1);
+      BSON_APPEND_INT32 (cmd, HANDSHAKE_CMD_LEGACY_HELLO, 1);
    }
 }
 

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -584,9 +584,9 @@ mongoc_topology_apply_scanned_srv_hosts (mongoc_uri_t *uri,
    bool had_valid_hosts = false;
 
    /* Validate that the hosts have a matching domain.
-   * If validation fails, log it.
-   * If no valid hosts remain, do not update the topology description.
-   */
+    * If validation fails, log it.
+    * If no valid hosts remain, do not update the topology description.
+    */
    LL_FOREACH (hosts, host)
    {
       if (mongoc_uri_validate_srv_result (uri, host->host, error)) {
@@ -617,20 +617,21 @@ mongoc_topology_apply_scanned_srv_hosts (mongoc_uri_t *uri,
  *--------------------------------------------------------------------------
  *
  * mongoc_topology_should_rescan_srv --
- * 
+ *
  *      Checks whether it is valid to rescan SRV records on the topology.
  *      Namely, that the topology type is Sharded or Unknown, and that
  *      the topology URI was configured with SRV.
- * 
+ *
  *      If this returns false, caller can stop scanning SRV records
  *      and does not need to try again in the future.
- * 
+ *
  *      NOTE: this method expects @topology's mutex to be locked on entry.
  *
  * --------------------------------------------------------------------------
  */
 bool
-mongoc_topology_should_rescan_srv (mongoc_topology_t *topology) {
+mongoc_topology_should_rescan_srv (mongoc_topology_t *topology)
+{
    const char *service;
 
    MONGOC_DEBUG_ASSERT (COMMON_PREFIX (mutex_is_locked) (&topology->mutex));
@@ -758,7 +759,8 @@ mongoc_topology_scan_once (mongoc_topology_t *topology, bool obey_cooldown)
    MONGOC_DEBUG_ASSERT (COMMON_PREFIX (mutex_is_locked) (&topology->mutex));
 
    if (mongoc_topology_should_rescan_srv (topology)) {
-      /* Prior to scanning hosts, update the list of SRV hosts, if applicable. */
+      /* Prior to scanning hosts, update the list of SRV hosts, if applicable.
+       */
       mongoc_topology_rescan_srv (topology);
    }
 
@@ -1286,8 +1288,11 @@ _mongoc_topology_update_from_handshake (mongoc_topology_t *topology,
    bson_mutex_lock (&topology->mutex);
 
    /* return false if server was removed from topology */
-   has_server = _mongoc_topology_update_no_lock (
-      sd->id, &sd->last_is_master, sd->round_trip_time_msec, topology, NULL);
+   has_server = _mongoc_topology_update_no_lock (sd->id,
+                                                 &sd->last_hello_response,
+                                                 sd->round_trip_time_msec,
+                                                 topology,
+                                                 NULL);
 
    /* if pooled, wake threads waiting in mongoc_topology_server_by_id */
    mongoc_cond_broadcast (&topology->cond_client);
@@ -1719,9 +1724,9 @@ _mongoc_topology_handle_app_error (mongoc_topology_t *topology,
       }
 
       /* Check if the error is "stale", i.e. the topologyVersion refers to an
-      * older
-      * version of the server than we have stored in the topology description.
-      */
+       * older
+       * version of the server than we have stored in the topology description.
+       */
       _find_topology_version (reply, &incoming_topology_version);
       if (mongoc_server_description_topology_version_cmp (
              &sd->topology_version, &incoming_topology_version) >= 0) {

--- a/src/libmongoc/tests/json-test.c
+++ b/src/libmongoc/tests/json-test.c
@@ -218,7 +218,7 @@ process_sdam_test_ismaster_responses (bson_t *phase,
 
          /* send ismaster through the topology description's handler */
          capture_logs (true);
-         mongoc_topology_description_handle_ismaster (
+         mongoc_topology_description_handle_hello (
             td, sd->id, &response, 1, NULL);
          if (td->servers->items_len == 0) {
             ASSERT_CAPTURED_LOG ("topology",
@@ -1739,8 +1739,9 @@ run_json_general_test (const json_test_config_t *config)
 
       /* expect "operation was interrupted", ignore "command not found" or "is
        * not supported" */
-      if (!r && (error.domain != MONGOC_ERROR_SERVER ||
-                 (error.code != 11601 && error.code != 59)) &&
+      if (!r &&
+          (error.domain != MONGOC_ERROR_SERVER ||
+           (error.code != 11601 && error.code != 59)) &&
           (strstr (error.message, "is unsupported") == NULL)) {
          MONGOC_WARNING ("Error in killAllSessions: %s", error.message);
       }

--- a/src/libmongoc/tests/json/server_discovery_and_monitoring/integration/isMaster-command-error.json
+++ b/src/libmongoc/tests/json/server_discovery_and_monitoring/integration/isMaster-command-error.json
@@ -1,7 +1,7 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.4"
+      "minServerVersion": "4.9"
     }
   ],
   "database_name": "sdam-tests",
@@ -17,7 +17,8 @@
         },
         "data": {
           "failCommands": [
-            "isMaster"
+            "isMaster",
+            "hello"
           ],
           "appName": "commandErrorHandshakeTest",
           "closeConnection": false,
@@ -36,14 +37,6 @@
           "object": "testRunner",
           "arguments": {
             "event": "ServerMarkedUnknownEvent",
-            "count": 1
-          }
-        },
-        {
-          "name": "waitForEvent",
-          "object": "testRunner",
-          "arguments": {
-            "event": "PoolClearedEvent",
             "count": 1
           }
         },
@@ -128,7 +121,8 @@
               },
               "data": {
                 "failCommands": [
-                  "isMaster"
+                  "isMaster",
+                  "hello"
                 ],
                 "appName": "commandErrorCheckTest",
                 "closeConnection": false,

--- a/src/libmongoc/tests/json/server_discovery_and_monitoring/integration/isMaster-network-error.json
+++ b/src/libmongoc/tests/json/server_discovery_and_monitoring/integration/isMaster-network-error.json
@@ -1,7 +1,7 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.4"
+      "minServerVersion": "4.9"
     }
   ],
   "database_name": "sdam-tests",
@@ -17,7 +17,8 @@
         },
         "data": {
           "failCommands": [
-            "isMaster"
+            "isMaster",
+            "hello"
           ],
           "appName": "networkErrorHandshakeTest",
           "closeConnection": true
@@ -35,14 +36,6 @@
           "object": "testRunner",
           "arguments": {
             "event": "ServerMarkedUnknownEvent",
-            "count": 1
-          }
-        },
-        {
-          "name": "waitForEvent",
-          "object": "testRunner",
-          "arguments": {
-            "event": "PoolClearedEvent",
             "count": 1
           }
         },
@@ -127,7 +120,8 @@
               },
               "data": {
                 "failCommands": [
-                  "isMaster"
+                  "isMaster",
+                  "hello"
                 ],
                 "appName": "networkErrorCheckTest",
                 "closeConnection": true

--- a/src/libmongoc/tests/json/server_discovery_and_monitoring/integration/isMaster-timeout.json
+++ b/src/libmongoc/tests/json/server_discovery_and_monitoring/integration/isMaster-timeout.json
@@ -17,7 +17,8 @@
         },
         "data": {
           "failCommands": [
-            "isMaster"
+            "isMaster",
+            "hello"
           ],
           "appName": "timeoutMonitorHandshakeTest",
           "blockConnection": true,
@@ -36,14 +37,6 @@
           "object": "testRunner",
           "arguments": {
             "event": "ServerMarkedUnknownEvent",
-            "count": 1
-          }
-        },
-        {
-          "name": "waitForEvent",
-          "object": "testRunner",
-          "arguments": {
-            "event": "PoolClearedEvent",
             "count": 1
           }
         },
@@ -128,7 +121,8 @@
               },
               "data": {
                 "failCommands": [
-                  "isMaster"
+                  "isMaster",
+                  "hello"
                 ],
                 "appName": "timeoutMonitorCheckTest",
                 "blockConnection": true,

--- a/src/libmongoc/tests/mock_server/mock-rs.c
+++ b/src/libmongoc/tests/mock_server/mock-rs.c
@@ -359,7 +359,7 @@ mock_rs_run (mock_rs_t *rs)
 
    /* enqueue unhandled requests in rs->q, they're retrieved with
     * mock_rs_receives_query() &co. rs_q_append is added first so it
-    * runs last, after auto_ismaster.
+    * runs last, after auto_hello.
     */
    for (i = 0; i < rs->servers.len; i++) {
       mock_server_autoresponds (

--- a/src/libmongoc/tests/mock_server/mock-rs.c
+++ b/src/libmongoc/tests/mock_server/mock-rs.c
@@ -375,15 +375,14 @@ mock_rs_run (mock_rs_t *rs)
    if (rs->has_primary) {
       /* primary's ismaster response */
       ismaster_reply = primary_json (rs);
-      mock_server_auto_ismaster (rs->primary, ismaster_reply);
+      mock_server_auto_hello (rs->primary, ismaster_reply);
       bson_free (ismaster_reply);
    }
 
    /* secondaries' ismaster response */
    for (i = 0; i < rs->n_secondaries; i++) {
       ismaster_reply = secondary_json (rs, i);
-      mock_server_auto_ismaster (get_server (&rs->secondaries, i),
-                                 ismaster_reply);
+      mock_server_auto_hello (get_server (&rs->secondaries, i), ismaster_reply);
       bson_free (ismaster_reply);
    }
 
@@ -391,7 +390,7 @@ mock_rs_run (mock_rs_t *rs)
    ismaster_reply = arbiter_json (rs);
 
    for (i = 0; i < rs->n_arbiters; i++) {
-      mock_server_auto_ismaster (get_server (&rs->arbiters, i), ismaster_reply);
+      mock_server_auto_hello (get_server (&rs->arbiters, i), ismaster_reply);
    }
 
    bson_free (ismaster_reply);
@@ -935,7 +934,7 @@ mock_rs_stepdown (mock_rs_t *rs)
    bson_reinit (&rs->primary_tags);
 
    json = secondary_json (rs, rs->n_secondaries - 1);
-   mock_server_auto_ismaster (rs->primary, json);
+   mock_server_auto_hello (rs->primary, json);
    bson_free (json);
 
    _mongoc_array_append_val (&rs->secondaries, rs->primary);
@@ -971,7 +970,7 @@ mock_rs_elect (mock_rs_t *rs, int id)
 
    /* primary_json() uses the current primary_tags */
    json = primary_json (rs);
-   mock_server_auto_ismaster (rs->primary, json);
+   mock_server_auto_hello (rs->primary, json);
    bson_free (json);
 
    ptrs = (mock_server_t **) rs->secondaries.data;

--- a/src/libmongoc/tests/mock_server/mock-rs.c
+++ b/src/libmongoc/tests/mock_server/mock-rs.c
@@ -120,12 +120,12 @@ ismaster_json (mock_rs_t *rs,
    char *json;
 
    if (type == MONGOC_SERVER_RS_PRIMARY) {
-      server_type = "'ismaster': true, 'secondary': false, ";
+      server_type = "'isWritablePrimary': true, 'secondary': false, ";
    } else if (type == MONGOC_SERVER_RS_SECONDARY) {
-      server_type = "'ismaster': false, 'secondary': true, ";
+      server_type = "'isWritablePrimary': false, 'secondary': true, ";
    } else {
       BSON_ASSERT (type == MONGOC_SERVER_RS_ARBITER);
-      server_type = "'ismaster': false, 'arbiterOnly': true, ";
+      server_type = "'isWritablePrimary': false, 'arbiterOnly': true, ";
    }
 
    if (rs->max_wire_version >= WIRE_VERSION_OP_MSG) {
@@ -322,7 +322,7 @@ mock_rs_run (mock_rs_t *rs)
    int i;
    mock_server_t *server;
    char *hosts_str;
-   char *ismaster_reply;
+   char *hello;
 
    if (rs->has_primary) {
       /* start primary */
@@ -374,26 +374,26 @@ mock_rs_run (mock_rs_t *rs)
    BSON_ASSERT (rs->max_wire_version > 0);
    if (rs->has_primary) {
       /* primary's ismaster response */
-      ismaster_reply = primary_json (rs);
-      mock_server_auto_hello (rs->primary, ismaster_reply);
-      bson_free (ismaster_reply);
+      hello = primary_json (rs);
+      mock_server_auto_hello (rs->primary, hello);
+      bson_free (hello);
    }
 
    /* secondaries' ismaster response */
    for (i = 0; i < rs->n_secondaries; i++) {
-      ismaster_reply = secondary_json (rs, i);
-      mock_server_auto_hello (get_server (&rs->secondaries, i), ismaster_reply);
-      bson_free (ismaster_reply);
+      hello = secondary_json (rs, i);
+      mock_server_auto_hello (get_server (&rs->secondaries, i), hello);
+      bson_free (hello);
    }
 
    /* arbiters' ismaster response */
-   ismaster_reply = arbiter_json (rs);
+   hello = arbiter_json (rs);
 
    for (i = 0; i < rs->n_arbiters; i++) {
-      mock_server_auto_hello (get_server (&rs->arbiters, i), ismaster_reply);
+      mock_server_auto_hello (get_server (&rs->arbiters, i), hello);
    }
 
-   bson_free (ismaster_reply);
+   bson_free (hello);
 
    if (rs->max_wire_version >= WIRE_VERSION_OP_MSG) {
       mock_rs_auto_endsessions (rs);

--- a/src/libmongoc/tests/mock_server/mock-server.c
+++ b/src/libmongoc/tests/mock_server/mock-server.c
@@ -527,7 +527,7 @@ auto_hello (request_t *request, void *data)
       return false;
    }
 
-   // Check whether we've got "hello" or legacy hello
+   /* Check whether we've got "hello" or legacy hello */
    is_hello = strcasecmp (request->command_name, "hello") == 0;
    is_legacy_hello =
       strcasecmp (request->command_name, HANDSHAKE_CMD_LEGACY_HELLO) == 0;
@@ -540,7 +540,7 @@ auto_hello (request_t *request, void *data)
       return false;
    }
 
-   // Convert responses for legacy hello
+   /* Convert responses for legacy hello */
    if (bson_iter_init_find (&iter, &response, "isWritablePrimary")) {
       BSON_APPEND_BOOL (
          &response, HANDSHAKE_RESPONSE_LEGACY_HELLO, bson_iter_bool (&iter));

--- a/src/libmongoc/tests/mock_server/mock-server.c
+++ b/src/libmongoc/tests/mock_server/mock-server.c
@@ -492,7 +492,7 @@ mock_server_remove_autoresponder (mock_server_t *server, int id)
 
 
 static bool
-auto_hello_generate_legacy_response (request_t *request,
+auto_hello_generate_response (request_t *request,
                                      void *data,
                                      bson_t *hello_response)
 {
@@ -571,7 +571,7 @@ auto_hello (request_t *request, void *data)
 }
 
 static void
-mock_server_free_callback (void *data)
+hello_callback_free (void *data)
 {
    hello_callback_t *callback = (hello_callback_t *) data;
 
@@ -597,7 +597,7 @@ mock_server_auto_hello_callback (mock_server_t *server,
    callback->destructor = destructor;
 
    return mock_server_autoresponds (
-      server, auto_hello, (void *) callback, mock_server_free_callback);
+      server, auto_hello, (void *) callback, hello_callback_free);
 }
 
 /*--------------------------------------------------------------------------
@@ -627,7 +627,7 @@ mock_server_auto_hello (mock_server_t *server, const char *response_json, ...)
    va_end (args);
 
    return mock_server_auto_hello_callback (server,
-                                           auto_hello_generate_legacy_response,
+                                           auto_hello_generate_response,
                                            (void *) formatted_response_json,
                                            bson_free);
 }

--- a/src/libmongoc/tests/mock_server/mock-server.c
+++ b/src/libmongoc/tests/mock_server/mock-server.c
@@ -72,9 +72,7 @@ struct _autoresponder_handle_t {
    int id;
 };
 
-typedef enum {
-   REPLY, HANGUP, RESET
-} reply_type_t;
+typedef enum { REPLY, HANGUP, RESET } reply_type_t;
 
 
 typedef struct {
@@ -947,6 +945,34 @@ mock_server_receives_ismaster (mock_server_t *server)
 
 /*--------------------------------------------------------------------------
  *
+ * mock_server_receives_hello --
+ *
+ *       Pop a client non-streaming hello call if one is enqueued,
+ *       or wait up to request_timeout_ms for the client to send a request.
+ *
+ * Returns:
+ *       A request you must request_destroy, or NULL if the current
+ *       request is not an hello command.
+ *
+ * Side effects:
+ *       Logs if the current request is not an hello command.
+ *
+ *--------------------------------------------------------------------------
+ */
+
+request_t *
+mock_server_receives_hello (mock_server_t *server)
+{
+   return mock_server_receives_command (
+      server,
+      "admin",
+      MONGOC_QUERY_SLAVE_OK,
+      "{'hello': 1, 'maxAwaitTimeMS': { '$exists': false }}");
+}
+
+
+/*--------------------------------------------------------------------------
+ *
  * mock_server_receives_query --
  *
  *       Pop a client request if one is enqueued, or wait up to
@@ -1088,9 +1114,8 @@ mock_server_receives_update (mock_server_t *server,
 
    request = mock_server_receives_request (server);
 
-   if (request &&
-       !request_matches_update (
-          request, ns, flags, selector_json, update_json)) {
+   if (request && !request_matches_update (
+                     request, ns, flags, selector_json, update_json)) {
       request_destroy (request);
       return NULL;
    }

--- a/src/libmongoc/tests/mock_server/mock-server.h
+++ b/src/libmongoc/tests/mock_server/mock-server.h
@@ -124,6 +124,9 @@ request_t *
 mock_server_receives_ismaster (mock_server_t *server);
 
 request_t *
+mock_server_receives_hello (mock_server_t *server);
+
+request_t *
 mock_server_receives_query (mock_server_t *server,
                             const char *ns,
                             mongoc_query_flags_t flags,

--- a/src/libmongoc/tests/mock_server/mock-server.h
+++ b/src/libmongoc/tests/mock_server/mock-server.h
@@ -64,9 +64,7 @@ void
 mock_server_remove_autoresponder (mock_server_t *server, int id);
 
 int
-mock_server_auto_ismaster (mock_server_t *server,
-                           const char *response_json,
-                           ...);
+mock_server_auto_hello (mock_server_t *server, const char *response_json, ...);
 
 int
 mock_server_auto_endsessions (mock_server_t *server);

--- a/src/libmongoc/tests/mock_server/mock-server.h
+++ b/src/libmongoc/tests/mock_server/mock-server.h
@@ -30,6 +30,7 @@
 
 typedef struct _mock_server_t mock_server_t;
 typedef struct _autoresponder_handle_t autoresponder_handle_t;
+typedef struct _hello_callback_t hello_callback_t;
 
 typedef struct _mock_server_bind_opts_t {
    struct sockaddr_in *bind_addr;
@@ -39,6 +40,10 @@ typedef struct _mock_server_bind_opts_t {
 } mock_server_bind_opts_t;
 
 typedef bool (*autoresponder_t) (request_t *request, void *data);
+
+typedef bool (*hello_callback_func_t) (request_t *request,
+                                       void *data,
+                                       bson_t *hello_response);
 
 typedef void (*destructor_t) (void *data);
 
@@ -62,6 +67,12 @@ mock_server_autoresponds (mock_server_t *server,
 
 void
 mock_server_remove_autoresponder (mock_server_t *server, int id);
+
+int
+mock_server_auto_hello_callback (mock_server_t *server,
+                                 hello_callback_func_t callback_func,
+                                 void *data,
+                                 destructor_t destructor);
 
 int
 mock_server_auto_hello (mock_server_t *server, const char *response_json, ...);
@@ -119,7 +130,8 @@ mock_server_receives_command (mock_server_t *server,
                               ...);
 
 request_t *
-mock_server_receives_ismaster (mock_server_t *server);
+mock_server_receives_legacy_hello (mock_server_t *server,
+                                   const char *match_json);
 
 request_t *
 mock_server_receives_hello (mock_server_t *server);

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -1142,7 +1142,7 @@ call_hello_with_host_and_port (char *host_and_port, bson_t *reply)
              NULL,
              reply,
              &error)) {
-         fprintf (stderr, "error calling hello: '%s'\n", error.message);
+         fprintf (stderr, "error calling legacy hello: '%s'\n", error.message);
          fprintf (stderr, "URI = %s\n", uri_str);
          abort ();
       }

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -1077,17 +1077,17 @@ test_framework_get_unix_domain_socket_uri_str ()
 /*
  *--------------------------------------------------------------------------
  *
- * call_ismaster_with_host_and_port --
+ * call_hello_with_host_and_port --
  *
- *       Call isMaster on a server, possibly over SSL.
+ *       Call hello or legacy hello on a server, possibly over SSL.
  *
  * Side effects:
- *       Fills reply with ismaster response. Logs and aborts on error.
+ *       Fills reply with hello response. Logs and aborts on error.
  *
  *--------------------------------------------------------------------------
  */
 static void
-call_ismaster_with_host_and_port (char *host_and_port, bson_t *reply)
+call_hello_with_host_and_port (char *host_and_port, bson_t *reply)
 {
    char *user;
    char *password;
@@ -1132,17 +1132,20 @@ call_ismaster_with_host_and_port (char *host_and_port, bson_t *reply)
 #endif
 
    if (!mongoc_client_command_simple (
-          client, "admin", tmp_bson ("{'hello': 1}"), NULL, reply, &error) &&
-       !mongoc_client_command_simple (
-          client,
-          "admin",
-          tmp_bson ("{'" HANDSHAKE_CMD_LEGACY_HELLO "': 1}"),
-          NULL,
-          reply,
-          &error)) {
-      fprintf (stderr, "error calling hello: '%s'\n", error.message);
-      fprintf (stderr, "URI = %s\n", uri_str);
-      abort ();
+          client, "admin", tmp_bson ("{'hello': 1}"), NULL, reply, &error)) {
+      bson_destroy (reply);
+
+      if (!mongoc_client_command_simple (
+             client,
+             "admin",
+             tmp_bson ("{'" HANDSHAKE_CMD_LEGACY_HELLO "': 1}"),
+             NULL,
+             reply,
+             &error)) {
+         fprintf (stderr, "error calling hello: '%s'\n", error.message);
+         fprintf (stderr, "URI = %s\n", uri_str);
+         abort ();
+      }
    }
 
    mongoc_client_destroy (client);
@@ -1153,22 +1156,22 @@ call_ismaster_with_host_and_port (char *host_and_port, bson_t *reply)
 /*
  *--------------------------------------------------------------------------
  *
- * call_ismaster --
+ * call_hello --
  *
- *       Call isMaster on the test server, possibly over SSL, using host
- *       and port from the environment.
+ *       Call hello or legacy hello on the test server, possibly over SSL, using
+ *       host and port from the environment.
  *
  * Side effects:
- *       Fills reply with ismaster response. Logs and aborts on error.
+ *       Fills reply with hello response. Logs and aborts on error.
  *
  *--------------------------------------------------------------------------
  */
 static void
-call_ismaster (bson_t *reply)
+call_hello (bson_t *reply)
 {
    char *host_and_port = test_framework_get_host_and_port ();
 
-   call_ismaster_with_host_and_port (host_and_port, reply);
+   call_hello_with_host_and_port (host_and_port, reply);
 
    bson_free (host_and_port);
 }
@@ -1265,7 +1268,7 @@ test_framework_get_uri_str_no_auth (const char *database_name)
       bson_free (env_uri_str);
    } else {
       /* construct a direct connection or replica set connection URI */
-      call_ismaster (&ismaster_response);
+      call_hello (&ismaster_response);
       uri_string = bson_string_new ("mongodb://");
 
       if ((name = set_name (&ismaster_response))) {
@@ -1472,7 +1475,7 @@ test_framework_replset_name (void)
    bson_iter_t iter;
    char *replset_name;
 
-   call_ismaster (&reply);
+   call_hello (&reply);
    if (!bson_iter_init_find (&iter, &reply, "setName")) {
       return NULL;
    }
@@ -1553,7 +1556,7 @@ test_framework_data_nodes_count (void)
    size_t count = 0;
 
 
-   call_ismaster (&reply);
+   call_hello (&reply);
    if (!bson_iter_init_find (&iter, &reply, "hosts")) {
       bson_destroy (&reply);
       return test_framework_mongos_count ();
@@ -1942,7 +1945,7 @@ test_framework_is_mongos (void)
    bson_iter_t iter;
    bool is_mongos;
 
-   call_ismaster (&reply);
+   call_hello (&reply);
 
    is_mongos = (bson_iter_init_find (&iter, &reply, "msg") &&
                 BSON_ITER_HOLDS_UTF8 (&iter) &&
@@ -1972,7 +1975,7 @@ test_framework_server_is_secondary (mongoc_client_t *client, uint32_t server_id)
    sd = mongoc_topology_server_by_id (client->topology, server_id, &error);
    ASSERT_OR_PRINT (sd, error);
 
-   call_ismaster_with_host_and_port (sd->host.host_and_port, &reply);
+   call_hello_with_host_and_port (sd->host.host_and_port, &reply);
 
    ret = bson_iter_init_find (&iter, &reply, "secondary") &&
          bson_iter_as_bool (&iter);
@@ -1991,7 +1994,7 @@ test_framework_clustertime_supported (void)
    bson_t reply;
    bool has_cluster_time;
 
-   call_ismaster (&reply);
+   call_hello (&reply);
    has_cluster_time = bson_has_field (&reply, "$clusterTime");
    bson_destroy (&reply);
 
@@ -2011,7 +2014,7 @@ test_framework_session_timeout_minutes (void)
       return -1;
    }
 
-   call_ismaster (&reply);
+   call_hello (&reply);
    if (bson_iter_init_find (&iter, &reply, "logicalSessionTimeoutMinutes")) {
       timeout = bson_iter_as_int64 (&iter);
    }
@@ -2028,7 +2031,7 @@ test_framework_get_max_wire_version (int64_t *max_version)
    bson_t reply;
    bson_iter_t iter;
 
-   call_ismaster (&reply);
+   call_hello (&reply);
    BSON_ASSERT (bson_iter_init_find (&iter, &reply, "maxWireVersion"));
    *max_version = bson_iter_as_int64 (&iter);
 
@@ -2238,7 +2241,7 @@ test_framework_max_write_batch_size (void)
    bson_iter_t iter;
    int64_t size;
 
-   call_ismaster (&reply);
+   call_hello (&reply);
 
    if (bson_iter_init_find (&iter, &reply, "maxWriteBatchSize")) {
       size = bson_iter_as_int64 (&iter);

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -1133,7 +1133,7 @@ call_ismaster_with_host_and_port (char *host_and_port, bson_t *reply)
 
    if (!mongoc_client_command_simple (
           client, "admin", tmp_bson ("{'isMaster': 1}"), NULL, reply, &error)) {
-      fprintf (stderr, "error calling ismaster: '%s'\n", error.message);
+      fprintf (stderr, "error calling hello: '%s'\n", error.message);
       fprintf (stderr, "URI = %s\n", uri_str);
       abort ();
    }

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -1132,7 +1132,14 @@ call_ismaster_with_host_and_port (char *host_and_port, bson_t *reply)
 #endif
 
    if (!mongoc_client_command_simple (
-          client, "admin", tmp_bson ("{'isMaster': 1}"), NULL, reply, &error)) {
+          client, "admin", tmp_bson ("{'hello': 1}"), NULL, reply, &error) &&
+       !mongoc_client_command_simple (
+          client,
+          "admin",
+          tmp_bson ("{'" HANDSHAKE_CMD_LEGACY_HELLO "': 1}"),
+          NULL,
+          reply,
+          &error)) {
       fprintf (stderr, "error calling hello: '%s'\n", error.message);
       fprintf (stderr, "URI = %s\n", uri_str);
       abort ();

--- a/src/libmongoc/tests/test-mongoc-async.c
+++ b/src/libmongoc/tests/test-mongoc-async.c
@@ -169,7 +169,7 @@ test_hello_impl (bool with_ssl)
 
       /* use "serverId" field to distinguish among responses */
       reply = bson_strdup_printf ("{'ok': 1,"
-                                  " 'isWritablePrimary': true,"
+                                  " '"HANDSHAKE_RESPONSE_LEGACY_HELLO"': true,"
                                   " 'minWireVersion': 0,"
                                   " 'maxWireVersion': 1000,"
                                   " 'serverId': %d}",
@@ -235,8 +235,8 @@ test_large_ismaster_helper (mongoc_async_cmd_t *acmd,
    }
    ASSERT_CMPINT (result, ==, MONGOC_ASYNC_CMD_SUCCESS);
 
-   ASSERT_HAS_FIELD (bson, "isWritablePrimary");
-   BSON_ASSERT (bson_iter_init_find (&iter, bson, "isWritablePrimary"));
+   ASSERT_HAS_FIELD (bson, HANDSHAKE_RESPONSE_LEGACY_HELLO);
+   BSON_ASSERT (bson_iter_init_find (&iter, bson, HANDSHAKE_RESPONSE_LEGACY_HELLO));
    BSON_ASSERT (BSON_ITER_HOLDS_BOOL (&iter) && bson_iter_bool (&iter));
 }
 

--- a/src/libmongoc/tests/test-mongoc-background-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-background-monitoring.c
@@ -735,7 +735,7 @@ test_streaming_succeeds (void)
    request = mock_server_receives_msg (
       tf->server,
       MONGOC_MSG_EXHAUST_ALLOWED,
-      tmp_bson ("{'isMaster': 1, 'topologyVersion': { '$exists': true}}"));
+      tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
    OBSERVE (tf, tf->observations->awaited);
@@ -760,7 +760,7 @@ test_streaming_hangup (void)
    request = mock_server_receives_msg (
       tf->server,
       MONGOC_MSG_EXHAUST_ALLOWED,
-      tmp_bson ("{'isMaster': 1, 'topologyVersion': { '$exists': true}}"));
+      tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
    OBSERVE (tf, tf->observations->awaited);
@@ -788,7 +788,7 @@ test_streaming_badreply (void)
    request = mock_server_receives_msg (
       tf->server,
       MONGOC_MSG_EXHAUST_ALLOWED,
-      tmp_bson ("{'isMaster': 1, 'topologyVersion': { '$exists': true}}"));
+      tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
    mock_server_replies_simple (request, "{'ok': 0}");
@@ -820,7 +820,7 @@ test_streaming_shutdown (void)
    request = mock_server_receives_msg (
       tf->server,
       MONGOC_MSG_EXHAUST_ALLOWED,
-      tmp_bson ("{'isMaster': 1, 'topologyVersion': { '$exists': true}}"));
+      tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
    _signal_shutdown (tf);
@@ -842,7 +842,7 @@ test_streaming_cancel (void)
    request = mock_server_receives_msg (
       tf->server,
       MONGOC_MSG_EXHAUST_ALLOWED,
-      tmp_bson ("{'isMaster': 1, 'topologyVersion': { '$exists': true}}"));
+      tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
    _request_cancel (tf);
@@ -862,7 +862,7 @@ test_streaming_cancel (void)
    request = mock_server_receives_msg (
       tf->server,
       MONGOC_MSG_EXHAUST_ALLOWED,
-      tmp_bson ("{'isMaster': 1, 'topologyVersion': { '$exists': true}}"));
+      tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 4);
    mock_server_replies_ok_and_destroys (request);
@@ -882,7 +882,7 @@ test_moretocome_succeeds (void)
    request = mock_server_receives_msg (
       tf->server,
       MONGOC_MSG_EXHAUST_ALLOWED,
-      tmp_bson ("{'isMaster': 1, 'topologyVersion': { '$exists': true}}"));
+      tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
    OBSERVE (tf, tf->observations->awaited);
@@ -916,7 +916,7 @@ test_moretocome_succeeds (void)
    request = mock_server_receives_msg (
       tf->server,
       MONGOC_MSG_EXHAUST_ALLOWED,
-      tmp_bson ("{'isMaster': 1, 'topologyVersion': { '$exists': true}}"));
+      tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_started == 5);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_failed == 0);
@@ -938,7 +938,7 @@ test_moretocome_hangup (void)
    request = mock_server_receives_msg (
       tf->server,
       MONGOC_MSG_EXHAUST_ALLOWED,
-      tmp_bson ("{'isMaster': 1, 'topologyVersion': { '$exists': true}}"));
+      tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
    OBSERVE (tf, tf->observations->awaited);
@@ -977,7 +977,7 @@ test_moretocome_badreply (void)
    request = mock_server_receives_msg (
       tf->server,
       MONGOC_MSG_EXHAUST_ALLOWED,
-      tmp_bson ("{'isMaster': 1, 'topologyVersion': { '$exists': true}}"));
+      tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
    mock_server_replies_opmsg (
@@ -1017,7 +1017,7 @@ test_moretocome_shutdown (void)
    request = mock_server_receives_msg (
       tf->server,
       MONGOC_MSG_EXHAUST_ALLOWED,
-      tmp_bson ("{'isMaster': 1, 'topologyVersion': { '$exists': true}}"));
+      tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
    mock_server_replies_opmsg (
@@ -1052,7 +1052,7 @@ test_moretocome_cancel (void)
    request = mock_server_receives_msg (
       tf->server,
       MONGOC_MSG_EXHAUST_ALLOWED,
-      tmp_bson ("{'isMaster': 1, 'topologyVersion': { '$exists': true}}"));
+      tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
    mock_server_replies_opmsg (
@@ -1091,7 +1091,7 @@ test_moretocome_cancel (void)
    request = mock_server_receives_msg (
       tf->server,
       MONGOC_MSG_EXHAUST_ALLOWED,
-      tmp_bson ("{'isMaster': 1, 'topologyVersion': { '$exists': true}}"));
+      tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 5);
    mock_server_replies_opmsg (
@@ -1109,7 +1109,7 @@ test_moretocome_cancel (void)
    request = mock_server_receives_msg (
       tf->server,
       MONGOC_MSG_EXHAUST_ALLOWED,
-      tmp_bson ("{'isMaster': 1, 'topologyVersion': { '$exists': true}}"));
+      tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 6);
    mock_server_replies_opmsg (

--- a/src/libmongoc/tests/test-mongoc-bulk.c
+++ b/src/libmongoc/tests/test-mongoc-bulk.c
@@ -2966,16 +2966,16 @@ test_unordered_bulk_writes_with_error (void)
    mock_server_run (server);
 
    /* server is "recovering": not master, not secondary */
-   mock_server_auto_ismaster (server,
-                              "{'ok': 1,"
-                              " 'maxWireVersion': %d,"
-                              " 'maxWriteBatchSize': 1,"
-                              " 'ismaster': true,"
-                              " 'secondary': false,"
-                              " 'setName': 'rs',"
-                              " 'hosts': ['%s']}",
-                              WIRE_VERSION_OP_MSG,
-                              mock_server_get_host_and_port (server));
+   mock_server_auto_hello (server,
+                           "{'ok': 1,"
+                           " 'maxWireVersion': %d,"
+                           " 'maxWriteBatchSize': 1,"
+                           " 'ismaster': true,"
+                           " 'secondary': false,"
+                           " 'setName': 'rs',"
+                           " 'hosts': ['%s']}",
+                           WIRE_VERSION_OP_MSG,
+                           mock_server_get_host_and_port (server));
 
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    /* disable retryable writes, so we move to the next operation on error */
@@ -3478,13 +3478,13 @@ _test_numerous (bool ordered)
 
    server = mock_server_new ();
    /* the real OP_MSG max batch is 100k docs, choose 3 for faster test */
-   mock_server_auto_ismaster (server,
-                              "{'ok': 1.0,"
-                              " 'ismaster': true,"
-                              " 'minWireVersion': 0,"
-                              " 'maxWireVersion': %d,"
-                              " 'maxWriteBatchSize': 3}",
-                              WIRE_VERSION_OP_MSG);
+   mock_server_auto_hello (server,
+                           "{'ok': 1.0,"
+                           " 'ismaster': true,"
+                           " 'minWireVersion': 0,"
+                           " 'maxWireVersion': %d,"
+                           " 'maxWriteBatchSize': 3}",
+                           WIRE_VERSION_OP_MSG);
 
    mock_server_run (server);
 

--- a/src/libmongoc/tests/test-mongoc-bulk.c
+++ b/src/libmongoc/tests/test-mongoc-bulk.c
@@ -4173,7 +4173,12 @@ _test_bulk_hint (bool pooled, bool use_primary)
 
    /* warm up the client so its server_id is valid */
    ret = mongoc_client_command_simple (
-      client, "admin", tmp_bson ("{'hello': 1}"), NULL, NULL, &error);
+      client,
+      "admin",
+      tmp_bson ("{'" HANDSHAKE_CMD_LEGACY_HELLO "': 1}"),
+      NULL,
+      NULL,
+      &error);
    ASSERT_OR_PRINT (ret, error);
 
    collection = mongoc_client_get_collection (client, "test", "test");

--- a/src/libmongoc/tests/test-mongoc-bulk.c
+++ b/src/libmongoc/tests/test-mongoc-bulk.c
@@ -173,13 +173,13 @@ test_bulk (void)
 
    bson_init (&up);
    bson_append_document_begin (&up, "$set", -1, &child);
-   bson_append_int32 (&child, "hello", -1, 123);
+   BSON_APPEND_INT32 (&child, HANDSHAKE_CMD_LEGACY_HELLO, 123);
    bson_append_document_end (&up, &child);
    mongoc_bulk_operation_update (bulk, &doc, &up, false);
    bson_destroy (&up);
 
    bson_init (&del);
-   BSON_APPEND_INT32 (&del, "hello", 123);
+   BSON_APPEND_INT32 (&del, HANDSHAKE_CMD_LEGACY_HELLO, 123);
    mongoc_bulk_operation_remove (bulk, &del);
    bson_destroy (&del);
 

--- a/src/libmongoc/tests/test-mongoc-bulk.c
+++ b/src/libmongoc/tests/test-mongoc-bulk.c
@@ -2970,7 +2970,7 @@ test_unordered_bulk_writes_with_error (void)
                            "{'ok': 1,"
                            " 'maxWireVersion': %d,"
                            " 'maxWriteBatchSize': 1,"
-                           " 'ismaster': true,"
+                           " 'isWritablePrimary': true,"
                            " 'secondary': false,"
                            " 'setName': 'rs',"
                            " 'hosts': ['%s']}",
@@ -3480,7 +3480,7 @@ _test_numerous (bool ordered)
    /* the real OP_MSG max batch is 100k docs, choose 3 for faster test */
    mock_server_auto_hello (server,
                            "{'ok': 1.0,"
-                           " 'ismaster': true,"
+                           " 'isWritablePrimary': true,"
                            " 'minWireVersion': 0,"
                            " 'maxWireVersion': %d,"
                            " 'maxWriteBatchSize': 3}",
@@ -4173,7 +4173,7 @@ _test_bulk_hint (bool pooled, bool use_primary)
 
    /* warm up the client so its server_id is valid */
    ret = mongoc_client_command_simple (
-      client, "admin", tmp_bson ("{'isMaster': 1}"), NULL, NULL, &error);
+      client, "admin", tmp_bson ("{'hello': 1}"), NULL, NULL, &error);
    ASSERT_OR_PRINT (ret, error);
 
    collection = mongoc_client_get_collection (client, "test", "test");

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -2086,7 +2086,7 @@ _check_mongocryptd_not_spawned (void)
 
    client = test_framework_client_new (
       "mongodb://localhost:27021/db?serverSelectionTimeoutMS=1000", NULL);
-   cmd = BCON_NEW ("ismaster", BCON_INT32 (1));
+   cmd = BCON_NEW ("hello", BCON_INT32 (1));
    ret = mongoc_client_command_simple (
       client, "keyvault", cmd, NULL /* read prefs */, NULL /* reply */, &error);
    BSON_ASSERT (!ret);

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -2086,7 +2086,7 @@ _check_mongocryptd_not_spawned (void)
 
    client = test_framework_client_new (
       "mongodb://localhost:27021/db?serverSelectionTimeoutMS=1000", NULL);
-   cmd = BCON_NEW ("hello", BCON_INT32 (1));
+   cmd = BCON_NEW (HANDSHAKE_CMD_LEGACY_HELLO, BCON_INT32 (1));
    ret = mongoc_client_command_simple (
       client, "keyvault", cmd, NULL /* read prefs */, NULL /* reply */, &error);
    BSON_ASSERT (!ret);

--- a/src/libmongoc/tests/test-mongoc-client.c
+++ b/src/libmongoc/tests/test-mongoc-client.c
@@ -841,7 +841,7 @@ test_wire_version (void)
    /* too new */
    mock_server_auto_hello (server,
                            "{'ok': 1.0,"
-                           " 'ismaster': true,"
+                           " 'isWritablePrimary': true,"
                            " 'minWireVersion': 10,"
                            " 'maxWireVersion': 11}");
 
@@ -861,7 +861,7 @@ test_wire_version (void)
    /* too old */
    mock_server_auto_hello (server,
                            "{'ok': 1.0,"
-                           " 'ismaster': true,"
+                           " 'isWritablePrimary': true,"
                            " 'minWireVersion': -1,"
                            " 'maxWireVersion': -1}");
 
@@ -878,7 +878,7 @@ test_wire_version (void)
    /* compatible again */
    mock_server_auto_hello (server,
                            "{'ok': 1.0,"
-                           " 'ismaster': true,"
+                           " 'isWritablePrimary': true,"
                            " 'minWireVersion': 2,"
                            " 'maxWireVersion': 5}");
 
@@ -1912,7 +1912,7 @@ test_seed_list (bool rs, connection_option_t connection_option, bool pooled)
    if (rs) {
       mock_server_auto_hello (server,
                               "{'ok': 1,"
-                              " 'ismaster': true,"
+                              " 'isWritablePrimary': true,"
                               " 'setName': 'rs',"
                               " 'hosts': ['%s']}",
                               mock_server_get_host_and_port (server));
@@ -1921,7 +1921,7 @@ test_seed_list (bool rs, connection_option_t connection_option, bool pooled)
    } else {
       mock_server_auto_hello (server,
                               "{'ok': 1,"
-                              " 'ismaster': true,"
+                              " 'isWritablePrimary': true,"
                               " 'msg': 'isdbgrid'}");
    }
 
@@ -2125,7 +2125,7 @@ test_recovering (void *ctx)
    /* server is "recovering": not master, not secondary */
    mock_server_auto_hello (server,
                            "{'ok': 1,"
-                           " 'ismaster': false,"
+                           " 'isWritablePrimary': false,"
                            " 'secondary': false,"
                            " 'setName': 'rs',"
                            " 'hosts': ['%s']}",
@@ -2358,10 +2358,10 @@ test_mongoc_client_mismatched_me (void)
    future = future_client_command_simple (
       client, "admin", tmp_bson ("{'ping': 1}"), prefs, NULL, &error);
 
-   request = mock_server_receives_ismaster (server);
+   request = mock_server_receives_legacy_hello (server, NULL);
    reply = bson_strdup_printf ("{'ok': 1,"
                                " 'setName': 'rs',"
-                               " 'ismaster': false,"
+                               " 'isWritablePrimary': false,"
                                " 'secondary': true,"
                                " 'minWireVersion': 2, 'maxWireVersion': 5,"
                                " 'me': 'foo.com'," /* mismatched "me" field */
@@ -2832,7 +2832,7 @@ test_mongoc_client_select_server_error_pooled (void)
 static void
 _test_mongoc_client_select_server_retry (bool retry_succeeds)
 {
-   char *ismaster;
+   char *hello;
    mock_server_t *server;
    mongoc_uri_t *uri;
    mongoc_client_t *client;
@@ -2843,11 +2843,11 @@ _test_mongoc_client_select_server_retry (bool retry_succeeds)
 
    server = mock_server_new ();
    mock_server_run (server);
-   ismaster = bson_strdup_printf ("{'ok': 1, 'ismaster': true,"
-                                  " 'secondary': false,"
-                                  " 'minWireVersion': 2, 'maxWireVersion': 5,"
-                                  " 'setName': 'rs', 'hosts': ['%s']}",
-                                  mock_server_get_host_and_port (server));
+   hello = bson_strdup_printf ("{'ok': 1, 'isWritablePrimary': true,"
+                               " 'secondary': false,"
+                               " 'minWireVersion': 2, 'maxWireVersion': 5,"
+                               " 'setName': 'rs', 'hosts': ['%s']}",
+                               mock_server_get_host_and_port (server));
 
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_utf8 (uri, "replicaSet", "rs");
@@ -2856,8 +2856,8 @@ _test_mongoc_client_select_server_retry (bool retry_succeeds)
 
    /* first selection succeeds */
    future = future_client_select_server (client, true, NULL, &error);
-   request = mock_server_receives_ismaster (server);
-   mock_server_replies_simple (request, ismaster);
+   request = mock_server_receives_legacy_hello (server, NULL);
+   mock_server_replies_simple (request, hello);
    request_destroy (request);
    sd = future_get_mongoc_server_description_ptr (future);
    ASSERT_OR_PRINT (sd, error);
@@ -2877,9 +2877,9 @@ _test_mongoc_client_select_server_retry (bool retry_succeeds)
    request_destroy (request);
 
    /* mongoc_client_select_server retries once */
-   request = mock_server_receives_ismaster (server);
+   request = mock_server_receives_legacy_hello (server, NULL);
    if (retry_succeeds) {
-      mock_server_replies_simple (request, ismaster);
+      mock_server_replies_simple (request, hello);
       sd = future_get_mongoc_server_description_ptr (future);
       ASSERT_OR_PRINT (sd, error);
       mongoc_server_description_destroy (sd);
@@ -2893,7 +2893,7 @@ _test_mongoc_client_select_server_retry (bool retry_succeeds)
    request_destroy (request);
    mongoc_client_destroy (client);
    mongoc_uri_destroy (uri);
-   bson_free (ismaster);
+   bson_free (hello);
    mock_server_destroy (server);
 }
 
@@ -2917,7 +2917,7 @@ test_mongoc_client_select_server_retry_fail (void)
 static void
 _test_mongoc_client_fetch_stream_retry (bool retry_succeeds)
 {
-   char *ismaster;
+   char *hello;
    mock_server_t *server;
    mongoc_uri_t *uri;
    mongoc_client_t *client;
@@ -2927,8 +2927,8 @@ _test_mongoc_client_fetch_stream_retry (bool retry_succeeds)
 
    server = mock_server_new ();
    mock_server_run (server);
-   ismaster = bson_strdup_printf (
-      "{'ok': 1, 'ismaster': true, 'minWireVersion': 2, 'maxWireVersion': 5}");
+   hello = bson_strdup_printf ("{'ok': 1, 'isWritablePrimary': true, "
+                               "'minWireVersion': 2, 'maxWireVersion': 5}");
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_int32 (uri, "socketCheckIntervalMS", 50);
    client = test_framework_client_new_from_uri (uri, NULL);
@@ -2936,8 +2936,8 @@ _test_mongoc_client_fetch_stream_retry (bool retry_succeeds)
    /* first time succeeds */
    future = future_client_command_simple (
       client, "db", tmp_bson ("{'cmd': 1}"), NULL, NULL, &error);
-   request = mock_server_receives_ismaster (server);
-   mock_server_replies_simple (request, ismaster);
+   request = mock_server_receives_legacy_hello (server, NULL);
+   mock_server_replies_simple (request, hello);
    request_destroy (request);
 
    request = mock_server_receives_command (
@@ -2962,9 +2962,9 @@ _test_mongoc_client_fetch_stream_retry (bool retry_succeeds)
    request_destroy (request);
 
    /* mongoc_client_select_server retries once */
-   request = mock_server_receives_ismaster (server);
+   request = mock_server_receives_legacy_hello (server, NULL);
    if (retry_succeeds) {
-      mock_server_replies_simple (request, ismaster);
+      mock_server_replies_simple (request, hello);
       request_destroy (request);
 
       request = mock_server_receives_command (
@@ -2981,7 +2981,7 @@ _test_mongoc_client_fetch_stream_retry (bool retry_succeeds)
    request_destroy (request);
    mongoc_client_destroy (client);
    mongoc_uri_destroy (uri);
-   bson_free (ismaster);
+   bson_free (hello);
    mock_server_destroy (server);
 }
 
@@ -3226,7 +3226,6 @@ _assert_ismaster_valid (request_t *request, bool needs_meta)
    ASSERT (request);
    request_doc = request_get_doc (request, 0);
    ASSERT (request_doc);
-   ASSERT (bson_has_field (request_doc, "isMaster"));
    ASSERT (bson_has_field (request_doc, HANDSHAKE_FIELD) == needs_meta);
 }
 
@@ -3276,8 +3275,8 @@ test_mongoc_handshake_pool (void)
    mongoc_client_t *client1;
    mongoc_client_t *client2;
    mongoc_client_pool_t *pool;
-   const char *const server_reply =
-      "{'ok': 1, 'ismaster': true, 'minWireVersion': 2, 'maxWireVersion': 5}";
+   const char *const server_reply = "{'ok': 1, 'isWritablePrimary': true, "
+                                    "'minWireVersion': 2, 'maxWireVersion': 5}";
    future_t *future;
 
    server = mock_server_new ();
@@ -3289,7 +3288,7 @@ test_mongoc_handshake_pool (void)
    pool = test_framework_client_pool_new_from_uri (uri, NULL);
 
    client1 = mongoc_client_pool_pop (pool);
-   request1 = mock_server_receives_ismaster (server);
+   request1 = mock_server_receives_legacy_hello (server, NULL);
    _assert_ismaster_valid (request1, true);
    mock_server_replies_simple (request1, server_reply);
    request_destroy (request1);
@@ -3298,7 +3297,7 @@ test_mongoc_handshake_pool (void)
    future = future_client_command_simple (
       client2, "test", tmp_bson ("{'ping': 1}"), NULL, NULL, NULL);
 
-   request2 = mock_server_receives_ismaster (server);
+   request2 = mock_server_receives_legacy_hello (server, NULL);
    _assert_ismaster_valid (request2, true);
    mock_server_replies_simple (request2, server_reply);
    request_destroy (request2);
@@ -3326,8 +3325,8 @@ _test_client_sends_handshake (bool pooled)
    future_t *future;
    mongoc_client_t *client;
    mongoc_client_pool_t *pool;
-   const char *const server_reply =
-      "{'ok': 1, 'ismaster': true, 'minWireVersion': 2, 'maxWireVersion': 5}";
+   const char *const server_reply = "{'ok': 1, 'isWritablePrimary': true, "
+                                    "'minWireVersion': 2, 'maxWireVersion': 5}";
    const int heartbeat_ms = 500;
 
    if (!TestSuite_CheckMockServerAllowed ()) {
@@ -3350,7 +3349,7 @@ _test_client_sends_handshake (bool pooled)
       future = _force_ismaster_with_ping (client, heartbeat_ms);
    }
 
-   request = mock_server_receives_ismaster (server);
+   request = mock_server_receives_legacy_hello (server, NULL);
 
    /* Make sure the isMaster request has a "client" field: */
    _assert_ismaster_valid (request, true);
@@ -3364,7 +3363,7 @@ _test_client_sends_handshake (bool pooled)
       future = _force_ismaster_with_ping (client, heartbeat_ms);
    }
 
-   request = mock_server_receives_ismaster (server);
+   request = mock_server_receives_legacy_hello (server, NULL);
    _assert_ismaster_valid (request, false);
 
    mock_server_replies_simple (request, server_reply);
@@ -3377,13 +3376,13 @@ _test_client_sends_handshake (bool pooled)
 
    /* Now wait for the client to send another isMaster command, but this
     * time the server hangs up */
-   request = mock_server_receives_ismaster (server);
+   request = mock_server_receives_legacy_hello (server, NULL);
    _assert_ismaster_valid (request, false);
    mock_server_hangs_up (request);
    request_destroy (request);
 
    /* Client retries once (CDRIVER-2075) */
-   request = mock_server_receives_ismaster (server);
+   request = mock_server_receives_legacy_hello (server, NULL);
    _assert_ismaster_valid (request, true);
    mock_server_hangs_up (request);
    request_destroy (request);
@@ -3401,7 +3400,7 @@ _test_client_sends_handshake (bool pooled)
 
    /* Now the client should try to reconnect. They think the server's down
     * so now they SHOULD send isMaster */
-   request = mock_server_receives_ismaster (server);
+   request = mock_server_receives_legacy_hello (server, NULL);
    _assert_ismaster_valid (request, true);
 
    mock_server_replies_simple (request, server_reply);
@@ -3444,8 +3443,8 @@ test_client_appname (bool pooled, bool use_uri)
    future_t *future;
    mongoc_client_t *client;
    mongoc_client_pool_t *pool;
-   const char *const server_reply =
-      "{'ok': 1, 'ismaster': true, 'minWireVersion': 2, 'maxWireVersion': 5}";
+   const char *const server_reply = "{'ok': 1, 'isWritablePrimary': true, "
+                                    "'minWireVersion': 2, 'maxWireVersion': 5}";
    const int heartbeat_ms = 500;
 
    server = mock_server_new ();
@@ -3472,13 +3471,10 @@ test_client_appname (bool pooled, bool use_uri)
       future = _force_ismaster_with_ping (client, heartbeat_ms);
    }
 
-   request = mock_server_receives_command (server,
-                                           "admin",
-                                           MONGOC_QUERY_SLAVE_OK,
-                                           "{'isMaster': 1,"
-                                           " 'client': {"
-                                           "    'application': {"
-                                           "       'name': 'testapp'}}}");
+   request = mock_server_receives_legacy_hello (server,
+                                                "{'client': {"
+                                                "    'application': {"
+                                                "       'name': 'testapp'}}}");
 
    mock_server_replies_simple (request, server_reply);
    if (!pooled) {
@@ -3803,7 +3799,8 @@ test_client_reset_connections (void)
    int autoresponder_id;
 
    server = mock_server_new ();
-   autoresponder_id = mock_server_auto_hello (server, "{ 'isMaster': 1.0 }");
+   autoresponder_id =
+      mock_server_auto_hello (server, "{ 'isWritablePrimary': true }");
    mock_server_run (server);
 
    /* After calling reset, check that connections are left as-is. Set
@@ -3818,6 +3815,7 @@ test_client_reset_connections (void)
 
    request = mock_server_receives_command (
       server, "admin", MONGOC_QUERY_SLAVE_OK, "{'ping': 1}");
+   BSON_ASSERT (request);
    mock_server_replies_simple (request, "{'ok': 1}");
 
    ASSERT (future_get_bool (future));

--- a/src/libmongoc/tests/test-mongoc-client.c
+++ b/src/libmongoc/tests/test-mongoc-client.c
@@ -839,11 +839,11 @@ test_wire_version (void)
    server = mock_server_new ();
 
    /* too new */
-   mock_server_auto_ismaster (server,
-                              "{'ok': 1.0,"
-                              " 'ismaster': true,"
-                              " 'minWireVersion': 10,"
-                              " 'maxWireVersion': 11}");
+   mock_server_auto_hello (server,
+                           "{'ok': 1.0,"
+                           " 'ismaster': true,"
+                           " 'minWireVersion': 10,"
+                           " 'maxWireVersion': 11}");
 
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));
@@ -859,11 +859,11 @@ test_wire_version (void)
    mongoc_cursor_destroy (cursor);
 
    /* too old */
-   mock_server_auto_ismaster (server,
-                              "{'ok': 1.0,"
-                              " 'ismaster': true,"
-                              " 'minWireVersion': -1,"
-                              " 'maxWireVersion': -1}");
+   mock_server_auto_hello (server,
+                           "{'ok': 1.0,"
+                           " 'ismaster': true,"
+                           " 'minWireVersion': -1,"
+                           " 'maxWireVersion': -1}");
 
    /* wait until it's time for next heartbeat */
    _mongoc_usleep (600 * 1000);
@@ -876,11 +876,11 @@ test_wire_version (void)
    mongoc_cursor_destroy (cursor);
 
    /* compatible again */
-   mock_server_auto_ismaster (server,
-                              "{'ok': 1.0,"
-                              " 'ismaster': true,"
-                              " 'minWireVersion': 2,"
-                              " 'maxWireVersion': 5}");
+   mock_server_auto_hello (server,
+                           "{'ok': 1.0,"
+                           " 'ismaster': true,"
+                           " 'minWireVersion': 2,"
+                           " 'maxWireVersion': 5}");
 
    /* wait until it's time for next heartbeat */
    _mongoc_usleep (600 * 1000);
@@ -1910,19 +1910,19 @@ test_seed_list (bool rs, connection_option_t connection_option, bool pooled)
    }
 
    if (rs) {
-      mock_server_auto_ismaster (server,
-                                 "{'ok': 1,"
-                                 " 'ismaster': true,"
-                                 " 'setName': 'rs',"
-                                 " 'hosts': ['%s']}",
-                                 mock_server_get_host_and_port (server));
+      mock_server_auto_hello (server,
+                              "{'ok': 1,"
+                              " 'ismaster': true,"
+                              " 'setName': 'rs',"
+                              " 'hosts': ['%s']}",
+                              mock_server_get_host_and_port (server));
 
       mongoc_uri_set_option_as_utf8 (uri, "replicaSet", "rs");
    } else {
-      mock_server_auto_ismaster (server,
-                                 "{'ok': 1,"
-                                 " 'ismaster': true,"
-                                 " 'msg': 'isdbgrid'}");
+      mock_server_auto_hello (server,
+                              "{'ok': 1,"
+                              " 'ismaster': true,"
+                              " 'msg': 'isdbgrid'}");
    }
 
    /* auto-respond to "foo" command */
@@ -2123,13 +2123,13 @@ test_recovering (void *ctx)
    mock_server_run (server);
 
    /* server is "recovering": not master, not secondary */
-   mock_server_auto_ismaster (server,
-                              "{'ok': 1,"
-                              " 'ismaster': false,"
-                              " 'secondary': false,"
-                              " 'setName': 'rs',"
-                              " 'hosts': ['%s']}",
-                              mock_server_get_host_and_port (server));
+   mock_server_auto_hello (server,
+                           "{'ok': 1,"
+                           " 'ismaster': false,"
+                           " 'secondary': false,"
+                           " 'setName': 'rs',"
+                           " 'hosts': ['%s']}",
+                           mock_server_get_host_and_port (server));
 
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_utf8 (uri, "replicaSet", "rs");
@@ -3803,7 +3803,7 @@ test_client_reset_connections (void)
    int autoresponder_id;
 
    server = mock_server_new ();
-   autoresponder_id = mock_server_auto_ismaster (server, "{ 'isMaster': 1.0 }");
+   autoresponder_id = mock_server_auto_hello (server, "{ 'isMaster': 1.0 }");
    mock_server_run (server);
 
    /* After calling reset, check that connections are left as-is. Set

--- a/src/libmongoc/tests/test-mongoc-client.c
+++ b/src/libmongoc/tests/test-mongoc-client.c
@@ -3275,8 +3275,9 @@ test_mongoc_handshake_pool (void)
    mongoc_client_t *client1;
    mongoc_client_t *client2;
    mongoc_client_pool_t *pool;
-   const char *const server_reply = "{'ok': 1, 'isWritablePrimary': true, "
-                                    "'minWireVersion': 2, 'maxWireVersion': 5}";
+   const char *const server_reply =
+      "{'ok': 1, '" HANDSHAKE_RESPONSE_LEGACY_HELLO "': true, "
+      "'minWireVersion': 2, 'maxWireVersion': 5}";
    future_t *future;
 
    server = mock_server_new ();

--- a/src/libmongoc/tests/test-mongoc-cluster.c
+++ b/src/libmongoc/tests/test-mongoc-cluster.c
@@ -320,7 +320,7 @@ static void
 _test_write_disconnect (void)
 {
    mock_server_t *server;
-   char *ismaster_response;
+   char *hello;
    mongoc_client_t *client;
    mongoc_collection_t *collection;
    bson_error_t error;
@@ -343,13 +343,13 @@ _test_write_disconnect (void)
     */
    future = future_client_command_simple (
       client, "db", tmp_bson ("{'ping': 1}"), NULL, NULL, &error);
-   request = mock_server_receives_ismaster (server);
-   ismaster_response = bson_strdup_printf ("{'ok': 1.0,"
-                                           " 'ismaster': true,"
-                                           " 'minWireVersion': 2,"
-                                           " 'maxWireVersion': 3}");
+   request = mock_server_receives_legacy_hello (server, NULL);
+   hello = bson_strdup_printf ("{'ok': 1.0,"
+                               " 'isWritablePrimary': true,"
+                               " 'minWireVersion': 2,"
+                               " 'maxWireVersion': 3}");
 
-   mock_server_replies_simple (request, ismaster_response);
+   mock_server_replies_simple (request, hello);
    request_destroy (request);
 
    request = mock_server_receives_command (
@@ -386,7 +386,7 @@ _test_write_disconnect (void)
    mongoc_collection_destroy (collection);
    request_destroy (request);
    future_destroy (future);
-   bson_free (ismaster_response);
+   bson_free (hello);
    mongoc_client_destroy (client);
    mock_server_destroy (server);
 }
@@ -427,7 +427,7 @@ test_cluster_command_notmaster (void)
    mock_server_auto_hello (server,
                            "{'ok': 1,"
                            " 'maxWireVersion': %d,"
-                           " 'ismaster': false,"
+                           " 'isWritablePrimary': false,"
                            " 'secondary': false,"
                            " 'setName': 'rs',"
                            " 'hosts': ['%s']}",
@@ -900,8 +900,8 @@ future_ping (mongoc_client_t *client, bson_error_t *error)
 static void
 _test_cluster_time_comparison (bool pooled)
 {
-   const char *ismaster =
-      "{'ok': 1.0, 'ismaster': true, 'msg': 'isdbgrid', 'maxWireVersion': 6}";
+   const char *hello = "{'ok': 1.0, 'isWritablePrimary': true, 'msg': "
+                       "'isdbgrid', 'maxWireVersion': 6}";
    mock_server_t *server;
    mongoc_uri_t *uri;
    mongoc_client_pool_t *pool = NULL;
@@ -926,13 +926,13 @@ _test_cluster_time_comparison (bool pooled)
    future = future_ping (client, &error);
 
    /* timestamp is 1 */
-   request = mock_server_receives_ismaster (server);
-   replies_with_cluster_time (request, 1, 1, ismaster);
+   request = mock_server_receives_legacy_hello (server, NULL);
+   replies_with_cluster_time (request, 1, 1, hello);
 
    if (pooled) {
       /* a pooled client handshakes its own connection */
-      request = mock_server_receives_ismaster (server);
-      replies_with_cluster_time (request, 1, 1, ismaster);
+      request = mock_server_receives_legacy_hello (server, NULL);
+      replies_with_cluster_time (request, 1, 1, hello);
    }
 
    request = receives_with_cluster_time (server, 1, 1, ping);
@@ -957,14 +957,13 @@ _test_cluster_time_comparison (bool pooled)
 
    if (pooled) {
       /* wait for next heartbeat, it should contain newest cluster time */
-      request = mock_server_receives_command (server,
-                                              "admin",
-                                              MONGOC_QUERY_SLAVE_OK,
-                                              "{'isMaster': 1, '$clusterTime': "
-                                              "{'clusterTime': {'$timestamp': "
-                                              "{'t': 2, 'i': 2}}}}");
+      request =
+         mock_server_receives_legacy_hello (server,
+                                            "{'$clusterTime': "
+                                            "{'clusterTime': {'$timestamp': "
+                                            "{'t': 2, 'i': 2}}}}");
 
-      replies_with_cluster_time (request, 2, 1, ismaster);
+      replies_with_cluster_time (request, 2, 1, hello);
 
       mongoc_client_pool_push (pool, client);
       mongoc_client_pool_destroy (pool);
@@ -972,14 +971,13 @@ _test_cluster_time_comparison (bool pooled)
       /* trigger next heartbeat, it should contain newest cluster time */
       _mongoc_usleep (750 * 1000); /* 750 ms */
       future = future_ping (client, &error);
-      request = mock_server_receives_command (server,
-                                              "admin",
-                                              MONGOC_QUERY_SLAVE_OK,
-                                              "{'isMaster': 1, '$clusterTime': "
-                                              "{'clusterTime': {'$timestamp': "
-                                              "{'t': 2, 'i': 2}}}}");
+      request =
+         mock_server_receives_legacy_hello (server,
+                                            "{'$clusterTime': "
+                                            "{'clusterTime': {'$timestamp': "
+                                            "{'t': 2, 'i': 2}}}}");
 
-      replies_with_cluster_time (request, 2, 1, ismaster);
+      replies_with_cluster_time (request, 2, 1, hello);
       request = receives_with_cluster_time (server, 2, 2, ping);
       mock_server_replies_ok_and_destroys (request);
       assert_ok (future, &error);
@@ -1031,10 +1029,10 @@ test_error_msg_t errors[] = {
    "not master" and "node is recovering" need only be substrings of the error
    message. */
 static void
-_test_not_master (bool pooled,
-                  bool use_op_msg,
-                  run_command_fn_t run_command,
-                  cleanup_fn_t cleanup_fn)
+_test_not_primary (bool pooled,
+                   bool use_op_msg,
+                   run_command_fn_t run_command,
+                   cleanup_fn_t cleanup_fn)
 {
    test_error_msg_t *test_error_msg;
    mock_server_t *server;
@@ -1126,32 +1124,32 @@ function_command_simple_cleanup (future_t *future)
 
 
 static void
-test_not_master_single_op_query (void)
+test_not_primary_single_op_query (void)
 {
-   _test_not_master (
+   _test_not_primary (
       false, false, future_command_simple, function_command_simple_cleanup);
 }
 
 
 static void
-test_not_master_pooled_op_query (void)
+test_not_primary_pooled_op_query (void)
 {
-   _test_not_master (
+   _test_not_primary (
       true, false, future_command_simple, function_command_simple_cleanup);
 }
 
 static void
-test_not_master_single_op_msg (void)
+test_not_primary_single_op_msg (void)
 {
-   _test_not_master (
+   _test_not_primary (
       false, true, future_command_simple, function_command_simple_cleanup);
 }
 
 
 static void
-test_not_master_pooled_op_msg (void)
+test_not_primary_pooled_op_msg (void)
 {
-   _test_not_master (
+   _test_not_primary (
       true, true, future_command_simple, function_command_simple_cleanup);
 }
 
@@ -1191,7 +1189,7 @@ future_command_private_cleanup (future_t *future)
 static void
 test_not_master_auth_single_op_query (void)
 {
-   _test_not_master (
+   _test_not_primary (
       false, false, future_command_private, future_command_private_cleanup);
 }
 
@@ -1199,14 +1197,14 @@ test_not_master_auth_single_op_query (void)
 static void
 test_not_master_auth_pooled_op_query (void)
 {
-   _test_not_master (
+   _test_not_primary (
       true, false, future_command_private, future_command_private_cleanup);
 }
 
 static void
 test_not_master_auth_single_op_msg (void)
 {
-   _test_not_master (
+   _test_not_primary (
       false, true, future_command_private, future_command_private_cleanup);
 }
 
@@ -1214,7 +1212,7 @@ test_not_master_auth_single_op_msg (void)
 static void
 test_not_master_auth_pooled_op_msg (void)
 {
-   _test_not_master (
+   _test_not_primary (
       true, true, future_command_private, future_command_private_cleanup);
 }
 
@@ -1234,10 +1232,10 @@ auto_ismaster (request_t *request, void *data)
    dollar_query_test_t *test;
    const char *cluster_time = "";
    const char *server_type;
-   char *ismaster;
+   char *hello;
 
    if (!request->is_command ||
-       strcasecmp (request->command_name, "ismaster") != 0) {
+       strcasecmp (request->command_name, HANDSHAKE_CMD_LEGACY_HELLO) != 0) {
       return false;
    }
 
@@ -1249,22 +1247,22 @@ auto_ismaster (request_t *request, void *data)
    }
 
    if (test->secondary) {
-      server_type = ", 'ismaster': false, 'secondary': true";
+      server_type = ", 'isWritablePrimary': false, 'secondary': true";
    } else {
-      server_type = ", 'ismaster': true, 'secondary': false";
+      server_type = ", 'isWritablePrimary': true, 'secondary': false";
    }
 
-   ismaster = bson_strdup_printf ("{'ok': 1.0,"
-                                  " 'minWireVersion': 0,"
-                                  " 'maxWireVersion': %d,"
-                                  " 'setName': 'rs' %s %s}",
-                                  WIRE_VERSION_OP_MSG,
-                                  server_type,
-                                  cluster_time);
+   hello = bson_strdup_printf ("{'ok': 1.0,"
+                               " 'minWireVersion': 0,"
+                               " 'maxWireVersion': %d,"
+                               " 'setName': 'rs' %s %s}",
+                               WIRE_VERSION_OP_MSG,
+                               server_type,
+                               cluster_time);
 
-   mock_server_replies_simple (request, ismaster);
+   mock_server_replies_simple (request, hello);
 
-   bson_free (ismaster);
+   bson_free (hello);
    request_destroy (request);
 
    return true;
@@ -1437,7 +1435,7 @@ dollar_query_test_t tests[] = {
    {NULL}};
 
 static void
-_test_cluster_ismaster_fails (bool hangup)
+_test_cluster_hello_fails (bool hangup)
 {
    mock_server_t *mock_server;
    mongoc_uri_t *uri;
@@ -1451,7 +1449,7 @@ _test_cluster_ismaster_fails (bool hangup)
 
    mock_server = mock_server_new ();
    autoresponder_id =
-      mock_server_auto_hello (mock_server, "{ 'isMaster': 1.0 }");
+      mock_server_auto_hello (mock_server, "{ 'isWritablePrimary': true }");
    mock_server_run (mock_server);
    uri = mongoc_uri_copy (mock_server_get_uri (mock_server));
    /* increase heartbeatFrequencyMS to prevent background server selection. */
@@ -1471,7 +1469,7 @@ _test_cluster_ismaster_fails (bool hangup)
       client, "test", tmp_bson ("{'ping': 1}"), NULL, NULL, &error);
    /* the client adds a cluster node, creating a stream to the server, and then
     * sends an ismaster request. */
-   request = mock_server_receives_ismaster (mock_server);
+   request = mock_server_receives_legacy_hello (mock_server, NULL);
    /* CDRIVER-2576: the server replies with an error, so
     * _mongoc_stream_run_hello returns NULL, which
     * _mongoc_cluster_run_hello must check. */
@@ -1497,16 +1495,16 @@ _test_cluster_ismaster_fails (bool hangup)
 }
 
 static void
-test_cluster_ismaster_fails (void)
+test_cluster_hello_fails (void)
 {
-   _test_cluster_ismaster_fails (false);
+   _test_cluster_hello_fails (false);
 }
 
 
 static void
-test_cluster_ismaster_hangup (void)
+test_cluster_hello_hangup (void)
 {
-   _test_cluster_ismaster_fails (true);
+   _test_cluster_hello_fails (true);
 }
 
 static void
@@ -1592,7 +1590,7 @@ test_advanced_cluster_time_not_sent_to_standalone (void)
    mock_server_auto_endsessions (server);
    mock_server_auto_hello (server,
                            "{'ok': 1.0,"
-                           " 'ismaster': true,"
+                           " 'isWritablePrimary': true,"
                            " 'minWireVersion': 0,"
                            " 'maxWireVersion': 6,"
                            " 'logicalSessionTimeoutMinutes': 30}");
@@ -1641,11 +1639,12 @@ test_advanced_cluster_time_not_sent_to_standalone (void)
 static bool
 _responder (request_t *req, void *data)
 {
-   char *ismaster;
+   char *hello;
 
-   ismaster = (char *) data;
-   if (0 == strcmp (req->command_name, "isMaster")) {
-      mock_server_replies_simple (req, ismaster);
+   hello = (char *) data;
+   if (0 == strcasecmp (req->command_name, HANDSHAKE_CMD_LEGACY_HELLO) ||
+       0 == strcasecmp (req->command_name, "hello")) {
+      mock_server_replies_simple (req, hello);
       request_destroy (req);
       return true;
    } else if (0 == strcmp (req->command_name, "serverStatus")) {
@@ -1694,7 +1693,7 @@ _initiator_fn (const mongoc_uri_t *uri,
 }
 
 static void
-_test_ismaster_on_unknown (char *ismaster)
+_test_hello_on_unknown (char *ismaster)
 {
    mock_server_t *mock_server;
    mongoc_client_pool_t *pool;
@@ -1734,17 +1733,17 @@ _test_ismaster_on_unknown (char *ismaster)
 }
 
 void
-test_ismaster_on_unknown (void)
+test_hello_on_unknown (void)
 {
    /* Test with pre-OP_MSG to test fix to CDRIVER-3404. */
-   _test_ismaster_on_unknown ("{ 'ok': 1.0, 'ismaster': true, "
-                              "'minWireVersion': 0, 'maxWireVersion': 5, "
-                              "'msg': 'isdbgrid'}");
+   _test_hello_on_unknown ("{ 'ok': 1.0, 'isWritablePrimary': true, "
+                           "'minWireVersion': 0, 'maxWireVersion': 5, "
+                           "'msg': 'isdbgrid'}");
 
    /* Test with OP_MSG. */
-   _test_ismaster_on_unknown ("{ 'ok': 1.0, 'ismaster': true, "
-                              "'minWireVersion': 0, 'maxWireVersion': 8, "
-                              "'msg': 'isdbgrid'}");
+   _test_hello_on_unknown ("{ 'ok': 1.0, 'isWritablePrimary': true, "
+                           "'minWireVersion': 0, 'maxWireVersion': 8, "
+                           "'msg': 'isdbgrid'}");
 }
 
 
@@ -1935,19 +1934,19 @@ test_cluster_install (TestSuite *suite)
       test_framework_skip_if_no_crypto);
    TestSuite_AddMockServerTest (suite,
                                 "/Cluster/not_master/single/op_query",
-                                test_not_master_single_op_query,
+                                test_not_primary_single_op_query,
                                 test_framework_skip_if_slow);
    TestSuite_AddMockServerTest (suite,
                                 "/Cluster/not_master/pooled/op_query",
-                                test_not_master_pooled_op_query,
+                                test_not_primary_pooled_op_query,
                                 test_framework_skip_if_slow);
    TestSuite_AddMockServerTest (suite,
                                 "/Cluster/not_master/single/op_msg",
-                                test_not_master_single_op_msg,
+                                test_not_primary_single_op_msg,
                                 test_framework_skip_if_slow);
    TestSuite_AddMockServerTest (suite,
                                 "/Cluster/not_master/pooled/op_msg",
-                                test_not_master_pooled_op_msg,
+                                test_not_primary_pooled_op_msg,
                                 test_framework_skip_if_slow);
    TestSuite_AddMockServerTest (suite,
                                 "/Cluster/not_master_auth/single/op_query",
@@ -1966,9 +1965,9 @@ test_cluster_install (TestSuite *suite)
                                 test_not_master_auth_pooled_op_msg,
                                 test_framework_skip_if_slow);
    TestSuite_AddMockServerTest (
-      suite, "/Cluster/ismaster_fails", test_cluster_ismaster_fails);
+      suite, "/Cluster/hello_fails", test_cluster_hello_fails);
    TestSuite_AddMockServerTest (
-      suite, "/Cluster/ismaster_hangup", test_cluster_ismaster_hangup);
+      suite, "/Cluster/hello_hangup", test_cluster_hello_hangup);
    TestSuite_AddMockServerTest (suite,
                                 "/Cluster/command_error/op_msg",
                                 test_cluster_command_error_op_msg);
@@ -1976,7 +1975,7 @@ test_cluster_install (TestSuite *suite)
                                 "/Cluster/command_error/op_query",
                                 test_cluster_command_error_op_query);
    TestSuite_AddMockServerTest (
-      suite, "/Cluster/ismaster_on_unknown/mock", test_ismaster_on_unknown);
+      suite, "/Cluster/hello_on_unknown/mock", test_hello_on_unknown);
    TestSuite_AddLive (
       suite, "/Cluster/cmd_on_unknown_serverid", test_cmd_on_unknown_serverid);
 }

--- a/src/libmongoc/tests/test-mongoc-cluster.c
+++ b/src/libmongoc/tests/test-mongoc-cluster.c
@@ -1234,7 +1234,11 @@ auto_ismaster (request_t *request, void *data)
    const char *server_type;
    char *hello;
 
-   if (!request->is_command ||
+   if (!request->is_command) {
+      return false;
+   }
+
+   if (strcasecmp (request->command_name, "hello") != 0 &&
        strcasecmp (request->command_name, HANDSHAKE_CMD_LEGACY_HELLO) != 0) {
       return false;
    }

--- a/src/libmongoc/tests/test-mongoc-cluster.c
+++ b/src/libmongoc/tests/test-mongoc-cluster.c
@@ -424,15 +424,15 @@ test_cluster_command_notmaster (void)
    mock_server_run (server);
 
    /* server is "recovering": not master, not secondary */
-   mock_server_auto_ismaster (server,
-                              "{'ok': 1,"
-                              " 'maxWireVersion': %d,"
-                              " 'ismaster': false,"
-                              " 'secondary': false,"
-                              " 'setName': 'rs',"
-                              " 'hosts': ['%s']}",
-                              WIRE_VERSION_OP_MSG - 1,
-                              mock_server_get_host_and_port (server));
+   mock_server_auto_hello (server,
+                           "{'ok': 1,"
+                           " 'maxWireVersion': %d,"
+                           " 'ismaster': false,"
+                           " 'secondary': false,"
+                           " 'setName': 'rs',"
+                           " 'hosts': ['%s']}",
+                           WIRE_VERSION_OP_MSG - 1,
+                           mock_server_get_host_and_port (server));
 
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_utf8 (uri, "replicaSet", "rs");
@@ -1451,7 +1451,7 @@ _test_cluster_ismaster_fails (bool hangup)
 
    mock_server = mock_server_new ();
    autoresponder_id =
-      mock_server_auto_ismaster (mock_server, "{ 'isMaster': 1.0 }");
+      mock_server_auto_hello (mock_server, "{ 'isMaster': 1.0 }");
    mock_server_run (mock_server);
    uri = mongoc_uri_copy (mock_server_get_uri (mock_server));
    /* increase heartbeatFrequencyMS to prevent background server selection. */
@@ -1590,12 +1590,12 @@ test_advanced_cluster_time_not_sent_to_standalone (void)
 
    server = mock_server_new ();
    mock_server_auto_endsessions (server);
-   mock_server_auto_ismaster (server,
-                              "{'ok': 1.0,"
-                              " 'ismaster': true,"
-                              " 'minWireVersion': 0,"
-                              " 'maxWireVersion': 6,"
-                              " 'logicalSessionTimeoutMinutes': 30}");
+   mock_server_auto_hello (server,
+                           "{'ok': 1.0,"
+                           " 'ismaster': true,"
+                           " 'minWireVersion': 0,"
+                           " 'maxWireVersion': 6,"
+                           " 'logicalSessionTimeoutMinutes': 30}");
    mock_server_run (server);
    client =
       test_framework_client_new_from_uri (mock_server_get_uri (server), NULL);

--- a/src/libmongoc/tests/test-mongoc-cluster.c
+++ b/src/libmongoc/tests/test-mongoc-cluster.c
@@ -1473,8 +1473,8 @@ _test_cluster_ismaster_fails (bool hangup)
     * sends an ismaster request. */
    request = mock_server_receives_ismaster (mock_server);
    /* CDRIVER-2576: the server replies with an error, so
-    * _mongoc_stream_run_ismaster returns NULL, which
-    * _mongoc_cluster_run_ismaster must check. */
+    * _mongoc_stream_run_hello returns NULL, which
+    * _mongoc_cluster_run_hello must check. */
 
    if (hangup) {
       capture_logs (true); /* suppress "failed to buffer" warning */

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -862,7 +862,7 @@ test_insert_bulk_empty (void)
 
 
 static void
-auto_ismaster (mock_server_t *server,
+auto_hello (mock_server_t *server,
                int32_t max_wire_version,
                int32_t max_message_size,
                int32_t max_bson_size,
@@ -3649,11 +3649,11 @@ test_find_and_modify_write_concern (int wire_version)
    collection =
       mongoc_client_get_collection (client, "test", "test_find_and_modify");
 
-   auto_ismaster (server,
-                  wire_version, /* max_wire_version */
-                  48000000,     /* max_message_size */
-                  16777216,     /* max_bson_size */
-                  1000);        /* max_write_batch_size */
+   auto_hello (server,
+               wire_version, /* max_wire_version */
+               48000000,     /* max_message_size */
+               16777216,     /* max_bson_size */
+               1000);        /* max_write_batch_size */
 
    BSON_APPEND_INT32 (&doc, "superduper", 77889);
 

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -879,7 +879,7 @@ auto_ismaster (mock_server_t *server,
                                         max_batch_size);
 
    BSON_ASSERT (max_wire_version > 0);
-   mock_server_auto_ismaster (server, response);
+   mock_server_auto_hello (server, response);
 
    bson_free (response);
 }
@@ -6441,8 +6441,9 @@ test_timeout_ms (void)
    bson_error_t error;
 
    /* no timeoutMS returns client's timeoutMS */
-   ASSERT_CMPINT (mongoc_collection_get_timeout_ms (coll), ==,
-		  mongoc_client_get_timeout_ms (client));
+   ASSERT_CMPINT (mongoc_collection_get_timeout_ms (coll),
+                  ==,
+                  mongoc_client_get_timeout_ms (client));
 
    /* negative timeouts are invalid */
    res = mongoc_collection_set_timeout_ms (coll, -1, &error);

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -868,7 +868,7 @@ auto_ismaster (mock_server_t *server,
                int32_t max_bson_size,
                int32_t max_batch_size)
 {
-   char *response = bson_strdup_printf ("{'ismaster': true, "
+   char *response = bson_strdup_printf ("{'isWritablePrimary': true, "
                                         " 'maxWireVersion': %d,"
                                         " 'maxBsonObjectSize': %d,"
                                         " 'maxMessageSizeBytes': %d,"

--- a/src/libmongoc/tests/test-mongoc-cursor.c
+++ b/src/libmongoc/tests/test-mongoc-cursor.c
@@ -437,14 +437,15 @@ _make_cmd_cursor_from_agg (mongoc_collection_t *coll)
 static mongoc_cursor_t *
 _make_cmd_deprecated_cursor (mongoc_collection_t *coll)
 {
-   return mongoc_collection_command (coll,
-                                     MONGOC_QUERY_SLAVE_OK,
-                                     0,
-                                     0,
-                                     0,
-                                     tmp_bson ("{'hello': 1}"),
-                                     NULL,
-                                     NULL);
+   return mongoc_collection_command (
+      coll,
+      MONGOC_QUERY_SLAVE_OK,
+      0,
+      0,
+      0,
+      tmp_bson ("{'" HANDSHAKE_CMD_LEGACY_HELLO "': 1}"),
+      NULL,
+      NULL);
 }
 
 

--- a/src/libmongoc/tests/test-mongoc-cursor.c
+++ b/src/libmongoc/tests/test-mongoc-cursor.c
@@ -1667,7 +1667,7 @@ test_cursor_hint_mongos_cmd (void)
 }
 
 
-/* Tests CDRIVER-562: after calling ismaster to handshake a new connection we
+/* Tests CDRIVER-562: after calling hello to handshake a new connection we
  * must update topology description with the server response. If not, this test
  * fails under auth with "auth failed" because we use the wrong auth protocol.
  */

--- a/src/libmongoc/tests/test-mongoc-cursor.c
+++ b/src/libmongoc/tests/test-mongoc-cursor.c
@@ -236,8 +236,9 @@ _test_common_server_hint_command_started (
    const char *cmd = mongoc_apm_command_started_get_command_name (event);
    test_common_server_hint_ctx_t *ctx;
    /* only check command associated with cursor priming. */
-   if (strcmp (cmd, "find") == 0 || strcmp (cmd, "isMaster") == 0 ||
-       strcmp (cmd, "listDatabases") == 0) {
+   if (strcmp (cmd, "find") == 0 ||
+       strcasecmp (cmd, HANDSHAKE_CMD_LEGACY_HELLO) == 0 ||
+       strcmp (cmd, "hello") == 0 || strcmp (cmd, "listDatabases") == 0) {
       ctx = (test_common_server_hint_ctx_t *)
          mongoc_apm_command_started_get_context (event);
       ASSERT_CMPSTR (host->host_and_port, ctx->expected_host_and_port);
@@ -441,7 +442,7 @@ _make_cmd_deprecated_cursor (mongoc_collection_t *coll)
                                      0,
                                      0,
                                      0,
-                                     tmp_bson ("{'isMaster': 1}"),
+                                     tmp_bson ("{'hello': 1}"),
                                      NULL,
                                      NULL);
 }

--- a/src/libmongoc/tests/test-mongoc-database.c
+++ b/src/libmongoc/tests/test-mongoc-database.c
@@ -1159,9 +1159,9 @@ test_get_collection_names_error (void)
    capture_logs (true);
 
    server = mock_server_new ();
-   mock_server_auto_ismaster (server,
-                              "{'ismaster': true,"
-                              " 'maxWireVersion': 3}");
+   mock_server_auto_hello (server,
+                           "{'ismaster': true,"
+                           " 'maxWireVersion': 3}");
    mock_server_run (server);
    client =
       test_framework_client_new_from_uri (mock_server_get_uri (server), NULL);
@@ -1220,8 +1220,9 @@ test_timeout_ms (void)
    bson_error_t error;
 
    /* no timeoutMS returns client's timeoutMS */
-   ASSERT_CMPINT (mongoc_database_get_timeout_ms (db), ==,
-		  mongoc_client_get_timeout_ms (client));
+   ASSERT_CMPINT (mongoc_database_get_timeout_ms (db),
+                  ==,
+                  mongoc_client_get_timeout_ms (client));
 
    /* negative timeouts are invalid */
    res = mongoc_database_set_timeout_ms (db, -1, &error);

--- a/src/libmongoc/tests/test-mongoc-database.c
+++ b/src/libmongoc/tests/test-mongoc-database.c
@@ -1160,7 +1160,7 @@ test_get_collection_names_error (void)
 
    server = mock_server_new ();
    mock_server_auto_hello (server,
-                           "{'ismaster': true,"
+                           "{'isWritablePrimary': true,"
                            " 'maxWireVersion': 3}");
    mock_server_run (server);
    client =

--- a/src/libmongoc/tests/test-mongoc-find-and-modify.c
+++ b/src/libmongoc/tests/test-mongoc-find-and-modify.c
@@ -29,7 +29,7 @@ auto_ismaster (mock_server_t *server,
                                         max_batch_size);
 
    BSON_ASSERT (max_wire_version > 0);
-   mock_server_auto_ismaster (server, response);
+   mock_server_auto_hello (server, response);
 
    bson_free (response);
 }

--- a/src/libmongoc/tests/test-mongoc-find-and-modify.c
+++ b/src/libmongoc/tests/test-mongoc-find-and-modify.c
@@ -18,7 +18,7 @@ auto_ismaster (mock_server_t *server,
                int32_t max_bson_size,
                int32_t max_batch_size)
 {
-   char *response = bson_strdup_printf ("{'ismaster': true, "
+   char *response = bson_strdup_printf ("{'isWritablePrimary': true, "
                                         " 'maxWireVersion': %d,"
                                         " 'maxBsonObjectSize': %d,"
                                         " 'maxMessageSizeBytes': %d,"

--- a/src/libmongoc/tests/test-mongoc-find-and-modify.c
+++ b/src/libmongoc/tests/test-mongoc-find-and-modify.c
@@ -12,7 +12,7 @@
 #include "mock_server/mock-server.h"
 
 static void
-auto_ismaster (mock_server_t *server,
+auto_hello (mock_server_t *server,
                int32_t max_wire_version,
                int32_t max_message_size,
                int32_t max_bson_size,
@@ -73,11 +73,11 @@ test_find_and_modify_bypass (bool bypass)
    collection =
       mongoc_client_get_collection (client, "test", "test_find_and_modify");
 
-   auto_ismaster (server,
-                  WIRE_VERSION_FAM_WRITE_CONCERN, /* max_wire_version */
-                  48000000,                       /* max_message_size */
-                  16777216,                       /* max_bson_size */
-                  1000);                          /* max_write_batch_size */
+   auto_hello (server,
+               WIRE_VERSION_FAM_WRITE_CONCERN, /* max_wire_version */
+               48000000,                       /* max_message_size */
+               16777216,                       /* max_bson_size */
+               1000);                          /* max_write_batch_size */
 
    BSON_APPEND_INT32 (&doc, "superduper", 77889);
 
@@ -169,11 +169,11 @@ test_find_and_modify_write_concern (int wire_version)
    collection =
       mongoc_client_get_collection (client, "test", "test_find_and_modify");
 
-   auto_ismaster (server,
-                  wire_version, /* max_wire_version */
-                  48000000,     /* max_message_size */
-                  16777216,     /* max_bson_size */
-                  1000);        /* max_write_batch_size */
+   auto_hello (server,
+               wire_version, /* max_wire_version */
+               48000000,     /* max_message_size */
+               16777216,     /* max_bson_size */
+               1000);        /* max_write_batch_size */
 
    BSON_APPEND_INT32 (&doc, "superduper", 77889);
 

--- a/src/libmongoc/tests/test-mongoc-handshake.c
+++ b/src/libmongoc/tests/test-mongoc-handshake.c
@@ -406,13 +406,13 @@ test_mongoc_handshake_too_big (void)
       client, "admin", tmp_bson ("{'ping': 1}"), NULL, NULL, NULL);
    request = mock_server_receives_legacy_hello (server, NULL);
 
-   /* Make sure the isMaster request has a handshake field, and it's not huge */
+   /* Make sure the hello request has a handshake field, and it's not huge */
    ASSERT (request);
    hello_doc = request_get_doc (request, 0);
    ASSERT (hello_doc);
    ASSERT (bson_has_field (hello_doc, HANDSHAKE_FIELD));
 
-   /* isMaster with handshake isn't too big */
+   /* hello with handshake isn't too big */
    bson_iter_init_find (&iter, hello_doc, HANDSHAKE_FIELD);
    ASSERT (BSON_ITER_HOLDS_DOCUMENT (&iter));
    bson_iter_document (&iter, &len, &dummy);

--- a/src/libmongoc/tests/test-mongoc-read-prefs.c
+++ b/src/libmongoc/tests/test-mongoc-read-prefs.c
@@ -282,40 +282,40 @@ _run_server (read_pref_test_type_t test_type, int32_t max_wire_version)
    BSON_ASSERT (max_wire_version > 0);
    switch (test_type) {
    case READ_PREF_TEST_STANDALONE:
-      mock_server_auto_ismaster (server,
-                                 "{'ok': 1,"
-                                 " 'maxWireVersion': %d,"
-                                 " 'ismaster': true}",
-                                 max_wire_version);
+      mock_server_auto_hello (server,
+                              "{'ok': 1,"
+                              " 'maxWireVersion': %d,"
+                              " 'ismaster': true}",
+                              max_wire_version);
       break;
    case READ_PREF_TEST_MONGOS:
-      mock_server_auto_ismaster (server,
-                                 "{'ok': 1,"
-                                 " 'maxWireVersion': %d,"
-                                 " 'ismaster': true,"
-                                 " 'msg': 'isdbgrid'}",
-                                 max_wire_version);
+      mock_server_auto_hello (server,
+                              "{'ok': 1,"
+                              " 'maxWireVersion': %d,"
+                              " 'ismaster': true,"
+                              " 'msg': 'isdbgrid'}",
+                              max_wire_version);
       break;
    case READ_PREF_TEST_PRIMARY:
-      mock_server_auto_ismaster (server,
-                                 "{'ok': 1,"
-                                 " 'maxWireVersion': %d,"
-                                 " 'ismaster': true,"
-                                 " 'setName': 'rs',"
-                                 " 'hosts': ['%s']}",
-                                 max_wire_version,
-                                 mock_server_get_host_and_port (server));
+      mock_server_auto_hello (server,
+                              "{'ok': 1,"
+                              " 'maxWireVersion': %d,"
+                              " 'ismaster': true,"
+                              " 'setName': 'rs',"
+                              " 'hosts': ['%s']}",
+                              max_wire_version,
+                              mock_server_get_host_and_port (server));
       break;
    case READ_PREF_TEST_SECONDARY:
-      mock_server_auto_ismaster (server,
-                                 "{'ok': 1,"
-                                 " 'maxWireVersion': %d,"
-                                 " 'ismaster': false,"
-                                 " 'secondary': true,"
-                                 " 'setName': 'rs',"
-                                 " 'hosts': ['%s']}",
-                                 max_wire_version,
-                                 mock_server_get_host_and_port (server));
+      mock_server_auto_hello (server,
+                              "{'ok': 1,"
+                              " 'maxWireVersion': %d,"
+                              " 'ismaster': false,"
+                              " 'secondary': true,"
+                              " 'setName': 'rs',"
+                              " 'hosts': ['%s']}",
+                              max_wire_version,
+                              mock_server_get_host_and_port (server));
       break;
    default:
       fprintf (stderr, "Invalid test_type: : %d\n", test_type);
@@ -993,7 +993,7 @@ _test_op_msg_direct_connection (bool is_mongos,
                                            " 'maxWireVersion': %d}",
                                            WIRE_VERSION_OP_MSG);
       server = mock_server_new ();
-      mock_server_auto_ismaster (server, ismaster);
+      mock_server_auto_hello (server, ismaster);
       bson_free (ismaster);
    }
 

--- a/src/libmongoc/tests/test-mongoc-read-prefs.c
+++ b/src/libmongoc/tests/test-mongoc-read-prefs.c
@@ -285,14 +285,14 @@ _run_server (read_pref_test_type_t test_type, int32_t max_wire_version)
       mock_server_auto_hello (server,
                               "{'ok': 1,"
                               " 'maxWireVersion': %d,"
-                              " 'ismaster': true}",
+                              " 'isWritablePrimary': true}",
                               max_wire_version);
       break;
    case READ_PREF_TEST_MONGOS:
       mock_server_auto_hello (server,
                               "{'ok': 1,"
                               " 'maxWireVersion': %d,"
-                              " 'ismaster': true,"
+                              " 'isWritablePrimary': true,"
                               " 'msg': 'isdbgrid'}",
                               max_wire_version);
       break;
@@ -300,7 +300,7 @@ _run_server (read_pref_test_type_t test_type, int32_t max_wire_version)
       mock_server_auto_hello (server,
                               "{'ok': 1,"
                               " 'maxWireVersion': %d,"
-                              " 'ismaster': true,"
+                              " 'isWritablePrimary': true,"
                               " 'setName': 'rs',"
                               " 'hosts': ['%s']}",
                               max_wire_version,
@@ -310,7 +310,7 @@ _run_server (read_pref_test_type_t test_type, int32_t max_wire_version)
       mock_server_auto_hello (server,
                               "{'ok': 1,"
                               " 'maxWireVersion': %d,"
-                              " 'ismaster': false,"
+                              " 'isWritablePrimary': false,"
                               " 'secondary': true,"
                               " 'setName': 'rs',"
                               " 'hosts': ['%s']}",
@@ -985,16 +985,16 @@ _test_op_msg_direct_connection (bool is_mongos,
    if (is_mongos) {
       server = mock_mongos_new (WIRE_VERSION_OP_MSG);
    } else {
-      char *ismaster = bson_strdup_printf ("{'ok': 1.0,"
-                                           " 'ismaster': true,"
-                                           " 'setName': 'rs0',"
-                                           " 'secondary': true,"
-                                           " 'minWireVersion': 0,"
-                                           " 'maxWireVersion': %d}",
-                                           WIRE_VERSION_OP_MSG);
+      char *hello = bson_strdup_printf ("{'ok': 1.0,"
+                                        " 'ismaster': true,"
+                                        " 'setName': 'rs0',"
+                                        " 'secondary': true,"
+                                        " 'minWireVersion': 0,"
+                                        " 'maxWireVersion': %d}",
+                                        WIRE_VERSION_OP_MSG);
       server = mock_server_new ();
-      mock_server_auto_hello (server, ismaster);
-      bson_free (ismaster);
+      mock_server_auto_hello (server, hello);
+      bson_free (hello);
    }
 
    mock_server_auto_endsessions (server);

--- a/src/libmongoc/tests/test-mongoc-scram.c
+++ b/src/libmongoc/tests/test-mongoc-scram.c
@@ -206,7 +206,7 @@ _check_mechanism (bool pooled,
    server = mock_server_new ();
    mock_server_auto_hello (server,
                            "{'ok': 1, 'minWireVersion': 3, "
-                           "'maxWireVersion': %d, 'ismaster': true, "
+                           "'maxWireVersion': %d, 'isWritablePrimary': true, "
                            "'saslSupportedMechs': [%s]}",
                            WIRE_VERSION_MAX,
                            server_mechs ? server_mechs : "");

--- a/src/libmongoc/tests/test-mongoc-scram.c
+++ b/src/libmongoc/tests/test-mongoc-scram.c
@@ -204,12 +204,12 @@ _check_mechanism (bool pooled,
    const char *used_mech;
 
    server = mock_server_new ();
-   mock_server_auto_ismaster (server,
-                              "{'ok': 1, 'minWireVersion': 3, "
-                              "'maxWireVersion': %d, 'ismaster': true, "
-                              "'saslSupportedMechs': [%s]}",
-                              WIRE_VERSION_MAX,
-                              server_mechs ? server_mechs : "");
+   mock_server_auto_hello (server,
+                           "{'ok': 1, 'minWireVersion': 3, "
+                           "'maxWireVersion': %d, 'ismaster': true, "
+                           "'saslSupportedMechs': [%s]}",
+                           WIRE_VERSION_MAX,
+                           server_mechs ? server_mechs : "");
 
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));

--- a/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
@@ -983,7 +983,7 @@ test_no_duplicates (void)
     * topology description. It differs in that it has the 'lastWrite' field,
     * which does not have an effect in equality comparison. */
    sd = mongoc_client_get_server_description (client, 1);
-   BSON_ASSERT (bson_has_field (&sd->last_is_master, "lastWrite"));
+   BSON_ASSERT (bson_has_field (&sd->last_hello_response, "lastWrite"));
    mongoc_server_description_destroy (sd);
 
    mongoc_uri_destroy (uri);

--- a/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
@@ -727,7 +727,7 @@ _test_heartbeat_events (bool pooled, bool succeeded)
       request_destroy (request);
    }
 
-   /* pooled client opens new socket, handshakes it by calling ismaster again */
+   /* pooled client opens new socket, handshakes it by calling hello again */
    if (pooled && succeeded) {
       request = mock_server_receives_ismaster (server);
       mock_server_replies (

--- a/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
@@ -711,7 +711,7 @@ _test_heartbeat_events (bool pooled, bool succeeded)
       client, "admin", tmp_bson ("{'foo': 1}"), NULL, NULL, &error);
 
    /* topology scanner calls ismaster once */
-   request = mock_server_receives_ismaster (server);
+   request = mock_server_receives_legacy_hello (server, NULL);
 
    if (succeeded) {
       mock_server_replies (
@@ -729,7 +729,7 @@ _test_heartbeat_events (bool pooled, bool succeeded)
 
    /* pooled client opens new socket, handshakes it by calling hello again */
    if (pooled && succeeded) {
-      request = mock_server_receives_ismaster (server);
+      request = mock_server_receives_legacy_hello (server, NULL);
       mock_server_replies (
          request,
          MONGOC_REPLY_NONE,
@@ -924,12 +924,12 @@ test_no_duplicates (void)
    bson_error_t error;
    future_t *future;
    mongoc_uri_t *uri;
-   char *first_ismaster_response =
-      "{'ok': 1.0, 'ismaster': true, 'minWireVersion': 0, 'maxWireVersion': 9}";
-   char *second_ismaster_response = "{'ok': 1.0, 'ismaster': true, "
-                                    "'minWireVersion': 0, 'maxWireVersion': 9, "
-                                    "'lastWrite': {'lastWriteDate': {'$date': "
-                                    "{'$numberLong': '123'}}, 'opTime': 2}}";
+   char *first_hello_response = "{'ok': 1.0, 'isWritablePrimary': true, "
+                                "'minWireVersion': 0, 'maxWireVersion': 9}";
+   char *second_hello_response = "{'ok': 1.0, 'isWritablePrimary': true, "
+                                 "'minWireVersion': 0, 'maxWireVersion': 9, "
+                                 "'lastWrite': {'lastWriteDate': {'$date': "
+                                 "{'$numberLong': '123'}}, 'opTime': 2}}";
    mongoc_apm_callbacks_t *callbacks;
    duplicates_counter_t duplicates_counter = {0};
    mongoc_server_description_t *sd;
@@ -949,8 +949,8 @@ test_no_duplicates (void)
    client = mongoc_client_pool_pop (pool);
 
    /* Topology scanning thread starts, and sends an ismaster. */
-   request = mock_server_receives_ismaster (server);
-   mock_server_replies_simple (request, first_ismaster_response);
+   request = mock_server_receives_legacy_hello (server, NULL);
+   mock_server_replies_simple (request, first_hello_response);
    request_destroy (request);
 
    /* Perform a ping, which creates a new connection, which performs the
@@ -961,8 +961,8 @@ test_no_duplicates (void)
                                           NULL /* read prefs */,
                                           NULL /* reply */,
                                           &error);
-   request = mock_server_receives_ismaster (server);
-   mock_server_replies_simple (request, second_ismaster_response);
+   request = mock_server_receives_legacy_hello (server, NULL);
+   mock_server_replies_simple (request, second_hello_response);
    request_destroy (request);
    request = mock_server_receives_msg (
       server, MONGOC_QUERY_NONE, tmp_bson ("{'ping': 1}"));

--- a/src/libmongoc/tests/test-mongoc-sdam.c
+++ b/src/libmongoc/tests/test-mongoc-sdam.c
@@ -753,7 +753,8 @@ test_prose_rtt (void *unused)
                 "{",
                 "failCommands",
                 "[",
-                "isMaster",
+                HANDSHAKE_CMD_LEGACY_HELLO,
+                "hello",
                 "]",
                 "blockConnection",
                 BCON_BOOL (true),
@@ -770,9 +771,8 @@ test_prose_rtt (void *unused)
     * RTT_TEST_TIMEOUT_SEC seconds, consider it a failure. */
    satisfied = false;
    start_us = bson_get_monotonic_time ();
-   while (!satisfied &&
-          bson_get_monotonic_time () <
-             start_us + RTT_TEST_TIMEOUT_SEC * 1000 * 1000) {
+   while (!satisfied && bson_get_monotonic_time () <
+                           start_us + RTT_TEST_TIMEOUT_SEC * 1000 * 1000) {
       mongoc_server_description_t *sd;
 
       sd = mongoc_client_select_server (

--- a/src/libmongoc/tests/test-mongoc-server-description.c
+++ b/src/libmongoc/tests/test-mongoc-server-description.c
@@ -110,10 +110,10 @@ test_server_description_equal (void)
    sd1.round_trip_time_msec = 1234;
    BSON_ASSERT (_mongoc_server_description_equal (&sd1, &sd2));
 
-   /* "lastWriteDate"/"opTime" are stored in last_is_master and not parsed out.
-    * Check that overwriting the stored reply does not factor into the equality
-    * check. */
-   bson_reinit (&sd1.last_is_master);
+   /* "lastWriteDate"/"opTime" are stored in last_hello_response and not parsed
+    * out. Check that overwriting the stored reply does not factor into the
+    * equality check. */
+   bson_reinit (&sd1.last_hello_response);
    BSON_ASSERT (_mongoc_server_description_equal (&sd1, &sd2));
 
    /* "error" differs, considered unequal. */

--- a/src/libmongoc/tests/test-mongoc-server-description.c
+++ b/src/libmongoc/tests/test-mongoc-server-description.c
@@ -297,6 +297,26 @@ test_server_description_ignores_rtt (void)
    bson_destroy (&ismaster);
 }
 
+static void
+test_server_description_hello (void)
+{
+   mongoc_server_description_t sd;
+   bson_error_t error;
+   bson_t hello_response;
+
+   bson_init (&hello_response);
+   BCON_APPEND (&hello_response, "isWritablePrimary", BCON_BOOL (true));
+
+   memset (&error, 0, sizeof (bson_error_t));
+   mongoc_server_description_init (&sd, "host:1234", 1);
+   BSON_ASSERT (sd.type == MONGOC_SERVER_UNKNOWN);
+   mongoc_server_description_handle_ismaster (&sd, &hello_response, 0, &error);
+   BSON_ASSERT (sd.type == MONGOC_SERVER_STANDALONE);
+
+   mongoc_server_description_cleanup (&sd);
+   bson_destroy (&hello_response);
+}
+
 void
 test_server_description_install (TestSuite *suite)
 {
@@ -308,4 +328,6 @@ test_server_description_install (TestSuite *suite)
    TestSuite_Add (suite,
                   "/server_description/ignores_unset_rtt",
                   test_server_description_ignores_rtt);
+   TestSuite_Add (
+      suite, "/server_description/hello", test_server_description_hello);
 }

--- a/src/libmongoc/tests/test-mongoc-server-description.c
+++ b/src/libmongoc/tests/test-mongoc-server-description.c
@@ -32,8 +32,7 @@ reset_basic_sd (mongoc_server_description_t *sd)
 
    mongoc_server_description_reset (sd);
    memset (&error, 0, sizeof (bson_error_t));
-   mongoc_server_description_handle_ismaster (
-      sd, ismaster, 0 /* rtt */, &error);
+   mongoc_server_description_handle_hello (sd, ismaster, 0 /* rtt */, &error);
    bson_destroy (ismaster);
 }
 
@@ -243,8 +242,7 @@ test_server_description_msg_without_isdbgrid (void)
                         "msg",
                         "isdbgrid");
    memset (&error, 0, sizeof (bson_error_t));
-   mongoc_server_description_handle_ismaster (
-      &sd, ismaster, 0 /* rtt */, &error);
+   mongoc_server_description_handle_hello (&sd, ismaster, 0 /* rtt */, &error);
    BSON_ASSERT (sd.type == MONGOC_SERVER_MONGOS);
 
    mongoc_server_description_reset (&sd);
@@ -255,8 +253,7 @@ test_server_description_msg_without_isdbgrid (void)
                         BCON_INT32 (WIRE_VERSION_MAX),
                         "msg",
                         "something_else");
-   mongoc_server_description_handle_ismaster (
-      &sd, ismaster, 0 /* rtt */, &error);
+   mongoc_server_description_handle_hello (&sd, ismaster, 0 /* rtt */, &error);
    BSON_ASSERT (sd.type == MONGOC_SERVER_STANDALONE);
 
    bson_destroy (ismaster);
@@ -279,16 +276,16 @@ test_server_description_ignores_rtt (void)
    ASSERT_CMPINT64 (sd.round_trip_time_msec, ==, MONGOC_RTT_UNSET);
    BSON_ASSERT (sd.type == MONGOC_SERVER_UNKNOWN);
    /* If MONGOC_RTT_UNSET is passed as the RTT, it remains MONGOC_RTT_UNSET. */
-   mongoc_server_description_handle_ismaster (
+   mongoc_server_description_handle_hello (
       &sd, &ismaster, MONGOC_RTT_UNSET, &error);
    ASSERT_CMPINT64 (sd.round_trip_time_msec, ==, MONGOC_RTT_UNSET);
    BSON_ASSERT (sd.type == MONGOC_SERVER_STANDALONE);
    /* The first real RTT overwrites the stored RTT. */
-   mongoc_server_description_handle_ismaster (&sd, &ismaster, 10, &error);
+   mongoc_server_description_handle_hello (&sd, &ismaster, 10, &error);
    ASSERT_CMPINT64 (sd.round_trip_time_msec, ==, 10);
    BSON_ASSERT (sd.type == MONGOC_SERVER_STANDALONE);
    /* But subsequent MONGOC_RTT_UNSET values do not effect it. */
-   mongoc_server_description_handle_ismaster (
+   mongoc_server_description_handle_hello (
       &sd, &ismaster, MONGOC_RTT_UNSET, &error);
    ASSERT_CMPINT64 (sd.round_trip_time_msec, ==, 10);
    BSON_ASSERT (sd.type == MONGOC_SERVER_STANDALONE);
@@ -310,7 +307,7 @@ test_server_description_hello (void)
    memset (&error, 0, sizeof (bson_error_t));
    mongoc_server_description_init (&sd, "host:1234", 1);
    BSON_ASSERT (sd.type == MONGOC_SERVER_UNKNOWN);
-   mongoc_server_description_handle_ismaster (&sd, &hello_response, 0, &error);
+   mongoc_server_description_handle_hello (&sd, &hello_response, 0, &error);
    BSON_ASSERT (sd.type == MONGOC_SERVER_STANDALONE);
 
    mongoc_server_description_cleanup (&sd);

--- a/src/libmongoc/tests/test-mongoc-speculative-auth.c
+++ b/src/libmongoc/tests/test-mongoc-speculative-auth.c
@@ -51,7 +51,7 @@ _force_ismaster_with_ping (mongoc_client_t *client)
    return future;
 }
 
-/* Call after we've dealt with the isMaster sent by
+/* Call after we've dealt with the hello sent by
  * _force_ismaster_with_ping */
 static void
 _respond_to_ping (future_t *future, mock_server_t *server, bool expect_ping)

--- a/src/libmongoc/tests/test-mongoc-speculative-auth.c
+++ b/src/libmongoc/tests/test-mongoc-speculative-auth.c
@@ -80,13 +80,16 @@ _respond_to_ping (future_t *future, mock_server_t *server, bool expect_ping)
 }
 
 static bool
-_auto_ismaster_without_speculative_auth (request_t *request, void *data)
+_auto_hello_without_speculative_auth (request_t *request, void *data)
 {
    const char *response_json = (const char *) data;
    char *quotes_replaced;
 
-   if (!request->is_command ||
-       strcasecmp (request->command_name, HANDSHAKE_CMD_LEGACY_HELLO) ||
+   if (!request->is_command) {
+      return false;
+   }
+
+   if (strcasecmp (request->command_name, HANDSHAKE_CMD_LEGACY_HELLO) &&
        strcmp (request->command_name, "hello")) {
       return false;
    }
@@ -141,7 +144,7 @@ _test_mongoc_speculative_auth (bool pooled,
 #endif
 
    mock_server_autoresponds (server,
-                             _auto_ismaster_without_speculative_auth,
+                             _auto_hello_without_speculative_auth,
                              "{'ok': 1, 'isWritablePrimary': true, "
                              "'minWireVersion': 2, 'maxWireVersion': 5}",
                              NULL);

--- a/src/libmongoc/tests/test-mongoc-topology-description.c
+++ b/src/libmongoc/tests/test-mongoc-topology-description.c
@@ -125,11 +125,11 @@ test_get_servers (void)
 
    /* servers "a" and "c" are mongos, but "b" remains unknown */
    sd_a = _sd_for_host (td, "a");
-   mongoc_topology_description_handle_ismaster (
+   mongoc_topology_description_handle_hello (
       td, sd_a->id, tmp_bson ("{'ok': 1, 'msg': 'isdbgrid'}"), 100, NULL);
 
    sd_c = _sd_for_host (td, "c");
-   mongoc_topology_description_handle_ismaster (
+   mongoc_topology_description_handle_hello (
       td, sd_c->id, tmp_bson ("{'ok': 1, 'msg': 'isdbgrid'}"), 100, NULL);
 
    sds = mongoc_topology_description_get_servers (td, &n);
@@ -183,7 +183,7 @@ test_topology_version_equal (void)
    mongoc_topology_set_apm_callbacks (topology, callbacks, &num_calls);
 
    sd = _sd_for_host (td, "host");
-   mongoc_topology_description_handle_ismaster (
+   mongoc_topology_description_handle_hello (
       td,
       sd->id,
       tmp_bson ("{'ok': 1, 'topologyVersion': " TV_2 " }"),
@@ -194,7 +194,7 @@ test_topology_version_equal (void)
 
    /* The subsequent ismaster has a topologyVersion that compares less, so the
     * ismaster skips. */
-   mongoc_topology_description_handle_ismaster (
+   mongoc_topology_description_handle_hello (
       td,
       sd->id,
       tmp_bson ("{'ok': 1, 'topologyVersion': " TV_1 " }"),

--- a/src/libmongoc/tests/test-mongoc-topology-reconcile.c
+++ b/src/libmongoc/tests/test-mongoc-topology-reconcile.c
@@ -382,13 +382,14 @@ test_topology_reconcile_from_handshake (void *ctx)
    client = mongoc_client_pool_pop (pool);
 
    /* command in the foreground (hello, just because it doesn't need auth) */
-   r = mongoc_client_read_command_with_opts (client,
-                                             "admin",
-                                             tmp_bson ("{'hello': 1}"),
-                                             NULL,
-                                             tmp_bson ("{'serverId': 1}"),
-                                             NULL,
-                                             &error);
+   r = mongoc_client_read_command_with_opts (
+      client,
+      "admin",
+      tmp_bson ("{'" HANDSHAKE_CMD_LEGACY_HELLO "': 1}"),
+      NULL,
+      tmp_bson ("{'serverId': 1}"),
+      NULL,
+      &error);
 
    ASSERT_OR_PRINT (r, error);
 
@@ -412,7 +413,13 @@ test_topology_reconcile_from_handshake (void *ctx)
 
    /* no serverId, waits for topology scan */
    r = mongoc_client_read_command_with_opts (
-      client, "admin", tmp_bson ("{'hello': 1}"), NULL, NULL, NULL, &error);
+      client,
+      "admin",
+      tmp_bson ("{'" HANDSHAKE_CMD_LEGACY_HELLO "': 1}"),
+      NULL,
+      NULL,
+      NULL,
+      &error);
 
    ASSERT_OR_PRINT (r, error);
    bson_mutex_lock (&data.mutex);

--- a/src/libmongoc/tests/test-mongoc-topology-reconcile.c
+++ b/src/libmongoc/tests/test-mongoc-topology-reconcile.c
@@ -247,10 +247,11 @@ _test_topology_reconcile_sharded (bool pooled)
       client->topology, MONGOC_SS_READ, primary_read_prefs, &error);
 
    /* mongos */
-   request = mock_server_receives_ismaster (mongos);
-   mock_server_replies_simple (request,
-                               "{'ok': 1, 'ismaster': true, 'minWireVersion': "
-                               "2, 'maxWireVersion': 5, 'msg': 'isdbgrid'}");
+   request = mock_server_receives_legacy_hello (mongos, NULL);
+   mock_server_replies_simple (
+      request,
+      "{'ok': 1, 'isWritablePrimary': true, 'minWireVersion': "
+      "2, 'maxWireVersion': 5, 'msg': 'isdbgrid'}");
 
    request_destroy (request);
 
@@ -258,11 +259,11 @@ _test_topology_reconcile_sharded (bool pooled)
    _mongoc_usleep (1000 * 1000);
 
    /* replica set secondary - topology removes it */
-   request = mock_server_receives_ismaster (secondary);
+   request = mock_server_receives_legacy_hello (secondary, NULL);
    secondary_response =
       bson_strdup_printf ("{'ok': 1, "
                           " 'setName': 'rs',"
-                          " 'ismaster': false,"
+                          " 'isWritablePrimary': false,"
                           " 'secondary': true,"
                           " 'minWireVersion': 2,"
                           " 'maxWireVersion': 5,"
@@ -380,10 +381,10 @@ test_topology_reconcile_from_handshake (void *ctx)
    /* ordinarily would start bg thread */
    client = mongoc_client_pool_pop (pool);
 
-   /* command in the foreground (ismaster, just because it doesn't need auth) */
+   /* command in the foreground (hello, just because it doesn't need auth) */
    r = mongoc_client_read_command_with_opts (client,
                                              "admin",
-                                             tmp_bson ("{'ismaster': 1}"),
+                                             tmp_bson ("{'hello': 1}"),
                                              NULL,
                                              tmp_bson ("{'serverId': 1}"),
                                              NULL,
@@ -411,7 +412,7 @@ test_topology_reconcile_from_handshake (void *ctx)
 
    /* no serverId, waits for topology scan */
    r = mongoc_client_read_command_with_opts (
-      client, "admin", tmp_bson ("{'ismaster': 1}"), NULL, NULL, NULL, &error);
+      client, "admin", tmp_bson ("{'hello': 1}"), NULL, NULL, NULL, &error);
 
    ASSERT_OR_PRINT (r, error);
    bson_mutex_lock (&data.mutex);

--- a/src/libmongoc/tests/test-mongoc-topology-scanner.c
+++ b/src/libmongoc/tests/test-mongoc-topology-scanner.c
@@ -304,7 +304,7 @@ test_topology_scanner_connection_error (void)
    ASSERT_ERROR_CONTAINS (error,
                           MONGOC_ERROR_SERVER_SELECTION,
                           MONGOC_ERROR_SERVER_SELECTION_FAILURE,
-                          "connection refused calling ismaster on "
+                          "connection refused calling hello on "
                           "'localhost:9876'");
 
    mongoc_client_destroy (client);
@@ -332,7 +332,7 @@ test_topology_scanner_socket_timeout (void)
 
    /* the mock server did accept connection, but never replied */
    expected_msg =
-      bson_strdup_printf ("socket timeout calling ismaster on '%s'",
+      bson_strdup_printf ("socket timeout calling hello on '%s'",
                           mongoc_uri_get_hosts (uri)->host_and_port);
 
    ASSERT_ERROR_CONTAINS (error,

--- a/src/libmongoc/tests/test-mongoc-topology-scanner.c
+++ b/src/libmongoc/tests/test-mongoc-topology-scanner.c
@@ -395,10 +395,14 @@ test_topology_scanner_blocking_initiator (void)
    data.client = client;
    mongoc_client_set_stream_initiator (client, slow_initiator, &data);
 
-   ASSERT_OR_PRINT (
-      mongoc_client_command_simple (
-         client, "admin", tmp_bson ("{'hello': 1}"), NULL, NULL, &error),
-      error);
+   ASSERT_OR_PRINT (mongoc_client_command_simple (
+                       client,
+                       "admin",
+                       tmp_bson ("{'" HANDSHAKE_CMD_LEGACY_HELLO "': 1}"),
+                       NULL,
+                       NULL,
+                       &error),
+                    error);
 
    mongoc_client_destroy (client);
    mongoc_uri_destroy (uri);

--- a/src/libmongoc/tests/test-mongoc-topology-scanner.c
+++ b/src/libmongoc/tests/test-mongoc-topology-scanner.c
@@ -153,7 +153,7 @@ test_topology_scanner_discovery (void)
 
    primary_response =
       bson_strdup_printf ("{'ok': 1, "
-                          " 'ismaster': true,"
+                          " 'isWritablePrimary': true,"
                           " 'setName': 'rs',"
                           " 'minWireVersion': 2,"
                           " 'maxWireVersion': 5,"
@@ -163,7 +163,7 @@ test_topology_scanner_discovery (void)
 
    secondary_response =
       bson_strdup_printf ("{'ok': 1, "
-                          " 'ismaster': false,"
+                          " 'isWritablePrimary': false,"
                           " 'secondary': true,"
                           " 'setName': 'rs',"
                           " 'minWireVersion': 2,"
@@ -181,7 +181,7 @@ test_topology_scanner_discovery (void)
       client->topology, MONGOC_SS_READ, secondary_pref, &error);
 
    /* a single scan discovers *and* checks the secondary */
-   request = mock_server_receives_ismaster (primary);
+   request = mock_server_receives_legacy_hello (primary, NULL);
    mock_server_replies_simple (request, primary_response);
    request_destroy (request);
 
@@ -189,7 +189,7 @@ test_topology_scanner_discovery (void)
    _mongoc_usleep (250 * 1000);
 
    /* a check of the secondary is scheduled in this scan */
-   request = mock_server_receives_ismaster (secondary);
+   request = mock_server_receives_legacy_hello (secondary, NULL);
    mock_server_replies_simple (request, secondary_response);
 
    /* scan completes */
@@ -236,7 +236,7 @@ test_topology_scanner_oscillate (void)
    /* server 0 says it's primary, but only server 1 is in the set */
    server0_response =
       bson_strdup_printf ("{'ok': 1, "
-                          " 'ismaster': true,"
+                          " 'isWritablePrimary': true,"
                           " 'setName': 'rs',"
                           " 'hosts': ['%s']}",
                           mock_server_get_host_and_port (server1));
@@ -244,7 +244,7 @@ test_topology_scanner_oscillate (void)
    /* the opposite */
    server1_response =
       bson_strdup_printf ("{'ok': 1, "
-                          " 'ismaster': true,"
+                          " 'isWritablePrimary': true,"
                           " 'setName': 'rs',"
                           " 'hosts': ['%s']}",
                           mock_server_get_host_and_port (server0));
@@ -261,14 +261,14 @@ test_topology_scanner_oscillate (void)
       client->topology, MONGOC_SS_READ, primary_pref, &error);
 
    /* a single scan discovers servers 0 and 1 */
-   request = mock_server_receives_ismaster (server0);
+   request = mock_server_receives_legacy_hello (server0, NULL);
    mock_server_replies_simple (request, server0_response);
    request_destroy (request);
 
    /* let client process that response */
    _mongoc_usleep (250 * 1000);
 
-   request = mock_server_receives_ismaster (server1);
+   request = mock_server_receives_legacy_hello (server1, NULL);
    mock_server_replies_simple (request, server1_response);
 
    /* we don't schedule another check of server0 */
@@ -397,7 +397,7 @@ test_topology_scanner_blocking_initiator (void)
 
    ASSERT_OR_PRINT (
       mongoc_client_command_simple (
-         client, "admin", tmp_bson ("{'ismaster': 1}"), NULL, NULL, &error),
+         client, "admin", tmp_bson ("{'hello': 1}"), NULL, NULL, &error),
       error);
 
    mongoc_client_destroy (client);

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -545,7 +545,7 @@ _test_topology_invalidate_server (bool pooled)
       BSON_ASSERT (sd->type == MONGOC_SERVER_UNKNOWN);
       BSON_ASSERT (sd->error.domain != 0);
       ASSERT_CMPINT64 (sd->round_trip_time_msec, ==, (int64_t) -1);
-      BSON_ASSERT (bson_empty (&sd->last_is_master));
+      BSON_ASSERT (bson_empty (&sd->last_hello_response));
       BSON_ASSERT (bson_empty (&sd->hosts));
       BSON_ASSERT (bson_empty (&sd->passives));
       BSON_ASSERT (bson_empty (&sd->arbiters));
@@ -1051,7 +1051,7 @@ test_multiple_selection_errors (void *context)
     */
    ASSERT_CONTAINS (error.message, "No suitable servers found");
    /* either "connection error" or "connection timeout" calling ismaster */
-   ASSERT_CONTAINS (error.message, "calling ismaster on 'example.com:2'");
+   ASSERT_CONTAINS (error.message, "calling hello on 'example.com:2'");
    ASSERT_CONTAINS (error.message, "[Failed to resolve 'doesntexist']");
 
    bson_destroy (&reply);
@@ -1906,13 +1906,13 @@ _test_request_scan_on_error (bool pooled,
          }
       } else {
          /* after the 'ping' command and returning, the server should
-            * have been marked as unknown. */
+          * have been marked as unknown. */
          BSON_ASSERT (sd->type == MONGOC_SERVER_UNKNOWN);
          ASSERT_CMPINT (sd->last_update_time_usec, >=, ping_started_usec);
          ASSERT_CMPINT (
             sd->last_update_time_usec, <=, bson_get_monotonic_time ());
          /* check that the error on the server description matches the error
-         * message in the response. */
+          * message in the response. */
          if (server_err) {
             ASSERT_CMPSTR (server_err, sd->error.message);
          }

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -1047,10 +1047,10 @@ test_multiple_selection_errors (void *context)
    /* Like:
     * "No suitable servers found (`serverselectiontryonce` set):
     *  [Failed to resolve 'doesntexist']
-    *  [connection error calling ismaster on 'example.com:2']"
+    *  [connection error calling hello on 'example.com:2']"
     */
    ASSERT_CONTAINS (error.message, "No suitable servers found");
-   /* either "connection error" or "connection timeout" calling ismaster */
+   /* either "connection error" or "connection timeout" calling hello */
    ASSERT_CONTAINS (error.message, "calling hello on 'example.com:2'");
    ASSERT_CONTAINS (error.message, "[Failed to resolve 'doesntexist']");
 
@@ -1088,7 +1088,7 @@ auto_ping (request_t *request, void *data)
 }
 
 
-/* Tests CDRIVER-562: after calling ismaster to handshake a new connection we
+/* Tests CDRIVER-562: after calling hello to handshake a new connection we
  * must update topology description with the server response.
  */
 static void

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -960,15 +960,15 @@ _test_select_succeed (bool try_once)
     * https://support.microsoft.com/en-us/help/175523/info-winsock-tcp-connection-performance-to-unused-ports
     */
    /* primary auto-responds, secondary never responds */
-   mock_server_auto_ismaster (primary,
-                              "{'ok': 1,"
-                              " 'ismaster': true,"
-                              " 'setName': 'rs',"
-                              " 'minWireVersion': 2,"
-                              " 'maxWireVersion': 5,"
-                              " 'hosts': ['127.0.0.1:%hu', '127.0.0.1:%hu']}",
-                              mock_server_get_port (primary),
-                              mock_server_get_port (secondary));
+   mock_server_auto_hello (primary,
+                           "{'ok': 1,"
+                           " 'ismaster': true,"
+                           " 'setName': 'rs',"
+                           " 'minWireVersion': 2,"
+                           " 'maxWireVersion': 5,"
+                           " 'hosts': ['127.0.0.1:%hu', '127.0.0.1:%hu']}",
+                           mock_server_get_port (primary),
+                           mock_server_get_port (secondary));
 
    uri_str = bson_strdup_printf ("mongodb://127.0.0.1:%hu,127.0.0.1:%hu/"
                                  "?replicaSet=rs&connectTimeoutMS=%d",
@@ -1107,14 +1107,14 @@ _test_server_removed_during_handshake (bool pooled)
    server = mock_server_new ();
    mock_server_run (server);
    mock_server_autoresponds (server, auto_ping, NULL, NULL);
-   mock_server_auto_ismaster (server,
-                              "{'ok': 1,"
-                              " 'ismaster': true,"
-                              " 'setName': 'rs',"
-                              " 'minWireVersion': 2,"
-                              " 'maxWireVersion': 5,"
-                              " 'hosts': ['%s']}",
-                              mock_server_get_host_and_port (server));
+   mock_server_auto_hello (server,
+                           "{'ok': 1,"
+                           " 'ismaster': true,"
+                           " 'setName': 'rs',"
+                           " 'minWireVersion': 2,"
+                           " 'maxWireVersion': 5,"
+                           " 'hosts': ['%s']}",
+                           mock_server_get_host_and_port (server));
 
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    /* no auto heartbeat */
@@ -1142,14 +1142,14 @@ _test_server_removed_during_handshake (bool pooled)
    mongoc_server_description_destroy (sd);
 
    /* primary changes setName */
-   mock_server_auto_ismaster (server,
-                              "{'ok': 1,"
-                              " 'ismaster': true,"
-                              " 'setName': 'BAD NAME',"
-                              " 'minWireVersion': 2,"
-                              " 'maxWireVersion': 5,"
-                              " 'hosts': ['%s']}",
-                              mock_server_get_host_and_port (server));
+   mock_server_auto_hello (server,
+                           "{'ok': 1,"
+                           " 'ismaster': true,"
+                           " 'setName': 'BAD NAME',"
+                           " 'minWireVersion': 2,"
+                           " 'maxWireVersion': 5,"
+                           " 'hosts': ['%s']}",
+                           mock_server_get_host_and_port (server));
 
    /* pretend to close a connection. does NOT affect server description yet */
    mongoc_cluster_disconnect_node (&client->cluster, 1);
@@ -1291,14 +1291,14 @@ test_add_and_scan_failure (void)
    server = mock_server_new ();
    mock_server_run (server);
    /* client will discover "fake" host and fail to connect */
-   mock_server_auto_ismaster (server,
-                              "{'ok': 1,"
-                              " 'ismaster': true,"
-                              " 'setName': 'rs',"
-                              " 'minWireVersion': 2,"
-                              " 'maxWireVersion': 5,"
-                              " 'hosts': ['%s', 'fake:1']}",
-                              mock_server_get_host_and_port (server));
+   mock_server_auto_hello (server,
+                           "{'ok': 1,"
+                           " 'ismaster': true,"
+                           " 'setName': 'rs',"
+                           " 'minWireVersion': 2,"
+                           " 'maxWireVersion': 5,"
+                           " 'hosts': ['%s', 'fake:1']}",
+                           mock_server_get_host_and_port (server));
 
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_utf8 (uri, "replicaSet", "rs");
@@ -1640,11 +1640,11 @@ test_incompatible_error (void)
                           "reports wire version 2, but this version of"
                           " libmongoc requires at least 3 (MongoDB 3.0)");
 
-   mock_server_auto_ismaster (server,
-                              "{'ok': 1.0,"
-                              " 'ismaster': true,"
-                              " 'minWireVersion': 10,"
-                              " 'maxWireVersion': 11}");
+   mock_server_auto_hello (server,
+                           "{'ok': 1.0,"
+                           " 'ismaster': true,"
+                           " 'minWireVersion': 10,"
+                           " 'maxWireVersion': 11}");
 
    /* wait until it's time for next heartbeat */
    _mongoc_usleep (600 * 1000);
@@ -1730,12 +1730,12 @@ test_cluster_time_updated_during_handshake ()
    mock_server_run (server);
    mock_server_autoresponds (server, auto_ping, NULL, NULL);
    cluster_time = cluster_time_fmt (1);
-   mock_server_auto_ismaster (server,
-                              "{'ok': 1, 'ismaster': true, 'setName': 'rs', "
-                              "'minWireVersion': 2, 'maxWireVersion': 7, "
-                              "'hosts': ['%s'], '$clusterTime': %s}",
-                              mock_server_get_host_and_port (server),
-                              cluster_time);
+   mock_server_auto_hello (server,
+                           "{'ok': 1, 'ismaster': true, 'setName': 'rs', "
+                           "'minWireVersion': 2, 'maxWireVersion': 7, "
+                           "'hosts': ['%s'], '$clusterTime': %s}",
+                           mock_server_get_host_and_port (server),
+                           cluster_time);
 
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    /* set a large heartbeatFrequencyMS so we don't do a background scan in
@@ -1760,12 +1760,12 @@ test_cluster_time_updated_during_handshake ()
    cluster_time = cluster_time_fmt (2);
 
    /* primary changes clusterTime */
-   mock_server_auto_ismaster (server,
-                              "{'ok': 1, 'ismaster': true, 'setName': 'rs', "
-                              "'minWireVersion': 2, 'maxWireVersion': 7, "
-                              "'hosts': ['%s'], '$clusterTime': %s}",
-                              mock_server_get_host_and_port (server),
-                              cluster_time);
+   mock_server_auto_hello (server,
+                           "{'ok': 1, 'ismaster': true, 'setName': 'rs', "
+                           "'minWireVersion': 2, 'maxWireVersion': 7, "
+                           "'hosts': ['%s'], '$clusterTime': %s}",
+                           mock_server_get_host_and_port (server),
+                           cluster_time);
 
    /* remove the node from the cluster to trigger an ismaster handshake. */
    mongoc_cluster_disconnect_node (&client->cluster, 1);
@@ -1985,14 +1985,14 @@ test_last_server_removed_warning (void)
    client = test_framework_client_new_from_uri (uri, NULL);
    read_prefs = mongoc_read_prefs_new (MONGOC_READ_PRIMARY);
 
-   mock_server_auto_ismaster (server,
-                              "{'ok': 1,"
-                              " 'ismaster': true,"
-                              " 'setName': 'rs',"
-                              " 'minWireVersion': 2,"
-                              " 'maxWireVersion': 5,"
-                              " 'hosts': ['127.0.0.1:%hu']}",
-                              mock_server_get_port (server));
+   mock_server_auto_hello (server,
+                           "{'ok': 1,"
+                           " 'ismaster': true,"
+                           " 'setName': 'rs',"
+                           " 'minWireVersion': 2,"
+                           " 'maxWireVersion': 5,"
+                           " 'hosts': ['127.0.0.1:%hu']}",
+                           mock_server_get_port (server));
 
    capture_logs (true);
    description = mongoc_topology_select (
@@ -2138,7 +2138,7 @@ test_slow_server_pooled (void)
       "%s, 'ismaster': false, 'secondary': true }", ismaster_common);
 
    /* Primary responds immediately, but secondary does not. */
-   mock_server_auto_ismaster (primary, ismaster_primary);
+   mock_server_auto_hello (primary, ismaster_primary);
 
    uri = mongoc_uri_copy (mock_server_get_uri (primary));
    /* Do not connect as topology type Single, so the client pool discovers the
@@ -2180,7 +2180,7 @@ test_slow_server_pooled (void)
    /* Set up an auto responder so future ismasters on the secondary do not
     * block until connectTimeoutMS. Otherwise, the shutdown sequence will be
     * blocked for connectTimeoutMS. */
-   mock_server_auto_ismaster (secondary, ismaster_secondary);
+   mock_server_auto_hello (secondary, ismaster_secondary);
    /* Respond to the first ismaster. */
    mock_server_replies_simple (request, ismaster_secondary);
    request_destroy (request);

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -2210,7 +2210,7 @@ _test_ismaster_versioned_api (bool pooled)
    mongoc_uri_t *uri;
    mongoc_client_pool_t *pool;
    mongoc_client_t *client;
-   char *ismaster;
+   char *hello;
    future_t *future;
    request_t *request;
    bson_error_t error;
@@ -2231,13 +2231,13 @@ _test_ismaster_versioned_api (bool pooled)
       client = test_framework_client_new_from_uri (uri, api);
    }
 
-   ismaster = bson_strdup_printf ("{'ok': 1,"
-                                  " 'ismaster': true,"
-                                  " 'setName': 'rs',"
-                                  " 'minWireVersion': 2,"
-                                  " 'maxWireVersion': 5,"
-                                  " 'hosts': ['%s']}",
-                                  mock_server_get_host_and_port (server));
+   hello = bson_strdup_printf ("{'ok': 1,"
+                               " 'isWritablePrimary': true,"
+                               " 'setName': 'rs',"
+                               " 'minWireVersion': 2,"
+                               " 'maxWireVersion': 5,"
+                               " 'hosts': ['%s']}",
+                               mock_server_get_host_and_port (server));
 
    /* For client pools, the first handshake happens when the client is popped.
     * For non-pooled clients, send a ping command to trigger a handshake. */
@@ -2246,10 +2246,10 @@ _test_ismaster_versioned_api (bool pooled)
          client, "admin", tmp_bson ("{'ping': 1}"), NULL, NULL, &error);
    }
 
-   request = mock_server_receives_ismaster (server);
+   request = mock_server_receives_hello (server);
    BSON_ASSERT (request);
    BSON_ASSERT (bson_has_field (request_get_doc (request, 0), "apiVersion"));
-   mock_server_replies_simple (request, ismaster);
+   mock_server_replies_simple (request, hello);
    request_destroy (request);
 
    if (!pooled) {
@@ -2270,7 +2270,7 @@ _test_ismaster_versioned_api (bool pooled)
    mongoc_server_api_destroy (api);
    mongoc_uri_destroy (uri);
    mock_server_destroy (server);
-   bson_free (ismaster);
+   bson_free (hello);
 }
 
 static void

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -1635,7 +1635,12 @@ test_incompatible_error (void)
 
    /* trigger connection, fails due to incompatibility */
    ASSERT (!mongoc_client_command_simple (
-      client, "admin", tmp_bson ("{'hello': 1}"), NULL, NULL, &error));
+      client,
+      "admin",
+      tmp_bson ("{'" HANDSHAKE_CMD_LEGACY_HELLO "': 1}"),
+      NULL,
+      NULL,
+      &error));
 
    ASSERT_ERROR_CONTAINS (error,
                           MONGOC_ERROR_PROTOCOL,
@@ -1652,7 +1657,12 @@ test_incompatible_error (void)
    /* wait until it's time for next heartbeat */
    _mongoc_usleep (600 * 1000);
    ASSERT (!mongoc_client_command_simple (
-      client, "admin", tmp_bson ("{'hello': 1}"), NULL, NULL, &error));
+      client,
+      "admin",
+      tmp_bson ("{'" HANDSHAKE_CMD_LEGACY_HELLO "': 1}"),
+      NULL,
+      NULL,
+      &error));
 
    msg = bson_strdup_printf ("requires wire version 10, but this version"
                              " of libmongoc only supports up to %d",
@@ -1689,7 +1699,12 @@ test_compatible_null_error_pointer (void)
 
    /* trigger connection, fails due to incompatibility */
    ASSERT (!mongoc_client_command_simple (
-      client, "admin", tmp_bson ("{'hello': 1}"), NULL, NULL, &error));
+      client,
+      "admin",
+      tmp_bson ("{'" HANDSHAKE_CMD_LEGACY_HELLO "': 1}"),
+      NULL,
+      NULL,
+      &error));
 
    ASSERT_ERROR_CONTAINS (
       error, MONGOC_ERROR_PROTOCOL, MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION, "");

--- a/src/libmongoc/tests/test-mongoc-transactions.c
+++ b/src/libmongoc/tests/test-mongoc-transactions.c
@@ -427,9 +427,10 @@ test_in_transaction (void *ctx)
 
 
 static bool
-hangup_except_ismaster (request_t *request, void *data)
+hangup_except_hello (request_t *request, void *data)
 {
-   if (!bson_strcasecmp (request->command_name, "ismaster")) {
+   if (!bson_strcasecmp (request->command_name, HANDSHAKE_CMD_LEGACY_HELLO) ||
+       !bson_strcasecmp (request->command_name, "hello")) {
       /* allow default response */
       return false;
    }
@@ -478,7 +479,7 @@ _test_transient_txn_err (bool hangup)
 
    if (hangup) {
       /* test that network errors have TransientTransactionError */
-      mock_server_autoresponds (server, hangup_except_ismaster, NULL, NULL);
+      mock_server_autoresponds (server, hangup_except_hello, NULL, NULL);
    } else {
       /* test server selection errors have TransientTransactionError */
       mock_server_destroy (server);

--- a/src/libmongoc/tests/test-mongoc-write-commands.c
+++ b/src/libmongoc/tests/test-mongoc-write-commands.c
@@ -392,18 +392,18 @@ test_split_opquery_with_options (void)
                           " 'maxBsonObjectSize': 100}";
 
    server = mock_server_new ();
-   mock_server_auto_ismaster (server, ismaster);
+   mock_server_auto_hello (server, ismaster);
    mock_server_run (server);
 
    /* Create an insert with two batches. Because of the reduced
-   * maxBsonObjectSize, each document must be less than 100 bytes.
-   * Because of the hardcoded allowance (see SERVER-10643), and our current
-   * incorrect batching logic (see CDRIVER-3310) the complete insert
-   * command can be can be 16k + 100 bytes.
-   * After CDRIVER-3310, update this test, since the allowance will not be
-   * taken into consideration for document batching.
-   * So create enough documents to fill up at least one batch.
-   */
+    * maxBsonObjectSize, each document must be less than 100 bytes.
+    * Because of the hardcoded allowance (see SERVER-10643), and our current
+    * incorrect batching logic (see CDRIVER-3310) the complete insert
+    * command can be can be 16k + 100 bytes.
+    * After CDRIVER-3310, update this test, since the allowance will not be
+    * taken into consideration for document batching.
+    * So create enough documents to fill up at least one batch.
+    */
    n_docs = ((BSON_OBJECT_ALLOWANCE) / tmp_bson ("{ '_id': 1 }")->len) +
             1; /* inexact, but errs towards more than enough documents. */
    docs = bson_malloc (sizeof (bson_t *) * n_docs);
@@ -476,7 +476,7 @@ test_opmsg_disconnect_mid_batch_helper (int wire_version)
                           " 'maxBsonObjectSize': 100}";
 
    server = mock_server_new ();
-   mock_server_auto_ismaster (server, ismaster, wire_version);
+   mock_server_auto_hello (server, ismaster, wire_version);
    mock_server_run (server);
 
    /* create enough documents for two batches. Note, because of our wonky
@@ -537,9 +537,9 @@ test_w0_legacy_insert_many (void)
 
    /* wire version will use OP_INSERT for w:0 insert many (since no OP_MSG) */
    server = mock_server_new ();
-   mock_server_auto_ismaster (server,
-                              "{'ismaster': true,"
-                              " 'maxWireVersion': 5}");
+   mock_server_auto_hello (server,
+                           "{'ismaster': true,"
+                           " 'maxWireVersion': 5}");
    mock_server_run (server);
 
    docs = bson_malloc (sizeof (bson_t *) * 2);

--- a/src/libmongoc/tests/test-mongoc-write-commands.c
+++ b/src/libmongoc/tests/test-mongoc-write-commands.c
@@ -385,14 +385,14 @@ test_split_opquery_with_options (void)
    int n_docs;
 
    /* Use a reduced maxBsonObjectSize, and wire version for OP_QUERY */
-   const char *ismaster = "{'ok': 1.0,"
-                          " 'ismaster': true,"
-                          " 'minWireVersion': 0,"
-                          " 'maxWireVersion': 5,"
-                          " 'maxBsonObjectSize': 100}";
+   const char *hello = "{'ok': 1.0,"
+                       " 'isWritablePrimary': true,"
+                       " 'minWireVersion': 0,"
+                       " 'maxWireVersion': 5,"
+                       " 'maxBsonObjectSize': 100}";
 
    server = mock_server_new ();
-   mock_server_auto_hello (server, ismaster);
+   mock_server_auto_hello (server, hello);
    mock_server_run (server);
 
    /* Create an insert with two batches. Because of the reduced
@@ -469,14 +469,14 @@ test_opmsg_disconnect_mid_batch_helper (int wire_version)
    int n_docs;
 
    /* Use a reduced maxBsonObjectSize, and wire version for OP_QUERY */
-   const char *ismaster = "{'ok': 1.0,"
-                          " 'ismaster': true,"
-                          " 'minWireVersion': 0,"
-                          " 'maxWireVersion': %d,"
-                          " 'maxBsonObjectSize': 100}";
+   const char *hello = "{'ok': 1.0,"
+                       " 'isWritablePrimary': true,"
+                       " 'minWireVersion': 0,"
+                       " 'maxWireVersion': %d,"
+                       " 'maxBsonObjectSize': 100}";
 
    server = mock_server_new ();
-   mock_server_auto_hello (server, ismaster, wire_version);
+   mock_server_auto_hello (server, hello, wire_version);
    mock_server_run (server);
 
    /* create enough documents for two batches. Note, because of our wonky
@@ -538,7 +538,7 @@ test_w0_legacy_insert_many (void)
    /* wire version will use OP_INSERT for w:0 insert many (since no OP_MSG) */
    server = mock_server_new ();
    mock_server_auto_hello (server,
-                           "{'ismaster': true,"
+                           "{'isWritablePrimary': true,"
                            " 'maxWireVersion': 5}");
    mock_server_run (server);
 

--- a/src/libmongoc/tests/unified/runner.c
+++ b/src/libmongoc/tests/unified/runner.c
@@ -424,14 +424,14 @@ test_destroy (test_t *test)
 }
 
 static bool
-is_replset (bson_t *ismaster_reply)
+is_replset (bson_t *hello_reply)
 {
-   if (bson_has_field (ismaster_reply, "setName")) {
+   if (bson_has_field (hello_reply, "setName")) {
       return true;
    }
 
-   if (bson_has_field (ismaster_reply, "isreplicaset") &&
-       bson_lookup_bool (ismaster_reply, "isreplicaset") == true) {
+   if (bson_has_field (hello_reply, "isreplicaset") &&
+       bson_lookup_bool (hello_reply, "isreplicaset") == true) {
       return true;
    }
 
@@ -463,7 +463,16 @@ get_topology_type (mongoc_client_t *client)
    const char *topology_type = "single";
 
    ret = mongoc_client_command_simple (
-      client, "admin", tmp_bson ("{'ismaster': 1}"), NULL, &reply, &error);
+      client, "admin", tmp_bson ("{'hello': 1}"), NULL, &reply, &error);
+   if (!ret) {
+      ret = mongoc_client_command_simple (
+         client,
+         "admin",
+         tmp_bson ("{'" HANDSHAKE_CMD_LEGACY_HELLO "': 1}"),
+         NULL,
+         &reply,
+         &error);
+   }
    ASSERT_OR_PRINT (ret, error);
 
    if (is_replset (&reply)) {

--- a/src/libmongoc/tests/unified/runner.c
+++ b/src/libmongoc/tests/unified/runner.c
@@ -465,6 +465,7 @@ get_topology_type (mongoc_client_t *client)
    ret = mongoc_client_command_simple (
       client, "admin", tmp_bson ("{'hello': 1}"), NULL, &reply, &error);
    if (!ret) {
+      bson_destroy (&reply);
       ret = mongoc_client_command_simple (
          client,
          "admin",


### PR DESCRIPTION
CDRIVER-3947

This changes the topology scanner to use the `hello` command when an API version is declared on the client. To make this work properly, I had to extend the mock server to not only handle legacy hello commands but also the new `hello` command.

While making those changes, I changed some of the terminology but didn't make a complete effort, as that's covered by the "Remove oppressive language" project.
I also started making changes to the hello autoresponder for mock servers to avoid tests having to specify their own responder for the purpose of checking the hello command body. However, I did not wrap up this refactoring as the diff is already getting large. I'll follow up in a separate PR.