### PR TITLE
CDRIVER-4130 Unconditionally use OP_MSG for server 5.1 and newer

### DIFF
--- a/src/libmongoc/doc/mongoc_collection_find_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_collection_find_with_opts.rst
@@ -132,7 +132,7 @@ Option                   BSON type           Option               BSON type
 ``allowDiskUse``         bool
 =======================  ==================  ===================  ==================
 
-All options are documented in the reference page for `the "find" command`_ in the MongoDB server manual, except for "maxAwaitTimeMS" and "sessionId".
+All options are documented in the reference page for `the "find" command`_ in the MongoDB server manual, except for "maxAwaitTimeMS", "sessionId", and "exhaust".
 
 "maxAwaitTimeMS" is the maximum amount of time for the server to wait on new documents to satisfy a query, if "tailable" and "awaitData" are both true.
 If no new documents are found, the tailable cursor receives an empty batch. The "maxAwaitTimeMS" option is ignored for MongoDB older than 3.4.
@@ -140,6 +140,8 @@ If no new documents are found, the tailable cursor receives an empty batch. The 
 To add a "sessionId", construct a :symbol:`mongoc_client_session_t` with :symbol:`mongoc_client_start_session`. You can begin a transaction with :symbol:`mongoc_client_session_start_transaction`, optionally with a :symbol:`mongoc_transaction_opt_t` that overrides the options inherited from ``collection``. Then use :symbol:`mongoc_client_session_append` to add the session to ``opts``. See the example code for :symbol:`mongoc_client_session_t`.
 
 To add a "readConcern", construct a :symbol:`mongoc_read_concern_t` with :symbol:`mongoc_read_concern_new` and configure it with :symbol:`mongoc_read_concern_set_level`. Then use :symbol:`mongoc_read_concern_append` to add the read concern to ``opts``.
+
+"exhaust" requests the construction of an exhaust cursor. For MongoDB servers before 5.1, this option converts the command into a legacy OP_QUERY message. For MongoDB servers 5.1 and newer, this option is ignored and a normal cursor is constructed instead.
 
 For some options like "collation", the driver returns an error if the server version is too old to support the feature.
 Any fields in ``opts`` that are not listed here are passed to the server unmodified.
@@ -153,7 +155,7 @@ The ``snapshot`` boolean option is removed in MongoDB 4.0. The ``maxScan`` optio
 
 .. seealso::
 
-  | `The "find" command`_ in the MongoDB Manual. All options listed there are supported by the C Driver.  For MongoDB servers before 3.2, or for exhaust queries, the driver transparently converts the query to a legacy OP_QUERY message.
+  | `The "find" command`_ in the MongoDB Manual. All options listed there are supported by the C Driver.  For MongoDB servers before 3.2, the driver transparently converts the query to a legacy OP_QUERY message.
 
 .. _the "find" command: https://docs.mongodb.org/master/reference/command/find/
 

--- a/src/libmongoc/src/mongoc/mongoc-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-cmd.c
@@ -181,7 +181,8 @@ mongoc_cmd_parts_append_opts (mongoc_cmd_parts_t *parts,
          parts->assembled.session = cs;
          continue;
       } else if (BSON_ITER_IS_KEY (iter, "serverId") ||
-                 BSON_ITER_IS_KEY (iter, "maxAwaitTimeMS")) {
+                 BSON_ITER_IS_KEY (iter, "maxAwaitTimeMS") ||
+                 BSON_ITER_IS_KEY (iter, "exhaust")) {
          continue;
       }
 

--- a/src/libmongoc/src/mongoc/mongoc-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-cmd.c
@@ -629,7 +629,8 @@ _mongoc_cmd_parts_assemble_mongod (mongoc_cmd_parts_t *parts,
       case MONGOC_TOPOLOGY_LOAD_BALANCED:
       case MONGOC_TOPOLOGY_DESCRIPTION_TYPES:
       default:
-         /* must not call this function w/ sharded, load balanced, or unknown topology type */
+         /* must not call this function w/ sharded, load balanced, or unknown
+          * topology type */
          BSON_ASSERT (false);
       }
    } /* if (!parts->is_write_command) */
