### PR TITLE
Fix CDRIVER3441 - document mongoc_handshake_data_append and alias as …

### DIFF
--- a/src/libmongoc/doc/mongoc_client_t.rst
+++ b/src/libmongoc/doc/mongoc_client_t.rst
@@ -89,4 +89,6 @@ Example
     mongoc_client_start_session
     mongoc_client_watch
     mongoc_client_write_command_with_opts
+    mongoc_handshake_data_append
+    
 

--- a/src/libmongoc/doc/mongoc_handshake.rst
+++ b/src/libmongoc/doc/mongoc_handshake.rst
@@ -1,0 +1,89 @@
+:man_page: mongoc_add_driver_info
+
+mongoc_add_driver_info()
+=========================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   bool
+   mongoc_add_driver_info (const char *driver_name,
+                           const char *driver_version,
+                           const char *platform);
+
+   bool
+   mongoc_handshake_data_append (const char *driver_name,
+                                 const char *driver_version,
+                                 const char *platform);
+
+Appends the given strings to the handshake data for the underlying C Driver.
+
+Description
+-----------
+
+This function is intended for use by drivers which wrap the C Driver.
+Calling this function will store the given strings as handshake data about
+the system and driver by appending them to the handshake data for the
+underlying C Driver. These values, along with other handshake data collected
+during mongoc_init will be sent to the server as part of the initial
+connection handshake in the "client" document. This function must not be
+called more than once, or after a handshake has been initiated.
+
+The passed in strings are copied, and don't have to remain valid after the
+call to mongoc_add_driver_info(). The driver may store truncated
+versions of the passed in strings.
+
+Note:
+  This function allocates memory, and therefore caution should be used when
+  using this in conjunction with bson_mem_set_vtable. If this function is
+  called before bson_mem_set_vtable, then bson_mem_restore_vtable must be
+  called before calling mongoc_cleanup. Failure to do so will result in
+  memory being freed by the wrong allocator.
+
+Note:
+  mongoc_handshake_data_append() is the previously undocumented, now-deprecated 
+  name for this function. It calls mongoc_add_driver_info().
+
+Parameters
+----------
+
+* ``driver_name``: An optional string storing the name of the wrapping driver
+* ``driver_version``: An optional string storing the version of the wrapping driver.
+* ``platform``: An optional string storing any information about the current platform, for example configure options or compile flags.
+
+Returns
+-------
+
+``true`` if the given fields are set successfully. Otherwise, it returns ``false`` and logs an error.
+
+The default handshake data the driver sends with "hello" looks something
+like:
+
+.. code-block:: c
+
+ client: {
+   driver: {
+     name: "mongoc",
+     version: "1.5.0"
+   },
+   os: {...},
+   platform: "CC=gcc CFLAGS=-Wall -pedantic"
+ }
+
+If we call
+  mongoc_add_driver_info ("phongo", "1.1.8", "CC=clang")
+and it returns true, the driver sends handshake data like:
+
+.. code-block::
+ client: {
+   driver: {
+     name: "mongoc / phongo",
+     version: "1.5.0 / 1.1.8"
+   },
+   os: {...},
+   platform: "CC=gcc CFLAGS=-Wall -pedantic / CC=clang"
+ }
+
+

--- a/src/libmongoc/doc/mongoc_handshake.rst
+++ b/src/libmongoc/doc/mongoc_handshake.rst
@@ -37,10 +37,6 @@ Note:
   called before calling mongoc_cleanup. Failure to do so will result in
   memory being freed by the wrong allocator.
 
-Note:
-  mongoc_handshake_data_append() was previously previously undocumented, 
-  and is now deprecated.
-
 Parameters
 ----------
 

--- a/src/libmongoc/doc/mongoc_handshake.rst
+++ b/src/libmongoc/doc/mongoc_handshake.rst
@@ -1,17 +1,12 @@
-:man_page: mongoc_add_driver_info
+:man_page: mongoc_handshake_data_append
 
-mongoc_add_driver_info()
+mongoc_handshake_data_append()
 =========================================
 
 Synopsis
 --------
 
 .. code-block:: c
