### PR TITLE
Reducing Warnings - Miscellaneous Warnings

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1843,19 +1843,17 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        export CFLAGS="-fPIC"
         export DEBUG="ON"
-        export EXTRA_CONFIGURE_FLAGS="-DENABLE_MONGOC=OFF"
+        export EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON -DENABLE_MONGOC=OFF"
         export SASL="AUTO"
         export SKIP_MOCK_TESTS="ON"
         export SSL="OPENSSL"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
         rm CMakeCache.txt
         set -o errexit
-        export CFLAGS="-fPIC"
         export COMPILE_LIBMONGOCRYPT="ON"
         export DEBUG="ON"
-        export EXTRA_CONFIGURE_FLAGS="-DENABLE_CLIENT_SIDE_ENCRYPTION=ON"
+        export EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON -DENABLE_CLIENT_SIDE_ENCRYPTION=ON"
         export SASL="AUTO"
         export SSL="OPENSSL"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
@@ -1875,19 +1873,17 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        export CFLAGS="-fPIC"
         export DEBUG="ON"
-        export EXTRA_CONFIGURE_FLAGS="-DENABLE_MONGOC=OFF"
+        export EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON -DENABLE_MONGOC=OFF"
         export SASL="AUTO"
         export SKIP_MOCK_TESTS="ON"
         export SSL="OPENSSL_STATIC"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
         rm CMakeCache.txt
         set -o errexit
-        export CFLAGS="-fPIC"
         export COMPILE_LIBMONGOCRYPT="ON"
         export DEBUG="ON"
-        export EXTRA_CONFIGURE_FLAGS="-DENABLE_CLIENT_SIDE_ENCRYPTION=ON"
+        export EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON -DENABLE_CLIENT_SIDE_ENCRYPTION=ON"
         export SASL="AUTO"
         export SSL="OPENSSL_STATIC"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
@@ -1907,19 +1903,17 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        export CFLAGS="-fPIC"
         export DEBUG="ON"
-        export EXTRA_CONFIGURE_FLAGS="-DENABLE_MONGOC=OFF"
+        export EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON -DENABLE_MONGOC=OFF"
         export SASL="AUTO"
         export SKIP_MOCK_TESTS="ON"
         export SSL="DARWIN"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
         rm CMakeCache.txt
         set -o errexit
-        export CFLAGS="-fPIC"
         export COMPILE_LIBMONGOCRYPT="ON"
         export DEBUG="ON"
-        export EXTRA_CONFIGURE_FLAGS="-DENABLE_CLIENT_SIDE_ENCRYPTION=ON"
+        export EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON -DENABLE_CLIENT_SIDE_ENCRYPTION=ON"
         export SASL="AUTO"
         export SSL="DARWIN"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
@@ -1939,19 +1933,17 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        export CFLAGS="-fPIC"
         export DEBUG="ON"
-        export EXTRA_CONFIGURE_FLAGS="-DENABLE_MONGOC=OFF"
+        export EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON -DENABLE_MONGOC=OFF"
         export SASL="AUTO"
         export SKIP_MOCK_TESTS="ON"
         export SSL="WINDOWS"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
         rm CMakeCache.txt
         set -o errexit
-        export CFLAGS="-fPIC"
         export COMPILE_LIBMONGOCRYPT="ON"
         export DEBUG="ON"
-        export EXTRA_CONFIGURE_FLAGS="-DENABLE_CLIENT_SIDE_ENCRYPTION=ON"
+        export EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON -DENABLE_CLIENT_SIDE_ENCRYPTION=ON"
         export SASL="AUTO"
         export SSL="WINDOWS"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
@@ -1969,10 +1961,10 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        export CFLAGS="-fPIC -fsanitize=address -fno-omit-frame-pointer -DBSON_MEMCHECK"
+        export CFLAGS="-fsanitize=address -fno-omit-frame-pointer -DBSON_MEMCHECK"
         export CHECK_LOG="ON"
         export DEBUG="ON"
-        export EXTRA_CONFIGURE_FLAGS="-DENABLE_MONGOC=OFF -DENABLE_EXTRA_ALIGNMENT=OFF"
+        export EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON -DENABLE_MONGOC=OFF -DENABLE_EXTRA_ALIGNMENT=OFF"
         export PATH="/usr/lib/llvm-3.8/bin:$PATH"
         export SKIP_MOCK_TESTS="ON"
         export SSL="OPENSSL"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,8 +83,11 @@ include(MongoC-Warnings)
 
 # Enable CCache, if possible
 include (CCache)
+
 # Link with LLD, if possible
-include (LLDLinker)
+if (NOT MSVC)
+   include (LLDLinker)
+endif ()
 
 set (BUILD_VERSION "0.0.0" CACHE STRING "Library version (for both libbson and libmongoc)")
 

--- a/build/evergreen_config_lib/tasks.py
+++ b/build/evergreen_config_lib/tasks.py
@@ -98,17 +98,16 @@ class CompileWithClientSideEncryption(CompileTask):
         # First, compile and install without CSE.
         # Then, compile and install libmongocrypt.
         compile_with_cse = CompileTask(*args,
-                                       CFLAGS="-fPIC",
                                        COMPILE_LIBMONGOCRYPT="ON",
-                                       EXTRA_CONFIGURE_FLAGS="-DENABLE_CLIENT_SIDE_ENCRYPTION=ON",
+                                       EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON -DENABLE_CLIENT_SIDE_ENCRYPTION=ON",
                                        **kwargs).to_dict()
         extra_script = "rm CMakeCache.txt\n" + \
                        compile_with_cse["commands"][0]["params"]["script"]
 
         # Skip running mock server tests, because those were already run in the non-CSE build.
