### PR TITLE
CDRIVER-4216 Replace 'git://' with 'https://' for drivers-evergreen-tools repo

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -729,7 +729,7 @@ functions:
         set -o errexit
         # Add AWS variables to a file.
         # Clone in one directory above so it does not get uploaded in working directory.
-        git clone --depth=1 git://github.com/mongodb-labs/drivers-evergreen-tools.git ../drivers-evergreen-tools
+        git clone --depth=1 https://github.com/mongodb-labs/drivers-evergreen-tools.git ../drivers-evergreen-tools
         cat <<EOF > ../drivers-evergreen-tools/.evergreen/auth_aws/aws_e2e_setup.json
         {
             "iam_auth_ecs_account" : "${iam_auth_ecs_account}",

--- a/.evergreen/run-aws-tests.sh
+++ b/.evergreen/run-aws-tests.sh
@@ -9,7 +9,7 @@
 # Optional environment variables:
 #
 # DRIVERS_TOOLS
-#   The path to clone of git://github.com/mongodb-labs/drivers-evergreen-tools.git.
+#   The path to clone of https://github.com/mongodb-labs/drivers-evergreen-tools.git.
 #   Defaults to $(pwd)../drivers-evergreen-tools
 # CDRIVER_BUILD
 #   The path to the build of mongo-c-driver (e.g. mongo-c-driver/cmake-build).

--- a/build/evergreen_config_lib/functions.py
+++ b/build/evergreen_config_lib/functions.py
@@ -523,7 +523,7 @@ all_functions = OD([
         shell_mongoc(r'''
         # Add AWS variables to a file.
         # Clone in one directory above so it does not get uploaded in working directory.
-        git clone --depth=1 git://github.com/mongodb-labs/drivers-evergreen-tools.git ../drivers-evergreen-tools
+        git clone --depth=1 https://github.com/mongodb-labs/drivers-evergreen-tools.git ../drivers-evergreen-tools
         cat <<EOF > ../drivers-evergreen-tools/.evergreen/auth_aws/aws_e2e_setup.json
         {
             "iam_auth_ecs_account" : "${iam_auth_ecs_account}",


### PR DESCRIPTION
A straightforward update that substitutes `git://` with `https://`, as [Github is planning to disable support](https://github.blog/2021-09-01-improving-git-protocol-security-github/) for the unencrypted Git protocol. The only instances of this protocol still being used in the C driver appears to be when cloning the [drivers-evergreen-tools](https://github.com/mongodb-labs/drivers-evergreen-tools) repository for Evergreen tasks.