### PR TITLE
CDRIVER-4059 service_id on command monitoring events

### DIFF
--- a/src/libmongoc/doc/mongoc_apm_command_failed_get_service_id.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_failed_get_service_id.rst
@@ -1,0 +1,26 @@
+:man_page: mongoc_apm_command_failed_get_service_id
+
+mongoc_apm_command_failed_get_service_id()
+==========================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  const bson_oid_t *
+  mongoc_apm_command_failed_get_service_id (
+     const mongoc_apm_command_failed_t *event);
+
+Returns this event's service ID, which identifies the MongoDB service behind a
+load balancer, or ``NULL`` if not connected to a load balanced cluster.
+
+Parameters
+----------
+
+* ``event``: A :symbol:`mongoc_apm_command_failed_t`.
+
+Returns
+-------
+
+A :symbol:`bson_oid_t` that should not be modified or freed or ``NULL``.

--- a/src/libmongoc/doc/mongoc_apm_command_failed_t.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_failed_t.rst
@@ -28,6 +28,7 @@ An event notification sent when the driver fails to execute a MongoDB command.
     mongoc_apm_command_failed_get_reply
     mongoc_apm_command_failed_get_request_id
     mongoc_apm_command_failed_get_server_id
+    mongoc_apm_command_failed_get_service_id
 
 .. seealso::
 

--- a/src/libmongoc/doc/mongoc_apm_command_started_get_service_id.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_started_get_service_id.rst
@@ -1,0 +1,26 @@
+:man_page: mongoc_apm_command_started_get_service_id
+
+mongoc_apm_command_started_get_service_id()
+===========================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  const bson_oid_t *
+  mongoc_apm_command_started_get_service_id (
+     const mongoc_apm_command_started_t *event);
+
+Returns this event's service ID, which identifies the MongoDB service behind a
+load balancer, or ``NULL`` if not connected to a load balanced cluster.
+
+Parameters
+----------
+
+* ``event``: A :symbol:`mongoc_apm_command_started_t`.
+
+Returns
+-------
+
+A :symbol:`bson_oid_t` that should not be modified or freed or ``NULL``.

--- a/src/libmongoc/doc/mongoc_apm_command_started_t.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_started_t.rst
@@ -31,4 +31,5 @@ An event notification sent when the driver begins executing a MongoDB command.
     mongoc_apm_command_started_get_operation_id
     mongoc_apm_command_started_get_request_id
     mongoc_apm_command_started_get_server_id
+    mongoc_apm_command_started_get_service_id
 

--- a/src/libmongoc/doc/mongoc_apm_command_succeeded_get_service_id.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_succeeded_get_service_id.rst
@@ -1,0 +1,26 @@
+:man_page: mongoc_apm_command_succeeded_get_service_id
+
+mongoc_apm_command_succeeded_get_service_id()
+=============================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  const bson_oid_t *
+  mongoc_apm_command_succeeded_get_service_id (
+     const mongoc_apm_command_succeeded_t *event);
+
+Returns this event's service ID, which identifies the MongoDB service behind a
+load balancer, or ``NULL`` if not connected to a load balanced cluster.
+
+Parameters
+----------
+
+* ``event``: A :symbol:`mongoc_apm_command_succeeded_t`.
+
+Returns
+-------
+
+A :symbol:`bson_oid_t` that should not be modified or freed or ``NULL``.

--- a/src/libmongoc/doc/mongoc_apm_command_succeeded_t.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_succeeded_t.rst
@@ -31,4 +31,5 @@ An event notification sent when the driver successfully executes a MongoDB comma
     mongoc_apm_command_succeeded_get_reply
     mongoc_apm_command_succeeded_get_request_id
     mongoc_apm_command_succeeded_get_server_id
+    mongoc_apm_command_succeeded_get_service_id
 

--- a/src/libmongoc/src/mongoc/mongoc-apm-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-apm-private.h
@@ -55,6 +55,7 @@ struct _mongoc_apm_command_started_t {
    int64_t operation_id;
    const mongoc_host_list_t *host;
    uint32_t server_id;
+   bson_oid_t service_id;
    void *context;
 };
 
