### PR TITLE
CDRIVER-3966 Sync transaction spec tests

### DIFF
--- a/src/libmongoc/tests/json/transactions/unified/mongos-unpin.json
+++ b/src/libmongoc/tests/json/transactions/unified/mongos-unpin.json
@@ -186,6 +186,55 @@
       ]
     },
     {
+      "description": "unpin after non-transient error on abort",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "abortTransaction"
+                ],
+                "errorCode": 91
+              }
+            }
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ]
+    },
+    {
       "description": "unpin when a new transaction is started",
       "operations": [
         {


### PR DESCRIPTION
Syncs transaction spec tests with mongodb/specifications@ec326862be443d11f0233cee2de32a95751144df. One change was missed in 2d7938aa068a1df70929a161c94642707cb4bd3e (#783).

Will merge once CI is green (ignoring ASAN failures).