### PR TITLE
CDRIVER-4158 make CXX enablement optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,13 @@ option (ENABLE_DEBUG_ASSERTIONS "Turn on runtime debug assertions" OFF)
 project (mongo-c-driver C)
 
 # Optionally enable C++ to do some C++-specific tests
-enable_language (CXX OPTIONAL)
+include (CheckLanguage)
+check_language (CXX)
+if (CMAKE_CXX_COMPILER)
+   enable_language (CXX)
+else ()
+   message (STATUS "No CXX support")
+endif ()
 
 if (NOT CMAKE_BUILD_TYPE)
    set (CMAKE_BUILD_TYPE "RelWithDebInfo")


### PR DESCRIPTION
Evergreen patch build: https://spruce.mongodb.com/version/6143d8c7d6d80a70550288d1/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

The BSON Atomics API fix broke the `rpm-package-build` task because the build environment does not include a C++ compiler by default.

Apparently, the CMake documentation contains this note regarding the `enable_language` command:

```
       The OPTIONAL keyword is a placeholder for future implementation and does not currently work. Instead you can
       use the CheckLanguage module to verify support before enabling.
```

So, the originally implemented change depends on a dummy feature.  The change in this PR instead takes the approach the suggested in the CMake documentation.