@@ -1024,7 +1025,8 @@ mongoc_cmd_parts_assemble (mongoc_cmd_parts_t *parts,
       ret = true;
    } else if (server_type == MONGOC_SERVER_MONGOS ||
               server_stream->topology_type == MONGOC_TOPOLOGY_LOAD_BALANCED) {
-      /* TODO (CDRIVER-4117) remove the check of the topology description type. */
+      /* TODO (CDRIVER-4117) remove the check of the topology description type.
+       */
       _mongoc_cmd_parts_assemble_mongos (parts, server_stream);
       ret = true;
    } else {

--- a/src/libmongoc/src/mongoc/mongoc-cursor-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor-cmd.c
@@ -51,7 +51,7 @@ _getmore_type (mongoc_cursor_t *cursor)
 
    if (
       /* Server version 5.1 and newer do not support OP_GETMORE. */
-      wire_version > WIRE_VERSION_SNAPSHOT_READS ||
+      wire_version > WIRE_VERSION_5_0 ||
       /* Fallback to legacy OP_GETMORE wire protocol messages if exhaust cursor
          requested with server version 3.6 or newer . */
       (wire_version >= WIRE_VERSION_FIND_CMD &&

--- a/src/libmongoc/src/mongoc/mongoc-cursor-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor-cmd.c
@@ -37,7 +37,7 @@ static getmore_type_t
 _getmore_type (mongoc_cursor_t *cursor)
 {
    mongoc_server_stream_t *server_stream;
-   bool use_cmd;
+   int32_t wire_version;
    data_cmd_t *data = (data_cmd_t *) cursor->impl.data;
    if (data->getmore_type != UNKNOWN) {
       return data->getmore_type;
@@ -46,10 +46,21 @@ _getmore_type (mongoc_cursor_t *cursor)
    if (!server_stream) {
       return UNKNOWN;
    }
-   use_cmd = server_stream->sd->max_wire_version >= WIRE_VERSION_FIND_CMD &&
-             !_mongoc_cursor_get_opt_bool (cursor, MONGOC_CURSOR_EXHAUST);
-   data->getmore_type = use_cmd ? GETMORE_CMD : OP_GETMORE;
+   wire_version = server_stream->sd->max_wire_version;
    mongoc_server_stream_cleanup (server_stream);
+
+   if (
+      /* Server version 5.1 and newer do not support OP_GETMORE. */
+      wire_version > WIRE_VERSION_SNAPSHOT_READS ||
+      /* Fallback to legacy OP_GETMORE wire protocol messages if exhaust cursor
+         requested with server version 3.6 or newer . */
+      (wire_version >= WIRE_VERSION_FIND_CMD &&
+       !_mongoc_cursor_get_opt_bool (cursor, MONGOC_CURSOR_EXHAUST))) {
+      data->getmore_type = GETMORE_CMD;
+   } else {
+      data->getmore_type = OP_GETMORE;
+   }
+
    return data->getmore_type;
 }
 

--- a/src/libmongoc/src/mongoc/mongoc-cursor-find.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor-find.c
@@ -47,7 +47,7 @@ _prime (mongoc_cursor_t *cursor)
    /* set all mongoc_impl_t function pointers. */
    if (
       /* Server version 5.1 and newer do not support OP_QUERY. */
-      wire_version > WIRE_VERSION_SNAPSHOT_READS ||
+      wire_version > WIRE_VERSION_5_0 ||
       /* Fallback to legacy OP_QUERY wire protocol messages if exhaust cursor
          requested with server version 3.6 or newer. */
       (wire_version >= WIRE_VERSION_FIND_CMD &&

--- a/src/libmongoc/src/mongoc/mongoc-cursor-find.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor-find.c
@@ -32,7 +32,7 @@ _mongoc_cursor_impl_find_opquery_init (mongoc_cursor_t *cursor, bson_t *filter);
 static mongoc_cursor_state_t
 _prime (mongoc_cursor_t *cursor)
 {
-   bool use_find_command;
+   int32_t wire_version;
    mongoc_server_stream_t *server_stream;
    data_find_t *data = (data_find_t *) cursor->impl.data;
 
@@ -41,15 +41,17 @@ _prime (mongoc_cursor_t *cursor)
    if (!server_stream) {
       return DONE;
    }
-   /* find_getmore_killcursors spec:
-    * "The find command does not support the exhaust flag from OP_QUERY." */
-   use_find_command =
-      server_stream->sd->max_wire_version >= WIRE_VERSION_FIND_CMD &&
-      !_mongoc_cursor_get_opt_bool (cursor, MONGOC_CURSOR_EXHAUST);
+   wire_version = server_stream->sd->max_wire_version;
    mongoc_server_stream_cleanup (server_stream);
 
    /* set all mongoc_impl_t function pointers. */
-   if (use_find_command) {
+   if (
+      /* Server version 5.1 and newer do not support OP_QUERY. */
+      wire_version > WIRE_VERSION_SNAPSHOT_READS ||
+      /* Fallback to legacy OP_QUERY wire protocol messages if exhaust cursor
+         requested with server version 3.6 or newer. */
+      (wire_version >= WIRE_VERSION_FIND_CMD &&
+       !_mongoc_cursor_get_opt_bool (cursor, MONGOC_CURSOR_EXHAUST))) {
       _mongoc_cursor_impl_find_cmd_init (cursor, &data->filter /* stolen */);
    } else {
       _mongoc_cursor_impl_find_opquery_init (cursor,

--- a/src/libmongoc/src/mongoc/mongoc-cursor.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor.c
@@ -1010,7 +1010,9 @@ _mongoc_cursor_run_command (mongoc_cursor_t *cursor,
       GOTO (done);
    }
 
-   /* Exhaust cursors with OP_MSG not yet supported. Fallback to normal cursor.
+   /* Exhaust cursors with OP_MSG not yet supported; fallback to normal cursor.
+    * user_query_flags is unused in OP_MSG, so this technically has no effect,
+    * but is done anyways to ensure the query flags match handling of options.
     */
    if (parts.user_query_flags & MONGOC_QUERY_EXHAUST) {
       parts.user_query_flags ^= MONGOC_QUERY_EXHAUST;

--- a/src/libmongoc/src/mongoc/mongoc-cursor.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor.c
@@ -963,7 +963,7 @@ _mongoc_cursor_run_command (mongoc_cursor_t *cursor,
          _mongoc_bson_init_if_set (reply);
          GOTO (done);
       }
-      if (_mongoc_cursor_get_opt_bool (cursor, "exhaust")) {
+      if (_mongoc_cursor_get_opt_bool (cursor, MONGOC_CURSOR_EXHAUST)) {
          MONGOC_WARNING (
             "exhaust cursors not supported with OP_MSG, using normal "
             "cursor instead");

--- a/src/libmongoc/src/mongoc/mongoc-cursor.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor.c
@@ -963,6 +963,11 @@ _mongoc_cursor_run_command (mongoc_cursor_t *cursor,
          _mongoc_bson_init_if_set (reply);
          GOTO (done);
       }
+      if (_mongoc_cursor_get_opt_bool (cursor, "exhaust")) {
+         MONGOC_WARNING (
+            "exhaust cursors not supported with OP_MSG, using normal "
+            "cursor instead");
+      }
    }
 
    if (parts.assembled.session) {
@@ -1003,6 +1008,12 @@ _mongoc_cursor_run_command (mongoc_cursor_t *cursor,
           cursor, server_stream, &parts.user_query_flags)) {
       _mongoc_bson_init_if_set (reply);
       GOTO (done);
+   }
+
+   /* Exhaust cursors with OP_MSG not yet supported. Fallback to normal cursor.
+    */
+   if (parts.user_query_flags & MONGOC_QUERY_EXHAUST) {
+      parts.user_query_flags ^= MONGOC_QUERY_EXHAUST;
    }
 
    /* we might use mongoc_cursor_set_hint to target a secondary but have no

--- a/src/libmongoc/tests/test-mongoc-read-prefs.c
+++ b/src/libmongoc/tests/test-mongoc-read-prefs.c
@@ -460,8 +460,8 @@ test_read_prefs_standalone_primary (void)
    mongoc_read_prefs_t *read_prefs;
 
    /* Server Selection Spec: for topology type single and server types other
-    * than mongos, "clients MUST always set the secondaryOk wire protocol flag on
-    * reads to ensure that any server type can handle the request."
+    * than mongos, "clients MUST always set the secondaryOk wire protocol flag
+    * on reads to ensure that any server type can handle the request."
     * */
    read_prefs = mongoc_read_prefs_new (MONGOC_READ_PRIMARY);
 
@@ -822,7 +822,8 @@ test_read_prefs_mongos_max_staleness (void)
       "{}");
 
    mock_server_replies_to_find (request,
-                                MONGOC_QUERY_EXHAUST | MONGOC_QUERY_SECONDARY_OK,
+                                MONGOC_QUERY_EXHAUST |
+                                   MONGOC_QUERY_SECONDARY_OK,
                                 0,
                                 1,
                                 "test.test",


### PR DESCRIPTION
The C driver currently supports [exhaust cursors with OP_QUERY wire protocol messages](https://jira.mongodb.org/browse/CDRIVER-242), but does not support [exhaust cursors with OP_MSG wire protocol messages](https://jira.mongodb.org/browse/CDRIVER-2807). MongoDB Server 5.1 and newer [removes support for OP_QUERY messages](https://jira.mongodb.org/browse/DRIVERS-1857). The [Find, getMore and killCursors commands Spec](https://github.com/mongodb/specifications/blob/8f6f0fd67a479f1a09ca34477823469d0dec0fa9/source/find_getmore_killcursors_commands.rst#exhaust) accordingly requires drivers supporting exhaust cursors to unconditionally use OP_MSG for server versions that support it. However, strict compliance with the spec as currently written would introduce a regression in supported features in the C driver as exhaust cursors with OP_MSG is not yet supported.

Several options were investigated and considered:

1. Prohibit exhaust cursor option given server 5.1 and newer. This would be the most spec-compliant solution, but possibly cause regressions in user code due to new cursor errors predecated on the server version and presence of the exhaust cursor option.
2. Fallback to normal cursor given server 5.1 and newer. This would preserve exhaust cursor behavior up to server 5.1 and minimize scope of regression to performance only (no errors).
3. Do nothing and postpone spec compliance until exhaust cursors with OP_MSG are implemented. Implementing support for exhaust cursors with OP_MSG requires a significant amount of work that is beyond the scope of CDRIVER-4130.

After some consultation, it was decided that Option 2 seems best: for server 5.1 and newer (where OP_QUERY is not supported), the exhaust cursor option will be ignored and a normal cursor will be constructed instead. Given the cursor interface does not distinguish normal cursors from exhaust cursors, this behavior should not be observable beyond log messages and/or possibly some performance regression. More importantly, it should not break existing code behavior while still permitting server upgrades.

Some tests were making use of exhaust cursors when not necessary. These tests were updated to use normal cursors instead. These changes should not be necessary for normal users.