### PR TITLE
CDRIVER-4068 add connectivity tests for serverless

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -479,6 +479,8 @@ functions:
         export REQUIRE_TLS12='${require_tls12}'
         export OBSOLETE_TLS='${obsolete_tls}'
         export VALGRIND='${valgrind}'
+        export ATLAS_SERVERLESS_SRV='${atlas_serverless_srv}'
+        export ATLAS_SERVERLESS='${atlas_serverless}'
         sh .evergreen/run-auth-tests.sh
   run mock server tests:
   - command: shell.exec

--- a/.evergreen/run-auth-tests.sh
+++ b/.evergreen/run-auth-tests.sh
@@ -22,6 +22,8 @@ set +o xtrace   # Don't echo commands
 # REQUIRE_TLS12=${require_tls12} # libmongoc requires TLS 1.2+
 # OBSOLETE_TLS=${obsolete_tls} # libmongoc was built with old TLS lib, don't try connecting to Atlas
 # VALGRIND=${valgrind} # Whether to run with valgrind
+# ATLAS_SERVERLESS_SRV=${atlas_serverless_srv} # Evergreen variable
+# ATLAS_SERVERLESS=${atlas_serverless} # Evergreen variable
 
 
 C_TIMEOUT="connectTimeoutMS=30000&serverSelectionTryOnce=false"
@@ -112,6 +114,10 @@ if [ $SSL -eq 1 ]; then
       $PING "$ATLAS_TLS12&${C_TIMEOUT}"
       echo "Connecting to Atlas with only TLS 1.2 enabled with SRV"
       $PING "$ATLAS_TLS12_SRV${C_TIMEOUT}"
+      echo "Connecting to Atlas Serverless with SRV"
+      $PING "$ATLAS_SERVERLESS_SRV/?${C_TIMEOUT}"
+      echo "Connecting to Atlas Serverless"
+      $PING "$ATLAS_SERVERLESS&${C_TIMEOUT}"
    fi
 fi
 

--- a/build/evergreen_config_lib/functions.py
+++ b/build/evergreen_config_lib/functions.py
@@ -340,6 +340,8 @@ all_functions = OD([
         export REQUIRE_TLS12='${require_tls12}'
         export OBSOLETE_TLS='${obsolete_tls}'
         export VALGRIND='${valgrind}'
+        export ATLAS_SERVERLESS_SRV='${atlas_serverless_srv}'
+        export ATLAS_SERVERLESS='${atlas_serverless}
         sh .evergreen/run-auth-tests.sh
         ''', silent=True),
     )),


### PR DESCRIPTION
Add a connectivity test to ensure we can connect and send a `ping` command to a live serverless instance.

Tests against the latest server are failing due to a recent server change. It is described in CDRIVER-4120 and resolved in #843.