### PR TITLE
CDRIVER-3320 Add BSON_GNUC_WARN_UNUSED_RESULT to exported functions

### DIFF
--- a/src/libmongoc/doc/mongoc_apm_callbacks_new.rst
+++ b/src/libmongoc/doc/mongoc_apm_callbacks_new.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_apm_callbacks_t *
-  mongoc_apm_callbacks_new (void);
+  mongoc_apm_callbacks_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Create a struct to hold event-notification callbacks.
 

--- a/src/libmongoc/doc/mongoc_auto_encryption_opts_new.rst
+++ b/src/libmongoc/doc/mongoc_auto_encryption_opts_new.rst
@@ -8,8 +8,8 @@ Synopsis
 
 .. code-block:: c
 
-   mongoc_auto_encryption_opts_t *
-   mongoc_auto_encryption_opts_new (void);
+  mongoc_auto_encryption_opts_t *
+  mongoc_auto_encryption_opts_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
 
 
 Create a new :symbol:`mongoc_auto_encryption_opts_t`.

--- a/src/libmongoc/doc/mongoc_client_command.rst
+++ b/src/libmongoc/doc/mongoc_client_command.rst
@@ -17,7 +17,8 @@ Synopsis
                          uint32_t batch_size,
                          const bson_t *query,
                          const bson_t *fields,
-                         const mongoc_read_prefs_t *read_prefs);
+                         const mongoc_read_prefs_t *read_prefs)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 This function is superseded by :symbol:`mongoc_client_command_with_opts()`, :symbol:`mongoc_client_read_command_with_opts()`, :symbol:`mongoc_client_write_command_with_opts()`, and :symbol:`mongoc_client_read_write_command_with_opts()`.
 

--- a/src/libmongoc/doc/mongoc_client_encryption_datakey_opts_new.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_datakey_opts_new.rst
@@ -8,7 +8,8 @@ Synopsis
 
 .. code-block:: c
 
-  mongoc_client_encryption_datakey_opts_t * mongoc_client_encryption_datakey_opts_new ();
+  mongoc_client_encryption_datakey_opts_t *
+  mongoc_client_encryption_datakey_opts_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Returns
 -------

--- a/src/libmongoc/doc/mongoc_client_encryption_encrypt_opts_new.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_encrypt_opts_new.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_client_encryption_encrypt_opts_t *
-  mongoc_client_encryption_encrypt_opts_new ();
+  mongoc_client_encryption_encrypt_opts_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Returns
 -------

--- a/src/libmongoc/doc/mongoc_client_encryption_new.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_new.rst
@@ -8,9 +8,9 @@ Synopsis
 
 .. code-block:: c
 
-   mongoc_client_encryption_t *
-   mongoc_client_encryption_new (mongoc_client_encryption_opts_t *opts,
-                                 bson_error_t *error);
+  mongoc_client_encryption_t *
+  mongoc_client_encryption_new (mongoc_client_encryption_opts_t *opts,
+                                bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Create a new :symbol:`mongoc_client_encryption_t`.
 

--- a/src/libmongoc/doc/mongoc_client_encryption_opts_new.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_opts_new.rst
@@ -8,7 +8,8 @@ Synopsis
 
 .. code-block:: c
 
-   mongoc_client_encryption_opts_t * mongoc_client_encryption_opts_new (void);
+  mongoc_client_encryption_opts_t *
+  mongoc_client_encryption_opts_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Returns
 -------

--- a/src/libmongoc/doc/mongoc_client_find_databases_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_client_find_databases_with_opts.rst
@@ -9,8 +9,8 @@ Synopsis
 .. code-block:: c
 
   mongoc_cursor_t *
-  mongoc_client_find_databases_with_opts (mongoc_client_t *client,
-                                          const bson_t *opts);
+  mongoc_client_find_databases_with_opts (
+     mongoc_client_t *client, const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Fetches a cursor containing documents, each corresponding to a database on this MongoDB server.
 

--- a/src/libmongoc/doc/mongoc_client_get_collection.rst
+++ b/src/libmongoc/doc/mongoc_client_get_collection.rst
@@ -11,7 +11,8 @@ Synopsis
   mongoc_collection_t *
   mongoc_client_get_collection (mongoc_client_t *client,
                                 const char *db,
-                                const char *collection);
+                                const char *collection)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Get a newly allocated :symbol:`mongoc_collection_t` for the collection named ``collection`` in the database named ``db``.
 

--- a/src/libmongoc/doc/mongoc_client_get_database.rst
+++ b/src/libmongoc/doc/mongoc_client_get_database.rst
@@ -9,7 +9,8 @@ Synopsis
 .. code-block:: c
 
   mongoc_database_t *
-  mongoc_client_get_database (mongoc_client_t *client, const char *name);
+  mongoc_client_get_database (mongoc_client_t *client,
+                              const char *name) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Get a newly allocated :symbol:`mongoc_database_t` for the database named ``name``.
 

--- a/src/libmongoc/doc/mongoc_client_get_database_names.rst
+++ b/src/libmongoc/doc/mongoc_client_get_database_names.rst
@@ -9,7 +9,9 @@ Synopsis
 .. code-block:: c
 
   char **
-  mongoc_client_get_database_names (mongoc_client_t *client, bson_error_t *error);
+  mongoc_client_get_database_names (mongoc_client_t *client, bson_error_t *error)
+     BSON_GNUC_WARN_UNUSED_RESULT
+     BSON_GNUC_DEPRECATED_FOR (mongoc_client_get_database_names_with_opts);
 
 Deprecated
 ----------

--- a/src/libmongoc/doc/mongoc_client_get_database_names_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_client_get_database_names_with_opts.rst
@@ -11,7 +11,8 @@ Synopsis
   char **
   mongoc_client_get_database_names_with_opts (mongoc_client_t *client,
                                               const bson_t *opts,
-                                              bson_error_t *error);
+                                              bson_error_t *error)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 This function queries the MongoDB server for a list of known databases.
 

--- a/src/libmongoc/doc/mongoc_client_get_default_database.rst
+++ b/src/libmongoc/doc/mongoc_client_get_default_database.rst
@@ -9,7 +9,8 @@ Synopsis
 .. code-block:: c
 
   mongoc_database_t *
-  mongoc_client_get_default_database (mongoc_client_t *client);
+  mongoc_client_get_default_database (mongoc_client_t *client)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Get the database named in the MongoDB connection URI, or ``NULL`` if the URI specifies none.
 

--- a/src/libmongoc/doc/mongoc_client_get_gridfs.rst
+++ b/src/libmongoc/doc/mongoc_client_get_gridfs.rst
@@ -12,7 +12,7 @@ Synopsis
   mongoc_client_get_gridfs (mongoc_client_t *client,
                             const char *db,
                             const char *prefix,
-                            bson_error_t *error);
+                            bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT;
 
 The ``mongoc_client_get_gridfs()`` function shall create a new :symbol:`mongoc_gridfs_t`. The ``db`` parameter is the name of the database which the gridfs instance should exist in. The ``prefix`` parameter corresponds to the gridfs collection namespacing; its default is "fs", thus the default GridFS collection names are "fs.files" and "fs.chunks".
 

--- a/src/libmongoc/doc/mongoc_client_get_handshake_description.rst
+++ b/src/libmongoc/doc/mongoc_client_get_handshake_description.rst
@@ -8,11 +8,12 @@ Synopsis
 
 .. code-block:: c
 
-   mongoc_server_description_t *
-   mongoc_client_get_handshake_description (mongoc_client_t *client,
-                                            uint32_t server_id,
-                                            bson_t *opts,
-                                            bson_error_t *error);
+  mongoc_server_description_t *
+  mongoc_client_get_handshake_description (mongoc_client_t *client,
+                                           uint32_t server_id,
+                                           bson_t *opts,
+                                           bson_error_t *error)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Returns a description constructed from the initial handshake response to a server.
 

--- a/src/libmongoc/doc/mongoc_client_get_server_description.rst
+++ b/src/libmongoc/doc/mongoc_client_get_server_description.rst
@@ -9,8 +9,8 @@ Synopsis
 .. code-block:: c
 
   mongoc_server_description_t *
-  mongoc_client_get_server_description (mongoc_client_t *client,
-                                        uint32_t server_id);
+  mongoc_client_get_server_description (
+     mongoc_client_t *client, uint32_t server_id) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Get information about the server specified by ``server_id``.
 

--- a/src/libmongoc/doc/mongoc_client_get_server_descriptions.rst
+++ b/src/libmongoc/doc/mongoc_client_get_server_descriptions.rst
@@ -10,7 +10,7 @@ Synopsis
 
   mongoc_server_description_t **
   mongoc_client_get_server_descriptions (const mongoc_client_t *client,
-                                         size_t *n);
+                                         size_t *n) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Fetches an array of :symbol:`mongoc_server_description_t` structs for all known servers in the topology. Returns no servers until the client connects. Returns a single server if the client is directly connected, or all members of a replica set if the client's MongoDB URI includes a "replicaSet" option, or all known mongos servers if the MongoDB URI includes a list of them.
 

