### PR TITLE
CDRIVER-3927 add KMS TLS tests for client side encryption

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -768,6 +768,18 @@ functions:
         if [ ! -d "drivers-evergreen-tools" ]; then
             git clone git@github.com:mongodb-labs/drivers-evergreen-tools.git --depth=1
         fi
+  run kms servers:
+  - command: shell.exec
+    params:
+      background: true
+      shell: bash
+      script: |-
+        set -o errexit
+        cd ./drivers-evergreen-tools/.evergreen/csfle
+        . ./activate_venv.sh
+        python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/server.pem --port 7999 &
+        python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000 &
+        python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 8001 &
   start load balancer:
   - command: shell.exec
     params:
@@ -3286,6 +3298,8 @@ tasks:
       SSL: openssl
       TOPOLOGY: server
       VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'on'
@@ -3449,6 +3463,8 @@ tasks:
       SSL: openssl
       TOPOLOGY: server
       VERSION: '5.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'on'
@@ -3612,6 +3628,8 @@ tasks:
       SSL: openssl
       TOPOLOGY: server
       VERSION: '4.4'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'on'
@@ -3775,6 +3793,8 @@ tasks:
       SSL: openssl
       TOPOLOGY: server
       VERSION: '4.2'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'on'
@@ -6766,6 +6786,8 @@ tasks:
       SSL: openssl
       TOPOLOGY: server
       VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -6818,6 +6840,8 @@ tasks:
       SSL: openssl-static
       TOPOLOGY: server
       VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -6870,6 +6894,8 @@ tasks:
       SSL: darwinssl
       TOPOLOGY: server
       VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -6922,6 +6948,8 @@ tasks:
       SSL: winssl
       TOPOLOGY: server
       VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -7099,6 +7127,8 @@ tasks:
       SSL: openssl
       TOPOLOGY: server
       VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -7151,6 +7181,8 @@ tasks:
       SSL: openssl-static
       TOPOLOGY: server
       VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -7203,6 +7235,8 @@ tasks:
       SSL: darwinssl
       TOPOLOGY: server
       VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -7255,6 +7289,8 @@ tasks:
       SSL: winssl
       TOPOLOGY: server
       VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -8282,6 +8318,8 @@ tasks:
       SSL: openssl
       TOPOLOGY: server
       VERSION: '5.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -8334,6 +8372,8 @@ tasks:
       SSL: openssl-static
       TOPOLOGY: server
       VERSION: '5.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -8386,6 +8426,8 @@ tasks:
       SSL: darwinssl
       TOPOLOGY: server
       VERSION: '5.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -8438,6 +8480,8 @@ tasks:
       SSL: winssl
       TOPOLOGY: server
       VERSION: '5.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -8590,6 +8634,8 @@ tasks:
       SSL: openssl
       TOPOLOGY: server
       VERSION: '5.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -8642,6 +8688,8 @@ tasks:
       SSL: openssl-static
       TOPOLOGY: server
       VERSION: '5.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -8694,6 +8742,8 @@ tasks:
       SSL: darwinssl
       TOPOLOGY: server
       VERSION: '5.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -8746,6 +8796,8 @@ tasks:
       SSL: winssl
       TOPOLOGY: server
       VERSION: '5.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -9773,6 +9825,8 @@ tasks:
       SSL: openssl
       TOPOLOGY: server
       VERSION: '4.4'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -9825,6 +9879,8 @@ tasks:
       SSL: openssl-static
       TOPOLOGY: server
       VERSION: '4.4'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -9877,6 +9933,8 @@ tasks:
       SSL: darwinssl
       TOPOLOGY: server
       VERSION: '4.4'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -9929,6 +9987,8 @@ tasks:
       SSL: winssl
       TOPOLOGY: server
       VERSION: '4.4'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -10081,6 +10141,8 @@ tasks:
       SSL: openssl
       TOPOLOGY: server
       VERSION: '4.4'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -10133,6 +10195,8 @@ tasks:
       SSL: openssl-static
       TOPOLOGY: server
       VERSION: '4.4'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -10185,6 +10249,8 @@ tasks:
       SSL: darwinssl
       TOPOLOGY: server
       VERSION: '4.4'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -10237,6 +10303,8 @@ tasks:
       SSL: winssl
       TOPOLOGY: server
       VERSION: '4.4'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -11264,6 +11332,8 @@ tasks:
       SSL: openssl
       TOPOLOGY: server
       VERSION: '4.2'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -11316,6 +11386,8 @@ tasks:
       SSL: openssl-static
       TOPOLOGY: server
       VERSION: '4.2'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -11368,6 +11440,8 @@ tasks:
       SSL: darwinssl
       TOPOLOGY: server
       VERSION: '4.2'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -11420,6 +11494,8 @@ tasks:
       SSL: winssl
       TOPOLOGY: server
       VERSION: '4.2'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -11572,6 +11648,8 @@ tasks:
       SSL: openssl
       TOPOLOGY: server
       VERSION: '4.2'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -11624,6 +11702,8 @@ tasks:
       SSL: openssl-static
       TOPOLOGY: server
       VERSION: '4.2'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -11676,6 +11756,8 @@ tasks:
       SSL: darwinssl
       TOPOLOGY: server
       VERSION: '4.2'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'
