### PR TITLE
Fix Win32 Warnings

### DIFF
--- a/src/common/common-thread-private.h
+++ b/src/common/common-thread-private.h
@@ -107,6 +107,7 @@ typedef struct {
 #define BSON_THREAD_FUN(_function_name, _arg_name) \
    unsigned(__stdcall _function_name) (void *(_arg_name))
 #define BSON_THREAD_FUN_TYPE(_function_name) \
+   unsigned (__stdcall * _function_name) (void *)
 #define BSON_THREAD_RETURN return 0
 #endif
 

--- a/src/common/common-thread-private.h
+++ b/src/common/common-thread-private.h
@@ -107,8 +107,7 @@ typedef struct {
 #define BSON_THREAD_FUN(_function_name, _arg_name) \
    unsigned(__stdcall _function_name) (void *(_arg_name))
 #define BSON_THREAD_FUN_TYPE(_function_name) \
-   unsigned(__stdcall * _function_name) (void *)
-#define BSON_THREAD_RETURN return
+#define BSON_THREAD_RETURN return 0
 #endif
 
 /* Functions that require definitions get the common prefix (_mongoc for

--- a/src/libbson/src/bson/bson-atomic.c
+++ b/src/libbson/src/bson/bson-atomic.c
@@ -51,27 +51,27 @@ bson_memory_barrier (void)
  * 32-bit x86 does not support 64-bit atomic integer operations.
  * We emulate that here using a spin lock and regular arithmetic operations
  */
-static int g64bitAtomicLock = 0;
+static int8_t g64bitAtomicLock = 0;
 
 static void
 _lock_64bit_atomic ()
 {
    int i;
-   if (bson_atomic_int_compare_exchange_weak (
+   if (bson_atomic_int8_compare_exchange_weak (
           &g64bitAtomicLock, 0, 1, bson_memory_order_acquire) == 0) {
       /* Successfully took the spinlock */
       return;
    }
    /* Failed. Try taking ten more times, then begin sleeping. */
    for (i = 0; i < 10; ++i) {
-      if (bson_atomic_int_compare_exchange_weak (
+      if (bson_atomic_int8_compare_exchange_weak (
              &g64bitAtomicLock, 0, 1, bson_memory_order_acquire) == 0) {
          /* Succeeded in taking the lock */
          return;
       }
    }
    /* Still don't have the lock. Spin and yield */
-   while (bson_atomic_int_compare_exchange_weak (
+   while (bson_atomic_int8_compare_exchange_weak (
              &g64bitAtomicLock, 0, 1, bson_memory_order_acquire) != 0) {
       bson_thrd_yield ();
    }
@@ -80,7 +80,7 @@ _lock_64bit_atomic ()
 static void
 _unlock_64bit_atomic ()
 {
-   int64_t rv = bson_atomic_int_exchange (
+   int64_t rv = bson_atomic_int8_exchange (
       &g64bitAtomicLock, 0, bson_memory_order_release);
    BSON_ASSERT (rv == 1 && "Released atomic lock while not holding it");
 }

--- a/src/libmongoc/src/mongoc/mongoc-cluster-sspi.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-sspi.c
@@ -161,6 +161,7 @@ _mongoc_cluster_auth_node_sspi (mongoc_cluster_t *cluster,
    int step;
    mongoc_server_stream_t *server_stream;
    bool ret = false;
+   mc_shared_tpld td = MC_SHARED_TPLD_NULL;
 
    state = _mongoc_cluster_sspi_new (cluster->uri, stream, sd->host.host);
 
@@ -222,8 +223,8 @@ _mongoc_cluster_auth_node_sspi (mongoc_cluster_t *cluster,
          }
       }
 
-      server_stream = _mongoc_cluster_create_server_stream (
-         cluster->client->topology, sd, stream);
+      mc_tpld_renew_ref (&td, cluster->client->topology);
+      server_stream = _mongoc_cluster_create_server_stream (td.ptr, sd, stream);
 
       if (!mongoc_cmd_parts_assemble (&parts, server_stream, error)) {
          mongoc_server_stream_cleanup (server_stream);
@@ -275,6 +276,7 @@ _mongoc_cluster_auth_node_sspi (mongoc_cluster_t *cluster,
 
    ret = true;
 failure:
+   mc_tpld_drop_ref (&td);
    bson_free (buf);
    bson_free (state);
    return ret;

--- a/src/libmongoc/src/mongoc/mongoc-shared.c
+++ b/src/libmongoc/src/mongoc/mongoc-shared.c
@@ -38,6 +38,7 @@ static bson_once_t g_shared_ptr_mtx_init_once = BSON_ONCE_INIT;
 static BSON_ONCE_FUN (_init_mtx)
 {
    bson_mutex_init (&g_shared_ptr_mtx);
+   BSON_ONCE_RETURN;
 }
 
 static void


### PR DESCRIPTION
There are some warnings that appear in code, including one major incompatible-pointer-type that only appears on Windows. This also fixes an incompatible pointer type used in bson-atomic.c appearing in some configuration of MinGW on Windows (CDRIVER-4221).