--- a/src/libmongoc/doc/mongoc_client_new.rst
+++ b/src/libmongoc/doc/mongoc_client_new.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_client_t *
-  mongoc_client_new (const char *uri_string);
+  mongoc_client_new (const char *uri_string) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Creates a new :symbol:`mongoc_client_t` using the URI string provided.
 

--- a/src/libmongoc/doc/mongoc_client_new_from_uri.rst
+++ b/src/libmongoc/doc/mongoc_client_new_from_uri.rst
@@ -9,7 +9,8 @@ Synopsis
 .. code-block:: c
 
   mongoc_client_t *
-  mongoc_client_new_from_uri (const mongoc_uri_t *uri);
+  mongoc_client_new_from_uri (const mongoc_uri_t *uri)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Creates a new :symbol:`mongoc_client_t` using the :symbol:`mongoc_uri_t` provided.
 

--- a/src/libmongoc/doc/mongoc_client_pool_new.rst
+++ b/src/libmongoc/doc/mongoc_client_pool_new.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_client_pool_t *
-  mongoc_client_pool_new (const mongoc_uri_t *uri);
+  mongoc_client_pool_new (const mongoc_uri_t *uri) BSON_GNUC_WARN_UNUSED_RESULT;
 
 This function creates a new :symbol:`mongoc_client_pool_t` using the :symbol:`mongoc_uri_t` provided.
 

--- a/src/libmongoc/doc/mongoc_client_pool_pop.rst
+++ b/src/libmongoc/doc/mongoc_client_pool_pop.rst
@@ -9,7 +9,8 @@ Synopsis
 .. code-block:: c
 
   mongoc_client_t *
-  mongoc_client_pool_pop (mongoc_client_pool_t *pool);
+  mongoc_client_pool_pop (mongoc_client_pool_t *pool)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Retrieve a :symbol:`mongoc_client_t` from the client pool, or create one. The total number of clients that can be created from this pool is limited by the URI option "maxPoolSize", default 100. If this number of clients has been created and all are in use, ``mongoc_client_pool_pop`` blocks until another thread returns a client with :symbol:`mongoc_client_pool_push()`. If the "waitQueueTimeoutMS" URI option was specified with a positive value, then ``mongoc_client_pool_pop`` will return ``NULL`` when the timeout expires.
 

--- a/src/libmongoc/doc/mongoc_client_pool_try_pop.rst
+++ b/src/libmongoc/doc/mongoc_client_pool_try_pop.rst
@@ -9,7 +9,8 @@ Synopsis
 .. code-block:: c
 
   mongoc_client_t *
-  mongoc_client_pool_try_pop (mongoc_client_pool_t *pool);
+  mongoc_client_pool_try_pop (mongoc_client_pool_t *pool)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 This function is identical to :symbol:`mongoc_client_pool_pop()` except it will return ``NULL`` instead of blocking for a client to become available.
 

--- a/src/libmongoc/doc/mongoc_client_select_server.rst
+++ b/src/libmongoc/doc/mongoc_client_select_server.rst
@@ -12,7 +12,7 @@ Synopsis
   mongoc_client_select_server (mongoc_client_t *client,
                                bool for_writes,
                                const mongoc_read_prefs_t *prefs,
-                               bson_error_t *error);
+                               bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Choose a server for an operation, according to the logic described in the Server Selection Spec.
 

--- a/src/libmongoc/doc/mongoc_client_watch.rst
+++ b/src/libmongoc/doc/mongoc_client_watch.rst
@@ -11,7 +11,7 @@ Synopsis
   mongoc_change_stream_t*
   mongoc_client_watch (mongoc_client_t *client,
                        const bson_t *pipeline,
-                       const bson_t *opts);
+                       const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
 
 A helper function to create a change stream. It is preferred to call this
 function over using a raw aggregation to create a change stream.

--- a/src/libmongoc/doc/mongoc_collection_copy.rst
+++ b/src/libmongoc/doc/mongoc_collection_copy.rst
@@ -9,7 +9,8 @@ Synopsis
 .. code-block:: c
 
   mongoc_collection_t *
-  mongoc_collection_copy (mongoc_collection_t *collection);
+  mongoc_collection_copy (mongoc_collection_t *collection)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_collection_find_indexes.rst
+++ b/src/libmongoc/doc/mongoc_collection_find_indexes.rst
@@ -11,6 +11,8 @@ Synopsis
   mongoc_cursor_t *
   mongoc_collection_find_indexes (mongoc_collection_t *collection,
                                   bson_error_t *error);
+     BSON_GNUC_WARN_UNUSED_RESULT
+     BSON_GNUC_DEPRECATED_FOR (mongoc_collection_find_indexes_with_opts);
 
 Deprecated
 ----------

--- a/src/libmongoc/doc/mongoc_collection_find_indexes_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_collection_find_indexes_with_opts.rst
@@ -10,7 +10,8 @@ Synopsis
 
   mongoc_cursor_t *
   mongoc_collection_find_indexes_with_opts (mongoc_collection_t *collection,
-                                            const bson_t *opts);
+                                            const bson_t *opts)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Fetches a cursor containing documents, each corresponding to an index on this collection.
 

--- a/src/libmongoc/doc/mongoc_collection_keys_to_index_string.rst
+++ b/src/libmongoc/doc/mongoc_collection_keys_to_index_string.rst
@@ -9,7 +9,8 @@ Synopsis
 .. code-block:: c
 
   char *
-  mongoc_collection_keys_to_index_string (const bson_t *keys);
+  mongoc_collection_keys_to_index_string (const bson_t *keys)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_collection_watch.rst
+++ b/src/libmongoc/doc/mongoc_collection_watch.rst
@@ -11,7 +11,7 @@ Synopsis
   mongoc_change_stream_t*
   mongoc_collection_watch (const mongoc_collection_t *coll,
                            const bson_t *pipeline,
-                           const bson_t *opts);
+                           const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
 
 A helper function to create a change stream. It is preferred to call this
 function over using a raw aggregation to create a change stream.

--- a/src/libmongoc/doc/mongoc_database_command.rst
+++ b/src/libmongoc/doc/mongoc_database_command.rst
@@ -16,7 +16,8 @@ Synopsis
                            uint32_t batch_size,
                            const bson_t *command,
                            const bson_t *fields,
-                           const mongoc_read_prefs_t *read_prefs);
+                           const mongoc_read_prefs_t *read_prefs)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 This function is superseded by :symbol:`mongoc_database_command_with_opts()`, :symbol:`mongoc_database_read_command_with_opts()`, :symbol:`mongoc_database_write_command_with_opts()`, and :symbol:`mongoc_database_read_write_command_with_opts()`.
 

--- a/src/libmongoc/doc/mongoc_database_copy.rst
+++ b/src/libmongoc/doc/mongoc_database_copy.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_database_t *
-  mongoc_database_copy (mongoc_database_t *database);
+  mongoc_database_copy (mongoc_database_t *database) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_database_create_collection.rst
+++ b/src/libmongoc/doc/mongoc_database_create_collection.rst
@@ -12,7 +12,8 @@ Synopsis
   mongoc_database_create_collection (mongoc_database_t *database,
                                      const char *name,
                                      const bson_t *opts,
-                                     bson_error_t *error);
+                                     bson_error_t *error)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_database_find_collections.rst
+++ b/src/libmongoc/doc/mongoc_database_find_collections.rst
@@ -12,6 +12,7 @@ Synopsis
   mongoc_database_find_collections (mongoc_database_t *database,
                                     const bson_t *filter,
                                     bson_error_t *error)
+     BSON_GNUC_WARN_UNUSED_RESULT
      BSON_GNUC_DEPRECATED_FOR (mongoc_database_find_collections_with_opts);
 
 Deprecated

--- a/src/libmongoc/doc/mongoc_database_find_collections_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_database_find_collections_with_opts.rst
@@ -10,7 +10,8 @@ Synopsis
 
   mongoc_cursor_t *
   mongoc_database_find_collections_with_opts (mongoc_database_t *database,
-                                              const bson_t *opts);
+                                              const bson_t *opts)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Fetches a cursor containing documents, each corresponding to a collection on this database.
 

--- a/src/libmongoc/doc/mongoc_database_get_collection.rst
+++ b/src/libmongoc/doc/mongoc_database_get_collection.rst
@@ -9,7 +9,8 @@ Synopsis
 .. code-block:: c
 
   mongoc_collection_t *
-  mongoc_database_get_collection (mongoc_database_t *database, const char *name);
+  mongoc_database_get_collection (mongoc_database_t *database,
+                                  const char *name) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Allocates a new :symbol:`mongoc_collection_t` structure for the collection named ``name`` in ``database``.
 

--- a/src/libmongoc/doc/mongoc_database_get_collection_names.rst
+++ b/src/libmongoc/doc/mongoc_database_get_collection_names.rst
@@ -10,7 +10,9 @@ Synopsis
 
   char **
   mongoc_database_get_collection_names (mongoc_database_t *database,
-                                        bson_error_t *error);
+                                        bson_error_t *error)
+     BSON_GNUC_WARN_UNUSED_RESULT
+     BSON_GNUC_DEPRECATED_FOR (mongoc_database_get_collection_names_with_opts);
 
 Deprecated
 ----------

