### PR TITLE
CDRIVER-4093 fix versioned API sample tests

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -51,7 +51,7 @@ get_mongodb_download_url_for ()
    _DISTRO=$1
    _VERSION=$2
 
-   VERSION_50="5.0.0"
+   VERSION_50="5.0.2"
    VERSION_44="4.4.6"
    VERSION_42="4.2.15"
    VERSION_40="4.0.25"

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -3826,7 +3826,6 @@ static void _test_sample_versioned_api_example_5_6_7_8 (void) {
       323,
       "Provided apiStrict:true, but the command count is not in API Version 1");
    ASSERT_CMPINT64 (-1, ==, count);
-   bson_destroy (&reply);
 #if 0
    /* This block not evaluated, but is inserted into documentation to represent the above reply.
     * Don't delete me! */

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -3747,7 +3747,6 @@ static void _test_sample_versioned_api_example_5_6_7_8 (void) {
    bson_t *filter;
 
    client = get_client_for_version_api_example ();
-   test_framework_monitor_commands (client);
    mongoc_client_set_error_api (client, MONGOC_ERROR_API_VERSION_2);
    mongoc_server_api_version_from_string ("1", &server_api_version);
    server_api = mongoc_server_api_new (server_api_version);

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -24,6 +24,7 @@
  */
 
 /* clang-format off */
+#include <assert.h>
 #include <mongoc/mongoc.h>
 #include <mongoc/mongoc-util-private.h>
 #include <mongoc/mongoc-database-private.h>
@@ -3594,7 +3595,6 @@ _test_sample_versioned_api_example_1 (void)
    mongoc_server_api_t *server_api = NULL;
    mongoc_server_api_version_t server_api_version;
    bson_error_t error;
-   bool ok;
 
    /* For a replica set, include the replica set name and a seedlist of the
     * members in the URI string; e.g.
@@ -3607,13 +3607,13 @@ _test_sample_versioned_api_example_1 (void)
     * client = mongoc_client_new (uri_sharded);
     */
 
+   /* Create a mongoc_client_t without server API options configured. */
    client = get_client_for_version_api_example ();
 
    mongoc_server_api_version_from_string ("1", &server_api_version);
    server_api = mongoc_server_api_new (server_api_version);
 
-   ok = mongoc_client_set_server_api (client, server_api, &error);
-   BSON_ASSERT (ok);
+   assert (mongoc_client_set_server_api (client, server_api, &error));
    /* End Versioned API Example 1 */
 
    mongoc_client_destroy (client);
@@ -3628,7 +3628,6 @@ _test_sample_versioned_api_example_2 (void)
    mongoc_server_api_t *server_api = NULL;
    mongoc_server_api_version_t server_api_version;
    bson_error_t error;
-   bool ok;
 
    /* For a replica set, include the replica set name and a seedlist of the
     * members in the URI string; e.g.
@@ -3641,14 +3640,14 @@ _test_sample_versioned_api_example_2 (void)
     * client = mongoc_client_new (uri_sharded);
     */
 
+   /* Create a mongoc_client_t without server API options configured. */
    client = get_client_for_version_api_example ();
 
    mongoc_server_api_version_from_string ("1", &server_api_version);
    server_api = mongoc_server_api_new (server_api_version);
    mongoc_server_api_strict (server_api, true);
 
-   ok = mongoc_client_set_server_api (client, server_api, &error);
-   BSON_ASSERT (ok);
+   assert (mongoc_client_set_server_api (client, server_api, &error));
    /* End Versioned API Example 2 */
 
    mongoc_client_destroy (client);
@@ -3663,7 +3662,6 @@ _test_sample_versioned_api_example_3 (void)
    mongoc_server_api_t *server_api = NULL;
    mongoc_server_api_version_t server_api_version;
    bson_error_t error;
-   bool ok;
 
    /* For a replica set, include the replica set name and a seedlist of the
     * members in the URI string; e.g.
@@ -3676,14 +3674,14 @@ _test_sample_versioned_api_example_3 (void)
     * client = mongoc_client_new (uri_sharded);
     */
 
+   /* Create a mongoc_client_t without server API options configured. */
    client = get_client_for_version_api_example ();
 
    mongoc_server_api_version_from_string ("1", &server_api_version);
    server_api = mongoc_server_api_new (server_api_version);
    mongoc_server_api_strict (server_api, false);
 
-   ok = mongoc_client_set_server_api (client, server_api, &error);
-   BSON_ASSERT (ok);
+   assert (mongoc_client_set_server_api (client, server_api, &error));
    /* End Versioned API Example 3 */
 
    mongoc_client_destroy (client);
@@ -3698,7 +3696,6 @@ _test_sample_versioned_api_example_4 (void)
    mongoc_server_api_t *server_api = NULL;
    mongoc_server_api_version_t server_api_version;
    bson_error_t error;
-   bool ok;
 
    /* For a replica set, include the replica set name and a seedlist of the
     * members in the URI string; e.g.
@@ -3711,14 +3708,14 @@ _test_sample_versioned_api_example_4 (void)
     * client = mongoc_client_new (uri_sharded);
     */
 
+   /* Create a mongoc_client_t without server API options configured. */
    client = get_client_for_version_api_example ();
 
    mongoc_server_api_version_from_string ("1", &server_api_version);
    server_api = mongoc_server_api_new (server_api_version);
    mongoc_server_api_deprecation_errors (server_api, true);
 
-   ok = mongoc_client_set_server_api (client, server_api, &error);
-   BSON_ASSERT (ok);
+   assert (mongoc_client_set_server_api (client, server_api, &error));
    /* End Versioned API Example 4 */
 
    mongoc_client_destroy (client);
@@ -3747,6 +3744,7 @@ static void _test_sample_versioned_api_example_5_6_7_8 (void) {
    int64_t count;
    bson_t *filter;
 
+   /* Create a mongoc_client_t without server API options configured. */
    client = get_client_for_version_api_example ();
    mongoc_client_set_error_api (client, MONGOC_ERROR_API_VERSION_2);
    mongoc_server_api_version_from_string ("1", &server_api_version);

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -3435,6 +3435,20 @@ get_client (void)
    return test_framework_new_default_client ();
 }
 
+/* Returns a test client without version API options configured. */
+static mongoc_client_t *
+get_client_for_version_api_example (void) {
+   mongoc_client_t *client;
+   mongoc_uri_t *uri;
+
+   uri = test_framework_get_uri ();
+   client = mongoc_client_new_from_uri (uri);
+   ASSERT (client);
+   test_framework_set_ssl_opts (client);
+   mongoc_uri_destroy (uri);
+   return client;
+}
+
 static bool
 callback (mongoc_client_session_t *session,
           void *ctx,
@@ -3580,6 +3594,7 @@ _test_sample_versioned_api_example_1 (void)
    mongoc_server_api_t *server_api = NULL;
    mongoc_server_api_version_t server_api_version;
    bson_error_t error;
+   bool ok;
 
    /* For a replica set, include the replica set name and a seedlist of the
     * members in the URI string; e.g.
@@ -3592,12 +3607,13 @@ _test_sample_versioned_api_example_1 (void)
     * client = mongoc_client_new (uri_sharded);
     */
 
-   client = get_client ();
+   client = get_client_for_version_api_example ();
 
    mongoc_server_api_version_from_string ("1", &server_api_version);
    server_api = mongoc_server_api_new (server_api_version);
 
-   mongoc_client_set_server_api (client, server_api, &error);
+   ok = mongoc_client_set_server_api (client, server_api, &error);
+   BSON_ASSERT (ok);
    /* End Versioned API Example 1 */
 
    mongoc_client_destroy (client);
@@ -3612,6 +3628,7 @@ _test_sample_versioned_api_example_2 (void)
    mongoc_server_api_t *server_api = NULL;
    mongoc_server_api_version_t server_api_version;
    bson_error_t error;
+   bool ok;
 
    /* For a replica set, include the replica set name and a seedlist of the
     * members in the URI string; e.g.
@@ -3624,13 +3641,14 @@ _test_sample_versioned_api_example_2 (void)
     * client = mongoc_client_new (uri_sharded);
     */
 
-   client = get_client ();
+   client = get_client_for_version_api_example ();
 
    mongoc_server_api_version_from_string ("1", &server_api_version);
    server_api = mongoc_server_api_new (server_api_version);
    mongoc_server_api_strict (server_api, true);
 
-   mongoc_client_set_server_api (client, server_api, &error);
+   ok = mongoc_client_set_server_api (client, server_api, &error);
+   BSON_ASSERT (ok);
    /* End Versioned API Example 2 */
 
    mongoc_client_destroy (client);
@@ -3645,6 +3663,7 @@ _test_sample_versioned_api_example_3 (void)
    mongoc_server_api_t *server_api = NULL;
    mongoc_server_api_version_t server_api_version;
    bson_error_t error;
+   bool ok;
 
    /* For a replica set, include the replica set name and a seedlist of the
     * members in the URI string; e.g.
@@ -3657,13 +3676,14 @@ _test_sample_versioned_api_example_3 (void)
     * client = mongoc_client_new (uri_sharded);
     */
 
-   client = get_client ();
+   client = get_client_for_version_api_example ();
 
    mongoc_server_api_version_from_string ("1", &server_api_version);
    server_api = mongoc_server_api_new (server_api_version);
    mongoc_server_api_strict (server_api, false);
 
-   mongoc_client_set_server_api (client, server_api, &error);
+   ok = mongoc_client_set_server_api (client, server_api, &error);
+   BSON_ASSERT (ok);
    /* End Versioned API Example 3 */
 
    mongoc_client_destroy (client);
@@ -3678,6 +3698,7 @@ _test_sample_versioned_api_example_4 (void)
    mongoc_server_api_t *server_api = NULL;
    mongoc_server_api_version_t server_api_version;
    bson_error_t error;
+   bool ok;
 
    /* For a replica set, include the replica set name and a seedlist of the
     * members in the URI string; e.g.
@@ -3690,13 +3711,14 @@ _test_sample_versioned_api_example_4 (void)
     * client = mongoc_client_new (uri_sharded);
     */
 
-   client = get_client ();
+   client = get_client_for_version_api_example ();
 
    mongoc_server_api_version_from_string ("1", &server_api_version);
    server_api = mongoc_server_api_new (server_api_version);
    mongoc_server_api_deprecation_errors (server_api, true);
 
-   mongoc_client_set_server_api (client, server_api, &error);
+   ok = mongoc_client_set_server_api (client, server_api, &error);
+   BSON_ASSERT (ok);
    /* End Versioned API Example 4 */
 
    mongoc_client_destroy (client);
@@ -3725,7 +3747,8 @@ static void _test_sample_versioned_api_example_5_6_7_8 (void) {
    int64_t count;
    bson_t *filter;
 
-   client = get_client ();
+   client = get_client_for_version_api_example ();
+   test_framework_monitor_commands (client);
    mongoc_client_set_error_api (client, MONGOC_ERROR_API_VERSION_2);
    mongoc_server_api_version_from_string ("1", &server_api_version);
    server_api = mongoc_server_api_new (server_api_version);

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -3743,7 +3743,6 @@ static void _test_sample_versioned_api_example_5_6_7_8 (void) {
    bson_t *docs[N_DOCS];
    int i;
    bson_t reply;
-   bson_t *cmd;
    int64_t count;
    bson_t *filter;
 
@@ -3812,24 +3811,29 @@ static void _test_sample_versioned_api_example_5_6_7_8 (void) {
    ASSERT_OR_PRINT (ok, error);
    bson_destroy (&reply);
 
-   cmd = BCON_NEW ("count", "sales");
-   ok = mongoc_database_command_simple (
-      db, cmd, NULL /* read_prefs */, &reply, &error);
-   ASSERT_ERROR_CONTAINS (error,
-                          MONGOC_ERROR_SERVER,
-                          323,
-                          "Provided apiStrict:true, but the command count is not in API Version 1");
-   ASSERT (!ok);
+   BEGIN_IGNORE_DEPRECATIONS;
+   count = mongoc_collection_count (sales,
+                                    MONGOC_QUERY_NONE,
+                                    NULL /* query */,
+                                    0 /* skip */,
+                                    0 /* limit */,
+                                    NULL /* read prefs */,
+                                    &error);
+   END_IGNORE_DEPRECATIONS;
+   ASSERT_ERROR_CONTAINS (
+      error,
+      MONGOC_ERROR_SERVER,
+      323,
+      "Provided apiStrict:true, but the command count is not in API Version 1");
+   ASSERT_CMPINT64 (-1, ==, count);
    bson_destroy (&reply);
 #if 0
    /* This block not evaluated, but is inserted into documentation to represent the above reply.
     * Don't delete me! */
    /* Start Versioned API Example 6 */
-   char *str = bson_as_json (&reply, NULL /* length */);
-   printf ("%s", str);
-   /* Prints the server reply:
-    * { "ok" : 0, "errmsg" : "Provided apiStrict:true, but the command count is not in API Version 1", "code" : 323, "codeName" : "APIStrictError" } */
-   bson_free (str);
+   printf ("%s", error.message);
+   /* Prints the error message:
+    * "Provided apiStrict:true, but the command count is not in API Version 1. Information on supported commands and migrations in API Version 1 can be found at https://dochub.mongodb.org/core/manual-versioned-api" */
    /* End Versioned API Example 6 */
 #endif
 
@@ -3848,7 +3852,6 @@ static void _test_sample_versioned_api_example_5_6_7_8 (void) {
    /* End Versioned API Example 8 */
 
    bson_destroy (filter);
-   bson_destroy (cmd);
    for (i = 0; i < N_DOCS; i++) {
       bson_destroy (docs[i]);
    }


### PR DESCRIPTION
Addresses test failures introduced in #843 to the versioned API tests and 5.0 sharded tests.