### PR TITLE
CDRIVER-3923 switch to new RHEL8 s390x Evergreen hosts

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -22022,11 +22022,11 @@ buildvariants:
   - .debug-compile !.sspi .nossl
   - .4.0 .openssl !.nosasl .server
   batchtime: 1440
-- name: zseries-rhel72
+- name: zseries-rhel83
   display_name: '*zSeries'
   expansions:
     CC: gcc
-  run_on: rhel72-zseries-test
+  run_on: rhel83-zseries-small
   tasks:
   - release-compile
   - debug-compile-nosasl-nossl

--- a/build/evergreen_config_lib/variants.py
+++ b/build/evergreen_config_lib/variants.py
@@ -520,9 +520,9 @@ all_variants = [
              '.4.0 .openssl !.nosasl .server'],
             {'CC': 'gcc'},
             batchtime=days(1)),
-    Variant('zseries-rhel72',
+    Variant('zseries-rhel83',
             '*zSeries',
-            'rhel72-zseries-test',
+            'rhel83-zseries-small',
             ['release-compile',
         #      '.compression', --> TODO: waiting on ticket CDRIVER-3258
              'debug-compile-nosasl-nossl',

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -25,6 +25,7 @@
 #include "mongoc/mongoc-client-private.h"
 #include "mongoc/mongoc-uri-private.h"
 #include "mongoc/mongoc-util-private.h"
+#include "mongoc/mongoc-linux-distro-scanner-private.h"
 
 #include "TestSuite.h"
 #include "test-conveniences.h"
@@ -2227,6 +2228,31 @@ int
 test_framework_skip_if_offline (void)
 {
    return test_framework_getenv_bool ("MONGOC_TEST_OFFLINE") ? 0 : 1;
+}
+
+
+int
+test_framework_skip_if_rhel8_zseries (void)
+{
+   /* CDRIVER-3923: It appears that when running on RHEL8 on zSeries the
+    * /server_discovery_and_monitoring/monitoring/heartbeat/pooled/dns test
+    * fails.  The best guess is that calling getaddrinfo() on that platform
+    * blocks for 5 seconds, while the test expects a server selection error
+    * after 3000 ms, or 3 seconds.  Skip the test when executing on RHEL8 on
+    * zSeries. */
+#ifdef __s390x__
+   char *name;
+   char *version;
+   _mongoc_linux_distro_scanner_get_distro (&name, &version);
+   bool rhel = strcmp (name, "Red Hat Enterprise Linux") == 0;
+   bool vers8 = version[0] == '8';
+   int skip = (rhel && vers8) ? 0 : 1;
+   bson_free (name);
+   bson_free (version);
+   return skip;
+#else
+   return 1;
+#endif
 }
 
 

--- a/src/libmongoc/tests/test-libmongoc.h
+++ b/src/libmongoc/tests/test-libmongoc.h
@@ -177,6 +177,8 @@ test_framework_skip_if_not_single (void);
 int
 test_framework_skip_if_offline (void);
 int
+test_framework_skip_if_rhel8_zseries (void);
+int
 test_framework_skip_if_slow (void);
 int
 test_framework_skip_if_slow_or_live (void);

--- a/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
@@ -1055,7 +1055,8 @@ test_sdam_monitoring_install (TestSuite *suite)
       test_heartbeat_fails_dns_pooled,
       NULL,
       NULL,
-      test_framework_skip_if_offline);
+      test_framework_skip_if_offline,
+      test_framework_skip_if_rhel8_zseries);
    TestSuite_AddMockServerTest (
       suite,
       "/server_discovery_and_monitoring/monitoring/no_duplicates",


### PR DESCRIPTION
Full patch build: https://spruce.mongodb.com/version/622e50b457e85a4b73b784fd/tasks

A few items to note:
- the new variant is named `zseries-rhel83`, but retains the same display name as before, `*zSeries`
- the `authentication-tests-openssl-nosasl` and `authentication-tests-openssl` tasks in the new variant fail, but they were also failing on the waterfall before this change
- all of the `test-*` tasks in the new variant are failing in the `SYSTEM FAILED` state; this is a result of the server not yet publishing builds for RHEL8 zSeries (the ticket for that is [SERVER-44074](https://jira.mongodb.org/browse/SERVER-44074)) and the tasks should turn green once the server builds are published
- based on the Slack discussion I have added a skip for the `/server_discovery_and_monitoring/monitoring/heartbeat/pooled/dns`, verifying that it is skipped on RHEL8 zSeries and not skipped on other platforms