### PR TITLE
CDRIVER-3573 remove hard-coded versions from test scripts

### DIFF
--- a/.evergreen/abi-compliance-check.sh
+++ b/.evergreen/abi-compliance-check.sh
@@ -10,9 +10,8 @@ mkdir abi-compliance/dumps
 # build the current changes
 export SKIP_MOCK_TESTS=ON
 export EXTRA_CONFIGURE_FLAGS="-DCMAKE_INSTALL_PREFIX=./abi-compliance/changes-install -DCMAKE_C_FLAGS=-g -Og"
-# TODO CDRIVER-3573: calculate this dynamically once calc_release_version.py works with non-master non-release branches
-echo "1.17.0-pre" > VERSION_CURRENT
-echo "1.16.2" > VERSION_RELEASED
+echo $(python ./build/calc_release_version.py --next-minor) > VERSION_CURRENT
+echo $(python ./build/calc_release_version.py --next-minor -p) > VERSION_RELEASED
 sh .evergreen/compile.sh
 make install
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -21,7 +21,6 @@ functions:
       shell: bash
       script: |-
         set -o errexit
-        # TODO: CDRIVER-3573 do not hardcode the version.
         if [ -n "${github_pr_number}" -o "${is_patch}" = "true" ]; then
            # This is a GitHub PR or patch build, probably branched from master
            echo $(python ./build/calc_release_version.py --next-minor) > VERSION_CURRENT

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -24,8 +24,7 @@ functions:
         # TODO: CDRIVER-3573 do not hardcode the version.
         if [ -n "${github_pr_number}" -o "${is_patch}" = "true" ]; then
            # This is a GitHub PR or patch build, probably branched from master
-           VERSION_CURRENT="1.18.0"
-           echo $VERSION_CURRENT > "VERSION_CURRENT"
+           echo $(python ./build/calc_release_version.py --next-minor) > VERSION_CURRENT
            VERSION=$VERSION_CURRENT-${version_id}
         else
            VERSION=latest

--- a/build/calc_release_version.py
+++ b/build/calc_release_version.py
@@ -138,7 +138,7 @@ def main():
     """
     The algorithm is roughly:
 
-        - Is the --next_minor flag passed? If "yes", then return the next minor
+        - Is the --next-minor flag passed? If "yes", then return the next minor
            release with a pre-release marker.
         - Is the current HEAD associated with a tag that looks like a release
            version?

--- a/build/calc_release_version.py
+++ b/build/calc_release_version.py
@@ -34,6 +34,8 @@ if DEBUG:
 
 # This option indicates we are to determine the previous release version
 PREVIOUS = len(sys.argv) > 1 and '-p' in sys.argv
+# This options indicates to output the next minor release version
+NEXT_MINOR = len(sys.argv) > 1 and '--next-minor' in sys.argv
 
 PREVIOUS_TAG_RE = re.compile('(?P<ver>(?P<vermaj>[0-9]+)\\.(?P<vermin>[0-9]+)'
                              '\\.(?P<verpatch>[0-9]+))')
@@ -100,22 +102,63 @@ def check_head_tag():
 
     return None
 
+def get_next_minor ():
+    """
+    get_next_minor does the following:
+    Inspect the branches that fit the convention for a release branch.
+    Choose the latest increment the minor version. Append .0 to form the new version (e.g., r1.21 becomes 1.22.0)
+    Append a pre-release marker. (e.g. 1.22.0 becomes 1.22.0-20220201+gitf6e6a7025d)
+    """
+    version_loose = LooseVersion('0.0.0')
+    head_commit_short = check_output(['git', 'rev-parse',
+                                                 '--revs-only', '--short=10',
+                                                 'HEAD^{commit}']).strip()
+    prerelease_marker = datetime.date.today().strftime('%Y%m%d') \
+            + '+git' + head_commit_short
+    version_new = {}
+    # Use refs (not branches) to get local branches plus remote branches
+    refs = check_output(['git', 'show-ref']).splitlines()
+    for ref in refs:
+        release_branch_match = RELEASE_BRANCH_RE.match(ref.split()[1])
+        if release_branch_match:
+            # Construct a candidate version from this branch name
+            version_new['major'] = int(release_branch_match.group('vermaj'))
+            version_new['minor'] = int(release_branch_match.group('vermin')) + 1
+            version_new['patch'] = 0
+            version_new['prerelease'] = prerelease_marker
+            new_version_loose = LooseVersion(str(version_new['major']) + '.' +
+                                                str(version_new['minor']) + '.' +
+                                                str(version_new['patch']) + '-' +
+                                                version_new['prerelease'])
+            if new_version_loose > version_loose:
+                version_loose = new_version_loose
+                if DEBUG:
+                    print('Found new best version "' + str(version_loose) \
+                            + '" based on branch "' \
+                            + release_branch_match.group('brname') + '"')
+    return str(version_loose)
+
 def main():
     """
     The algorithm is roughly:
 
