### PR TITLE
CDRIVER-3897 add tests for time-series collections

### DIFF
--- a/src/libmongoc/doc/mongoc_database_create_collection.rst
+++ b/src/libmongoc/doc/mongoc_database_create_collection.rst
@@ -29,6 +29,8 @@ This function creates a :symbol:`mongoc_collection_t` from the given :symbol:`mo
 
 If no write concern is provided in ``opts``, the database's write concern is used.
 
+For a list of all options, see `the MongoDB Manual entry on the create command <https://docs.mongodb.org/manual/reference/command/create/>`_.
+
 Errors
 ------
 

--- a/src/libmongoc/tests/json/collection-management/timeseries-collection.json
+++ b/src/libmongoc/tests/json/collection-management/timeseries-collection.json
@@ -53,12 +53,11 @@
           "object": "database0",
           "arguments": {
             "collection": "test",
-            "expireAfterSeconds": {
-              "$numberLong": "604800"
-            },
+            "expireAfterSeconds": 604800,
             "timeseries": {
               "timeField": "time",
-              "metaField": "meta"
+              "metaField": "meta",
+              "granularity": "minutes"
             }
           }
         },
@@ -87,9 +86,11 @@
               "commandStartedEvent": {
                 "command": {
                   "create": "test",
+                  "expireAfterSeconds": 604800,
                   "timeseries": {
                     "timeField": "time",
-                    "metaField": "meta"
+                    "metaField": "meta",
+                    "granularity": "minutes"
                   }
                 },
                 "databaseName": "ts-tests"
@@ -114,12 +115,11 @@
           "object": "database0",
           "arguments": {
             "collection": "test",
-            "expireAfterSeconds": {
-              "$numberLong": "604800"
-            },
+            "expireAfterSeconds": 604800,
             "timeseries": {
               "timeField": "time",
-              "metaField": "meta"
+              "metaField": "meta",
+              "granularity": "minutes"
             }
           }
         },
@@ -154,6 +154,34 @@
               }
             ]
           }
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "time": 1
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "time": {
+                "$date": {
+                  "$numberLong": "1552949630482"
+                }
+              }
+            },
+            {
+              "_id": 1,
+              "time": {
+                "$date": {
+                  "$numberLong": "1552949630483"
+                }
+              }
+            }
+          ]
         }
       ],
       "expectEvents": [
@@ -172,9 +200,11 @@
               "commandStartedEvent": {
                 "command": {
                   "create": "test",
+                  "expireAfterSeconds": 604800,
                   "timeseries": {
                     "timeField": "time",
-                    "metaField": "meta"
+                    "metaField": "meta",
+                    "granularity": "minutes"
                   }
                 },
                 "databaseName": "ts-tests"
@@ -203,6 +233,18 @@
                     }
                   ]
                 }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "test",
+                  "filter": {},
+                  "sort": {
+                    "time": 1
+                  }
+                },
+                "databaseName": "ts-tests"
               }
             }
           ]

--- a/src/libmongoc/tests/json/collection-management/timeseries-collection.json
+++ b/src/libmongoc/tests/json/collection-management/timeseries-collection.json
@@ -1,0 +1,213 @@
+{
+  "description": "timeseries-collection",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "5.0"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "ts-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "ts-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "createCollection with all options",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "expireAfterSeconds": {
+              "$numberLong": "604800"
+            },
+            "timeseries": {
+              "timeField": "time",
+              "metaField": "meta"
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "ts-tests",
+            "collectionName": "test"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "test"
+                },
+                "databaseName": "ts-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "create": "test",
+                  "timeseries": {
+                    "timeField": "time",
+                    "metaField": "meta"
+                  }
+                },
+                "databaseName": "ts-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "insertMany with duplicate ids",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "expireAfterSeconds": {
+              "$numberLong": "604800"
+            },
+            "timeseries": {
+              "timeField": "time",
+              "metaField": "meta"
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "ts-tests",
+            "collectionName": "test"
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1,
+                "time": {
+                  "$date": {
+                    "$numberLong": "1552949630482"
+                  }
+                }
+              },
+              {
+                "_id": 1,
+                "time": {
+                  "$date": {
+                    "$numberLong": "1552949630483"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "test"
+                },
+                "databaseName": "ts-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "create": "test",
+                  "timeseries": {
+                    "timeField": "time",
+                    "metaField": "meta"
+                  }
+                },
+                "databaseName": "ts-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "time": {
+                        "$date": {
+                          "$numberLong": "1552949630482"
+                        }
+                      }
+                    },
+                    {
+                      "_id": 1,
+                      "time": {
+                        "$date": {
+                          "$numberLong": "1552949630483"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/libmongoc/tests/unified/runner.c
+++ b/src/libmongoc/tests/unified/runner.c
@@ -1153,7 +1153,7 @@ test_check_outcome_collection (test_t *test,
       expected_sorted = bson_copy_and_sort (&expected);
 
 
-      if (!bson_equal (&actual, &expected)) {
+      if (!bson_equal (actual_sorted, expected_sorted)) {
          test_set_error (error,
                          "expected %s, but got %s",
                          tmp_json (expected_sorted),
@@ -1493,4 +1493,6 @@ test_install_unified (TestSuite *suite)
    run_unified_tests (suite, JSON_DIR "/crud/unified");
 
    run_unified_tests (suite, JSON_DIR "/transactions/unified");
+
+   run_unified_tests (suite, JSON_DIR "/collection-management");
 }


### PR DESCRIPTION
Resyncs tests to include the new time-series spec tests and fixes a bug in the unified test runner's outcome matching. No code changes were required.

- `authentication-tests-openssl-nosasl` task failures are due to CDRIVER-3998
- `test-asan-latest-*` task failures will be resolved with the Ubuntu 18.04 upgrade to pull in latest server releases: CDRIVER-3946