### PR TITLE
CDRIVER-4225 Explicitly set CA and cert file for use by KMS TLS connections

### DIFF
--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -31,41 +31,9 @@ fi
 if [ "$SSL" != "nossl" ]; then
    export MONGOC_TEST_SSL_WEAK_CERT_VALIDATION="off"
    export MONGOC_TEST_SSL_PEM_FILE="src/libmongoc/tests/x509gen/client.pem"
-
-   case "$OS" in
-      cygwin*)
-         certutil.exe -addstore "Root" "src\libmongoc\tests\x509gen\ca.pem"
-         ;;
-      darwin*)
-         sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain src/libmongoc/tests/x509gen/ca.pem
-         ;;
-      *)
-         if [ -f /etc/redhat-release ]; then
-            echo "Copying CA certificate to /usr/share/pki/ca-trust-source/anchors..."
-            sudo cp -v src/libmongoc/tests/x509gen/ca.pem /usr/share/pki/ca-trust-source/anchors/cdriver.crt || true
-            if [ -f /usr/share/pki/ca-trust-source/anchors/cdriver.crt ]; then
-               echo "Copying CA certificate to /usr/share/pki/ca-trust-source/anchors... done."
-               sudo update-ca-trust enable --verbose
-               sudo update-ca-trust extract --verbose
-            else
-               echo "Copying CA certificate to /usr/share/pki/ca-trust-source/anchors... failed."
-               export MONGOC_TEST_SKIP_KMS_TLS_TESTS=on
-               export MONGOC_TEST_SSL_CA_FILE="src/libmongoc/tests/x509gen/ca.pem"
-            fi
-         else
-            echo "Copying CA certificate to /usr/local/share/ca-certificates..."
-            sudo cp -v src/libmongoc/tests/x509gen/ca.pem /usr/local/share/ca-certificates/cdriver.crt || true
-            if [ -f /usr/local/share/ca-certificates/cdriver.crt ]; then
-               echo "Copying CA certificate to /usr/local/share/ca-certificates... done."
-               sudo update-ca-certificates --verbose
-            else
-               echo "Copying CA certificate to /usr/local/share/ca-certificates... failed."
-               export MONGOC_TEST_SKIP_KMS_TLS_TESTS=on
-               export MONGOC_TEST_SSL_CA_FILE="src/libmongoc/tests/x509gen/ca.pem"
-            fi
-         fi
-         ;;
-   esac
+   export MONGOC_TEST_SSL_CA_FILE="src/libmongoc/tests/x509gen/ca.pem"
+   export MONGOC_TEST_CSFLE_TLS_CERTIFICATE_KEY_FILE="src/libmongoc/tests/x509gen/client.pem"
+   export MONGOC_TEST_CSFLE_TLS_CA_FILE="src/libmongoc/tests/x509gen/ca.pem"
 fi
 
 export MONGOC_ENABLE_MAJORITY_READ_CONCERN=on

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -272,10 +272,6 @@ The path to `ca.pem` and `client.pem` must be passed through the following envir
 * `MONGOC_TEST_CSFLE_TLS_CA_FILE=<string>`
 * `MONGOC_TEST_CSFLE_TLS_CERTIFICATE_KEY_FILE=<string>`
 
-KMS TLS tests for Client-Side Field Level Encryption can be skipped by defining:
-
-* `MONGOC_TEST_SKIP_KMS_TLS_TESTS=on`
-
 Specification tests may be filtered by their description:
 
 * `MONGOC_JSON_SUBTEST=<string>`


### PR DESCRIPTION
Thanks to CDRIVER-4206, the KMS TLS connections can now use user-provided CA and certificate files rather than depending on system certificate registration. This PR removes system cert registration and associated test skip condition checks, replacing them with use of the new `tls_opts` fields whose values are set by the `MONGOC_TEST_CSFLE_TLS_CA_FILE` and `MONGOC_TEST_CSFLE_TLS_CERTIFICATE_KEY_FILE` environment variables.