### PR TITLE
CDRIVER-3636 exclude PossiblePrimary from MSS check

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-topology-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description.c
@@ -541,7 +541,9 @@ mongoc_topology_description_lowest_max_wire_version (
    for (i = 0; (size_t) i < td->servers->items_len; i++) {
       sd = (mongoc_server_description_t *) mongoc_set_get_item (td->servers, i);
 
-      if (sd->type != MONGOC_SERVER_UNKNOWN && sd->max_wire_version < ret) {
+      if (sd->type != MONGOC_SERVER_UNKNOWN &&
+          sd->type != MONGOC_SERVER_POSSIBLE_PRIMARY &&
+          sd->max_wire_version < ret) {
          ret = sd->max_wire_version;
       }
    }

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/MaxStalenessTooSmall.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/MaxStalenessTooSmall.json
@@ -14,8 +14,7 @@
   },
   "read_preference": {
     "mode": "Nearest",
-    "maxStalenessSeconds": 90
+    "maxStalenessSeconds": 1
   },
-  "suitable_servers": [],
-  "in_latency_window": []
+  "error": true
 }

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/Unavailable.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/Unavailable.json
@@ -1,0 +1,60 @@
+{
+  "topology_description": {
+    "type": "ReplicaSetNoPrimary",
+    "servers": [
+      {
+        "address": "a:27017",
+        "type": "PossiblePrimary",
+        "avg_rtt_ms": 5,
+        "maxWireVersion": 0
+      },
+      {
+        "address": "b:27017",
+        "type": "Unknown",
+        "avg_rtt_ms": 5,
+        "maxWireVersion": 0
+      },
+      {
+        "address": "c:27017",
+        "type": "RSSecondary",
+        "maxWireVersion": 5,
+        "avg_rtt_ms": 5,
+        "lastWrite": {
+          "lastWriteDate": {
+            "$numberLong": "1"
+          }
+        }
+      }
+    ]
+  },
+  "read_preference": {
+    "mode": "Nearest",
+    "maxStalenessSeconds": 120
+  },
+  "suitable_servers": [
+    {
+      "address": "c:27017",
+      "type": "RSSecondary",
+      "maxWireVersion": 5,
+      "avg_rtt_ms": 5,
+      "lastWrite": {
+        "lastWriteDate": {
+          "$numberLong": "1"
+        }
+      }
+    }
+  ],
+  "in_latency_window": [
+    {
+      "address": "c:27017",
+      "type": "RSSecondary",
+      "maxWireVersion": 5,
+      "avg_rtt_ms": 5,
+      "lastWrite": {
+        "lastWriteDate": {
+          "$numberLong": "1"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Do not check PossiblePrimary servers in the maxWireVersion check
for topology support of maxStalenessSeconds