@@ -67,6 +68,7 @@ struct _mongoc_apm_command_succeeded_t {
    int64_t operation_id;
    const mongoc_host_list_t *host;
    uint32_t server_id;
+   bson_oid_t service_id;
    void *context;
 };
 
@@ -80,6 +82,7 @@ struct _mongoc_apm_command_failed_t {
    int64_t operation_id;
    const mongoc_host_list_t *host;
    uint32_t server_id;
+   bson_oid_t service_id;
    void *context;
 };
 
@@ -155,6 +158,7 @@ mongoc_apm_command_started_init (mongoc_apm_command_started_t *event,
                                  int64_t operation_id,
                                  const mongoc_host_list_t *host,
                                  uint32_t server_id,
+                                 const bson_oid_t *service_id,
                                  bool *is_redacted, /* out */
                                  void *context);
 
@@ -177,6 +181,7 @@ mongoc_apm_command_succeeded_init (mongoc_apm_command_succeeded_t *event,
                                    int64_t operation_id,
                                    const mongoc_host_list_t *host,
                                    uint32_t server_id,
+                                   const bson_oid_t *service_id,
                                    bool force_redaction,
                                    void *context);
 
@@ -193,6 +198,7 @@ mongoc_apm_command_failed_init (mongoc_apm_command_failed_t *event,
                                 int64_t operation_id,
                                 const mongoc_host_list_t *host,
                                 uint32_t server_id,
+                                const bson_oid_t *service_id,
                                 bool force_redaction,
                                 void *context);
 

--- a/src/libmongoc/src/mongoc/mongoc-apm.h
+++ b/src/libmongoc/src/mongoc/mongoc-apm.h
@@ -99,6 +99,9 @@ mongoc_apm_command_started_get_host (const mongoc_apm_command_started_t *event);
 MONGOC_EXPORT (uint32_t)
 mongoc_apm_command_started_get_server_id (
    const mongoc_apm_command_started_t *event);
+MONGOC_EXPORT (const bson_oid_t *)
+mongoc_apm_command_started_get_service_id (
+   const mongoc_apm_command_started_t *event);
 MONGOC_EXPORT (void *)
 mongoc_apm_command_started_get_context (
    const mongoc_apm_command_started_t *event);
