### PR TITLE
CDRIVER-4097 Implement srvMaxHosts for initial DNS seedlist and SRV polling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,6 +222,8 @@ NOT tested, enable them with:
 
 * `MONGOC_TEST_DNS_LOADBALANCED=on` assumes a load balanced sharded cluster is running with mongoses on ports 27017 and 27018 and TLS enabled. The load balancer can be listening on any port.
 
+* `MONGOC_TEST_DNS_SRV_POLLING=on` assumes a sharded cluster is running with mongoses on ports 27017, 27018, 27019, and 27020 and TLS enabled.
+
 The mock server timeout threshold for future functions can be set with:
 
 * `MONGOC_TEST_FUTURE_TIMEOUT_MS=<int>`

--- a/src/libmongoc/doc/mongoc_uri_t.rst
+++ b/src/libmongoc/doc/mongoc_uri_t.rst
@@ -101,6 +101,7 @@ MONGOC_URI_SOCKETTIMEOUTMS                 sockettimeoutms                   300
 MONGOC_URI_REPLICASET                      replicaset                        Empty (no replicaset)             The name of the Replica Set that the driver should connect to.
 MONGOC_URI_ZLIBCOMPRESSIONLEVEL            zlibcompressionlevel              -1                                When the MONGOC_URI_COMPRESSORS includes "zlib" this options configures the zlib compression level, when the zlib compressor is used to compress client data.
 MONGOC_URI_LOADBALANCED                    loadbalanced                      false                             If true, this indicates the driver is connecting to a MongoDB cluster behind a load balancer.
+MONGOC_URI_SRVMAXHOSTS                     srvmaxhosts                       0                                 If zero, the number of hosts in DNS results is unlimited. If greater than zero, the number of hosts in DNS results is limited to being less than or equal to the given value.
 ========================================== ================================= ================================= ============================================================================================================================================================================================================================================
 
 Setting any of the \*timeoutMS options above to ``0`` will be interpreted as "use the default value".

--- a/src/libmongoc/src/mongoc/mongoc-host-list-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-host-list-private.h
@@ -53,7 +53,7 @@ _mongoc_host_list_from_hostport_with_err (mongoc_host_list_t *host_list,
                                           bson_error_t *error);
 
 int
-_mongoc_host_list_length (mongoc_host_list_t *list);
+_mongoc_host_list_length (const mongoc_host_list_t *list);
 
 bool
 _mongoc_host_list_compare_one (const mongoc_host_list_t *host_a,

--- a/src/libmongoc/src/mongoc/mongoc-host-list.c
+++ b/src/libmongoc/src/mongoc/mongoc-host-list.c
@@ -131,9 +131,9 @@ _mongoc_host_list_copy_all (const mongoc_host_list_t *src)
 }
 
 int
-_mongoc_host_list_length (mongoc_host_list_t *list)
+_mongoc_host_list_length (const mongoc_host_list_t *list)
 {
-   mongoc_host_list_t *tmp;
+   const mongoc_host_list_t *tmp;
    int counter = 0;
 
    tmp = list;

--- a/src/libmongoc/src/mongoc/mongoc-host-list.c
+++ b/src/libmongoc/src/mongoc/mongoc-host-list.c
@@ -240,8 +240,7 @@ _mongoc_host_list_from_string_with_err (mongoc_host_list_t *link_,
                          MONGOC_ERROR_COMMAND,
                          MONGOC_ERROR_COMMAND_INVALID_ARG,
                          "If present, port should immediately follow the \"]\""
-                         "in an IPv6 address"
-                         );
+                         "in an IPv6 address");
          return false;
       }
 
@@ -259,8 +258,7 @@ _mongoc_host_list_from_string_with_err (mongoc_host_list_t *link_,
          bson_set_error (error,
                          MONGOC_ERROR_COMMAND,
                          MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Missing matching bracket \"[\""
-                         );
+                         "Missing matching bracket \"[\"");
          return false;
       }
 
@@ -278,8 +276,7 @@ _mongoc_host_list_from_string_with_err (mongoc_host_list_t *link_,
          bson_set_error (error,
                          MONGOC_ERROR_COMMAND,
                          MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Bad address, \":\" should not be first character"
-                        );
+                         "Bad address, \":\" should not be first character");
          return false;
       }
 
@@ -287,8 +284,7 @@ _mongoc_host_list_from_string_with_err (mongoc_host_list_t *link_,
          bson_set_error (error,
                          MONGOC_ERROR_COMMAND,
                          MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Port could not be parsed"
-                        );
+                         "Port could not be parsed");
          return false;
       }
 

