### PR TITLE
CDRIVER-4074 - Update documentation for Time Series

### DIFF
--- a/src/libmongoc/doc/mongoc_database_create_collection.rst
+++ b/src/libmongoc/doc/mongoc_database_create_collection.rst
@@ -31,6 +31,8 @@ If no write concern is provided in ``opts``, the database's write concern is use
 
 For a list of all options, see `the MongoDB Manual entry on the create command <https://docs.mongodb.org/manual/reference/command/create/>`_.
 
+This function can also be used to create a `Time Series Collection <https://docs.mongodb.com/manual/core/timeseries-collections/>`_.
+
 Errors
 ------
 


### PR DESCRIPTION
Adds a note with a link to Time Series Collections from database
creation.

It may not be immediately clear to users that time series collections
can be created through mongoc_database_create_collection().

Signed-off-by: Jesse Williamson <jesse.williamson@mongodb.com>