### PR TITLE
Remove use COMMON_PREFIX for decorating common lib names

### DIFF
--- a/build/future_function_templates/future.c.template
+++ b/build/future_function_templates/future.c.template
@@ -56,9 +56,9 @@ void
 future_start (future_t *future,
               BSON_THREAD_FUN_TYPE (start_routine))
 {
-   int r = COMMON_PREFIX (thread_create) (&future->thread,
-                               start_routine,
-                               (void *) future);
+   int r = mcommon_thread_create (&future->thread,
+                                  start_routine,
+                                  (void *) future);
 
    BSON_ASSERT (!r);
 }
@@ -97,7 +97,7 @@ future_wait_max (future_t *future, int64_t timeout_ms)
       future->awaited = true;
 
       /* free memory */
-      COMMON_PREFIX (thread_join) (future->thread);
+      mcommon_thread_join (future->thread);
    }
 
    return resolved;

--- a/src/common/common-b64-private.h
+++ b/src/common/common-b64-private.h
@@ -21,36 +21,43 @@
 
 #include <bson/bson.h>
 
-/* When encoding from "network" (raw data) to "presentation" (base64 encoded).
+#define mcommon_b64_ntop_calculate_target_size \
+   COMMON_NAME (b64_ntop_calculate_target_size)
+#define mcommon_b64_pton_calculate_target_size \
+   COMMON_NAME (b64_pton_calculate_target_size)
+#define mcommon_b64_ntop COMMON_NAME (b64_ntop)
+#define mcommon_b64_pton COMMON_NAME (b64_pton)
+
+/**
+ * When encoding from "network" (raw data) to "presentation" (base64 encoded).
  * Includes the trailing null byte. */
-size_t COMMON_PREFIX (bson_b64_ntop_calculate_target_size) (size_t raw_size);
+size_t
+mcommon_b64_ntop_calculate_target_size (size_t raw_size);
 
 /* When encoding from "presentation" (base64 encoded) to "network" (raw data).
  * This may be an overestimate if the base64 data includes spaces. For a more
- * accurate size, call bson_b64_pton (src, NULL, 0), which will read the src
+ * accurate size, call b64_pton (src, NULL, 0), which will read the src
  * data and return an exact size. */
-size_t COMMON_PREFIX (bson_b64_pton_calculate_target_size) (
-   size_t base64_encoded_size);
+size_t
+mcommon_b64_pton_calculate_target_size (size_t base64_encoded_size);
 
 /* Returns the number of bytes written (excluding NULL byte) to target on
  * success or -1 on error. Adds a trailing NULL byte.
  * Encodes from "network" (raw data) to "presentation" (base64 encoded),
  * hence the obscure name "ntop".
  */
-int COMMON_PREFIX (bson_b64_ntop) (uint8_t const *src,
-                                   size_t srclength,
-                                   char *target,
-                                   size_t targsize);
+int
+mcommon_b64_ntop (uint8_t const *src,
+                  size_t srclength,
+                  char *target,
+                  size_t targsize);
 
-/* If target is not NULL, the number of bytes written to target on success or -1
- * on error.
- * If target is NULL, returns the exact number of bytes that would be
- * written to target on decoding.
- * Encodes from "presentation" (base64 encoded) to "network" (raw data),
- * hence the obscure name "pton".
+/** If target is not NULL, the number of bytes written to target on success or
+ * -1 on error. If target is NULL, returns the exact number of bytes that would
+ * be written to target on decoding. Encodes from "presentation" (base64
+ * encoded) to "network" (raw data), hence the obscure name "pton".
  */
-int COMMON_PREFIX (bson_b64_pton) (char const *src,
-                                   uint8_t *target,
-                                   size_t targsize);
+int
+mcommon_b64_pton (char const *src, uint8_t *target, size_t targsize);
 
 #endif /* COMMON_B64_PRIVATE_H */

--- a/src/common/common-b64.c
+++ b/src/common/common-b64.c
@@ -113,10 +113,11 @@ static const char Pad64 = '=';
  *    characters followed by one "=" padding character.
  */
 
-int COMMON_PREFIX (bson_b64_ntop) (uint8_t const *src,
-                                   size_t srclength,
-                                   char *target,
-                                   size_t targsize)
+int
+mcommon_b64_ntop (uint8_t const *src,
+                  size_t srclength,
+                  char *target,
+                  size_t targsize)
 {
    size_t datalength = 0;
    uint8_t input[3];
@@ -517,9 +518,8 @@ mongoc_b64_pton_len (char const *src)
 }
 
 