--- a/src/libmongoc/src/mongoc/mongoc-topology-description-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description-private.h
@@ -47,6 +47,7 @@ struct _mongoc_topology_description_t {
    bson_oid_t max_election_id;
    bson_error_t compatibility_error;
    uint32_t max_server_id;
+   int32_t max_hosts; /* srvMaxHosts */
    bool stale;
    unsigned int rand_seed;
 

--- a/src/libmongoc/src/mongoc/mongoc-topology-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description.c
@@ -150,6 +150,7 @@ _mongoc_topology_description_copy_to (const mongoc_topology_description_t *src,
            &src->compatibility_error,
            sizeof (bson_error_t));
    dst->max_server_id = src->max_server_id;
+   dst->max_hosts = src->max_hosts;
    dst->stale = src->stale;
    memcpy (&dst->apm_callbacks,
            &src->apm_callbacks,
@@ -2284,10 +2285,33 @@ mongoc_topology_description_get_servers (
 
 typedef struct {
    mongoc_host_list_t *host_list;
+   size_t num_missing;
+} _count_num_hosts_to_remove_ctx_t;
+
+static bool
+_count_num_hosts_to_remove (void *sd_void, void *ctx_void)
+{
+   mongoc_server_description_t *sd;
+   _count_num_hosts_to_remove_ctx_t *ctx;
+   mongoc_host_list_t *host_list;
+
+   sd = sd_void;
+   ctx = ctx_void;
+   host_list = ctx->host_list;
+
+   if (!_mongoc_host_list_contains_one (host_list, &sd->host)) {
+      ++ctx->num_missing;
+   }
+
+   return true;
+}
+
+typedef struct {
+   mongoc_host_list_t *host_list;
    mongoc_topology_description_t *td;
 } _remove_if_not_in_host_list_ctx_t;
 
-bool
+static bool
 _remove_if_not_in_host_list_cb (void *sd_void, void *ctx_void)
 {
    _remove_if_not_in_host_list_ctx_t *ctx;
@@ -2311,19 +2335,88 @@ void
 mongoc_topology_description_reconcile (mongoc_topology_description_t *td,
                                        mongoc_host_list_t *host_list)
 {
-   mongoc_host_list_t *host;
-   _remove_if_not_in_host_list_ctx_t ctx;
+   mongoc_set_t *servers;
+   size_t host_list_length;
+   size_t num_missing;
 
-   LL_FOREACH (host_list, host)
+   BSON_ASSERT_PARAM (td);
+
+   servers = mc_tpld_servers (td);
+   host_list_length = _mongoc_host_list_length (host_list);
+
+   /* Avoid removing all servers in topology, even temporarily, by deferring
+    * actual removal until after new hosts have been added. */
    {
-      /* "add" is really an "upsert" */
-      mongoc_topology_description_add_server (td, host->host_and_port, NULL);
+      _count_num_hosts_to_remove_ctx_t ctx;
+
+      ctx.host_list = host_list;
+      ctx.num_missing = 0u;
+
+      mongoc_set_for_each (servers, _count_num_hosts_to_remove, &ctx);
+
+      num_missing = ctx.num_missing;
    }
 
-   ctx.host_list = host_list;
-   ctx.td = td;
-   mongoc_set_for_each (
-      mc_tpld_servers (td), _remove_if_not_in_host_list_cb, &ctx);
+   /* Polling SRV Records for mongos Discovery Spec: If srvMaxHosts is zero or
+    * greater than or equal to the number of valid hosts, each valid new host
+    * MUST be added to the topology as Unknown. */
+   if (td->max_hosts == 0 || (size_t) td->max_hosts >= host_list_length) {
+      mongoc_host_list_t *host;
+
+      LL_FOREACH (host_list, host)
+      {
+         /* "add" is really an "upsert" */
+         mongoc_topology_description_add_server (td, host->host_and_port, NULL);
+      }
+   }
+
+   /* Polling SRV Records for mongos Discovery Spec: If srvMaxHosts is greater
+    * than zero and less than the number of valid hosts, valid new hosts MUST be
+    * randomly selected and added to the topology as Unknown until the topology
+    * has srvMaxHosts hosts. */
+   else {
+      const size_t max_with_missing = td->max_hosts + num_missing;
+
+      size_t idx = 0u;
+      size_t hl_array_size = 0u;
+
+      /* Polling SRV Records for mongos Discovery Spec: Drivers MUST use the
+       * same randomization algorithm as they do for initial selection.
+       * Do not limit size of results yet (pass host_list_length) as we want to
+       * update any existing hosts in the topology, but add new hosts.
+       */
+      const mongoc_host_list_t *const *hl_array = _mongoc_apply_srv_max_hosts (
+         host_list, host_list_length, &hl_array_size);
+
+      for (idx = 0u;
+           servers->items_len < max_with_missing && idx < hl_array_size;
+           ++idx) {
+         const mongoc_host_list_t *const elem = hl_array[idx];
+
+         /* "add" is really an "upsert" */
+         mongoc_topology_description_add_server (td, elem->host_and_port, NULL);
+      }
+
+      /* There should not be a situation where all items in the valid host list
+       * were traversed without the number of hosts in the topology reaching
+       * srvMaxHosts. */
+      BSON_ASSERT (servers->items_len == max_with_missing);
+
+      bson_free ((void *) hl_array);
+   }
+
+   /* Polling SRV Records for mongos Discovery Spec: For all verified host
+    * names, as returned through the DNS SRV query, the driver MUST remove
+    * all hosts that are part of the topology, but are no longer in the
+    * returned set of valid hosts. */
+   {
+      _remove_if_not_in_host_list_ctx_t ctx;
+
+      ctx.host_list = host_list;
+      ctx.td = td;
+
+      mongoc_set_for_each (servers, _remove_if_not_in_host_list_cb, &ctx);
+   }
 }
 
 

--- a/src/libmongoc/src/mongoc/mongoc-topology-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description.c
@@ -2417,6 +2417,11 @@ mongoc_topology_description_reconcile (mongoc_topology_description_t *td,
 
       mongoc_set_for_each (servers, _remove_if_not_in_host_list_cb, &ctx);
    }
+
+   /* At this point, the number of hosts in the host list should not exceed
+    * srvMaxHosts. */
+   BSON_ASSERT (td->max_hosts == 0 ||
+                servers->items_len <= (size_t) td->max_hosts);
 }
 
 

--- a/src/libmongoc/src/mongoc/mongoc-topology-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-private.h
@@ -588,4 +588,9 @@ _mongoc_topology_invalidate_server (mongoc_topology_t *td, uint32_t server_id)
    mc_tpld_modify_commit (tdmod);
 }
 
+const mongoc_host_list_t **
+_mongoc_apply_srv_max_hosts (const mongoc_host_list_t *hl,
+                             int32_t max_hosts,
+                             size_t *hl_array_size);
+
 #endif

--- a/src/libmongoc/src/mongoc/mongoc-topology-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-private.h
@@ -588,6 +588,13 @@ _mongoc_topology_invalidate_server (mongoc_topology_t *td, uint32_t server_id)
    mc_tpld_modify_commit (tdmod);
 }
 
+/* Return an array view to `max_hosts` or fewer elements of `hl`, or NULL if
+ * `hl` is empty. The size of the returned array is written to `hl_array_size`
+ * even if `hl` is empty.
+ *
+ * The returned array must be freed with `bson_free()`. The elements of the
+ * array must not be freed, as they are still owned by `hl`.
+ */
 const mongoc_host_list_t **
 _mongoc_apply_srv_max_hosts (const mongoc_host_list_t *hl,
                              int32_t max_hosts,

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -518,6 +518,9 @@ mongoc_topology_new (const mongoc_uri_t *uri, bool single_threaded)
       topology->valid = false;
    }
 
+   td->max_hosts =
+      mongoc_uri_get_option_as_int32 (uri, MONGOC_URI_SRVMAXHOSTS, 0);
+
    /*
     * Set topology type from URI:
     *   + if directConnection=true
@@ -595,10 +598,8 @@ mongoc_topology_new (const mongoc_uri_t *uri, bool single_threaded)
       size_t hl_array_size = 0u;
       uint32_t id = 0u;
 
-      const mongoc_host_list_t *const *hl_array = _mongoc_apply_srv_max_hosts (
-         hl,
-         mongoc_uri_get_option_as_int32 (uri, MONGOC_URI_SRVMAXHOSTS, 0),
-         &hl_array_size);
+      const mongoc_host_list_t *const *hl_array =
+         _mongoc_apply_srv_max_hosts (hl, td->max_hosts, &hl_array_size);
 
       for (idx = 0u; idx < hl_array_size; ++idx) {
          const mongoc_host_list_t *const elem = hl_array[idx];

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -305,7 +305,8 @@ _mongoc_apply_srv_max_hosts (const mongoc_host_list_t *hl,
     * Drivers SHOULD use the `Fisher-Yates shuffle` for randomization. */
    for (idx = hl_size - 1u; idx > 0u; --idx) {
       /* 0 <= swap_pos <= idx */
-      const size_t swap_pos = _mongoc_rand_size_t (0u, idx);
+      const size_t swap_pos =
+         _mongoc_rand_size_t (0u, idx, _mongoc_simple_rand_size_t);
 
       const mongoc_host_list_t *tmp = hl_array[swap_pos];
       hl_array[swap_pos] = hl_array[idx];

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -302,7 +302,7 @@ _mongoc_apply_srv_max_hosts (const mongoc_host_list_t *hl,
    /* Initial DNS Seedlist Discovery Spec: If `srvMaxHosts` is greater than zero
     * and less than the number of hosts in the DNS result, the driver MUST
     * randomly select that many hosts and use them to populate the seedlist.
-    * Drivers SHOULD use the `Fisher-Yates shuffle`_ for randomization. */
+    * Drivers SHOULD use the `Fisher-Yates shuffle` for randomization. */
    for (idx = hl_size - 1u; idx > 0u; --idx) {
       /* 0 <= swap_pos <= idx */
       const size_t swap_pos = _mongoc_rand_size_t (0u, idx);

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -35,6 +35,8 @@
 
 #include "utlist.h"
 
+#include <stdint.h>
+
 static void
 _topology_collect_errors (const mongoc_topology_description_t *topology,
                           bson_error_t *error_out);
@@ -263,6 +265,58 @@ _tpld_destroy_and_free (void *tpl_descr)
    mongoc_topology_description_destroy (td);
 }
 
+const mongoc_host_list_t **
+_mongoc_apply_srv_max_hosts (const mongoc_host_list_t *hl,
+                             const int32_t max_hosts,
+                             size_t *const hl_array_size)
+{
+   size_t hl_size;
+   size_t idx;
+   const mongoc_host_list_t **hl_array;
+
+   BSON_ASSERT (max_hosts >= 0);
+   BSON_ASSERT_PARAM (hl_array_size);
+
+   hl_size = (size_t) _mongoc_host_list_length (hl);
+
+   if (hl_size == 0) {
+      *hl_array_size = 0;
+      return NULL;
+   }
+
+   hl_array = bson_malloc (hl_size * sizeof (mongoc_host_list_t *));
+
+   for (idx = 0u; hl; hl = hl->next) {
+      hl_array[idx++] = hl;
+   }
+
+   if (max_hosts == 0 ||             /* Unlimited. */
+       hl_size == 1u ||              /* Trivial case. */
+       hl_size <= (size_t) max_hosts /* Already satisfies limit. */
+   ) {
+      /* No random shuffle or selection required. */
+      *hl_array_size = hl_size;
+      return hl_array;
+   }
+
+   /* Initial DNS Seedlist Discovery Spec: If `srvMaxHosts` is greater than zero
+    * and less than the number of hosts in the DNS result, the driver MUST
+    * randomly select that many hosts and use them to populate the seedlist.
+    * Drivers SHOULD use the `Fisher-Yates shuffle`_ for randomization. */
+   for (idx = hl_size - 1u; idx > 0u; --idx) {
+      /* 0 <= swap_pos <= idx */
+      const size_t swap_pos = _mongoc_rand_size_t (0u, idx);
+
+      const mongoc_host_list_t *tmp = hl_array[swap_pos];
+      hl_array[swap_pos] = hl_array[idx];
+      hl_array[idx] = tmp;
+   }
+
+   *hl_array_size = max_hosts;
+
+   return hl_array;
+}
+
 /*
  *-------------------------------------------------------------------------
  *
@@ -285,9 +339,9 @@ mongoc_topology_new (const mongoc_uri_t *uri, bool single_threaded)
    int64_t heartbeat;
    mongoc_topology_t *topology;
    mongoc_topology_description_type_t init_type;
+   mongoc_topology_description_t *td;
    const char *service;
    char *prefixed_service;
-   uint32_t id;
    const mongoc_host_list_t *hl;
    mongoc_rr_data_t rr_data;
    bool has_directconnection;
@@ -322,11 +376,10 @@ mongoc_topology_new (const mongoc_uri_t *uri, bool single_threaded)
    topology->_shared_descr_._sptr_ = mongoc_shared_ptr_create (
       bson_malloc0 (sizeof (mongoc_topology_description_t)),
       _tpld_destroy_and_free);
-   mongoc_topology_description_init (mc_tpld_unsafe_get_mutable (topology),
-                                     heartbeat);
+   td = mc_tpld_unsafe_get_mutable (topology);
+   mongoc_topology_description_init (td, heartbeat);
 
-   mc_tpld_unsafe_get_mutable (topology)->set_name =
-      bson_strdup (mongoc_uri_get_replica_set (uri));
+   td->set_name = bson_strdup (mongoc_uri_get_replica_set (uri));
 
    topology->uri = mongoc_uri_copy (uri);
    topology->cse_state = MONGOC_CSE_DISABLED;
@@ -461,6 +514,10 @@ mongoc_topology_new (const mongoc_uri_t *uri, bool single_threaded)
       topology->valid = false;
    }
 
+   if (!mongoc_uri_finalize_srv (topology->uri, &topology->scanner->error)) {
+      topology->valid = false;
+   }
+
    /*
     * Set topology type from URI:
     *   + if directConnection=true
@@ -517,7 +574,7 @@ mongoc_topology_new (const mongoc_uri_t *uri, bool single_threaded)
       }
    }
 
-   mc_tpld_unsafe_get_mutable (topology)->type = init_type;
+   td->type = init_type;
 
    if (!topology->single_threaded) {
       topology->server_monitors = mongoc_set_new (1, NULL, NULL);
@@ -533,16 +590,29 @@ mongoc_topology_new (const mongoc_uri_t *uri, bool single_threaded)
       return topology;
    }
 
-   while (hl) {
-      mongoc_topology_description_add_server (
-         mc_tpld_unsafe_get_mutable (topology), hl->host_and_port, &id);
-      mongoc_topology_scanner_add (topology->scanner, hl, id, false);
+   {
+      size_t idx = 0u;
+      size_t hl_array_size = 0u;
+      uint32_t id = 0u;
 
-      hl = hl->next;
+      const mongoc_host_list_t *const *hl_array = _mongoc_apply_srv_max_hosts (
+         hl,
+         mongoc_uri_get_option_as_int32 (uri, MONGOC_URI_SRVMAXHOSTS, 0),
+         &hl_array_size);
+
+      for (idx = 0u; idx < hl_array_size; ++idx) {
+         const mongoc_host_list_t *const elem = hl_array[idx];
+
+         mongoc_topology_description_add_server (td, elem->host_and_port, &id);
+         mongoc_topology_scanner_add (topology->scanner, elem, id, false);
+      }
+
+      bson_free ((void *) hl_array);
    }
 
    return topology;
 }
+
 /*
  *-------------------------------------------------------------------------
  *

--- a/src/libmongoc/src/mongoc/mongoc-uri-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-uri-private.h
@@ -88,6 +88,16 @@ _mongoc_uri_init_scram (const mongoc_uri_t *uri,
 bool
 mongoc_uri_finalize_loadbalanced (const mongoc_uri_t *uri, bson_error_t *error);
 
+/* mongoc_uri_finalize_srv validates constraints for SRV URI options.
+ * For example, it is invalid to have loadBalanced=true with srvMaxHosts=1.
+ * This is expected to be called whenever URI options may change (e.g.
+ * parsing a new URI or applying TXT records).
+ * Returns false and sets @error on failure.
+ * Returns true and does not modify @error on success.
+ */
+bool
+mongoc_uri_finalize_srv (const mongoc_uri_t *uri, bson_error_t *error);
+
 BSON_END_DECLS
 
 

--- a/src/libmongoc/src/mongoc/mongoc-uri.c
+++ b/src/libmongoc/src/mongoc/mongoc-uri.c
@@ -3129,7 +3129,7 @@ mongoc_uri_finalize_loadbalanced (const mongoc_uri_t *uri, bson_error_t *error)
    if (uri->hosts && uri->hosts->next) {
       MONGOC_URI_ERROR (
          error,
-         "URI with \"%s\" enabled must must not contain more than one host",
+         "URI with \"%s\" enabled must not contain more than one host",
          MONGOC_URI_LOADBALANCED);
       return false;
    }

--- a/src/libmongoc/src/mongoc/mongoc-uri.c
+++ b/src/libmongoc/src/mongoc/mongoc-uri.c
@@ -3118,10 +3118,14 @@ mongoc_uri_finalize_loadbalanced (const mongoc_uri_t *uri, bson_error_t *error)
       return true;
    }
 
-   if (!uri->hosts || (uri->hosts && uri->hosts->next)) {
-      MONGOC_URI_ERROR (error,
-                        "URI with \"%s\" enabled must contain exactly one host",
-                        MONGOC_URI_LOADBALANCED);
+   /* Load Balancer Spec: When `loadBalanced=true` is provided in the connection
+    * string, the driver MUST throw an exception if the connection string
+    * contains more than one host/port. */
+   if (uri->hosts && uri->hosts->next) {
+      MONGOC_URI_ERROR (
+         error,
+         "URI with \"%s\" enabled must must not contain more than one host",
+         MONGOC_URI_LOADBALANCED);
       return false;
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-uri.c
+++ b/src/libmongoc/src/mongoc/mongoc-uri.c
@@ -735,7 +735,8 @@ mongoc_uri_option_is_int32 (const char *key)
           !strcasecmp (key, MONGOC_URI_MAXIDLETIMEMS) ||
           !strcasecmp (key, MONGOC_URI_WAITQUEUEMULTIPLE) ||
           !strcasecmp (key, MONGOC_URI_WAITQUEUETIMEOUTMS) ||
-          !strcasecmp (key, MONGOC_URI_ZLIBCOMPRESSIONLEVEL);
+          !strcasecmp (key, MONGOC_URI_ZLIBCOMPRESSIONLEVEL) ||
+          !strcasecmp (key, MONGOC_URI_SRVMAXHOSTS);
 }
 
 bool
@@ -1569,6 +1570,10 @@ mongoc_uri_parse (mongoc_uri_t *uri, const char *str, bson_error_t *error)
    }
 
    if (!mongoc_uri_finalize_loadbalanced (uri, error)) {
+      goto error;
+   }
+
+   if (!mongoc_uri_finalize_srv (uri, error)) {
       goto error;
    }
 
@@ -3147,6 +3152,64 @@ mongoc_uri_finalize_loadbalanced (const mongoc_uri_t *uri, bson_error_t *error)
          MONGOC_URI_LOADBALANCED,
          MONGOC_URI_DIRECTCONNECTION);
       return false;
+   }
+
+   return true;
+}
+
+bool
+mongoc_uri_finalize_srv (const mongoc_uri_t *uri, bson_error_t *error)
+{
+   /* Initial DNS Seedlist Discovery Spec: The driver MUST report an error if
+    * either the `srvServiceName` or `srvMaxHosts` URI options are specified
+    * with a non-SRV URI */
+   if (!uri->is_srv && mongoc_uri_has_option (uri, MONGOC_URI_SRVMAXHOSTS)) {
+      MONGOC_URI_ERROR (error,
+                        "%s must not be specified with a non-SRV URI",
+                        MONGOC_URI_SRVMAXHOSTS);
+      return false;
+   }
+
+   if (uri->is_srv) {
+      const int32_t max_hosts =
+         mongoc_uri_get_option_as_int32 (uri, MONGOC_URI_SRVMAXHOSTS, 0);
+
+      /* Initial DNS Seedless Discovery Spec: This option requires a
+       * non-negative integer and defaults to zero (i.e. no limit). */
+      if (max_hosts < 0) {
+         MONGOC_URI_ERROR (error,
+                           "%s is required to be a non-negative integer, but "
+                           "has value %" PRId32,
+                           MONGOC_URI_SRVMAXHOSTS,
+                           max_hosts);
+         return false;
+      }
+
+      if (max_hosts > 0) {
+         /* Initial DNS Seedless Discovery spec: If srvMaxHosts is a positive
+          * integer, the driver MUST throw an error if the connection string
+          * contains a `replicaSet` option. */
+         if (mongoc_uri_has_option (uri, MONGOC_URI_REPLICASET)) {
+            MONGOC_URI_ERROR (error,
+                              "%s must not be specified with %s",
+                              MONGOC_URI_SRVMAXHOSTS,
+                              MONGOC_URI_REPLICASET);
+            return false;
+         }
+
+         /* Initial DNS Seedless Discovery Spec: If srvMaxHosts is a positive
+          * integer, the driver MUST throw an error if the connection string
+          * contains a `loadBalanced` option with a value of `true`.
+          */
+         if (mongoc_uri_get_option_as_bool (
+                uri, MONGOC_URI_LOADBALANCED, false)) {
+            MONGOC_URI_ERROR (error,
+                              "%s must not be specified with %s=true",
+                              MONGOC_URI_SRVMAXHOSTS,
+                              MONGOC_URI_LOADBALANCED);
+            return false;
+         }
+      }
    }
 
    return true;

--- a/src/libmongoc/src/mongoc/mongoc-uri.c
+++ b/src/libmongoc/src/mongoc/mongoc-uri.c
@@ -1132,7 +1132,8 @@ mongoc_uri_apply_options (mongoc_uri_t *uri,
                                MONGOC_ERROR_COMMAND,
                                MONGOC_ERROR_COMMAND_INVALID_ARG,
                                "Failed to set %s to %d",
-                               canon, bval);
+                               canon,
+                               bval);
                return false;
             }
          } else {
@@ -2316,8 +2317,7 @@ mongoc_uri_unescape (const char *escaped_string)
 #else
              (1 != sscanf (&ptr[1], "%02x", &hex))
 #endif
-             ||
-             0 == hex) {
+             || 0 == hex) {
             bson_string_free (str, true);
             MONGOC_WARNING ("Invalid %% escape sequence");
             return NULL;

--- a/src/libmongoc/src/mongoc/mongoc-uri.h
+++ b/src/libmongoc/src/mongoc/mongoc-uri.h
@@ -62,6 +62,7 @@
 #define MONGOC_URI_SLAVEOK "slaveok"
 #define MONGOC_URI_SOCKETCHECKINTERVALMS "socketcheckintervalms"
 #define MONGOC_URI_SOCKETTIMEOUTMS "sockettimeoutms"
+#define MONGOC_URI_SRVMAXHOSTS "srvMaxHosts"
 #define MONGOC_URI_TLS "tls"
 #define MONGOC_URI_TLSCERTIFICATEKEYFILE "tlscertificatekeyfile"
 #define MONGOC_URI_TLSCERTIFICATEKEYFILEPASSWORD "tlscertificatekeyfilepassword"

--- a/src/libmongoc/src/mongoc/mongoc-util-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-util-private.h
@@ -159,29 +159,77 @@ _mongoc_document_is_pipeline (const bson_t *document);
 char *
 _mongoc_getenv (const char *name);
 
+/* Returns a uniformly-distributed uint32_t generated using
+ * `_mongoc_rand_bytes()` if a source of cryptographic randomness is available
+ * (defined only if `MONGOC_ENABLE_CRYPTO` is defined).
+ */
+uint32_t
+_mongoc_crypto_rand_uint32_t (void);
+
+/* Returns a uniformly-distributed uint64_t generated using
+ * `_mongoc_rand_bytes()` if a source of cryptographic randomness is available
+ * (defined only if `MONGOC_ENABLE_CRYPTO` is defined).
+ */
+uint64_t
+_mongoc_crypto_rand_uint64_t (void);
+
+/* Returns a uniformly-distributed size_t generated using
+ * `_mongoc_rand_bytes()` if a source of cryptographic randomness is available
+ * (defined only if `MONGOC_ENABLE_CRYPTO` is defined).
+ */
+size_t
+_mongoc_crypto_rand_size_t (void);
+
+/* Returns a uniformly-distributed random uint32_t generated using `rand()`.
+ * Note: may invoke `srand()`, which may not be thread-safe. Concurrent calls to
+ * `_mongoc_simple_rand_*()` functions, however, is thread-safe. */
+uint32_t
+_mongoc_simple_rand_uint32_t (void);
+
+/* Returns a uniformly-distributed random uint64_t generated using `rand()`.
+ * Note: may invoke `srand()`, which may not be thread-safe. Concurrent calls to
+ * `_mongoc_simple_rand_*()` functions, however, is thread-safe. */
+uint64_t
+_mongoc_simple_rand_uint64_t (void);
+
+/* Returns a uniformly-distributed random size_t generated using `rand()`.
+ * Note: may invoke `srand()`, which may not be thread-safe. Concurrent calls to
+ * `_mongoc_simple_rand_*()` functions, however, is thread-safe. */
+uint64_t
+_mongoc_simple_rand_size_t (void);
+
 /* Returns a uniformly-distributed random integer in the range [min, max].
  *
  * The size of the range [min, max] must not equal the size of the representable
  * range of uint32_t (`min == 0 && max == UINT32_MAX` must not be true).
+ *
+ * The generator `rand` must return a random integer uniformly distributed in
+ * the full range of representable values of uint32_t.
  */
 uint32_t
-_mongoc_rand_uint32_t (uint32_t min, uint32_t max);
+_mongoc_rand_uint32_t (uint32_t min, uint32_t max, uint32_t (*rand) (void));
 
 /* Returns a uniformly-distributed random integer in the range [min, max].
  *
  * The size of the range [min, max] must not equal the size of the representable
  * range of uint64_t (`min == 0 && max == UINT64_MAX` must not be true).
+ *
+ * The generator `rand` must return a random integer uniformly distributed in
+ * the full range of representable values of uint64_t.
  */
 uint64_t
-_mongoc_rand_uint64_t (uint64_t min, uint64_t max);
+_mongoc_rand_uint64_t (uint64_t min, uint64_t max, uint64_t (*rand) (void));
 
 /* Returns a uniformly-distributed random integer in the range [min, max].
  *
  * The size of the range [min, max] must not equal the size of the representable
  * range of size_t (`min == 0 && max == SIZE_MAX` must not be true).
+ *
+ * The generator `rand` must return a random integer uniformly distributed in
+ * the full range of representable values of size_t.
  */
 size_t
-_mongoc_rand_size_t (size_t min, size_t max);
+_mongoc_rand_size_t (size_t min, size_t max, size_t (*rand) (void));
 
 BSON_END_DECLS
 

--- a/src/libmongoc/src/mongoc/mongoc-util-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-util-private.h
@@ -195,7 +195,7 @@ _mongoc_simple_rand_uint64_t (void);
 /* Returns a uniformly-distributed random size_t generated using `rand()`.
  * Note: may invoke `srand()`, which may not be thread-safe. Concurrent calls to
  * `_mongoc_simple_rand_*()` functions, however, is thread-safe. */
-uint64_t
+size_t
 _mongoc_simple_rand_size_t (void);
 
 /* Returns a uniformly-distributed random integer in the range [min, max].

--- a/src/libmongoc/src/mongoc/mongoc-util-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-util-private.h
@@ -26,6 +26,8 @@
 #include <strings.h>
 #endif
 
+#include <stdint.h>
+
 /* string comparison functions for Windows */
 #ifdef _WIN32
 #define strcasecmp _stricmp
@@ -156,6 +158,30 @@ _mongoc_document_is_pipeline (const bson_t *document);
  */
 char *
 _mongoc_getenv (const char *name);
+
+/* Returns a uniformly-distributed random integer in the range [min, max].
+ *
+ * The size of the range [min, max] must not equal the size of the representable
+ * range of uint32_t (`min == 0 && max == UINT32_MAX` must not be true).
+ */
+uint32_t
+_mongoc_rand_uint32_t (uint32_t min, uint32_t max);
+
+/* Returns a uniformly-distributed random integer in the range [min, max].
+ *
+ * The size of the range [min, max] must not equal the size of the representable
+ * range of uint64_t (`min == 0 && max == UINT64_MAX` must not be true).
+ */
+uint64_t
+_mongoc_rand_uint64_t (uint64_t min, uint64_t max);
+
+/* Returns a uniformly-distributed random integer in the range [min, max].
+ *
+ * The size of the range [min, max] must not equal the size of the representable
+ * range of size_t (`min == 0 && max == SIZE_MAX` must not be true).
+ */
+size_t
+_mongoc_rand_size_t (size_t min, size_t max);
 
 BSON_END_DECLS
 

--- a/src/libmongoc/src/mongoc/mongoc-util.c
+++ b/src/libmongoc/src/mongoc/mongoc-util.c
@@ -727,7 +727,7 @@ uint32_t
 _mongoc_rand_uint32_t (uint32_t min, uint32_t max)
 {
    BSON_ASSERT (min <= max);
-   BSON_ASSERT (min != 0u && max != UINT32_MAX);
+   BSON_ASSERT (min != 0u || max != UINT32_MAX);
 
    return _mongoc_rand_nduid32 (max - min + 1u, _mongoc_simple_rand_uint32_t) +
           min;
@@ -737,7 +737,7 @@ uint64_t
 _mongoc_rand_uint64_t (uint64_t min, uint64_t max)
 {
    BSON_ASSERT (min <= max);
-   BSON_ASSERT (min != 0u && max != UINT64_MAX);
+   BSON_ASSERT (min != 0u || max != UINT64_MAX);
 
    return _mongoc_rand_java64 (max - min + 1u, _mongoc_simple_rand_uint64_t) +
           min;

--- a/src/libmongoc/src/mongoc/mongoc-util.c
+++ b/src/libmongoc/src/mongoc/mongoc-util.c
@@ -776,10 +776,10 @@ _mongoc_rand_uint64_t (uint64_t min, uint64_t max, uint64_t (*rand) (void))
 BSON_STATIC_ASSERT2 (_mongoc_simple_rand_size_t,
                      sizeof (size_t) == sizeof (uint64_t));
 
-uint64_t
+size_t
 _mongoc_simple_rand_size_t (void)
 {
-   return (uint64_t) _mongoc_simple_rand_uint64_t ();
+   return (size_t) _mongoc_simple_rand_uint64_t ();
 }
 
 size_t
@@ -797,10 +797,10 @@ _mongoc_rand_size_t (size_t min, size_t max, size_t (*rand) (void))
 BSON_STATIC_ASSERT2 (_mongoc_simple_rand_size_t,
                      sizeof (size_t) == sizeof (uint32_t));
 
-uint32_t
+size_t
 _mongoc_simple_rand_size_t (void)
 {
-   return (uint32_t) _mongoc_simple_rand_uint32_t ();
+   return (size_t) _mongoc_simple_rand_uint32_t ();
 }
 
 size_t

--- a/src/libmongoc/src/mongoc/mongoc-util.c
+++ b/src/libmongoc/src/mongoc/mongoc-util.c
@@ -804,7 +804,7 @@ _mongoc_simple_rand_size_t (void)
 }
 
 size_t
-_mongoc_rand_size_t (size_t min, size_t max)
+_mongoc_rand_size_t (size_t min, size_t max, size_t (*rand) (void))
 {
    BSON_ASSERT (min <= max);
    BSON_ASSERT (min != 0u || max != UINT32_MAX);

--- a/src/libmongoc/tests/json/initial_dns_seedlist_discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.json
+++ b/src/libmongoc/tests/json/initial_dns_seedlist_discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test20.test.build.10gen.cc/?srvMaxHosts=1",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because positive integer for srvMaxHosts conflicts with loadBalanced=true (TXT)"
+}

--- a/src/libmongoc/tests/json/initial_dns_seedlist_discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true.json
+++ b/src/libmongoc/tests/json/initial_dns_seedlist_discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test3.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=1",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because positive integer for srvMaxHosts conflicts with loadBalanced=true"
+}

--- a/src/libmongoc/tests/json/initial_dns_seedlist_discovery/load-balanced/srvMaxHosts-zero-txt.json
+++ b/src/libmongoc/tests/json/initial_dns_seedlist_discovery/load-balanced/srvMaxHosts-zero-txt.json
@@ -1,0 +1,14 @@
+{
+  "uri": "mongodb+srv://test20.test.build.10gen.cc/?srvMaxHosts=0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "options": {
+    "loadBalanced": true,
+    "srvMaxHosts": 0,
+    "ssl": true
+  }
+}