--- a/src/libmongoc/doc/mongoc_database_get_collection_names_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_database_get_collection_names_with_opts.rst
@@ -11,7 +11,8 @@ Synopsis
   char **
   mongoc_database_get_collection_names_with_opts (mongoc_database_t *database,
                                                   const bson_t *opts,
-                                                  bson_error_t *error);
+                                                  bson_error_t *error)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Fetches a ``NULL`` terminated array of ``NULL-byte`` terminated ``char*`` strings containing the names of all of the collections in ``database``.
 

--- a/src/libmongoc/doc/mongoc_database_watch.rst
+++ b/src/libmongoc/doc/mongoc_database_watch.rst
@@ -11,7 +11,7 @@ Synopsis
   mongoc_change_stream_t*
   mongoc_database_watch (const mongoc_database_t *db,
                          const bson_t *pipeline,
-                         const bson_t *opts);
+                         const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
 
 A helper function to create a change stream. It is preferred to call this
 function over using a raw aggregation to create a change stream.

--- a/src/libmongoc/doc/mongoc_find_and_modify_opts_new.rst
+++ b/src/libmongoc/doc/mongoc_find_and_modify_opts_new.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_find_and_modify_opts_t *
-  mongoc_find_and_modify_opts_new (void);
+  mongoc_find_and_modify_opts_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Returns
 -------

--- a/src/libmongoc/doc/mongoc_gridfs_bucket_find.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_bucket_find.rst
@@ -8,10 +8,10 @@ Synopsis
 
 .. code-block:: c
 
-   mongoc_cursor_t *
-   mongoc_gridfs_bucket_find (mongoc_gridfs_bucket_t *bucket,
-                              const bson_t *filter,
-                              const bson_t *opts);
+  mongoc_cursor_t *
+  mongoc_gridfs_bucket_find (mongoc_gridfs_bucket_t *bucket,
+                             const bson_t *filter,
+                             const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_gridfs_bucket_new.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_bucket_new.rst
@@ -12,7 +12,7 @@ Synopsis
   mongoc_gridfs_bucket_new (mongoc_database_t *db,
                             const bson_t *opts,
                             const mongoc_read_prefs_t *read_prefs,
-                            bson_error_t* error);
+                            bson_error_t* error) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_gridfs_bucket_open_download_stream.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_bucket_open_download_stream.rst
@@ -8,10 +8,11 @@ Synopsis
 
 .. code-block:: c
 
-   mongoc_stream_t *
-   mongoc_gridfs_bucket_open_download_stream (mongoc_gridfs_bucket_t *bucket,
-                                              const bson_value_t *file_id,
-                                              bson_error_t *error);
+  mongoc_stream_t *
+  mongoc_gridfs_bucket_open_download_stream (mongoc_gridfs_bucket_t *bucket,
+                                             const bson_value_t *file_id,
+                                             bson_error_t *error)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_gridfs_bucket_open_upload_stream.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_bucket_open_upload_stream.rst
@@ -13,7 +13,8 @@ Synopsis
                                             const char *filename,
                                             const bson_t *opts,
                                             bson_value_t *file_id,
-                                            bson_error_t *error);
+                                            bson_error_t *error)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_gridfs_bucket_open_upload_stream_with_id.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_bucket_open_upload_stream_with_id.rst
@@ -8,12 +8,13 @@ Synopsis
 
 .. code-block:: c
 
-   mongoc_stream_t *
-   mongoc_gridfs_bucket_open_upload_stream_with_id (mongoc_gridfs_bucket_t *bucket,
-                                                    const bson_value_t *file_id,
-                                                    const char *filename,
-                                                    const bson_t *opts,
-                                                    bson_error_t *error);
+  mongoc_stream_t *
+  mongoc_gridfs_bucket_open_upload_stream_with_id (mongoc_gridfs_bucket_t *bucket,
+                                                   const bson_value_t *file_id,
+                                                   const char *filename,
+                                                   const bson_t *opts,
+                                                   bson_error_t *error)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_gridfs_create_file.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_create_file.rst
@@ -10,7 +10,8 @@ Synopsis
 
   mongoc_gridfs_file_t *
   mongoc_gridfs_create_file (mongoc_gridfs_t *gridfs,
-                             mongoc_gridfs_file_opt_t *opt);
+                             mongoc_gridfs_file_opt_t *opt)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_gridfs_create_file_from_stream.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_create_file_from_stream.rst
@@ -11,7 +11,8 @@ Synopsis
   mongoc_gridfs_file_t *
   mongoc_gridfs_create_file_from_stream (mongoc_gridfs_t *gridfs,
                                          mongoc_stream_t *stream,
-                                         mongoc_gridfs_file_opt_t *opt);
+                                         mongoc_gridfs_file_opt_t *opt)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_gridfs_file_list_next.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_file_list_next.rst
@@ -9,7 +9,8 @@ Synopsis
 .. code-block:: c
 
   mongoc_gridfs_file_t *
-  mongoc_gridfs_file_list_next (mongoc_gridfs_file_list_t *list);
+  mongoc_gridfs_file_list_next (mongoc_gridfs_file_list_t *list)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_gridfs_find.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_find.rst
@@ -14,7 +14,8 @@ Synopsis
 .. code-block:: c
 
   mongoc_gridfs_file_list_t *
-  mongoc_gridfs_find (mongoc_gridfs_t *gridfs, const bson_t *query)
+  mongoc_gridfs_find (mongoc_gridfs_t *gridfs,
+                      const bson_t *query) BSON_GNUC_WARN_UNUSED_RESULT
      BSON_GNUC_DEPRECATED_FOR (mongoc_gridfs_find_with_opts);
 
 Parameters

--- a/src/libmongoc/doc/mongoc_gridfs_find_one.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_find_one.rst
@@ -16,7 +16,7 @@ Synopsis
   mongoc_gridfs_file_t *
   mongoc_gridfs_find_one (mongoc_gridfs_t *gridfs,
                           const bson_t *query,
-                          bson_error_t *error)
+                          bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT
      BSON_GNUC_DEPRECATED_FOR (mongoc_gridfs_find_one_with_opts);
 
 Parameters

--- a/src/libmongoc/doc/mongoc_gridfs_find_one_by_filename.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_find_one_by_filename.rst
@@ -11,7 +11,8 @@ Synopsis
   mongoc_gridfs_file_t *
   mongoc_gridfs_find_one_by_filename (mongoc_gridfs_t *gridfs,
                                       const char *filename,
-                                      bson_error_t *error);
+                                      bson_error_t *error)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_matcher_new.rst
+++ b/src/libmongoc/doc/mongoc_matcher_new.rst
@@ -9,7 +9,8 @@ Synopsis
 .. code-block:: c
 
   mongoc_matcher_t *
-  mongoc_matcher_new (const bson_t *query, bson_error_t *error);
+  mongoc_matcher_new (const bson_t *query, bson_error_t *error)
+     BSON_GNUC_WARN_UNUSED_RESULT BSON_GNUC_DEPRECATED;
 
 Create a new :symbol:`mongoc_matcher_t` using the query specification provided.
 

--- a/src/libmongoc/doc/mongoc_read_concern_copy.rst
+++ b/src/libmongoc/doc/mongoc_read_concern_copy.rst
@@ -9,7 +9,8 @@ Synopsis
 .. code-block:: c
 
   mongoc_read_concern_t *
-  mongoc_read_concern_copy (const mongoc_read_concern_t *read_concern);
+  mongoc_read_concern_copy (const mongoc_read_concern_t *read_concern)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_read_concern_new.rst
+++ b/src/libmongoc/doc/mongoc_read_concern_new.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_read_concern_t *
-  mongoc_read_concern_new (void);
+  mongoc_read_concern_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Returns
 -------

--- a/src/libmongoc/doc/mongoc_read_prefs_copy.rst
+++ b/src/libmongoc/doc/mongoc_read_prefs_copy.rst
@@ -9,7 +9,8 @@ Synopsis
 .. code-block:: c
 
   mongoc_read_prefs_t *
-  mongoc_read_prefs_copy (const mongoc_read_prefs_t *read_prefs);
+  mongoc_read_prefs_copy (const mongoc_read_prefs_t *read_prefs)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_read_prefs_new.rst
+++ b/src/libmongoc/doc/mongoc_read_prefs_new.rst
@@ -9,7 +9,8 @@ Synopsis
 .. code-block:: c
 
   mongoc_read_prefs_t *
-  mongoc_read_prefs_new (mongoc_read_mode_t read_mode);
+  mongoc_read_prefs_new (mongoc_read_mode_t read_mode)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_server_api_copy.rst
+++ b/src/libmongoc/doc/mongoc_server_api_copy.rst
@@ -9,7 +9,8 @@ Synopsis
 .. code-block:: c
 
   mongoc_server_api_t *
-  mongoc_server_api_copy (const mongoc_server_api_t *api);
+  mongoc_server_api_copy (const mongoc_server_api_t *api)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Creates a deep copy of ``api``.
 