-int COMMON_PREFIX (bson_b64_pton) (char const *src,
-                                   uint8_t *target,
-                                   size_t targsize)
+int
+mcommon_b64_pton (char const *src, uint8_t *target, size_t targsize)
 {
    static mongoc_common_once_t once = MONGOC_COMMON_ONCE_INIT;
 
@@ -535,7 +535,8 @@ int COMMON_PREFIX (bson_b64_pton) (char const *src,
       return mongoc_b64_pton_len (src);
 }
 
-size_t COMMON_PREFIX (bson_b64_ntop_calculate_target_size) (size_t raw_size)
+size_t
+mcommon_b64_ntop_calculate_target_size (size_t raw_size)
 {
    size_t num_bits = raw_size * 8;
    /* Calculate how many groups of six bits this contains, adding 5 to round up
@@ -547,8 +548,8 @@ size_t COMMON_PREFIX (bson_b64_ntop_calculate_target_size) (size_t raw_size)
    return num_b64_chars_with_padding + 1;
 }
 
-size_t COMMON_PREFIX (bson_b64_pton_calculate_target_size) (
-   size_t base64_encoded_size)
+size_t
+mcommon_b64_pton_calculate_target_size (size_t base64_encoded_size)
 {
    /* Without inspecting the data, we don't know how many padding characters
     * there are. Assuming none, that means each character represents 6 bits of

--- a/src/common/common-md5-private.h
+++ b/src/common/common-md5-private.h
@@ -23,11 +23,16 @@
 
 BSON_BEGIN_DECLS
 
-void COMMON_PREFIX (_bson_md5_init) (bson_md5_t *pms);
-void COMMON_PREFIX (_bson_md5_append) (bson_md5_t *pms,
-                                       const uint8_t *data,
-                                       uint32_t nbytes);
-void COMMON_PREFIX (_bson_md5_finish) (bson_md5_t *pms, uint8_t digest[16]);
+#define mcommon_md5_init COMMON_NAME (md5_init)
+#define mcommon_md5_append COMMON_NAME (md5_append)
+#define mcommon_md5_finish COMMON_NAME (md5_finish)
+
+void
+mcommon_md5_init (bson_md5_t *pms);
+void
+mcommon_md5_append (bson_md5_t *pms, const uint8_t *data, uint32_t nbytes);
+void
+mcommon_md5_finish (bson_md5_t *pms, uint8_t digest[16]);
 
 BSON_END_DECLS
 

--- a/src/common/common-md5.c
+++ b/src/common/common-md5.c
@@ -324,7 +324,8 @@ bson_md5_process (bson_md5_t *md5, const uint8_t *data)
    md5->abcd[3] += d;
 }
 
-void COMMON_PREFIX (_bson_md5_init) (bson_md5_t *pms)
+void
+mcommon_md5_init (bson_md5_t *pms)
 {
    pms->count[0] = pms->count[1] = 0;
    pms->abcd[0] = 0x67452301;
@@ -333,9 +334,8 @@ void COMMON_PREFIX (_bson_md5_init) (bson_md5_t *pms)
    pms->abcd[3] = 0x10325476;
 }
 
-void COMMON_PREFIX (_bson_md5_append) (bson_md5_t *pms,
-                                       const uint8_t *data,
-                                       uint32_t nbytes)
+void
+mcommon_md5_append (bson_md5_t *pms, const uint8_t *data, uint32_t nbytes)
 {
    const uint8_t *p = data;
    int left = nbytes;
@@ -373,7 +373,8 @@ void COMMON_PREFIX (_bson_md5_append) (bson_md5_t *pms,
 }
 
 
-void COMMON_PREFIX (_bson_md5_finish) (bson_md5_t *pms, uint8_t digest[16])
+void
+mcommon_md5_finish (bson_md5_t *pms, uint8_t digest[16])
 {
    static const uint8_t pad[64] = {
       0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -386,10 +387,9 @@ void COMMON_PREFIX (_bson_md5_finish) (bson_md5_t *pms, uint8_t digest[16])
    for (i = 0; i < 8; ++i)
       data[i] = (uint8_t) (pms->count[i >> 2] >> ((i & 3) << 3));
    /* Pad to 56 bytes mod 64. */
-   COMMON_PREFIX (_bson_md5_append)
-   (pms, pad, ((55 - (pms->count[0] >> 3)) & 63) + 1);
+   mcommon_md5_append (pms, pad, ((55 - (pms->count[0] >> 3)) & 63) + 1);
    /* Append the length. */
-   COMMON_PREFIX (_bson_md5_append) (pms, data, sizeof (data));
+   mcommon_md5_append (pms, data, sizeof (data));
    for (i = 0; i < 16; ++i)
       digest[i] = (uint8_t) (pms->abcd[i >> 2] >> ((i & 3) << 3));
 }

--- a/src/common/common-prelude.h
+++ b/src/common/common-prelude.h
@@ -19,15 +19,10 @@
 #error "Only <mongoc/mongoc.h> or <bson/bson.h> can be included directly."
 #endif
 
-#ifndef COMMON_PREFIX_
-#define COMMON_PREFIX_
-#endif
-#define JOINER(x, y) x##_##y
-#define NAME_EVALUATOR(x, y) JOINER (x, y)
-#define COMMON_PREFIX(name) NAME_EVALUATOR (COMMON_PREFIX_, name)
+#define COMMON_NAME_1(a, b) a##_##b
 
-#if defined(COMMON_PREFIX_) && !defined(__INTELLISENSE__)
-#define COMMON_NAME(Name) NAME_EVALUATOR (COMMON_PREFIX_, Name)
+#if defined(MCOMMON_NAME_PREFIX) && !defined(__INTELLISENSE__)
+#define COMMON_NAME(Name) COMMON_NAME_1 (MCOMMON_NAME_PREFIX, Name)
 #else
-#define COMMON_NAME(Name) NAME_EVALUATOR (mcommon_, Name)
+#define COMMON_NAME(Name) COMMON_NAME_1 (mcommon, Name)
 #endif

--- a/src/common/common-prelude.h
+++ b/src/common/common-prelude.h
@@ -25,3 +25,9 @@
 #define JOINER(x, y) x##_##y
 #define NAME_EVALUATOR(x, y) JOINER (x, y)
 #define COMMON_PREFIX(name) NAME_EVALUATOR (COMMON_PREFIX_, name)
+
+#if defined(COMMON_PREFIX_) && !defined(__INTELLISENSE__)
+#define COMMON_NAME(Name) NAME_EVALUATOR (COMMON_PREFIX_, Name)
+#else
+#define COMMON_NAME(Name) Name
+#endif

--- a/src/common/common-prelude.h
+++ b/src/common/common-prelude.h
@@ -29,5 +29,5 @@
 #if defined(COMMON_PREFIX_) && !defined(__INTELLISENSE__)
 #define COMMON_NAME(Name) NAME_EVALUATOR (COMMON_PREFIX_, Name)
 #else
-#define COMMON_NAME(Name) Name
+#define COMMON_NAME(Name) NAME_EVALUATOR (mcommon_, Name)
 #endif

--- a/src/common/common-thread-private.h
+++ b/src/common/common-thread-private.h
@@ -29,6 +29,9 @@
 
 BSON_BEGIN_DECLS
 
+#define mcommon_thread_create COMMON_NAME (thread_create)
+#define mcommon_thread_join COMMON_NAME (thread_join)
+
 #if defined(BSON_OS_UNIX)
 #include <pthread.h>
 
@@ -107,17 +110,19 @@ typedef struct {
 #define BSON_THREAD_FUN(_function_name, _arg_name) \
    unsigned (__stdcall _function_name) (void *(_arg_name))
 #define BSON_THREAD_FUN_TYPE(_function_name) \
-   unsigned(__stdcall * _function_name) (void *)
+   unsigned (__stdcall * _function_name) (void *)
 #define BSON_THREAD_RETURN return 0
 #endif
 
 /* Functions that require definitions get the common prefix (_mongoc for
  * libmongoc or _bson for libbson) to avoid duplicate symbols when linking both
  * libbson and libmongoc statically. */
-int COMMON_PREFIX (thread_join) (bson_thread_t thread);
-int COMMON_PREFIX (thread_create) (bson_thread_t *thread,
-                                   BSON_THREAD_FUN_TYPE (func),
-                                   void *arg);
+int
+mcommon_thread_join (bson_thread_t thread);
+int
+mcommon_thread_create (bson_thread_t *thread,
+                       BSON_THREAD_FUN_TYPE (func),
+                       void *arg);
 
 #if defined(MONGOC_ENABLE_DEBUG_ASSERTIONS) && defined(BSON_OS_UNIX)
 bool COMMON_PREFIX (mutex_is_locked) (bson_mutex_t *mutex);

--- a/src/common/common-thread-private.h
+++ b/src/common/common-thread-private.h
@@ -125,7 +125,9 @@ mcommon_thread_create (bson_thread_t *thread,
                        void *arg);
 
 #if defined(MONGOC_ENABLE_DEBUG_ASSERTIONS) && defined(BSON_OS_UNIX)
-bool COMMON_PREFIX (mutex_is_locked) (bson_mutex_t *mutex);
+#define mcommon_mutex_is_locked COMMON_NAME (mutex_is_locked)
+bool
+mcommon_mutex_is_locked (bson_mutex_t *mutex);
 #endif
 
 /**

--- a/src/common/common-thread.c
+++ b/src/common/common-thread.c
@@ -17,13 +17,15 @@
 #include "common-thread-private.h"
 
 #if defined(BSON_OS_UNIX)
-int COMMON_PREFIX (thread_create) (bson_thread_t *thread,
-                                   BSON_THREAD_FUN_TYPE (func),
-                                   void *arg)
+int
+mcommon_thread_create (bson_thread_t *thread,
+                       BSON_THREAD_FUN_TYPE (func),
+                       void *arg)
 {
    return pthread_create (thread, NULL, func, arg);
 }
-int COMMON_PREFIX (thread_join) (bson_thread_t thread)
+int
+mcommon_thread_join (bson_thread_t thread)
 {
    return pthread_join (thread, NULL);
 }
@@ -37,9 +39,10 @@ bool COMMON_PREFIX (mutex_is_locked) (bson_mutex_t *mutex)
 #endif
 
 #else
-int COMMON_PREFIX (thread_create) (bson_thread_t *thread,
-                                   BSON_THREAD_FUN_TYPE (func),
-                                   void *arg)
+int
+mcommon_thread_create (bson_thread_t *thread,
+                       BSON_THREAD_FUN_TYPE (func),
+                       void *arg)
 {
    *thread = (HANDLE) _beginthreadex (NULL, 0, func, arg, 0, NULL);
    if (0 == *thread) {
@@ -47,7 +50,8 @@ int COMMON_PREFIX (thread_create) (bson_thread_t *thread,
    }
    return 0;
 }
-int COMMON_PREFIX (thread_join) (bson_thread_t thread)
+int
+mcommon_thread_join (bson_thread_t thread)
 {
    int ret;
 

--- a/src/common/common-thread.c
+++ b/src/common/common-thread.c
@@ -31,7 +31,8 @@ mcommon_thread_join (bson_thread_t thread)
 }
 
 #if defined(MONGOC_ENABLE_DEBUG_ASSERTIONS) && defined(BSON_OS_UNIX)
-bool COMMON_PREFIX (mutex_is_locked) (bson_mutex_t *mutex)
+bool
+mcommon_mutex_is_locked (bson_mutex_t *mutex)
 {
    return mutex->valid_tid &&
           pthread_equal (pthread_self (), mutex->lock_owner);

--- a/src/libbson/CMakeLists.txt
+++ b/src/libbson/CMakeLists.txt
@@ -214,7 +214,7 @@ target_compile_definitions (bson_shared
    PRIVATE
       BSON_COMPILATION
       JSONSL_PARSE_NAN
-      COMMON_PREFIX_=_bson_common
+      MCOMMON_NAME_PREFIX=_bson_mcommon
 )
 # Several directories in the source and build trees contain headers we would like
 # include via relative reference, but they all end up in the same install path
@@ -283,7 +283,7 @@ if (MONGOC_ENABLE_STATIC_BUILD)
       PRIVATE
          BSON_COMPILATION
          JSONSL_PARSE_NAN
-         COMMON_PREFIX_=_bson_common
+         MCOMMON_NAME_PREFIX=_bson_mcommon
    )
    if (NOT WIN32 AND ENABLE_PIC)
       target_compile_options (bson_static PUBLIC -fPIC)

--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -866,7 +866,7 @@ _bson_json_parse_binary_elem (bson_json_reader_t *reader,
 
    if (bs == BSON_JSON_LF_BINARY) {
       data->binary.has_binary = true;
-      binary_len = COMMON_PREFIX (bson_b64_pton (val_w_null, NULL, 0));
+      binary_len = mcommon_b64_pton (val_w_null, NULL, 0);
       if (binary_len < 0) {
          _bson_json_read_set_error (
             reader,
@@ -875,9 +875,9 @@ _bson_json_parse_binary_elem (bson_json_reader_t *reader,
       }
 
       _bson_json_buf_ensure (&bson->bson_type_buf[0], (size_t) binary_len + 1);
-      if (COMMON_PREFIX (bson_b64_pton (val_w_null,
-                                        bson->bson_type_buf[0].buf,
-                                        (size_t) binary_len + 1) < 0)) {
+      if (mcommon_b64_pton (val_w_null,
+                            bson->bson_type_buf[0].buf,
+                            (size_t) binary_len + 1) < 0) {
          _bson_json_read_set_error (
             reader,
             "Invalid input string \"%s\", looking for base64-encoded binary",

--- a/src/libbson/src/bson/bson-md5.c
+++ b/src/libbson/src/bson/bson-md5.c
@@ -7,18 +7,18 @@
 void
 bson_md5_init (bson_md5_t *pms)
 {
-   COMMON_PREFIX (_bson_md5_init (pms));
+   mcommon_md5_init (pms);
 }
 
 
 void
 bson_md5_append (bson_md5_t *pms, const uint8_t *data, uint32_t nbytes)
 {
-   COMMON_PREFIX (_bson_md5_append (pms, data, nbytes));
+   mcommon_md5_append (pms, data, nbytes);
 }
 
 void
 bson_md5_finish (bson_md5_t *pms, uint8_t digest[16])
 {
-   COMMON_PREFIX (_bson_md5_finish (pms, digest));
+   mcommon_md5_finish (pms, digest);
 }

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -2693,10 +2693,9 @@ _bson_as_json_visit_binary (const bson_iter_t *iter,
    size_t b64_len;
    char *b64;
 
-   b64_len = COMMON_PREFIX (bson_b64_ntop_calculate_target_size (v_binary_len));
+   b64_len = mcommon_b64_ntop_calculate_target_size (v_binary_len);
    b64 = bson_malloc0 (b64_len);
-   BSON_ASSERT (
-      COMMON_PREFIX (bson_b64_ntop (v_binary, v_binary_len, b64, b64_len) != -1));
+   BSON_ASSERT (mcommon_b64_ntop (v_binary, v_binary_len, b64, b64_len) != -1);
 
    if (state->mode == BSON_JSON_MODE_CANONICAL ||
        state->mode == BSON_JSON_MODE_RELAXED) {

--- a/src/libbson/tests/test-b64.c
+++ b/src/libbson/tests/test-b64.c
@@ -29,14 +29,13 @@ _test_encode_helper (char *input,
    size_t target_size;
    int ret;
 
-   target_size = COMMON_PREFIX (bson_b64_ntop_calculate_target_size (input_len));
+   target_size = mcommon_b64_ntop_calculate_target_size (input_len);
    output = bson_malloc (target_size);
 
    /* bson_ntop_calculate_target_size includes trailing NULL. */
    ASSERT_CMPSIZE_T (target_size, ==, (size_t) expected_output_len + 1);
    /* returned value does not count trailing NULL. */
-   ret = COMMON_PREFIX (bson_b64_ntop (
-      (uint8_t *) input, input_len, output, target_size));
+   ret = mcommon_b64_ntop ((uint8_t *) input, input_len, output, target_size);
    ASSERT_CMPINT (target_size - 1, ==, ret);
    ASSERT_CMPSTR (output, expected_output);
    bson_free (output);
@@ -58,21 +57,21 @@ test_bson_b64_encode (void)
 
    /* Even on empty input, the output is still NULL terminated. */
    output[0] = 'a';
-   ret = COMMON_PREFIX (bson_b64_ntop ((uint8_t *) "", 0, output, 1));
+   ret = mcommon_b64_ntop ((uint8_t *) "", 0, output, 1);
    ASSERT_CMPINT (ret, ==, 0);
    BSON_ASSERT (output[0] == '\0');
 
    /* Test NULL input. */
-   ret = COMMON_PREFIX (bson_b64_ntop (NULL, 0, output, 32));
+   ret = mcommon_b64_ntop (NULL, 0, output, 32);
    ASSERT_CMPINT (0, ==, ret);
    BSON_ASSERT (output[0] == '\0');
 
    /* Test NULL output */
-   ret = COMMON_PREFIX (bson_b64_ntop (NULL, 0, NULL, 0));
+   ret = mcommon_b64_ntop (NULL, 0, NULL, 0);
    ASSERT_CMPINT (-1, ==, ret);
 
    /* Test output not large enough. */
-   ret = COMMON_PREFIX (bson_b64_ntop ((uint8_t *) "test", 4, output, 1));
+   ret = mcommon_b64_ntop ((uint8_t *) "test", 4, output, 1);
    ASSERT_CMPINT (-1, ==, ret);
 }
 
@@ -87,8 +86,7 @@ _test_decode_helper (char *input,
    int exact_target_size;
    int ret;
 
-   target_size =
-      COMMON_PREFIX (bson_b64_pton_calculate_target_size (strlen (input)));
+   target_size = mcommon_b64_pton_calculate_target_size (strlen (input));
    output = bson_malloc (target_size);
    /* bson_malloc returns NULL if requesting 0 bytes, memcmp expects non-NULL.
     */
@@ -96,13 +94,13 @@ _test_decode_helper (char *input,
       output = bson_malloc (1);
    }
 
-   /* Calling COMMON_PREFIX (bson_b64_pton) with a NULL output is valid, and
+   /* Calling mcommon_b64_pton with a NULL output is valid, and
     * returns the exact target size. */
-   exact_target_size = COMMON_PREFIX (bson_b64_pton (input, NULL, 0));
+   exact_target_size = mcommon_b64_pton (input, NULL, 0);
    ASSERT_CMPINT (exact_target_size, ==, expected_output_len);
    ASSERT_CMPSIZE_T (target_size, ==, (size_t) expected_calculated_target_size);
 
-   ret = COMMON_PREFIX (bson_b64_pton (input, output, target_size));
+   ret = mcommon_b64_pton (input, output, target_size);
    ASSERT_CMPINT (expected_output_len, ==, ret);
    BSON_ASSERT (0 == memcmp (output, expected_output, ret));
    bson_free (output);
@@ -123,20 +121,20 @@ test_bson_b64_decode (void)
    _test_decode_helper ("Zm9vYmFy", "foobar", 6, 6);
 
    /* Test NULL input. */
-   ret = COMMON_PREFIX (bson_b64_pton (NULL, output, 32));
+   ret = mcommon_b64_pton (NULL, output, 32);
    ASSERT_CMPINT (ret, ==, -1);
 
    /* Test NULL output. */
-   ret = COMMON_PREFIX (bson_b64_pton ("Zm8=", NULL, 0));
+   ret = mcommon_b64_pton ("Zm8=", NULL, 0);
    /* The return value is actually the number of bytes for output. */
    ASSERT_CMPINT (ret, ==, 2);
 
    /* Test output not large enough. */
-   ret = COMMON_PREFIX (bson_b64_pton ("Zm9vYmFy", output, 1));
+   ret = mcommon_b64_pton ("Zm9vYmFy", output, 1);
    ASSERT_CMPINT (ret, ==, -1);
 
    /* Test malformed base64 */
-   ret = COMMON_PREFIX (bson_b64_pton ("bad!", output, 32));
+   ret = mcommon_b64_pton ("bad!", output, 32);
    ASSERT_CMPINT (ret, ==, -1);
 }
 

--- a/src/libbson/tests/test-oid.c
+++ b/src/libbson/tests/test-oid.c
@@ -292,13 +292,12 @@ test_bson_oid_init_with_threads (void)
 
       for (i = 0; i < N_THREADS; i++) {
          contexts[i] = bson_context_new (flags);
-         r = COMMON_PREFIX (thread_create) (
-            &threads[i], oid_worker, contexts[i]);
+         r = mcommon_thread_create (&threads[i], oid_worker, contexts[i]);
          BSON_ASSERT (r == 0);
       }
 
       for (i = 0; i < N_THREADS; i++) {
-         COMMON_PREFIX (thread_join) (threads[i]);
+         mcommon_thread_join (threads[i]);
       }
 
       for (i = 0; i < N_THREADS; i++) {
@@ -315,12 +314,12 @@ test_bson_oid_init_with_threads (void)
       context = bson_context_new (BSON_CONTEXT_THREAD_SAFE);
 
       for (i = 0; i < N_THREADS; i++) {
-         r = COMMON_PREFIX (thread_create) (&threads[i], oid_worker, context);
+         r = mcommon_thread_create (&threads[i], oid_worker, context);
          BSON_ASSERT (r == 0);
       }
 
       for (i = 0; i < N_THREADS; i++) {
-         r = COMMON_PREFIX (thread_join) (threads[i]);
+         r = mcommon_thread_join (threads[i]);
          BSON_ASSERT (r == 0);
       }
 

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -777,7 +777,7 @@ target_compile_definitions (mongoc_shared
    PRIVATE
       MONGOC_COMPILATION
       ${KMS_MSG_DEFINITIONS}
-      COMMON_PREFIX_=_mongoc_common
+      MCOMMON_NAME_PREFIX=_mongoc_mcommon
 )
 # Several directories in the source and build trees contain headers we would like
 # include via relative reference, but they all end up in the same install path
@@ -816,7 +816,7 @@ if (MONGOC_ENABLE_STATIC_BUILD)
       PRIVATE
          MONGOC_COMPILATION
          ${KMS_MSG_DEFINITIONS}
-         COMMON_PREFIX_=_mongoc_common
+         MCOMMON_NAME_PREFIX=_mongoc_mcommon
    )
    # Several directories in the source and build trees contain headers we would like
    # include via relative reference, but they all end up in the same install path
@@ -870,7 +870,7 @@ function (mongoc_add_test test use_shared)
          PUBLIC
             "MONGOC_COMPILATION"
             "BSON_COMPILATION"
-            "COMMON_PREFIX_=_mongoc_common"
+            "MCOMMON_NAME_PREFIX=_mongoc_mcommon"
       )
       if (${use_shared})
          target_link_libraries (${test} mongoc_shared ${LIBRARIES})