--- a/src/libmongoc/tests/json/initial_dns_seedlist_discovery/load-balanced/srvMaxHosts-zero.json
+++ b/src/libmongoc/tests/json/initial_dns_seedlist_discovery/load-balanced/srvMaxHosts-zero.json
@@ -1,0 +1,14 @@
+{
+  "uri": "mongodb+srv://test3.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "options": {
+    "loadBalanced": true,
+    "srvMaxHosts": 0,
+    "ssl": true
+  }
+}

--- a/src/libmongoc/tests/json/initial_dns_seedlist_discovery/replica-set/srvMaxHosts-conflicts_with_replicaSet-txt.json
+++ b/src/libmongoc/tests/json/initial_dns_seedlist_discovery/replica-set/srvMaxHosts-conflicts_with_replicaSet-txt.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test5.test.build.10gen.cc/?srvMaxHosts=1",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because positive integer for srvMaxHosts conflicts with replicaSet option (TXT)"
+}

--- a/src/libmongoc/tests/json/initial_dns_seedlist_discovery/replica-set/srvMaxHosts-conflicts_with_replicaSet.json
+++ b/src/libmongoc/tests/json/initial_dns_seedlist_discovery/replica-set/srvMaxHosts-conflicts_with_replicaSet.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=1",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because positive integer for srvMaxHosts conflicts with replicaSet option"
+}

