### PR TITLE
CDRIVER-4166 permit NULL platform argument to mongoc_handshake_data_append()

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-handshake.c
+++ b/src/libmongoc/src/mongoc/mongoc-handshake.c
@@ -633,7 +633,7 @@ mongoc_handshake_data_append (const char *driver_name,
    if (platform) {
       /* we check for an empty string as a special case to avoid an unnecessary
        * delimiter being added in front of the string by _append_and_truncate */
-      if (strcmp (_mongoc_handshake_get ()->platform, "") == 0) {
+      if (_mongoc_handshake_get()->platform[0] == '\0') {
          bson_free (_mongoc_handshake_get ()->platform);
          _mongoc_handshake_get ()->platform =
             bson_strdup_printf ("%.*s", platform_space, platform);

--- a/src/libmongoc/src/mongoc/mongoc-handshake.c
+++ b/src/libmongoc/src/mongoc/mongoc-handshake.c
@@ -473,8 +473,7 @@ _append_platform_field (bson_t *doc, const char *platform)
                             1 +
 
                             /* key size */
-                            (int) strlen (HANDSHAKE_PLATFORM_FIELD) +
-                            1 +
+                            (int) strlen (HANDSHAKE_PLATFORM_FIELD) + 1 +
 
                             /* 4 bytes for length of string */
                             4);

--- a/src/libmongoc/src/mongoc/mongoc-handshake.c
+++ b/src/libmongoc/src/mongoc/mongoc-handshake.c
@@ -633,7 +633,7 @@ mongoc_handshake_data_append (const char *driver_name,
    if (platform) {
       /* we check for an empty string as a special case to avoid an unnecessary
        * delimiter being added in front of the string by _append_and_truncate */
-      if (_mongoc_handshake_get()->platform[0] == '\0') {
+      if (_mongoc_handshake_get ()->platform[0] == '\0') {
          bson_free (_mongoc_handshake_get ()->platform);
          _mongoc_handshake_get ()->platform =
             bson_strdup_printf ("%.*s", platform_space, platform);

--- a/src/libmongoc/tests/test-mongoc-handshake.c
+++ b/src/libmongoc/tests/test-mongoc-handshake.c
@@ -182,7 +182,6 @@ test_mongoc_handshake_data_append_success (void)
    server = mock_server_new ();
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));
-   mongoc_uri_set_option_as_int32 (uri, MONGOC_URI_HEARTBEATFREQUENCYMS, 500);
    mongoc_uri_set_option_as_utf8 (uri, MONGOC_URI_APPNAME, "testapp");
    pool = test_framework_client_pool_new_from_uri (uri, NULL);
 
@@ -292,7 +291,6 @@ test_mongoc_handshake_data_append_null_args (void)
    server = mock_server_new ();
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));
-   mongoc_uri_set_option_as_int32 (uri, MONGOC_URI_HEARTBEATFREQUENCYMS, 500);
    mongoc_uri_set_option_as_utf8 (uri, MONGOC_URI_APPNAME, "testapp");
    pool = test_framework_client_pool_new_from_uri (uri, NULL);
 

--- a/src/libmongoc/tests/test-mongoc-handshake.c
+++ b/src/libmongoc/tests/test-mongoc-handshake.c
@@ -174,11 +174,6 @@ test_mongoc_handshake_data_append_success (void)
    const char *driver_version = "version abc";
    const char *platform = "./configure -nottoomanyflags";
 
-   char big_string[HANDSHAKE_MAX_SIZE];
-
-   memset (big_string, 'a', HANDSHAKE_MAX_SIZE - 1);
-   big_string[HANDSHAKE_MAX_SIZE - 1] = '\0';
-
    _reset_handshake ();
    /* Make sure setting the handshake works */
    ASSERT (
@@ -289,11 +284,6 @@ test_mongoc_handshake_data_append_null_args (void)
    bson_iter_t md_iter;
    bson_iter_t inner_iter;
    const char *val;
-
-   char big_string[HANDSHAKE_MAX_SIZE];
-
-   memset (big_string, 'a', HANDSHAKE_MAX_SIZE - 1);
-   big_string[HANDSHAKE_MAX_SIZE - 1] = '\0';
 
    _reset_handshake ();
    /* Make sure setting the handshake works */

--- a/src/libmongoc/tests/test-mongoc-handshake.c
+++ b/src/libmongoc/tests/test-mongoc-handshake.c
@@ -277,6 +277,122 @@ test_mongoc_handshake_data_append_success (void)
 
 
 static void
+test_mongoc_handshake_data_append_null_args (void)
+{
+   mock_server_t *server;
+   mongoc_uri_t *uri;
+   mongoc_client_t *client;
+   mongoc_client_pool_t *pool;
+   request_t *request;
+   const bson_t *request_doc;
+   bson_iter_t iter;
+   bson_iter_t md_iter;
+   bson_iter_t inner_iter;
+   const char *val;
+
+   char big_string[HANDSHAKE_MAX_SIZE];
+
+   memset (big_string, 'a', HANDSHAKE_MAX_SIZE - 1);
+   big_string[HANDSHAKE_MAX_SIZE - 1] = '\0';
+
+   _reset_handshake ();
+   /* Make sure setting the handshake works */
+   ASSERT (mongoc_handshake_data_append (NULL, NULL, NULL));
+
+   server = mock_server_new ();
+   mock_server_run (server);
+   uri = mongoc_uri_copy (mock_server_get_uri (server));
+   mongoc_uri_set_option_as_int32 (uri, MONGOC_URI_HEARTBEATFREQUENCYMS, 500);
+   mongoc_uri_set_option_as_utf8 (uri, MONGOC_URI_APPNAME, "testapp");
+   pool = test_framework_client_pool_new_from_uri (uri, NULL);
+
+   /* Force topology scanner to start */
+   client = mongoc_client_pool_pop (pool);
+
+   request = mock_server_receives_legacy_hello (server, NULL);
+   ASSERT (request);
+   request_doc = request_get_doc (request, 0);
+   ASSERT (request_doc);
+   ASSERT (bson_has_field (request_doc, HANDSHAKE_FIELD));
+
+   ASSERT (bson_iter_init_find (&iter, request_doc, HANDSHAKE_FIELD));
+   ASSERT (bson_iter_recurse (&iter, &md_iter));
+
+   ASSERT (bson_iter_find (&md_iter, "application"));
+   ASSERT (BSON_ITER_HOLDS_DOCUMENT (&md_iter));
+   ASSERT (bson_iter_recurse (&md_iter, &inner_iter));
+   ASSERT (bson_iter_find (&inner_iter, "name"));
+   val = bson_iter_utf8 (&inner_iter, NULL);
+   ASSERT (val);
+   ASSERT_CMPSTR (val, "testapp");
+
+   /* Make sure driver.name and driver.version and platform are all right */
+   ASSERT (bson_iter_find (&md_iter, "driver"));
+   ASSERT (BSON_ITER_HOLDS_DOCUMENT (&md_iter));
+   ASSERT (bson_iter_recurse (&md_iter, &inner_iter));
+   ASSERT (bson_iter_find (&inner_iter, "name"));
+   ASSERT (BSON_ITER_HOLDS_UTF8 (&inner_iter));
+   val = bson_iter_utf8 (&inner_iter, NULL);
+   ASSERT (val);
+   ASSERT (strstr (val, " / ") == NULL); /* No append delimiter */
+
+   ASSERT (bson_iter_find (&inner_iter, "version"));
+   ASSERT (BSON_ITER_HOLDS_UTF8 (&inner_iter));
+   val = bson_iter_utf8 (&inner_iter, NULL);
+   ASSERT (val);
+   ASSERT (strstr (val, " / ") == NULL); /* No append delimiter */
+
+   /* Check os type not empty */
+   ASSERT (bson_iter_find (&md_iter, "os"));
+   ASSERT (BSON_ITER_HOLDS_DOCUMENT (&md_iter));
+   ASSERT (bson_iter_recurse (&md_iter, &inner_iter));
+
+   ASSERT (bson_iter_find (&inner_iter, "type"));
+   ASSERT (BSON_ITER_HOLDS_UTF8 (&inner_iter));
+   val = bson_iter_utf8 (&inner_iter, NULL);
+   ASSERT (val);
+   ASSERT (strlen (val) > 0);
+
+   /* Check os version valid */
+   ASSERT (bson_iter_find (&inner_iter, "version"));
+   ASSERT (BSON_ITER_HOLDS_UTF8 (&inner_iter));
+   val = bson_iter_utf8 (&inner_iter, NULL);
+   _check_os_version_valid (val);
+
+   /* Check os arch is valid */
+   ASSERT (bson_iter_find (&inner_iter, "architecture"));
+   ASSERT (BSON_ITER_HOLDS_UTF8 (&inner_iter));
+   val = bson_iter_utf8 (&inner_iter, NULL);
+   ASSERT (val);
+   _check_arch_string_valid (val);
+
+   /* Not checking os_name, as the spec says it can be NULL. */
+
+   /* Check platform field ok */
+   ASSERT (bson_iter_find (&md_iter, "platform"));
+   ASSERT (BSON_ITER_HOLDS_UTF8 (&md_iter));
+   val = bson_iter_utf8 (&md_iter, NULL);
+   ASSERT (val);
+   /* standard val are < 100, may be truncated on some platform */
+   if (strlen (val) < 250) {
+      /* `printf("%s", NULL)` -> "(null)" with libstdc++, libc++, and STL */
+      ASSERT (strstr (val, "null") == NULL);
+   }
+
+   mock_server_replies_simple (request, "{'ok': 1, 'isWritablePrimary': true}");
+   request_destroy (request);
+
+   /* Cleanup */
+   mongoc_client_pool_push (pool, client);
+   mongoc_client_pool_destroy (pool);
+   mongoc_uri_destroy (uri);
+   mock_server_destroy (server);
+
+   _reset_handshake ();
+}
+
+
+static void
 _test_platform (bool platform_oversized)
 {
    mongoc_handshake_t *md;
@@ -842,6 +958,9 @@ test_handshake_install (TestSuite *suite)
    TestSuite_AddMockServerTest (suite,
                                 "/MongoDB/handshake/success",
                                 test_mongoc_handshake_data_append_success);
+   TestSuite_AddMockServerTest (suite,
+                                "/MongoDB/handshake/null_args",
+                                test_mongoc_handshake_data_append_null_args);
    TestSuite_Add (suite,
                   "/MongoDB/handshake/big_platform",
                   test_mongoc_handshake_big_platform);

--- a/src/libmongoc/tests/test-mongoc-handshake.c
+++ b/src/libmongoc/tests/test-mongoc-handshake.c
@@ -818,7 +818,7 @@ test_mongoc_handshake_race_condition (void)
          BSON_ASSERT (!COMMON_PREFIX (thread_create) (
             &threads[j], &handshake_append_worker, NULL));
       }
-for (j = 0; j < 4; ++j) {
+      for (j = 0; j < 4; ++j) {
          COMMON_PREFIX (thread_join) (threads[j]);
       }
    }


### PR DESCRIPTION
`mongoc_handshake_data_append()` [special-cases](https://github.com/mongodb/mongo-c-driver/blob/130938ad44a6516e6c399b9d25e5fe1b0464f14f/src/libmongoc/src/mongoc/mongoc-handshake.c#L638) the first write to `mongoc_handshake_t::platform` to avoid inserting a leading delimiter. This special-case branch does not protect against a `NULL` value for the `platform` parameter; other branches use the [`NULL` check](https://github.com/mongodb/mongo-c-driver/blob/130938ad44a6516e6c399b9d25e5fe1b0464f14f/src/libmongoc/src/mongoc/mongoc-handshake.c#L590) within the `_append_and_truncate()` helper function. However, this bug was likely not detected due to both `vsnprintf()` (Unix/macOS) and `_vsnprintf_s()` (Windows), [used internally](https://github.com/mongodb/mongo-c-driver/blob/130938ad44a6516e6c399b9d25e5fe1b0464f14f/src/libbson/src/bson/bson-string.c#L585) by `bson_strdup_printf()`, outputting `"(null)"` given a null argument corresponding to a `"%s"` string specifier across libstdc++, libc++, and STL. This is unfortunate but permitted given this condition falls under undefined behavior:

```c
#include <stdio.h>

int main(void) {
  printf("%s\n", NULL);
}
```
```
(null)
```

This PR therefore:
1. makes the optional nature of parameters explicit in `mongoc_handshake_data_append()` by lifting the `NULL` check out of `_append_and_truncate()`,
2. ensures all branches, including the special-case mentioned above, are protected by a corresponding null check, and
3. adds a new test `/MongoDB/handshake/null_args` explicitly asserting for the absense of a `"null"` string in the result given a `NULL` platform argument.