### PR TITLE
Update NEWS for 1.20.0 and 1.19.2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,18 @@ Thanks to everyone who contributed to the development of this release.
 
 --Kevin Albertson
 
+mongo-c-driver 1.19.2
+=====================
+
+Announcing libmongoc 1.19.2.
+
+Bug fixes:
+
+* Fix assert on invalid URI options in client pools connected to load balanced clusters when a topology closed callback is registered.
+
+Thanks to everyone who contributed to the development of this release.
+
+--Kevin Albertson
 
 mongo-c-driver 1.19.0
 =====================

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,20 @@
+libmongoc 1.20.0
+================
+
+Features:
+
+  * Improve multi-threaded performance of client pool.
+  * Support KMIP as a provider for Client-Side Field Level Encryption (CSFLE).
+
+Thanks to everyone who contributed to the development of this release.
+
+  * Kevin Albertson
+  * Ezra Chung
+  * Colby Pike
+  * Jesse Williamson
+  * Jeremy Mikola
+  * Kaitlin Mahar
+
 mongo-c-driver 1.19.2
 =====================
 

--- a/NEWS
+++ b/NEWS
@@ -46,6 +46,7 @@ Thanks to everyone who contributed to the development of this release.
 
 --Kevin Albertson
 
+
 mongo-c-driver 1.19.0
 =====================
 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,16 @@
+mongo-c-driver 1.19.2
+=====================
+
+Announcing libmongoc 1.19.2.
+
+Bug fixes:
+
+* Fix assert on invalid URI options in client pools connected to load balanced clusters when a topology closed callback is registered.
+
+Thanks to everyone who contributed to the development of this release.
+
+--Kevin Albertson
+
 libmongoc 1.19.1
 ================
 
@@ -13,19 +26,6 @@ Thanks to everyone who contributed to the development of this release.
 
   * Kevin Albertson
   * Ezra Chung
-
---Kevin Albertson
-
-mongo-c-driver 1.19.2
-=====================
-
-Announcing libmongoc 1.19.2.
-
-Bug fixes:
-
-* Fix assert on invalid URI options in client pools connected to load balanced clusters when a topology closed callback is registered.
-
-Thanks to everyone who contributed to the development of this release.
 
 --Kevin Albertson
 

--- a/src/libbson/NEWS
+++ b/src/libbson/NEWS
@@ -12,6 +12,15 @@ Thanks to everyone who contributed to the development of this release.
   * Roberto C. Sánchez
   * Ezra Chung
 
+libbson 1.19.2
+==============
+
+Announcing libbson 1.19.2.
+
+No changes since 1.19.1; release to keep pace with libmongoc's version.
+
+--Kevin Albertson
+
 libbson 1.19.1
 ==============
 

--- a/src/libbson/NEWS
+++ b/src/libbson/NEWS
@@ -3,7 +3,7 @@ libbson 1.20.0
 
 Features:
 
-  * Improve atomics API
+  * Improve atomics API.
 
 Thanks to everyone who contributed to the development of this release.
 

--- a/src/libbson/NEWS
+++ b/src/libbson/NEWS
@@ -1,3 +1,17 @@
+libbson 1.20.0
+==============
+
+Features:
+
+  * Improve atomics API
+
+Thanks to everyone who contributed to the development of this release.
+
+  * Colby Pike
+  * Kevin Albertson
+  * Roberto C. Sánchez
+  * Ezra Chung
+
 libbson 1.19.1
 ==============
 


### PR DESCRIPTION
# Summary
- Copy `NEWS` and `src/libbson/NEWS` changes from 1.19.2.
- Copy `NEWS` and `src/libbson/NEWS` changes from 1.20.0. 
- Note atomics in `src/libbson/NEWS` and add contributors list.

After this is merged the 1.20.0 community announcement and GitHub release notes will be updated with the new release notes.
