### PR TITLE
CDRIVER-4274 Increase wait time for mock KMS server startup to 5 minutes

### DIFF
--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -93,7 +93,7 @@ export MONGOC_TEST_MONITORING_VERBOSE=on
 if [ "$CLIENT_SIDE_ENCRYPTION" = "on" ]; then
    echo "Waiting for mock KMS servers to start..."
    wait_for_kms_server() {
-      for i in $(seq 60); do
+      for i in $(seq 300); do
          # Exit code 7: "Failed to connect to host".
          if curl -s "localhost:$1"; test $? -ne 7; then
             return 0


### PR DESCRIPTION
Flaky mock KMS server startup failures as reported in CDRIVER-4274 seem to be addressed by raising the wait duration up from 1 minute to 5 minutes per [patch results](https://spruce.mongodb.com/version/6201961761837d0dfe173e88/) (none of the failing tasks are due to mock KMS server startup failure). It seems like the background processes launching the mock KMS servers were not being given enough time (1 minute was too short).