### PR TITLE
CDRIVER-4204 / CDRIVER-4152 resync max staleness tests

### DIFF
--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/DefaultNoMaxStaleness.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/DefaultNoMaxStaleness.json
@@ -7,7 +7,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 50,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1000001"
@@ -19,7 +19,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -37,7 +37,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 50,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"
@@ -49,7 +49,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"
@@ -63,7 +63,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/LastUpdateTime.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/LastUpdateTime.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 5
+        "maxWireVersion": 6
       },
       {
         "address": "b:27017",
@@ -25,7 +25,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 5
+        "maxWireVersion": 6
       },
       {
         "address": "c:27017",
@@ -37,7 +37,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 5
+        "maxWireVersion": 6
       }
     ]
   },
@@ -56,7 +56,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 5
+      "maxWireVersion": 6
     },
     {
       "address": "b:27017",
@@ -68,7 +68,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 5
+      "maxWireVersion": 6
     }
   ],
   "in_latency_window": [
@@ -82,7 +82,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 5
+      "maxWireVersion": 6
     }
   ]
 }

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/Nearest.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/Nearest.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 5
+        "maxWireVersion": 6
       },
       {
         "address": "b:27017",
@@ -25,7 +25,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 5
+        "maxWireVersion": 6
       },
       {
         "address": "c:27017",
@@ -37,7 +37,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 5
+        "maxWireVersion": 6
       }
     ]
   },
@@ -56,7 +56,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 5
+      "maxWireVersion": 6
     },
     {
       "address": "b:27017",
@@ -68,7 +68,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 5
+      "maxWireVersion": 6
     }
   ],
   "in_latency_window": [
@@ -82,7 +82,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 5
+      "maxWireVersion": 6
     }
   ]
 }

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/Nearest2.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/Nearest2.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 5
+        "maxWireVersion": 6
       },
       {
         "address": "b:27017",
@@ -25,7 +25,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 5
+        "maxWireVersion": 6
       },
       {
         "address": "c:27017",
@@ -37,7 +37,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 5
+        "maxWireVersion": 6
       }
     ]
   },
@@ -56,7 +56,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 5
+      "maxWireVersion": 6
     },
     {
       "address": "b:27017",
@@ -68,7 +68,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 5
+      "maxWireVersion": 6
     }
   ],
   "in_latency_window": [
@@ -82,7 +82,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 5
+      "maxWireVersion": 6
     }
   ]
 }

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/OneKnownTwoUnavailable.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/OneKnownTwoUnavailable.json
@@ -1,0 +1,60 @@
+{
+  "topology_description": {
+    "type": "ReplicaSetNoPrimary",
+    "servers": [
+      {
+        "address": "a:27017",
+        "type": "PossiblePrimary",
+        "avg_rtt_ms": 5,
+        "maxWireVersion": 0
+      },
+      {
+        "address": "b:27017",
+        "type": "Unknown",
+        "avg_rtt_ms": 5,
+        "maxWireVersion": 0
+      },
+      {
+        "address": "c:27017",
+        "type": "RSSecondary",
+        "maxWireVersion": 6,
+        "avg_rtt_ms": 5,
+        "lastWrite": {
+          "lastWriteDate": {
+            "$numberLong": "1"
+          }
+        }
+      }
+    ]
+  },
+  "read_preference": {
+    "mode": "Nearest",
+    "maxStalenessSeconds": 120
+  },
+  "suitable_servers": [
+    {
+      "address": "c:27017",
+      "type": "RSSecondary",
+      "maxWireVersion": 6,
+      "avg_rtt_ms": 5,
+      "lastWrite": {
+        "lastWriteDate": {
+          "$numberLong": "1"
+        }
+      }
+    }
+  ],
+  "in_latency_window": [
+    {
+      "address": "c:27017",
+      "type": "RSSecondary",
+      "maxWireVersion": 6,
+      "avg_rtt_ms": 5,
+      "lastWrite": {
+        "lastWriteDate": {
+          "$numberLong": "1"
+        }
+      }
+    }
+  ]
+}

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/PrimaryPreferred.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/PrimaryPreferred.json
@@ -8,7 +8,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1000001"
@@ -20,7 +20,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -39,7 +39,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"
@@ -53,7 +53,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/PrimaryPreferred_tags.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/PrimaryPreferred_tags.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "tags": {
           "data_center": "tokyo"
         }
@@ -28,7 +28,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "tags": {
           "data_center": "nyc"
         }
@@ -58,7 +58,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "tags": {
         "data_center": "tokyo"
       }
