### PR TITLE
Bump WIRE_VERSION_MAX to 14

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-client-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-private.h
@@ -42,8 +42,8 @@
 BSON_BEGIN_DECLS
 
 /* protocol versions this driver can speak */
-#define WIRE_VERSION_MIN 3	/* a.k.a. minWireVersion */
-#define WIRE_VERSION_MAX 14	/* a.k.a. maxWireVersion */
+#define WIRE_VERSION_MIN 3  /* a.k.a. minWireVersion */
+#define WIRE_VERSION_MAX 14 /* a.k.a. maxWireVersion */
 
 /* first version that supported "find" and "getMore" commands */
 #define WIRE_VERSION_FIND_CMD 4

--- a/src/libmongoc/src/mongoc/mongoc-client-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-private.h
@@ -42,8 +42,8 @@
 BSON_BEGIN_DECLS
 
 /* protocol versions this driver can speak */
-#define WIRE_VERSION_MIN 3
-#define WIRE_VERSION_MAX 13
+#define WIRE_VERSION_MIN 3	/* a.k.a. minWireVersion */
+#define WIRE_VERSION_MAX 14	/* a.k.a. maxWireVersion */
 
 /* first version that supported "find" and "getMore" commands */
 #define WIRE_VERSION_FIND_CMD 4


### PR DESCRIPTION
Updates the wire protocol max version to 14.

Added comments to help when searching for maxWireVersion.

See: https://jira.mongodb.org/browse/CDRIVER-4165

Signed-off-by: Jesse Williamson <jesse.williamson@mongodb.com>