-        super(CompileWithClientSideEncryption, self).__init__(*args, CFLAGS="-fPIC",
+        super(CompileWithClientSideEncryption, self).__init__(*args,
                                                               extra_script=extra_script,
-                                                              EXTRA_CONFIGURE_FLAGS="-DENABLE_MONGOC=OFF",
+                                                              EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON -DENABLE_MONGOC=OFF",
                                                               SKIP_MOCK_TESTS="ON",
                                                               **kwargs)
         self.add_tags('client-side-encryption', 'special')
@@ -128,10 +127,10 @@ class CompileWithClientSideEncryptionAsan(CompileTask):
 
         # Skip running mock server tests, because those were already run in the non-CSE build.
         super(CompileWithClientSideEncryptionAsan, self).__init__(*args,
-                                                                  CFLAGS="-fPIC -fsanitize=address -fno-omit-frame-pointer -DBSON_MEMCHECK",
+                                                                  CFLAGS="-fsanitize=address -fno-omit-frame-pointer -DBSON_MEMCHECK",
                                                                   extra_script=extra_script,
                                                                   CHECK_LOG="ON",
-                                                                  EXTRA_CONFIGURE_FLAGS="-DENABLE_MONGOC=OFF -DENABLE_EXTRA_ALIGNMENT=OFF",
+                                                                  EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON -DENABLE_MONGOC=OFF -DENABLE_EXTRA_ALIGNMENT=OFF",
                                                                   PATH='/usr/lib/llvm-3.8/bin:$PATH',
                                                                   SKIP_MOCK_TESTS="ON",
                                                                   **kwargs)

--- a/src/kms-message/src/kms_request_str.c
+++ b/src/kms-message/src/kms_request_str.c
@@ -324,7 +324,7 @@ kms_request_str_append_stripped (kms_request_str_t *str,
 
    kms_request_str_reserve (str, appended->len);
 
-   // msvcrt is unhappy when it gets non-ANSI characters in isspace
+   /* msvcrt is unhappy when it gets non-ANSI characters in isspace */
    while (*src >= 0 && isspace (*src)) {
       ++src;
    }

--- a/src/libmongoc/tests/TestSuite.h
+++ b/src/libmongoc/tests/TestSuite.h
@@ -274,9 +274,9 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
    ASSERT_CMPINT_HELPER (a, eq, b, PRIu32, uint32_t)
 #define ASSERT_CMPUINT64(a, eq, b) \
    ASSERT_CMPINT_HELPER (a, eq, b, PRIu64, uint64_t)
-#define ASSERT_CMPSIZE_T(a, eq, b) ASSERT_CMPINT_HELPER (a, eq, b, "zd", size_t)
+#define ASSERT_CMPSIZE_T(a, eq, b) ASSERT_CMPINT_HELPER (a, eq, b, "zu", size_t)
 #define ASSERT_CMPSSIZE_T(a, eq, b) \
-   ASSERT_CMPINT_HELPER (a, eq, b, "zx", ssize_t)
+   ASSERT_CMPINT_HELPER (a, eq, b, "zd", ssize_t)
 #define ASSERT_CMPDOUBLE(a, eq, b) ASSERT_CMPINT_HELPER (a, eq, b, "f", double)
 #define ASSERT_CMPVOID(a, eq, b) ASSERT_CMPINT_HELPER (a, eq, b, "p", void *)
 


### PR DESCRIPTION
This is the first in a series of PRs intended to reduce the set of warnings currently being observed when building the C driver.

This PR addresses the following warnings:

* LLDLinker on Windows

The LLDLinker module as currently written does not support MSVC, but was being [unconditionally included](https://github.com/mongodb/mongo-c-driver/commit/14a8be487c2189c8716c40d0eeb3d1f518ca472a). Its inclusion has been conditioned on not being compiled with MSVC.

* `-fPIC` on Windows

MSVC does not recognize the `-fPIC` flag, but it was being [unconditionally passed](https://github.com/mongodb/mongo-c-driver/commit/547c93cb29c19b0606d1a674d5c61b960b9b6236) as an compilation argument. Instances of the flag have been replaced by use of the `ENABLE_PIC` CMake configuration option.

* Format specifies for `size_t` and `ssize_t`

The [format specifiers](https://github.com/mongodb/mongo-c-driver/commit/7f413137dc5b7dfb715aa8b6c0d3a2563ad9d111) in assertion macros comparing `size_t` and `ssize_t` values were using incorrectly/inconsistent specifiers. `size_t` was being printed using the signed specifier, and `ssize_t` was being printed in hexadecimal representation. They have been fixed to use the correct specifier for signedness (unsigned and signed) and consistent representation (both in decimal).

* C++ style comment in kms_request_str.c

A [stray C++ style comment](https://github.com/mongodb/mongo-c-driver/commit/f3afa3a91fba9b8ebc71fd812388d0507b300600) in kms_request_str.c has been edited to conform to C90 requirements.