### PR TITLE
dump mock logs if RPM build fails in Evergreen

### DIFF
--- a/.evergreen/build_snapshot_rpm.sh
+++ b/.evergreen/build_snapshot_rpm.sh
@@ -118,7 +118,7 @@ echo "Building source RPM ..."
 rpmbuild -bs ${spec_file}
 echo "Building binary RPMs ..."
 mock_result=$(readlink -f ../mock-result)
-sudo mock --resultdir="${mock_result}" --use-bootstrap-image --isolation=simple -r ${config} --no-clean --no-cleanup-after --rebuild ~/rpmbuild/SRPMS/${package}-${snapshot_version}*.src.rpm
+sudo mock --resultdir="${mock_result}" --use-bootstrap-image --isolation=simple -r ${config} --no-clean --no-cleanup-after --rebuild ~/rpmbuild/SRPMS/${package}-${snapshot_version}*.src.rpm || ( cd "${mock_result}" ; cat *.log ; exit 1 )
 sudo mock -r ${config} --use-bootstrap-image --isolation=simple --copyin "${mock_result}" /tmp
 
 sudo mock -r ${config} --use-bootstrap-image --isolation=simple --cwd "/tmp/${build_dir}" --chroot -- /bin/sh -c "(


### PR DESCRIPTION
Evergreen patch build: https://spruce.mongodb.com/version/6144edef3627e00c42d4e86b/tasks

A failure on the C++ driver waterfall (which uses the same script for building RPMs) is what prompted me to make this change.