--- a/src/libmongoc/tests/json/initial_dns_seedlist_discovery/replica-set/srvMaxHosts-equal_to_srv_records.json
+++ b/src/libmongoc/tests/json/initial_dns_seedlist_discovery/replica-set/srvMaxHosts-equal_to_srv_records.json
@@ -1,0 +1,17 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2",
+  "numSeeds": 2,
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "srvMaxHosts": 2,
+    "ssl": true
+  }
+}

--- a/src/libmongoc/tests/json/initial_dns_seedlist_discovery/replica-set/srvMaxHosts-greater_than_srv_records.json
+++ b/src/libmongoc/tests/json/initial_dns_seedlist_discovery/replica-set/srvMaxHosts-greater_than_srv_records.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=3",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "srvMaxHosts": 3,
+    "ssl": true
+  }
+}

--- a/src/libmongoc/tests/json/initial_dns_seedlist_discovery/replica-set/srvMaxHosts-invalid_integer.json
+++ b/src/libmongoc/tests/json/initial_dns_seedlist_discovery/replica-set/srvMaxHosts-invalid_integer.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=-1",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because srvMaxHosts is not greater than or equal to zero"
+}

--- a/src/libmongoc/tests/json/initial_dns_seedlist_discovery/replica-set/srvMaxHosts-invalid_type.json
+++ b/src/libmongoc/tests/json/initial_dns_seedlist_discovery/replica-set/srvMaxHosts-invalid_type.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=foo",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because srvMaxHosts is not an integer"
+}

