### PR TITLE
CDRIVER-4085 add server connectionId to command monitoring events

### DIFF
--- a/src/libmongoc/doc/mongoc_apm_command_failed_get_server_connection_id.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_failed_get_server_connection_id.rst
@@ -1,0 +1,30 @@
+:man_page: mongoc_apm_command_failed_get_server_connection_id
+
+mongoc_apm_command_failed_get_server_connection_id()
+====================================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  void *
+  mongoc_apm_command_failed_get_server_connection_id (
+     const mongoc_apm_command_failed_t *event);
+
+Returns this event's context.
+
+Parameters
+----------
+
+* ``event``: A :symbol:`mongoc_apm_command_failed_t`.
+
+Returns
+-------
+
+The pointer passed with :symbol:`mongoc_client_set_apm_callbacks` or :symbol:`mongoc_client_pool_set_apm_callbacks`.
+
+.. seealso::
+
+  | :doc:`Introduction to Application Performance Monitoring <application-performance-monitoring>`
+

--- a/src/libmongoc/doc/mongoc_apm_command_failed_t.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_failed_t.rst
@@ -29,6 +29,7 @@ An event notification sent when the driver fails to execute a MongoDB command.
     mongoc_apm_command_failed_get_request_id
     mongoc_apm_command_failed_get_server_id
     mongoc_apm_command_failed_get_service_id
+    mongoc_apm_command_failed_get_server_connection_id
 
 .. seealso::
 

--- a/src/libmongoc/doc/mongoc_apm_command_started_get_server_connection_id.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_started_get_server_connection_id.rst
@@ -1,0 +1,30 @@
+:man_page: mongoc_apm_command_started_get_server_connection_id
+
+mongoc_apm_command_started_get_server_connection_id()
+=====================================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  void *
+  mongoc_apm_command_started_get_server_connection_id (
+     const mongoc_apm_command_started_t *event);
+
+Returns this event's context.
+
+Parameters
+----------
+
+* ``event``: A :symbol:`mongoc_apm_command_started_t`.
+
+Returns
+-------
+
+The pointer passed with :symbol:`mongoc_client_set_apm_callbacks` or :symbol:`mongoc_client_pool_set_apm_callbacks`.
+
+.. seealso::
+
+  | :doc:`Introduction to Application Performance Monitoring <application-performance-monitoring>`
+

--- a/src/libmongoc/doc/mongoc_apm_command_started_t.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_started_t.rst
@@ -32,4 +32,5 @@ An event notification sent when the driver begins executing a MongoDB command.
     mongoc_apm_command_started_get_request_id
     mongoc_apm_command_started_get_server_id
     mongoc_apm_command_started_get_service_id
+    mongoc_apm_command_started_get_server_connection_id
 

--- a/src/libmongoc/doc/mongoc_apm_command_succeeded_get_server_connection_id.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_succeeded_get_server_connection_id.rst
@@ -1,0 +1,30 @@
+:man_page: mongoc_apm_command_succeeded_get_server_connection_id
+
+mongoc_apm_command_succeeded_get_server_connection_id()
+=======================================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  void *
+  mongoc_apm_command_succeeded_get_server_connection_id (
+     const mongoc_apm_command_succeeded_t *event);
+
+Returns this event's context.
+
+Parameters
+----------
+
+* ``event``: A :symbol:`mongoc_apm_command_succeeded_t`.
+
+Returns
+-------
+
+The pointer passed with :symbol:`mongoc_client_set_apm_callbacks` or :symbol:`mongoc_client_pool_set_apm_callbacks`.
+
+.. seealso::
+
+  | :doc:`Introduction to Application Performance Monitoring <application-performance-monitoring>`
+

--- a/src/libmongoc/doc/mongoc_apm_command_succeeded_t.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_succeeded_t.rst
@@ -32,4 +32,5 @@ An event notification sent when the driver successfully executes a MongoDB comma
     mongoc_apm_command_succeeded_get_request_id
     mongoc_apm_command_succeeded_get_server_id
     mongoc_apm_command_succeeded_get_service_id
+    mongoc_apm_command_succeeded_get_server_connection_id
 

--- a/src/libmongoc/src/mongoc/mongoc-apm-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-apm-private.h
@@ -56,6 +56,7 @@ struct _mongoc_apm_command_started_t {
    const mongoc_host_list_t *host;
    uint32_t server_id;
    bson_oid_t service_id;
+   int32_t server_connection_id;
    void *context;
 };
 
@@ -69,6 +70,7 @@ struct _mongoc_apm_command_succeeded_t {
    const mongoc_host_list_t *host;
    uint32_t server_id;
    bson_oid_t service_id;
+   int32_t server_connection_id;
    void *context;
 };
 
