### PR TITLE
CDRIVER-4076 skip legacy opcode / getLastError tests on pre 5.1

### DIFF
--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -2931,7 +2931,7 @@ main (int argc, char *argv[])
  * does not support legacy wire protocol op codes.
  *
  * As of SERVER-57457 and SERVER-57391, the following legacy wire protocol
- * op codes have been removed in the server:
+ * op codes have been removed in the server 5.1:
  * - OP_KILL_CURSORS
  * - OP_INSERT
  * - OP_UPDATE
@@ -2950,6 +2950,24 @@ test_framework_supports_legacy_opcodes (void) {
 
 int
 test_framework_skip_if_no_legacy_opcodes (void) {
+   if (!TestSuite_CheckLive()) {
+      return 0;
+   }
+
+   if (test_framework_supports_legacy_opcodes ()) {
+      return 1;
+   }
+
+   return 0;
+}
+
+/* SERVER-57390 removed the getLastError command on 5.1 servers. */
+int
+test_framework_skip_if_no_getlasterror (void) {
+   if (!TestSuite_CheckLive()) {
+      return 0;
+   }
+
    if (test_framework_supports_legacy_opcodes ()) {
       return 1;
    }

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -2484,6 +2484,8 @@ WIRE_VERSION_CHECKS (8)
 WIRE_VERSION_CHECKS (9)
 /* wire versions 10, 11, 12 were internal to the 5.0 release cycle */
 WIRE_VERSION_CHECKS (13)
+/* wire version 14 begins with the 5.1 prerelease. */
+WIRE_VERSION_CHECKS (14)
 
 int
 test_framework_skip_if_no_dual_ip_hostname (void)
@@ -2922,4 +2924,35 @@ main (int argc, char *argv[])
    mongoc_cleanup ();
 
    return ret;
+}
+
+/*
+ * test_framework_skip_if_no_legacy_opcodes returns 0 if the connected server
+ * does not support legacy wire protocol op codes.
+ *
+ * As of SERVER-57457 and SERVER-57391, the following legacy wire protocol
+ * op codes have been removed in the server:
+ * - OP_KILL_CURSORS
+ * - OP_INSERT
+ * - OP_UPDATE
+ * - OP_DELETE
+ * - OP_GET_MORE
+ * - OP_QUERY (for any command other than isMaster, which drivers use to
+ * initially discover the min/max wire version of a server)
+ */
+bool
+test_framework_supports_legacy_opcodes (void) {
+   if (test_framework_skip_if_max_wire_version_less_than_14 () == 0) {
+      return true;
+   }
+   return false;
+}
+
+int
+test_framework_skip_if_no_legacy_opcodes (void) {
+   if (test_framework_supports_legacy_opcodes ()) {
+      return 1;
+   }
+
+   return 0;
 }

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -2942,10 +2942,8 @@ main (int argc, char *argv[])
  */
 bool
 test_framework_supports_legacy_opcodes (void) {
-   if (test_framework_skip_if_max_wire_version_less_than_14 () == 0) {
-      return true;
-   }
-   return false;
+   /* Wire v14+ removed legacy opcodes */
+   return test_framework_skip_if_max_wire_version_less_than_14() == 0;
 }
 
 int

--- a/src/libmongoc/tests/test-libmongoc.h
+++ b/src/libmongoc/tests/test-libmongoc.h
@@ -192,6 +192,8 @@ WIRE_VERSION_CHECK_DECLS (8)
 WIRE_VERSION_CHECK_DECLS (9)
 /* wire versions 10, 11, 12 were internal to the 5.0 release cycle */
 WIRE_VERSION_CHECK_DECLS (13)
+/* wire version 14 begins with the 5.1 prerelease. */
+WIRE_VERSION_CHECK_DECLS (14)
 
 #undef WIRE_VERSION_CHECK_DECLS
 
@@ -241,5 +243,11 @@ test_framework_skip_if_no_aws (void);
 
 int
 test_framework_skip_if_no_setenv (void);
+
+bool
+test_framework_supports_legacy_opcodes (void);
+
+int
+test_framework_skip_if_no_legacy_opcodes (void);
 
 #endif

--- a/src/libmongoc/tests/test-libmongoc.h
+++ b/src/libmongoc/tests/test-libmongoc.h
@@ -250,4 +250,10 @@ test_framework_supports_legacy_opcodes (void);
 int
 test_framework_skip_if_no_legacy_opcodes (void);
 
+int
+test_framework_skip_if_no_getlasterror (void);
+
+int
+test_framework_skip_if_no_exhaust_cursors (void);
+
 #endif

--- a/src/libmongoc/tests/test-mongoc-bulk.c
+++ b/src/libmongoc/tests/test-mongoc-bulk.c
@@ -5014,7 +5014,7 @@ test_bulk_install (TestSuite *suite)
    TestSuite_AddLive (suite, "/BulkOperation/split", test_bulk_split);
    TestSuite_AddLive (suite,
                       "/BulkOperation/write_concern/split",
-                      test_bulk_write_concern_split);
+                      test_bulk_write_concern_split, test_framework_skip_if_no_legacy_opcodes);
    TestSuite_AddMockServerTest (suite,
                                 "/BulkOperation/hint/single/command/secondary",
                                 test_hint_single_command_secondary);

