### PR TITLE
CDRIVER-4028 Print correct error message when DNS resolution fails

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -306,7 +306,6 @@ _mongoc_hstrerror (int code)
    case HOST_NOT_FOUND:
       return "The specified host is unknown.";
    case NO_ADDRESS:
-   case NO_DATA:
       return "The requested name is valid but does not have an IP address.";
    case NO_RECOVERY:
       return "A nonrecoverable name server error occurred.";

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -299,6 +299,25 @@ typedef bool (*mongoc_rr_callback_t) (const char *service,
                                       mongoc_rr_data_t *rr_data,
                                       bson_error_t *error);
 
+static const char *
+_mongoc_hstrerror (int code)
+{
+   switch (code) {
+   case HOST_NOT_FOUND:
+      return "The specified host is unknown.";
+   case NO_ADDRESS:
+   case NO_DATA:
+      return "The requested name is valid but does not have an IP address.";
+   case NO_RECOVERY:
+      return "A nonrecoverable name server error occurred.";
+   case TRY_AGAIN:
+      return "A temporary error occurred on an authoritative name server. Try "
+             "again later.";
+   default:
+      return "An unknown error occurred.";
+   }
+}
+
 static bool
 srv_callback (const char *service,
               ns_msg *ns_answer,
@@ -328,7 +347,7 @@ srv_callback (const char *service,
    if (size < 1) {
       DNS_ERROR ("Invalid record in SRV answer for \"%s\": \"%s\"",
                  service,
-                 strerror (h_errno));
+                 _mongoc_hstrerror (h_errno));
    }
 
    if (!_mongoc_host_list_from_hostport_with_err (
@@ -474,7 +493,7 @@ _mongoc_get_rr_search (const char *service,
          DNS_ERROR ("Failed to look up %s record \"%s\": %s",
                     rr_type_name,
                     service,
-                    strerror (h_errno));
+                    _mongoc_hstrerror (h_errno));
       }
    } while (size >= buffer_size);
 
@@ -495,7 +514,7 @@ _mongoc_get_rr_search (const char *service,
                     i,
                     rr_type_name,
                     service,
-                    strerror (h_errno));
+                    _mongoc_hstrerror (h_errno));
       }
 
       /* Skip records that don't match the ones we requested. CDRIVER-3628 shows


### PR DESCRIPTION
CDRIVER-4028

I'll backport the resulting commit to r1.17 after merging.