--- a/src/libmongoc/tests/json/initial_dns_seedlist_discovery/replica-set/srvMaxHosts-less_than_srv_records.json
+++ b/src/libmongoc/tests/json/initial_dns_seedlist_discovery/replica-set/srvMaxHosts-less_than_srv_records.json
@@ -1,0 +1,13 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=1",
+  "numSeeds": 1,
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "srvMaxHosts": 1,
+    "ssl": true
+  }
+}

--- a/src/libmongoc/tests/json/initial_dns_seedlist_discovery/replica-set/srvMaxHosts-zero-txt.json
+++ b/src/libmongoc/tests/json/initial_dns_seedlist_discovery/replica-set/srvMaxHosts-zero-txt.json
@@ -1,0 +1,17 @@
+{
+  "uri": "mongodb+srv://test5.test.build.10gen.cc/?srvMaxHosts=0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "authSource": "thisDB",
+    "replicaSet": "repl0",
+    "srvMaxHosts": 0,
+    "ssl": true
+  }
+}

--- a/src/libmongoc/tests/json/initial_dns_seedlist_discovery/replica-set/srvMaxHosts-zero.json
+++ b/src/libmongoc/tests/json/initial_dns_seedlist_discovery/replica-set/srvMaxHosts-zero.json
@@ -1,0 +1,17 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "srvMaxHosts": 0,
+    "ssl": true
+  }
+}

