### PR TITLE
CDRIVER-4284 Avoid empty OpenSSL error condition on handshake failure

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl.c
@@ -544,7 +544,7 @@ _mongoc_stream_tls_openssl_check_closed (mongoc_stream_t *stream) /* IN */
 
 
 static bool
-_mongoc_stream_tls_openssl_cert_verify_failed (SSL *ssl, bson_error_t *error)
+_mongoc_stream_tls_openssl_set_verify_cert_error (SSL *ssl, bson_error_t *error)
 {
    BSON_ASSERT_PARAM (ssl);
    BSON_ASSERT_PARAM (error);
@@ -606,7 +606,7 @@ _mongoc_stream_tls_openssl_handshake (mongoc_stream_t *stream,
       }
 
       /* Try to relay certificate failure reason from OpenSSL library if any. */
-      if (_mongoc_stream_tls_openssl_cert_verify_failed (ssl, error)) {
+      if (_mongoc_stream_tls_openssl_set_verify_cert_error (ssl, error)) {
          RETURN (false);
       }
 
@@ -635,7 +635,7 @@ _mongoc_stream_tls_openssl_handshake (mongoc_stream_t *stream,
    *events = 0;
 
    /* Try to relay certificate failure reason from OpenSSL library if any. */
-   if (_mongoc_stream_tls_openssl_cert_verify_failed (ssl, error)) {
+   if (_mongoc_stream_tls_openssl_set_verify_cert_error (ssl, error)) {
       RETURN (false);
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl.c
@@ -640,17 +640,13 @@ _mongoc_stream_tls_openssl_handshake (mongoc_stream_t *stream,
    }
 
    /* Otherwise, try to relay error info from OpenSSL. */
-   {
-      const unsigned long code = ERR_get_error ();
-
-      if (error != 0) {
-         bson_set_error (error,
-                         MONGOC_ERROR_STREAM,
-                         MONGOC_ERROR_STREAM_SOCKET,
-                         "TLS handshake failed: %s",
-                         ERR_error_string (code, NULL));
-         RETURN (false);
-      }
+   if (ERR_peek_error () != 0) {
+      bson_set_error (error,
+                      MONGOC_ERROR_STREAM,
+                      MONGOC_ERROR_STREAM_SOCKET,
+                      "TLS handshake failed: %s",
+                      ERR_error_string (ERR_get_error (), NULL));
+      RETURN (false);
    }
 
    /* Otherwise, use simple error info. */


### PR DESCRIPTION
CDRIVER-4284 reports a scenario where `ERR_get_error` is used to construct failure information despite the possibility that the OpenSSL library may not contain error info to be reported. This PR ensures that there is a meaningful error message is guaranteed to be relayed even if OpenSSL does not provide error info.