### PR TITLE
bson-atomic.h: Fix compiler warning in bson_atomic_thread_fence()

### DIFF
--- a/src/libbson/src/bson/bson-atomic.h
+++ b/src/libbson/src/bson/bson-atomic.h
@@ -722,7 +722,7 @@ bson_atomic_ptr_fetch (void *volatile const *ptr, enum bson_memory_order ord)
  * @brief Generate a full-fence memory barrier at the call site.
  */
 static BSON_INLINE void
-bson_atomic_thread_fence ()
+bson_atomic_thread_fence (void)
 {
    BSON_IF_MSVC (MemoryBarrier ();)
    BSON_IF_GNU_LIKE (__sync_synchronize ();)


### PR DESCRIPTION
Fixes following compiler warning appearing constantly while building
open5gs project, which uses libbson:

/usr/include/libbson-1.0/bson/bson-atomic.h:725:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  725 | bson_atomic_thread_fence ()
      | ^~~~~~~~~~~~~~~~~~~~~~~~