-
-   bool
-   mongoc_add_driver_info (const char *driver_name,
-                           const char *driver_version,
-                           const char *platform);
 
    bool
    mongoc_handshake_data_append (const char *driver_name,
@@ -32,7 +27,7 @@ connection handshake in the "client" document. This function must not be
 called more than once, or after a handshake has been initiated.
 
 The passed in strings are copied, and don't have to remain valid after the
-call to mongoc_add_driver_info(). The driver may store truncated
+call to mongoc_handshake_data_append(). The driver may store truncated
 versions of the passed in strings.
 
 Note:
@@ -43,8 +38,8 @@ Note:
   memory being freed by the wrong allocator.
 
 Note:
-  mongoc_handshake_data_append() is the previously undocumented, now-deprecated 
-  name for this function. It calls mongoc_add_driver_info().
+  mongoc_handshake_data_append() was previously previously undocumented, 
+  and is now deprecated.
 
 Parameters
 ----------
@@ -73,7 +68,7 @@ like:
  }
 
 If we call
-  mongoc_add_driver_info ("phongo", "1.1.8", "CC=clang")
+  mongoc_handshake_data_append ("phongo", "1.1.8", "CC=clang")
 and it returns true, the driver sends handshake data like:
 
 .. code-block::

--- a/src/libmongoc/doc/mongoc_handshake_data_append.rst
+++ b/src/libmongoc/doc/mongoc_handshake_data_append.rst
@@ -67,7 +67,7 @@ like:
  }
 
 If we call
-:symbol:`mongoc_handshake_data_append` ("phongo", "1.1.8", "CC=clang")
+:symbol:`mongoc_handshake_data_append` ("phongo", "1.1.8", "CC=clang / ")
 and it returns true, the driver sends handshake data like:
 
 .. code-block:: c
@@ -78,7 +78,7 @@ and it returns true, the driver sends handshake data like:
      version: "1.5.0 / 1.1.8"
    },
    os: {...},
-   platform: "CC=gcc CFLAGS=-Wall -pedantic / CC=clang"
+   platform: "CC=clang / gcc CFLAGS=-Wall -pedantic"
  }
 
 

--- a/src/libmongoc/doc/mongoc_handshake_data_append.rst
+++ b/src/libmongoc/doc/mongoc_handshake_data_append.rst
@@ -24,17 +24,20 @@ the system and driver by appending them to the handshake data for the
 underlying C Driver. These values, along with other handshake data collected
 during mongoc_init will be sent to the server as part of the initial
 connection handshake in the "client" document. This function must not be