--- a/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
@@ -828,7 +828,7 @@ _client_second (mongoc_cluster_t *cluster,
    char *signature = NULL;
    const char *date = NULL;
    const size_t server_nonce_str_len =
-      COMMON_PREFIX (bson_b64_ntop_calculate_target_size (64));
+      mcommon_b64_ntop_calculate_target_size (64);
    char *server_nonce_str = NULL;
    const char *body = "Action=GetCallerIdentity&Version=2011-06-15";
    bson_t client_payload = BSON_INITIALIZER;
@@ -853,7 +853,7 @@ _client_second (mongoc_cluster_t *cluster,
                            kms_request_get_error (request));
    }
 
-   if (COMMON_PREFIX (bson_b64_ntop) (
+   if (mcommon_b64_ntop (
           server_nonce, 64, server_nonce_str, server_nonce_str_len) == -1) {
       AUTH_ERROR_AND_FAIL ("Failed to parse server nonce");
    }

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -1175,8 +1175,7 @@ _mongoc_cluster_auth_node_plain (mongoc_cluster_t *cluster,
 
    str = bson_strdup_printf ("%c%s%c%s", '\0', username, '\0', password);
    len = strlen (username) + strlen (password) + 2;
-   buflen = COMMON_PREFIX (
-      bson_b64_ntop ((const uint8_t *) str, len, buf, sizeof buf));
+   buflen = mcommon_b64_ntop ((const uint8_t *) str, len, buf, sizeof buf);
    bson_free (str);
 
    if (buflen == -1) {

--- a/src/libmongoc/src/mongoc/mongoc-cyrus.c
+++ b/src/libmongoc/src/mongoc/mongoc-cyrus.c
@@ -343,11 +343,10 @@ _mongoc_cyrus_start (mongoc_cyrus_t *sasl,
    }
 
    *outbuflen = 0;
-   outbuf_capacity =
-      COMMON_PREFIX (bson_b64_ntop_calculate_target_size (raw_len));
+   outbuf_capacity = mcommon_b64_ntop_calculate_target_size (raw_len);
    *outbuf = bson_malloc (outbuf_capacity);
 
-   b64_ret = COMMON_PREFIX (bson_b64_ntop) (
+   b64_ret = mcommon_b64_ntop (
       (uint8_t *) raw, raw_len, (char *) *outbuf, outbuf_capacity);
    if (b64_ret == -1) {
       bson_set_error (error,
@@ -411,11 +410,10 @@ _mongoc_cyrus_step (mongoc_cyrus_t *sasl,
    }
 
    decoded_len = 0;
-   decoded_capacity =
-      COMMON_PREFIX (bson_b64_pton_calculate_target_size) (inbuflen);
+   decoded_capacity = mcommon_b64_pton_calculate_target_size (inbuflen);
    decoded = bson_malloc (decoded_capacity);
-   b64_ret = COMMON_PREFIX (bson_b64_pton) (
-      (char *) inbuf, (uint8_t *) decoded, decoded_capacity);
+   b64_ret =
+      mcommon_b64_pton ((char *) inbuf, (uint8_t *) decoded, decoded_capacity);
    if (b64_ret == -1) {
       bson_set_error (error,
                       MONGOC_ERROR_SASL,
@@ -442,9 +440,9 @@ _mongoc_cyrus_step (mongoc_cyrus_t *sasl,
    }
 
    *outbuflen = 0;
-   outbuf_capacity = COMMON_PREFIX (bson_b64_ntop_calculate_target_size (rawlen));
+   outbuf_capacity = mcommon_b64_ntop_calculate_target_size (rawlen);
    *outbuf = bson_malloc0 (outbuf_capacity);
-   b64_ret = COMMON_PREFIX (bson_b64_ntop) (
+   b64_ret = mcommon_b64_ntop (
       (const uint8_t *) raw, rawlen, (char *) *outbuf, outbuf_capacity);
    if (b64_ret == -1) {
       bson_set_error (error,

--- a/src/libmongoc/src/mongoc/mongoc-scram.c
+++ b/src/libmongoc/src/mongoc/mongoc-scram.c
@@ -291,11 +291,10 @@ _mongoc_scram_start (mongoc_scram_t *scram,
       goto FAIL;
    }
 
-   scram->encoded_nonce_len =
-      COMMON_PREFIX (bson_b64_ntop (nonce,
-                                    sizeof (nonce),
-                                    scram->encoded_nonce,
-                                    sizeof (scram->encoded_nonce)));
+   scram->encoded_nonce_len = mcommon_b64_ntop (nonce,
+                                                sizeof (nonce),
+                                                scram->encoded_nonce,
+                                                sizeof (scram->encoded_nonce));
 
    if (-1 == scram->encoded_nonce_len) {
       bson_set_error (error,
@@ -489,10 +488,10 @@ _mongoc_scram_generate_client_proof (mongoc_scram_t *scram,
       client_proof[i] = scram->client_key[i] ^ client_signature[i];
    }
 
-   r = COMMON_PREFIX (bson_b64_ntop (client_proof,
-                                     _scram_hash_size (scram),
-                                     (char *) outbuf + *outbuflen,
-                                     outbufmax - *outbuflen));
+   r = mcommon_b64_ntop (client_proof,
+                         _scram_hash_size (scram),
+                         (char *) outbuf + *outbuflen,
+                         outbufmax - *outbuflen);
 
    if (-1 == r) {
       return false;
@@ -703,8 +702,8 @@ _mongoc_scram_step2 (mongoc_scram_t *scram,
       goto BUFFER;
    }
 
-   decoded_salt_len = COMMON_PREFIX (bson_b64_pton (
-      (char *) val_s, decoded_salt, sizeof (decoded_salt)));
+   decoded_salt_len =
+      mcommon_b64_pton ((char *) val_s, decoded_salt, sizeof (decoded_salt));
 
    if (-1 == decoded_salt_len) {
       bson_set_error (error,
@@ -839,10 +838,10 @@ _mongoc_scram_verify_server_signature (mongoc_scram_t *scram,
                        server_signature);
 
    encoded_server_signature_len =
-      COMMON_PREFIX (bson_b64_ntop (server_signature,
-                                    _scram_hash_size (scram),
-                                    encoded_server_signature,
-                                    sizeof (encoded_server_signature)));
+      mcommon_b64_ntop (server_signature,
+                        _scram_hash_size (scram),
+                        encoded_server_signature,
+                        sizeof (encoded_server_signature));
    if (encoded_server_signature_len == -1) {
       return false;
    }

--- a/src/libmongoc/src/mongoc/mongoc-server-monitor.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-monitor.c
@@ -131,7 +131,7 @@ _server_monitor_heartbeat_started (mongoc_server_monitor_t *server_monitor,
 {
    mongoc_apm_server_heartbeat_started_t event;
    MONGOC_DEBUG_ASSERT (
-      !COMMON_PREFIX (mutex_is_locked) (&server_monitor->topology->apm_mutex));
+      !mcommon_mutex_is_locked (&server_monitor->topology->apm_mutex));
 
    if (!server_monitor->apm_callbacks.server_heartbeat_started) {
       return;

--- a/src/libmongoc/src/mongoc/mongoc-server-monitor.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-monitor.c
@@ -1170,8 +1170,8 @@ mongoc_server_monitor_run (mongoc_server_monitor_t *server_monitor)
    if (server_monitor->shared.state == MONGOC_THREAD_OFF) {
       server_monitor->is_rtt = false;
       server_monitor->shared.state = MONGOC_THREAD_RUNNING;
-      COMMON_PREFIX (thread_create)
-      (&server_monitor->thread, _server_monitor_thread, server_monitor);
+      mcommon_thread_create (
+         &server_monitor->thread, _server_monitor_thread, server_monitor);
    }
    bson_mutex_unlock (&server_monitor->shared.mutex);
 }
@@ -1183,8 +1183,8 @@ mongoc_server_monitor_run_as_rtt (mongoc_server_monitor_t *server_monitor)
    if (server_monitor->shared.state == MONGOC_THREAD_OFF) {
       server_monitor->is_rtt = true;
       server_monitor->shared.state = MONGOC_THREAD_RUNNING;
-      COMMON_PREFIX (thread_create)
-      (&server_monitor->thread, _server_monitor_rtt_thread, server_monitor);
+      mcommon_thread_create (
+         &server_monitor->thread, _server_monitor_rtt_thread, server_monitor);
    }
    bson_mutex_unlock (&server_monitor->shared.mutex);
 }
@@ -1206,7 +1206,7 @@ mongoc_server_monitor_request_shutdown (mongoc_server_monitor_t *server_monitor)
       server_monitor->shared.state = MONGOC_THREAD_SHUTTING_DOWN;
    }
    if (server_monitor->shared.state == MONGOC_THREAD_JOINABLE) {
-      COMMON_PREFIX (thread_join) (server_monitor->thread);
+      mcommon_thread_join (server_monitor->thread);
       server_monitor->shared.state = MONGOC_THREAD_OFF;
    }
    if (server_monitor->shared.state == MONGOC_THREAD_OFF) {
@@ -1235,7 +1235,7 @@ mongoc_server_monitor_wait_for_shutdown (
    }
 
    /* Shutdown requested, but thread is not yet off. Wait. */
-   COMMON_PREFIX (thread_join) (server_monitor->thread);
+   mcommon_thread_join (server_monitor->thread);
    bson_mutex_lock (&server_monitor->shared.mutex);
    server_monitor->shared.state = MONGOC_THREAD_OFF;
    bson_mutex_unlock (&server_monitor->shared.mutex);

--- a/src/libmongoc/src/mongoc/mongoc-topology-background-monitoring.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-background-monitoring.c
@@ -163,8 +163,8 @@ _mongoc_topology_background_monitoring_start (mongoc_topology_t *topology)
       /* Start SRV polling thread. */
       if (mongoc_topology_should_rescan_srv (topology)) {
          topology->is_srv_polling = true;
-         COMMON_PREFIX (thread_create)
-         (&topology->srv_polling_thread, srv_polling_run, topology);
+         mcommon_thread_create (
+            &topology->srv_polling_thread, srv_polling_run, topology);
       }
    }
 
@@ -348,7 +348,7 @@ _mongoc_topology_background_monitoring_stop (mongoc_topology_t *topology)
 
    /* Wait for SRV polling thread. */
    if (topology->is_srv_polling) {
-      COMMON_PREFIX (thread_join) (topology->srv_polling_thread);
+      mcommon_thread_join (topology->srv_polling_thread);
    }
 
    /* Signal clients that are waiting on server selection to stop immediately,

--- a/src/libmongoc/src/mongoc/mongoc-util.c
+++ b/src/libmongoc/src/mongoc/mongoc-util.c
@@ -70,10 +70,10 @@ _mongoc_hex_md5 (const char *input)
    char digest_str[33];
    int i;
 
-   COMMON_PREFIX (_bson_md5_init (&md5));
-   COMMON_PREFIX (_bson_md5_append (
-      &md5, (const uint8_t *) input, (uint32_t) strlen (input)));
-   COMMON_PREFIX (_bson_md5_finish (&md5, digest));
+   mcommon_md5_init (&md5);
+   mcommon_md5_append (
+      &md5, (const uint8_t *) input, (uint32_t) strlen (input));
+   mcommon_md5_finish (&md5, digest);
 
    for (i = 0; i < sizeof digest; i++) {
       bson_snprintf (&digest_str[i * 2], 3, "%02x", digest[i]);

--- a/src/libmongoc/tests/json-test-operations.c
+++ b/src/libmongoc/tests/json-test-operations.c
@@ -141,7 +141,7 @@ static void
 start_thread (json_test_worker_thread_t *wt)
 {
    wt->shutdown_requested = false;
-   COMMON_PREFIX (thread_create) (&wt->thread, json_test_worker_thread_run, wt);
+   mcommon_thread_create (&wt->thread, json_test_worker_thread_run, wt);
 }
 
 static void
@@ -160,7 +160,7 @@ wait_for_thread (json_test_worker_thread_t *wt)
    wt->shutdown_requested = true;
    mongoc_cond_broadcast (&wt->cond);
    bson_mutex_unlock (&wt->mutex);
-   COMMON_PREFIX (thread_join) (wt->thread);
+   mcommon_thread_join (wt->thread);
 }
 
 void

--- a/src/libmongoc/tests/mock_server/future.c
+++ b/src/libmongoc/tests/mock_server/future.c
@@ -531,9 +531,9 @@ void
 future_start (future_t *future,
               BSON_THREAD_FUN_TYPE (start_routine))
 {
-   int r = COMMON_PREFIX (thread_create) (&future->thread,
-                               start_routine,
-                               (void *) future);
+   int r = mcommon_thread_create (&future->thread,
+                                  start_routine,
+                                  (void *) future);
 
    BSON_ASSERT (!r);
 }
@@ -572,7 +572,7 @@ future_wait_max (future_t *future, int64_t timeout_ms)
       future->awaited = true;
 
       /* free memory */
-      COMMON_PREFIX (thread_join) (future->thread);
+      mcommon_thread_join (future->thread);
    }
 
    return resolved;

--- a/src/libmongoc/tests/mock_server/mock-server.c
+++ b/src/libmongoc/tests/mock_server/mock-server.c
@@ -388,7 +388,7 @@ mock_server_run (mock_server_t *server)
       bound_port);
    server->uri = mongoc_uri_new (server->uri_str);
 
-   r = COMMON_PREFIX (thread_create) (
+   r = mcommon_thread_create (
       &server->main_thread, main_thread, (void *) server);
    BSON_ASSERT (r == 0);
    while (!server->running) {
@@ -1682,7 +1682,7 @@ mock_server_destroy (mock_server_t *server)
    }
 
    bson_mutex_unlock (&server->mutex);
-   COMMON_PREFIX (thread_join) (server->main_thread);
+   mcommon_thread_join (server->main_thread);
 
    _mongoc_array_destroy (&server->worker_threads);
 
@@ -1808,7 +1808,7 @@ static BSON_THREAD_FUN (main_thread, data)
          closure->port = port;
 
          bson_mutex_lock (&server->mutex);
-         r = COMMON_PREFIX (thread_create) (&thread, worker_thread, closure);
+         r = mcommon_thread_create (&thread, worker_thread, closure);
          BSON_ASSERT (r == 0);
          _mongoc_array_append_val (&server->worker_threads, thread);
          bson_mutex_unlock (&server->mutex);
@@ -1822,8 +1822,8 @@ static BSON_THREAD_FUN (main_thread, data)
    bson_mutex_unlock (&server->mutex);
 
    for (i = 0; i < worker_threads.len; i++) {
-      COMMON_PREFIX (thread_join)
-      (_mongoc_array_index (&worker_threads, bson_thread_t, i));
+      mcommon_thread_join (
+         _mongoc_array_index (&worker_threads, bson_thread_t, i));
    }
 
    _mongoc_array_destroy (&worker_threads);

--- a/src/libmongoc/tests/ssl-test.c
+++ b/src/libmongoc/tests/ssl-test.c
@@ -307,14 +307,14 @@ ssl_test (mongoc_ssl_opt_t *client,
    bson_mutex_init (&data.cond_mutex);
    mongoc_cond_init (&data.cond);
 
-   r = COMMON_PREFIX (thread_create) (threads, &ssl_test_server, &data);
+   r = mcommon_thread_create (threads, &ssl_test_server, &data);
    BSON_ASSERT (r == 0);
 
-   r = COMMON_PREFIX (thread_create) (threads + 1, &ssl_test_client, &data);
+   r = mcommon_thread_create (threads + 1, &ssl_test_client, &data);
    BSON_ASSERT (r == 0);
 
    for (i = 0; i < 2; i++) {
-      r = COMMON_PREFIX (thread_join) (threads[i]);
+      r = mcommon_thread_join (threads[i]);
       BSON_ASSERT (r == 0);
    }
 

--- a/src/libmongoc/tests/test-mongoc-client-pool.c
+++ b/src/libmongoc/tests/test-mongoc-client-pool.c
@@ -451,8 +451,8 @@ test_client_pool_max_pool_size_exceeded (void)
    bson_mutex_init (&args->mutex);
    mongoc_cond_init (&args->cond);
 
-   COMMON_PREFIX (thread_create) (&thread1, worker, args);
-   COMMON_PREFIX (thread_create) (&thread2, worker, args);
+   mcommon_thread_create (&thread1, worker, args);
+   mcommon_thread_create (&thread2, worker, args);
 
    bson_mutex_lock (&args->mutex);
    while (args->nleft > 0) {
@@ -462,8 +462,8 @@ test_client_pool_max_pool_size_exceeded (void)
    }
    bson_mutex_unlock (&args->mutex);
 
-   COMMON_PREFIX (thread_join) (thread1);
-   COMMON_PREFIX (thread_join) (thread2);
+   mcommon_thread_join (thread1);
+   mcommon_thread_join (thread2);
 
    mongoc_uri_destroy (uri);
    mongoc_client_pool_destroy (pool);

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -2193,14 +2193,14 @@ _test_multi_threaded (bool external_key_vault)
    client1 = mongoc_client_pool_pop (pool);
    client2 = mongoc_client_pool_pop (pool);
 
-   r = COMMON_PREFIX (thread_create) (threads, _worker_thread, client1);
+   r = mcommon_thread_create (threads, _worker_thread, client1);
    BSON_ASSERT (r == 0);
 
-   r = COMMON_PREFIX (thread_create) (threads + 1, _worker_thread, client2);
+   r = mcommon_thread_create (threads + 1, _worker_thread, client2);
    BSON_ASSERT (r == 0);
 
    for (i = 0; i < 2; i++) {
-      r = COMMON_PREFIX (thread_join) (threads[i]);
+      r = mcommon_thread_join (threads[i]);
       BSON_ASSERT (r == 0);
    }
 

--- a/src/libmongoc/tests/test-mongoc-gssapi.c
+++ b/src/libmongoc/tests/test-mongoc-gssapi.c
@@ -134,13 +134,13 @@ main (void)
    closure.pool = mongoc_client_pool_new (uri);
 
    for (i = 0; i < NTHREADS; i++) {
-      r = COMMON_PREFIX (thread_create) (
+      r = mcommon_thread_create (
          &threads[i], gssapi_kerberos_worker, (void *) &closure);
       BSON_ASSERT (r == 0);
    }
 
    for (i = 0; i < NTHREADS; i++) {
-      COMMON_PREFIX (thread_join) (threads[i]);
+      mcommon_thread_join (threads[i]);
    }
 
    bson_mutex_lock (&closure.mutex);

--- a/src/libmongoc/tests/test-mongoc-handshake.c
+++ b/src/libmongoc/tests/test-mongoc-handshake.c
@@ -922,11 +922,11 @@ test_mongoc_handshake_race_condition (void)
       _reset_handshake ();
 
       for (j = 0; j < 4; ++j) {
-         BSON_ASSERT (!COMMON_PREFIX (thread_create) (
+         BSON_ASSERT (!mcommon_thread_create (
             &threads[j], &handshake_append_worker, NULL));
       }
       for (j = 0; j < 4; ++j) {
-         COMMON_PREFIX (thread_join) (threads[j]);
+         mcommon_thread_join (threads[j]);
       }
    }
 

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -2481,7 +2481,7 @@ typedef struct {
 } change_stream_ctx_t;
 
 
-static 
+static
 BSON_THREAD_FUN (insert_docs, p)
 {
    change_stream_ctx_t *ctx = (change_stream_ctx_t *) p;
@@ -2529,7 +2529,7 @@ test_sample_change_stream_command (sample_command_fn_t fn,
          client, db->name, "inventory");
       ctx.done = false;
 
-      r = COMMON_PREFIX (thread_create) (&thread, insert_docs, (void *) &ctx);
+      r = mcommon_thread_create (&thread, insert_docs, (void *) &ctx);
       ASSERT_OR_PRINT_ERRNO (r == 0, r);
 
       capture_logs (true);
@@ -2539,7 +2539,7 @@ test_sample_change_stream_command (sample_command_fn_t fn,
       bson_mutex_lock (&ctx.lock);
       ctx.done = true;
       bson_mutex_unlock (&ctx.lock);
-      COMMON_PREFIX (thread_join) (thread);
+      mcommon_thread_join (thread);
 
       mongoc_collection_destroy (ctx.collection);
       mongoc_client_destroy (client);
@@ -2630,7 +2630,7 @@ test_example_change_stream (mongoc_database_t *db)
 
    mongoc_change_stream_destroy (stream);
    /* End Changestream Example 4 */
-   
+
    bson_destroy (&opts);
    bson_destroy (pipeline);
    mongoc_collection_destroy (collection);

--- a/src/libmongoc/tests/test-mongoc-socket.c
+++ b/src/libmongoc/tests/test-mongoc-socket.c
@@ -344,14 +344,14 @@ _test_mongoc_socket_check_closed (int32_t server_sleep_ms)
    mongoc_cond_init (&data.cond);
    data.server_sleep_ms = server_sleep_ms;
 
-   r = COMMON_PREFIX (thread_create) (threads, &socket_test_server, &data);
+   r = mcommon_thread_create (threads, &socket_test_server, &data);
    BSON_ASSERT (r == 0);
 
-   r = COMMON_PREFIX (thread_create) (threads + 1, &socket_test_client, &data);
+   r = mcommon_thread_create (threads + 1, &socket_test_client, &data);
    BSON_ASSERT (r == 0);
 
    for (i = 0; i < 2; i++) {
-      r = COMMON_PREFIX (thread_join) (threads[i]);
+      r = mcommon_thread_join (threads[i]);
       BSON_ASSERT (r == 0);
    }
 
@@ -384,14 +384,14 @@ test_mongoc_socket_sendv (void *ctx)
    bson_mutex_init (&data.cond_mutex);
    mongoc_cond_init (&data.cond);
 
-   r = COMMON_PREFIX (thread_create) (threads, &sendv_test_server, &data);
+   r = mcommon_thread_create (threads, &sendv_test_server, &data);
    BSON_ASSERT (r == 0);
 
-   r = COMMON_PREFIX (thread_create) (threads + 1, &sendv_test_client, &data);
+   r = mcommon_thread_create (threads + 1, &sendv_test_client, &data);
    BSON_ASSERT (r == 0);
 
    for (i = 0; i < 2; i++) {
-      r = COMMON_PREFIX (thread_join) (threads[i]);
+      r = mcommon_thread_join (threads[i]);
       BSON_ASSERT (r == 0);
    }
 

--- a/src/libmongoc/tests/test-mongoc-stream-tls-error.c
+++ b/src/libmongoc/tests/test-mongoc-stream-tls-error.c
@@ -204,14 +204,14 @@ test_mongoc_tls_hangup (void)
    bson_mutex_init (&data.cond_mutex);
    mongoc_cond_init (&data.cond);
 
-   r = COMMON_PREFIX (thread_create) (threads, &ssl_error_server, &data);
+   r = mcommon_thread_create (threads, &ssl_error_server, &data);
    BSON_ASSERT (r == 0);
 
-   r = COMMON_PREFIX (thread_create) (threads + 1, &ssl_hangup_client, &data);
+   r = mcommon_thread_create (threads + 1, &ssl_hangup_client, &data);
    BSON_ASSERT (r == 0);
 
    for (i = 0; i < 2; i++) {
-      r = COMMON_PREFIX (thread_join) (threads[i]);
+      r = mcommon_thread_join (threads[i]);
       BSON_ASSERT (r == 0);
    }
 
@@ -327,15 +327,14 @@ test_mongoc_tls_handshake_stall (void)
    bson_mutex_init (&data.cond_mutex);
    mongoc_cond_init (&data.cond);
 
-   r = COMMON_PREFIX (thread_create) (threads, &ssl_error_server, &data);
+   r = mcommon_thread_create (threads, &ssl_error_server, &data);
    BSON_ASSERT (r == 0);
 
-   r = COMMON_PREFIX (thread_create) (
-      threads + 1, &handshake_stall_client, &data);
+   r = mcommon_thread_create (threads + 1, &handshake_stall_client, &data);
    BSON_ASSERT (r == 0);
 
    for (i = 0; i < 2; i++) {
-      r = COMMON_PREFIX (thread_join) (threads[i]);
+      r = mcommon_thread_join (threads[i]);
       BSON_ASSERT (r == 0);
    }
 


### PR DESCRIPTION
The use of `COMMON_PREFIX` is to ensure that the decorated names are different when compiled into libbson versus libmongoc, but make things quite cluttered and strangely formatted at the call site. While I don't like heavy use on the preprocessor, `#define`-ing the names to a more readable alias makes it much easier to use and read those decorated names. I chose an arbitrary `mcommon` prefix for the names, but any sufficiently unique name will do.

(The guard on `__INTELLISENSE__` is to hide the decorated names from autocomplete tools.)

(AFAIK, this has no effect on any public API, nor visible symbols in any dynamic libraries.)