### PR TITLE
use legacy atomics on gcc < 5

### DIFF
--- a/src/libbson/src/bson/bson-atomic.h
+++ b/src/libbson/src/bson/bson-atomic.h
@@ -47,15 +47,15 @@ enum bson_memory_order {
 #define MSVC_MEMORDER_SUFFIX(X)
 #endif
 
-#if defined(USE_LEGACY_GCC_ATOMICS) || (!defined(__clang__) && \
-   __GNUC__ == 4 && __GNUC_MINOR__ >= 1 && __GNUC_MINOR__ < 9)
+#if defined(USE_LEGACY_GCC_ATOMICS) || \
+   (!defined(__clang__) && __GNUC__ == 4)
 #define BSON_USE_LEGACY_GCC_ATOMICS
 #else
 #undef BSON_USE_LEGACY_GCC_ATOMICS
 #endif
 
 /* Not all GCC-like compilers support the current __atomic built-ins.  Older
- * GCC (pre-4.9) used different built-ins named with the __sync prefix.  When
+ * GCC (pre-5) used different built-ins named with the __sync prefix.  When
  * compiling with such older GCC versions, it is necessary to use the applicable
  * functions, which requires redefining BSON_IF_GNU_LIKE and defining the
  * additional BSON_IF_GNU_LEGACY_ATOMICS macro here. */


### PR DESCRIPTION
So, it turns out that we need to use legacy atomics on all gcc 4.x versions.  The original change in #889 still results in build failures on Debian 8 (gcc 4.9).  It seems that using the new `__atomic` built-ins requires setting `-std=c11`.  It is not clear that we want to require that for legacy platforms, so expanding the check in this way seems like the better way.

Full patch build (filtered down to the Debian 8 variant): https://spruce.mongodb.com/version/618d9bcd0305b93ba3051410/tasks?page=0&variant=%5Egcc49%24