@@ -83,6 +85,7 @@ struct _mongoc_apm_command_failed_t {
    const mongoc_host_list_t *host;
    uint32_t server_id;
    bson_oid_t service_id;
+   int32_t server_connection_id;
    void *context;
 };
 
@@ -159,6 +162,7 @@ mongoc_apm_command_started_init (mongoc_apm_command_started_t *event,
                                  const mongoc_host_list_t *host,
                                  uint32_t server_id,
                                  const bson_oid_t *service_id,
+                                 int32_t server_connection_id,
                                  bool *is_redacted, /* out */
                                  void *context);
 
@@ -182,6 +186,7 @@ mongoc_apm_command_succeeded_init (mongoc_apm_command_succeeded_t *event,
                                    const mongoc_host_list_t *host,
                                    uint32_t server_id,
                                    const bson_oid_t *service_id,
+                                   int32_t server_connection_id,
                                    bool force_redaction,
                                    void *context);
 
@@ -199,6 +204,7 @@ mongoc_apm_command_failed_init (mongoc_apm_command_failed_t *event,
                                 const mongoc_host_list_t *host,
                                 uint32_t server_id,
                                 const bson_oid_t *service_id,
+                                int32_t server_connection_id,
                                 bool force_redaction,
                                 void *context);
 

--- a/src/libmongoc/src/mongoc/mongoc-apm.c
+++ b/src/libmongoc/src/mongoc/mongoc-apm.c
@@ -77,6 +77,7 @@ mongoc_apm_command_started_init (mongoc_apm_command_started_t *event,
                                  const mongoc_host_list_t *host,
                                  uint32_t server_id,
                                  const bson_oid_t *service_id,
+                                 int32_t server_connection_id,
                                  bool *is_redacted, /* out */
                                  void *context)
 {
@@ -132,6 +133,7 @@ mongoc_apm_command_started_init (mongoc_apm_command_started_t *event,
    event->host = host;
    event->server_id = server_id;
    event->context = context;
+   event->server_connection_id = server_connection_id;
 
    bson_oid_copy_unsafe (service_id, &event->service_id);
 }
@@ -156,17 +158,19 @@ mongoc_apm_command_started_init_with_cmd (mongoc_apm_command_started_t *event,
                                           bool *is_redacted, /* out */
                                           void *context)
 {
-   mongoc_apm_command_started_init (event,
-                                    cmd->command,
-                                    cmd->db_name,
-                                    cmd->command_name,
-                                    request_id,
-                                    cmd->operation_id,
-                                    &cmd->server_stream->sd->host,
-                                    cmd->server_stream->sd->id,
-                                    &cmd->server_stream->sd->service_id,
-                                    is_redacted,
-                                    context);
+   mongoc_apm_command_started_init (
+      event,
+      cmd->command,
+      cmd->db_name,
+      cmd->command_name,
+      request_id,
+      cmd->operation_id,
+      &cmd->server_stream->sd->host,
+      cmd->server_stream->sd->id,
+      &cmd->server_stream->sd->service_id,
+      cmd->server_stream->sd->server_connection_id,
+      is_redacted,
+      context);
 
    /* OP_MSG document sequence for insert, update, or delete? */
    append_documents_from_cmd (cmd, event);
@@ -204,6 +208,7 @@ mongoc_apm_command_succeeded_init (mongoc_apm_command_succeeded_t *event,
                                    const mongoc_host_list_t *host,
                                    uint32_t server_id,
                                    const bson_oid_t *service_id,
+                                   int32_t server_connection_id,
                                    bool force_redaction,
                                    void *context)
 {
@@ -227,6 +232,7 @@ mongoc_apm_command_succeeded_init (mongoc_apm_command_succeeded_t *event,
    event->operation_id = operation_id;
    event->host = host;
    event->server_id = server_id;
+   event->server_connection_id = server_connection_id;
    event->context = context;
 
    bson_oid_copy_unsafe (service_id, &event->service_id);
@@ -265,6 +271,7 @@ mongoc_apm_command_failed_init (mongoc_apm_command_failed_t *event,
                                 const mongoc_host_list_t *host,
                                 uint32_t server_id,
                                 const bson_oid_t *service_id,
+                                int32_t server_connection_id,
                                 bool force_redaction,
                                 void *context)
 {
@@ -289,6 +296,7 @@ mongoc_apm_command_failed_init (mongoc_apm_command_failed_t *event,
    event->operation_id = operation_id;
    event->host = host;
    event->server_id = server_id;
+   event->server_connection_id = server_connection_id;
    event->context = context;
 
    bson_oid_copy_unsafe (service_id, &event->service_id);
@@ -378,6 +386,14 @@ mongoc_apm_command_started_get_service_id (
 }
 
 
+int32_t
+mongoc_apm_command_started_get_server_connection_id (
+   const mongoc_apm_command_started_t *event)
+{
+   return event->server_connection_id;
+}
+
+
 void *
 mongoc_apm_command_started_get_context (
    const mongoc_apm_command_started_t *event)
@@ -454,6 +470,14 @@ mongoc_apm_command_succeeded_get_service_id (
    }
 
    return &event->service_id;
+}
+
+
+int32_t
+mongoc_apm_command_succeeded_get_server_connection_id (
+   const mongoc_apm_command_succeeded_t *event)
+{
+   return event->server_connection_id;
 }
 
 
@@ -537,6 +561,14 @@ mongoc_apm_command_failed_get_service_id (
    }
 
    return &event->service_id;
+}
+
+
+int32_t
+mongoc_apm_command_failed_get_server_connection_id (
+   const mongoc_apm_command_failed_t *event)
+{
+   return event->server_connection_id;
 }
 
 

--- a/src/libmongoc/src/mongoc/mongoc-apm.h
+++ b/src/libmongoc/src/mongoc/mongoc-apm.h
@@ -102,6 +102,9 @@ mongoc_apm_command_started_get_server_id (
 MONGOC_EXPORT (const bson_oid_t *)
 mongoc_apm_command_started_get_service_id (
    const mongoc_apm_command_started_t *event);
+MONGOC_EXPORT (int32_t)
+mongoc_apm_command_started_get_server_connection_id (
+   const mongoc_apm_command_started_t *event);
 MONGOC_EXPORT (void *)
 mongoc_apm_command_started_get_context (
    const mongoc_apm_command_started_t *event);
@@ -131,6 +134,9 @@ mongoc_apm_command_succeeded_get_server_id (
    const mongoc_apm_command_succeeded_t *event);
 MONGOC_EXPORT (const bson_oid_t *)
 mongoc_apm_command_succeeded_get_service_id (
+   const mongoc_apm_command_succeeded_t *event);
+MONGOC_EXPORT (int32_t)
+mongoc_apm_command_succeeded_get_server_connection_id (
    const mongoc_apm_command_succeeded_t *event);
 MONGOC_EXPORT (void *)
 mongoc_apm_command_succeeded_get_context (
@@ -163,6 +169,9 @@ mongoc_apm_command_failed_get_server_id (
    const mongoc_apm_command_failed_t *event);
 MONGOC_EXPORT (const bson_oid_t *)
 mongoc_apm_command_failed_get_service_id (
+   const mongoc_apm_command_failed_t *event);
+MONGOC_EXPORT (int32_t)
+mongoc_apm_command_failed_get_server_connection_id (
    const mongoc_apm_command_failed_t *event);
 MONGOC_EXPORT (void *)
 mongoc_apm_command_failed_get_context (

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -2360,6 +2360,7 @@ _mongoc_client_monitor_op_killcursors (mongoc_cluster_t *cluster,
                                     &server_stream->sd->host,
                                     server_stream->sd->id,
                                     &server_stream->sd->service_id,
+                                    server_stream->sd->server_connection_id,
                                     NULL,
                                     client->apm_context);
 
@@ -2408,6 +2409,7 @@ _mongoc_client_monitor_op_killcursors_succeeded (
                                       &server_stream->sd->host,
                                       server_stream->sd->id,
                                       &server_stream->sd->service_id,
+                                      server_stream->sd->server_connection_id,
                                       false,
                                       client->apm_context);
 
@@ -2452,6 +2454,7 @@ _mongoc_client_monitor_op_killcursors_failed (
                                    &server_stream->sd->host,
                                    server_stream->sd->id,
                                    &server_stream->sd->service_id,
+                                   server_stream->sd->server_connection_id,
                                    false,
                                    client->apm_context);
 

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -575,18 +575,19 @@ mongoc_cluster_run_command_monitored (mongoc_cluster_t *cluster,
       if (!cmd->is_acknowledged) {
          bson_append_int32 (&fake_reply, "ok", 2, 1);
       }
-      mongoc_apm_command_succeeded_init (&succeeded_event,
-                                         bson_get_monotonic_time () - started,
-                                         cmd->is_acknowledged ? reply
-                                                              : &fake_reply,
-                                         cmd->command_name,
-                                         request_id,
-                                         cmd->operation_id,
-                                         &server_stream->sd->host,
-                                         server_id,
-                                         &server_stream->sd->service_id,
-                                         is_redacted,
-                                         cluster->client->apm_context);
+      mongoc_apm_command_succeeded_init (
+         &succeeded_event,
+         bson_get_monotonic_time () - started,
+         cmd->is_acknowledged ? reply : &fake_reply,
+         cmd->command_name,
+         request_id,
+         cmd->operation_id,
+         &server_stream->sd->host,
+         server_id,
+         &server_stream->sd->service_id,
+         server_stream->sd->server_connection_id,
+         is_redacted,
+         cluster->client->apm_context);
 
       callbacks->succeeded (&succeeded_event);
       mongoc_apm_command_succeeded_cleanup (&succeeded_event);
@@ -603,6 +604,7 @@ mongoc_cluster_run_command_monitored (mongoc_cluster_t *cluster,
                                       &server_stream->sd->host,
                                       server_id,
                                       &server_stream->sd->service_id,
+                                      server_stream->sd->server_connection_id,
                                       is_redacted,
                                       cluster->client->apm_context);
 

--- a/src/libmongoc/src/mongoc/mongoc-cursor-legacy.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor-legacy.c
@@ -63,6 +63,7 @@ _mongoc_cursor_monitor_legacy_get_more (mongoc_cursor_t *cursor,
                                     &server_stream->sd->host,
                                     server_stream->sd->id,
                                     &server_stream->sd->service_id,
+                                    server_stream->sd->server_connection_id,
                                     NULL,
                                     client->apm_context);
 

--- a/src/libmongoc/src/mongoc/mongoc-cursor.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor.c
@@ -726,6 +726,7 @@ _mongoc_cursor_monitor_command (mongoc_cursor_t *cursor,
                                     &server_stream->sd->host,
                                     server_stream->sd->id,
                                     &server_stream->sd->service_id,
+                                    server_stream->sd->server_connection_id,
                                     NULL,
                                     client->apm_context);
 
@@ -808,6 +809,7 @@ _mongoc_cursor_monitor_succeeded (mongoc_cursor_t *cursor,
                                       &stream->sd->host,
                                       stream->sd->id,
                                       &stream->sd->service_id,
+                                      stream->sd->server_connection_id,
                                       false,
                                       client->apm_context);
 
@@ -854,6 +856,7 @@ _mongoc_cursor_monitor_failed (mongoc_cursor_t *cursor,
                                    &stream->sd->host,
                                    stream->sd->id,
                                    &stream->sd->service_id,
+                                   stream->sd->server_connection_id,
                                    false,
                                    client->apm_context);
 

--- a/src/libmongoc/src/mongoc/mongoc-server-description-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-server-description-private.h
@@ -45,6 +45,8 @@
 
 #define MONGOC_RTT_UNSET -1
 
+#define MONGOC_NO_SERVER_CONNECTION_ID -1
+
 typedef enum {
    MONGOC_SERVER_UNKNOWN,
    MONGOC_SERVER_STANDALONE,
@@ -123,6 +125,7 @@ struct _mongoc_server_description_t {
     * service IDs. The only server generation is mapped from kZeroServiceID */
    mongoc_generation_map_t *_generation_map_;
    bson_oid_t service_id;
+   int32_t server_connection_id;
 };
 
 /** Get a mutable pointer to the server's generation map */

--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -98,6 +98,7 @@ mongoc_server_description_reset (mongoc_server_description_t *sd)
    sd->set_version = MONGOC_NO_SET_VERSION;
    bson_oid_copy_unsafe (&kObjectIdZero, &sd->election_id);
    bson_oid_copy_unsafe (&kObjectIdZero, &sd->service_id);
+   sd->server_connection_id = MONGOC_NO_SERVER_CONNECTION_ID;
 }
 
 /*
@@ -738,6 +739,10 @@ mongoc_server_description_handle_hello (mongoc_server_description_t *sd,
          if (!BSON_ITER_HOLDS_OID (&iter))
             goto failure;
          bson_oid_copy_unsafe (bson_iter_oid (&iter), &sd->service_id);
+      } else if (strcmp ("connectionId", bson_iter_key (&iter)) == 0) {
+         if (!BSON_ITER_HOLDS_INT32 (&iter))
+            goto failure;
+         sd->server_connection_id = bson_iter_int32 (&iter);
       }
    }
 
@@ -824,6 +829,7 @@ mongoc_server_description_new_copy (
    bson_init (&copy->compressors);
    bson_copy_to (&description->topology_version, &copy->topology_version);
    bson_oid_copy (&description->service_id, &copy->service_id);
+   copy->server_connection_id = description->server_connection_id;
 
    if (description->has_hello_response) {
       /* calls mongoc_server_description_reset */

--- a/src/libmongoc/src/mongoc/mongoc-write-command-legacy.c
+++ b/src/libmongoc/src/mongoc/mongoc-write-command-legacy.c
@@ -56,6 +56,7 @@ _mongoc_monitor_legacy_write (mongoc_client_t *client,
       &stream->sd->host,
       stream->sd->id,
       &stream->sd->service_id,
+      stream->sd->server_connection_id,
       NULL,
       client->apm_context);
 
@@ -107,6 +108,7 @@ _mongoc_monitor_legacy_write_succeeded (mongoc_client_t *client,
       &stream->sd->host,
       stream->sd->id,
       &stream->sd->service_id,
+      stream->sd->server_connection_id,
       false,
       client->apm_context);
 

--- a/src/libmongoc/tests/json/command_monitoring/unified/pre-42-server-connection-id.json
+++ b/src/libmongoc/tests/json/command_monitoring/unified/pre-42-server-connection-id.json
@@ -1,0 +1,101 @@
+{
+  "description": "pre-42-server-connection-id",
+  "schemaVersion": "1.6",
+  "runOnRequirements": [
+    {
+      "maxServerVersion": "4.0.99"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent",
+          "commandFailedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "server-connection-id-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "database",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "server-connection-id-tests",
+      "collectionName": "coll",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "command events do not include server connection id",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "$or": true
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "hasServerConnectionId": false
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "insert",
+                "hasServerConnectionId": false
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "hasServerConnectionId": false
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "find",
+                "hasServerConnectionId": false
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/libmongoc/tests/json/command_monitoring/unified/server-connection-id.json
+++ b/src/libmongoc/tests/json/command_monitoring/unified/server-connection-id.json
@@ -1,0 +1,101 @@
+{
+  "description": "server-connection-id",
+  "schemaVersion": "1.6",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.2"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent",
+          "commandFailedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "server-connection-id-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "database",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "server-connection-id-tests",
+      "collectionName": "coll",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "command events include server connection id",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "$or": true
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "hasServerConnectionId": true
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "insert",
+                "hasServerConnectionId": true
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "hasServerConnectionId": true
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "find",
+                "hasServerConnectionId": true
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/libmongoc/tests/unified/entity-map.c
+++ b/src/libmongoc/tests/unified/entity-map.c
@@ -200,6 +200,8 @@ command_started (const mongoc_apm_command_started_t *started)
                      &event->service_id);
    }
 
+   event->server_connection_id = started->server_connection_id;
+
    if (should_ignore_event (entity, event)) {
       event_destroy (event);
       return;
@@ -225,6 +227,8 @@ command_failed (const mongoc_apm_command_failed_t *failed)
                      &event->service_id);
    }
 
+   event->server_connection_id = failed->server_connection_id;
+
    if (should_ignore_event (entity, event)) {
       event_destroy (event);
       return;
@@ -249,6 +253,8 @@ command_succeeded (const mongoc_apm_command_succeeded_t *succeeded)
       bson_oid_copy (mongoc_apm_command_succeeded_get_service_id (succeeded),
                      &event->service_id);
    }
+
+   event->server_connection_id = succeeded->server_connection_id;
 
    if (should_ignore_event (entity, event)) {
       event_destroy (event);

--- a/src/libmongoc/tests/unified/entity-map.h
+++ b/src/libmongoc/tests/unified/entity-map.h
@@ -30,6 +30,7 @@ typedef struct _event_t {
    bson_t *command;
    bson_t *reply;
    bson_oid_t service_id;
+   int32_t server_connection_id;
    struct _event_t *next;
 } event_t;
 

--- a/src/libmongoc/tests/unified/runner.c
+++ b/src/libmongoc/tests/unified/runner.c
@@ -1119,9 +1119,7 @@ test_check_event (test_t *test,
    }
 
    if (expected_has_server_connection_id) {
-      bool has_server_connection_id = false;
-
-      has_server_connection_id =
+      const bool has_server_connection_id =
          actual->server_connection_id != MONGOC_NO_SERVER_CONNECTION_ID;
 
       if (*expected_has_server_connection_id && !has_server_connection_id) {


### PR DESCRIPTION
Evergreen patch build: https://spruce.mongodb.com/version/625f6c3057e85a68b11bea04/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

I've reviewed the tasks that are green on the base commit and red on the patch build.  The few failures are unrelated (e.g., the longstanding ccache bug on Ubuntu, the failure to build with static libssl on RHEL, etc.).