### PR TITLE
CDRIVER-4093 add versioned API strict examples 5-8

### DIFF
--- a/src/libmongoc/tests/test-mongoc-primary-stepdown.c
+++ b/src/libmongoc/tests/test-mongoc-primary-stepdown.c
@@ -241,8 +241,7 @@ test_not_primary_keep_pool (mongoc_client_t *client)
       coll, tmp_bson ("{'test': 1}"), NULL, NULL, &error);
    ASSERT (!res);
    ASSERT_CMPINT (error.code, ==, 10107);
-   ASSERT_CONTAINS (error.message,
-                    "Failing command due to 'failCommand' failpoint");
+   ASSERT_CONTAINS (error.message, "failpoint");
 
    /* Execute a second insert, verify that it succeeds */
    res = mongoc_collection_insert_one (
@@ -308,8 +307,7 @@ test_not_primary_reset_pool (mongoc_client_t *client)
       coll, tmp_bson ("{'test': 1}"), NULL, NULL, &error);
    ASSERT (!res);
    ASSERT_CMPINT (error.code, ==, 10107);
-   ASSERT_CONTAINS (error.message,
-                    "Failing command due to 'failCommand' failpoint");
+   ASSERT_CONTAINS (error.message, "failpoint");
 
    /* Verify that the pool has been cleared */
    ASSERT_CMPINT ((conn_count + 1), ==, _connection_count (client, primary_id));
@@ -376,8 +374,7 @@ test_shutdown_reset_pool (mongoc_client_t *client)
       coll, tmp_bson ("{'test': 1}"), NULL, NULL, &error);
    ASSERT (!res);
    ASSERT_CMPINT (error.code, ==, 91);
-   ASSERT_CONTAINS (error.message,
-                    "Failing command due to 'failCommand' failpoint");
+   ASSERT_CONTAINS (error.message, "failpoint");
 
    /* Verify that the pool has been cleared */
    ASSERT_CMPINT ((conn_count + 1), ==, _connection_count (client, primary_id));
@@ -444,8 +441,7 @@ test_interrupted_shutdown_reset_pool (mongoc_client_t *client)
       coll, tmp_bson ("{'test': 1}"), NULL, NULL, &error);
    ASSERT (!res);
    ASSERT_CMPINT (error.code, ==, 11600);
-   ASSERT_CONTAINS (error.message,
-                    "Failing command due to 'failCommand' failpoint");
+   ASSERT_CONTAINS (error.message, "failpoint");
 
    /* Verify that the pool has been cleared */
    ASSERT_CMPINT ((conn_count + 1), ==, _connection_count (client, primary_id));

--- a/src/libmongoc/tests/test-mongoc-retryable-reads.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-reads.c
@@ -263,8 +263,7 @@ test_retry_reads_off (void *ctx)
    res = mongoc_collection_read_command_with_opts (
       collection, cmd, NULL, NULL, NULL, &error);
    ASSERT (!res);
-   ASSERT_CONTAINS (error.message,
-                    "Failing command due to 'failCommand' failpoint");
+   ASSERT_CONTAINS (error.message, "failpoint");
 
    deactivate_fail_points (client, server_id);
 

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -3711,8 +3711,8 @@ static int64_t iso_to_unix (const char* iso_str) {
 
 static void _test_sample_versioned_api_example_5_6_7_8 (void) {
 #define N_DOCS 8
-   mongoc_client_t *client = NULL;
-   mongoc_server_api_t *server_api = NULL;
+   mongoc_client_t *client;
+   mongoc_server_api_t *server_api;
    mongoc_server_api_version_t server_api_version;
    bool ok;
    bson_error_t error;

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -3795,8 +3795,8 @@ static void _test_sample_versioned_api_example_5_6_7_8 (void) {
    ASSERT_ERROR_CONTAINS (error,
                           MONGOC_ERROR_SERVER,
                           323,
-                          "Provided apiStrict:true, but the command count is "
-                          "not in API Version 1.");
+                          "Provided apiStrict:true, but the command count is not in API Version 1");
+   ASSERT (!ok);
    bson_destroy (&reply);
 #if 0
    /* This block not evaluated, but is inserted into documentation to represent the above reply.

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -3801,7 +3801,7 @@ static void _test_sample_versioned_api_example_5_6_7_8 (void) {
 #if 0
    /* This block not evaluated, but is inserted into documentation to represent the above reply.
     * Don't delete me! */
-   /* Begin Versioned API Example 6 */
+   /* Start Versioned API Example 6 */
    char *str = bson_as_json (&reply, NULL /* length */);
    printf ("%s", str);
    /* Prints the server reply:


### PR DESCRIPTION
This also includes a fix for tests against latest server builds (CDRIVER-4120).