@@ -75,7 +75,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "tags": {
         "data_center": "tokyo"
       }

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/Secondary.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/Secondary.json
@@ -8,7 +8,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "125002"
@@ -23,7 +23,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -38,7 +38,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -53,7 +53,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -80,7 +80,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "2"
@@ -97,7 +97,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "2"

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/SecondaryPreferred.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/SecondaryPreferred.json
@@ -7,7 +7,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1000001"
@@ -19,7 +19,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -38,7 +38,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"
@@ -52,7 +52,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/SecondaryPreferred_tags.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/SecondaryPreferred_tags.json
@@ -8,7 +8,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "125002"
@@ -23,7 +23,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -38,7 +38,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -53,7 +53,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -80,7 +80,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "2"
@@ -97,7 +97,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "2"

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/ZeroMaxStaleness.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetNoPrimary/ZeroMaxStaleness.json
@@ -7,7 +7,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -19,7 +19,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 4,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/DefaultNoMaxStaleness.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/DefaultNoMaxStaleness.json
@@ -7,7 +7,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 50,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1000001"
@@ -19,7 +19,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -37,7 +37,7 @@
       "type": "RSPrimary",
       "avg_rtt_ms": 50,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"
@@ -49,7 +49,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"
@@ -63,7 +63,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/LastUpdateTime.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/LastUpdateTime.json
@@ -13,7 +13,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 5
+        "maxWireVersion": 6
       },
       {
         "address": "b:27017",
@@ -25,7 +25,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 5
+        "maxWireVersion": 6
       },
       {
         "address": "c:27017",
@@ -37,7 +37,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 5
+        "maxWireVersion": 6
       }
     ]
   },
@@ -56,7 +56,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 5
+      "maxWireVersion": 6
     },
     {
       "address": "b:27017",
@@ -68,7 +68,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 5
+      "maxWireVersion": 6
     }
   ],
   "in_latency_window": [
@@ -82,7 +82,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 5
+      "maxWireVersion": 6
     }
   ]
 }

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/LongHeartbeat.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/LongHeartbeat.json
@@ -8,7 +8,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -20,7 +20,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 50,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -39,7 +39,7 @@
       "type": "RSPrimary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"
@@ -51,7 +51,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 50,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"
@@ -65,7 +65,7 @@
       "type": "RSPrimary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/LongHeartbeat2.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/LongHeartbeat2.json
@@ -8,7 +8,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -20,7 +20,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/MaxStalenessTooSmall.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/MaxStalenessTooSmall.json
@@ -8,7 +8,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -20,7 +20,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/MaxStalenessWithModePrimary.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/MaxStalenessWithModePrimary.json
@@ -7,7 +7,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -19,7 +19,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/Nearest.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/Nearest.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 5
+        "maxWireVersion": 6
       },
       {
         "address": "b:27017",
@@ -25,7 +25,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 5
+        "maxWireVersion": 6
       },
       {
         "address": "c:27017",
@@ -37,7 +37,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 5
+        "maxWireVersion": 6
       }
     ]
   },
@@ -56,7 +56,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 5
+      "maxWireVersion": 6
     },
     {
       "address": "b:27017",
@@ -68,7 +68,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 5
+      "maxWireVersion": 6
     }
   ],
   "in_latency_window": [
@@ -82,7 +82,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 5
+      "maxWireVersion": 6
     }
   ]
 }

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/Nearest2.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/Nearest2.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 5
+        "maxWireVersion": 6
       },
       {
         "address": "b:27017",
@@ -25,7 +25,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 5
+        "maxWireVersion": 6
       },
       {
         "address": "c:27017",
@@ -37,7 +37,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 5
+        "maxWireVersion": 6
       }
     ]
   },
@@ -56,7 +56,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 5
+      "maxWireVersion": 6
     },
     {
       "address": "b:27017",
@@ -68,7 +68,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 5
+      "maxWireVersion": 6
     }
   ],
   "in_latency_window": [
@@ -82,7 +82,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 5
+      "maxWireVersion": 6
     }
   ]
 }

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/Nearest_tags.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/Nearest_tags.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "tags": {
           "data_center": "tokyo"
         }
@@ -28,7 +28,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "tags": {
           "data_center": "nyc"
         }
@@ -58,7 +58,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "tags": {
         "data_center": "tokyo"
       }
@@ -75,7 +75,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "tags": {
         "data_center": "tokyo"
       }

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/PrimaryPreferred.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/PrimaryPreferred.json
@@ -8,7 +8,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -20,7 +20,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -39,7 +39,7 @@
       "type": "RSPrimary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"