--- a/src/libmongoc/tests/test-mongoc-bulk.c
+++ b/src/libmongoc/tests/test-mongoc-bulk.c
@@ -4026,7 +4026,7 @@ typedef enum { HANGUP, SERVER_ERROR, ERR_TYPE_LAST } err_type_t;
 
 
 static void
-test_bulk_write_concern_split (void)
+test_bulk_write_concern_split (void* unused)
 {
    mongoc_client_t *client;
    mongoc_bulk_operation_t *bulk;
@@ -5012,9 +5012,12 @@ test_bulk_install (TestSuite *suite)
    TestSuite_AddLive (
       suite, "/BulkOperation/OP_MSG/max_msg_size", test_bulk_max_msg_size);
    TestSuite_AddLive (suite, "/BulkOperation/split", test_bulk_split);
-   TestSuite_AddLive (suite,
+   TestSuite_AddFull (suite,
                       "/BulkOperation/write_concern/split",
-                      test_bulk_write_concern_split, test_framework_skip_if_no_legacy_opcodes);
+                      test_bulk_write_concern_split,
+                      NULL /* dtor */,
+                      NULL /* ctx */,
+                      test_framework_skip_if_no_legacy_opcodes);
    TestSuite_AddMockServerTest (suite,
                                 "/BulkOperation/hint/single/command/secondary",
                                 test_hint_single_command_secondary);

--- a/src/libmongoc/tests/test-mongoc-bulk.c
+++ b/src/libmongoc/tests/test-mongoc-bulk.c
@@ -5017,7 +5017,7 @@ test_bulk_install (TestSuite *suite)
                       test_bulk_write_concern_split,
                       NULL /* dtor */,
                       NULL /* ctx */,
-                      test_framework_skip_if_no_legacy_opcodes);
+                      test_framework_skip_if_no_getlasterror);
    TestSuite_AddMockServerTest (suite,
                                 "/BulkOperation/hint/single/command/secondary",
                                 test_hint_single_command_secondary);

--- a/src/libmongoc/tests/test-mongoc-command-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-command-monitoring.c
@@ -1032,7 +1032,8 @@ test_killcursors_deprecated (void)
    ASSERT_OR_PRINT (r, error);
    set_cmd_test_callbacks (client, (void *) &test);
 
-   /* deprecated function without "db" or "collection", skips APM. This sends OP_KILL_CURSORS. */
+   /* deprecated function without "db" or "collection", skips APM.This sends
+    * OP_KILL_CURSORS. */
    mongoc_client_kill_cursor (client, 123);
 
    ASSERT_CMPINT (0, ==, test.started_calls);
@@ -1244,7 +1245,10 @@ test_command_monitoring_install (TestSuite *suite)
       suite, "/command_monitoring/client_cmd/op_ids", test_client_cmd_op_ids);
    TestSuite_AddFull (suite,
                       "/command_monitoring/killcursors_deprecated",
-                      test_killcursors_deprecated, NULL /* dtor */, NULL /* ctx */, test_framework_skip_if_no_legacy_opcodes);
+                      test_killcursors_deprecated,
+                      NULL /* dtor */,
+                      NULL /* ctx */,
+                      test_framework_skip_if_no_legacy_opcodes);
    TestSuite_AddMockServerTest (suite,
                                 "/command_monitoring/failed_reply_mock",
                                 test_command_failed_reply_mock);

--- a/src/libmongoc/tests/test-mongoc-command-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-command-monitoring.c
@@ -1015,7 +1015,7 @@ test_client_cmd_op_ids (void)
 
 
 static void
