### PR TITLE
CDRIVER-4250: Expose internal validation as mongoc_uri_finalize_options

### DIFF
--- a/src/libmongoc/doc/mongoc_uri_finalize_options.rst
+++ b/src/libmongoc/doc/mongoc_uri_finalize_options.rst
@@ -1,0 +1,35 @@
+:man_page: mongoc_uri_finalize_options
+
+mongoc_uri_finalize_options()
+=============================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  bool
+  mongoc_uri_finalize_options (mongoc_uri_t *uri);
+                               bson_error_t *error);
+
+Parameters
+----------
+
+* ``uri``: A :symbol:`mongoc_uri_t`.
+* ``error``: An optional location for a :symbol:`bson_error_t <errors>` or ``NULL``.
+
+Description
+-----------
+
+Finalizes URI options and checks for invalid combinations of options.
+
+This function should be called after setting individual options on a URI and
+before using the URI to construct a client or client pool. It is not necessary
+to call this function if additional options have not been set on the URI after
+its construction from a string (e.g. :symbol:`mongoc_uri_new_with_error`).
+
+Returns
+-------
+
+Returns true if ``uri`` is successfully finalized and valid; otherwise false and
+populates ``error`` with the error description.

--- a/src/libmongoc/doc/mongoc_uri_set_auth_mechanism.rst
+++ b/src/libmongoc/doc/mongoc_uri_set_auth_mechanism.rst
@@ -32,3 +32,7 @@ Returns false if the option cannot be set, for example if ``value`` is not valid
 .. only:: html
 
   .. include:: includes/seealso/authmechanism.txt
+
+.. seealso::
+
+  | :symbol:`mongoc_uri_finalize_options`

--- a/src/libmongoc/doc/mongoc_uri_set_auth_source.rst
+++ b/src/libmongoc/doc/mongoc_uri_set_auth_source.rst
@@ -32,3 +32,7 @@ Returns false if the option cannot be set, for example if ``value`` is not valid
 .. only:: html
 
   .. include:: includes/seealso/authmechanism.txt
+
+.. seealso::
+
+  | :symbol:`mongoc_uri_finalize_options`

--- a/src/libmongoc/doc/mongoc_uri_set_compressors.rst
+++ b/src/libmongoc/doc/mongoc_uri_set_compressors.rst
@@ -43,3 +43,6 @@ Returns false if the option cannot be set, for example if ``compressors`` is not
 Logs a warning to stderr with the :doc:`MONGOC_WARNING <logging>` macro
 if compressor is not available.
 
+.. seealso::
+
+  | :symbol:`mongoc_uri_finalize_options`

--- a/src/libmongoc/doc/mongoc_uri_set_database.rst
+++ b/src/libmongoc/doc/mongoc_uri_set_database.rst
@@ -29,3 +29,6 @@ Returns
 
 Returns false if the option cannot be set, for example if ``database`` is not valid UTF-8.
 
+.. seealso::
+
+  | :symbol:`mongoc_uri_finalize_options`

--- a/src/libmongoc/doc/mongoc_uri_set_mechanism_properties.rst
+++ b/src/libmongoc/doc/mongoc_uri_set_mechanism_properties.rst
@@ -52,3 +52,6 @@ Example
 
   .. include:: includes/seealso/authmechanism.txt
 
+.. seealso::
+
+  | :symbol:`mongoc_uri_finalize_options`

--- a/src/libmongoc/doc/mongoc_uri_set_option_as_bool.rst
+++ b/src/libmongoc/doc/mongoc_uri_set_option_as_bool.rst
@@ -34,3 +34,6 @@ Returns
 
 True if successfully set (the named option is a known option of type bool).
 
+.. seealso::
+
+  | :symbol:`mongoc_uri_finalize_options`