-        1. Is the current HEAD associated with a tag that looks like a release
+        - Is the --next_minor flag passed? If "yes", then return the next minor
+           release with a pre-release marker.
+        - Is the current HEAD associated with a tag that looks like a release
            version?
-        2. If "yes" then use that as the version
-        3. If "no" then is the current branch master?
-        4. If "yes" the current branch is master, then inspect the branches that
-           fit the convention for a release branch and choose the latest;
-           increment the minor version, append .0 to form the new version (e.g.,
-           releases/v3.3 becomes 3.4.0), and append a pre-release marker
-        5. If "no" the current branch is not master, then determine the most
+        - If "yes" then use that as the version
+        - If "no" then is the current branch master?
+        - If "yes" the current branch is master, then return the next minor
+           release with a pre-release marker.
+        - If "no" the current branch is not master, then determine the most
            recent tag in history; strip any pre-release marker, increment the
            patch version, and append a new pre-release marker
     """
+
+    if NEXT_MINOR:
+        if DEBUG:
+            print('Calculating next minor release')
+        return get_next_minor ()
 
     head_tag_ver = check_head_tag()
     if head_tag_ver:

--- a/build/evergreen_config_lib/functions.py
+++ b/build/evergreen_config_lib/functions.py
@@ -27,11 +27,9 @@ all_functions = OD([
                 ('directory', 'mongoc'),
             ]))]),
         shell_mongoc(r'''
-        # TODO: CDRIVER-3573 do not hardcode the version.
         if [ -n "${github_pr_number}" -o "${is_patch}" = "true" ]; then
            # This is a GitHub PR or patch build, probably branched from master
-           VERSION_CURRENT="1.18.0"
-           echo $VERSION_CURRENT > "VERSION_CURRENT"
+           echo $(python ./build/calc_release_version.py --next-minor) > VERSION_CURRENT
            VERSION=$VERSION_CURRENT-${version_id}
         else
            VERSION=latest


### PR DESCRIPTION
# Summary
- Add a `--next-minor` version flag to calc_release_version.py.
- Remove hard coded version numbers for C driver builds from test scripts.

# Background and motivation

calc_release_version.py is used to calculate release versions by inspecting git history. When checked out to a non-release non-master branch, calc_release_version.py prints a version based off of the `1.11.0` tag `1.11.1-20220201+gitf6e6a7025d`. The `1.11.0` tag is erroneously on the `master` branch. Evergreen patch builds check out a revision. That necessitated hard coding the version in test scripts.

It results in this [misleading report](https://mciuploads.s3.amazonaws.com/mongo-c-driver/releng/99fe2b528b0e0d869cb0687baeacf23b602ad3c8/mongo_c_driver_99fe2b528b0e0d869cb0687baeacf23b602ad3c8/mongo_c_driver_releng_99fe2b528b0e0d869cb0687baeacf23b602ad3c8_22_02_04_14_07_54/abi-compliance/compat_report.htmlcompat_report.html) for the abi-compliance-check task, as well as the [documentation](https://mciuploads.s3.amazonaws.com/mongo-c-driver/docs/libmongoc/1.18.0-61f4505ec9ec440837fd3e36/index.html) uploaded to the make-release-archive task.

Adding a `--next-minor` flag to calc_release_version.py seemed reasonable to always request to return the "next minor" version, regardless of what is checked out.

With the changes applied, the [new ABI report](https://mciuploads.s3.amazonaws.com/mongo-c-driver/releng/f6e6a7025d3c65a24e3c32c2763dadf3ef5b804a/61f9fe025623431bfbc697db/mongo_c_driver_releng_patch_f6e6a7025d3c65a24e3c32c2763dadf3ef5b804a_61f9fe025623431bfbc697db_22_02_02_03_44_03/abi-compliance/compat_report.htmlcompat_report.html) and [documentation](https://mciuploads.s3.amazonaws.com/mongo-c-driver/docs/libmongoc/-61f9fe025623431bfbc697db/index.html) have the correct versions.