@@ -11728,6 +11810,8 @@ tasks:
       SSL: winssl
       TOPOLOGY: server
       VERSION: '4.2'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
     vars:
       ASAN: 'off'

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -37,11 +37,20 @@ if [ "$SSL" != "nossl" ]; then
          certutil.exe -addstore "Root" "src\libmongoc\tests\x509gen\ca.pem"
          ;;
       *)
-         sudo cp -v src/libmongoc/tests/x509gen/ca.pem /usr/local/share/ca-certificates/cdriver.crt || true
-         if [ -f /usr/local/share/ca-certificates/cdriver.crt ]; then
-            sudo update-ca-certificates
+         if [ -f /etc/redhat-release ]; then
+            sudo cp -v src/libmongoc/tests/x509gen/ca.pem /usr/share/pki/ca-trust-source/anchors/cdriver.crt || true
+            if [ -f /usr/share/pki/ca-trust-source/anchors/cdriver.crt ]; then
+               sudo update-ca-trust
+            else
+               export MONGOC_TEST_SSL_CA_FILE="src/libmongoc/tests/x509gen/ca.pem"
+            fi
          else
-            export MONGOC_TEST_SSL_CA_FILE="src/libmongoc/tests/x509gen/ca.pem"
+            sudo cp -v src/libmongoc/tests/x509gen/ca.pem /usr/local/share/ca-certificates/cdriver.crt || true
+            if [ -f /usr/local/share/ca-certificates/cdriver.crt ]; then
+               sudo update-ca-certificates
+            else
+               export MONGOC_TEST_SSL_CA_FILE="src/libmongoc/tests/x509gen/ca.pem"
+            fi
          fi
          ;;
    esac

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -31,12 +31,20 @@ fi
 if [ "$SSL" != "nossl" ]; then
    export MONGOC_TEST_SSL_WEAK_CERT_VALIDATION="off"
    export MONGOC_TEST_SSL_PEM_FILE="src/libmongoc/tests/x509gen/client.pem"
-   sudo cp src/libmongoc/tests/x509gen/ca.pem /usr/local/share/ca-certificates/cdriver.crt || true
-   if [ -f /usr/local/share/ca-certificates/cdriver.crt ]; then
-      sudo update-ca-certificates
-   else
-      export MONGOC_TEST_SSL_CA_FILE="src/libmongoc/tests/x509gen/ca.pem"
-   fi
+
+   case "$OS" in
+      cygwin*)
+         certutil.exe -addstore "Root" "src\libmongoc\tests\x509gen\ca.pem"
+         ;;
+      *)
+         sudo cp -v src/libmongoc/tests/x509gen/ca.pem /usr/local/share/ca-certificates/cdriver.crt || true
+         if [ -f /usr/local/share/ca-certificates/cdriver.crt ]; then
+            sudo update-ca-certificates
+         else
+            export MONGOC_TEST_SSL_CA_FILE="src/libmongoc/tests/x509gen/ca.pem"
+         fi
+         ;;
+   esac
 fi
 
 export MONGOC_ENABLE_MAJORITY_READ_CONCERN=on

