### PR TITLE
CDRIVER-4297 use static decls for OpenSSL 1.1 polyfills

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-crypto-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-crypto-openssl.c
@@ -39,13 +39,13 @@ mongoc_crypto_openssl_hmac_sha1 (mongoc_crypto_t *crypto,
 }
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20700000L)
-EVP_MD_CTX *
+static EVP_MD_CTX *
 EVP_MD_CTX_new (void)
 {
    return bson_malloc0 (sizeof (EVP_MD_CTX));
 }
 
-void
+static void
 EVP_MD_CTX_free (EVP_MD_CTX *ctx)
 {
    EVP_MD_CTX_cleanup (ctx);


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-4297

See https://github.com/mongodb/mongo-php-driver/issues/1302 for discussion why having these symbol public is bad

Notice: others are already hidden
ex: https://github.com/mongodb/mongo-c-driver/blob/master/src/kms-message/src/kms_crypto_libcrypto.c#L25