### PR TITLE
CDRIVER-4035 use runAdminCommand.arguments.readPreference

### DIFF
--- a/src/libmongoc/tests/json-test-operations.c
+++ b/src/libmongoc/tests/json-test-operations.c
@@ -2568,7 +2568,7 @@ json_test_operation (json_test_ctx_t *ctx,
          test_framework_set_ssl_opts (client);
          admin_db = mongoc_client_get_database (client, "admin");
          bson_destroy (reply);
-         res = command (admin_db, test, operation, session, NULL, reply);
+         res = command (admin_db, test, operation, session, read_prefs, reply);
          if (!res) {
             test_error ("admin command failed: %s", bson_as_json (reply, NULL));
          }


### PR DESCRIPTION
Fixes the test failure associated with the [rediscover-quickly-after-stepdown](https://github.com/mongodb/specifications/blob/c48d7f416e51dce8fd4c8d05bdb05790508ca3bb/source/server-discovery-and-monitoring/tests/integration/rediscover-quickly-after-step-down.yml#L34-L42) SDAM specification test.

The test runner was not passing a read preference. No read preference defaults to a primary read preference. The test operation requires sending to a secondary.