### PR TITLE
fix CMake version check for OpenSSL 1.1+ on Windows

### DIFF
--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -196,8 +196,8 @@ if (NOT ENABLE_SSL STREQUAL OFF)
 endif ()
 
 if (OPENSSL_FOUND)
-   if (WIN32 AND OPENSSL_VERSION GREATER 1.1 AND NOT
-         ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.7)
+   if (WIN32 AND OPENSSL_VERSION VERSION_GREATER 1.1 AND NOT
+         ${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.7)
       message (FATAL_ERROR "Building against OpenSSL 1.1.0 and later requires CMake 3.7 or later (hint:"
          " You can also compile against Windows Secure Transport with -DENABLE_SSL=WINDOWS")
    endif ()

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -196,8 +196,8 @@ if (NOT ENABLE_SSL STREQUAL OFF)
 endif ()
 
 if (OPENSSL_FOUND)
-   if (WIN32 AND OPENSSL_VERSION VERSION_GREATER 1.1 AND NOT
-         ${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.7)
+   if (WIN32 AND OPENSSL_VERSION VERSION_GREATER 1.1 AND
+         ${CMAKE_VERSION} VERSION_LESS 3.7)
       message (FATAL_ERROR "Building against OpenSSL 1.1.0 and later requires CMake 3.7 or later (hint:"
          " You can also compile against Windows Secure Transport with -DENABLE_SSL=WINDOWS")
    endif ()


### PR DESCRIPTION
As it stands, this check does not function as intended on the CMake versions that I tried (3.22 and 3.23).

I suspect it would not work from CMake 3.10 until CMake 3.70 (were such a version ever to exist); the comparison appears to a floating-point comparison instead of a version comparison.

I took the error message

> `requires CMake 3.7 or later`

at face value and assumed that `${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.7` is correct instead of `${CMAKE_VERSION} VERSION_GREATER 3.7` which would be the direct translation from the previous version of the script.