--- a/src/libmongoc/doc/mongoc_server_api_new.rst
+++ b/src/libmongoc/doc/mongoc_server_api_new.rst
@@ -9,7 +9,8 @@ Synopsis
 .. code-block:: c
 
   mongoc_server_api_t *
-  mongoc_server_api_new (mongoc_server_api_version_t version);
+  mongoc_server_api_new (mongoc_server_api_version_t version)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Create a struct to hold server API preferences.
 

--- a/src/libmongoc/doc/mongoc_server_description_new_copy.rst
+++ b/src/libmongoc/doc/mongoc_server_description_new_copy.rst
@@ -10,7 +10,7 @@ Synopsis
 
   mongoc_server_description_t *
   mongoc_server_description_new_copy (
-     const mongoc_server_description_t *description);
+     const mongoc_server_description_t *description) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_session_opts_clone.rst
+++ b/src/libmongoc/doc/mongoc_session_opts_clone.rst
@@ -9,7 +9,8 @@ Synopsis
 .. code-block:: c
 
   mongoc_session_opt_t *
-  mongoc_session_opts_clone (const mongoc_session_opt_t *opts);
+  mongoc_session_opts_clone (const mongoc_session_opt_t *opts)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Create a copy of a session options struct.
 

--- a/src/libmongoc/doc/mongoc_session_opts_get_transaction_opts.rst
+++ b/src/libmongoc/doc/mongoc_session_opts_get_transaction_opts.rst
@@ -8,8 +8,9 @@ Synopsis
 
 .. code-block:: c
 
-   mongoc_transaction_opt_t *
-   mongoc_session_opts_get_transaction_opts (const mongoc_client_session_t *session);
+  mongoc_transaction_opt_t *
+  mongoc_session_opts_get_transaction_opts (
+     const mongoc_client_session_t *session) BSON_GNUC_WARN_UNUSED_RESULT;
 
 The options for the current transaction started with this session. The resulting :symbol:`mongoc_transaction_opt_t` should be freed with :symbol:`mongoc_transaction_opts_destroy`. If this ``session`` is not in a transaction, then the returned value is ``NULL``. See :symbol:`mongoc_client_session_in_transaction()`. 
 

--- a/src/libmongoc/doc/mongoc_socket_accept.rst
+++ b/src/libmongoc/doc/mongoc_socket_accept.rst
@@ -9,7 +9,8 @@ Synopsis
 .. code-block:: c
 
   mongoc_socket_t *
-  mongoc_socket_accept (mongoc_socket_t *sock, int64_t expire_at);
+  mongoc_socket_accept (mongoc_socket_t *sock,
+                        int64_t expire_at) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_socket_getnameinfo.rst
+++ b/src/libmongoc/doc/mongoc_socket_getnameinfo.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   char *
-  mongoc_socket_getnameinfo (mongoc_socket_t *sock);
+  mongoc_socket_getnameinfo (mongoc_socket_t *sock) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_socket_new.rst
+++ b/src/libmongoc/doc/mongoc_socket_new.rst
@@ -9,7 +9,9 @@ Synopsis
 .. code-block:: c
 
   mongoc_socket_t *
-  mongoc_socket_new (int domain, int type, int protocol);
+  mongoc_socket_new (int domain,
+                     int type,
+                     int protocol) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_stream_buffered_new.rst
+++ b/src/libmongoc/doc/mongoc_stream_buffered_new.rst
@@ -9,7 +9,8 @@ Synopsis
 .. code-block:: c
 
   mongoc_stream_t *
-  mongoc_stream_buffered_new (mongoc_stream_t *base_stream, size_t buffer_size);
+  mongoc_stream_buffered_new (mongoc_stream_t *base_stream,
+                          size_t buffer_size) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_stream_file_new.rst
+++ b/src/libmongoc/doc/mongoc_stream_file_new.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_stream_t *
-  mongoc_stream_file_new (int fd);
+  mongoc_stream_file_new (int fd) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_stream_file_new_for_path.rst
+++ b/src/libmongoc/doc/mongoc_stream_file_new_for_path.rst
@@ -9,7 +9,9 @@ Synopsis
 .. code-block:: c
 
   mongoc_stream_t *
-  mongoc_stream_file_new_for_path (const char *path, int flags, int mode);
+  mongoc_stream_file_new_for_path (const char *path,
+                                   int flags,
+                                   int mode) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_stream_gridfs_new.rst
+++ b/src/libmongoc/doc/mongoc_stream_gridfs_new.rst
@@ -9,7 +9,8 @@ Synopsis
 .. code-block:: c
 
   mongoc_stream_t *
-  mongoc_stream_gridfs_new (mongoc_gridfs_file_t *file);
+  mongoc_stream_gridfs_new (mongoc_gridfs_file_t *file)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_stream_socket_new.rst
+++ b/src/libmongoc/doc/mongoc_stream_socket_new.rst
@@ -9,7 +9,8 @@ Synopsis
 .. code-block:: c
 
   mongoc_stream_t *
-  mongoc_stream_socket_new (mongoc_socket_t *socket);
+  mongoc_stream_socket_new (mongoc_socket_t *socket)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_topology_description_get_servers.rst
+++ b/src/libmongoc/doc/mongoc_topology_description_get_servers.rst
@@ -10,7 +10,8 @@ Synopsis
 
   mongoc_server_description_t **
   mongoc_topology_description_get_servers (
-     const mongoc_topology_description_t *td, size_t *n);
+     const mongoc_topology_description_t *td,
+     size_t *n) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Fetches an array of :symbol:`mongoc_server_description_t` structs for all known servers in the topology.
 

--- a/src/libmongoc/doc/mongoc_topology_description_new_copy.rst
+++ b/src/libmongoc/doc/mongoc_topology_description_new_copy.rst
@@ -10,7 +10,8 @@ Synopsis
 
   mongoc_topology_description_t *
   mongoc_topology_description_new_copy (
-     const mongoc_topology_description_t *description);
+     const mongoc_topology_description_t *description)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_transaction_opts_clone.rst
+++ b/src/libmongoc/doc/mongoc_transaction_opts_clone.rst
@@ -9,7 +9,8 @@ Synopsis
 .. code-block:: c
 
   mongoc_transaction_opt_t *
-  mongoc_transaction_opts_clone (const mongoc_transaction_opt_t *opts);
+  mongoc_transaction_opts_clone (const mongoc_transaction_opt_t *opts)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Create a copy of a transaction options struct.
 

--- a/src/libmongoc/doc/mongoc_uri_copy.rst
+++ b/src/libmongoc/doc/mongoc_uri_copy.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_uri_t *
-  mongoc_uri_copy (const mongoc_uri_t *uri);
+  mongoc_uri_copy (const mongoc_uri_t *uri) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_uri_unescape.rst
+++ b/src/libmongoc/doc/mongoc_uri_unescape.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   char *
-  mongoc_uri_unescape (const char *escaped_string);
+  mongoc_uri_unescape (const char *escaped_string) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_write_concern_copy.rst
+++ b/src/libmongoc/doc/mongoc_write_concern_copy.rst
@@ -9,7 +9,8 @@ Synopsis
 .. code-block:: c
 
   mongoc_write_concern_t *
-  mongoc_write_concern_copy (const mongoc_write_concern_t *write_concern);
+  mongoc_write_concern_copy (const mongoc_write_concern_t *write_concern)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_write_concern_new.rst
+++ b/src/libmongoc/doc/mongoc_write_concern_new.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_write_concern_t *
-  mongoc_write_concern_new (void);
+  mongoc_write_concern_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Returns
 -------