@@ -53,7 +53,7 @@
       "type": "RSPrimary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/SecondaryPreferred.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/SecondaryPreferred.json
@@ -7,7 +7,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1000001"
@@ -19,7 +19,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -38,7 +38,7 @@
       "type": "RSPrimary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"
@@ -52,7 +52,7 @@
       "type": "RSPrimary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/SecondaryPreferred_tags.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/SecondaryPreferred_tags.json
@@ -8,7 +8,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "125002"
@@ -20,7 +20,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -35,7 +35,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 50,
         "lastUpdateTime": 1,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1000001"
@@ -50,7 +50,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -65,7 +65,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -92,7 +92,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "2"
@@ -107,7 +107,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 50,
       "lastUpdateTime": 1,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"
@@ -124,7 +124,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "2"

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/SecondaryPreferred_tags2.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/SecondaryPreferred_tags2.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 5
+        "maxWireVersion": 6
       },
       {
         "address": "b:27017",
@@ -25,7 +25,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "tags": {
           "data_center": "tokyo"
         }
@@ -40,7 +40,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "tags": {
           "data_center": "nyc"
         }
@@ -70,7 +70,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "tags": {
         "data_center": "tokyo"
       }
@@ -87,7 +87,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "tags": {
         "data_center": "tokyo"
       }

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/Secondary_tags.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/Secondary_tags.json
@@ -8,7 +8,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "125002"
@@ -20,7 +20,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -35,7 +35,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 50,
         "lastUpdateTime": 1,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1000001"
@@ -50,7 +50,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -65,7 +65,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -92,7 +92,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "2"
@@ -107,7 +107,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 50,
       "lastUpdateTime": 1,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"
@@ -124,7 +124,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "2"

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/Secondary_tags2.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/Secondary_tags2.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 5
+        "maxWireVersion": 6
       },
       {
         "address": "b:27017",
@@ -25,7 +25,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "tags": {
           "data_center": "tokyo"
         }
@@ -40,7 +40,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "tags": {
           "data_center": "nyc"
         }
@@ -70,7 +70,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "tags": {
         "data_center": "tokyo"
       }
@@ -87,7 +87,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "tags": {
         "data_center": "tokyo"
       }

--- a/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/ZeroMaxStaleness.json
+++ b/src/libmongoc/tests/json/max_staleness/ReplicaSetWithPrimary/ZeroMaxStaleness.json
@@ -7,7 +7,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -19,7 +19,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 4,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"

--- a/src/libmongoc/tests/json/max_staleness/Sharded/SmallMaxStaleness.json
+++ b/src/libmongoc/tests/json/max_staleness/Sharded/SmallMaxStaleness.json
@@ -8,7 +8,7 @@
         "type": "Mongos",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -20,7 +20,7 @@
         "type": "Mongos",
         "avg_rtt_ms": 50,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -39,7 +39,7 @@
       "type": "Mongos",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"
@@ -51,7 +51,7 @@
       "type": "Mongos",
       "avg_rtt_ms": 50,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"
@@ -65,7 +65,7 @@
       "type": "Mongos",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"

--- a/src/libmongoc/tests/json/max_staleness/Single/SmallMaxStaleness.json
+++ b/src/libmongoc/tests/json/max_staleness/Single/SmallMaxStaleness.json
@@ -8,7 +8,7 @@
         "type": "Standalone",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 5,
+        "maxWireVersion": 6,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -27,7 +27,7 @@
       "type": "Standalone",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"
@@ -41,7 +41,7 @@
       "type": "Standalone",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 5,
+      "maxWireVersion": 6,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"

--- a/src/libmongoc/tests/json/max_staleness/Unknown/SmallMaxStaleness.json
+++ b/src/libmongoc/tests/json/max_staleness/Unknown/SmallMaxStaleness.json
@@ -6,7 +6,7 @@
       {
         "address": "a:27017",
         "type": "Unknown",
-        "maxWireVersion": 5
+        "maxWireVersion": 6
       }
     ]
   },


### PR DESCRIPTION
Resyncs the max staleness spec tests to commit e2914e7c88ad8578b78f26706bfa8e0737d0fcc0. This covers CDRIVER-4152 and CDRIVER-4204.

Tests were resynced using the following command from the [mongo-c-driver-tools](https://github.com/10gen/mongo-c-driver-tools) repo:
`ONLY=MAX_STALENESS ../mongo-c-driver-tools/update-c-spec-tests.sh`