-test_killcursors_deprecated (void)
+test_killcursors_deprecated (void* unused)
 {
    cmd_test_t test;
    mongoc_client_t *client;

--- a/src/libmongoc/tests/test-mongoc-command-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-command-monitoring.c
@@ -1032,7 +1032,7 @@ test_killcursors_deprecated (void)
    ASSERT_OR_PRINT (r, error);
    set_cmd_test_callbacks (client, (void *) &test);
 
-   /* deprecated function without "db" or "collection", skips APM */
+   /* deprecated function without "db" or "collection", skips APM. This sends OP_KILL_CURSORS. */
    mongoc_client_kill_cursor (client, 123);
 
    ASSERT_CMPINT (0, ==, test.started_calls);
@@ -1242,9 +1242,9 @@ test_command_monitoring_install (TestSuite *suite)
       suite, "/command_monitoring/client_cmd_simple", test_client_cmd_simple);
    TestSuite_AddLive (
       suite, "/command_monitoring/client_cmd/op_ids", test_client_cmd_op_ids);
-   TestSuite_AddLive (suite,
+   TestSuite_AddFull (suite,
                       "/command_monitoring/killcursors_deprecated",
-                      test_killcursors_deprecated);
+                      test_killcursors_deprecated, NULL /* dtor */, NULL /* ctx */, test_framework_skip_if_no_legacy_opcodes);
    TestSuite_AddMockServerTest (suite,
                                 "/command_monitoring/failed_reply_mock",
                                 test_command_failed_reply_mock);

--- a/src/libmongoc/tests/test-mongoc-command-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-command-monitoring.c
@@ -1032,7 +1032,7 @@ test_killcursors_deprecated (void* unused)
    ASSERT_OR_PRINT (r, error);
    set_cmd_test_callbacks (client, (void *) &test);
 
-   /* deprecated function without "db" or "collection", skips APM.This sends
+   /* deprecated function without "db" or "collection", skips APM. This sends
     * OP_KILL_CURSORS. */
    mongoc_client_kill_cursor (client, 123);
 

--- a/src/libmongoc/tests/test-mongoc-cursor.c
+++ b/src/libmongoc/tests/test-mongoc-cursor.c
@@ -652,8 +652,10 @@ extern void
 _mongoc_cursor_impl_find_opquery_init (mongoc_cursor_t *cursor, bson_t *filter);
 
 /* Tests killing a cursor with mongo_cursor_destroy and a real server.
- * Asserts that the cursor ID is no longer valid by attempting to get another batch of results with the previously killed cursor ID.
- * Uses OP_GET_MORE (on servers older than 3.2) or a getMore command (servers 3.2+) to iterate the cursor ID.
+ * Asserts that the cursor ID is no longer valid by attempting to get another
+ * batch of results with the previously killed cursor ID. Uses OP_GET_MORE (on
+ * servers older than 3.2) or a getMore command (servers 3.2+) to iterate the
+ * cursor ID.
  */
 static void
 test_kill_cursor_live (void)
@@ -724,68 +726,22 @@ test_kill_cursor_live (void)
 
       mongoc_cursor_destroy (cursor);
    } else {
-      bson_t* cmd;
+      bson_t *cmd;
 
-      cmd = BCON_NEW ("getMore", BCON_INT64 (ctx.cursor_id), "collection", mongoc_collection_get_name(collection));
-      r = mongoc_client_command_simple (client, "test", cmd, NULL /* read prefs */, NULL /* reply */, &error);
+      cmd = BCON_NEW ("getMore",
+                      BCON_INT64 (ctx.cursor_id),
+                      "collection",
+                      mongoc_collection_get_name (collection));
+      r = mongoc_client_command_simple (
+         client, "test", cmd, NULL /* read prefs */, NULL /* reply */, &error);
       ASSERT (!r);
-      ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_QUERY, MONGOC_SERVER_ERR_CURSOR_NOT_FOUND, "not found");
+      ASSERT_ERROR_CONTAINS (error,
+                             MONGOC_ERROR_QUERY,
+                             MONGOC_SERVER_ERR_CURSOR_NOT_FOUND,
+                             "not found");
       bson_destroy (cmd);
    }
 