--- a/build/evergreen_config_lib/functions.py
+++ b/build/evergreen_config_lib/functions.py
@@ -556,6 +556,15 @@ all_functions = OD([
         fi
         ''', test=False)
     )),
+    ('run kms servers', Function(
+        shell_exec(r'''
+        cd ./drivers-evergreen-tools/.evergreen/csfle
+        . ./activate_venv.sh
+        python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/server.pem --port 7999 &
+        python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000 &
+        python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 8001 &
+        ''', test=False, background=True),
+    )),
     ('start load balancer', Function(
         shell_exec(r'''
         export DRIVERS_TOOLS=./drivers-evergreen-tools

--- a/build/evergreen_config_lib/tasks.py
+++ b/build/evergreen_config_lib/tasks.py
@@ -548,6 +548,8 @@ class IntegrationTask(MatrixTask):
         extra = {}
         if self.cse:
             extra["CLIENT_SIDE_ENCRYPTION"] = "on"
+            commands.append(func('clone drivers-evergreen-tools'))
+            commands.append(func('run kms servers'))
         commands.append(run_tests(VALGRIND=self.on_off('valgrind'),
                                   ASAN='on' if self.sanitizer == 'asan' else 'off',
                                   AUTH=self.display('auth'),

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -939,7 +939,6 @@ set (test-libmongoc-sources
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-change-stream.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-client-pool.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-client-session.c
-   ${PROJECT_SOURCE_DIR}/tests/test-mongoc-client-side-encryption.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-client.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-cluster.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-cmd.c
@@ -1024,6 +1023,7 @@ set (test-libmongoc-sources
 if (MONGOC_ENABLE_SSL)
    set (test-libmongoc-sources ${test-libmongoc-sources}
       ${PROJECT_SOURCE_DIR}/tests/ssl-test.c
+      ${PROJECT_SOURCE_DIR}/tests/test-mongoc-client-side-encryption.c
       ${PROJECT_SOURCE_DIR}/tests/test-mongoc-stream-tls-error.c
       ${PROJECT_SOURCE_DIR}/tests/test-mongoc-stream-tls.c
       ${PROJECT_SOURCE_DIR}/tests/test-mongoc-x509.c

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel-private.h
@@ -74,13 +74,16 @@ mongoc_secure_channel_realloc_buf (size_t *size,
 
 bool
 mongoc_secure_channel_handshake_step_1 (mongoc_stream_tls_t *tls,
-                                        char *hostname);
+                                        char *hostname,
+                                        bson_error_t *error);
 bool
 mongoc_secure_channel_handshake_step_2 (mongoc_stream_tls_t *tls,
-                                        char *hostname);
+                                        char *hostname,
+                                        bson_error_t *error);
 bool
 mongoc_secure_channel_handshake_step_3 (mongoc_stream_tls_t *tls,
-                                        char *hostname);
+                                        char *hostname,
+                                        bson_error_t *error);
 
 
 BSON_END_DECLS

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -111,7 +111,7 @@ mongoc_secure_channel_setup_certificate_from_file (const char *filename)
       NULL, /* phCertStore, OUT, HCERTSTORE.., unused, for now */
       NULL, /* phMsg, OUT, HCRYPTMSG, only for PKC7, unused */
       (const void **) &cert /* ppvContext, OUT, the Certificate Context */
-      );
+   );
 
    if (!cert) {
       MONGOC_ERROR ("Failed to extract public key from '%s'. Error 0x%.8X",
@@ -429,7 +429,7 @@ mongoc_secure_channel_setup_crl (
       NULL, /* phCertStore, OUT, HCERTSTORE.., unused, for now */
       NULL, /* phMsg, OUT, HCRYPTMSG, only for PKC7, unused */
       (const void **) &cert /* ppvContext, OUT, the Certificate Context */
-      );
+   );
    bson_free (str);
 
    if (!cert) {
@@ -609,7 +609,7 @@ mongoc_secure_channel_handshake_step_1 (mongoc_stream_tls_t *tls,
       &outbuf_desc,                       /* pOutput OUT param */
       &secure_channel->ret_flags,         /* pfContextAttr OUT param */
       &secure_channel->ctxt->time_stamp   /* ptsExpiry OUT param */
-      );
+   );
 
    if (sspi_status != SEC_I_CONTINUE_NEEDED) {
       MONGOC_ERROR ("initial InitializeSecurityContext failed: %ld",

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -2932,6 +2932,7 @@ main (int argc, char *argv[])
    test_stream_tls_install (&suite);
    test_x509_install (&suite);
    test_stream_tls_error_install (&suite);
+   test_client_side_encryption_install (&suite);
 #endif
 #ifdef MONGOC_ENABLE_SASL_CYRUS
    test_cyrus_install (&suite);
@@ -2941,7 +2942,6 @@ main (int argc, char *argv[])
    test_crud_install (&suite);
    test_mongohouse_install (&suite);
    test_apm_install (&suite);
-   test_client_side_encryption_install (&suite);
    test_server_description_install (&suite);
    test_aws_install (&suite);
    test_streamable_hello_install (&suite);

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -661,7 +661,8 @@ static char *
 _uri_str_from_env (void)
 {
    if (test_framework_getenv_bool ("MONGOC_TEST_LOADBALANCED")) {
-      char *loadbalanced_uri_str = test_framework_getenv ("SINGLE_MONGOS_LB_URI");
+      char *loadbalanced_uri_str =
+         test_framework_getenv ("SINGLE_MONGOS_LB_URI");
       if (!loadbalanced_uri_str) {
          test_error ("SINGLE_MONGOS_LB_URI and MULTI_MONGOS_LB_URI must be set "
                      "when MONGOC_TEST_LOADBALANCED is enabled");
@@ -1408,7 +1409,8 @@ test_framework_get_uri ()
 }
 
 mongoc_uri_t *
-test_framework_get_uri_multi_mongos_loadbalanced () {
+test_framework_get_uri_multi_mongos_loadbalanced ()
+{
    char *uri_str_no_auth;
    char *uri_str;
    mongoc_uri_t *uri;
@@ -2989,14 +2991,16 @@ main (int argc, char *argv[])
  * initially discover the min/max wire version of a server)
  */
 bool
-test_framework_supports_legacy_opcodes (void) {
+test_framework_supports_legacy_opcodes (void)
+{
    /* Wire v14+ removed legacy opcodes */
-   return test_framework_skip_if_max_wire_version_less_than_14() == 0;
+   return test_framework_skip_if_max_wire_version_less_than_14 () == 0;
 }
 
 int
-test_framework_skip_if_no_legacy_opcodes (void) {
-   if (!TestSuite_CheckLive()) {
+test_framework_skip_if_no_legacy_opcodes (void)
+{
+   if (!TestSuite_CheckLive ()) {
       return 0;
    }
 
@@ -3009,8 +3013,9 @@ test_framework_skip_if_no_legacy_opcodes (void) {
 
 /* SERVER-57390 removed the getLastError command on 5.1 servers. */
 int
-test_framework_skip_if_no_getlasterror (void) {
-   if (!TestSuite_CheckLive()) {
+test_framework_skip_if_no_getlasterror (void)
+{
+   if (!TestSuite_CheckLive ()) {
       return 0;
    }
 


### PR DESCRIPTION
This PR comes in three parts:

1. Ensure that all four SSL libraries (OpenSSL, Secure Channel, Secure Transport, LibreSSL) report descriptive errors for each certificate verification failure.

The TLS handshake implementation for OpenSSL and Secure Channel require some modification to report descriptive certificate verification errors. The TLS handshake implementation for Secure Transport and LibreSSL do not require any modification to obtain descriptive error messages.

2. Add tests that verify correct error (or lack thereof) against mock KMS servers.

Client Side Encryption tests were unconditionally being included by the test suite even when SSL is not enabled, despite CSE [requiring SSL to be enabled](https://github.com/mongodb/mongo-c-driver/blob/a4c8c66f3638e59a6acc6733dc8e36b71062fcca/src/libmongoc/CMakeLists.txt#L414). Therefore, the relevant source file and test functions are now moved into appropriate conditionals so they are only built and run when `MONGOC_ENABLE_SSL` is defined by the build system.

Existing unit test helper functions are modified to enable reuse of AWS KMS provider setup helpers for KMS TLS tests separately from other KMS providers. The test function `test_kms_tls_cert_valid()`, which confirms a valid TLS handshake on valid server certificate, is not required by CDRIVER-3927, but nevertheless useful to confirm proper CA certificate registration in the environment. It explicitly calls `mongoc_stream_tls_handshake_block()` and relevant setup functions rather `mongoc_client_encryption_create_datakey()` to avoid unnecessary errors on datakey creation due to running against the mock KMS server.

3. Enable KMS TLS tests on Evergreen.

Evergreen config scripts are updated to start mock KMS servers in the background only for tasks with Client Side Encryption enabled. The run_tests.sh script also requires an update to ensure proper CA certificate registration on Windows and Red Hat Linux, which use different commands and directories.