### PR TITLE
CDRIVER-4160 more robust Python selection for integration tests

### DIFF
--- a/.evergreen/integration-tests.sh
+++ b/.evergreen/integration-tests.sh
@@ -124,6 +124,12 @@ case "$OS" in
          PYTHON=python
       fi
 
+      PIP=pip
+      if ! $PYTHON -c "import virtualenv" ; then
+         PYTHON=python3
+         PIP=pip3
+      fi
+
       $PYTHON -m virtualenv venv
       cd venv
       . bin/activate
@@ -136,7 +142,7 @@ case "$OS" in
          echo "Disabling pip cache"
          PIP_PARAM="--no-cache-dir"
       fi
-      pip $PIP_PARAM install .
+      $PIP $PIP_PARAM install .
       cd ../..
       mongo-orchestration -f orchestration.config -e default --socket-timeout-ms=60000 --bind=127.0.0.1  --enable-majority-read-concern start > $MONGO_ORCHESTRATION_HOME/out.log 2> $MONGO_ORCHESTRATION_HOME/err.log < /dev/null &
       ;;


### PR DESCRIPTION
This specifically addresses the situation on Ubuntu 16.04 Evergreen
hosts, which have the virtualenv module installed only for Python 3.

Currently, tasks on Ubuntu 16.04 that execute the `.evergreen/integration-tests.sh` land in the `system-failed` state on Evergreen.  This change allows the tasks to run to completion.

Evergreen patch build: https://spruce.mongodb.com/version/6144dc983627e00c42d46fa5/tasks