### PR TITLE
CDRIVER-4010 support 'let' option for aggregate command

### DIFF
--- a/build/generate-opts.py
+++ b/build/generate-opts.py
@@ -320,7 +320,8 @@ opts_structs = OrderedDict([
         bypass_option,
         collation_option,
         server_option,
-        ('batchSize', {'type': 'int32_t', 'help': 'An ``int32`` representing number of documents requested to be returned on each call to :symbol:`mongoc_cursor_next`', 'check_set': True})
+        ('batchSize', {'type': 'int32_t', 'help': 'An ``int32`` representing number of documents requested to be returned on each call to :symbol:`mongoc_cursor_next`', 'check_set': True}),
+        ('let', {'type': 'document', 'help': 'A BSON document consisting of any number of parameter names, each followed by definitions of constants in the MQL Aggregate Expression language'})
     ])),
 
     ('mongoc_find_and_modify_appended_opts_t', Struct([

--- a/src/libmongoc/doc/includes/aggregate-opts.txt
+++ b/src/libmongoc/doc/includes/aggregate-opts.txt
@@ -12,3 +12,4 @@
 * ``collation``: Configure textual comparisons. See :ref:`Setting Collation Order <setting_collation_order>`, and `the MongoDB Manual entry on Collation <https://docs.mongodb.com/manual/reference/collation/>`_. Collation requires MongoDB 3.2 or later, otherwise an error is returned.
 * ``serverId``: To target a specific server, include an int32 "serverId" field. Obtain the id by calling :symbol:`mongoc_client_select_server`, then :symbol:`mongoc_server_description_id` on its return value.
 * ``batchSize``: An ``int32`` representing number of documents requested to be returned on each call to :symbol:`mongoc_cursor_next`
+* ``let``: A BSON document consisting of any number of parameter names, each followed by definitions of constants in the MQL Aggregate Expression language

--- a/src/libmongoc/src/mongoc/mongoc-opts-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-opts-private.h
@@ -185,6 +185,7 @@ typedef struct _mongoc_aggregate_opts_t {
    uint32_t serverId;
    int32_t batchSize;
    bool batchSize_is_set;
+   bson_t let;
    bson_t extra;
 } mongoc_aggregate_opts_t;
 

--- a/src/libmongoc/src/mongoc/mongoc-opts.c
+++ b/src/libmongoc/src/mongoc/mongoc-opts.c
@@ -1885,6 +1885,7 @@ _mongoc_aggregate_opts_parse (
    mongoc_aggregate_opts->serverId = 0;
    mongoc_aggregate_opts->batchSize = 0;
    mongoc_aggregate_opts->batchSize_is_set = false;
+   bson_init (&mongoc_aggregate_opts->let);
    bson_init (&mongoc_aggregate_opts->extra);
 
    if (!opts) {
@@ -1967,6 +1968,15 @@ _mongoc_aggregate_opts_parse (
 
          mongoc_aggregate_opts->batchSize_is_set = true;
       }
+      else if (!strcmp (bson_iter_key (&iter), "let")) {
+         if (!_mongoc_convert_document (
+               client,
+               &iter,
+               &mongoc_aggregate_opts->let,
+               error)) {
+            return false;
+         }
+      }
       else {
          /* unrecognized values are copied to "extra" */
          if (!BSON_APPEND_VALUE (
@@ -1993,6 +2003,7 @@ _mongoc_aggregate_opts_cleanup (mongoc_aggregate_opts_t *mongoc_aggregate_opts)
       mongoc_write_concern_destroy (mongoc_aggregate_opts->writeConcern);
    }
    bson_destroy (&mongoc_aggregate_opts->collation);
+   bson_destroy (&mongoc_aggregate_opts->let);
    bson_destroy (&mongoc_aggregate_opts->extra);
 }
 


### PR DESCRIPTION
Full patch build: https://spruce.mongodb.com/version/60d5ee4be3c33111e05b9faa/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

I checked quite a few of the failures in that patch build in every single case (with one exception*) the failure in the patch build was identical to the failure of the same task in the base commit.  *The one exception is a Valgrind test that had a hard failure in the base commit but which timed out in the patch build.

Based on this, it seems like the C driver already has the necessary support, so simply updating the CRUD JSON test is all we need to do.