### PR TITLE
CDRIVER-4110: Default for causal_consistency depends on snapshot

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-client-session-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-session-private.h
@@ -38,14 +38,9 @@ struct _mongoc_transaction_opt_t {
    int64_t max_commit_time_ms;
 };
 
-typedef enum {
-   MONGOC_SESSION_NO_OPTS = 0,
-   MONGOC_SESSION_CAUSAL_CONSISTENCY = (1 << 0),
-   MONGOC_SESSION_SNAPSHOT = (2 << 0),
-} mongoc_session_flag_t;
-
 struct _mongoc_session_opt_t {
-   mongoc_session_flag_t flags;
+   mongoc_optional_t causal_consistency;
+   mongoc_optional_t snapshot;
    mongoc_transaction_opt_t default_txn_opts;
 };
 

--- a/src/libmongoc/tests/test-mongoc-transactions.c
+++ b/src/libmongoc/tests/test-mongoc-transactions.c
@@ -1167,35 +1167,6 @@ test_max_commit_time_ms_is_reset (void *ctx)
 }
 
 void
-test_snapshot_session_prose_1 (void *ctx)
-{
-   mongoc_client_t *client = NULL;
-   mongoc_session_opt_t *session_opts = NULL;
-   bson_error_t error;
-   bool r;
-
-   client = test_framework_new_default_client ();
-   BSON_ASSERT (client);
-
-   session_opts = mongoc_session_opts_new ();
-   mongoc_session_opts_set_causal_consistency (session_opts, true);
-   mongoc_session_opts_set_snapshot (session_opts, true);
-
-   /* assert that starting session with causal consistency and snapshot enabled
-    * results in an error. */
-   r = mongoc_client_start_session (client, session_opts, &error);
-   ASSERT (!r);
-   ASSERT_ERROR_CONTAINS (
-      error,
-      MONGOC_ERROR_CLIENT,
-      MONGOC_ERROR_CLIENT_SESSION_FAILURE,
-      "Only one of causal consistency and snapshot can be enabled.");
-
-   mongoc_session_opts_destroy (session_opts);
-   mongoc_client_destroy (client);
-}
-
-void
 test_transactions_install (TestSuite *suite)
 {
    char resolved[PATH_MAX];
@@ -1286,10 +1257,4 @@ test_transactions_install (TestSuite *suite)
                       NULL,
                       NULL,
                       test_framework_skip_if_no_crypto);
-   TestSuite_AddFull (suite,
-                      "/transactions/snapshot_sessions_prose_1",
-                      test_snapshot_session_prose_1,
-                      NULL,
-                      NULL,
-                      test_framework_skip_if_no_txns);
 }

--- a/src/libmongoc/tests/unified/entity-map.c
+++ b/src/libmongoc/tests/unified/entity-map.c
@@ -587,8 +587,6 @@ session_opts_new (bson_t *bson, bson_error_t *error)
       mongoc_session_opts_set_causal_consistency (opts, *causal_consistency);
    }
    if (snapshot) {
-      /* Set causal consistency to false to allow snapshot */
-      mongoc_session_opts_set_causal_consistency (opts, false);
       mongoc_session_opts_set_snapshot (opts, *snapshot);
    }
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-4110

 * Removes a work-around from the unified test runner originally introduced in https://github.com/mongodb/mongo-c-driver/commit/d5f73e18eac7acaa05f31c4ffde68c9cd565704a.
 * Relocates the snapshot prose test, since it's part of the session spec (not transactions)
 * Use `mongoc_optional_t` in `mongoc_session_opt_t` to track values for `causalConsistency` and `snapshot` options, and enforce the `causalConsistency` logic in the corresponding getter method.