### PR TITLE
Add instructions to enable fail points for test suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,11 +120,12 @@ the .rst files.
 
 ### Testing
 
-To run the entire test suite, including authentication tests,
-start `mongod` with auth enabled:
+To run the entire test suite, including authentication and support for the
+`configureFailPoint` command, start `mongod` with security and test commands
+enabled:
 
 ```
-$ mongod --auth
+$ mongod --auth --setParameter enableTestCommands=1
 ```
 
 In another terminal, use the `mongo` shell to create a user:


### PR DESCRIPTION
Several tests require use of the [`configureFailPoint` command](https://github.com/mongodb/specifications/blob/master/source/unified-test-format/unified-test-format.rst#configuring-fail-points) to trigger server-side errors. The command must be enabled via configuration file or command line option when starting `mongod`.

The `configureFailPoint` command is not yet documented; see [DOCS-10784](https://jira.mongodb.org/browse/DOCS-10784).

---

This PR is motivated by my experience following written instructions to run the test suite locally. After following instructions, several tests were failing due to the error: `no such command: 'configureFailPoint'`.

Diagnosing this issue was difficult due to the `configureFailPoint` command having little to no documentation. It is however mentioned in the [unified test format specification](https://github.com/mongodb/specifications/blob/df6be82f865e9b72444488fd62ae1eb5fca18569/source/unified-test-format/unified-test-format.rst#server-fail-points). To _correctly_ run the entire test suite, fail points must be enabled via the `enableTestCommands` server parameter. Discovering this was difficult due to relevant information being scattered around in unusual locations; notably, it is not mentioned in any official documentation pages.

This PR seeks to improve the accuracy of testing instructions by explicitly including the command line option when starting `mongod`.