### PR TITLE
CDRIVER-3895: Sync CRUD tests for dots/dollars

### DIFF
--- a/src/libmongoc/tests/json/crud/unified/aggregate-let.json
+++ b/src/libmongoc/tests/json/crud/unified/aggregate-let.json
@@ -23,6 +23,13 @@
         "database": "database0",
         "collectionName": "coll0"
       }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database0",
+        "collectionName": "coll1"
+      }
     }
   ],
   "initialData": [
@@ -34,6 +41,11 @@
           "_id": 1
         }
       ]
+    },
+    {
+      "collectionName": "coll1",
+      "databaseName": "crud-tests",
+      "documents": []
     }
   ],
   "tests": [
@@ -42,6 +54,109 @@
       "runOnRequirements": [
         {
           "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "$expr": {
+                    "$eq": [
+                      "$_id",
+                      "$$id"
+                    ]
+                  }
+                }
+              },
+              {
+                "$project": {
+                  "_id": 0,
+                  "x": "$$x",
+                  "y": "$$y",
+                  "rand": "$$rand"
+                }
+              }
+            ],
+            "let": {
+              "id": 1,
+              "x": "foo",
+              "y": {
+                "$literal": "bar"
+              },
+              "rand": {
+                "$rand": {}
+              }
+            }
+          },
+          "expectResult": [
+            {
+              "x": "foo",
+              "y": "bar",
+              "rand": {
+                "$$type": "double"
+              }
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "$expr": {
+                          "$eq": [
+                            "$_id",
+                            "$$id"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": 0,
+                        "x": "$$x",
+                        "y": "$$y",
+                        "rand": "$$rand"
+                      }
+                    }
+                  ],
+                  "let": {
+                    "id": 1,
+                    "x": "foo",
+                    "y": {
+                      "$literal": "bar"
+                    },
+                    "rand": {
+                      "$rand": {}
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate with let option and dollar-prefixed $literal value",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0",
+          "topologies": [
+            "single",
+            "replicaset"
+          ]
         }
       ],
       "operations": [
@@ -183,6 +298,174 @@
                   ],
                   "let": {
                     "x": "foo"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate to collection with let option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "$expr": {
+                    "$eq": [
+                      "$_id",
+                      "$$id"
+                    ]
+                  }
+                }
+              },
+              {
+                "$project": {
+                  "_id": 1
+                }
+              },
+              {
+                "$out": "coll1"
+              }
+            ],
+            "let": {
+              "id": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "$expr": {
+                          "$eq": [
+                            "$_id",
+                            "$$id"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$out": "coll1"
+                    }
+                  ],
+                  "let": {
+                    "id": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll1",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate to collection with let option unsupported (server-side error)",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "2.6.0",
+          "maxServerVersion": "4.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "$expr": {
+                    "$eq": [
+                      "$_id",
+                      "$$id"
+                    ]
+                  }
+                }
+              },
+              {
+                "$project": {
+                  "_id": 1
+                }
+              },
+              {
+                "$out": "coll1"
+              }
+            ],
+            "let": {
+              "id": 1
+            }
+          },
+          "expectError": {
+            "errorContains": "unrecognized field 'let'",
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "$expr": {
+                          "$eq": [
+                            "$_id",
+                            "$$id"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$out": "coll1"
+                    }
+                  ],
+                  "let": {
+                    "id": 1
                   }
                 }
               }

--- a/src/libmongoc/tests/json/crud/unified/insertOne-dots_and_dollars.json
+++ b/src/libmongoc/tests/json/crud/unified/insertOne-dots_and_dollars.json
@@ -63,7 +63,6 @@
             }
           },
           "expectResult": {
-            "insertedCount": 1,
             "insertedId": {
               "$$unsetOrMatches": 1
             }
@@ -166,7 +165,6 @@
             }
           },
           "expectResult": {
-            "insertedCount": 1,
             "insertedId": {
               "$$unsetOrMatches": 1
             }
@@ -221,7 +219,6 @@
             }
           },
           "expectResult": {
-            "insertedCount": 1,
             "insertedId": {
               "$$unsetOrMatches": 1
             }
@@ -280,7 +277,6 @@
             }
           },
           "expectResult": {
-            "insertedCount": 1,
             "insertedId": {
               "$$unsetOrMatches": 1
             }
@@ -390,7 +386,6 @@
             }
           },
           "expectResult": {
-            "insertedCount": 1,
             "insertedId": {
               "$$unsetOrMatches": {
                 "a.b": 1
@@ -501,7 +496,6 @@
             }
           },
           "expectResult": {
-            "insertedCount": 1,
             "insertedId": {
               "$$unsetOrMatches": 1
             }


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-3895

Synced with mongodb/specifications@fc21cb7330925647e7961c324f1594096025c17e (see https://github.com/mongodb/specifications/pull/1028 for more context).

Note: this also pulls in test changes relevant to aggregate let support (CDRIVER-4010)

@rcsanchez97: The previous PR for CDRIVER-3895 (#801) introduced `aggregate-let.json` and this PR pulls in the latest updates from https://github.com/mongodb/specifications/commit/3a58fc612b3520030a97a1161a5651c451c40f8e. Per @kevinAlbs' comment in [CDRIVER-4010](https://jira.mongodb.org/browse/CDRIVER-4010?focusedCommentId=3881139&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-3881139) there may be no other work required for that ticket (perhaps beyond documentation if applicable) if the spec tests currently pass.