--- a/src/libmongoc/tests/json/initial_dns_seedlist_discovery/sharded/srvMaxHosts-equal_to_srv_records.json
+++ b/src/libmongoc/tests/json/initial_dns_seedlist_discovery/sharded/srvMaxHosts-equal_to_srv_records.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2",
+  "numSeeds": 2,
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "options": {
+    "srvMaxHosts": 2,
+    "ssl": true
+  }
+}

--- a/src/libmongoc/tests/json/initial_dns_seedlist_discovery/sharded/srvMaxHosts-greater_than_srv_records.json
+++ b/src/libmongoc/tests/json/initial_dns_seedlist_discovery/sharded/srvMaxHosts-greater_than_srv_records.json
@@ -1,0 +1,15 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=3",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "options": {
+    "srvMaxHosts": 3,
+    "ssl": true
+  }
+}

--- a/src/libmongoc/tests/json/initial_dns_seedlist_discovery/sharded/srvMaxHosts-invalid_integer.json
+++ b/src/libmongoc/tests/json/initial_dns_seedlist_discovery/sharded/srvMaxHosts-invalid_integer.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=-1",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because srvMaxHosts is not greater than or equal to zero"
+}

--- a/src/libmongoc/tests/json/initial_dns_seedlist_discovery/sharded/srvMaxHosts-invalid_type.json
+++ b/src/libmongoc/tests/json/initial_dns_seedlist_discovery/sharded/srvMaxHosts-invalid_type.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=foo",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because srvMaxHosts is not an integer"
+}

--- a/src/libmongoc/tests/json/initial_dns_seedlist_discovery/sharded/srvMaxHosts-less_than_srv_records.json
+++ b/src/libmongoc/tests/json/initial_dns_seedlist_discovery/sharded/srvMaxHosts-less_than_srv_records.json
@@ -1,0 +1,9 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=1",
+  "numSeeds": 1,
+  "numHosts": 1,
+  "options": {
+    "srvMaxHosts": 1,
+    "ssl": true
+  }
+}

--- a/src/libmongoc/tests/json/initial_dns_seedlist_discovery/sharded/srvMaxHosts-zero.json
+++ b/src/libmongoc/tests/json/initial_dns_seedlist_discovery/sharded/srvMaxHosts-zero.json
@@ -1,0 +1,15 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "options": {
+    "srvMaxHosts": 0,
+    "ssl": true
+  }
+}

--- a/src/libmongoc/tests/json/uri-options/srv-options.json
+++ b/src/libmongoc/tests/json/uri-options/srv-options.json
@@ -1,0 +1,96 @@
+{
+  "tests": [
+    {
+      "description": "SRV URI with srvMaxHosts",
+      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "srvMaxHosts": 2
+      }
+    },
+    {
+      "description": "SRV URI with negative integer for srvMaxHosts",
+      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=-1",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "SRV URI with invalid type for srvMaxHosts",
+      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=foo",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "Non-SRV URI with srvMaxHosts",
+      "uri": "mongodb://example.com/?srvMaxHosts=2",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "SRV URI with positive srvMaxHosts and replicaSet",
+      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2&replicaSet=foo",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "SRV URI with positive srvMaxHosts and loadBalanced=true",
+      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2&loadBalanced=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "SRV URI with positive srvMaxHosts and loadBalanced=false",
+      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2&loadBalanced=false",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "loadBalanced": false,
+        "srvMaxHosts": 2
+      }
+    },
+    {
+      "description": "SRV URI with srvMaxHosts=0 and replicaSet",
+      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=0&replicaSet=foo",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "replicaSet": "foo",
+        "srvMaxHosts": 0
+      }
+    },
+    {
+      "description": "SRV URI with srvMaxHosts=0 and loadBalanced=true",
+      "uri": "mongodb+srv://test3.test.build.10gen.cc/?srvMaxHosts=0&loadBalanced=true",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "loadBalanced": true,
+        "srvMaxHosts": 0
+      }
+    }
+  ]
+}

--- a/src/libmongoc/tests/test-mongoc-connection-uri.c
+++ b/src/libmongoc/tests/test-mongoc-connection-uri.c
@@ -101,7 +101,9 @@ run_uri_test (const char *uri_string,
           strstr (uri_string, "heartbeatFrequencyMS=-2") ||
           strstr (uri_string, "w=-2") || strstr (uri_string, "wTimeoutMS=-2") ||
           strstr (uri_string, "zlibCompressionLevel=-2") ||
-          strstr (uri_string, "zlibCompressionLevel=10")) {
+          strstr (uri_string, "zlibCompressionLevel=10") ||
+          strstr (uri_string, "srvMaxHosts=-1") ||
+          strstr (uri_string, "srvMaxHosts=foo")) {
          MONGOC_WARNING ("Error parsing URI: '%s'", error.message);
          return;
       }

--- a/src/libmongoc/tests/test-mongoc-dns.c
+++ b/src/libmongoc/tests/test-mongoc-dns.c
@@ -440,11 +440,14 @@ test_all_spec_tests (TestSuite *suite)
 
    test_framework_resolve_path (
       JSON_DIR "/initial_dns_seedlist_discovery/sharded", resolved);
-   install_json_test_suite_with_check (suite,
-                                       resolved,
-                                       test_dns,
-                                       test_dns_check_loadbalanced,
-                                       test_framework_skip_if_no_crypto);
+   install_json_test_suite_with_check (
+      suite,
+      resolved,
+      test_dns,
+      /* Topology of load-balancer tests satisfy topology requirements of
+       * sharded tests, even though a load balancer is not required. */
+      test_dns_check_loadbalanced,
+      test_framework_skip_if_no_crypto);
 }
 
 extern bool

--- a/src/libmongoc/tests/test-mongoc-dns.c
+++ b/src/libmongoc/tests/test-mongoc-dns.c
@@ -784,7 +784,12 @@ _prose_test_update_srv_single (void *resource)
    client = resource;
 
    _mongoc_usleep (2000 * RESCAN_INTERVAL_MS);
-   _prose_test_ping (client);
+
+   /* Avoid ping given `loadBalanced=true`; see prose test 9. */
+   if (!mongoc_uri_get_option_as_bool (
+          client->uri, MONGOC_URI_LOADBALANCED, false)) {
+      _prose_test_ping (client);
+   }
 }
 
 static void

