### PR TITLE
CDRIVER-4000 Remove undefined macro

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-apm.c
+++ b/src/libmongoc/src/mongoc/mongoc-apm.c
@@ -900,7 +900,7 @@ mongoc_apm_is_sensitive_command (const char *command_name,
    }
 
    if (0 != strcasecmp (command_name, "hello") &&
-       0 != strcasecmp (command_name, HANDSHAKE_CMD_LEGACY_HELLO)) {
+       0 != strcasecmp (command_name, "ismaster")) {
       return false;
    }
 
@@ -926,7 +926,7 @@ mongoc_apm_is_sensitive_reply (const char *command_name, const bson_t *reply)
    }
 
    if (0 != strcasecmp (command_name, "hello") &&
-       0 != strcasecmp (command_name, HANDSHAKE_CMD_LEGACY_HELLO)) {
+       0 != strcasecmp (command_name, "ismaster")) {
       return false;
    }
 


### PR DESCRIPTION
Fix backport of CDRIVER-4000 to r1.17 branch.

Merge this only to the r1.17 branch.

Patch in progress: https://spruce.mongodb.com/version/60e47dea3627e06703e137b6/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC