### PR TITLE
CDRIVER-4145 do not monitor an invalid topology

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-topology-background-monitoring.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-background-monitoring.c
@@ -134,6 +134,10 @@ _mongoc_topology_background_monitoring_start (mongoc_topology_t *topology)
    BSON_ASSERT (!topology->single_threaded);
    MONGOC_DEBUG_ASSERT (COMMON_PREFIX (mutex_is_locked) (&topology->mutex));
 
+   if (!topology->valid) {
+      return;
+   }
+
    if (topology->scanner_state == MONGOC_TOPOLOGY_SCANNER_BG_RUNNING) {
       return;
    }

--- a/src/libmongoc/src/mongoc/mongoc-topology-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-private.h
@@ -141,6 +141,11 @@ typedef struct _mongoc_topology_t {
 
    /* This is overridable for SRV polling tests to mock DNS records. */
    _mongoc_rr_resolver_fn rr_resolver;
+
+   /* valid is false when mongoc_topology_new failed to construct a valid topology.
+    * This could occur if the URI is invalid.
+    * An invalid topology does not monitor servers. */
+   bool valid;
 } mongoc_topology_t;
 
 mongoc_topology_t *

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -3023,5 +3023,6 @@ test_framework_skip_if_no_getlasterror (void) {
 
 bool
 test_framework_is_loadbalanced (void) {
-   return test_framework_getenv_bool ("MONGOC_TEST_LOADBALANCED");
+   return test_framework_getenv_bool ("MONGOC_TEST_LOADBALANCED") ||
+          test_framework_getenv_bool ("MONGOC_TEST_DNS_LOADBALANCED");
 }


### PR DESCRIPTION
**Background**
Configuring a client with multiple hosts and the `loadBalanced=true` option, like `mongodb://host1,host2/?loadBalanced=true`, is an error. This comes from the [Load Balanced specification](https://github.com/mongodb/specifications/blob/2b0e9ed07446b2a92ac66216d19da59b7f582e69/source/load-balancers/load-balancers.rst#uri-validation):

> When loadBalanced=true is provided in the connection string, the driver MUST throw an exception in the following cases:
>
> - The connection string contains more than one host/port.

A single-threaded `mongoc_client_t` and multi-threaded `mongoc_client_pool_t` share behavior in a `mongoc_topology_t`. The `mongoc_topology_t` is constructed with a URI in `mongoc_topology_new`. In the invalid case for single-threaded, a `mongoc_client_t` [does not add servers to the topology description](https://github.com/mongodb/mongo-c-driver/blob/130938ad44a6516e6c399b9d25e5fe1b0464f14f/src/libmongoc/src/mongoc/mongoc-topology.c#L527-L539) which bypasses single-threaded monitoring. Multi-threaded monitoring still started background threads, triggering the assertion in the call to [_mongoc_topology_description_monitor_opening](https://github.com/kevinAlbs/mongo-c-driver/blob/6550b7d25da2b8ba8c9291cfed5f28f46fbb80ec/src/libmongoc/src/mongoc/mongoc-topology-background-monitoring.c#L152:L152).

**Scope of Change**
- Do not start background monitoring on an invalid topology.
- Check for `MONGOC_TEST_DNS_LOADBALANCED` in `test_framework_is_loadbalanced`. This determines whether to mock the `serviceID`.

**Testing**
There are no new tests introduced in this PR. There are tests for invalid URI configurations with load balancer. This was failing on the Evergreen waterfall on tests that are not part of the subset that runs on GitHub PR patch builds. I reconfigured the patch build attached to this PR to run the [test-dns-loadbalanced-openssl](https://spruce.mongodb.com/version/61537b9e32f41730f0d2f131/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&variant=gcc75) task, which now succeeds.