--- a/src/libmongoc/tests/test-mongoc-dns.c
+++ b/src/libmongoc/tests/test-mongoc-dns.c
@@ -743,47 +743,58 @@ typedef struct {
 /* invalid_topology_opening is used as a callback for the
  * test_invalid_topology_pooled and test_invalid_topology_single tests. */
 static void
-invalid_topology_opening (const mongoc_apm_topology_opening_t *event) {
-   cb_stats_t *stats = (cb_stats_t*) mongoc_apm_topology_opening_get_context (event);
+invalid_topology_opening (const mongoc_apm_topology_opening_t *event)
+{
+   cb_stats_t *stats =
+      (cb_stats_t *) mongoc_apm_topology_opening_get_context (event);
    stats->num_topology_opening++;
 }
 
 /* invalid_topology_closed is used as a callback for the
  * test_invalid_topology_pooled and test_invalid_topology_single tests. */
 static void
-invalid_topology_closed (const mongoc_apm_topology_closed_t *event) {
-   cb_stats_t *stats = (cb_stats_t*) mongoc_apm_topology_closed_get_context (event);
+invalid_topology_closed (const mongoc_apm_topology_closed_t *event)
+{
+   cb_stats_t *stats =
+      (cb_stats_t *) mongoc_apm_topology_closed_get_context (event);
    stats->num_topology_closed++;
 }
 
 /* invalid_server_closed is used as a callback for the
  * test_invalid_topology_pooled and test_invalid_topology_single tests. */
 static void
-invalid_server_closed (const mongoc_apm_server_closed_t *event) {
-   cb_stats_t *stats = (cb_stats_t*) mongoc_apm_server_closed_get_context (event);
+invalid_server_closed (const mongoc_apm_server_closed_t *event)
+{
+   cb_stats_t *stats =
+      (cb_stats_t *) mongoc_apm_server_closed_get_context (event);
    stats->num_server_closed++;
 }
 
 /* invalid_server_opening is used as a callback for the
  * test_invalid_topology_pooled and test_invalid_topology_single tests. */
 static void
-invalid_server_opening (const mongoc_apm_server_opening_t *event) {
-   cb_stats_t *stats = (cb_stats_t*) mongoc_apm_server_opening_get_context (event);
+invalid_server_opening (const mongoc_apm_server_opening_t *event)
+{
+   cb_stats_t *stats =
+      (cb_stats_t *) mongoc_apm_server_opening_get_context (event);
    stats->num_server_opening++;
 }
 
 /* CDRIVER-4184 Test that an invalid topology does not emit a topology_closed
  * event. */
 static void
-test_invalid_topology_pooled (void *unused) {
+test_invalid_topology_pooled (void *unused)
+{
    mongoc_client_pool_t *pool;
    mongoc_client_t *client;
    mongoc_uri_t *uri;
    mongoc_apm_callbacks_t *cbs;
    cb_stats_t stats = {0};
 
-   /* TXT record for test20.test.build.10gen.cc resolves to "loadBalanced=true". */
-   uri = mongoc_uri_new ("mongodb+srv://test20.test.build.10gen.cc/?replicaSet=rs0");
+   /* TXT record for test20.test.build.10gen.cc resolves to "loadBalanced=true".
+    */
+   uri = mongoc_uri_new (
+      "mongodb+srv://test20.test.build.10gen.cc/?replicaSet=rs0");
    pool = mongoc_client_pool_new (uri);
    cbs = mongoc_apm_callbacks_new ();
    mongoc_apm_set_topology_opening_cb (cbs, invalid_topology_opening);
@@ -792,9 +803,10 @@ test_invalid_topology_pooled (void *unused) {
    mongoc_apm_set_server_closed_cb (cbs, invalid_server_closed);
    mongoc_client_pool_set_apm_callbacks (pool, cbs, &stats);
 
-   ASSERT_CMPINT(stats.num_topology_opening, ==, 0);
+   ASSERT_CMPINT (stats.num_topology_opening, ==, 0);
 
-   /* Pop a client to attempt to start monitoring. Monitoring emits the topology_opening event on valid topologies. */
+   /* Pop a client to attempt to start monitoring. Monitoring emits the
+    * topology_opening event on valid topologies. */
    client = mongoc_client_pool_pop (pool);
    mongoc_client_pool_push (pool, client);
 
@@ -802,16 +814,17 @@ test_invalid_topology_pooled (void *unused) {
    mongoc_client_pool_destroy (pool);
    mongoc_uri_destroy (uri);
 
-   ASSERT_CMPINT(stats.num_topology_opening, ==, 0);
-   ASSERT_CMPINT(stats.num_server_opening, ==, 0);
-   ASSERT_CMPINT(stats.num_server_closed, ==, 0);
-   ASSERT_CMPINT(stats.num_topology_closed, ==, 0);
+   ASSERT_CMPINT (stats.num_topology_opening, ==, 0);
+   ASSERT_CMPINT (stats.num_server_opening, ==, 0);
+   ASSERT_CMPINT (stats.num_server_closed, ==, 0);
+   ASSERT_CMPINT (stats.num_topology_closed, ==, 0);
 }
 
 /* CDRIVER-4184 Test that an invalid topology does not emit a topology_closed
  * event. */
 static void
-test_invalid_topology_single (void *unused) {
+test_invalid_topology_single (void *unused)
+{
    mongoc_client_t *client;
    mongoc_uri_t *uri;
    mongoc_apm_callbacks_t *cbs;
@@ -819,8 +832,10 @@ test_invalid_topology_single (void *unused) {
    bson_error_t error;
    mongoc_server_description_t *sd;
 
-   /* TXT records for test20.test.build.10gen.cc resolve to loadBalanced=true. */
-   uri = mongoc_uri_new ("mongodb+srv://test20.test.build.10gen.cc/?replicaSet=true");
+   /* TXT records for test20.test.build.10gen.cc resolve to loadBalanced=true.
+    */
+   uri = mongoc_uri_new (
+      "mongodb+srv://test20.test.build.10gen.cc/?replicaSet=true");
    client = mongoc_client_new_from_uri (uri);
    cbs = mongoc_apm_callbacks_new ();
    mongoc_apm_set_topology_opening_cb (cbs, invalid_topology_opening);
@@ -829,27 +844,27 @@ test_invalid_topology_single (void *unused) {
    mongoc_apm_set_server_closed_cb (cbs, invalid_server_closed);
    mongoc_client_set_apm_callbacks (client, cbs, &stats);
 
-   ASSERT_CMPINT(stats.num_topology_opening, ==, 0);
+   ASSERT_CMPINT (stats.num_topology_opening, ==, 0);
 
    /* Perform server selection. Server selection emits the topology_opening
     * event on valid topologies. */
    sd = mongoc_client_select_server (
       client, false /* for_writes */, NULL /* read_prefs */, &error);
-   ASSERT_ERROR_CONTAINS (
-      error,
-      MONGOC_ERROR_SERVER_SELECTION,
-      MONGOC_ERROR_SERVER_SELECTION_FAILURE,
-      "URI with \"loadbalanced\" enabled must not contain option \"replicaset\"");
+   ASSERT_ERROR_CONTAINS (error,
+                          MONGOC_ERROR_SERVER_SELECTION,
+                          MONGOC_ERROR_SERVER_SELECTION_FAILURE,
+                          "URI with \"loadbalanced\" enabled must not contain "
+                          "option \"replicaset\"");
    ASSERT (!sd);
 
    mongoc_apm_callbacks_destroy (cbs);
    mongoc_client_destroy (client);
    mongoc_uri_destroy (uri);
 
-   ASSERT_CMPINT(stats.num_topology_opening, ==, 0);
-   ASSERT_CMPINT(stats.num_server_opening, ==, 0);
-   ASSERT_CMPINT(stats.num_server_closed, ==, 0);
-   ASSERT_CMPINT(stats.num_topology_closed, ==, 0);
+   ASSERT_CMPINT (stats.num_topology_opening, ==, 0);
+   ASSERT_CMPINT (stats.num_server_opening, ==, 0);
+   ASSERT_CMPINT (stats.num_server_closed, ==, 0);
+   ASSERT_CMPINT (stats.num_topology_closed, ==, 0);
 }
 
 void

--- a/src/libmongoc/tests/test-mongoc-dns.c
+++ b/src/libmongoc/tests/test-mongoc-dns.c
@@ -1,13 +1,15 @@
-#include <mongoc/mongoc-util-private.h>
-#include <mongoc/mongoc-client-pool-private.h>
+#include "mongoc/mongoc-util-private.h"
+#include "mongoc/mongoc-client-pool-private.h"
 #include "mongoc/mongoc.h"
 #include "mongoc/mongoc-host-list-private.h"
+#include "mongoc/mongoc-thread-private.h"
+#include "mongoc/mongoc-uri-private.h"
+#include "mongoc/utlist.h"
+
 #ifdef MONGOC_ENABLE_SSL
 #include "mongoc/mongoc-ssl.h"
 #include "mongoc/mongoc-ssl-private.h"
 #endif
-#include "mongoc/mongoc-thread-private.h"
-#include "mongoc/mongoc-uri-private.h"
 
 #include "json-test.h"
 #include "test-libmongoc.h"
@@ -446,7 +448,9 @@ dump_hosts (mongoc_host_list_t *hosts)
    mongoc_host_list_t *host;
 
    MONGOC_DEBUG ("hosts:");
-   for (host = hosts; host; host = hosts->next) {
+
+   LL_FOREACH (hosts, host)
+   {
       MONGOC_DEBUG ("- %s", host->host_and_port);
    }
 }

--- a/src/libmongoc/tests/test-mongoc-dns.c
+++ b/src/libmongoc/tests/test-mongoc-dns.c
@@ -660,7 +660,7 @@ _mock_rr_resolver_prose_test_9 (const char *service,
 }
 
 static void
-_prose_loadbalanced_ping (mongoc_client_t *client)
+_prose_test_ping (mongoc_client_t *client)
 {
    bson_error_t error;
    bson_t *cmd = BCON_NEW ("ping", BCON_INT32 (1));
@@ -784,7 +784,7 @@ _prose_test_update_srv_single (void *resource)
    client = resource;
 
    _mongoc_usleep (2000 * RESCAN_INTERVAL_MS);
-   _prose_loadbalanced_ping (client);
+   _prose_test_ping (client);
 }
 
 static void


### PR DESCRIPTION
This PR implements CDRIVER-4097, which introduces the [`srvMaxHosts` URI option](https://github.com/mongodb/specifications/blob/b508f6d2a1819882d40c4e7e73b95fc8ae3bdfe5/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst#srvmaxhosts). This option limits number of hosts during [initial DNS seedlist discovery](https://github.com/mongodb/specifications/blob/b508f6d2a1819882d40c4e7e73b95fc8ae3bdfe5/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst#querying-dns) and [SRV polling for mongos discovery](https://github.com/mongodb/specifications/blob/b508f6d2a1819882d40c4e7e73b95fc8ae3bdfe5/source/polling-srv-records-for-mongos-discovery/polling-srv-records-for-mongos-discovery.rst#implementation).

Any changes involving the `srvServiceName` URI option were deliberately skipped; this feature should be addressed separately as CDRIVER-4086.

This PR comes in three major parts:

1. URI Options

First, a [bug](https://github.com/mongodb/mongo-c-driver/commit/29e1ec913127d3acbdfe835c7267c44f1734b5ef) in the validation of load balancer URI options had to be addressed to permit valid execution of `srvMaxHosts`-related tests.

Then, the necessary URI option parsing features [were implemented](https://github.com/mongodb/mongo-c-driver/commit/2a67283dde3cb41f242a65262f0dbf1ad3c2a140) and corresponding spec tests [added](https://github.com/mongodb/mongo-c-driver/commit/1406b6ffa7896e052ae0ae4d990a53718d62d12b) to the uri-options directory. Note that some test cases had to be [added to the warning filters](https://github.com/mongodb/mongo-c-driver/commit/1406b6ffa7896e052ae0ae4d990a53718d62d12b#diff-de273c6f735cdbe82c59b0bd26c6157ba527804980ccdf42bbcb6b2988379e3bR104-R106) as CDRIVER-3167 has not yet been addressed.

2. Initial DNS Seedlist Discovery

There were two drive-by improvements during this step. The first was the addition of a `const`-qualifier to a [read-only host list function](https://github.com/mongodb/mongo-c-driver/commit/82e32bb294c0c463cca8f6a4619f1e52477762cf). The second was fixing [an infinite loop bug](https://github.com/mongodb/mongo-c-driver/commit/e995831720c9a89c137f99efa90de51287fb2d0f) in `dump_hosts()` (only triggered by certain test failures) due to an incorrect induction step.

As the Initial Seedlist Discovery Spec requires [random shuffling and selection](https://github.com/mongodb/specifications/blob/b508f6d2a1819882d40c4e7e73b95fc8ae3bdfe5/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst#querying-dns) of hosts, I took the opportunity to introduce a set of [uniform random integer functions](https://github.com/mongodb/mongo-c-driver/commit/bec90ab95c46f3fdfc35a302a88b24c29ef33947). These are `_mongoc_rand_uint32_t`, `_mongoc_rand_uint64_t`, and `_mongoc_rand_size_t` respectively, each returning a random integer in the range `[min, max]` with uniform distribution. The algorithms used are as described in ["Fast Random Integer Generation in an Interval" by Daniel Lemire](https://arxiv.org/abs/1805.10941). The "nearly divisionless" algorithm proposed by the paper is used for 32-bit integers. The "Java algorithm" is used for 64-bit integers as the nearly divisionless algorithm requires using 128-bit integers during computation; I did not want to attempt to introduce `__int128` into the C driver due to consistent cross-platform compatibility being [effectively non-existent](https://quuxplusone.github.io/blog/2019/02/28/is-int128-integral/).

With the new random number generators, implementing the filtering of initial DNS seedlist hosts was [relatively straightforward](https://github.com/mongodb/mongo-c-driver/commit/0480de8fb1ad6434ad168914516f7fcae067ce2e).

The new spec tests for Initial Seedlist Discovery also required [some modification to test code](https://github.com/mongodb/mongo-c-driver/commit/adf0c12f3fb68cf250414e76d88b1dc6bb8bfd68#diff-c80a6c3e231807c673e7da7a1f5db8c468ba7027084fa9fc5d7cc2489365823d) to accomodate the new `numHosts` parameter. Evergreen/CI scripts did not have to be updated to accomodate the new `sharded` spec tests, as the `load-balancer` spec test setup also happens to [satisfy the conditions required](https://github.com/mongodb/specifications/tree/b508f6d2a1819882d40c4e7e73b95fc8ae3bdfe5/source/initial-dns-seedlist-discovery/tests#test-setup) to correctly run `sharded` spec tests (a mongos server on ports 27017 and 27018). These new `sharded` spec tests can therefore be run alongside existing `load-balancer` tests on Evergreen.

3. SRV Polling for mongos Discovery

There was some [awkward math required](https://github.com/mongodb/mongo-c-driver/commit/976aaa58312ea98c14a7edf75520638fdb58469b#diff-6eef3e5d332b14e922ca887b8a8ba5b39efd0a109ebc9b27923cdcae15575061R2378) to preserve the correct order of operations, where the [addition of new valid hosts](https://github.com/mongodb/mongo-c-driver/commit/976aaa58312ea98c14a7edf75520638fdb58469b#diff-6eef3e5d332b14e922ca887b8a8ba5b39efd0a109ebc9b27923cdcae15575061R2360-R2406) (within the limit as described by `srvMaxHosts`) must come _before_ [removal of missing hosts](https://github.com/mongodb/mongo-c-driver/commit/976aaa58312ea98c14a7edf75520638fdb58469b#diff-6eef3e5d332b14e922ca887b8a8ba5b39efd0a109ebc9b27923cdcae15575061R2408-R2419) to avoid generating [a misleading warning](https://github.com/mongodb/mongo-c-driver/blob/2078ab2272ad72df091a757fba9d45285221477d/src/libmongoc/src/mongoc/mongoc-topology-description.c#L995). If the warning can be disabled or removed, the implementation of `mongoc_topology_description_reconcile` could be made simpler.

Finally, prose tests 10, 11, and 12 were [added](https://github.com/mongodb/mongo-c-driver/commit/2444d18e1a4301678b90d113bfbe5d35def6e738) according to the [SRV Polling Tests Spec](https://github.com/mongodb/specifications/tree/b508f6d2a1819882d40c4e7e73b95fc8ae3bdfe5/source/polling-srv-records-for-mongos-discovery/tests). However, due to the verbosity and repetition of the existing patterns used by prose tests, I took the opportunity to perform some [dependency inversion](https://github.com/mongodb/mongo-c-driver/commit/435e15daca3ab13503a3167f339968f97858bd95) (or is it ["Inversion of Control"](https://en.wikipedia.org/wiki/Inversion_of_control)? Either way, some kind of "inversion" is involved) to simplify the implementation of the prose test code. To better understand the intent of this refactor, I recommend comparing the state of a single prose test before and after the change in separate views, rather than side-by-side or inline as a diff.

The SRV Polling prose tests have been given the [`test_dns_check_srv_polling()` skip condition](https://github.com/mongodb/mongo-c-driver/commit/2444d18e1a4301678b90d113bfbe5d35def6e738#diff-c80a6c3e231807c673e7da7a1f5db8c468ba7027084fa9fc5d7cc2489365823dR388-R392) such that they are only run if the `MONGOC_TEST_DNS_SRV_POLLING` environment variable is set to `on`. This is due to current Evergreen scripts not yet being configured to create the required sharded cluster configuration with mongos instances running on 4 ports. Supporting this will take additional work as described by CDRIVER-4230. Note, this means that the Evergreen tasks being run for this PR do _not_ currently evaluate the SRV Polling prose tests, unliked the sharded tests for Initial DNS Seedlist Discovery, although they have been verified locally as passing given the correct sharded cluster configuration.