### PR TITLE
document fam reply is empty for w0

### DIFF
--- a/src/libmongoc/doc/mongoc_collection_find_and_modify_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_collection_find_and_modify_with_opts.rst
@@ -32,6 +32,8 @@ Update and return an object.
 
 ``reply`` is always initialized, and must be freed with :symbol:`bson:bson_destroy()`.
 
+If an unacknowledged write concern is set (through :symbol:`mongoc_find_and_modify_opts_append`), the output ``reply`` is always an empty document.
+
 Errors
 ------
 


### PR DESCRIPTION
If an unacknowledged write concern is used as an option for a
mongoc_find_and_modify_with_opts, the output reply document is
always empty.