### PR TITLE
CDRIVER-3934 Correctly handle network errors during speculative authentication

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -2425,6 +2425,12 @@ mongoc_cluster_fetch_stream_single (mongoc_cluster_t *cluster,
       _mongoc_scram_destroy (&scanner_node->scram);
 #endif
 
+      if (!scanner_node->stream) {
+         memcpy (error, &sd->error, sizeof *error);
+         mongoc_server_description_destroy (sd);
+         return NULL;
+      }
+
       if (!has_speculative_auth &&
           !_mongoc_cluster_auth_node (cluster,
                                       scanner_node->stream,

--- a/src/libmongoc/tests/test-mongoc-change-stream.c
+++ b/src/libmongoc/tests/test-mongoc-change-stream.c
@@ -776,12 +776,14 @@ test_change_stream_resumable_error (void)
                                     "db",
                                     MONGOC_QUERY_SLAVE_OK,
                                     "{ 'getMore': 123, 'collection': 'coll' }");
+   BSON_ASSERT (request);
    mock_server_hangs_up (request);
    request_destroy (request);
 
    /* Retry command */
    request = mock_server_receives_command (
       server, "db", MONGOC_QUERY_SLAVE_OK, watch_cmd);
+   BSON_ASSERT (request);
    mock_server_replies_simple (
       request,
       "{'cursor': {'id': 124,'ns': 'db.coll','firstBatch': []},'ok': 1 }");


### PR DESCRIPTION
CDRIVER-3934

Also adds an assertion to avoid memory access failure that appeared once with VS15