### PR TITLE
CDRIVER-4158: Fix bson-atomic.h for compatibility with C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,9 @@ option (ENABLE_DEBUG_ASSERTIONS "Turn on runtime debug assertions" OFF)
 
 project (mongo-c-driver C)
 
+# Optionally enable C++ to do some C++-specific tests
+enable_language(CXX OPTIONAL)
+
 if (NOT CMAKE_BUILD_TYPE)
    set (CMAKE_BUILD_TYPE "RelWithDebInfo")
    message (

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ option (ENABLE_DEBUG_ASSERTIONS "Turn on runtime debug assertions" OFF)
 project (mongo-c-driver C)
 
 # Optionally enable C++ to do some C++-specific tests
-enable_language(CXX OPTIONAL)
+enable_language (CXX OPTIONAL)
 
 if (NOT CMAKE_BUILD_TYPE)
    set (CMAKE_BUILD_TYPE "RelWithDebInfo")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,5 +46,9 @@ if (CMAKE_CXX_COMPILER)
    # Add a C++ source file that will #include the main C headers. This "library"
    # does nothing other than validate that the C headers are valid C++ headers.
    add_library (mongoc-cxx-check STATIC cpp-check.cpp)
-   target_link_libraries (mongoc-cxx-check PRIVATE mongoc_static)
+   if (TARGET mongoc_static)
+      target_link_libraries (mongoc-cxx-check PRIVATE mongoc_static)
+   else ()
+      target_link_libraries (mongoc-cxx-check PRIVATE mongoc_shared)
+   endif ()
 endif ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,7 @@ file (GLOB_RECURSE src_kms_message_DIST RELATIVE "${SOURCE_DIR}" kms-message/*)
 
 set_local_dist (src_DIST_local
    CMakeLists.txt
+   cpp-check.cpp
 )
 
 set (src_DIST
@@ -46,4 +47,4 @@ if (CMAKE_CXX_COMPILER)
    # does nothing other than validate that the C headers are valid C++ headers.
    add_library (mongoc-cxx-check STATIC cpp-check.cpp)
    target_link_libraries (mongoc-cxx-check PRIVATE mongoc_static)
-endif()
+endif ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,3 +39,11 @@ set (src_DIST
    ${src_kms_message_DIST}
    PARENT_SCOPE
 )
+
+
+if (CMAKE_CXX_COMPILER)
+   # Add a C++ source file that will #include the main C headers. This "library"
+   # does nothing other than validate that the C headers are valid C++ headers.
+   add_library (mongoc-cxx-check STATIC cpp-check.cpp)
+   target_link_libraries (mongoc-cxx-check PRIVATE mongoc_static)
+endif()

--- a/src/cpp-check.cpp
+++ b/src/cpp-check.cpp
@@ -1,0 +1,6 @@
+/**
+ * The sole purpose of this file is to check that the mongoc headers can be
+ * included in a C++ file without error.
+ */
+#include <bson/bson.h>
+#include <mongoc/mongoc.h>

--- a/src/libbson/src/bson/bson-atomic.h
+++ b/src/libbson/src/bson/bson-atomic.h
@@ -285,7 +285,7 @@ enum bson_memory_order {
 #define DECL_ATOMIC_STDINT(Name, VCSuffix) \
    DECL_ATOMIC_INTEGRAL (Name, Name##_t, VCSuffix)
 
-#if _MSC_VER
+#ifdef _MSC_VER
 /* MSVC expects precise types for their atomic intrinsics. */
 DECL_ATOMIC_INTEGRAL (int8, char, 8);
 DECL_ATOMIC_INTEGRAL (int16, short, 16)

--- a/src/libbson/src/bson/bson-atomic.h
+++ b/src/libbson/src/bson/bson-atomic.h
@@ -146,8 +146,8 @@ enum bson_memory_order {
       Type volatile const *a, enum bson_memory_order order)                   \
    {                                                                          \
       /* MSVC doesn't have a load intrinsic, so just add zero */              \
-      BSON_IF_MSVC (                                                          \
-         return bson_atomic_##NamePart##_fetch_add ((void *) a, 0, order);)   \
+      BSON_IF_MSVC (return bson_atomic_##NamePart##_fetch_add (               \
+                              (Type volatile *) a, 0, order);)                \
       /* GNU doesn't want RELEASE order for the fetch operation, so we can't  \
        * just use DEF_ATOMIC_OP. */                                           \
       BSON_IF_GNU_LIKE (switch (order) {                                      \
@@ -285,9 +285,19 @@ enum bson_memory_order {
 #define DECL_ATOMIC_STDINT(Name, VCSuffix) \
    DECL_ATOMIC_INTEGRAL (Name, Name##_t, VCSuffix)
 
+#if _MSC_VER
+/* MSVC expects precise types for their atomic intrinsics. */
+DECL_ATOMIC_INTEGRAL (int8, char, 8);
+DECL_ATOMIC_INTEGRAL (int16, short, 16)
+DECL_ATOMIC_INTEGRAL (int32, long, )
+DECL_ATOMIC_INTEGRAL (int, long, )
+#else
+/* Other compilers that we support provide generic intrinsics */
 DECL_ATOMIC_STDINT (int8, 8)
 DECL_ATOMIC_STDINT (int16, 16)
 DECL_ATOMIC_STDINT (int32, )
+DECL_ATOMIC_INTEGRAL (int, int, )
+#endif
 
 extern int64_t
 _bson_emul_atomic_int64_fetch_add (int64_t volatile *val,
@@ -314,7 +324,11 @@ bson_thrd_yield (void);
 
 #if (defined(_MSC_VER) && !defined(_M_IX86)) || (defined(__LP64__) && __LP64__)
 /* (64-bit intrinsics are only available in x64) */
+#ifdef _MSC_VER
+DECL_ATOMIC_INTEGRAL (int64, __int64, 64)
+#else
 DECL_ATOMIC_STDINT (int64, 64)
+#endif
 #else
 static BSON_INLINE int64_t
 bson_atomic_int64_fetch (int64_t volatile *val, enum bson_memory_order order)
@@ -366,8 +380,6 @@ bson_atomic_int64_compare_exchange_weak (int64_t volatile *val,
       val, expect_value, new_value, order);
 }
 #endif
-
-DECL_ATOMIC_INTEGRAL (int, int, )
 
 static BSON_INLINE void *
 bson_atomic_ptr_exchange (void *volatile *ptr,


### PR DESCRIPTION
Fixes CDRIVER-4158. There was some implicit cross-casting going on in the headers that is not valid C++ code.

This also adds a C++ utility target that is only compiled to check that the public headers are valid C++ code.