@@ -125,6 +128,9 @@ mongoc_apm_command_succeeded_get_host (
    const mongoc_apm_command_succeeded_t *event);
 MONGOC_EXPORT (uint32_t)
 mongoc_apm_command_succeeded_get_server_id (
+   const mongoc_apm_command_succeeded_t *event);
+MONGOC_EXPORT (const bson_oid_t *)
+mongoc_apm_command_succeeded_get_service_id (
    const mongoc_apm_command_succeeded_t *event);
 MONGOC_EXPORT (void *)
 mongoc_apm_command_succeeded_get_context (
@@ -154,6 +160,9 @@ MONGOC_EXPORT (const mongoc_host_list_t *)
 mongoc_apm_command_failed_get_host (const mongoc_apm_command_failed_t *event);
 MONGOC_EXPORT (uint32_t)
 mongoc_apm_command_failed_get_server_id (
+   const mongoc_apm_command_failed_t *event);
+MONGOC_EXPORT (const bson_oid_t *)
+mongoc_apm_command_failed_get_service_id (
    const mongoc_apm_command_failed_t *event);
 MONGOC_EXPORT (void *)
 mongoc_apm_command_failed_get_context (

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -2364,6 +2364,7 @@ _mongoc_client_monitor_op_killcursors (mongoc_cluster_t *cluster,
                                     operation_id,
                                     &server_stream->sd->host,
                                     server_stream->sd->id,
+                                    &server_stream->sd->service_id,
                                     NULL,
                                     client->apm_context);
 
@@ -2411,6 +2412,7 @@ _mongoc_client_monitor_op_killcursors_succeeded (
                                       operation_id,
                                       &server_stream->sd->host,
                                       server_stream->sd->id,
+                                      &server_stream->sd->service_id,
                                       false,
                                       client->apm_context);
 
@@ -2454,6 +2456,7 @@ _mongoc_client_monitor_op_killcursors_failed (
                                    operation_id,
                                    &server_stream->sd->host,
                                    server_stream->sd->id,
+                                   &server_stream->sd->service_id,
                                    false,
                                    client->apm_context);
 

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -585,6 +585,7 @@ mongoc_cluster_run_command_monitored (mongoc_cluster_t *cluster,
                                          cmd->operation_id,
                                          &server_stream->sd->host,
                                          server_id,
+                                         &server_stream->sd->service_id,
                                          is_redacted,
                                          cluster->client->apm_context);
 
@@ -602,6 +603,7 @@ mongoc_cluster_run_command_monitored (mongoc_cluster_t *cluster,
                                       cmd->operation_id,
                                       &server_stream->sd->host,
                                       server_id,
+                                      &server_stream->sd->service_id,
                                       is_redacted,
                                       cluster->client->apm_context);
 

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -859,7 +859,8 @@ _mongoc_stream_run_hello (mongoc_cluster_t *cluster,
 
    mongoc_server_description_init (handshake_sd, address, server_id);
    /* send the error from run_command IN to handle_hello */
-   mongoc_server_description_handle_hello (handshake_sd, &reply, rtt_msec, error);
+   mongoc_server_description_handle_hello (
+      handshake_sd, &reply, rtt_msec, error);
 
    if (cluster->requires_auth && speculative_auth_response) {
       _mongoc_topology_scanner_parse_speculative_authentication (
@@ -868,7 +869,8 @@ _mongoc_stream_run_hello (mongoc_cluster_t *cluster,
 
    bson_destroy (&reply);
 
-   r = _mongoc_topology_update_from_handshake (cluster->client->topology, handshake_sd);
+   r = _mongoc_topology_update_from_handshake (cluster->client->topology,
+                                               handshake_sd);
    if (!r) {
       mongoc_server_description_reset (handshake_sd);
       bson_set_error (&handshake_sd->error,
@@ -2123,8 +2125,13 @@ _mongoc_cluster_add_node (mongoc_cluster_t *cluster,
 
    if (cluster->requires_auth) {
       /* Complete speculative authentication */
-      bool is_auth = _mongoc_cluster_finish_speculative_auth (
-         cluster, stream, handshake_sd, &speculative_auth_response, &scram, error);
+      bool is_auth =
+         _mongoc_cluster_finish_speculative_auth (cluster,
+                                                  stream,
+                                                  handshake_sd,
+                                                  &speculative_auth_response,
+                                                  &scram,
+                                                  error);
 
       if (!is_auth && !_mongoc_cluster_auth_node (cluster,
                                                   cluster_node->stream,
@@ -2582,7 +2589,7 @@ _mongoc_cluster_create_server_stream (
     * lock while copying topology->description.logical_time below */
    bson_mutex_lock (&topology->mutex);
    server_stream =
-         mongoc_server_stream_new (&topology->description, sd, stream);
+      mongoc_server_stream_new (&topology->description, sd, stream);
    bson_mutex_unlock (&topology->mutex);
 
    return server_stream;
@@ -2649,7 +2656,7 @@ mongoc_cluster_fetch_stream_pooled (mongoc_cluster_t *cluster,
       _mongoc_cluster_add_node (cluster, server_id, error);
    if (cluster_node) {
       return _mongoc_cluster_create_server_stream (
-            topology, cluster_node->handshake_sd, cluster_node->stream, error);
+         topology, cluster_node->handshake_sd, cluster_node->stream, error);
    } else {
       return NULL;
    }

--- a/src/libmongoc/src/mongoc/mongoc-cursor-legacy.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor-legacy.c
@@ -478,9 +478,9 @@ _mongoc_cursor_op_query_find (mongoc_cursor_t *cursor,
    started = bson_get_monotonic_time ();
 
    /* When the user explicitly provides a readConcern -- but the server
-       * doesn't support readConcern, we must error:
-       * https://github.com/mongodb/specifications/blob/master/source/read-write-concern/read-write-concern.rst#errors-1
-       */
+    * doesn't support readConcern, we must error:
+    * https://github.com/mongodb/specifications/blob/master/source/read-write-concern/read-write-concern.rst#errors-1
+    */
    if (cursor->read_concern->level != NULL &&
        server_stream->sd->max_wire_version < WIRE_VERSION_READ_CONCERN) {
       bson_set_error (&cursor->error,

--- a/src/libmongoc/src/mongoc/mongoc-cursor-legacy.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor-legacy.c
@@ -62,6 +62,7 @@ _mongoc_cursor_monitor_legacy_get_more (mongoc_cursor_t *cursor,
                                     cursor->operation_id,
                                     &server_stream->sd->host,
                                     server_stream->sd->id,
+                                    &server_stream->sd->service_id,
                                     NULL,
                                     client->apm_context);
 

--- a/src/libmongoc/src/mongoc/mongoc-cursor.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor.c
@@ -606,7 +606,7 @@ mongoc_cursor_destroy (mongoc_cursor_t *cursor)
       cursor->client->in_exhaust = false;
       if (cursor->state != DONE) {
          /* The only way to stop an exhaust cursor is to kill the connection
-            */
+          */
          mongoc_cluster_disconnect_node (&cursor->client->cluster,
                                          cursor->server_id);
       }
@@ -1008,7 +1008,8 @@ _mongoc_cursor_run_command (mongoc_cursor_t *cursor,
    /* we might use mongoc_cursor_set_hint to target a secondary but have no
     * read preference, so the secondary rejects the read. same if we have a
     * direct connection to a secondary (topology type "single"). with
-    * OP_QUERY we handle this by setting secondaryOk. here we use $readPreference.
+    * OP_QUERY we handle this by setting secondaryOk. here we use
+    * $readPreference.
     */
    cmd_name = _mongoc_get_command_name (command);
    is_primary =

--- a/src/libmongoc/src/mongoc/mongoc-cursor.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor.c
@@ -711,6 +711,7 @@ _mongoc_cursor_monitor_command (mongoc_cursor_t *cursor,
                                     cursor->operation_id,
                                     &server_stream->sd->host,
                                     server_stream->sd->id,
+                                    &server_stream->sd->service_id,
                                     NULL,
                                     client->apm_context);
 
@@ -792,6 +793,7 @@ _mongoc_cursor_monitor_succeeded (mongoc_cursor_t *cursor,
                                       cursor->operation_id,
                                       &stream->sd->host,
                                       stream->sd->id,
+                                      &stream->sd->service_id,
                                       false,
                                       client->apm_context);
 
@@ -837,6 +839,7 @@ _mongoc_cursor_monitor_failed (mongoc_cursor_t *cursor,
                                    cursor->operation_id,
                                    &stream->sd->host,
                                    stream->sd->id,
+                                   &stream->sd->service_id,
                                    false,
                                    client->apm_context);
 

--- a/src/libmongoc/src/mongoc/mongoc-server-description-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-server-description-private.h
@@ -109,8 +109,8 @@ struct _mongoc_server_description_t {
    1. a monitor receives a network error
    2. an app thread receives any network error before completing a handshake
    3. an app thread receives a non-timeout network error after the handshake
-   4. an app thread receives a "not primary" or "node is recovering" error from a
-   pre-4.2 server.
+   4. an app thread receives a "not primary" or "node is recovering" error from
+   a pre-4.2 server.
    */
 
    /* generation only applies to a server description tied to a connection.

--- a/src/libmongoc/src/mongoc/mongoc-write-command-legacy.c
+++ b/src/libmongoc/src/mongoc/mongoc-write-command-legacy.c
@@ -55,6 +55,7 @@ _mongoc_monitor_legacy_write (mongoc_client_t *client,
       command->operation_id,
       &stream->sd->host,
       stream->sd->id,
+      &stream->sd->service_id,
       NULL,
       client->apm_context);
 
@@ -105,6 +106,7 @@ _mongoc_monitor_legacy_write_succeeded (mongoc_client_t *client,
       command->operation_id,
       &stream->sd->host,
       stream->sd->id,
+      &stream->sd->service_id,
       false,
       client->apm_context);
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-4059

It's not often that I add new API methods, so please let me know if I missed anything. AFAICT, the docs don't report the version number when a particular method was introduced.