### PR TITLE
CDRIVER-4332 resync types CSFLE test

### DIFF
--- a/src/libmongoc/tests/json/client_side_encryption/types.json
+++ b/src/libmongoc/tests/json/client_side_encryption/types.json
@@ -504,7 +504,7 @@
             }
           },
           "result": {
-            "errorContains": "Cannot use deterministic encryption for element of type: double"
+            "errorContains": "element of type: double"
           }
         }
       ]
@@ -551,7 +551,7 @@
             }
           },
           "result": {
-            "errorContains": "Cannot use deterministic encryption for element of type: decimal"
+            "errorContains": "element of type: decimal"
           }
         }
       ]
@@ -883,7 +883,7 @@
             }
           },
           "result": {
-            "errorContains": "Cannot use deterministic encryption for element of type: javascriptWithScope"
+            "errorContains": "element of type: javascriptWithScope"
           }
         }
       ]
@@ -928,7 +928,7 @@
             }
           },
           "result": {
-            "errorContains": "Cannot use deterministic encryption for element of type: object"
+            "errorContains": "element of type: object"
           }
         }
       ]
@@ -1547,7 +1547,7 @@
             }
           },
           "result": {
-            "errorContains": "Cannot use deterministic encryption for element of type: array"
+            "errorContains": "element of type: array"
           }
         }
       ]
@@ -1592,7 +1592,7 @@
             }
           },
           "result": {
-            "errorContains": "Cannot use deterministic encryption for element of type: bool"
+            "errorContains": "element of type: bool"
           }
         }
       ]


### PR DESCRIPTION
# Summary
Resync the `types` CSFLE test to https://github.com/mongodb/specifications/commit/6a7158d51b4c41f2f4a9c1293c5e1dceb93ab5c2 to resolve test failures on mongocryptd 6.0.0-alpha.

# Background & Motivation
The `badQueries` test is not included in C driver tests due to CDRIVER-3387. Only the `types` test was resynced.