### PR TITLE
add option to ignore system CMake

### DIFF
--- a/.evergreen/find-cmake.sh
+++ b/.evergreen/find-cmake.sh
@@ -11,7 +11,7 @@ find_cmake ()
     CMAKE="/Applications/Cmake.app/Contents/bin/cmake"
   elif [ -f "/opt/cmake/bin/cmake" ]; then
     CMAKE="/opt/cmake/bin/cmake"
-  elif command -v cmake 2>/dev/null; then
+  elif [ -z "$IGNORE_SYSTEM_CMAKE" ] && command -v cmake 2>/dev/null; then
      CMAKE=cmake
   elif uname -a | grep -iq 'x86_64 GNU/Linux'; then
      if [ -f "$(pwd)/cmake-3.11.0/bin/cmake" ]; then


### PR DESCRIPTION
(This change would help facilitate building on platforms with a system CMake that is too old, like Amazon Linux 2, that has CMake version 2.8 at /usr/bin/cmake).

Evergreen patch build: https://spruce.mongodb.com/version/61cba5b63e8e86449da91664/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC