### PR TITLE
CDRIVER-4091 - Truncation in strncpy() causes build error

### DIFF
--- a/src/libmongoc/tests/test-mongoc-mongohouse.c
+++ b/src/libmongoc/tests/test-mongoc-mongohouse.c
@@ -151,7 +151,6 @@ cmd_succeeded_cb (const mongoc_apm_command_succeeded_t *event)
 
    /* Store cursor information from our initial find. */
    if (strcmp (cmd, "find") == 0) {
-      const char *temp;
 
       BSON_ASSERT (!test->parsed_cursor);
 
@@ -164,9 +163,8 @@ cmd_succeeded_cb (const mongoc_apm_command_succeeded_t *event)
       BSON_ASSERT (bson_iter_find_descendant (&iter, "cursor.ns", &child_iter));
       BSON_ASSERT (BSON_ITER_HOLDS_UTF8 (&child_iter));
 
-      temp = bson_iter_utf8 (&child_iter, NULL);
-      test->cursor_ns = (char *) bson_malloc0 (strlen (temp));
-      strncpy (test->cursor_ns, temp, strlen (temp));
+      test->cursor_ns = bson_strdup(bson_iter_utf8(&child_iter, NULL));
+      BSON_ASSERT (NULL != test->cursor_ns);
 
       test->parsed_cursor = true;
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-4091

gcc 9.3.0 complains that because the strncpy() call uses the source's size as a bound,
the trailing NULL will not be copied.

Replaced with:
updated allocation size of destination to include room for the NULL character
eliminated redundant srlen()
changed strncpy() call to strcpy(), which includes the trailing NULL

Signed-off-by: Jesse Williamson <jesse.williamson@mongodb.com>
