### PR TITLE
CDRIVER-4001 Temporarily fix batchSize behaviour for getMore

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-cursor.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor.c
@@ -1709,7 +1709,7 @@ _mongoc_cursor_prepare_getmore_command (mongoc_cursor_t *cursor,
       bson_append_int64 (command,
                          MONGOC_CURSOR_BATCH_SIZE,
                          MONGOC_CURSOR_BATCH_SIZE_LEN,
-                         abs (_mongoc_n_return (cursor)));
+                         batch_size);
    }
 
    /* Find, getMore And killCursors Commands Spec: "In the case of a tailable

--- a/src/libmongoc/tests/json/command_monitoring/find.json
+++ b/src/libmongoc/tests/json/command_monitoring/find.json
@@ -356,7 +356,7 @@
               },
               "collection": "test",
               "batchSize": {
-                "$numberLong": "1"
+                "$numberLong": "3"
               }
             },
             "command_name": "getMore",
@@ -497,7 +497,7 @@
               },
               "collection": "test",
               "batchSize": {
-                "$numberLong": "1"
+                "$numberLong": "3"
               }
             },
             "command_name": "getMore",

--- a/src/libmongoc/tests/json/unified/poc-command-monitoring.json
+++ b/src/libmongoc/tests/json/unified/poc-command-monitoring.json
@@ -149,7 +149,7 @@
                     ]
                   },
                   "collection": "test",
-                  "batchSize": 1
+                  "batchSize": 3
                 },
                 "commandName": "getMore",
                 "databaseName": "command-monitoring-tests"

--- a/src/libmongoc/tests/test-mongoc-cursor.c
+++ b/src/libmongoc/tests/test-mongoc-cursor.c
@@ -1908,7 +1908,7 @@ _test_cursor_n_return_find_cmd (mongoc_cursor_t *cursor,
             &getmore_cmd, "batchSize", tmp_bson ("{'$exists': false}"));
       }
 
-      ASSERT (match_bson (request_get_doc (request, 0), &getmore_cmd, true));
+      assert_match_bson (request_get_doc (request, 0), &getmore_cmd, true);
 
       reply = bson_string_new (NULL);
       cursor_finished = (reply_no == 2);
@@ -1956,28 +1956,28 @@ _test_cursor_n_return (bool find_with_opts)
                                       0,         /* skip              */
                                       3,         /* limit             */
                                       0,         /* batch_size        */
-                                      {3, 2, 1}, /* expected_n_return */
+                                      {1, 1, 1}, /* expected_n_return */
                                       {1, 1, 1}  /* reply_length      */
                                    },
                                    {
                                       0,         /* skip              */
                                       5,         /* limit             */
                                       2,         /* batch_size        */
-                                      {2, 2, 1}, /* expected_n_return */
+                                      {2, 2, 2}, /* expected_n_return */
                                       {2, 2, 1}  /* reply_length      */
                                    },
                                    {
                                       0,         /* skip              */
                                       4,         /* limit             */
                                       7,         /* batch_size        */
-                                      {4, 2, 1}, /* expected_n_return */
+                                      {4, 7, 7}, /* expected_n_return */
                                       {2, 1, 1}  /* reply_length      */
                                    },
                                    {
                                       0,            /* skip              */
                                       -3,           /* limit             */
                                       1,            /* batch_size        */
-                                      {-3, -3, -3}, /* expected_n_return */
+                                      {1, 1, 1}, /* expected_n_return */
                                       {1, 1, 1}     /* reply_length      */
                                    }};
 


### PR DESCRIPTION
CDRIVER-4001

This PR proposes a fix for a number of tests that are currently failing due to slot-based execution (SBE) in the latest 5.0 builds. With SBE enabled we see the server keep the cursor alive when the end of a cursor is reached at the end of a batch. This usually doesn't occur too often, but the getMore command logic replicates the OP_GET_MORE behaviour of reducing the size of the last batch to fetch exactly `limit` documents. This triggers the unintended server behaviour for every cursor. While neither mandated nor prohibited, this behaviour is somewhat enforced by the command monitoring spec tests.

This PR updates the logic for the getMore command (OP_GET_MORE is unaffected) to always send the intended batch size. These changes can be safely reverted once the server behaviour is fixed, or when a better solution comes around.