### PR TITLE
CDRIVER-4112 use arm64 hosts for rpm-package-build

### DIFF
--- a/.evergreen/build_snapshot_rpm.sh
+++ b/.evergreen/build_snapshot_rpm.sh
@@ -39,7 +39,7 @@ done
 
 package=mongo-c-driver
 spec_file=../mongo-c-driver.spec
-config=${MOCK_TARGET_CONFIG:=fedora-34-x86_64}
+config=${MOCK_TARGET_CONFIG:=fedora-35-aarch64}
 
 if [ ! -x /usr/bin/rpmbuild -o ! -x /usr/bin/rpmspec ]; then
   echo "Missing the rpmbuild or rpmspec utility from the rpm-build package"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -27282,7 +27282,7 @@ buildvariants:
   - debian-package-build
   - name: rpm-package-build
     distros:
-    - rhel80-test
+    - rhel82-arm64-small
   batchtime: 1440
 - name: tsan-ubuntu
   display_name: Thread Sanitizer (TSAN) Tests (Ubuntu 18.04)

--- a/.evergreen/spec.patch
+++ b/.evergreen/spec.patch
@@ -1,5 +1,5 @@
---- mongo-c-driver.spec.orig	2020-11-30 10:07:51.831526659 -0500
-+++ mongo-c-driver.spec	2020-11-30 10:09:59.029834450 -0500
+--- mongo-c-driver.spec.orig	2021-07-29 18:30:42.094477733 -0400
++++ mongo-c-driver.spec	2021-07-29 18:31:06.347021236 -0400
 @@ -10,14 +10,14 @@
  %global gh_project   mongo-c-driver
  %global libname      libmongoc
@@ -33,7 +33,7 @@
  
  %description devel
  This package contains the header files and development libraries
-@@ -128,7 +126,6 @@
+@@ -130,7 +128,6 @@
  %endif
      -DENABLE_EXAMPLES:BOOL=OFF \
      -DENABLE_UNINSTALL:BOOL=OFF \


### PR DESCRIPTION
Patch build: https://spruce.mongodb.com/version/61032dce850e6118fbedda87/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC