### PR TITLE
CDRIVER-4156 use Python from toolchain on Ubuntu 14.04 Evergreen hosts

### DIFF
--- a/.evergreen/integration-tests.sh
+++ b/.evergreen/integration-tests.sh
@@ -117,6 +117,9 @@ case "$OS" in
       if [ -f /opt/python/2.7/bin/python ]; then
          # Python toolchain installation.
          PYTHON=/opt/python/2.7/bin/python
+      elif [ "x$(lsb_release -cs)" = "xtrusty" -a -f /opt/mongodbtoolchain/v2/bin/python ]; then
+         # Python toolchain installation.
+         PYTHON=/opt/mongodbtoolchain/v2/bin/python
       else
          PYTHON=python
       fi


### PR DESCRIPTION
Evergreen patch build: https://evergreen.mongodb.com/version/613fe728c9ec444561e48f6b?redirect_spruce_users=true

c.f. discussion in #867 