### PR TITLE
eliminate dead store operations that caused scan-build failures

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-cmd.c
@@ -827,7 +827,7 @@ mongoc_cmd_parts_assemble (mongoc_cmd_parts_t *parts,
    const char *cmd_name;
    bool is_get_more;
    const mongoc_read_prefs_t *prefs_ptr;
-   mongoc_read_mode_t mode = mongoc_read_prefs_get_mode (parts->read_prefs);
+   mongoc_read_mode_t mode;
    bool ret = false;
 
    ENTRY;

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -1747,7 +1747,6 @@ test_compatible_null_error_pointer (void)
    mock_server_run (server);
    client =
       test_framework_client_new_from_uri (mock_server_get_uri (server), NULL);
-   mc_tpld_unsafe_get_const (client->topology);
 
    /* trigger connection, fails due to incompatibility */
    ASSERT (!mongoc_client_command_simple (

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -1747,7 +1747,7 @@ test_compatible_null_error_pointer (void)
    mock_server_run (server);
    client =
       test_framework_client_new_from_uri (mock_server_get_uri (server), NULL);
-   td = mc_tpld_unsafe_get_const (client->topology);
+   mc_tpld_unsafe_get_const (client->topology);
 
    /* trigger connection, fails due to incompatibility */
    ASSERT (!mongoc_client_command_simple (


### PR DESCRIPTION
Evergreen patch build: https://spruce.mongodb.com/version/623cd28b61837d50964ea4e1/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&taskName=scan-build (it is a complete patch build, but the link has it filtered down to only scan-build tasks)

@vector-of-bool I requested your review as well since this required tweaking code that was committed by you in the last few months.