--- a/src/libmongoc/src/mongoc/mongoc-apm.h
+++ b/src/libmongoc/src/mongoc/mongoc-apm.h
@@ -322,7 +322,7 @@ typedef void (*mongoc_apm_server_heartbeat_failed_cb_t) (
  */
 
 MONGOC_EXPORT (mongoc_apm_callbacks_t *)
-mongoc_apm_callbacks_new (void);
+mongoc_apm_callbacks_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (void)
 mongoc_apm_callbacks_destroy (mongoc_apm_callbacks_t *callbacks);
 MONGOC_EXPORT (void)

--- a/src/libmongoc/src/mongoc/mongoc-bulk-operation.h
+++ b/src/libmongoc/src/mongoc/mongoc-bulk-operation.h
@@ -123,7 +123,7 @@ mongoc_bulk_operation_set_bypass_document_validation (
  * collections.
  */
 MONGOC_EXPORT (mongoc_bulk_operation_t *)
-mongoc_bulk_operation_new (bool ordered);
+mongoc_bulk_operation_new (bool ordered) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (void)
 mongoc_bulk_operation_set_write_concern (
    mongoc_bulk_operation_t *bulk, const mongoc_write_concern_t *write_concern);

--- a/src/libmongoc/src/mongoc/mongoc-client-pool.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-pool.h
@@ -38,15 +38,17 @@ typedef struct _mongoc_client_pool_t mongoc_client_pool_t;
 
 
 MONGOC_EXPORT (mongoc_client_pool_t *)
-mongoc_client_pool_new (const mongoc_uri_t *uri);
+mongoc_client_pool_new (const mongoc_uri_t *uri) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (void)
 mongoc_client_pool_destroy (mongoc_client_pool_t *pool);
 MONGOC_EXPORT (mongoc_client_t *)
-mongoc_client_pool_pop (mongoc_client_pool_t *pool);
+mongoc_client_pool_pop (mongoc_client_pool_t *pool)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (void)
 mongoc_client_pool_push (mongoc_client_pool_t *pool, mongoc_client_t *client);
 MONGOC_EXPORT (mongoc_client_t *)
-mongoc_client_pool_try_pop (mongoc_client_pool_t *pool);
+mongoc_client_pool_try_pop (mongoc_client_pool_t *pool)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (void)
 mongoc_client_pool_max_size (mongoc_client_pool_t *pool,
                              uint32_t max_pool_size);

--- a/src/libmongoc/src/mongoc/mongoc-client-session.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-session.h
@@ -47,7 +47,8 @@ MONGOC_EXPORT (mongoc_transaction_opt_t *)
 mongoc_transaction_opts_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
 
 MONGOC_EXPORT (mongoc_transaction_opt_t *)
-mongoc_transaction_opts_clone (const mongoc_transaction_opt_t *opts);
+mongoc_transaction_opts_clone (const mongoc_transaction_opt_t *opts)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 
 MONGOC_EXPORT (void)
 mongoc_transaction_opts_destroy (mongoc_transaction_opt_t *opts);
@@ -107,10 +108,11 @@ mongoc_session_opts_get_default_transaction_opts (
 
 MONGOC_EXPORT (mongoc_transaction_opt_t *)
 mongoc_session_opts_get_transaction_opts (
-   const mongoc_client_session_t *session);
+   const mongoc_client_session_t *session) BSON_GNUC_WARN_UNUSED_RESULT;
 
 MONGOC_EXPORT (mongoc_session_opt_t *)
-mongoc_session_opts_clone (const mongoc_session_opt_t *opts);
+mongoc_session_opts_clone (const mongoc_session_opt_t *opts)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 
 MONGOC_EXPORT (void)
 mongoc_session_opts_destroy (mongoc_session_opt_t *opts);

--- a/src/libmongoc/src/mongoc/mongoc-client-side-encryption.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-side-encryption.h
@@ -25,15 +25,17 @@
 struct _mongoc_client_t;
 struct _mongoc_client_pool_t;
 
-#define MONGOC_AEAD_AES_256_CBC_HMAC_SHA_512_RANDOM "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
-#define MONGOC_AEAD_AES_256_CBC_HMAC_SHA_512_DETERMINISTIC "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+#define MONGOC_AEAD_AES_256_CBC_HMAC_SHA_512_RANDOM \
+   "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+#define MONGOC_AEAD_AES_256_CBC_HMAC_SHA_512_DETERMINISTIC \
+   "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
 
 BSON_BEGIN_DECLS
 
 typedef struct _mongoc_auto_encryption_opts_t mongoc_auto_encryption_opts_t;
 
 MONGOC_EXPORT (mongoc_auto_encryption_opts_t *)
-mongoc_auto_encryption_opts_new (void);
+mongoc_auto_encryption_opts_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
 
 MONGOC_EXPORT (void)
 mongoc_auto_encryption_opts_destroy (mongoc_auto_encryption_opts_t *opts);
@@ -74,7 +76,7 @@ typedef struct _mongoc_client_encryption_datakey_opts_t
    mongoc_client_encryption_datakey_opts_t;
 
 MONGOC_EXPORT (mongoc_client_encryption_opts_t *)
-mongoc_client_encryption_opts_new (void);
+mongoc_client_encryption_opts_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
 
 MONGOC_EXPORT (void)
 mongoc_client_encryption_opts_destroy (mongoc_client_encryption_opts_t *opts);
@@ -94,7 +96,7 @@ mongoc_client_encryption_opts_set_kms_providers (
 
 MONGOC_EXPORT (mongoc_client_encryption_t *)
 mongoc_client_encryption_new (mongoc_client_encryption_opts_t *opts,
-                              bson_error_t *error);
+                              bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT;
 
 MONGOC_EXPORT (void)
 mongoc_client_encryption_destroy (
@@ -122,7 +124,7 @@ mongoc_client_encryption_decrypt (mongoc_client_encryption_t *client_encryption,
                                   bson_error_t *error);
 
 MONGOC_EXPORT (mongoc_client_encryption_encrypt_opts_t *)
-mongoc_client_encryption_encrypt_opts_new (void);
+mongoc_client_encryption_encrypt_opts_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
 
 MONGOC_EXPORT (void)
 mongoc_client_encryption_encrypt_opts_destroy (
@@ -141,7 +143,7 @@ mongoc_client_encryption_encrypt_opts_set_algorithm (
    mongoc_client_encryption_encrypt_opts_t *opts, const char *algorithm);
 
 MONGOC_EXPORT (mongoc_client_encryption_datakey_opts_t *)
-mongoc_client_encryption_datakey_opts_new (void);
+mongoc_client_encryption_datakey_opts_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
 
 MONGOC_EXPORT (void)
 mongoc_client_encryption_datakey_opts_destroy (

--- a/src/libmongoc/src/mongoc/mongoc-client.h
+++ b/src/libmongoc/src/mongoc/mongoc-client.h
@@ -103,9 +103,10 @@ typedef mongoc_stream_t *(*mongoc_stream_initiator_t) (
 
 
 MONGOC_EXPORT (mongoc_client_t *)
-mongoc_client_new (const char *uri_string);
+mongoc_client_new (const char *uri_string) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (mongoc_client_t *)
-mongoc_client_new_from_uri (const mongoc_uri_t *uri);
+mongoc_client_new_from_uri (const mongoc_uri_t *uri)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (const mongoc_uri_t *)
 mongoc_client_get_uri (const mongoc_client_t *client);
 MONGOC_EXPORT (void)
@@ -121,7 +122,8 @@ mongoc_client_command (mongoc_client_t *client,
                        uint32_t batch_size,
                        const bson_t *query,
                        const bson_t *fields,
-                       const mongoc_read_prefs_t *read_prefs);
+                       const mongoc_read_prefs_t *read_prefs)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (void)
 mongoc_client_kill_cursor (mongoc_client_t *client,
                            int64_t cursor_id) BSON_GNUC_DEPRECATED;
@@ -180,31 +182,37 @@ mongoc_client_start_session (mongoc_client_t *client,
                              const mongoc_session_opt_t *opts,
                              bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (mongoc_database_t *)
-mongoc_client_get_database (mongoc_client_t *client, const char *name);
+mongoc_client_get_database (mongoc_client_t *client,
+                            const char *name) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (mongoc_database_t *)
-mongoc_client_get_default_database (mongoc_client_t *client);
+mongoc_client_get_default_database (mongoc_client_t *client)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (mongoc_gridfs_t *)
 mongoc_client_get_gridfs (mongoc_client_t *client,
                           const char *db,
                           const char *prefix,
-                          bson_error_t *error);
+                          bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (mongoc_collection_t *)
 mongoc_client_get_collection (mongoc_client_t *client,
                               const char *db,
-                              const char *collection);
+                              const char *collection)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (char **)
 mongoc_client_get_database_names (mongoc_client_t *client, bson_error_t *error)
+   BSON_GNUC_WARN_UNUSED_RESULT
    BSON_GNUC_DEPRECATED_FOR (mongoc_client_get_database_names_with_opts);
 MONGOC_EXPORT (char **)
 mongoc_client_get_database_names_with_opts (mongoc_client_t *client,
                                             const bson_t *opts,
-                                            bson_error_t *error);
+                                            bson_error_t *error)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (mongoc_cursor_t *)
-mongoc_client_find_databases (mongoc_client_t *client, bson_error_t *error)
+mongoc_client_find_databases (mongoc_client_t *client,
+                              bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT
    BSON_GNUC_DEPRECATED_FOR (mongoc_client_find_databases_with_opts);
 MONGOC_EXPORT (mongoc_cursor_t *)
-mongoc_client_find_databases_with_opts (mongoc_client_t *client,
-                                        const bson_t *opts);
+mongoc_client_find_databases_with_opts (
+   mongoc_client_t *client, const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (bool)
 mongoc_client_get_server_status (mongoc_client_t *client,
                                  mongoc_read_prefs_t *read_prefs,
@@ -240,11 +248,11 @@ mongoc_client_set_apm_callbacks (mongoc_client_t *client,
                                  mongoc_apm_callbacks_t *callbacks,
                                  void *context);
 MONGOC_EXPORT (mongoc_server_description_t *)
-mongoc_client_get_server_description (mongoc_client_t *client,
-                                      uint32_t server_id);
+mongoc_client_get_server_description (
+   mongoc_client_t *client, uint32_t server_id) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (mongoc_server_description_t **)
 mongoc_client_get_server_descriptions (const mongoc_client_t *client,
-                                       size_t *n);
+                                       size_t *n) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (void)
 mongoc_server_descriptions_destroy_all (mongoc_server_description_t **sds,
                                         size_t n);
@@ -252,7 +260,7 @@ MONGOC_EXPORT (mongoc_server_description_t *)
 mongoc_client_select_server (mongoc_client_t *client,
                              bool for_writes,
                              const mongoc_read_prefs_t *prefs,
-                             bson_error_t *error);
+                             bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (bool)
 mongoc_client_set_error_api (mongoc_client_t *client, int32_t version);
 MONGOC_EXPORT (bool)
@@ -260,7 +268,7 @@ mongoc_client_set_appname (mongoc_client_t *client, const char *appname);
 MONGOC_EXPORT (mongoc_change_stream_t *)
 mongoc_client_watch (mongoc_client_t *client,
                      const bson_t *pipeline,
-                     const bson_t *opts);
+                     const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (void)
 mongoc_client_reset (mongoc_client_t *client);
 
@@ -278,7 +286,8 @@ MONGOC_EXPORT (mongoc_server_description_t *)
 mongoc_client_get_handshake_description (mongoc_client_t *client,
                                          uint32_t server_id,
                                          bson_t *opts,
-                                         bson_error_t *error);
+                                         bson_error_t *error)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 
 BSON_END_DECLS
 

--- a/src/libmongoc/src/mongoc/mongoc-collection.h
+++ b/src/libmongoc/src/mongoc/mongoc-collection.h
@@ -47,7 +47,8 @@ mongoc_collection_aggregate (mongoc_collection_t *collection,
 MONGOC_EXPORT (void)
 mongoc_collection_destroy (mongoc_collection_t *collection);
 MONGOC_EXPORT (mongoc_collection_t *)
-mongoc_collection_copy (mongoc_collection_t *collection);
+mongoc_collection_copy (mongoc_collection_t *collection)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (mongoc_cursor_t *)
 mongoc_collection_command (mongoc_collection_t *collection,
                            mongoc_query_flags_t flags,
@@ -149,10 +150,12 @@ mongoc_collection_ensure_index (mongoc_collection_t *collection,
 MONGOC_EXPORT (mongoc_cursor_t *)
 mongoc_collection_find_indexes (mongoc_collection_t *collection,
                                 bson_error_t *error)
+   BSON_GNUC_WARN_UNUSED_RESULT
    BSON_GNUC_DEPRECATED_FOR (mongoc_collection_find_indexes_with_opts);
 MONGOC_EXPORT (mongoc_cursor_t *)
 mongoc_collection_find_indexes_with_opts (mongoc_collection_t *collection,
-                                          const bson_t *opts);
+                                          const bson_t *opts)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (mongoc_cursor_t *)
 mongoc_collection_find (mongoc_collection_t *collection,
                         mongoc_query_flags_t flags,
@@ -326,7 +329,8 @@ MONGOC_EXPORT (const bson_t *)
 mongoc_collection_get_last_error (const mongoc_collection_t *collection)
    BSON_GNUC_DEPRECATED;
 MONGOC_EXPORT (char *)
-mongoc_collection_keys_to_index_string (const bson_t *keys);
+mongoc_collection_keys_to_index_string (const bson_t *keys)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (bool)
 mongoc_collection_validate (mongoc_collection_t *collection,
                             const bson_t *options,
@@ -335,7 +339,7 @@ mongoc_collection_validate (mongoc_collection_t *collection,
 MONGOC_EXPORT (mongoc_change_stream_t *)
 mongoc_collection_watch (const mongoc_collection_t *coll,
                          const bson_t *pipeline,
-                         const bson_t *opts);
+                         const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (int64_t)
 mongoc_collection_count_documents (mongoc_collection_t *coll,
                                    const bson_t *filter,

--- a/src/libmongoc/src/mongoc/mongoc-database.h
+++ b/src/libmongoc/src/mongoc/mongoc-database.h
@@ -56,9 +56,10 @@ MONGOC_EXPORT (mongoc_cursor_t *)
 mongoc_database_aggregate (mongoc_database_t *db,
                            const bson_t *pipeline,
                            const bson_t *opts,
-                           const mongoc_read_prefs_t *read_prefs);
+                           const mongoc_read_prefs_t *read_prefs)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (mongoc_database_t *)
-mongoc_database_copy (mongoc_database_t *database);
+mongoc_database_copy (mongoc_database_t *database) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (mongoc_cursor_t *)
 mongoc_database_command (mongoc_database_t *database,
                          mongoc_query_flags_t flags,
@@ -67,7 +68,8 @@ mongoc_database_command (mongoc_database_t *database,
                          uint32_t batch_size,
                          const bson_t *command,
                          const bson_t *fields,
-                         const mongoc_read_prefs_t *read_prefs);
+                         const mongoc_read_prefs_t *read_prefs)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (bool)
 mongoc_database_read_command_with_opts (mongoc_database_t *database,
                                         const bson_t *command,
@@ -116,7 +118,8 @@ MONGOC_EXPORT (mongoc_collection_t *)
 mongoc_database_create_collection (mongoc_database_t *database,
                                    const char *name,
                                    const bson_t *options,
-                                   bson_error_t *error);
+                                   bson_error_t *error)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (const mongoc_read_prefs_t *)
 mongoc_database_get_read_prefs (const mongoc_database_t *database);
 MONGOC_EXPORT (void)
@@ -136,24 +139,29 @@ MONGOC_EXPORT (mongoc_cursor_t *)
 mongoc_database_find_collections (mongoc_database_t *database,
                                   const bson_t *filter,
                                   bson_error_t *error)
+   BSON_GNUC_WARN_UNUSED_RESULT
    BSON_GNUC_DEPRECATED_FOR (mongoc_database_find_collections_with_opts);
 MONGOC_EXPORT (mongoc_cursor_t *)
 mongoc_database_find_collections_with_opts (mongoc_database_t *database,
-                                            const bson_t *opts);
+                                            const bson_t *opts)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (char **)
 mongoc_database_get_collection_names (mongoc_database_t *database,
                                       bson_error_t *error)
+   BSON_GNUC_WARN_UNUSED_RESULT
    BSON_GNUC_DEPRECATED_FOR (mongoc_database_get_collection_names_with_opts);
 MONGOC_EXPORT (char **)
 mongoc_database_get_collection_names_with_opts (mongoc_database_t *database,
                                                 const bson_t *opts,
-                                                bson_error_t *error);
+                                                bson_error_t *error)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (mongoc_collection_t *)
-mongoc_database_get_collection (mongoc_database_t *database, const char *name);
+mongoc_database_get_collection (mongoc_database_t *database,
+                                const char *name) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (mongoc_change_stream_t *)
 mongoc_database_watch (const mongoc_database_t *db,
                        const bson_t *pipeline,
-                       const bson_t *opts);
+                       const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
 
 BSON_END_DECLS
 

--- a/src/libmongoc/src/mongoc/mongoc-find-and-modify.h
+++ b/src/libmongoc/src/mongoc/mongoc-find-and-modify.h
@@ -35,7 +35,7 @@ typedef enum {
 typedef struct _mongoc_find_and_modify_opts_t mongoc_find_and_modify_opts_t;
 
 MONGOC_EXPORT (mongoc_find_and_modify_opts_t *)
-mongoc_find_and_modify_opts_new (void);
+mongoc_find_and_modify_opts_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
 
 MONGOC_EXPORT (bool)
 mongoc_find_and_modify_opts_set_sort (mongoc_find_and_modify_opts_t *opts,

--- a/src/libmongoc/src/mongoc/mongoc-gridfs-bucket.h
+++ b/src/libmongoc/src/mongoc/mongoc-gridfs-bucket.h
@@ -32,21 +32,23 @@ MONGOC_EXPORT (mongoc_gridfs_bucket_t *)
 mongoc_gridfs_bucket_new (mongoc_database_t *db,
                           const bson_t *opts,
                           const mongoc_read_prefs_t *read_prefs,
-                          bson_error_t *error);
+                          bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT;
 
 MONGOC_EXPORT (mongoc_stream_t *)
 mongoc_gridfs_bucket_open_upload_stream (mongoc_gridfs_bucket_t *bucket,
                                          const char *filename,
                                          const bson_t *opts,
                                          bson_value_t *file_id,
-                                         bson_error_t *error);
+                                         bson_error_t *error)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 
 MONGOC_EXPORT (mongoc_stream_t *)
 mongoc_gridfs_bucket_open_upload_stream_with_id (mongoc_gridfs_bucket_t *bucket,
                                                  const bson_value_t *file_id,
                                                  const char *filename,
                                                  const bson_t *opts,
-                                                 bson_error_t *error);
+                                                 bson_error_t *error)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 
 MONGOC_EXPORT (bool)
 mongoc_gridfs_bucket_upload_from_stream (mongoc_gridfs_bucket_t *bucket,
@@ -67,7 +69,8 @@ mongoc_gridfs_bucket_upload_from_stream_with_id (mongoc_gridfs_bucket_t *bucket,
 MONGOC_EXPORT (mongoc_stream_t *)
 mongoc_gridfs_bucket_open_download_stream (mongoc_gridfs_bucket_t *bucket,
                                            const bson_value_t *file_id,
-                                           bson_error_t *error);
+                                           bson_error_t *error)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 
 MONGOC_EXPORT (bool)
 mongoc_gridfs_bucket_download_to_stream (mongoc_gridfs_bucket_t *bucket,
@@ -83,7 +86,7 @@ mongoc_gridfs_bucket_delete_by_id (mongoc_gridfs_bucket_t *bucket,
 MONGOC_EXPORT (mongoc_cursor_t *)
 mongoc_gridfs_bucket_find (mongoc_gridfs_bucket_t *bucket,
                            const bson_t *filter,
-                           const bson_t *opts);
+                           const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
 
 MONGOC_EXPORT (bool)
 mongoc_gridfs_bucket_stream_error (mongoc_stream_t *stream,

--- a/src/libmongoc/src/mongoc/mongoc-gridfs-file-list.h
+++ b/src/libmongoc/src/mongoc/mongoc-gridfs-file-list.h
@@ -32,7 +32,8 @@ typedef struct _mongoc_gridfs_file_list_t mongoc_gridfs_file_list_t;
 
 
 MONGOC_EXPORT (mongoc_gridfs_file_t *)
-mongoc_gridfs_file_list_next (mongoc_gridfs_file_list_t *list);
+mongoc_gridfs_file_list_next (mongoc_gridfs_file_list_t *list)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (void)
 mongoc_gridfs_file_list_destroy (mongoc_gridfs_file_list_t *list);
 MONGOC_EXPORT (bool)

--- a/src/libmongoc/src/mongoc/mongoc-gridfs.h
+++ b/src/libmongoc/src/mongoc/mongoc-gridfs.h
@@ -37,17 +37,20 @@ typedef struct _mongoc_gridfs_t mongoc_gridfs_t;
 MONGOC_EXPORT (mongoc_gridfs_file_t *)
 mongoc_gridfs_create_file_from_stream (mongoc_gridfs_t *gridfs,
                                        mongoc_stream_t *stream,
-                                       mongoc_gridfs_file_opt_t *opt);
+                                       mongoc_gridfs_file_opt_t *opt)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (mongoc_gridfs_file_t *)
 mongoc_gridfs_create_file (mongoc_gridfs_t *gridfs,
-                           mongoc_gridfs_file_opt_t *opt);
+                           mongoc_gridfs_file_opt_t *opt)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (mongoc_gridfs_file_list_t *)
-mongoc_gridfs_find (mongoc_gridfs_t *gridfs, const bson_t *query)
+mongoc_gridfs_find (mongoc_gridfs_t *gridfs,
+                    const bson_t *query) BSON_GNUC_WARN_UNUSED_RESULT
    BSON_GNUC_DEPRECATED_FOR (mongoc_gridfs_find_with_opts);
 MONGOC_EXPORT (mongoc_gridfs_file_t *)
 mongoc_gridfs_find_one (mongoc_gridfs_t *gridfs,
                         const bson_t *query,
-                        bson_error_t *error)
+                        bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT
    BSON_GNUC_DEPRECATED_FOR (mongoc_gridfs_find_one_with_opts);
 MONGOC_EXPORT (mongoc_gridfs_file_list_t *)
 mongoc_gridfs_find_with_opts (mongoc_gridfs_t *gridfs,
@@ -62,7 +65,8 @@ mongoc_gridfs_find_one_with_opts (mongoc_gridfs_t *gridfs,
 MONGOC_EXPORT (mongoc_gridfs_file_t *)
 mongoc_gridfs_find_one_by_filename (mongoc_gridfs_t *gridfs,
                                     const char *filename,
-                                    bson_error_t *error);
+                                    bson_error_t *error)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (bool)
 mongoc_gridfs_drop (mongoc_gridfs_t *gridfs, bson_error_t *error);
 MONGOC_EXPORT (void)

--- a/src/libmongoc/src/mongoc/mongoc-matcher.h
+++ b/src/libmongoc/src/mongoc/mongoc-matcher.h
@@ -30,8 +30,8 @@ typedef struct _mongoc_matcher_t mongoc_matcher_t;
 
 
 MONGOC_EXPORT (mongoc_matcher_t *)
-mongoc_matcher_new (const bson_t *query,
-                    bson_error_t *error) BSON_GNUC_DEPRECATED;
+mongoc_matcher_new (const bson_t *query, bson_error_t *error)
+   BSON_GNUC_WARN_UNUSED_RESULT BSON_GNUC_DEPRECATED;
 MONGOC_EXPORT (bool)
 mongoc_matcher_match (const mongoc_matcher_t *matcher,
                       const bson_t *document) BSON_GNUC_DEPRECATED;

--- a/src/libmongoc/src/mongoc/mongoc-read-concern.h
+++ b/src/libmongoc/src/mongoc/mongoc-read-concern.h
@@ -36,9 +36,10 @@ typedef struct _mongoc_read_concern_t mongoc_read_concern_t;
 
 
 MONGOC_EXPORT (mongoc_read_concern_t *)
-mongoc_read_concern_new (void);
+mongoc_read_concern_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (mongoc_read_concern_t *)
-mongoc_read_concern_copy (const mongoc_read_concern_t *read_concern);
+mongoc_read_concern_copy (const mongoc_read_concern_t *read_concern)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (void)
 mongoc_read_concern_destroy (mongoc_read_concern_t *read_concern);
 MONGOC_EXPORT (const char *)

--- a/src/libmongoc/src/mongoc/mongoc-read-prefs.h
+++ b/src/libmongoc/src/mongoc/mongoc-read-prefs.h
@@ -43,9 +43,11 @@ typedef enum {
 
 
 MONGOC_EXPORT (mongoc_read_prefs_t *)
-mongoc_read_prefs_new (mongoc_read_mode_t read_mode);
+mongoc_read_prefs_new (mongoc_read_mode_t read_mode)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (mongoc_read_prefs_t *)
-mongoc_read_prefs_copy (const mongoc_read_prefs_t *read_prefs);
+mongoc_read_prefs_copy (const mongoc_read_prefs_t *read_prefs)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (void)
 mongoc_read_prefs_destroy (mongoc_read_prefs_t *read_prefs);
 MONGOC_EXPORT (mongoc_read_mode_t)
@@ -69,7 +71,8 @@ mongoc_read_prefs_set_max_staleness_seconds (mongoc_read_prefs_t *read_prefs,
 MONGOC_EXPORT (const bson_t *)
 mongoc_read_prefs_get_hedge (const mongoc_read_prefs_t *read_prefs);
 MONGOC_EXPORT (void)
-mongoc_read_prefs_set_hedge (mongoc_read_prefs_t *read_prefs, const bson_t *hedge);
+mongoc_read_prefs_set_hedge (mongoc_read_prefs_t *read_prefs,
+                             const bson_t *hedge);
 MONGOC_EXPORT (bool)
 mongoc_read_prefs_is_valid (const mongoc_read_prefs_t *read_prefs);
 

--- a/src/libmongoc/src/mongoc/mongoc-server-api.h
+++ b/src/libmongoc/src/mongoc/mongoc-server-api.h
@@ -38,10 +38,12 @@ mongoc_server_api_version_from_string (const char *version,
                                        mongoc_server_api_version_t *out);
 
 MONGOC_EXPORT (mongoc_server_api_t *)
-mongoc_server_api_new (mongoc_server_api_version_t version);
+mongoc_server_api_new (mongoc_server_api_version_t version)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 
 MONGOC_EXPORT (mongoc_server_api_t *)
-mongoc_server_api_copy (const mongoc_server_api_t *api);
+mongoc_server_api_copy (const mongoc_server_api_t *api)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 
 MONGOC_EXPORT (void)
 mongoc_server_api_destroy (mongoc_server_api_t *api);

--- a/src/libmongoc/src/mongoc/mongoc-server-description.h
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.h
@@ -34,7 +34,7 @@ mongoc_server_description_destroy (mongoc_server_description_t *description);
 
 MONGOC_EXPORT (mongoc_server_description_t *)
 mongoc_server_description_new_copy (
-   const mongoc_server_description_t *description);
+   const mongoc_server_description_t *description) BSON_GNUC_WARN_UNUSED_RESULT;
 
 MONGOC_EXPORT (uint32_t)
 mongoc_server_description_id (const mongoc_server_description_t *description);

--- a/src/libmongoc/src/mongoc/mongoc-socket.h
+++ b/src/libmongoc/src/mongoc/mongoc-socket.h
@@ -39,7 +39,7 @@
 #endif
 
 #if defined(_AIX) && !defined(MONGOC_HAVE_SS_FAMILY)
-# define ss_family __ss_family
+#define ss_family __ss_family
 #endif
 
 #include "mongoc-iovec.h"
@@ -59,7 +59,8 @@ typedef struct {
 } mongoc_socket_poll_t;
 
 MONGOC_EXPORT (mongoc_socket_t *)
-mongoc_socket_accept (mongoc_socket_t *sock, int64_t expire_at);
+mongoc_socket_accept (mongoc_socket_t *sock,
+                      int64_t expire_at) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (int)
 mongoc_socket_bind (mongoc_socket_t *sock,
                     const struct sockaddr *addr,
@@ -72,7 +73,7 @@ mongoc_socket_connect (mongoc_socket_t *sock,
                        mongoc_socklen_t addrlen,
                        int64_t expire_at);
 MONGOC_EXPORT (char *)
-mongoc_socket_getnameinfo (mongoc_socket_t *sock);
+mongoc_socket_getnameinfo (mongoc_socket_t *sock) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (void)
 mongoc_socket_destroy (mongoc_socket_t *sock);
 MONGOC_EXPORT (int)
@@ -84,7 +85,9 @@ mongoc_socket_getsockname (mongoc_socket_t *sock,
 MONGOC_EXPORT (int)
 mongoc_socket_listen (mongoc_socket_t *sock, unsigned int backlog);
 MONGOC_EXPORT (mongoc_socket_t *)
-mongoc_socket_new (int domain, int type, int protocol);
+mongoc_socket_new (int domain,
+                   int type,
+                   int protocol) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (ssize_t)
 mongoc_socket_recv (mongoc_socket_t *sock,
                     void *buf,

--- a/src/libmongoc/src/mongoc/mongoc-stream-buffered.h
+++ b/src/libmongoc/src/mongoc/mongoc-stream-buffered.h
@@ -29,7 +29,8 @@ BSON_BEGIN_DECLS
 
 
 MONGOC_EXPORT (mongoc_stream_t *)
-mongoc_stream_buffered_new (mongoc_stream_t *base_stream, size_t buffer_size);
+mongoc_stream_buffered_new (mongoc_stream_t *base_stream,
+                        size_t buffer_size) BSON_GNUC_WARN_UNUSED_RESULT;
 
 
 BSON_END_DECLS

--- a/src/libmongoc/src/mongoc/mongoc-stream-file.h
+++ b/src/libmongoc/src/mongoc/mongoc-stream-file.h
@@ -30,9 +30,11 @@ typedef struct _mongoc_stream_file_t mongoc_stream_file_t;
 
 
 MONGOC_EXPORT (mongoc_stream_t *)
-mongoc_stream_file_new (int fd);
+mongoc_stream_file_new (int fd) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (mongoc_stream_t *)
-mongoc_stream_file_new_for_path (const char *path, int flags, int mode);
+mongoc_stream_file_new_for_path (const char *path,
+                                 int flags,
+                                 int mode) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (int)
 mongoc_stream_file_get_fd (mongoc_stream_file_t *stream);
 

--- a/src/libmongoc/src/mongoc/mongoc-stream-gridfs.h
+++ b/src/libmongoc/src/mongoc/mongoc-stream-gridfs.h
@@ -30,7 +30,8 @@ BSON_BEGIN_DECLS
 
 
 MONGOC_EXPORT (mongoc_stream_t *)
-mongoc_stream_gridfs_new (mongoc_gridfs_file_t *file);
+mongoc_stream_gridfs_new (mongoc_gridfs_file_t *file)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 
 
 BSON_END_DECLS

--- a/src/libmongoc/src/mongoc/mongoc-stream-socket.h
+++ b/src/libmongoc/src/mongoc/mongoc-stream-socket.h
@@ -31,7 +31,7 @@ typedef struct _mongoc_stream_socket_t mongoc_stream_socket_t;
 
 
 MONGOC_EXPORT (mongoc_stream_t *)
-mongoc_stream_socket_new (mongoc_socket_t *socket);
+mongoc_stream_socket_new (mongoc_socket_t *socket) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (mongoc_socket_t *)
 mongoc_stream_socket_get_socket (mongoc_stream_socket_t *stream);
 

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-libressl.h
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-libressl.h
@@ -31,7 +31,7 @@ MONGOC_EXPORT (mongoc_stream_t *)
 mongoc_stream_tls_libressl_new (mongoc_stream_t *base_stream,
                                 const char *host,
                                 mongoc_ssl_opt_t *opt,
-                                int client);
+                                int client) BSON_GNUC_WARN_UNUSED_RESULT;
 
 BSON_END_DECLS
 

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl.h
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl.h
@@ -30,7 +30,7 @@ MONGOC_EXPORT (mongoc_stream_t *)
 mongoc_stream_tls_openssl_new (mongoc_stream_t *base_stream,
                                const char *host,
                                mongoc_ssl_opt_t *opt,
-                               int client);
+                               int client) BSON_GNUC_WARN_UNUSED_RESULT;
 
 BSON_END_DECLS
 

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.h
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.h
@@ -30,7 +30,7 @@ MONGOC_EXPORT (mongoc_stream_t *)
 mongoc_stream_tls_secure_channel_new (mongoc_stream_t *base_stream,
                                       const char *host,
                                       mongoc_ssl_opt_t *opt,
-                                      int client);
+                                      int client) BSON_GNUC_WARN_UNUSED_RESULT;
 
 BSON_END_DECLS
 

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-transport.h
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-transport.h
@@ -30,7 +30,8 @@ MONGOC_EXPORT (mongoc_stream_t *)
 mongoc_stream_tls_secure_transport_new (mongoc_stream_t *base_stream,
                                         const char *host,
                                         mongoc_ssl_opt_t *opt,
-                                        int client);
+                                        int client)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 
 BSON_END_DECLS
 

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls.h
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls.h
@@ -51,11 +51,11 @@ MONGOC_EXPORT (mongoc_stream_t *)
 mongoc_stream_tls_new_with_hostname (mongoc_stream_t *base_stream,
                                      const char *host,
                                      mongoc_ssl_opt_t *opt,
-                                     int client);
+                                     int client) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (mongoc_stream_t *)
 mongoc_stream_tls_new (mongoc_stream_t *base_stream,
                        mongoc_ssl_opt_t *opt,
-                       int client)
+                       int client) BSON_GNUC_WARN_UNUSED_RESULT
    BSON_GNUC_DEPRECATED_FOR (mongoc_stream_tls_new_with_hostname);
 
 

--- a/src/libmongoc/src/mongoc/mongoc-topology-description.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description.h
@@ -35,7 +35,8 @@ mongoc_topology_description_destroy (
 
 MONGOC_EXPORT (mongoc_topology_description_t *)
 mongoc_topology_description_new_copy (
-   const mongoc_topology_description_t *description);
+   const mongoc_topology_description_t *description)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 
 MONGOC_EXPORT (bool)
 mongoc_topology_description_has_readable_server (
@@ -50,7 +51,8 @@ mongoc_topology_description_type (const mongoc_topology_description_t *td);
 
 MONGOC_EXPORT (mongoc_server_description_t **)
 mongoc_topology_description_get_servers (
-   const mongoc_topology_description_t *td, size_t *n);
+   const mongoc_topology_description_t *td,
+   size_t *n) BSON_GNUC_WARN_UNUSED_RESULT;
 
 BSON_END_DECLS
 

--- a/src/libmongoc/src/mongoc/mongoc-uri.h
+++ b/src/libmongoc/src/mongoc/mongoc-uri.h
@@ -94,7 +94,7 @@ typedef struct _mongoc_uri_t mongoc_uri_t;
 
 
 MONGOC_EXPORT (mongoc_uri_t *)
-mongoc_uri_copy (const mongoc_uri_t *uri);
+mongoc_uri_copy (const mongoc_uri_t *uri) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (void)
 mongoc_uri_destroy (mongoc_uri_t *uri);
 MONGOC_EXPORT (mongoc_uri_t *)
@@ -202,7 +202,7 @@ mongoc_uri_get_ssl (const mongoc_uri_t *uri)
 MONGOC_EXPORT (bool)
 mongoc_uri_get_tls (const mongoc_uri_t *uri);
 MONGOC_EXPORT (char *)
-mongoc_uri_unescape (const char *escaped_string);
+mongoc_uri_unescape (const char *escaped_string) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (const mongoc_read_prefs_t *)
 mongoc_uri_get_read_prefs_t (const mongoc_uri_t *uri);
 MONGOC_EXPORT (void)

--- a/src/libmongoc/src/mongoc/mongoc-write-concern.h
+++ b/src/libmongoc/src/mongoc/mongoc-write-concern.h
@@ -37,9 +37,10 @@ typedef struct _mongoc_write_concern_t mongoc_write_concern_t;
 
 
 MONGOC_EXPORT (mongoc_write_concern_t *)
-mongoc_write_concern_new (void);
+mongoc_write_concern_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (mongoc_write_concern_t *)
-mongoc_write_concern_copy (const mongoc_write_concern_t *write_concern);
+mongoc_write_concern_copy (const mongoc_write_concern_t *write_concern)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (void)
 mongoc_write_concern_destroy (mongoc_write_concern_t *write_concern);
 MONGOC_EXPORT (bool)


### PR DESCRIPTION
All functions declared with `MONGOC_EXPORT` were examined in this pass.

Any exported functions whose return value which the C driver documentation described as "newly allocated" or "should be freed" were given the `BSON_GNUC_WARN_UNUSED_RESULT` attribute. If there was not a documentation page corresponding to the function, or if the documentation did not describe how the result should be handled, the definition was examined for the presence of any calls to a `*_new()`-like, `*_malloc()`-like, `*_copy()`, or `*_clone()`-like functions as an indicator instead.

No additional warnings appear to have been generated relative to base commit (583213df9) as a result of these changes when building the C driver. Yay for no (obvious) leaks!🎉

Code formatting was also applied to all modified files. These formatting changes can be reverted if deemed unnecessary.