### PR TITLE
CDRIVER-4237 - Address incompatible pointer warnings on GCC 4.8.5

### DIFF
--- a/src/libbson/src/bson/bson-atomic.h
+++ b/src/libbson/src/bson/bson-atomic.h
@@ -343,7 +343,7 @@ enum bson_memory_order {
 
 #if defined(_MSC_VER) || defined(BSON_USE_LEGACY_GCC_ATOMICS)
 /* MSVC expects precise types for their atomic intrinsics. */
-DECL_ATOMIC_INTEGRAL (int8, char, 8);
+DECL_ATOMIC_INTEGRAL (int8, char, 8)
 DECL_ATOMIC_INTEGRAL (int16, short, 16)
 #if !defined(BSON_EMULATE_INT32)
 DECL_ATOMIC_INTEGRAL (int32, long, )

--- a/src/libbson/src/bson/bson-atomic.h
+++ b/src/libbson/src/bson/bson-atomic.h
@@ -342,14 +342,24 @@ enum bson_memory_order {
    DECL_ATOMIC_INTEGRAL (Name, Name##_t, VCSuffix)
 
 #if defined(_MSC_VER) || defined(BSON_USE_LEGACY_GCC_ATOMICS)
-/* MSVC expects precise types for their atomic intrinsics. */
-DECL_ATOMIC_INTEGRAL (int8, char, 8)
+/* MSVC and GCC require built-in types (not typedefs) for their atomic
+ * intrinsics. */
+#if defined(_MSC_VER)
+#define DECL_ATOMIC_INTEGRAL_INT8 char  /* int8_t -> char */
+#define DECL_ATOMIC_INTEGRAL_INT32 long /* int32_t -> long */
+#define DECL_ATOMIC_INTEGRAL_INT long   /* Only long overloads */
+#else
+#define DECL_ATOMIC_INTEGRAL_INT8 signed char
+#define DECL_ATOMIC_INTEGRAL_INT32 int
+#define DECL_ATOMIC_INTEGRAL_INT int
+#endif
+DECL_ATOMIC_INTEGRAL (int8, DECL_ATOMIC_INTEGRAL_INT8, 8)
 DECL_ATOMIC_INTEGRAL (int16, short, 16)
 #if !defined(BSON_EMULATE_INT32)
-DECL_ATOMIC_INTEGRAL (int32, long, )
+DECL_ATOMIC_INTEGRAL (int32, DECL_ATOMIC_INTEGRAL_INT32, )
 #endif
 #if !defined(BSON_EMULATE_INT)
-DECL_ATOMIC_INTEGRAL (int, long, )
+DECL_ATOMIC_INTEGRAL (int, DECL_ATOMIC_INTEGRAL_INT, )
 #endif
 #else
 /* Other compilers that we support provide generic intrinsics */

--- a/src/libbson/src/bson/bson-atomic.h
+++ b/src/libbson/src/bson/bson-atomic.h
@@ -345,9 +345,9 @@ enum bson_memory_order {
 /* MSVC and GCC require built-in types (not typedefs) for their atomic
  * intrinsics. */
 #if defined(_MSC_VER)
-#define DECL_ATOMIC_INTEGRAL_INT8 char  /* int8_t -> char */
-#define DECL_ATOMIC_INTEGRAL_INT32 long /* int32_t -> long */
-#define DECL_ATOMIC_INTEGRAL_INT long   /* Only long overloads */
+#define DECL_ATOMIC_INTEGRAL_INT8 char
+#define DECL_ATOMIC_INTEGRAL_INT32 long
+#define DECL_ATOMIC_INTEGRAL_INT long
 #else
 #define DECL_ATOMIC_INTEGRAL_INT8 signed char
 #define DECL_ATOMIC_INTEGRAL_INT32 int

--- a/src/libbson/src/bson/bson-atomic.h
+++ b/src/libbson/src/bson/bson-atomic.h
@@ -167,6 +167,10 @@ enum bson_memory_order {
    } while (0)
 
 
+/* Address empty macro argument warnings prior to C99. */
+#define DECL_ATOMIC_INTEGRAL_EMPTY_ARG
+
+
 #define DECL_ATOMIC_INTEGRAL(NamePart, Type, VCIntrinSuffix)                  \
    static BSON_INLINE Type bson_atomic_##NamePart##_fetch_add (               \
       Type volatile *a, Type addend, enum bson_memory_order ord)              \
@@ -261,8 +265,12 @@ enum bson_memory_order {
       case bson_memory_order_release:                                         \
       case bson_memory_order_acq_rel:                                         \
       case bson_memory_order_seq_cst:                                         \
-         DEF_ATOMIC_CMPEXCH_STRONG (                                          \
-            VCIntrinSuffix, , __ATOMIC_SEQ_CST, a, actual, new_value);        \
+         DEF_ATOMIC_CMPEXCH_STRONG (VCIntrinSuffix,                           \
+                                    DECL_ATOMIC_EMPTY_MACRO_ARG,              \
+                                    __ATOMIC_SEQ_CST,                         \
+                                    a,                                        \
+                                    actual,                                   \
+                                    new_value);                               \
          break;                                                               \
       case bson_memory_order_acquire:                                         \
          DEF_ATOMIC_CMPEXCH_STRONG (VCIntrinSuffix,                           \
@@ -305,8 +313,12 @@ enum bson_memory_order {
       case bson_memory_order_release:                                         \
       case bson_memory_order_acq_rel:                                         \
       case bson_memory_order_seq_cst:                                         \
-         DEF_ATOMIC_CMPEXCH_WEAK (                                            \
-            VCIntrinSuffix, , __ATOMIC_SEQ_CST, a, actual, new_value);        \
+         DEF_ATOMIC_CMPEXCH_WEAK (VCIntrinSuffix,                             \
+                                  DECL_ATOMIC_EMPTY_MACRO_ARG,                \
+                                  __ATOMIC_SEQ_CST,                           \
+                                  a,                                          \
+                                  actual,                                     \
+                                  new_value);                                 \
          break;                                                               \
       case bson_memory_order_acquire:                                         \
          DEF_ATOMIC_CMPEXCH_WEAK (VCIntrinSuffix,                             \
@@ -345,9 +357,9 @@ enum bson_memory_order {
 /* MSVC and GCC require built-in types (not typedefs) for their atomic
  * intrinsics. */
 #if defined(_MSC_VER)
-#define DECL_ATOMIC_INTEGRAL_INT8 char  /* int8_t -> char */
-#define DECL_ATOMIC_INTEGRAL_INT32 long /* int32_t -> long */
-#define DECL_ATOMIC_INTEGRAL_INT long   /* Only long overloads */
+#define DECL_ATOMIC_INTEGRAL_INT8 char
+#define DECL_ATOMIC_INTEGRAL_INT32 long
+#define DECL_ATOMIC_INTEGRAL_INT long
 #else
 #define DECL_ATOMIC_INTEGRAL_INT8 signed char
 #define DECL_ATOMIC_INTEGRAL_INT32 int
@@ -356,20 +368,24 @@ enum bson_memory_order {
 DECL_ATOMIC_INTEGRAL (int8, DECL_ATOMIC_INTEGRAL_INT8, 8)
 DECL_ATOMIC_INTEGRAL (int16, short, 16)
 #if !defined(BSON_EMULATE_INT32)
-DECL_ATOMIC_INTEGRAL (int32, DECL_ATOMIC_INTEGRAL_INT32, )
+DECL_ATOMIC_INTEGRAL (int32,
+                      DECL_ATOMIC_INTEGRAL_INT32,
+                      DECL_ATOMIC_EMPTY_MACRO_ARG)
 #endif
 #if !defined(BSON_EMULATE_INT)
-DECL_ATOMIC_INTEGRAL (int, DECL_ATOMIC_INTEGRAL_INT, )
+DECL_ATOMIC_INTEGRAL (int,
+                      DECL_ATOMIC_INTEGRAL_INT,
+                      DECL_ATOMIC_EMPTY_MACRO_ARG)
 #endif
 #else
 /* Other compilers that we support provide generic intrinsics */
 DECL_ATOMIC_STDINT (int8, 8)
 DECL_ATOMIC_STDINT (int16, 16)
 #if !defined(BSON_EMULATE_INT32)
-DECL_ATOMIC_STDINT (int32, )
+DECL_ATOMIC_STDINT (int32, DECL_ATOMIC_EMPTY_MACRO_ARG)
 #endif
 #if !defined(BSON_EMULATE_INT)
-DECL_ATOMIC_INTEGRAL (int, int, )
+DECL_ATOMIC_INTEGRAL (int, int, DECL_ATOMIC_EMPTY_MACRO_ARG)
 #endif
 #endif
 
@@ -611,15 +627,19 @@ bson_atomic_ptr_exchange (void *volatile *ptr,
    /* The older __sync_val_compare_and_swap also takes oldval */
 #if defined(BSON_USE_LEGACY_GCC_ATOMICS)
    DEF_ATOMIC_OP (_InterlockedExchangePointer,
-                  ,
+                  DECL_ATOMIC_EMPTY_MACRO_ARG,
                   __sync_val_compare_and_swap,
                   ord,
                   ptr,
                   *ptr,
                   new_value);
 #else
-   DEF_ATOMIC_OP (
-      _InterlockedExchangePointer, __atomic_exchange_n, , ord, ptr, new_value);
+   DEF_ATOMIC_OP (_InterlockedExchangePointer,
+                  __atomic_exchange_n,
+                  DECL_ATOMIC_EMPTY_MACRO_ARG,
+                  ord,
+                  ptr,
+                  new_value);
 #endif
 }
 
@@ -633,8 +653,12 @@ bson_atomic_ptr_compare_exchange_strong (void *volatile *ptr,
    case bson_memory_order_release:
    case bson_memory_order_acq_rel:
    case bson_memory_order_seq_cst:
-      DEF_ATOMIC_CMPEXCH_STRONG (
-         Pointer, , __ATOMIC_SEQ_CST, ptr, expect, new_value);
+      DEF_ATOMIC_CMPEXCH_STRONG (Pointer,
+                                 DECL_ATOMIC_EMPTY_MACRO_ARG,
+                                 __ATOMIC_SEQ_CST,
+                                 ptr,
+                                 expect,
+                                 new_value);
       return expect;
    case bson_memory_order_relaxed:
       DEF_ATOMIC_CMPEXCH_STRONG (Pointer,
@@ -676,8 +700,12 @@ bson_atomic_ptr_compare_exchange_weak (void *volatile *ptr,
    case bson_memory_order_release:
    case bson_memory_order_acq_rel:
    case bson_memory_order_seq_cst:
-      DEF_ATOMIC_CMPEXCH_WEAK (
-         Pointer, , __ATOMIC_SEQ_CST, ptr, expect, new_value);
+      DEF_ATOMIC_CMPEXCH_WEAK (Pointer,
+                               DECL_ATOMIC_EMPTY_MACRO_ARG,
+                               __ATOMIC_SEQ_CST,
+                               ptr,
+                               expect,
+                               new_value);
       return expect;
    case bson_memory_order_relaxed:
       DEF_ATOMIC_CMPEXCH_WEAK (Pointer,

--- a/src/libbson/src/bson/bson-atomic.h
+++ b/src/libbson/src/bson/bson-atomic.h
@@ -47,8 +47,7 @@ enum bson_memory_order {
 #define MSVC_MEMORDER_SUFFIX(X)
 #endif
 
-#if defined(USE_LEGACY_GCC_ATOMICS) || \
-   (!defined(__clang__) && __GNUC__ == 4)
+#if defined(USE_LEGACY_GCC_ATOMICS) || (!defined(__clang__) && __GNUC__ == 4)
 #define BSON_USE_LEGACY_GCC_ATOMICS
 #else
 #undef BSON_USE_LEGACY_GCC_ATOMICS
@@ -74,7 +73,8 @@ enum bson_memory_order {
 #define BSON_EMULATE_INT
 #endif
 
-#define DEF_ATOMIC_OP(MSVC_Intrinsic, GNU_Intrinsic, GNU_Legacy_Intrinsic, Order, ...) \
+#define DEF_ATOMIC_OP(                                                       \
+   MSVC_Intrinsic, GNU_Intrinsic, GNU_Legacy_Intrinsic, Order, ...)          \
    do {                                                                      \
       switch (Order) {                                                       \
       case bson_memory_order_acq_rel:                                        \
@@ -127,47 +127,43 @@ enum bson_memory_order {
    } while (0)
 
 
-#define DEF_ATOMIC_CMPEXCH_STRONG(                                          \
-   VCSuffix1, VCSuffix2, GNU_MemOrder, Ptr, ExpectActualVar, NewValue)      \
-   do {                                                                     \
-      BSON_IF_MSVC (ExpectActualVar = BSON_CONCAT3 (                        \
-                       _InterlockedCompareExchange, VCSuffix1, VCSuffix2) ( \
-                       Ptr, NewValue, ExpectActualVar);)                    \
-      BSON_IF_GNU_LIKE (                                                    \
-         (void) __atomic_compare_exchange_n (Ptr,                           \
-                                             &ExpectActualVar,              \
-                                             NewValue,                      \
-                                             false, /* Not weak */          \
-                                             GNU_MemOrder,                  \
-                                             GNU_MemOrder);)                \
-      BSON_IF_GNU_LEGACY_ATOMICS (                                          \
-         __typeof__ (ExpectActualVar) _val;                                 \
-         _val = __sync_val_compare_and_swap (Ptr,                           \
-                                             ExpectActualVar,               \
-                                             NewValue);                     \
-         ExpectActualVar = _val;)                                           \
+#define DEF_ATOMIC_CMPEXCH_STRONG(                                            \
+   VCSuffix1, VCSuffix2, GNU_MemOrder, Ptr, ExpectActualVar, NewValue)        \
+   do {                                                                       \
+      BSON_IF_MSVC (ExpectActualVar = BSON_CONCAT3 (                          \
+                       _InterlockedCompareExchange, VCSuffix1, VCSuffix2) (   \
+                       Ptr, NewValue, ExpectActualVar);)                      \
+      BSON_IF_GNU_LIKE (                                                      \
+         (void) __atomic_compare_exchange_n (Ptr,                             \
+                                             &ExpectActualVar,                \
+                                             NewValue,                        \
+                                             false, /* Not weak */            \
+                                             GNU_MemOrder,                    \
+                                             GNU_MemOrder);)                  \
+      BSON_IF_GNU_LEGACY_ATOMICS (                                            \
+         __typeof__ (ExpectActualVar) _val;                                   \
+         _val = __sync_val_compare_and_swap (Ptr, ExpectActualVar, NewValue); \
+         ExpectActualVar = _val;)                                             \
    } while (0)
 
 
-#define DEF_ATOMIC_CMPEXCH_WEAK(                                            \
-   VCSuffix1, VCSuffix2, GNU_MemOrder, Ptr, ExpectActualVar, NewValue)      \
-   do {                                                                     \
-      BSON_IF_MSVC (ExpectActualVar = BSON_CONCAT3 (                        \
-                       _InterlockedCompareExchange, VCSuffix1, VCSuffix2) ( \
-                       Ptr, NewValue, ExpectActualVar);)                    \
-      BSON_IF_GNU_LIKE (                                                    \
-         (void) __atomic_compare_exchange_n (Ptr,                           \
-                                             &ExpectActualVar,              \
-                                             NewValue,                      \
-                                             true, /* Yes weak */           \
-                                             GNU_MemOrder,                  \
-                                             GNU_MemOrder);)                \
-      BSON_IF_GNU_LEGACY_ATOMICS (                                          \
-         __typeof__ (ExpectActualVar) _val;                                 \
-         _val = __sync_val_compare_and_swap (Ptr,                           \
-                                             ExpectActualVar,               \
-                                             NewValue);                     \
-         ExpectActualVar = _val;)                                           \
+#define DEF_ATOMIC_CMPEXCH_WEAK(                                              \
+   VCSuffix1, VCSuffix2, GNU_MemOrder, Ptr, ExpectActualVar, NewValue)        \
+   do {                                                                       \
+      BSON_IF_MSVC (ExpectActualVar = BSON_CONCAT3 (                          \
+                       _InterlockedCompareExchange, VCSuffix1, VCSuffix2) (   \
+                       Ptr, NewValue, ExpectActualVar);)                      \
+      BSON_IF_GNU_LIKE (                                                      \
+         (void) __atomic_compare_exchange_n (Ptr,                             \
+                                             &ExpectActualVar,                \
+                                             NewValue,                        \
+                                             true, /* Yes weak */             \
+                                             GNU_MemOrder,                    \
+                                             GNU_MemOrder);)                  \
+      BSON_IF_GNU_LEGACY_ATOMICS (                                            \
+         __typeof__ (ExpectActualVar) _val;                                   \
+         _val = __sync_val_compare_and_swap (Ptr, ExpectActualVar, NewValue); \
+         ExpectActualVar = _val;)                                             \
    } while (0)
 
 
@@ -217,7 +213,10 @@ enum bson_memory_order {
          default:                                                             \
             BSON_UNREACHABLE ("Invalid bson_memory_order value");             \
       })                                                                      \
-      BSON_IF_GNU_LEGACY_ATOMICS ({ __sync_synchronize (); return *a; })      \
+      BSON_IF_GNU_LEGACY_ATOMICS ({                                           \
+         __sync_synchronize ();                                               \
+         return *a;                                                           \
+      })                                                                      \
    }                                                                          \
                                                                               \
    static BSON_INLINE Type bson_atomic_##NamePart##_exchange (                \
@@ -342,24 +341,24 @@ enum bson_memory_order {
 #define DECL_ATOMIC_STDINT(Name, VCSuffix) \
    DECL_ATOMIC_INTEGRAL (Name, Name##_t, VCSuffix)
 
-#if defined(_MSC_VER) || defined (BSON_USE_LEGACY_GCC_ATOMICS)
+#if defined(_MSC_VER) || defined(BSON_USE_LEGACY_GCC_ATOMICS)
 /* MSVC expects precise types for their atomic intrinsics. */
 DECL_ATOMIC_INTEGRAL (int8, char, 8);
 DECL_ATOMIC_INTEGRAL (int16, short, 16)
-#if !defined (BSON_EMULATE_INT32)
+#if !defined(BSON_EMULATE_INT32)
 DECL_ATOMIC_INTEGRAL (int32, long, )
 #endif
-#if !defined (BSON_EMULATE_INT)
+#if !defined(BSON_EMULATE_INT)
 DECL_ATOMIC_INTEGRAL (int, long, )
 #endif
 #else
 /* Other compilers that we support provide generic intrinsics */
 DECL_ATOMIC_STDINT (int8, 8)
 DECL_ATOMIC_STDINT (int16, 16)
-#if !defined (BSON_EMULATE_INT32)
+#if !defined(BSON_EMULATE_INT32)
 DECL_ATOMIC_STDINT (int32, )
 #endif
-#if !defined (BSON_EMULATE_INT)
+#if !defined(BSON_EMULATE_INT)
 DECL_ATOMIC_INTEGRAL (int, int, )
 #endif
 #endif
@@ -609,12 +608,8 @@ bson_atomic_ptr_exchange (void *volatile *ptr,
                   *ptr,
                   new_value);
 #else
-   DEF_ATOMIC_OP (_InterlockedExchangePointer,
-                  __atomic_exchange_n,
-                  ,
-                  ord,
-                  ptr,
-                  new_value);
+   DEF_ATOMIC_OP (
+      _InterlockedExchangePointer, __atomic_exchange_n, , ord, ptr, new_value);
 #endif
 }
 


### PR DESCRIPTION
This PR aims to resolve CDRIVER-4237, depended on by [PHP-2013](https://jira.mongodb.org/browse/PHPC-2013).

~Four~ Three types of warnings are addressed by this PR (as described by GCC 4.8.5):
- ISO C does not allow extra `;` outside of a function [-Wpedantic]
- passing argument `{N}` of `{func}` from incompatible pointer type [enabled by default]
- pointer targets in passing argument `{N}` of `{func}` differ in signedness [-Wpointer-sign]
- ~empty macro arguments are undefined in ISO C90 and ISO C++98 [enabled by default]~

Followup changes in addition to the current set may need to be added to fully resolve [PHP-2013](https://jira.mongodb.org/browse/PHPC-2013). These will be added as demanded in response to code review.