### PR TITLE
Skip tests with dots and dollars in field names on 5.0+

### DIFF
--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -6674,20 +6674,24 @@ test_collection_install (TestSuite *suite)
                       NULL,
                       test_framework_skip_if_slow_or_live);
    TestSuite_AddLive (suite, "/Collection/many_return", test_many_return);
-   TestSuite_AddFull (suite,
-                      "/Collection/insert_one_validate",
-                      test_insert_one_validate,
-                      NULL,
-                      NULL,
-                      TestSuite_CheckLive,
-                      test_framework_skip_if_max_wire_version_more_than_9);
-   TestSuite_AddFull (suite,
-                      "/Collection/insert_many_validate",
-                      test_insert_many_validate,
-                      NULL,
-                      NULL,
-                      TestSuite_CheckLive,
-                      test_framework_skip_if_max_wire_version_more_than_9);
+   TestSuite_AddFull (
+      suite,
+      "/Collection/insert_one_validate",
+      test_insert_one_validate,
+      NULL,
+      NULL,
+      TestSuite_CheckLive,
+      /* TODO: remove checks when removing validation for dots and dollars */
+      test_framework_skip_if_max_wire_version_more_than_9);
+   TestSuite_AddFull (
+      suite,
+      "/Collection/insert_many_validate",
+      test_insert_many_validate,
+      NULL,
+      NULL,
+      TestSuite_CheckLive,
+      /* TODO: remove checks when removing validation for dots and dollars */
+      test_framework_skip_if_max_wire_version_more_than_9);
    TestSuite_AddMockServerTest (suite, "/Collection/limit", test_find_limit);
    TestSuite_AddMockServerTest (
       suite, "/Collection/batch_size", test_find_batch_size);
@@ -6739,13 +6743,15 @@ test_collection_install (TestSuite *suite)
    TestSuite_AddLive (suite,
                       "/Collection/estimated_document_count_live",
                       test_estimated_document_count_live);
-   TestSuite_AddFull (suite,
-                      "/Collection/insert_bulk_validate",
-                      test_insert_bulk_validate,
-                      NULL,
-                      NULL,
-                      TestSuite_CheckLive,
-                      test_framework_skip_if_max_wire_version_more_than_9);
+   TestSuite_AddFull (
+      suite,
+      "/Collection/insert_bulk_validate",
+      test_insert_bulk_validate,
+      NULL,
+      NULL,
+      TestSuite_CheckLive,
+      /* TODO: remove checks when removing validation for dots and dollars */
+      test_framework_skip_if_max_wire_version_more_than_9);
    TestSuite_AddMockServerTest (suite,
                                 "/Collection/aggregate_with_batch_size",
                                 test_aggregate_with_batch_size);

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -4016,7 +4016,7 @@ _test_insert_validate (insert_fn_t insert_fn)
 }
 
 static void
-test_insert_bulk_validate (void)
+test_insert_bulk_validate (void *ctx)
 {
    mongoc_client_t *client;
    mongoc_collection_t *collection;
@@ -4067,14 +4067,14 @@ test_insert_bulk_validate (void)
 
 
 static void
-test_insert_one_validate (void)
+test_insert_one_validate (void *ctx)
 {
    _test_insert_validate (insert_one);
 }
 
 
 static void
-test_insert_many_validate (void)
+test_insert_many_validate (void *ctx)
 {
    _test_insert_validate (insert_many);
 }
@@ -6674,10 +6674,20 @@ test_collection_install (TestSuite *suite)
                       NULL,
                       test_framework_skip_if_slow_or_live);
    TestSuite_AddLive (suite, "/Collection/many_return", test_many_return);
-   TestSuite_AddLive (
-      suite, "/Collection/insert_one_validate", test_insert_one_validate);
-   TestSuite_AddLive (
-      suite, "/Collection/insert_many_validate", test_insert_many_validate);
+   TestSuite_AddFull (suite,
+                      "/Collection/insert_one_validate",
+                      test_insert_one_validate,
+                      NULL,
+                      NULL,
+                      TestSuite_CheckLive,
+                      test_framework_skip_if_max_wire_version_more_than_9);
+   TestSuite_AddFull (suite,
+                      "/Collection/insert_many_validate",
+                      test_insert_many_validate,
+                      NULL,
+                      NULL,
+                      TestSuite_CheckLive,
+                      test_framework_skip_if_max_wire_version_more_than_9);
    TestSuite_AddMockServerTest (suite, "/Collection/limit", test_find_limit);
    TestSuite_AddMockServerTest (
       suite, "/Collection/batch_size", test_find_batch_size);
@@ -6729,8 +6739,13 @@ test_collection_install (TestSuite *suite)
    TestSuite_AddLive (suite,
                       "/Collection/estimated_document_count_live",
                       test_estimated_document_count_live);
-   TestSuite_AddLive (
-      suite, "/Collection/insert_bulk_validate", test_insert_bulk_validate);
+   TestSuite_AddFull (suite,
+                      "/Collection/insert_bulk_validate",
+                      test_insert_bulk_validate,
+                      NULL,
+                      NULL,
+                      TestSuite_CheckLive,
+                      test_framework_skip_if_max_wire_version_more_than_9);
    TestSuite_AddMockServerTest (suite,
                                 "/Collection/aggregate_with_batch_size",
                                 test_aggregate_with_batch_size);


### PR DESCRIPTION
Follows #793. Versioned API tests are fixed by #792. With all patches applied, tests pass again: https://spruce.mongodb.com/version/60a62eabc9ec443716160e3d/tasks

Note that these tests will be replaced by spec tests after the completion of DRIVERS-1237 (see https://github.com/mongodb/specifications/pull/980)