### PR TITLE
Remove c-driver-benchmark-mongo32 from mongo-c-driver-perf

### DIFF
--- a/.evergreen/benchmark.yml
+++ b/.evergreen/benchmark.yml
@@ -18,8 +18,6 @@ variables:
 
   ## Common download urls (merge in as hashes)
   mongo_download_url_prefixes:
-    mongo_v32: &mongo_v32
-      mongo_url: "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.2.10.tgz"
     mongo_v44: &mongo_v44
       mongo_url: "http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-rhel62-v4.4-latest.tgz"
     mongo_v50_ubuntu: &mongo_v50_ubuntu
@@ -274,21 +272,11 @@ buildvariants:
 - name: c-driver-benchmark-compile
   display_name: "C Driver Benchmark Compile"
   expansions:
-    <<: [ *cflags_64, *mongo_v32, *benchmark_common ]
+    <<: [ *cflags_64, *mongo_v44, *benchmark_common ]
     file: c-binaries-centos6
   run_on:
      - rhel62-small
   tasks: *benchmark_compile
-
-- name: c-driver-benchmark-mongo32
-  display_name: "C Driver Benchmark Mongo 3.2"
-  expansions:
-    <<: [ *cflags_64, *mongo_v32, *benchmark_common ]
-    file: c-binaries-centos6
-    compile_variant: c-driver-benchmark-compile
-  run_on:
-     - centos6-perf
-  tasks: *benchmark_tests
 
 - name: c-driver-benchmark-mongo44
   display_name: "C Driver Benchmark Mongo 4.4"


### PR DESCRIPTION
CDRIVER-4098 (#926) neglected to remove the [c-driver-benchmark-mongo32](https://evergreen.mongodb.com/task/mongo_c_driver_perf_c_driver_benchmark_mongo32_BenchMarkTests_3d0f609537dd8c120dbbce9ed4a8e29519b1b191_22_01_28_17_09_12) task from the [mongo-c-driver-perf Evergreen matrix](https://evergreen.mongodb.com/waterfall/mongo-c-driver-perf). This PR removes this benchmark with MongoDB server 3.2, which is now below the supported minimum wire version corresponding to server 3.6.