--- a/src/libmongoc/doc/mongoc_uri_set_option_as_int32.rst
+++ b/src/libmongoc/doc/mongoc_uri_set_option_as_int32.rst
@@ -38,3 +38,4 @@ True if successfully set (the named option is a known option of type int32 or in
 
   | :symbol:`mongoc_uri_set_option_as_int64()`
 
+  | :symbol:`mongoc_uri_finalize_options`

--- a/src/libmongoc/doc/mongoc_uri_set_option_as_int64.rst
+++ b/src/libmongoc/doc/mongoc_uri_set_option_as_int64.rst
@@ -40,3 +40,4 @@ True if successfully set (the named option is a known option of type int64).
 
   | :symbol:`mongoc_uri_set_option_as_int32()`
 
+  | :symbol:`mongoc_uri_finalize_options`

--- a/src/libmongoc/doc/mongoc_uri_set_option_as_utf8.rst
+++ b/src/libmongoc/doc/mongoc_uri_set_option_as_utf8.rst
@@ -34,3 +34,6 @@ Returns
 
 True if successfully set (the named option is a known option of string type).
 
+.. seealso::
+
+  | :symbol:`mongoc_uri_finalize_options`

--- a/src/libmongoc/doc/mongoc_uri_set_password.rst
+++ b/src/libmongoc/doc/mongoc_uri_set_password.rst
@@ -27,3 +27,6 @@ Returns
 
 Returns false if the option cannot be set, for example if ``password`` is not valid UTF-8.
 
+.. seealso::
+
+  | :symbol:`mongoc_uri_finalize_options`

--- a/src/libmongoc/doc/mongoc_uri_set_read_concern.rst
+++ b/src/libmongoc/doc/mongoc_uri_set_read_concern.rst
@@ -23,3 +23,6 @@ Description
 
 Sets a MongoDB URI's read concern option, after the URI has been parsed from a string.
 
+.. seealso::
+
+  | :symbol:`mongoc_uri_finalize_options`

--- a/src/libmongoc/doc/mongoc_uri_set_read_prefs_t.rst
+++ b/src/libmongoc/doc/mongoc_uri_set_read_prefs_t.rst
@@ -23,3 +23,6 @@ Description
 
 Sets a MongoDB URI's read preferences, after the URI has been parsed from a string.
 
+.. seealso::
+
+  | :symbol:`mongoc_uri_finalize_options`

--- a/src/libmongoc/doc/mongoc_uri_set_username.rst
+++ b/src/libmongoc/doc/mongoc_uri_set_username.rst
@@ -27,3 +27,6 @@ Returns
 
 Returns false if the option cannot be set, for example if ``username`` is not valid UTF-8.
 
+.. seealso::
+
+  | :symbol:`mongoc_uri_finalize_options`

--- a/src/libmongoc/doc/mongoc_uri_set_write_concern.rst
+++ b/src/libmongoc/doc/mongoc_uri_set_write_concern.rst
@@ -23,3 +23,6 @@ Description
 
 Sets a MongoDB URI's write concern option, after the URI has been parsed from a string.
 
+.. seealso::
+
+  | :symbol:`mongoc_uri_finalize_options`

--- a/src/libmongoc/doc/mongoc_uri_t.rst
+++ b/src/libmongoc/doc/mongoc_uri_t.rst
@@ -283,6 +283,7 @@ MONGOC_URI_SAFE                            safe                              {tr
 
     mongoc_uri_copy
     mongoc_uri_destroy
+    mongoc_uri_finalize_options
     mongoc_uri_get_auth_mechanism
     mongoc_uri_get_auth_source
     mongoc_uri_get_compressors

--- a/src/libmongoc/src/mongoc/mongoc-uri.c
+++ b/src/libmongoc/src/mongoc/mongoc-uri.c
@@ -1620,9 +1620,8 @@ mongoc_uri_parse (mongoc_uri_t *uri, const char *str, bson_error_t *error)
       }
    }
 
-   /* TODO (CDRIVER-3723) Consider moving all "finalize" calls into one function
-    * that is additionally called after initial SRV and TXT records are applied
-    * in mongoc_topology_new. */
+   /* TODO (CDRIVER-3723) Consider calling mongoc_uri_finalize_options after 
+    * initial SRV and TXT records are applied in mongoc_topology_new. */
    if (!mongoc_uri_finalize_options (uri, error)) {
       goto error;
    }
