### PR TITLE
CDRIVER-4151 Replace static TestFnCtx with allocated object

### DIFF
--- a/src/libmongoc/tests/TestSuite.c
+++ b/src/libmongoc/tests/TestSuite.c
@@ -365,9 +365,9 @@ _TestSuite_AddFull (TestSuite *suite,  /* IN */
 
 
 void
-_TestSuite_TestFnCtxDtor (TestFnCtx *ctx)
+_TestSuite_TestFnCtxDtor (void *ctx)
 {
-   TestFuncDtor dtor = ctx->dtor;
+   TestFuncDtor dtor = ((TestFnCtx *) ctx)->dtor;
    if (dtor) {
       dtor (ctx);
    }

--- a/src/libmongoc/tests/TestSuite.c
+++ b/src/libmongoc/tests/TestSuite.c
@@ -364,6 +364,17 @@ _TestSuite_AddFull (TestSuite *suite,  /* IN */
 }
 
 
+void
+_TestSuite_TestFnCtxDtor (TestFnCtx *ctx)
+{
+   TestFuncDtor dtor = ctx->dtor;
+   if (dtor) {
+      dtor (ctx);
+   }
+   free (ctx);
+}
+
+
 #if defined(_WIN32)
 static void
 _print_getlasterror_win (const char *msg)
@@ -873,8 +884,7 @@ test_matches (TestSuite *suite, Test *test)
    }
 
    for (i = 0; i < suite->match_patterns.len; i++) {
-      char *pattern =
-         _mongoc_array_index (&suite->match_patterns, char *, i);
+      char *pattern = _mongoc_array_index (&suite->match_patterns, char *, i);
       if (TestSuite_TestMatchesName (suite, test, pattern)) {
          return true;
       }

--- a/src/libmongoc/tests/TestSuite.h
+++ b/src/libmongoc/tests/TestSuite.h
@@ -716,7 +716,7 @@ _TestSuite_AddFull (TestSuite *suite,
                     void *ctx,
                     ...);
 void
-_TestSuite_TestFnCtxDtor (TestFnCtx *ctx);
+_TestSuite_TestFnCtxDtor (void *ctx);
 #define TestSuite_AddFull(_suite, _name, _func, _dtor, _ctx, ...) \
    _TestSuite_AddFull (_suite, _name, _func, _dtor, _ctx, __VA_ARGS__, NULL)
 #define TestSuite_AddFullWithTestFn(                \


### PR DESCRIPTION
The solution to CDRIVER-3632 (merged in https://github.com/mongodb/mongo-c-driver/pull/865) introduced a bug in `TestSuite_Add()` and `TestSuite_AddLive()` where the static `TestFnCtx` object generated by the new `TestSuite_AddFullWithTestFn()`, pointed-to by each `Test` object created on invocation of `TestSuite_Add()` or `TestSuite_AddLive()`, is modified by a subsequent call to `TestSuite_Add()` or `TestSuite_AddLive()`. This has the effect of incorrectly (effectively) modifying `_Test::ctx->func` to point the _last_ (and _only_ the last) `test_fn` given to `TestSuite_Add()` or `TestSuite_AddLive()` respectively (each has their own static local variable):

```c
void
TestSuite_Add (TestSuite *suite, /* IN */
               const char *name, /* IN */
               TestFunc func)    /* IN */
{
   /* Expanded:
         TestSuite_AddFullWithTestFn (
            suite, name, TestSuite_AddHelper, NULL, func, TestSuite_CheckDummy);
    */
   do {
      static TestFnCtx ctx;
      ctx.test_fn = (TestFunc) (func);
      _TestSuite_AddFull (suite,
                          name,
                          TestSuite_AddHelper,
                          NULL,
                          &ctx,
                          TestSuite_CheckDummy,
                          NULL);
   } while (0);
}
```

The alternative dynamically allocating solution documented in CDRIVER-3632 neatly addresses this issue by instead allocating a unique `TestFnCtx` on each call to `TestSuite_AddFullWithTestFn()`, eliminating the involuntary shared state across different `Test` objects created by calls to `TestSuite_Add()` and `TestSuite_AddLive()`:

```c
void
TestSuite_Add (TestSuite *suite, /* IN */
               const char *name, /* IN */
               TestFunc func)    /* IN */
{
   /* Expanded:
         TestSuite_AddFullWithTestFn (
            suite, name, TestSuite_AddHelper, NULL, func, TestSuite_CheckDummy);
    */
   do {
      TestFnCtx *ctx = malloc (sizeof (TestFnCtx));
      ctx->test_fn = (TestFunc) (func);
      ctx->dtor = NULL;
      _TestSuite_AddFull (suite,
                          name,
                          TestSuite_AddHelper,
                          _TestSuite_TestFnCtxDtor,
                          ctx,
                          TestSuite_CheckDummy,
                          NULL);
   } while (0);
}
```