### PR TITLE
CDRIVER-4264 Address build failures on VS 2013 variants on Evergreen

### DIFF
--- a/src/libbson/src/bson/bson-atomic.c
+++ b/src/libbson/src/bson/bson-atomic.c
@@ -48,7 +48,7 @@ bson_memory_barrier (void)
 }
 
 /**
- * Some platforms do not support compiler intrinsics for atomic operations.
+ * Some platforms do not support compiler ics for atomic operations.
  * We emulate that here using a spin lock and regular arithmetic operations
  */
 static int8_t gEmulAtomicLock = 0;
@@ -244,4 +244,17 @@ _bson_emul_atomic_int_compare_exchange_weak (volatile int *p,
    /* We're emulating. We can't do a weak version. */
    return _bson_emul_atomic_int_compare_exchange_strong (
       p, expect_value, new_value, order);
+}
+
+void *
+_bson_emul_atomic_ptr_exchange (void *volatile *p,
+                                void *n,
+                                enum bson_memory_order _unused)
+{
+   void *ret;
+   _lock_emul_atomic ();
+   ret = *p;
+   *p = n;
+   _unlock_emul_atomic ();
+   return ret;
 }

--- a/src/libbson/src/bson/bson-atomic.c
+++ b/src/libbson/src/bson/bson-atomic.c
@@ -195,8 +195,8 @@ _bson_emul_atomic_int32_compare_exchange_weak (volatile int32_t *p,
 
 int
 _bson_emul_atomic_int_fetch_add (volatile int *p,
-                                   int n,
-                                   enum bson_memory_order _unused)
+                                 int n,
+                                 enum bson_memory_order _unused)
 {
    int ret;
    _lock_emul_atomic ();
@@ -208,8 +208,8 @@ _bson_emul_atomic_int_fetch_add (volatile int *p,
 
 int
 _bson_emul_atomic_int_exchange (volatile int *p,
-                                  int n,
-                                  enum bson_memory_order _unused)
+                                int n,
+                                enum bson_memory_order _unused)
 {
    int ret;
    _lock_emul_atomic ();
@@ -221,9 +221,9 @@ _bson_emul_atomic_int_exchange (volatile int *p,
 
 int
 _bson_emul_atomic_int_compare_exchange_strong (volatile int *p,
-                                                 int expect_value,
-                                                 int new_value,
-                                                 enum bson_memory_order _unused)
+                                               int expect_value,
+                                               int new_value,
+                                               enum bson_memory_order _unused)
 {
    int ret;
    _lock_emul_atomic ();
@@ -237,9 +237,9 @@ _bson_emul_atomic_int_compare_exchange_strong (volatile int *p,
 
 int
 _bson_emul_atomic_int_compare_exchange_weak (volatile int *p,
-                                               int expect_value,
-                                               int new_value,
-                                               enum bson_memory_order order)
+                                             int expect_value,
+                                             int new_value,
+                                             enum bson_memory_order order)
 {
    /* We're emulating. We can't do a weak version. */
    return _bson_emul_atomic_int_compare_exchange_strong (

--- a/src/libbson/src/bson/bson-atomic.c
+++ b/src/libbson/src/bson/bson-atomic.c
@@ -48,7 +48,7 @@ bson_memory_barrier (void)
 }
 
 /**
- * Some platforms do not support compiler ics for atomic operations.
+ * Some platforms do not support compiler intrinsics for atomic operations.
  * We emulate that here using a spin lock and regular arithmetic operations
  */
 static int8_t gEmulAtomicLock = 0;

--- a/src/libbson/src/bson/bson-atomic.h
+++ b/src/libbson/src/bson/bson-atomic.h
@@ -74,7 +74,7 @@ enum bson_memory_order {
 #endif
 
 /* CDRIVER-4264 Contrary to documentation, VS 2013 targeting x86 does not
- * correctly/consistently provide _IntrinsicPointerExchange. */
+ * correctly/consistently provide _InterlockedPointerExchange. */
 #if defined(_MSC_VER) && _MSC_VER < 1900 && defined(_M_IX86)
 #define BSON_EMULATE_PTR
 #endif

--- a/src/libbson/src/bson/bson-atomic.h
+++ b/src/libbson/src/bson/bson-atomic.h
@@ -73,6 +73,12 @@ enum bson_memory_order {
 #define BSON_EMULATE_INT
 #endif
 
+/* CDRIVER-4264 Contrary to documentation, VS 2013 targeting x86 does not
+ * correctly/consistently provide _IntrinsicPointerExchange. */
+#if defined(_MSC_VER) && _MSC_VER < 1900 && defined(_M_IX86)
+#define BSON_EMULATE_PTR
+#endif
+
 #define DEF_ATOMIC_OP(                                                       \
    MSVC_Intrinsic, GNU_Intrinsic, GNU_Legacy_Intrinsic, Order, ...)          \
    do {                                                                      \
@@ -433,6 +439,11 @@ _bson_emul_atomic_int_compare_exchange_weak (int volatile *val,
                                              int new_value,
                                              enum bson_memory_order);
 
+BSON_EXPORT (void *)
+_bson_emul_atomic_ptr_exchange (void *volatile *val,
+                                void *v,
+                                enum bson_memory_order);
+
 BSON_EXPORT (void)
 bson_thrd_yield (void);
 
@@ -608,8 +619,10 @@ bson_atomic_ptr_exchange (void *volatile *ptr,
                           void *new_value,
                           enum bson_memory_order ord)
 {
+#if defined(BSON_EMULATE_PTR)
+   return _bson_emul_atomic_ptr_exchange (ptr, new_value, ord);
+#elif defined(BSON_USE_LEGACY_GCC_ATOMICS)
    /* The older __sync_val_compare_and_swap also takes oldval */
-#if defined(BSON_USE_LEGACY_GCC_ATOMICS)
    DEF_ATOMIC_OP (_InterlockedExchangePointer,
                   ,
                   __sync_val_compare_and_swap,
@@ -750,6 +763,8 @@ BSON_EXPORT (int32_t) bson_atomic_int_add (volatile int32_t *p, int32_t n);
 BSON_GNUC_DEPRECATED_FOR ("bson_atomic_int64_fetch_add")
 BSON_EXPORT (int64_t) bson_atomic_int64_add (volatile int64_t *p, int64_t n);
 
+
+#undef BSON_EMULATE_PTR
 #undef BSON_EMULATE_INT32
 #undef BSON_EMULATE_INT
 

--- a/src/libmongoc/tests/TestSuite.c
+++ b/src/libmongoc/tests/TestSuite.c
@@ -113,45 +113,6 @@ static BSON_ONCE_FUN (_test_suite_ensure_mutex_once)
 }
 
 
-static void
-_handle_signal (int signum)
-{
-   const char *s = "\nProcess was interrupted by the delivery of a signal.\n";
-   const char *sigstr;
-   size_t n;
-   switch (signum) {
-   case SIGABRT:
-      sigstr = "SIGABRT - Abnormal termination";
-      break;
-   case SIGINT:
-      sigstr = "SIGINT - Interrupted";
-      break;
-   case SIGTERM:
-      sigstr = "SIGTERM - Termination requested";
-      break;
-   case SIGSEGV:
-      sigstr = "SIGSEGV - Access violation";
-      break;
-   default:
-      sigstr = "(Unknown signal delivered)";
-   }
-#ifdef BSON_OS_UNIX
-   /* On POSIX these APIs are signal-safe */
-   n = write (STDERR_FILENO, s, strlen (s));
-   n = write (STDERR_FILENO, "  ", 2);
-   n = write (STDERR_FILENO, sigstr, strlen (sigstr));
-   n = write (STDERR_FILENO, "\n", 1);
-   fsync (STDERR_FILENO);
-#else
-   /* On Windows these APIs are signal-safe */
-   fprintf (stderr, "\n%s\n  %s\n", s, sigstr);
-   fflush (stderr);
-#endif
-   _Exit (signum);
-   (void) n;
-}
-
-
 void
 TestSuite_Init (TestSuite *suite, const char *name, int argc, char **argv)
 {
@@ -167,11 +128,6 @@ TestSuite_Init (TestSuite *suite, const char *name, int argc, char **argv)
    suite->silent = false;
    suite->ctest_run = NULL;
    _mongoc_array_init (&suite->match_patterns, sizeof (char *));
-
-   suite->prev_sigabrt = signal (SIGABRT, _handle_signal);
-   suite->prev_sigint = signal (SIGINT, _handle_signal);
-   suite->prev_sigterm = signal (SIGTERM, _handle_signal);
-   suite->prev_sigsegv = signal (SIGSEGV, _handle_signal);
 
    for (i = 1; i < argc; i++) {
       if (0 == strcmp ("-d", argv[i])) {
@@ -1100,11 +1056,6 @@ TestSuite_Destroy (TestSuite *suite)
    }
 
    _mongoc_array_destroy (&suite->match_patterns);
-
-   signal (SIGABRT, suite->prev_sigabrt);
-   signal (SIGINT, suite->prev_sigint);
-   signal (SIGTERM, suite->prev_sigterm);
-   signal (SIGSEGV, suite->prev_sigsegv);
 }
 
 

--- a/src/libmongoc/tests/TestSuite.h
+++ b/src/libmongoc/tests/TestSuite.h
@@ -674,11 +674,6 @@ struct _TestSuite {
    int silent;
    bson_string_t *mock_server_log_buf;
    FILE *mock_server_log;
-
-   void (*prev_sigabrt) (int);
-   void (*prev_sigint) (int);
-   void (*prev_sigterm) (int);
-   void (*prev_sigsegv) (int);
 };
 
 

--- a/src/libmongoc/tests/json-test.c
+++ b/src/libmongoc/tests/json-test.c
@@ -1930,7 +1930,7 @@ _install_json_test_suite_with_check (TestSuite *suite,
    char joined[PATH_MAX];
    char resolved[PATH_MAX];
 
-   snprintf (joined, PATH_MAX, "%s/%s", base, subdir);
+   bson_snprintf (joined, PATH_MAX, "%s/%s", base, subdir);
    ASSERT (realpath (joined, resolved));
 
    if (suite->ctest_run) {

--- a/src/libmongoc/tests/test-mongoc-uri.c
+++ b/src/libmongoc/tests/test-mongoc-uri.c
@@ -11,10 +11,6 @@
 #include "test-libmongoc.h"
 #include "test-conveniences.h"
 
-#ifdef _WIN32
-#define snprintf _snprintf
-#endif
-
 static void
 test_mongoc_uri_new (void)
 {
@@ -1579,7 +1575,7 @@ test_mongoc_uri_tls_ssl (const char *tls,
    mongoc_uri_t *uri;
    bson_error_t err;
 
-   snprintf (url_buffer,
+   bson_snprintf (url_buffer,
              sizeof (url_buffer),
              "mongodb://CN=client,OU=kerneluser,O=10Gen,L=New York City,"
              "ST=New York,C=US@ldaptest.10gen.cc/?"
@@ -1617,7 +1613,7 @@ test_mongoc_uri_tls_ssl (const char *tls,
    mongoc_uri_destroy (uri);
 
 
-   snprintf (url_buffer,
+   bson_snprintf (url_buffer,
              sizeof (url_buffer),
              "mongodb://localhost/?%s=true&%s=key.pem&%s=ca.pem",
              tls,
@@ -1650,7 +1646,7 @@ test_mongoc_uri_tls_ssl (const char *tls,
    mongoc_uri_destroy (uri);
 
 
-   snprintf (
+   bson_snprintf (
       url_buffer, sizeof (url_buffer), "mongodb://localhost/?%s=true", tls);
    uri = mongoc_uri_new (url_buffer);
 
@@ -1670,7 +1666,7 @@ test_mongoc_uri_tls_ssl (const char *tls,
    mongoc_uri_destroy (uri);
 
 
-   snprintf (url_buffer,
+   bson_snprintf (url_buffer,
              sizeof (url_buffer),
              "mongodb://localhost/?%s=true&%s=pa$$word!&%s=encrypted.pem",
              tls,
@@ -1703,7 +1699,7 @@ test_mongoc_uri_tls_ssl (const char *tls,
    mongoc_uri_destroy (uri);
 
 
-   snprintf (url_buffer,
+   bson_snprintf (url_buffer,
              sizeof (url_buffer),
              "mongodb://localhost/?%s=true&%s=true",
              tls,
@@ -1730,7 +1726,7 @@ test_mongoc_uri_tls_ssl (const char *tls,
    mongoc_uri_destroy (uri);
 
 
-   snprintf (url_buffer,
+   bson_snprintf (url_buffer,
              sizeof (url_buffer),
              "mongodb://localhost/?%s=foo.pem",
              tlsCertificateKeyFile);
@@ -1740,7 +1736,7 @@ test_mongoc_uri_tls_ssl (const char *tls,
    mongoc_uri_destroy (uri);
 
 
-   snprintf (url_buffer,
+   bson_snprintf (url_buffer,
              sizeof (url_buffer),
              "mongodb://localhost/?%s=foo.pem",
              tlsCAFile);
@@ -1750,7 +1746,7 @@ test_mongoc_uri_tls_ssl (const char *tls,
    mongoc_uri_destroy (uri);
 
 
-   snprintf (url_buffer,
+   bson_snprintf (url_buffer,
              sizeof (url_buffer),
              "mongodb://localhost/?%s=true",
              tlsAllowInvalidCertificates);
@@ -1764,7 +1760,7 @@ test_mongoc_uri_tls_ssl (const char *tls,
    mongoc_uri_destroy (uri);
 
 
-   snprintf (url_buffer,
+   bson_snprintf (url_buffer,
              sizeof (url_buffer),
              "mongodb://localhost/?%s=true",
              tlsAllowInvalidHostnames);
@@ -1778,7 +1774,7 @@ test_mongoc_uri_tls_ssl (const char *tls,
    mongoc_uri_destroy (uri);
 
 
-   snprintf (url_buffer,
+   bson_snprintf (url_buffer,
              sizeof (url_buffer),
              "mongodb://localhost/?%s=false&%s=foo.pem",
              tls,
@@ -1789,7 +1785,7 @@ test_mongoc_uri_tls_ssl (const char *tls,
    mongoc_uri_destroy (uri);
 
 
-   snprintf (url_buffer,
+   bson_snprintf (url_buffer,
              sizeof (url_buffer),
              "mongodb://localhost/?%s=false&%s=foo.pem",
              tls,
@@ -1800,7 +1796,7 @@ test_mongoc_uri_tls_ssl (const char *tls,
    mongoc_uri_destroy (uri);
 
 
-   snprintf (url_buffer,
+   bson_snprintf (url_buffer,
              sizeof (url_buffer),
              "mongodb://localhost/?%s=false&%s=true",
              tls,
@@ -1815,7 +1811,7 @@ test_mongoc_uri_tls_ssl (const char *tls,
    mongoc_uri_destroy (uri);
 
 
-   snprintf (url_buffer,
+   bson_snprintf (url_buffer,
              sizeof (url_buffer),
              "mongodb://localhost/?%s=false&%s=false",
              tls,
@@ -1837,7 +1833,7 @@ test_mongoc_uri_tls_ssl (const char *tls,
 
    /* Mixing options okay so long as they match */
    capture_logs (true);
-   snprintf (url_buffer,
+   bson_snprintf (url_buffer,
              sizeof (url_buffer),
              "mongodb://localhost/?%s=true&%s=true",
              tls,
@@ -1849,7 +1845,7 @@ test_mongoc_uri_tls_ssl (const char *tls,
 
    /* Same option with different values okay, latter overrides */
    capture_logs (true);
-   snprintf (url_buffer,
+   bson_snprintf (url_buffer,
              sizeof (url_buffer),
              "mongodb://localhost/?%s=true&%s=false",
              tls,
@@ -1869,7 +1865,7 @@ test_mongoc_uri_tls_ssl (const char *tls,
 
    /* Mixing options not okay if values differ */
    capture_logs (false);
-   snprintf (url_buffer,
+   bson_snprintf (url_buffer,
              sizeof (url_buffer),
              "mongodb://localhost/?%s=true&%s=false",
              tls,
@@ -1892,7 +1888,7 @@ test_mongoc_uri_tls_ssl (const char *tls,
 
    /* No conflict appears with implicit tls=true via SRV */
    capture_logs (false);
-   snprintf (url_buffer,
+   bson_snprintf (url_buffer,
              sizeof (url_buffer),
              "mongodb+srv://a.b.c/?%s=foo.pem",
              tlsCAFile);


### PR DESCRIPTION
Per CDRIVER-4264, there are three compilation errors preventing successful compilation [on VS 2013 variants](https://evergreen.mongodb.com/version/mongo_c_driver_7a35cf865629122267c3d59cca0f922c5e455f0d). This PR addresses each of these warnings:

- `'_Exit' undefined; assuming extern returning int`

VS 2013 only provides partial support for the C99 standard. This support apparently does not extend to providing the `_Exit` function, which is a C99 feature. Given that its use in the test suite (to report the type of signal triggering failure) is [not strictly necessary](https://github.com/mongodb/mongo-c-driver/pull/870#discussion_r712657428), I have [opted for its removal](https://github.com/mongodb/mongo-c-driver/commit/5b0dbb33a76eb0c1d837de790fc313c963b5bf53).

- `'snprintf' undefined; assuming extern returning int`

`snprintf` is also a C99 feature. Some files in libmongoc were directly invoking `snprintf` despite libbson providing `bson_snprintf` to address standard / platform compatibility issues. These instances [were substituted with](https://github.com/mongodb/mongo-c-driver/commit/9f9f48b761c4d4f3bebae9ea41f8a5a19727dbf6) `bson_snprintf`.

- `'_InterlockedExchangePointer': identifier not found`

This issue only manifested when building with VS 2013 targeting x86 (i686). I do not yet fully understand the reason behind this issue. According to [a Boost patch](https://github.com/boostorg/winapi/commit/bb91190323166485a338b416446020a47be8beff) (note, "MSVC-12" == "VS 2013") in response to [a report of similar build failures](https://lists.boost.org/Archives/boost/2019/07/246563.php), the issue is apparently due to a conflict between the `<intrin.h>` and `<winnt.h>` libraries when targeting x86 with VS 2013. This is in spite of [Microsoft documentation](https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2013/853x471w(v=vs.120)) indicating support for the intrinsic when targeting x86. Consequently, I have opted to [emulating the intrinsic](https://github.com/mongodb/mongo-c-driver/commit/77bbfee6a927af39a8040f18a6a2c37624b5791c) given VS 2013 and x86.