### PR TITLE
CDRIVER-4106 Update numbers for existing SRV polling prose tests.

### DIFF
--- a/src/libmongoc/tests/test-mongoc-dns.c
+++ b/src/libmongoc/tests/test-mongoc-dns.c
@@ -633,8 +633,8 @@ _prose_loadbalanced_ping (mongoc_client_t *client)
 }
 
 /*
-   Implements the following prose test described in the SRV polling test README:
-   Test that SRV polling is not done for load balalanced clusters. Connect to
+   Implements prose test 9 as described in the SRV polling test README:
+   Test that SRV polling is not done for load balanced clusters. Connect to
    mongodb+srv://test3.test.build.10gen.cc/?loadBalanced=true, mock the addition
    of the following DNS record, wait until 2*rescanSRVIntervalMS, and assert
    that the final topology description only contains one server
@@ -643,7 +643,7 @@ _prose_loadbalanced_ping (mongoc_client_t *client)
    localhost.test.build.10gen.cc.
 */
 static void
-_prose_loadbalanced_run (bool pooled)
+_prose_test_9 (bool pooled)
 {
    mongoc_client_pool_t *pool;
    mongoc_uri_t *uri;
@@ -717,15 +717,15 @@ _prose_loadbalanced_run (bool pooled)
 }
 
 static void
-test_prose_loadbalanced_single (void *unused)
+prose_test_9_single (void *unused)
 {
-   _prose_loadbalanced_run (false);
+   _prose_test_9 (false);
 }
 
 static void
-test_prose_loadbalanced_pooled (void *unused)
+prose_test_9_pooled (void *unused)
 {
-   _prose_loadbalanced_run (true);
+   _prose_test_9 (true);
 }
 
 void
@@ -757,16 +757,16 @@ test_dns_install (TestSuite *suite)
     * Discovery" spec. */
    TestSuite_AddFull (
       suite,
-      "/initial_dns_seedlist_discovery/srv_polling/prose_loadbalanced/single",
-      test_prose_loadbalanced_single,
+      "/initial_dns_seedlist_discovery/srv_polling/prose_test_9/single",
+      prose_test_9_single,
       NULL,
       NULL,
       test_dns_check_loadbalanced);
 
    TestSuite_AddFull (
       suite,
-      "/initial_dns_seedlist_discovery/srv_polling/prose_loadbalanced/pooled",
-      test_prose_loadbalanced_pooled,
+      "/initial_dns_seedlist_discovery/srv_polling/prose_test_9/pooled",
+      prose_test_9_pooled,
       NULL,
       NULL,
       test_dns_check_loadbalanced);


### PR DESCRIPTION
Only [prose test 9](https://github.com/mongodb/specifications/blob/df6be82f865e9b72444488fd62ae1eb5fca18569/source/polling-srv-records-for-mongos-discovery/tests/README.rst#9-test-that-srv-polling-is-not-done-for-load-balalanced-clusters) is [currently implemented](https://github.com/mongodb/mongo-c-driver/blob/0d6a8ba27ed5cd94a26e4db879f61b545799193f/src/libmongoc/tests/test-mongoc-dns.c#L646) according to spec. Behavior of [`test_srv_polling_mocked`](https://github.com/mongodb/mongo-c-driver/blob/0d6a8ba27ed5cd94a26e4db879f61b545799193f/src/libmongoc/tests/test-mongoc-dns.c#L500) does not conform to prose tests described by spec. Therefore, only names related to prose test 9 are updated with numbering.

Prose tests 1 through 8 are to be implemented separately; see CDRIVER-4125.

---

This resolves CDRIVER-4106.

Names of tests and test functions are modelled after existing numbered prose tests such as those in [test-mongoc-crud.c](https://github.com/mongodb/mongo-c-driver/blob/0d6a8ba27ed5cd94a26e4db879f61b545799193f/src/libmongoc/tests/test-mongoc-crud.c#L173).