### PR TITLE
CDRIVER-3978 mix time to avoid duplicate RAND_bytes for the same PIDs

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-rand-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-rand-openssl.c
@@ -28,6 +28,18 @@
 int
 _mongoc_rand_bytes (uint8_t *buf, int num)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10101000L
+   /* Versions of OpenSSL before 1.1.1 can potentially produce the same random
+    * sequences in processes with the same PID. Rather than attempt to detect
+    * PID changes (useful for parent/child forking but not if PIDs wrap), mix
+    * the current time into the generator's state.
+    * See also: https://wiki.openssl.org/index.php/Random_fork-safety */
+   struct timeval tv;
+
+   bson_gettimeofday (&tv);
+   RAND_add (&tv, sizeof(tv), 0.0);
+#endif
+
    return RAND_bytes (buf, num);
 }
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-3978

I opted not to implement PID-change detection, as https://www.agwa.name/blog/post/libressls_prng_is_unsafe_on_linux described a case where a grandparent and grandchild could theoretically shares the same PID.

Always mixing the current time before calling `RAND_bytes` seemed much simpler. This is the same approach taken in PHP (https://github.com/php/php-src/blob/php-8.0.8/ext/openssl/openssl.c#L936), and another patch to OpenSSL (https://github.com/openssl/openssl/commit/3cd8547a2018ada88a4303067a2aa15eadc17f39) mentioned in https://wiki.openssl.org/index.php/Random_fork-safety.

Will cherry-pick to r1.17 after merging.