### PR TITLE
Mention LoadBalanced topology type in docs

### DIFF
--- a/src/libmongoc/doc/mongoc_topology_description_type.rst
+++ b/src/libmongoc/doc/mongoc_topology_description_type.rst
@@ -26,4 +26,5 @@ This function returns a string, one of the topology types defined in the Server 
 * Sharded
 * ReplicaSetNoPrimary
 * ReplicaSetWithPrimary
+* LoadBalanced
 


### PR DESCRIPTION
Noticed the new type was missing from the list 🙂