@@ -3306,7 +3305,7 @@ mongoc_uri_finalize_srv (const mongoc_uri_t *uri, bson_error_t *error)
 bool
 mongoc_uri_finalize_options (mongoc_uri_t *uri, bson_error_t *error)
 {
-   BSON_ASSERT (uri);
+   BSON_ASSERT_PARAM (uri);
 
    if (!mongoc_uri_finalize_tls (uri, error)) {
       return false;

--- a/src/libmongoc/src/mongoc/mongoc-uri.c
+++ b/src/libmongoc/src/mongoc/mongoc-uri.c
@@ -1404,7 +1404,7 @@ mongoc_uri_finalize_auth (mongoc_uri_t *uri,
 {
    bson_iter_t iter;
    const char *source = NULL;
-   bool require_auth = uri->username != NULL;
+   const bool require_auth = uri->username != NULL;
 
    if (bson_iter_init_find_case (
           &iter, &uri->credentials, MONGOC_URI_AUTHSOURCE)) {

--- a/src/libmongoc/src/mongoc/mongoc-uri.c
+++ b/src/libmongoc/src/mongoc/mongoc-uri.c
@@ -1400,11 +1400,11 @@ mongoc_uri_finalize_tls (mongoc_uri_t *uri, bson_error_t *error)
 
 static bool
 mongoc_uri_finalize_auth (mongoc_uri_t *uri,
-                          bson_error_t *error,
-                          bool require_auth)
+                          bson_error_t *error)
 {
    bson_iter_t iter;
    const char *source = NULL;
+   bool require_auth = uri->username != NULL;
 
    if (bson_iter_init_find_case (
           &iter, &uri->credentials, MONGOC_URI_AUTHSOURCE)) {
@@ -1569,7 +1569,6 @@ mongoc_uri_parse (mongoc_uri_t *uri, const char *str, bson_error_t *error)
 {
    char *before_slash = NULL;
    const char *tmp;
-   bool require_auth = false;
 
    if (!bson_utf8_validate (str, strlen (str), false /* allow_null */)) {
       MONGOC_URI_ERROR (error, "%s", "Invalid UTF-8 in URI");
@@ -1624,24 +1623,7 @@ mongoc_uri_parse (mongoc_uri_t *uri, const char *str, bson_error_t *error)
    /* TODO (CDRIVER-3723) Consider moving all "finalize" calls into one function
     * that is additionally called after initial SRV and TXT records are applied
     * in mongoc_topology_new. */
-   if (!mongoc_uri_finalize_tls (uri, error)) {
-      goto error;
-   }
-
-   require_auth = uri->username != NULL;
-   if (!mongoc_uri_finalize_auth (uri, error, require_auth)) {
-      goto error;
-   }
-
-   if (!mongoc_uri_finalize_directconnection (uri, error)) {
-      goto error;
-   }
-
-   if (!mongoc_uri_finalize_loadbalanced (uri, error)) {
-      goto error;
-   }
-
-   if (!mongoc_uri_finalize_srv (uri, error)) {
+   if (!mongoc_uri_finalize_options (uri, error)) {
       goto error;
    }
 
@@ -3316,6 +3298,34 @@ mongoc_uri_finalize_srv (const mongoc_uri_t *uri, bson_error_t *error)
             return false;
          }
       }
+   }
+
+   return true;
+}
+
+bool
+mongoc_uri_finalize_options (mongoc_uri_t *uri, bson_error_t *error)
+{
+   BSON_ASSERT (uri);
+
+   if (!mongoc_uri_finalize_tls (uri, error)) {
+      return false;
+   }
+
+   if (!mongoc_uri_finalize_auth (uri, error)) {
+      return false;
+   }
+
+   if (!mongoc_uri_finalize_directconnection (uri, error)) {
+      return false;
+   }
+
+   if (!mongoc_uri_finalize_loadbalanced (uri, error)) {
+      return false;
+   }
+
+   if (!mongoc_uri_finalize_srv (uri, error)) {
+      return false;
    }
 
    return true;

--- a/src/libmongoc/src/mongoc/mongoc-uri.h
+++ b/src/libmongoc/src/mongoc/mongoc-uri.h
@@ -225,6 +225,8 @@ mongoc_uri_get_read_concern (const mongoc_uri_t *uri);
 MONGOC_EXPORT (void)
 mongoc_uri_set_read_concern (mongoc_uri_t *uri,
                              const mongoc_read_concern_t *rc);
+MONGOC_EXPORT (bool)
+mongoc_uri_finalize_options (mongoc_uri_t *uri, bson_error_t *error);
 
 BSON_END_DECLS
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-4250

I originally considered using a name like `is_valid` or `validate` but realized these do more than just _check_ the options. `mongoc_uri_finalize_tls` and `mongoc_uri_finalize_auth` actually modify the URI in certain cases.

I was fairly liberal with the `seealso` links and placed them on any function that can be used to alter the URI after it is constructed/parsed. Finalization technically isn't necessary after setting something like read prefs on a URI, but I felt it didn't hurt to be consistent (esp. if logic changes down the line). I also decided _not_ to reference the new function on the client and pool constructors since it wouldn't apply to all (or even the most common) use cases.