### PR TITLE
CDRIVER-3653 use handshake metadata for connection checks

### DIFF
--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -983,6 +983,7 @@ set (test-libmongoc-sources
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-server-description.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-server-selection-errors.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-server-selection.c
+   ${PROJECT_SOURCE_DIR}/tests/test-mongoc-server-stream.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-set.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-socket.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-speculative-auth.c

--- a/src/libmongoc/doc/mongoc_client_get_handshake_description.rst
+++ b/src/libmongoc/doc/mongoc_client_get_handshake_description.rst
@@ -21,21 +21,14 @@ Description
 
 :symbol:`mongoc_client_get_handshake_description` is distinct from :symbol:`mongoc_client_get_server_description`. :symbol:`mongoc_client_get_server_description` returns a server description constructed from monitoring, which may differ from the server description constructed from the connection handshake.
 
-Use this function only for building a language driver that wraps the C Driver. When writing applications in C, higher-level functions automatically select a suitable server.
+:symbol:`mongoc_client_get_handshake_description` will attempt to establish a connection to the server if a connection was not already established. It will perform the MongoDB handshake and authentication if required.
 
-:symbol:`mongoc_client_get_handshake_description` does not attempt to establish a connection to the server if a connection was not already established. If a connection has not been established, this returns ``NULL`` and sets ``error``.
+Use this function only for building a language driver that wraps the C Driver. When writing applications in C, higher-level functions automatically select a suitable server.
 
 Single-threaded client behavior
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-To ensure a connection has been established ensure that the server is selectable (e.g. by calling :symbol:`mongoc_client_select_server`) or that an operation has successfully run on the server (e.g. by sending "ping").
 
-If the established connection has not completed authentication, calling :symbol:`mongoc_client_get_handshake_description` will complete authentication on the connection.
-
-Single-threaded clients only have one active connection to each server. The one connection is used for both monitoring and application operations. However, the server description returned by :symbol:`mongoc_client_get_handshake_description` may still differ from :symbol:`mongoc_client_get_server_description`. Notably, if connected to a load balanced cluster, the :symbol:`mongoc_client_get_server_description` will describe the load balancer server (:symbol:`mongoc_server_description_type` will return "LoadBalancer"). And :symbol:`mongoc_client_get_handshake_description` will describe the backing server.
-
-Pooled client behavior
-^^^^^^^^^^^^^^^^^^^^^^
-To ensure a connection has been established ensure an operation has successfully run on a server (e.g. by sending "ping").
+Single-threaded clients only have one active connection to each server. The one connection is used for both monitoring and application operations. However, the server description returned by :symbol:`mongoc_client_get_handshake_description` may still differ from the server description returned by :symbol:`mongoc_client_get_server_description`. Notably, if connected to a load balanced cluster, the :symbol:`mongoc_client_get_server_description` will describe the load balancer server (:symbol:`mongoc_server_description_type` will return "LoadBalancer"). And :symbol:`mongoc_client_get_handshake_description` will describe the backing server.
 
 Parameters
 ----------
@@ -48,7 +41,7 @@ Parameters
 Returns
 -------
 
-A :symbol:`mongoc_server_description_t` that must be freed with :symbol:`mongoc_server_description_destroy`. If a connection has not been successfully established to a server, returns NULL and ``error`` is filled out.
+A :symbol:`mongoc_server_description_t` that must be freed with :symbol:`mongoc_server_description_destroy`. If a connection has not been successfully established to a server, returns ``NULL`` and ``error`` is filled out.
 
 
 See Also

--- a/src/libmongoc/doc/mongoc_client_get_handshake_description.rst
+++ b/src/libmongoc/doc/mongoc_client_get_handshake_description.rst
@@ -28,7 +28,7 @@ Use this function only for building a language driver that wraps the C Driver. W
 Single-threaded client behavior
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Single-threaded clients only have one active connection to each server. The one connection is used for both monitoring and application operations. However, the server description returned by :symbol:`mongoc_client_get_handshake_description` may still differ from the server description returned by :symbol:`mongoc_client_get_server_description`. Notably, if connected to a load balanced cluster, the :symbol:`mongoc_client_get_server_description` will describe the load balancer server (:symbol:`mongoc_server_description_type` will return "LoadBalancer"). And :symbol:`mongoc_client_get_handshake_description` will describe the backing server.
+Single-threaded clients only have one active connection to each server. The one connection is used for both monitoring and application operations. However, the server description returned by :symbol:`mongoc_client_get_handshake_description` may still differ from the server description returned by :symbol:`mongoc_client_get_server_description`. Notably, if connected to a load balanced cluster, the server description returned by :symbol:`mongoc_client_get_server_description` will describe the load balancer server (:symbol:`mongoc_server_description_type` will return "LoadBalancer"). And the server description returned by :symbol:`mongoc_client_get_handshake_description` will describe the backing server.
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_client_get_handshake_description.rst
+++ b/src/libmongoc/doc/mongoc_client_get_handshake_description.rst
@@ -21,13 +21,21 @@ Description
 
 :symbol:`mongoc_client_get_handshake_description` is distinct from :symbol:`mongoc_client_get_server_description`. :symbol:`mongoc_client_get_server_description` returns a server description constructed from monitoring, which may differ from the server description constructed from the connection handshake.
 
-:symbol:`mongoc_client_get_handshake_description` does not attempt to establish a connection to the server if a connection was not already established. It will complete authentication on a single-threaded client if the connection has not yet been used by an operation.
-
-To establish a connection on a single-threaded client, ensure the server is selectable (the monitoring connection is the only connection made to the server). This can be done with a function like :symbol:`mongoc_client_select_server`, or any function which performs server selection.
-
-To establish a connection on a pooled client, send a command (e.g. ping) to the server.
-
 Use this function only for building a language driver that wraps the C Driver. When writing applications in C, higher-level functions automatically select a suitable server.
+
+:symbol:`mongoc_client_get_handshake_description` does not attempt to establish a connection to the server if a connection was not already established. If a connection has not been established, this returns ``NULL`` and sets ``error``.
+
+Single-threaded client behavior
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+To ensure a connection has been established ensure that the server is selectable (e.g. by calling :symbol:`mongoc_client_select_server`) or that an operation has successfully run on the server (e.g. by sending "ping").
+
+If the established connection has not completed authentication, calling :symbol:`mongoc_client_get_handshake_description` will complete authentication on the connection.
+
+Single-threaded clients only have one active connection to each server. The one connection is used for both monitoring and application operations. However, the server description returned by :symbol:`mongoc_client_get_handshake_description` may still differ from :symbol:`mongoc_client_get_server_description`. Notably, if connected to a load balanced cluster, the :symbol:`mongoc_client_get_server_description` will describe the load balancer server (:symbol:`mongoc_server_description_type` will return "LoadBalancer"). And :symbol:`mongoc_client_get_handshake_description` will describe the backing server.
+
+Pooled client behavior
+^^^^^^^^^^^^^^^^^^^^^^
+To ensure a connection has been established ensure an operation has successfully run on a server (e.g. by sending "ping").
 
 Parameters
 ----------
@@ -48,3 +56,4 @@ See Also
 
 - :symbol:`mongoc_client_select_server` To select a server from read preferences.
 - :symbol:`mongoc_client_get_server_description` To obtain the server description from monitoring for a server.
+- :symbol:`mongoc_server_description_type` To obtain the type of server from a server description.

--- a/src/libmongoc/doc/mongoc_client_get_handshake_description.rst
+++ b/src/libmongoc/doc/mongoc_client_get_handshake_description.rst
@@ -1,0 +1,50 @@
+:man_page: mongoc_client_get_handshake_description
+
+mongoc_client_get_handshake_description()
+=========================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   mongoc_server_description_t *
+   mongoc_client_get_handshake_description (mongoc_client_t *client,
+                                            uint32_t server_id,
+                                            bson_t *opts,
+                                            bson_error_t *error);
+
+Returns a description constructed from the initial handshake response to a server.
+
+Description
+-----------
+
+:symbol:`mongoc_client_get_handshake_description` is distinct from :symbol:`mongoc_client_get_server_description`. :symbol:`mongoc_client_get_server_description` returns a server description constructed from monitoring, which may differ from the server description constructed from the connection handshake.
+
+:symbol:`mongoc_client_get_handshake_description` does not attempt to establish a connection to the server if a connection was not already established. It will complete authentication on a single-threaded client if the connection has not yet been used by an operation.
+
+To establish a connection on a single-threaded client, ensure the server is selectable (the monitoring connection is the only connection made to the server). This can be done with a function like :symbol:`mongoc_client_select_server`, or any function which performs server selection.
+
+To establish a connection on a pooled client, send a command (e.g. ping) to the server.
+
+Use this function only for building a language driver that wraps the C Driver. When writing applications in C, higher-level functions automatically select a suitable server.
+
+Parameters
+----------
+
+* ``client``: A :symbol:`mongoc_client_t`.
+* ``server_id``: The ID of the server. This can be obtained from the server description of :symbol:`mongoc_client_select_server`.
+* ``opts``: Unused. Pass ``NULL``.
+* ``error``: An optional location for a :symbol:`bson_error_t <errors>` or ``NULL``.
+
+Returns
+-------
+
+A :symbol:`mongoc_server_description_t` that must be freed with :symbol:`mongoc_server_description_destroy`. If a connection has not been successfully established to a server, returns NULL and ``error`` is filled out.
+
+
+See Also
+--------
+
+- :symbol:`mongoc_client_select_server` To select a server from read preferences.
+- :symbol:`mongoc_client_get_server_description` To obtain the server description from monitoring for a server.

--- a/src/libmongoc/doc/mongoc_client_t.rst
+++ b/src/libmongoc/doc/mongoc_client_t.rst
@@ -61,6 +61,7 @@ Example
     mongoc_client_get_database_names_with_opts
     mongoc_client_get_default_database
     mongoc_client_get_gridfs
+    mongoc_client_get_handshake_description
     mongoc_client_get_max_bson_size
     mongoc_client_get_max_message_size
     mongoc_client_get_read_concern

--- a/src/libmongoc/doc/mongoc_server_description_type.rst
+++ b/src/libmongoc/doc/mongoc_server_description_type.rst
@@ -24,6 +24,7 @@ This function returns a string, one of the server types defined in the Server Di
 * Standalone
 * Mongos
 * PossiblePrimary
+* LoadBalancer
 * RSPrimary
 * RSSecondary
 * RSArbiter

--- a/src/libmongoc/src/mongoc/mongoc-change-stream.c
+++ b/src/libmongoc/src/mongoc/mongoc-change-stream.c
@@ -15,6 +15,7 @@
  */
 
 #include <bson/bson.h>
+#include "mongoc-cluster-private.h"
 #include "mongoc-change-stream-private.h"
 #include "mongoc-collection-private.h"
 #include "mongoc-client-private.h"
@@ -235,23 +236,12 @@ _make_cursor (mongoc_change_stream_t *stream)
    bson_t reply;
    bson_t getmore_opts = BSON_INITIALIZER;
    bson_iter_t iter;
-   mongoc_server_description_t *sd;
-   uint32_t server_id;
+   mongoc_server_stream_t *server_stream;
 
    BSON_ASSERT (stream);
    BSON_ASSERT (!stream->cursor);
    bson_init (&command);
    bson_copy_to (&(stream->opts.extra), &command_opts);
-   sd = mongoc_client_select_server (
-      stream->client, false /* for_writes */, stream->read_prefs, &stream->err);
-   if (!sd) {
-      goto cleanup;
-   }
-   server_id = mongoc_server_description_id (sd);
-   bson_append_int32 (&command_opts, "serverId", 8, server_id);
-   bson_append_int32 (&getmore_opts, "serverId", 8, server_id);
-   stream->max_wire_version = sd->max_wire_version;
-   mongoc_server_description_destroy (sd);
 
    if (bson_iter_init_find (&iter, &command_opts, "sessionId")) {
       if (!_mongoc_client_session_from_iter (
@@ -288,6 +278,19 @@ _make_cursor (mongoc_change_stream_t *stream)
    if (cs && !mongoc_client_session_append (cs, &getmore_opts, &stream->err)) {
       goto cleanup;
    }
+
+   server_stream = mongoc_cluster_stream_for_reads (
+      &stream->client->cluster, stream->read_prefs, cs, &reply, &stream->err);
+   if (!server_stream) {
+      bson_destroy (&stream->err_doc);
+      bson_copy_to (&reply, &stream->err_doc);
+      bson_destroy (&reply);
+      goto cleanup;
+   }
+   bson_append_int32 (&command_opts, "serverId", 8, server_stream->sd->id);
+   bson_append_int32 (&getmore_opts, "serverId", 8, server_stream->sd->id);
+   stream->max_wire_version = server_stream->sd->max_wire_version;
+   mongoc_server_stream_cleanup (server_stream);
 
    if (stream->read_concern && !bson_has_field (&command_opts, "readConcern")) {
       mongoc_read_concern_append (stream->read_concern, &command_opts);

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -3154,7 +3154,7 @@ mongoc_client_get_handshake_description (mongoc_client_t *client,
 
    server_stream = mongoc_cluster_stream_for_server (&client->cluster,
                                                      server_id,
-                                                     false /* reconnect */,
+                                                     true /* reconnect */,
                                                      NULL /* client session */,
                                                      NULL /* reply */,
                                                      error);

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -3142,3 +3142,27 @@ mongoc_client_set_server_api (mongoc_client_t *client,
    bson_mutex_unlock (&client->topology->mutex);
    return true;
 }
+
+mongoc_server_description_t *
+mongoc_client_get_handshake_description (mongoc_client_t *client,
+                                         uint32_t server_id,
+                                         bson_t *opts,
+                                         bson_error_t *error)
+{
+   mongoc_server_stream_t *server_stream;
+   mongoc_server_description_t *sd;
+
+   server_stream = mongoc_cluster_stream_for_server (&client->cluster,
+                                                     server_id,
+                                                     false /* reconnect */,
+                                                     NULL /* client session */,
+                                                     NULL /* reply */,
+                                                     error);
+   if (!server_stream) {
+      return NULL;
+   }
+
+   sd = mongoc_server_description_new_copy (server_stream->sd);
+   mongoc_server_stream_cleanup (server_stream);
+   return sd;
+}

--- a/src/libmongoc/src/mongoc/mongoc-client.h
+++ b/src/libmongoc/src/mongoc/mongoc-client.h
@@ -274,6 +274,12 @@ mongoc_client_set_server_api (mongoc_client_t *client,
                               const mongoc_server_api_t *api,
                               bson_error_t *error);
 
+MONGOC_EXPORT (mongoc_server_description_t *)
+mongoc_client_get_handshake_description (mongoc_client_t *client,
+                                         uint32_t server_id,
+                                         bson_t *opts,
+                                         bson_error_t *error);
+
 BSON_END_DECLS
 
 

--- a/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
@@ -70,7 +70,7 @@ _run_command (mongoc_cluster_t *cluster,
    /* Drivers must not append session ids to auth commands per sessions spec. */
    parts.prohibit_lsid = true;
    server_stream = _mongoc_cluster_create_server_stream (
-      cluster->client->topology, sd->id, stream, error);
+      cluster->client->topology, sd, stream, error);
    if (!server_stream) {
       /* error was set by mongoc_topology_description_server_by_id */
       bson_init (reply);

--- a/src/libmongoc/src/mongoc/mongoc-cluster-cyrus.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-cyrus.c
@@ -83,7 +83,7 @@ _mongoc_cluster_auth_node_cyrus (mongoc_cluster_t *cluster,
       TRACE ("SASL: authenticating (step %d)", sasl.step);
 
       server_stream = _mongoc_cluster_create_server_stream (
-         cluster->client->topology, sd->id, stream, error);
+         cluster->client->topology, sd, stream, error);
 
       if (!server_stream) {
          bson_destroy (&cmd);

--- a/src/libmongoc/src/mongoc/mongoc-cluster-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-private.h
@@ -45,13 +45,8 @@ typedef struct _mongoc_cluster_node_t {
    mongoc_stream_t *stream;
    char *connection_address;
    uint32_t generation;
-
-   /* TODO CDRIVER-3653, these fields are unused. */
-   int32_t max_wire_version;
-   int32_t min_wire_version;
-   int32_t max_write_batch_size;
-   int32_t max_bson_obj_size;
-   int32_t max_msg_size;
+   /* handshake_sd is a server description created from the handshake on the stream. */
+   mongoc_server_description_t *handshake_sd;
 } mongoc_cluster_node_t;
 
 typedef struct _mongoc_cluster_t {
@@ -172,7 +167,7 @@ _mongoc_cluster_get_conversation_id (const bson_t *reply);
 
 mongoc_server_stream_t *
 _mongoc_cluster_create_server_stream (mongoc_topology_t *topology,
-                                      uint32_t server_id,
+                                      const mongoc_server_description_t *sd,
                                       mongoc_stream_t *stream,
                                       bson_error_t *error /* OUT */);
 

--- a/src/libmongoc/src/mongoc/mongoc-cluster-sspi.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-sspi.c
@@ -223,7 +223,7 @@ _mongoc_cluster_auth_node_sspi (mongoc_cluster_t *cluster,
       }
 
       server_stream = _mongoc_cluster_create_server_stream (
-         cluster->client->topology, sd->id, stream, error);
+         cluster->client->topology, sd, stream, error);
 
       if (!server_stream ||
           !mongoc_cmd_parts_assemble (&parts, server_stream, error)) {

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -765,7 +765,8 @@ _mongoc_stream_run_hello (mongoc_cluster_t *cluster,
    bson_t reply;
    int64_t start;
    int64_t rtt_msec;
-   mongoc_server_description_t *sd;
+   mongoc_server_description_t empty_sd;
+   mongoc_server_description_t *handshake_sd;
    mongoc_server_stream_t *server_stream;
    bson_t *copied_command = NULL;
    bool r;
@@ -809,8 +810,11 @@ _mongoc_stream_run_hello (mongoc_cluster_t *cluster,
     * Then _mongoc_cluster_stream_for_server also handles the error, and
     * invalidates again.
     */
+   mongoc_server_description_init (&empty_sd, address, server_id);
+   empty_sd.max_wire_version = WIRE_VERSION_MIN;
    server_stream = _mongoc_cluster_create_server_stream (
-      cluster->client->topology, server_id, stream, error);
+      cluster->client->topology, &empty_sd, stream, error);
+   mongoc_server_description_cleanup (&empty_sd);
    if (!server_stream) {
       bson_destroy (copied_command);
       RETURN (NULL);
@@ -819,7 +823,6 @@ _mongoc_stream_run_hello (mongoc_cluster_t *cluster,
    /* Always use OP_QUERY for the handshake, regardless of whether the last
     * known hello indicates the server supports a newer wire protocol.
     */
-   server_stream->sd->max_wire_version = WIRE_VERSION_MIN;
    memset (&hello_cmd, 0, sizeof (hello_cmd));
    hello_cmd.db_name = "admin";
    hello_cmd.command = command;
@@ -848,12 +851,12 @@ _mongoc_stream_run_hello (mongoc_cluster_t *cluster,
 
    rtt_msec = (bson_get_monotonic_time () - start) / 1000;
 
-   sd = (mongoc_server_description_t *) bson_malloc0 (
+   handshake_sd = (mongoc_server_description_t *) bson_malloc0 (
       sizeof (mongoc_server_description_t));
 
-   mongoc_server_description_init (sd, address, server_id);
+   mongoc_server_description_init (handshake_sd, address, server_id);
    /* send the error from run_command IN to handle_hello */
-   mongoc_server_description_handle_hello (sd, &reply, rtt_msec, error);
+   mongoc_server_description_handle_hello (handshake_sd, &reply, rtt_msec, error);
 
    if (cluster->requires_auth && speculative_auth_response) {
       _mongoc_topology_scanner_parse_speculative_authentication (
@@ -862,10 +865,10 @@ _mongoc_stream_run_hello (mongoc_cluster_t *cluster,
 
    bson_destroy (&reply);
 
-   r = _mongoc_topology_update_from_handshake (cluster->client->topology, sd);
+   r = _mongoc_topology_update_from_handshake (cluster->client->topology, handshake_sd);
    if (!r) {
-      mongoc_server_description_reset (sd);
-      bson_set_error (&sd->error,
+      mongoc_server_description_reset (handshake_sd);
+      bson_set_error (&handshake_sd->error,
                       MONGOC_ERROR_STREAM,
                       MONGOC_ERROR_STREAM_NOT_ESTABLISHED,
                       "\"%s\" removed from topology",
@@ -878,7 +881,7 @@ _mongoc_stream_run_hello (mongoc_cluster_t *cluster,
       bson_destroy (copied_command);
    }
 
-   RETURN (sd);
+   RETURN (handshake_sd);
 }
 
 /*
@@ -934,12 +937,6 @@ _mongoc_cluster_run_hello (mongoc_cluster_t *cluster,
       memcpy (error, &sd->error, sizeof (bson_error_t));
       mongoc_server_description_destroy (sd);
       return NULL;
-   } else {
-      node->max_write_batch_size = sd->max_write_batch_size;
-      node->min_wire_version = sd->min_wire_version;
-      node->max_wire_version = sd->max_wire_version;
-      node->max_bson_obj_size = sd->max_bson_obj_size;
-      node->max_msg_size = sd->max_msg_size;
    }
 
    return sd;
@@ -1071,7 +1068,7 @@ _mongoc_cluster_auth_node_cr (mongoc_cluster_t *cluster,
                           &command);
    parts.prohibit_lsid = true;
    server_stream = _mongoc_cluster_create_server_stream (
-      cluster->client->topology, sd->id, stream, error);
+      cluster->client->topology, sd, stream, error);
    if (!server_stream) {
       bson_destroy (&command);
       bson_destroy (&reply);
@@ -1208,7 +1205,7 @@ _mongoc_cluster_auth_node_plain (mongoc_cluster_t *cluster,
       &parts, cluster->client, "$external", MONGOC_QUERY_SECONDARY_OK, &b);
    parts.prohibit_lsid = true;
    server_stream = _mongoc_cluster_create_server_stream (
-      cluster->client->topology, sd->id, stream, error);
+      cluster->client->topology, sd, stream, error);
    if (!server_stream) {
       bson_destroy (&b);
       bson_destroy (&reply);
@@ -1322,7 +1319,7 @@ _mongoc_cluster_auth_node_x509 (mongoc_cluster_t *cluster,
       &parts, cluster->client, "$external", MONGOC_QUERY_SECONDARY_OK, &cmd);
    parts.prohibit_lsid = true;
    server_stream = _mongoc_cluster_create_server_stream (
-      cluster->client->topology, sd->id, stream, error);
+      cluster->client->topology, sd, stream, error);
    if (!server_stream) {
       bson_destroy (&cmd);
       bson_destroy (&reply);
@@ -1436,12 +1433,13 @@ _mongoc_cluster_get_auth_cmd_scram (mongoc_crypto_hash_algorithm_t algo,
  */
 
 static bool
-_mongoc_cluster_run_scram_command (mongoc_cluster_t *cluster,
-                                   mongoc_stream_t *stream,
-                                   uint32_t server_id,
-                                   const bson_t *cmd,
-                                   bson_t *reply,
-                                   bson_error_t *error)
+_mongoc_cluster_run_scram_command (
+   mongoc_cluster_t *cluster,
+   mongoc_stream_t *stream,
+   const mongoc_server_description_t *handshake_sd,
+   const bson_t *cmd,
+   bson_t *reply,
+   bson_error_t *error)
 {
    mongoc_cmd_parts_t parts;
    mongoc_server_stream_t *server_stream;
@@ -1458,7 +1456,7 @@ _mongoc_cluster_run_scram_command (mongoc_cluster_t *cluster,
       &parts, cluster->client, auth_source, MONGOC_QUERY_SECONDARY_OK, cmd);
    parts.prohibit_lsid = true;
    server_stream = _mongoc_cluster_create_server_stream (
-      cluster->client->topology, server_id, stream, error);
+      cluster->client->topology, handshake_sd, stream, error);
    if (!server_stream) {
       bson_destroy (reply);
       return false;
@@ -1501,13 +1499,14 @@ _mongoc_cluster_run_scram_command (mongoc_cluster_t *cluster,
  */
 
 static bool
-_mongoc_cluster_auth_scram_start (mongoc_cluster_t *cluster,
-                                  mongoc_stream_t *stream,
-                                  uint32_t server_id,
-                                  mongoc_crypto_hash_algorithm_t algo,
-                                  mongoc_scram_t *scram,
-                                  bson_t *reply,
-                                  bson_error_t *error)
+_mongoc_cluster_auth_scram_start (
+   mongoc_cluster_t *cluster,
+   mongoc_stream_t *stream,
+   const mongoc_server_description_t *handshake_sd,
+   mongoc_crypto_hash_algorithm_t algo,
+   mongoc_scram_t *scram,
+   bson_t *reply,
+   bson_error_t *error)
 {
    bson_t cmd;
 
@@ -1522,7 +1521,7 @@ _mongoc_cluster_auth_scram_start (mongoc_cluster_t *cluster,
    }
 
    if (!_mongoc_cluster_run_scram_command (
-          cluster, stream, server_id, &cmd, reply, error)) {
+          cluster, stream, handshake_sd, &cmd, reply, error)) {
       bson_destroy (&cmd);
 
       return false;
@@ -1644,12 +1643,13 @@ _mongoc_cluster_scram_handle_reply (mongoc_scram_t *scram,
  */
 
 static bool
-_mongoc_cluster_auth_scram_continue (mongoc_cluster_t *cluster,
-                                     mongoc_stream_t *stream,
-                                     uint32_t server_id,
-                                     mongoc_scram_t *scram,
-                                     const bson_t *sasl_start_reply,
-                                     bson_error_t *error)
+_mongoc_cluster_auth_scram_continue (
+   mongoc_cluster_t *cluster,
+   mongoc_stream_t *stream,
+   const mongoc_server_description_t *handshake_sd,
+   mongoc_scram_t *scram,
+   const bson_t *sasl_start_reply,
+   bson_error_t *error)
 {
    bson_t cmd;
    uint8_t buf[4096] = {0};
@@ -1688,7 +1688,7 @@ _mongoc_cluster_auth_scram_continue (mongoc_cluster_t *cluster,
       TRACE ("SCRAM: authenticating (step %d)", scram->step);
 
       if (!_mongoc_cluster_run_scram_command (
-             cluster, stream, server_id, &cmd, &reply_local, error)) {
+             cluster, stream, handshake_sd, &cmd, &reply_local, error)) {
          bson_destroy (&cmd);
          return false;
       }
@@ -1747,7 +1747,7 @@ _mongoc_cluster_auth_scram_continue (mongoc_cluster_t *cluster,
 static bool
 _mongoc_cluster_auth_node_scram (mongoc_cluster_t *cluster,
                                  mongoc_stream_t *stream,
-                                 uint32_t server_id,
+                                 mongoc_server_description_t *handshake_sd,
                                  mongoc_crypto_hash_algorithm_t algo,
                                  bson_error_t *error)
 {
@@ -1760,12 +1760,12 @@ _mongoc_cluster_auth_node_scram (mongoc_cluster_t *cluster,
    _mongoc_cluster_init_scram (cluster, &scram, algo);
 
    if (!_mongoc_cluster_auth_scram_start (
-          cluster, stream, server_id, algo, &scram, &reply, error)) {
+          cluster, stream, handshake_sd, algo, &scram, &reply, error)) {
       goto failure;
    }
 
    if (!_mongoc_cluster_auth_scram_continue (
-          cluster, stream, server_id, &scram, &reply, error)) {
+          cluster, stream, handshake_sd, &scram, &reply, error)) {
       bson_destroy (&reply);
 
       goto failure;
@@ -1799,7 +1799,7 @@ _mongoc_cluster_auth_node_scram_sha_1 (mongoc_cluster_t *cluster,
    return false;
 #else
    return _mongoc_cluster_auth_node_scram (
-      cluster, stream, sd->id, MONGOC_CRYPTO_ALGORITHM_SHA_1, error);
+      cluster, stream, sd, MONGOC_CRYPTO_ALGORITHM_SHA_1, error);
 #endif
 }
 
@@ -1818,7 +1818,7 @@ _mongoc_cluster_auth_node_scram_sha_256 (mongoc_cluster_t *cluster,
    return false;
 #else
    return _mongoc_cluster_auth_node_scram (
-      cluster, stream, sd->id, MONGOC_CRYPTO_ALGORITHM_SHA_256, error);
+      cluster, stream, sd, MONGOC_CRYPTO_ALGORITHM_SHA_256, error);
 #endif
 }
 
@@ -1945,6 +1945,7 @@ _mongoc_cluster_node_destroy (mongoc_cluster_node_t *node)
    /* Failure, or Replica Set reconfigure without this node */
    mongoc_stream_failed (node->stream);
    bson_free (node->connection_address);
+   mongoc_server_description_destroy (node->handshake_sd);
 
    bson_free (node);
 }
@@ -1974,30 +1975,24 @@ _mongoc_cluster_node_new (mongoc_stream_t *stream,
    node->connection_address = bson_strdup (connection_address);
    node->generation = generation;
 
-   node->max_wire_version = MONGOC_DEFAULT_WIRE_VERSION;
-   node->min_wire_version = MONGOC_DEFAULT_WIRE_VERSION;
-
-   node->max_write_batch_size = MONGOC_DEFAULT_WRITE_BATCH_SIZE;
-   node->max_bson_obj_size = MONGOC_DEFAULT_BSON_OBJ_SIZE;
-   node->max_msg_size = MONGOC_DEFAULT_MAX_MSG_SIZE;
-
    return node;
 }
 
 static bool
-_mongoc_cluster_finish_speculative_auth (mongoc_cluster_t *cluster,
-                                         mongoc_stream_t *stream,
-                                         mongoc_server_description_t *sd,
-                                         bson_t *speculative_auth_response,
-                                         mongoc_scram_t *scram,
-                                         bson_error_t *error)
+_mongoc_cluster_finish_speculative_auth (
+   mongoc_cluster_t *cluster,
+   mongoc_stream_t *stream,
+   mongoc_server_description_t *handshake_sd,
+   bson_t *speculative_auth_response,
+   mongoc_scram_t *scram,
+   bson_error_t *error)
 {
    const char *mechanism =
       _mongoc_topology_scanner_get_speculative_auth_mechanism (cluster->uri);
    bool ret = false;
    bool auth_handled = false;
 
-   BSON_ASSERT (sd);
+   BSON_ASSERT (handshake_sd);
    BSON_ASSERT (speculative_auth_response);
 
    if (!mechanism) {
@@ -2028,8 +2023,12 @@ _mongoc_cluster_finish_speculative_auth (mongoc_cluster_t *cluster,
 
       auth_handled = true;
 
-      ret = _mongoc_cluster_auth_scram_continue (
-         cluster, stream, sd->id, scram, speculative_auth_response, error);
+      ret = _mongoc_cluster_auth_scram_continue (cluster,
+                                                 stream,
+                                                 handshake_sd,
+                                                 scram,
+                                                 speculative_auth_response,
+                                                 error);
    }
 #endif
 
@@ -2065,7 +2064,7 @@ _mongoc_cluster_finish_speculative_auth (mongoc_cluster_t *cluster,
  *
  *--------------------------------------------------------------------------
  */
-static mongoc_stream_t *
+static mongoc_cluster_node_t *
 _mongoc_cluster_add_node (mongoc_cluster_t *cluster,
                           uint32_t generation,
                           uint32_t server_id,
@@ -2074,7 +2073,7 @@ _mongoc_cluster_add_node (mongoc_cluster_t *cluster,
    mongoc_host_list_t *host = NULL;
    mongoc_cluster_node_t *cluster_node = NULL;
    mongoc_stream_t *stream;
-   mongoc_server_description_t *sd;
+   mongoc_server_description_t *handshake_sd;
    mongoc_handshake_sasl_supported_mechs_t sasl_supported_mechs;
    mongoc_scram_t scram = {0};
    bson_t speculative_auth_response = BSON_INITIALIZER;
@@ -2108,36 +2107,44 @@ _mongoc_cluster_add_node (mongoc_cluster_t *cluster,
    cluster_node =
       _mongoc_cluster_node_new (stream, generation, host->host_and_port);
 
-   sd = _mongoc_cluster_run_hello (cluster,
-                                   cluster_node,
-                                   server_id,
-                                   cluster->scram_cache,
-                                   &scram,
-                                   &speculative_auth_response,
-                                   error);
-   if (!sd) {
+   handshake_sd = _mongoc_cluster_run_hello (cluster,
+                                             cluster_node,
+                                             server_id,
+                                             cluster->scram_cache,
+                                             &scram,
+                                             &speculative_auth_response,
+                                             error);
+   if (!handshake_sd) {
       GOTO (error);
    }
 
-   _mongoc_handshake_parse_sasl_supported_mechs (&sd->last_hello_response,
-                                                 &sasl_supported_mechs);
+   _mongoc_handshake_parse_sasl_supported_mechs (
+      &handshake_sd->last_hello_response, &sasl_supported_mechs);
 
    if (cluster->requires_auth) {
       /* Complete speculative authentication */
       bool is_auth = _mongoc_cluster_finish_speculative_auth (
-         cluster, stream, sd, &speculative_auth_response, &scram, error);
+         cluster, stream, handshake_sd, &speculative_auth_response, &scram, error);
 
-      if (!is_auth &&
-          !_mongoc_cluster_auth_node (
-             cluster, cluster_node->stream, sd, &sasl_supported_mechs, error)) {
+      if (!is_auth && !_mongoc_cluster_auth_node (cluster,
+                                                  cluster_node->stream,
+                                                  handshake_sd,
+                                                  &sasl_supported_mechs,
+                                                  error)) {
          MONGOC_WARNING ("Failed authentication to %s (%s)",
                          host->host_and_port,
                          error->message);
-         mongoc_server_description_destroy (sd);
+         mongoc_server_description_destroy (handshake_sd);
          GOTO (error);
       }
    }
-   mongoc_server_description_destroy (sd);
+
+   /* Transfer ownership of the server description into the cluster node. */
+   cluster_node->handshake_sd = handshake_sd;
+   /* Copy the generation from the cluster node.
+    * TODO (CDRIVER-4078) do not store the generation counter on the server
+    * description */
+   cluster_node->handshake_sd->generation = generation;
 
    bson_destroy (&speculative_auth_response);
    mongoc_set_add (cluster->nodes, server_id, cluster_node);
@@ -2147,7 +2154,7 @@ _mongoc_cluster_add_node (mongoc_cluster_t *cluster,
    _mongoc_scram_destroy (&scram);
 #endif
 
-   RETURN (stream);
+   RETURN (cluster_node);
 
 error:
    bson_destroy (&speculative_auth_response);
@@ -2352,7 +2359,8 @@ mongoc_cluster_fetch_stream_single (mongoc_cluster_t *cluster,
                                     bson_error_t *error /* OUT */)
 {
    mongoc_topology_t *topology;
-   mongoc_server_description_t *sd;
+   mongoc_server_description_t *monitor_sd;
+   mongoc_server_description_t *handshake_sd;
    mongoc_topology_scanner_node_t *scanner_node;
    char *address;
 
@@ -2381,11 +2389,8 @@ mongoc_cluster_fetch_stream_single (mongoc_cluster_t *cluster,
    }
 
    if (scanner_node->stream) {
-      sd = mongoc_topology_server_by_id (topology, server_id, error);
-
-      if (!sd) {
-         return NULL;
-      }
+      handshake_sd =
+         mongoc_server_description_new_copy (scanner_node->handshake_sd);
    } else {
       if (!reconnect_ok) {
          stream_not_found (
@@ -2411,15 +2416,13 @@ mongoc_cluster_fetch_stream_single (mongoc_cluster_t *cluster,
       }
       bson_free (address);
 
-      sd = mongoc_topology_server_by_id (topology, server_id, error);
-      if (!sd) {
-         return NULL;
-      }
+      handshake_sd =
+         mongoc_server_description_new_copy (scanner_node->handshake_sd);
    }
 
-   if (sd->type == MONGOC_SERVER_UNKNOWN) {
-      memcpy (error, &sd->error, sizeof *error);
-      mongoc_server_description_destroy (sd);
+   if (handshake_sd->type == MONGOC_SERVER_UNKNOWN) {
+      memcpy (error, &handshake_sd->error, sizeof *error);
+      mongoc_server_description_destroy (handshake_sd);
       return NULL;
    }
 
@@ -2429,37 +2432,48 @@ mongoc_cluster_fetch_stream_single (mongoc_cluster_t *cluster,
       bool has_speculative_auth = _mongoc_cluster_finish_speculative_auth (
          cluster,
          scanner_node->stream,
-         sd,
+         handshake_sd,
          &scanner_node->speculative_auth_response,
          &scanner_node->scram,
-         &sd->error);
+         &handshake_sd->error);
 
 #ifdef MONGOC_ENABLE_CRYPTO
       _mongoc_scram_destroy (&scanner_node->scram);
 #endif
 
       if (!scanner_node->stream) {
-         memcpy (error, &sd->error, sizeof *error);
-         mongoc_server_description_destroy (sd);
+         memcpy (error, &handshake_sd->error, sizeof *error);
+         mongoc_server_description_destroy (handshake_sd);
          return NULL;
       }
 
       if (!has_speculative_auth &&
           !_mongoc_cluster_auth_node (cluster,
                                       scanner_node->stream,
-                                      sd,
+                                      handshake_sd,
                                       &scanner_node->sasl_supported_mechs,
-                                      &sd->error)) {
-         memcpy (error, &sd->error, sizeof *error);
-         mongoc_server_description_destroy (sd);
+                                      &handshake_sd->error)) {
+         memcpy (error, &handshake_sd->error, sizeof *error);
+         mongoc_server_description_destroy (handshake_sd);
          return NULL;
       }
 
       scanner_node->has_auth = true;
    }
 
+   /* Always copy the latest generation from the shared server description. */
+   monitor_sd = mongoc_topology_server_by_id (topology, server_id, error);
+   if (!monitor_sd) {
+      mongoc_server_description_destroy (handshake_sd);
+      return NULL;
+   }
+   /* TODO: (CDRIVER-4078) do not store the generation counter as part of the
+    * server description. */
+   handshake_sd->generation = monitor_sd->generation;
+   mongoc_server_description_destroy (monitor_sd);
+
    return mongoc_server_stream_new (
-      &topology->description, sd, scanner_node->stream);
+      &topology->description, handshake_sd, scanner_node->stream);
 }
 
 
@@ -2519,27 +2533,21 @@ done:
 }
 
 mongoc_server_stream_t *
-_mongoc_cluster_create_server_stream (mongoc_topology_t *topology,
-                                      uint32_t server_id,
-                                      mongoc_stream_t *stream,
-                                      bson_error_t *error /* OUT */)
+_mongoc_cluster_create_server_stream (
+   mongoc_topology_t *topology,
+   const mongoc_server_description_t *handshake_sd,
+   mongoc_stream_t *stream,
+   bson_error_t *error /* OUT */)
 {
    mongoc_server_description_t *sd;
    mongoc_server_stream_t *server_stream = NULL;
 
+   sd = mongoc_server_description_new_copy (handshake_sd);
    /* can't just use mongoc_topology_server_by_id(), since we must hold the
     * lock while copying topology->description.logical_time below */
    bson_mutex_lock (&topology->mutex);
-
-   sd = mongoc_server_description_new_copy (
-      mongoc_topology_description_server_by_id (
-         &topology->description, server_id, error));
-
-   if (sd) {
-      server_stream =
+   server_stream =
          mongoc_server_stream_new (&topology->description, sd, stream);
-   }
-
    bson_mutex_unlock (&topology->mutex);
 
    return server_stream;
@@ -2553,7 +2561,6 @@ mongoc_cluster_fetch_stream_pooled (mongoc_cluster_t *cluster,
                                     bson_error_t *error /* OUT */)
 {
    mongoc_topology_t *topology;
-   mongoc_stream_t *stream;
    mongoc_cluster_node_t *cluster_node;
    mongoc_server_description_t *sd;
    bool has_server_description = false;
@@ -2586,8 +2593,15 @@ mongoc_cluster_fetch_stream_pooled (mongoc_cluster_t *cluster,
           */
          mongoc_cluster_disconnect_node (cluster, server_id);
       } else {
-         return _mongoc_cluster_create_server_stream (
-            topology, server_id, cluster_node->stream, error);
+         mongoc_server_stream_t *stream;
+
+         bson_mutex_lock (&topology->mutex);
+         stream = mongoc_server_stream_new (
+            &topology->description,
+            mongoc_server_description_new_copy (cluster_node->handshake_sd),
+            cluster_node->stream);
+         bson_mutex_unlock (&topology->mutex);
+         return stream;
       }
    }
 
@@ -2597,10 +2611,18 @@ mongoc_cluster_fetch_stream_pooled (mongoc_cluster_t *cluster,
       return NULL;
    }
 
-   stream = _mongoc_cluster_add_node (cluster, generation, server_id, error);
-   if (stream) {
-      return _mongoc_cluster_create_server_stream (
-         topology, server_id, stream, error);
+   cluster_node =
+      _mongoc_cluster_add_node (cluster, generation, server_id, error);
+   if (cluster_node) {
+      mongoc_server_stream_t *stream;
+
+      bson_mutex_lock (&topology->mutex);
+      stream = mongoc_server_stream_new (
+         &topology->description,
+         mongoc_server_description_new_copy (cluster_node->handshake_sd),
+         cluster_node->stream);
+      bson_mutex_unlock (&topology->mutex);
+      return stream;
    } else {
       return NULL;
    }
@@ -2873,8 +2895,8 @@ _mongoc_cluster_min_of_max_obj_size_nodes (void *item, void *ctx)
    mongoc_cluster_node_t *node = (mongoc_cluster_node_t *) item;
    int32_t *current_min = (int32_t *) ctx;
 
-   if (node->max_bson_obj_size < *current_min) {
-      *current_min = node->max_bson_obj_size;
+   if (node->handshake_sd->max_bson_obj_size < *current_min) {
+      *current_min = node->handshake_sd->max_bson_obj_size;
    }
    return true;
 }
@@ -2897,8 +2919,8 @@ _mongoc_cluster_min_of_max_msg_size_nodes (void *item, void *ctx)
    mongoc_cluster_node_t *node = (mongoc_cluster_node_t *) item;
    int32_t *current_min = (int32_t *) ctx;
 
-   if (node->max_msg_size < *current_min) {
-      *current_min = node->max_msg_size;
+   if (node->handshake_sd->max_msg_size < *current_min) {
+      *current_min = node->handshake_sd->max_msg_size;
    }
    return true;
 }
@@ -3015,6 +3037,7 @@ mongoc_cluster_check_interval (mongoc_cluster_t *cluster, uint32_t server_id)
    bson_error_t error;
    bool r = true;
    mongoc_server_stream_t *server_stream;
+   mongoc_server_description_t *handshake_sd;
 
    topology = cluster->client->topology;
 
@@ -3036,6 +3059,9 @@ mongoc_cluster_check_interval (mongoc_cluster_t *cluster, uint32_t server_id)
    if (!stream) {
       return false;
    }
+
+   handshake_sd = scanner_node->handshake_sd;
+   BSON_ASSERT (handshake_sd);
 
    now = bson_get_monotonic_time ();
 
@@ -3059,7 +3085,7 @@ mongoc_cluster_check_interval (mongoc_cluster_t *cluster, uint32_t server_id)
          &parts, cluster->client, "admin", MONGOC_QUERY_SECONDARY_OK, &command);
       parts.prohibit_lsid = true;
       server_stream = _mongoc_cluster_create_server_stream (
-         cluster->client->topology, server_id, stream, &error);
+         cluster->client->topology, handshake_sd, stream, &error);
       if (!server_stream) {
          bson_destroy (&command);
          return false;

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -2592,15 +2592,8 @@ mongoc_cluster_fetch_stream_pooled (mongoc_cluster_t *cluster,
           */
          mongoc_cluster_disconnect_node (cluster, server_id);
       } else {
-         mongoc_server_stream_t *stream;
-
-         bson_mutex_lock (&topology->mutex);
-         stream = mongoc_server_stream_new (
-            &topology->description,
-            mongoc_server_description_new_copy (cluster_node->handshake_sd),
-            cluster_node->stream);
-         bson_mutex_unlock (&topology->mutex);
-         return stream;
+         return _mongoc_cluster_create_server_stream (
+            topology, cluster_node->handshake_sd, cluster_node->stream, error);
       }
    }
 
@@ -2613,15 +2606,8 @@ mongoc_cluster_fetch_stream_pooled (mongoc_cluster_t *cluster,
    cluster_node =
       _mongoc_cluster_add_node (cluster, generation, server_id, error);
    if (cluster_node) {
-      mongoc_server_stream_t *stream;
-
-      bson_mutex_lock (&topology->mutex);
-      stream = mongoc_server_stream_new (
-         &topology->description,
-         mongoc_server_description_new_copy (cluster_node->handshake_sd),
-         cluster_node->stream);
-      bson_mutex_unlock (&topology->mutex);
-      return stream;
+      return _mongoc_cluster_create_server_stream (
+            topology, cluster_node->handshake_sd, cluster_node->stream, error);
    } else {
       return NULL;
    }

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -811,7 +811,6 @@ _mongoc_stream_run_hello (mongoc_cluster_t *cluster,
     * invalidates again.
     */
    mongoc_server_description_init (&empty_sd, address, server_id);
-   empty_sd.max_wire_version = WIRE_VERSION_MIN;
    server_stream = _mongoc_cluster_create_server_stream (
       cluster->client->topology, &empty_sd, stream, error);
    mongoc_server_description_cleanup (&empty_sd);

--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -122,6 +122,7 @@ mongoc_server_description_init (mongoc_server_description_t *sd,
    sd->id = id;
    sd->type = MONGOC_SERVER_UNKNOWN;
    sd->round_trip_time_msec = MONGOC_RTT_UNSET;
+   sd->generation = 0;
 
    if (!_mongoc_host_list_from_string (&sd->host, address)) {
       MONGOC_WARNING ("Failed to parse uri for %s", address);

--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -123,6 +123,7 @@ mongoc_server_description_init (mongoc_server_description_t *sd,
    sd->type = MONGOC_SERVER_UNKNOWN;
    sd->round_trip_time_msec = MONGOC_RTT_UNSET;
    sd->generation = 0;
+   sd->opened = 0;
 
    if (!_mongoc_host_list_from_string (&sd->host, address)) {
       MONGOC_WARNING ("Failed to parse uri for %s", address);

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner-private.h
@@ -30,6 +30,7 @@
 #include "mongoc-scram-private.h"
 #include "mongoc-ssl.h"
 #include "mongoc-crypto-private.h"
+#include "mongoc-server-description-private.h"
 
 BSON_BEGIN_DECLS
 
@@ -78,6 +79,10 @@ typedef struct mongoc_topology_scanner_node {
    bool negotiated_sasl_supported_mechs;
    bson_t speculative_auth_response;
    mongoc_scram_t scram;
+
+   /* handshake_sd is a server description constructed from the response of the
+    * initial handshake. It is bound to the lifetime of stream. */
+   mongoc_server_description_t *handshake_sd;
 } mongoc_topology_scanner_node_t;
 
 typedef struct mongoc_topology_scanner {

--- a/src/libmongoc/tests/TestSuite.c
+++ b/src/libmongoc/tests/TestSuite.c
@@ -137,6 +137,8 @@ TestSuite_Init (TestSuite *suite, const char *name, int argc, char **argv)
    suite->flags = 0;
    suite->prgname = bson_strdup (argv[0]);
    suite->silent = false;
+   _mongoc_array_init (&suite->match_patterns, sizeof (char *));
+   _mongoc_array_init (&suite->skip_patterns, sizeof (char *));
 
    for (i = 1; i < argc; i++) {
       if (0 == strcmp ("-d", argv[i])) {
@@ -177,10 +179,24 @@ TestSuite_Init (TestSuite *suite, const char *name, int argc, char **argv)
                  (0 == strcmp ("--silent", argv[i]))) {
          suite->silent = true;
       } else if (0 == strcmp ("-l", argv[i])) {
+         char *val;
          if (argc - 1 == i) {
             test_error ("-l requires an argument.");
          }
-         suite->testname = bson_strdup (argv[++i]);
+         val = bson_strdup (argv[++i]);
+         _mongoc_array_append_val (&suite->match_patterns, val);
+      } else if (0 == strcmp ("--skip", argv[i])) {
+         char *val;
+         if (argc - 1 == i) {
+            test_error ("--skip requires an argument.");
+         }
+         val = bson_strdup (argv[++i]);
+         _mongoc_array_append_val (&suite->skip_patterns, val);
+      } else if (0 == strcmp ("--after", argv[i])) {
+         if (argc - 1 == i) {
+            test_error ("--after requires an argument.");
+         }
+         suite->after = bson_strdup (argv[++i]);
       } else {
          test_error ("Unknown option: %s\n"
                      "Try using the --help option.",
@@ -662,21 +678,24 @@ done:
 static void
 TestSuite_PrintHelp (TestSuite *suite) /* IN */
 {
-   printf ("usage: %s [OPTIONS]\n"
-           "\n"
-           "Options:\n"
-           "    -h, --help    Show this help menu.\n"
-           "    --list-tests  Print list of available tests.\n"
-           "    -f, --no-fork Do not spawn a process per test (abort on first "
-           "error).\n"
-           "    -l NAME       Run test by name, e.g. \"/Client/command\" or "
-           "\"/Client/*\".\n"
-           "    -s, --silent  Suppress all output.\n"
-           "    -F FILENAME   Write test results (JSON) to FILENAME.\n"
-           "    -d            Print debug output (useful if a test hangs).\n"
-           "    -t, --trace   Enable mongoc tracing (useful to debug tests).\n"
-           "\n",
-           suite->prgname);
+   printf (
+      "usage: %s [OPTIONS]\n"
+      "\n"
+      "Options:\n"
+      "    -h, --help       Show this help menu.\n"
+      "    --list-tests     Print list of available tests.\n"
+      "    -f, --no-fork    Do not spawn a process per test (abort on first "
+      "error).\n"
+      "    -l PATTERN       Run test by name, e.g. \"/Client/command\" or "
+      "\"/Client/*\". May be repeated.\n"
+      "    -s, --silent     Suppress all output.\n"
+      "    -F FILENAME      Write test results (JSON) to FILENAME.\n"
+      "    -d               Print debug output (useful if a test hangs).\n"
+      "    -t, --trace      Enable mongoc tracing (useful to debug tests).\n"
+      "    --skip PATTERN   Skip test by name or pattern. May be repeated.\n"
+      "    --after NAME     Start running tests after this test name.\n"
+      "\n",
+      suite->prgname);
 }
 
 
@@ -857,36 +876,6 @@ TestSuite_PrintJsonFooter (FILE *stream) /* IN */
    fflush (stream);
 }
 
-
-static int
-TestSuite_RunSerial (TestSuite *suite) /* IN */
-{
-   Test *test;
-   int count = 0;
-   int status = 0;
-
-   for (test = suite->tests; test; test = test->next) {
-      count++;
-   }
-
-   for (test = suite->tests; test; test = test->next) {
-      status += TestSuite_RunTest (suite, test, &count);
-      count--;
-   }
-
-   if (suite->silent) {
-      return status;
-   }
-
-   TestSuite_PrintJsonFooter (stdout);
-   if (suite->outfile) {
-      TestSuite_PrintJsonFooter (suite->outfile);
-   }
-
-   return status;
-}
-
-
 static bool
 TestSuite_TestMatchesName (const TestSuite *suite,
                            const Test *test,
@@ -906,26 +895,70 @@ TestSuite_TestMatchesName (const TestSuite *suite,
 }
 
 
+bool
+test_matches (TestSuite *suite, Test *test)
+{
+   int i;
+   bool matches;
+
+   /* If no match patterns were provided, then assume all match unless they are
+    * skipped. */
+   if (suite->match_patterns.len == 0) {
+      matches = true;
+   } else {
+      matches = false;
+      for (i = 0; i < suite->match_patterns.len; i++) {
+         char *pattern =
+            _mongoc_array_index (&suite->match_patterns, char *, i);
+         if (TestSuite_TestMatchesName (suite, test, pattern)) {
+            matches = true;
+            break;
+         }
+      }
+   }
+
+   /* Remove it if it matches anything in the skips. */
+   for (i = 0; i < suite->skip_patterns.len; i++) {
+      char *pattern = _mongoc_array_index (&suite->skip_patterns, char *, i);
+      if (TestSuite_TestMatchesName (suite, test, pattern)) {
+         return false;
+      }
+   }
+
+   return matches;
+}
+
 static int
-TestSuite_RunNamed (TestSuite *suite,     /* IN */
-                    const char *testname) /* IN */
+TestSuite_RunAll (TestSuite *suite /* IN */)
 {
    Test *test;
    int count = 0;
    int status = 0;
+   int num_to_skip = 0;
 
    ASSERT (suite);
-   ASSERT (testname);
 
    /* initialize "count" so we can omit comma after last test output */
    for (test = suite->tests; test; test = test->next) {
-      if (TestSuite_TestMatchesName (suite, test, testname)) {
+      if (test_matches (suite, test)) {
          count++;
+      }
+      if (suite->after && 0 == strcmp (test->name, suite->after)) {
+         num_to_skip = count - 1;
       }
    }
 
+   if (suite->after && num_to_skip == 0) {
+      test_error ("Error: specified --after \"%s\", but no tests matched", suite->after);
+   }
+
    for (test = suite->tests; test; test = test->next) {
-      if (TestSuite_TestMatchesName (suite, test, testname)) {
+      if (num_to_skip > 0) {
+         num_to_skip--;
+         count--;
+         continue;
+      }
+      if (test_matches (suite, test)) {
          status += TestSuite_RunTest (suite, test, &count);
          count--;
       }
@@ -971,11 +1004,7 @@ TestSuite_Run (TestSuite *suite) /* IN */
 
    start_us = bson_get_monotonic_time ();
    if (suite->tests) {
-      if (suite->testname) {
-         failures += TestSuite_RunNamed (suite, suite->testname);
-      } else {
-         failures += TestSuite_RunSerial (suite);
-      }
+      failures += TestSuite_RunAll (suite);
    } else if (!suite->silent) {
       TestSuite_PrintJsonFooter (stdout);
       if (suite->outfile) {
@@ -994,6 +1023,7 @@ TestSuite_Destroy (TestSuite *suite)
 {
    Test *test;
    Test *tmp;
+   int i;
 
    bson_mutex_lock (&gTestMutex);
    gTestSuite = NULL;
@@ -1019,7 +1049,18 @@ TestSuite_Destroy (TestSuite *suite)
 
    free (suite->name);
    free (suite->prgname);
-   free (suite->testname);
+   for (i = 0; i < suite->skip_patterns.len; i++) {
+      char *val = _mongoc_array_index (&suite->skip_patterns, char *, i);
+      bson_free (val);
+   }
+   _mongoc_array_destroy (&suite->skip_patterns);
+   for (i = 0; i < suite->match_patterns.len; i++) {
+      char *val = _mongoc_array_index (&suite->match_patterns, char *, i);
+      bson_free (val);
+   }
+
+   _mongoc_array_destroy (&suite->match_patterns);
+   free (suite->after);
 }
 
 

--- a/src/libmongoc/tests/TestSuite.h
+++ b/src/libmongoc/tests/TestSuite.h
@@ -24,6 +24,7 @@
 #include <math.h>
 #include <stdlib.h>
 
+#include "mongoc/mongoc-array-private.h"
 #include "mongoc/mongoc-util-private.h"
 
 
@@ -660,13 +661,15 @@ struct _Test {
 struct _TestSuite {
    char *prgname;
    char *name;
-   char *testname;
+   mongoc_array_t match_patterns;
+   mongoc_array_t skip_patterns;
    Test *tests;
    FILE *outfile;
    int flags;
    int silent;
    bson_string_t *mock_server_log_buf;
    FILE *mock_server_log;
+   char *after;
 };
 
 

--- a/src/libmongoc/tests/TestSuite.h
+++ b/src/libmongoc/tests/TestSuite.h
@@ -24,7 +24,6 @@
 #include <math.h>
 #include <stdlib.h>
 
-#include "mongoc/mongoc-array-private.h"
 #include "mongoc/mongoc-util-private.h"
 
 
@@ -661,15 +660,13 @@ struct _Test {
 struct _TestSuite {
    char *prgname;
    char *name;
-   mongoc_array_t match_patterns;
-   mongoc_array_t skip_patterns;
+   char *testname;
    Test *tests;
    FILE *outfile;
    int flags;
    int silent;
    bson_string_t *mock_server_log_buf;
    FILE *mock_server_log;
-   char *after;
 };
 
 

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -274,6 +274,8 @@ extern void
 test_result_install (TestSuite *suite);
 extern void
 test_loadbalanced_install (TestSuite *suite);
+extern void
+test_server_stream_install (TestSuite *suite);
 
 typedef struct {
    mongoc_log_level_t level;
@@ -2909,6 +2911,7 @@ main (int argc, char *argv[])
    test_bson_util_install (&suite);
    test_result_install (&suite);
    test_loadbalanced_install (&suite);
+   test_server_stream_install (&suite);
 
    ret = TestSuite_Run (&suite);
 

--- a/src/libmongoc/tests/test-mongoc-change-stream.c
+++ b/src/libmongoc/tests/test-mongoc-change-stream.c
@@ -1167,7 +1167,7 @@ test_change_stream_server_selection_fails (void)
    ASSERT_ERROR_CONTAINS (err,
                           MONGOC_ERROR_SERVER_SELECTION,
                           MONGOC_ERROR_SERVER_SELECTION_FAILURE,
-                          "No suitable servers found");
+                          "No servers yet eligible for rescan");
    mongoc_change_stream_destroy (cs);
    mongoc_collection_destroy (coll);
    mongoc_client_destroy (client);
@@ -2493,6 +2493,13 @@ prose_test_17 (void)
    request = mock_server_receives_msg (
       server,
       MONGOC_QUERY_NONE,
+      tmp_bson (
+         "{ 'killCursors': 'coll', 'cursors': [{ '$numberLong': '123'}]}"));
+   mock_server_replies_ok_and_destroys (request);
+
+   request = mock_server_receives_msg (
+      server,
+      MONGOC_QUERY_NONE,
       tmp_bson ("{ 'aggregate': 'coll', 'pipeline': [ { "
                 "'$changeStream': { 'startAfter': {'x': 1}, 'resumeAfter': { "
                 "'$exists': false }, 'startAtOperationTime': { '$exists': "
@@ -2569,6 +2576,13 @@ prose_test_18 (void)
       "['ResumableChangeStreamError'], 'ok': 0 }");
 
    request_destroy (request);
+
+   request = mock_server_receives_msg (
+      server,
+      MONGOC_QUERY_NONE,
+      tmp_bson (
+         "{ 'killCursors': 'coll', 'cursors': [{ '$numberLong': '123'}]}"));
+   mock_server_replies_ok_and_destroys (request);
 
    request = mock_server_receives_msg (
       server,

--- a/src/libmongoc/tests/test-mongoc-client.c
+++ b/src/libmongoc/tests/test-mongoc-client.c
@@ -4040,6 +4040,7 @@ test_mongoc_client_get_handshake_hello_response_single (void)
 void
 test_mongoc_client_get_handshake_hello_response_pooled (void)
 {
+   mongoc_client_pool_t *pool;
    mongoc_client_t *client;
    mongoc_server_description_t *monitor_sd;
    mongoc_server_description_t *invalidated_sd;
@@ -4047,7 +4048,8 @@ test_mongoc_client_get_handshake_hello_response_pooled (void)
    bson_error_t error = {0};
    bool ret;
 
-   client = test_framework_new_default_client ();
+   pool = test_framework_new_default_client_pool ();
+   client = mongoc_client_pool_pop (pool);
    monitor_sd = mongoc_client_select_server (
       client, false /* for writes */, NULL /* read prefs */, &error);
    ASSERT_OR_PRINT (monitor_sd, error);
@@ -4084,7 +4086,8 @@ test_mongoc_client_get_handshake_hello_response_pooled (void)
    mongoc_server_description_destroy (handshake_sd);
    mongoc_server_description_destroy (invalidated_sd);
    mongoc_server_description_destroy (monitor_sd);
-   mongoc_client_destroy (client);
+   mongoc_client_pool_push (pool, client);
+   mongoc_client_pool_destroy (pool);
 }
 
 void

--- a/src/libmongoc/tests/test-mongoc-client.c
+++ b/src/libmongoc/tests/test-mongoc-client.c
@@ -571,10 +571,22 @@ test_mongoc_client_speculative_auth_failure (bool pooled)
    if (!r) {
       r = mongoc_cursor_error (cursor, &error);
       BSON_ASSERT (r);
-      ASSERT_ERROR_CONTAINS (error,
-                             MONGOC_ERROR_CLIENT,
-                             MONGOC_ERROR_CLIENT_AUTHENTICATE,
-                             "Failed to send \"saslContinue\" command");
+      /* A client pool on servers supporting speculative auth (4.4+) will get an
+       * error on saslContinue and subsequently attempt to start auth from the
+       * beginning. The failpoint closes the stream causing an error from
+       * saslStart. */
+      if (pooled &&
+          test_framework_max_wire_version_at_least (WIRE_VERSION_4_4)) {
+         ASSERT_ERROR_CONTAINS (error,
+                                MONGOC_ERROR_CLIENT,
+                                MONGOC_ERROR_CLIENT_AUTHENTICATE,
+                                "Failed to send \"saslStart\" command");
+      } else {
+         ASSERT_ERROR_CONTAINS (error,
+                                MONGOC_ERROR_CLIENT,
+                                MONGOC_ERROR_CLIENT_AUTHENTICATE,
+                                "Failed to send \"saslContinue\" command");
+      }
    }
 
    mongoc_cursor_destroy (cursor);
@@ -817,19 +829,25 @@ test_mongoc_client_authenticate_timeout (void *context)
 }
 
 
+/* Update: this test was changed after CDRIVER-3653 was fixed.
+ * Originally, the test used cursor operations, assuming changes in the
+ * min/maxWireVersion from the mock server would be re-evaluated on each cursor
+ * operation.
+ * After CDRIVER-3653 was fixed, this is no longer true. The cursor will examine
+ * the server description associated with the connection handshake. If the
+ * connection has not been closed, changes from monitoring will not affect the
+ * connection's server description.
+ * This test now uses mongoc_client_select_server to validate wire version
+ * checks. */
 static void
 test_wire_version (void)
 {
    mongoc_uri_t *uri;
-   mongoc_collection_t *collection;
-   mongoc_cursor_t *cursor;
    mongoc_client_t *client;
    mock_server_t *server;
-   const bson_t *doc;
    bson_error_t error;
    bson_t q = BSON_INITIALIZER;
-   future_t *future;
-   request_t *request;
+   mongoc_server_description_t *sd;
 
    if (!test_framework_skip_if_slow ()) {
       bson_destroy (&q);
@@ -849,14 +867,10 @@ test_wire_version (void)
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_int32 (uri, "heartbeatFrequencyMS", 500);
    client = test_framework_client_new_from_uri (uri, NULL);
-   collection = mongoc_client_get_collection (client, "test", "test");
-
-   cursor = mongoc_collection_find_with_opts (collection, &q, NULL, NULL);
-   BSON_ASSERT (!mongoc_cursor_next (cursor, &doc));
-   BSON_ASSERT (mongoc_cursor_error (cursor, &error));
+   sd = mongoc_client_select_server (client, true, NULL, &error);
+   BSON_ASSERT (!sd);
    BSON_ASSERT (error.domain == MONGOC_ERROR_PROTOCOL);
    BSON_ASSERT (error.code == MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION);
-   mongoc_cursor_destroy (cursor);
 
    /* too old */
    mock_server_auto_hello (server,
@@ -867,13 +881,10 @@ test_wire_version (void)
 
    /* wait until it's time for next heartbeat */
    _mongoc_usleep (600 * 1000);
-
-   cursor = mongoc_collection_find_with_opts (collection, &q, NULL, NULL);
-   BSON_ASSERT (!mongoc_cursor_next (cursor, &doc));
-   BSON_ASSERT (mongoc_cursor_error (cursor, &error));
+   sd = mongoc_client_select_server (client, true, NULL, &error);
+   BSON_ASSERT (!sd);
    BSON_ASSERT (error.domain == MONGOC_ERROR_PROTOCOL);
    BSON_ASSERT (error.code == MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION);
-   mongoc_cursor_destroy (cursor);
 
    /* compatible again */
    mock_server_auto_hello (server,
@@ -884,21 +895,11 @@ test_wire_version (void)
 
    /* wait until it's time for next heartbeat */
    _mongoc_usleep (600 * 1000);
-   cursor = mongoc_collection_find_with_opts (collection, &q, NULL, NULL);
-   future = future_cursor_next (cursor, &doc);
-   request = mock_server_receives_request (server);
-   mock_server_replies_to_find (
-      request, MONGOC_QUERY_SECONDARY_OK, 0, 0, "test.test", "{}", true);
-
-   /* no error */
-   BSON_ASSERT (future_get_bool (future));
-   BSON_ASSERT (!mongoc_cursor_error (cursor, &error));
+   sd = mongoc_client_select_server (client, true, NULL, &error);
+   ASSERT_OR_PRINT (sd, error);
+   mongoc_server_description_destroy (sd);
 
    bson_destroy (&q);
-   request_destroy (request);
-   future_destroy (future);
-   mongoc_cursor_destroy (cursor);
-   mongoc_collection_destroy (collection);
    mongoc_client_destroy (client);
    mongoc_uri_destroy (uri);
    mock_server_destroy (server);
@@ -3997,6 +3998,96 @@ test_mongoc_client_recv_network_error (void)
 }
 
 void
+test_mongoc_client_get_handshake_hello_response_single (void)
+{
+   mongoc_client_t *client;
+   mongoc_server_description_t *monitor_sd;
+   mongoc_server_description_t *invalidated_sd;
+   mongoc_server_description_t *handshake_sd;
+   bson_error_t error = {0};
+
+   client = test_framework_new_default_client ();
+   /* Perform server selection to establish a connection. */
+   monitor_sd = mongoc_client_select_server (
+      client, false /* for writes */, NULL /* read prefs */, &error);
+   ASSERT_OR_PRINT (monitor_sd, error);
+   BSON_ASSERT (
+      0 != strcmp ("Unknown", mongoc_server_description_type (monitor_sd)));
+
+   /* Invalidate the server. */
+   mongoc_topology_invalidate_server (client->topology, monitor_sd->id, &error);
+
+   /* Get the new invalidated server description from monitoring. */
+   invalidated_sd =
+      mongoc_client_get_server_description (client, monitor_sd->id);
+   BSON_ASSERT (NULL != invalidated_sd);
+   ASSERT_CMPSTR ("Unknown", mongoc_server_description_type (invalidated_sd));
+
+   /* The previously established connection should have a valid server
+    * description. */
+   handshake_sd = mongoc_client_get_handshake_description (
+      client, monitor_sd->id, NULL /* opts */, &error);
+   ASSERT_OR_PRINT (handshake_sd, error);
+   BSON_ASSERT (
+      0 != strcmp ("Unknown", mongoc_server_description_type (handshake_sd)));
+
+   mongoc_server_description_destroy (handshake_sd);
+   mongoc_server_description_destroy (invalidated_sd);
+   mongoc_server_description_destroy (monitor_sd);
+   mongoc_client_destroy (client);
+}
+
+void
+test_mongoc_client_get_handshake_hello_response_pooled (void)
+{
+   mongoc_client_t *client;
+   mongoc_server_description_t *monitor_sd;
+   mongoc_server_description_t *invalidated_sd;
+   mongoc_server_description_t *handshake_sd;
+   bson_error_t error = {0};
+   bool ret;
+
+   client = test_framework_new_default_client ();
+   monitor_sd = mongoc_client_select_server (
+      client, false /* for writes */, NULL /* read prefs */, &error);
+   ASSERT_OR_PRINT (monitor_sd, error);
+   BSON_ASSERT (
+      0 != strcmp ("Unknown", mongoc_server_description_type (monitor_sd)));
+
+   /* Send a ping to establish a connection. */
+   ret = mongoc_client_command_simple_with_server_id (client,
+                                                      "admin",
+                                                      tmp_bson ("{'ping': 1}"),
+                                                      NULL,
+                                                      monitor_sd->id,
+                                                      NULL /* reply */,
+                                                      &error);
+   ASSERT_OR_PRINT (ret, error);
+
+   /* Invalidate the server. */
+   mongoc_topology_invalidate_server (client->topology, monitor_sd->id, &error);
+
+   /* Get the new invalidated server description from monitoring. */
+   invalidated_sd =
+      mongoc_client_get_server_description (client, monitor_sd->id);
+   BSON_ASSERT (NULL != invalidated_sd);
+   ASSERT_CMPSTR ("Unknown", mongoc_server_description_type (invalidated_sd));
+
+   /* The previously established connection should have a valid server
+    * description. */
+   handshake_sd = mongoc_client_get_handshake_description (
+      client, monitor_sd->id, NULL /* opts */, &error);
+   ASSERT_OR_PRINT (handshake_sd, error);
+   BSON_ASSERT (MONGOC_SERVER_UNKNOWN !=
+                mongoc_server_description_type (handshake_sd));
+
+   mongoc_server_description_destroy (handshake_sd);
+   mongoc_server_description_destroy (invalidated_sd);
+   mongoc_server_description_destroy (monitor_sd);
+   mongoc_client_destroy (client);
+}
+
+void
 test_client_install (TestSuite *suite)
 {
    if (test_framework_getenv_bool ("MONGOC_CHECK_IPV6")) {
@@ -4289,4 +4380,10 @@ test_client_install (TestSuite *suite)
    TestSuite_AddMockServerTest (suite,
                                 "/Client/recv_network_error",
                                 test_mongoc_client_recv_network_error);
+   TestSuite_AddLive (suite,
+                      "/Client/get_handshake_hello_response/single",
+                      test_mongoc_client_get_handshake_hello_response_single);
+   TestSuite_AddLive (suite,
+                      "/Client/get_handshake_hello_response/pooled",
+                      test_mongoc_client_get_handshake_hello_response_pooled);
 }

--- a/src/libmongoc/tests/test-mongoc-cluster.c
+++ b/src/libmongoc/tests/test-mongoc-cluster.c
@@ -1751,8 +1751,12 @@ _test_cmd_on_unknown_serverid (bool pooled)
    mongoc_uri_t *uri;
 
    uri = test_framework_get_uri ();
-   /* Set a high heartbeatFrequencyMS so subsequent topology scans do not
-    * interfere with the test. */
+   /* Set a lower heartbeatFrequencyMS.
+    * Servers supporting streamable hello will only respond to an awaitable
+    * hello until heartbeatFrequencyMS has passed or the server had changed
+    * state. This test marks the server Unknown in the client's topology
+    * description. During cleanup, _mongoc_client_end_sessions will attempt to
+    * do server selection again and wait for a server to become discovered. */
    mongoc_uri_set_option_as_int32 (uri, MONGOC_URI_HEARTBEATFREQUENCYMS, 5000);
 
    if (pooled) {

--- a/src/libmongoc/tests/test-mongoc-server-stream.c
+++ b/src/libmongoc/tests/test-mongoc-server-stream.c
@@ -90,7 +90,7 @@ test_server_stream_ties_server_description_pooled (void *unused)
    request = mock_server_receives_legacy_hello (server, NULL);
    mock_server_replies_simple (request, HELLO_POST_OPMSG);
    request_destroy (request);
-   /* Check that the mock server recieves an OP_MSG. */
+   /* Check that the mock server receives an OP_MSG. */
    request = mock_server_receives_msg (server, 0, tmp_bson ("{'ping': 1}"));
    ASSERT_CMPINT ((int) request->opcode, ==, (int) MONGOC_OPCODE_MSG);
    mock_server_replies_ok_and_destroys (request);

--- a/src/libmongoc/tests/test-mongoc-server-stream.c
+++ b/src/libmongoc/tests/test-mongoc-server-stream.c
@@ -124,9 +124,9 @@ test_server_stream_ties_server_description_pooled (void *unused)
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 
-   /* Check that selecting the server still returns the OP_MSG server */
+   /* Check that selecting the server still returns the OP_QUERY server */
    sd = mongoc_client_select_server (
-      client_opquery, true /* for writes */, NULL /* read prefs */, &error);
+      client_opmsg, true /* for writes */, NULL /* read prefs */, &error);
    ASSERT_OR_PRINT (sd, error);
    ASSERT_MATCH (mongoc_server_description_hello_response (sd),
                  "{'maxWireVersion': 6}");
@@ -177,7 +177,7 @@ test_server_stream_ties_server_description_single (void *unused)
    future_destroy (future);
 
    /* Muck with the topology description. */
-   /* Pass in an empty error. */
+   /* Pass in a zeroed out error. */
    memset (&error, 0, sizeof (bson_error_t));
    mongoc_topology_description_handle_hello (
       &client->topology->description, 1, tmp_bson (HELLO_PRE_OPMSG), 0, &error);

--- a/src/libmongoc/tests/test-mongoc-server-stream.c
+++ b/src/libmongoc/tests/test-mongoc-server-stream.c
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2021-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mock_server/mock-server.h"
+#include "mock_server/request.h"
+#include "mock_server/future.h"
+#include "mock_server/future-functions.h"
+#include "mongoc.h"
+#include "mongoc-client-private.h"
+#include "test-conveniences.h"
+#include "test-libmongoc.h"
+#include "TestSuite.h"
+
+#define HELLO_PRE_OPMSG                                         \
+   "{'ok': 1, 'isWritablePrimary': true, 'minWireVersion': 0, " \
+   "'maxWireVersion': 5 }"
+#define HELLO_POST_OPMSG                                        \
+   "{'ok': 1, 'isWritablePrimary': true, 'minWireVersion': 0, " \
+   "'maxWireVersion': 6 }"
+
+/* Test that a connection uses the server description from the handshake when
+ * checking wire version (instead of the server description from the topology
+ * description). */
+static void
+test_server_stream_ties_server_description_pooled (void *unused)
+{
+   mongoc_client_pool_t *pool;
+   mongoc_client_t *client_opquery;
+   mongoc_client_t *client_opmsg;
+   mongoc_uri_t *uri;
+   mock_server_t *server;
+   request_t *request;
+   future_t *future;
+   bson_error_t error;
+   mongoc_server_description_t *sd;
+
+   server = mock_server_new ();
+   mock_server_run (server);
+   uri = mongoc_uri_copy (mock_server_get_uri (server));
+   pool = mongoc_client_pool_new (uri);
+   client_opquery = mongoc_client_pool_pop (pool);
+   client_opmsg = mongoc_client_pool_pop (pool);
+
+   /* Respond to the monitoring legacy hello with wire version pre 3.6 (before
+    * OP_MSG). */
+   request = mock_server_receives_legacy_hello (server, NULL);
+   mock_server_replies_simple (request, HELLO_PRE_OPMSG);
+   request_destroy (request);
+
+   /* Create a connection on client_opquery. */
+   future = future_client_command_simple (client_opquery,
+                                          "admin",
+                                          tmp_bson ("{'ping': 1}"),
+                                          NULL /* read prefs */,
+                                          NULL /* reply */,
+                                          &error);
+   /* The first command on a pooled client creates a new connection. */
+   request = mock_server_receives_legacy_hello (server, NULL);
+   mock_server_replies_simple (request, HELLO_PRE_OPMSG);
+   request_destroy (request);
+   /* Check that the mock server receives an OP_QUERY. */
+   request = mock_server_receives_command (
+      server, "admin", MONGOC_QUERY_SECONDARY_OK, "{'ping': 1}");
+   ASSERT_CMPINT ((int) request->opcode, ==, (int) MONGOC_OPCODE_QUERY);
+   mock_server_replies_ok_and_destroys (request);
+   ASSERT_OR_PRINT (future_get_bool (future), error);
+   future_destroy (future);
+
+   /* Create a connection on client_opmsg. */
+   future = future_client_command_simple (client_opmsg,
+                                          "admin",
+                                          tmp_bson ("{'ping': 1}"),
+                                          NULL /* read prefs */,
+                                          NULL /* reply */,
+                                          &error);
+   /* The first command on a pooled client creates a new connection. */
+   request = mock_server_receives_legacy_hello (server, NULL);
+   mock_server_replies_simple (request, HELLO_POST_OPMSG);
+   request_destroy (request);
+   /* Check that the mock server recieves an OP_MSG. */
+   request = mock_server_receives_msg (server, 0, tmp_bson ("{'ping': 1}"));
+   ASSERT_CMPINT ((int) request->opcode, ==, (int) MONGOC_OPCODE_MSG);
+   mock_server_replies_ok_and_destroys (request);
+   ASSERT_OR_PRINT (future_get_bool (future), error);
+   future_destroy (future);
+
+   /* Re-use client_opquery, to ensure it still uses opquery. */
+   future = future_client_command_simple (client_opquery,
+                                          "admin",
+                                          tmp_bson ("{'ping': 1}"),
+                                          NULL /* read prefs */,
+                                          NULL /* reply */,
+                                          &error);
+   request = mock_server_receives_command (
+      server, "admin", MONGOC_QUERY_SECONDARY_OK, "{'ping': 1}");
+   ASSERT_CMPINT ((int) request->opcode, ==, (int) MONGOC_OPCODE_QUERY);
+   mock_server_replies_ok_and_destroys (request);
+   ASSERT_OR_PRINT (future_get_bool (future), error);
+   future_destroy (future);
+
+   /* Re-use client_opmsg, to ensure it still uses opmsg. */
+   future = future_client_command_simple (client_opmsg,
+                                          "admin",
+                                          tmp_bson ("{'ping': 1}"),
+                                          NULL /* read prefs */,
+                                          NULL /* reply */,
+                                          &error);
+   request = mock_server_receives_msg (server, 0, tmp_bson ("{'ping': 1}"));
+   ASSERT_CMPINT ((int) request->opcode, ==, (int) MONGOC_OPCODE_MSG);
+   mock_server_replies_ok_and_destroys (request);
+   ASSERT_OR_PRINT (future_get_bool (future), error);
+   future_destroy (future);
+
+   /* Check that selecting the server still returns the OP_MSG server */
+   sd = mongoc_client_select_server (
+      client_opquery, true /* for writes */, NULL /* read prefs */, &error);
+   ASSERT_OR_PRINT (sd, error);
+   ASSERT_MATCH (mongoc_server_description_hello_response (sd),
+                 "{'maxWireVersion': 6}");
+   mongoc_server_description_destroy (sd);
+
+   mock_server_destroy (server);
+   mongoc_uri_destroy (uri);
+   mongoc_client_pool_push (pool, client_opquery);
+   mongoc_client_pool_push (pool, client_opmsg);
+   mongoc_client_pool_destroy (pool);
+}
+
+/* Test that a connection uses the server description from the handshake when
+ * checking wire version (instead of the server description from the topology
+ * description). */
+static void
+test_server_stream_ties_server_description_single (void *unused)
+{
+   mongoc_client_t *client;
+   mongoc_uri_t *uri;
+   mock_server_t *server;
+   request_t *request;
+   future_t *future;
+   bson_error_t error;
+   mongoc_server_description_t *sd;
+
+   server = mock_server_new ();
+   mock_server_run (server);
+   uri = mongoc_uri_copy (mock_server_get_uri (server));
+   client = mongoc_client_new_from_uri (uri);
+
+   /* Create a connection on client. */
+   future = future_client_command_simple (client,
+                                          "admin",
+                                          tmp_bson ("{'ping': 1}"),
+                                          NULL /* read prefs */,
+                                          NULL /* reply */,
+                                          &error);
+   /* The first command on a client creates a new connection. */
+   request = mock_server_receives_legacy_hello (server, NULL);
+   mock_server_replies_simple (request, HELLO_POST_OPMSG);
+   request_destroy (request);
+   /* Check that the mock server receives an OP_MSG. */
+   request = mock_server_receives_msg (server, 0, tmp_bson ("{'ping': 1}"));
+   ASSERT_CMPINT ((int) request->opcode, ==, (int) MONGOC_OPCODE_MSG);
+   mock_server_replies_ok_and_destroys (request);
+   ASSERT_OR_PRINT (future_get_bool (future), error);
+   future_destroy (future);
+
+   /* Muck with the topology description. */
+   /* Pass in an empty error. */
+   memset (&error, 0, sizeof (bson_error_t));
+   mongoc_topology_description_handle_hello (
+      &client->topology->description, 1, tmp_bson (HELLO_PRE_OPMSG), 0, &error);
+
+   /* Send another command, it should still use OP_MSG. */
+   future = future_client_command_simple (client,
+                                          "admin",
+                                          tmp_bson ("{'ping': 1}"),
+                                          NULL /* read prefs */,
+                                          NULL /* reply */,
+                                          &error);
+   request = mock_server_receives_msg (server, 0, tmp_bson ("{'ping': 1}"));
+   ASSERT_CMPINT ((int) request->opcode, ==, (int) MONGOC_OPCODE_MSG);
+   mock_server_replies_ok_and_destroys (request);
+   ASSERT_OR_PRINT (future_get_bool (future), error);
+   future_destroy (future);
+
+   /* Check that selecting the server returns the OP_QUERY server */
+   sd = mongoc_client_select_server (
+      client, true /* for writes */, NULL /* read prefs */, &error);
+   ASSERT_OR_PRINT (sd, error);
+   ASSERT_MATCH (mongoc_server_description_hello_response (sd),
+                 "{'maxWireVersion': 5}");
+   mongoc_server_description_destroy (sd);
+
+   mock_server_destroy (server);
+   mongoc_uri_destroy (uri);
+   mongoc_client_destroy (client);
+}
+
+
+void
+test_server_stream_install (TestSuite *suite)
+{
+   TestSuite_AddFull (suite,
+                      "/server_stream/ties_server_description/pooled",
+                      test_server_stream_ties_server_description_pooled,
+                      NULL /* dtor */,
+                      NULL /* ctx */,
+                      NULL);
+   TestSuite_AddFull (suite,
+                      "/server_stream/ties_server_description/single",
+                      test_server_stream_ties_server_description_single,
+                      NULL /* dtor */,
+                      NULL /* ctx */,
+                      NULL);
+}


### PR DESCRIPTION
**Terms**
- **handshake description** is a server description constructed during connection handshake.
- **monitor description** is a server description constructed and updated in server monitoring.

**Motivation**
- libmongoc currently uses monitor descriptions when constructing commands (to check wire version, how to pass read preferences, etc.). This is racy, and the cause of bugs like CDRIVER-3404.
- Supporting load balancer requires setting the monitor description to an empty LoadBalancer description. A load balancer can front many backing servers. Connections must track the handshake description to work correctly with load balancers.

**Summary**
- Store handshake descriptions alongside their corresponding connections.
- Update change stream and transactions wire version checks to check the handshake description instead of the monitor description.
- Update auth commands to use the handshake description when constructing commands.
- Add `mongoc_client_get_handshake_description` for wrapping drivers to obtain a handshake description.

**Notes**
- As a happy consequence, change streams now send a killCursors command when resuming due to an error that marks a server unknown. Previously this would clear the wire version on the connection. 