-called more than once, or after a handshake has been initiated.
+called more than once, or after server monitoring begins. For a single-threaded 
+:symbol:`mongoc_client_t`, server monitoring begins on the first operation 
+requiring a server. For a :symbol:`mongoc_client_pool_t`, server monitoring 
+begins on the first call to `:symbol:`mongoc_client_pool_pop`.
 
 The passed in strings are copied, and don't have to remain valid after the
-call to mongoc_handshake_data_append(). The driver may store truncated
+call to :symbol:`mongoc_handshake_data_append`. The driver may store truncated
 versions of the passed in strings.
 
-Note:
+.. note::
   This function allocates memory, and therefore caution should be used when
-  using this in conjunction with bson_mem_set_vtable. If this function is
-  called before bson_mem_set_vtable, then bson_mem_restore_vtable must be
-  called before calling mongoc_cleanup. Failure to do so will result in
+  using this in conjunction with :symbol:`bson_mem_set_vtable`. If this function is
+  called before :symbol:`bson_mem_set_vtable`, then :symbol:`bson_mem_restore_vtable` must be
+  called before calling :symbol:`mongoc_cleanup`. Failure to do so will result in
   memory being freed by the wrong allocator.
 
 Parameters
@@ -64,7 +67,7 @@ like:
  }
 
 If we call
-mongoc_handshake_data_append ("phongo", "1.1.8", "CC=clang")
+:symbol:`mongoc_handshake_data_append` ("phongo", "1.1.8", "CC=clang")
 and it returns true, the driver sends handshake data like:
 
 .. code-block:: c

--- a/src/libmongoc/doc/mongoc_handshake_data_append.rst
+++ b/src/libmongoc/doc/mongoc_handshake_data_append.rst
@@ -1,7 +1,7 @@
 :man_page: mongoc_handshake_data_append
 
 mongoc_handshake_data_append()
-=========================================
+==============================
 
 Synopsis
 --------
@@ -64,10 +64,11 @@ like:
  }
 
 If we call
-  mongoc_handshake_data_append ("phongo", "1.1.8", "CC=clang")
+mongoc_handshake_data_append ("phongo", "1.1.8", "CC=clang")
 and it returns true, the driver sends handshake data like:
 
-.. code-block::
+.. code-block:: c
+
  client: {
    driver: {
      name: "mongoc / phongo",

--- a/src/libmongoc/src/mongoc/mongoc-handshake.c
+++ b/src/libmongoc/src/mongoc/mongoc-handshake.c
@@ -39,12 +39,12 @@
 /*
  * Global handshake data instance. Initialized at startup from mongoc_init
  *
- * Can be modified by calls to mongoc_add_driver_info
+ * Can be modified by calls to mongoc_handshake_data_append
  */
 static mongoc_handshake_t gMongocHandshake;
 
 /*
- * Used for thread-safety in mongoc_add_driver_info
+ * Used for thread-safety in mongoc_handshake_data_append
  */
 static bson_mutex_t gHandshakeLock;
 
@@ -615,9 +615,9 @@ _append_and_truncate (char **s, const char *suffix, int max_len)
  * All arguments are optional.
  */
 bool
-mongoc_add_driver_info (const char *driver_name,
-                        const char *driver_version,
-                        const char *platform)
+mongoc_handshake_data_append (const char *driver_name,
+                              const char *driver_version,
+                              const char *platform)
 {
    int platform_space;
 
@@ -656,16 +656,6 @@ mongoc_add_driver_info (const char *driver_name,
    bson_mutex_unlock (&gHandshakeLock);
 
    return true;
-}
-
-/* This is the previous-undocumented legacy call, and remains provided for
-compatibility; users should instead call mongoc_add_driver_info():
-*/
-bool mongoc_handshake_data_append(const char *driver_name,
-                                  const char *driver_version,
-                                  const char *platform)
-{
- return mongoc_add_driver_info(driver_name, driver_version, platform);
 }
 
 mongoc_handshake_t *

--- a/src/libmongoc/src/mongoc/mongoc-handshake.c
+++ b/src/libmongoc/src/mongoc/mongoc-handshake.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,12 +39,12 @@
 /*
  * Global handshake data instance. Initialized at startup from mongoc_init
  *
- * Can be modified by calls to mongoc_handshake_data_append
+ * Can be modified by calls to mongoc_add_driver_info
  */
 static mongoc_handshake_t gMongocHandshake;
 
 /*
- * Used for thread-safety in mongoc_handshake_data_append
+ * Used for thread-safety in mongoc_add_driver_info
  */
 static bson_mutex_t gHandshakeLock;
 
@@ -615,9 +615,9 @@ _append_and_truncate (char **s, const char *suffix, int max_len)
  * All arguments are optional.
  */
 bool
-mongoc_handshake_data_append (const char *driver_name,
-                              const char *driver_version,
-                              const char *platform)
+mongoc_add_driver_info (const char *driver_name,
+                        const char *driver_version,
+                        const char *platform)
 {
    int platform_space;
 
@@ -656,6 +656,16 @@ mongoc_handshake_data_append (const char *driver_name,
    bson_mutex_unlock (&gHandshakeLock);
 
    return true;
+}
+
+/* This is the previous-undocumented legacy call, and remains provided for
+compatibility; users should instead call mongoc_add_driver_info():
+*/
+bool mongoc_handshake_data_append(const char *driver_name,
+                                  const char *driver_version,
+                                  const char *platform)
+{
+ return mongoc_add_driver_info(driver_name, driver_version, platform);
 }
 
 mongoc_handshake_t *

--- a/src/libmongoc/src/mongoc/mongoc-handshake.h
+++ b/src/libmongoc/src/mongoc/mongoc-handshake.h
@@ -29,12 +29,6 @@ BSON_BEGIN_DECLS
 #define MONGOC_HANDSHAKE_APPNAME_MAX 128
 
 MONGOC_EXPORT (bool) 
-mongoc_add_driver_info (const char *driver_name,
-                        const char *driver_version,
-                        const char *platform);
-
-// Note: this just calls mongoc_add_driver_info():
-MONGOC_EXPORT (bool)
 mongoc_handshake_data_append (const char *driver_name,
                               const char *driver_version,
                               const char *platform);

--- a/src/libmongoc/src/mongoc/mongoc-handshake.h
+++ b/src/libmongoc/src/mongoc/mongoc-handshake.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MongoDB, Inc.
+ * Copyright 2016-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ BSON_BEGIN_DECLS
 #define MONGOC_HANDSHAKE_APPNAME_MAX 128
 
 /**
- * mongoc_handshake_data_append:
+ * mongoc_add_driver_info:
  *
  * This function is intended for use by drivers which wrap the C Driver.
  * Calling this function will store the given strings as handshake data about
@@ -40,7 +40,7 @@ BSON_BEGIN_DECLS
  * called more than once, or after a handshake has been initiated.
  *
  * The passed in strings are copied, and don't have to remain valid after the
- * call to mongoc_handshake_data_append(). The driver may store truncated
+ * call to mongoc_add_driver_info(). The driver may store truncated
  * versions of the passed in strings.
  *
  * Note:
@@ -73,7 +73,7 @@ BSON_BEGIN_DECLS
  *  }
  *
  * If we call
- *   mongoc_handshake_data_append ("phongo", "1.1.8", "CC=clang")
+ *   mongoc_add_driver_info ("phongo", "1.1.8", "CC=clang")
  * and it returns true, the driver sends handshake data like:
  *  client: {
  *    driver: {
@@ -85,6 +85,22 @@ BSON_BEGIN_DECLS
  *  }
  *
  */
+MONGOC_EXPORT (bool) 
+mongoc_add_driver_info (const char *driver_name,
+                        const char *driver_version,
+                        const char *platform);
+
+/**
+ * mongoc_handshake_data_append:
+ * 
+ * This function is intended for use by drivers which wrap the C Driver. It
+ * calls mongoc_add_driver_info().
+ *
+ * @See: mongoc_add_driver_info().
+ * @Note: This is the older name for this previously-undocumented function; 
+ *        mongoc_add_driver_info() should be preferred.
+ *
+*/
 MONGOC_EXPORT (bool)
 mongoc_handshake_data_append (const char *driver_name,
                               const char *driver_version,

--- a/src/libmongoc/src/mongoc/mongoc-handshake.h
+++ b/src/libmongoc/src/mongoc/mongoc-handshake.h
@@ -28,79 +28,12 @@ BSON_BEGIN_DECLS
 
 #define MONGOC_HANDSHAKE_APPNAME_MAX 128
 
-/**
- * mongoc_add_driver_info:
- *
- * This function is intended for use by drivers which wrap the C Driver.
- * Calling this function will store the given strings as handshake data about
- * the system and driver by appending them to the handshake data for the
- * underlying C Driver. These values, along with other handshake data collected
- * during mongoc_init will be sent to the server as part of the initial
- * connection handshake in the "client" document. This function cannot be
- * called more than once, or after a handshake has been initiated.
- *
- * The passed in strings are copied, and don't have to remain valid after the
- * call to mongoc_add_driver_info(). The driver may store truncated
- * versions of the passed in strings.
- *
- * Note:
- *   This function allocates memory, and therefore caution should be used when
- *   using this in conjunction with bson_mem_set_vtable. If this function is
- *   called before bson_mem_set_vtable, then bson_mem_restore_vtable must be
- *   called before calling mongoc_cleanup. Failure to do so will result in
- *   memory being freed by the wrong allocator.
- *
- *
- * @driver_name: An optional string storing the name of the wrapping driver
- * @driver_version: An optional string storing the version of the wrapping
- * driver.
- * @platform: An optional string storing any information about the current
- *            platform, for example configure options or compile flags.
- *
- *
- * Returns true if the given fields are set successfully. Otherwise, it returns
- * false and logs an error.
- *
- * The default handshake data the driver sends with "hello" looks something
- * like:
- *  client: {
- *    driver: {
- *      name: "mongoc",
- *      version: "1.5.0"
- *    },
- *    os: {...},
- *    platform: "CC=gcc CFLAGS=-Wall -pedantic"
- *  }
- *
- * If we call
- *   mongoc_add_driver_info ("phongo", "1.1.8", "CC=clang")
- * and it returns true, the driver sends handshake data like:
- *  client: {
- *    driver: {
- *      name: "mongoc / phongo",
- *      version: "1.5.0 / 1.1.8"
- *    },
- *    os: {...},
- *    platform: "CC=gcc CFLAGS=-Wall -pedantic / CC=clang"
- *  }
- *
- */
 MONGOC_EXPORT (bool) 
 mongoc_add_driver_info (const char *driver_name,
                         const char *driver_version,
                         const char *platform);
 
-/**
- * mongoc_handshake_data_append:
- * 
- * This function is intended for use by drivers which wrap the C Driver. It
- * calls mongoc_add_driver_info().
- *
- * @See: mongoc_add_driver_info().
- * @Note: This is the older name for this previously-undocumented function; 
- *        mongoc_add_driver_info() should be preferred.
- *
-*/
+// Note: this just calls mongoc_add_driver_info():
 MONGOC_EXPORT (bool)
 mongoc_handshake_data_append (const char *driver_name,
                               const char *driver_version,

--- a/src/libmongoc/tests/test-mongoc-handshake.c
+++ b/src/libmongoc/tests/test-mongoc-handshake.c
@@ -818,13 +818,26 @@ test_mongoc_handshake_race_condition (void)
          BSON_ASSERT (!COMMON_PREFIX (thread_create) (
             &threads[j], &handshake_append_worker, NULL));
       }
-
-      for (j = 0; j < 4; ++j) {
+for (j = 0; j < 4; ++j) {
          COMMON_PREFIX (thread_join) (threads[j]);
       }
    }
 
    _reset_handshake ();
+}
+
+/* This test checks that we can call the deprecated mongoc_handshake_data_append()
+function with the same parameters as mongoc_add_driver_info(). It does not repeat
+actual checks beyond simple validation, as we do assume the the implementation 
+forwards to mongoc_add_driver_info(): */
+static void
+test_mongoc_handshake_data_append (void)
+{
+   _reset_handshake ();
+
+   mongoc_add_driver_info ("driver_name", "driver_version", "platform");
+
+   _reset_handshake();
 }
 
 void
@@ -865,4 +878,9 @@ test_handshake_install (TestSuite *suite)
    TestSuite_Add (suite,
                   "/MongoDB/handshake/race_condition",
                   test_mongoc_handshake_race_condition);
+
+   /* Test deprecated forwarding function: */
+   TestSuite_Add (suite,
+                  "/MongoDB/handshake/data_append",
+                  test_mongoc_handshake_data_append);
 }

--- a/src/libmongoc/tests/test-mongoc-handshake.c
+++ b/src/libmongoc/tests/test-mongoc-handshake.c
@@ -31,7 +31,7 @@
 #include "mock_server/mock-server.h"
 
 /*
- * Call this before any test which uses mongoc_handshake_data_append, to
+ * Call this before any test which uses mongoc_add_driver_info, to
  * reset the global state and unfreeze the handshake struct. Call it
  * after a test so later tests don't have a weird handshake document
  *
@@ -157,7 +157,7 @@ _check_os_version_valid (const char *os_version)
 }
 
 static void
-test_mongoc_handshake_data_append_success (void)
+test_mongoc_add_driver_info_success (void)
 {
    mock_server_t *server;
    mongoc_uri_t *uri;
@@ -182,7 +182,7 @@ test_mongoc_handshake_data_append_success (void)
    _reset_handshake ();
    /* Make sure setting the handshake works */
    ASSERT (
-      mongoc_handshake_data_append (driver_name, driver_version, platform));
+      mongoc_add_driver_info (driver_name, driver_version, platform));
 
    server = mock_server_new ();
    mock_server_run (server);
@@ -313,7 +313,7 @@ _test_platform (bool platform_oversized)
    md->platform[platform_len - 1] = '\0';
 
    /* returns true, but ignores the suffix; there's no room */
-   ASSERT (mongoc_handshake_data_append (NULL, NULL, platform_suffix));
+   ASSERT (mongoc_add_driver_info (NULL, NULL, platform_suffix));
    ASSERT (!strstr (md->platform, "b"));
    ASSERT (_mongoc_handshake_build_doc_with_application (&doc, "my app"));
    ASSERT_CMPUINT32 (doc.len, ==, (uint32_t) HANDSHAKE_MAX_SIZE);
@@ -338,7 +338,7 @@ test_mongoc_handshake_oversized_platform (void)
 
 
 static void
-test_mongoc_handshake_data_append_after_cmd (void)
+test_mongoc_add_driver_info_after_cmd (void)
 {
    mongoc_client_pool_t *pool;
    mongoc_client_t *client;
@@ -354,7 +354,7 @@ test_mongoc_handshake_data_append_after_cmd (void)
    client = mongoc_client_pool_pop (pool);
 
    capture_logs (true);
-   ASSERT (!mongoc_handshake_data_append ("a", "a", "a"));
+   ASSERT (!mongoc_add_driver_info ("a", "a", "a"));
    capture_logs (false);
 
    mongoc_client_pool_push (pool, client);
@@ -392,7 +392,7 @@ test_mongoc_handshake_too_big (void)
 
    memset (big_string, 'a', BUFFER_SIZE - 1);
    big_string[BUFFER_SIZE - 1] = '\0';
-   ASSERT (mongoc_handshake_data_append (NULL, NULL, big_string));
+   ASSERT (mongoc_add_driver_info (NULL, NULL, big_string));
 
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    /* avoid rare test timeouts */
@@ -505,7 +505,7 @@ test_mongoc_platform_truncate (int drop)
    memset (big_string, 'a', handshake_remaining_space + 1);
    big_string[handshake_remaining_space + 1] = '\0';
 
-   ASSERT (mongoc_handshake_data_append (NULL, NULL, big_string));
+   ASSERT (mongoc_add_driver_info (NULL, NULL, big_string));
    ASSERT (_mongoc_handshake_build_doc_with_application (&doc, "my app"));
 
    /* doc.len being strictly less than HANDSHAKE_MAX_SIZE proves that we have
@@ -799,12 +799,12 @@ static BSON_THREAD_FUN (handshake_append_worker, data)
    const char *driver_version = "version abc";
    const char *platform = "./configure -nottoomanyflags";
 
-   mongoc_handshake_data_append (driver_name, driver_version, platform);
+   mongoc_add_driver_info (driver_name, driver_version, platform);
 
    BSON_THREAD_RETURN;
 }
 
-/* Run 1000 iterations of mongoc_handshake_data_append() using 4 threads */
+/* Run 1000 iterations of mongoc_add_driver_info() using 4 threads */
 static void
 test_mongoc_handshake_race_condition (void)
 {
@@ -842,7 +842,7 @@ test_handshake_install (TestSuite *suite)
 
    TestSuite_AddMockServerTest (suite,
                                 "/MongoDB/handshake/success",
-                                test_mongoc_handshake_data_append_success);
+                                test_mongoc_add_driver_info_success);
    TestSuite_Add (suite,
                   "/MongoDB/handshake/big_platform",
                   test_mongoc_handshake_big_platform);
@@ -851,7 +851,7 @@ test_handshake_install (TestSuite *suite)
                   test_mongoc_handshake_oversized_platform);
    TestSuite_Add (suite,
                   "/MongoDB/handshake/failure",
-                  test_mongoc_handshake_data_append_after_cmd);
+                  test_mongoc_add_driver_info_after_cmd);
    TestSuite_AddMockServerTest (
       suite, "/MongoDB/handshake/too_big", test_mongoc_handshake_too_big);
    TestSuite_Add (


### PR DESCRIPTION
Fix CDRIVER3441 - document mongoc_handshake_data_append and alias as mongoc_add_driver_info

I took a slightly different tack on this and made the older form an alias to the preferred,
newer one.

https://jira.mongodb.org/browse/CDRIVER-3441

Signed-off-by: Jesse Williamson <jesse.williamson@mongodb.com>