-   mongoc_bulk_operation_destroy (bulk);
-   mongoc_collection_destroy (collection);
-   mongoc_client_destroy (client);
-   mongoc_apm_callbacks_destroy (callbacks);
-}
-
-/* Test that sending a legacy OP_GET_MORE with an invalid cursor ID returns an error. */ 
-static void test_legacy_get_more_invalid_cursorid_live (void) {
-  mongoc_apm_callbacks_t *callbacks;
-   mongoc_client_t *client;
-   mongoc_collection_t *collection;
-   bson_t *b;
-   mongoc_bulk_operation_t *bulk;
-   int i;
-   bson_error_t error;
-   uint32_t server_id;
-   bool r;
-   mongoc_cursor_t *cursor;
-   const bson_t *doc;
-   killcursors_test_t ctx;
-
-   ctx.succeeded_count = 0;
-
-   callbacks = mongoc_apm_callbacks_new ();
-   mongoc_apm_set_command_succeeded_cb (callbacks, killcursors_succeeded);
-   client = test_framework_new_default_client ();
-   mongoc_client_set_apm_callbacks (client, callbacks, &ctx);
-   collection = get_test_collection (client, "test");
-   b = tmp_bson ("{}");
-   bulk = mongoc_collection_create_bulk_operation_with_opts (collection, NULL);
-   for (i = 0; i < 200; i++) {
-      mongoc_bulk_operation_insert (bulk, b);
-   }
-
-   server_id = mongoc_bulk_operation_execute (bulk, NULL, &error);
-   ASSERT_OR_PRINT (server_id > 0, error);
-
-   b = bson_new ();
-   cursor = _mongoc_cursor_find_new (
-      client, collection->ns, b, NULL, NULL, NULL, NULL);
-   /* override the typical priming, and immediately transition to an OPQUERY
-    * find cursor. */
-   cursor->impl.destroy (&cursor->impl);
-   _mongoc_cursor_impl_find_opquery_init (cursor, b);
-
-   cursor->cursor_id = ctx.cursor_id;
-   cursor->state = END_OF_BATCH; /* meaning, "finished reading first batch" */
-   r = mongoc_cursor_next (cursor, &doc);
-   ASSERT (!r);
-   ASSERT (mongoc_cursor_error (cursor, &error));
-   ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_CURSOR, 16, "cursor is invalid");
-
-   mongoc_cursor_destroy (cursor);
    mongoc_bulk_operation_destroy (bulk);
    mongoc_collection_destroy (collection);
    mongoc_client_destroy (client);

--- a/src/libmongoc/tests/test-mongoc-exhaust.c
+++ b/src/libmongoc/tests/test-mongoc-exhaust.c
@@ -666,19 +666,22 @@ test_exhaust_install (TestSuite *suite)
                       test_exhaust_cursor_single,
                       NULL,
                       NULL,
-                      skip_if_mongos);
+                      skip_if_mongos,
+                      test_framework_skip_if_no_legacy_opcodes);
    TestSuite_AddFull (suite,
                       "/Client/exhaust_cursor/pool",
                       test_exhaust_cursor_pool,
                       NULL,
                       NULL,
-                      skip_if_mongos);
+                      skip_if_mongos,
+                      test_framework_skip_if_no_legacy_opcodes);
    TestSuite_AddFull (suite,
                       "/Client/exhaust_cursor/batches",
                       test_exhaust_cursor_multi_batch,
                       NULL,
                       NULL,
-                      skip_if_mongos);
+                      skip_if_mongos,
+                      test_framework_skip_if_no_legacy_opcodes);
    TestSuite_AddLive (suite,
                       "/Client/set_max_await_time_ms",
                       test_cursor_set_max_await_time_ms);


### PR DESCRIPTION
__Background__

The latest 5.1 pre-release removes support for:
- [legacy wire protocol op codes](https://docs.mongodb.com/manual/reference/mongodb-wire-protocol/) in [SERVER-57457](https://jira.mongodb.org/browse/SERVER-57457) and [SERVER-57391](https://jira.mongodb.org/browse/SERVER-57391).
- The deprecated `getLastError` command in [SERVER-57390](https://jira.mongodb.org/browse/SERVER-57390)
- This also addresses CDRIVER-4092 by fixing tests that send OP_GET_MORE and legacy OP_QUERY

__Changes__

- Skip `/command_monitoring/kill_cursors_deprecated` on latest servers since it tests sending OP_KILL_CURSORS.
- Skip `/BulkOperation/write_concern/split` on latest servers since it sends `getLastError`.
- Update `test_kill_cursor_live` to use the [`getMore` command on newer servers](https://docs.mongodb.com/manual/reference/command/getMore/), and the legacy `OP_GET_MORE` on older servers.
- Skip exhaust cursor tests on latest servers, since exhaust cursors use the legacy `OP_QUERY` code.
