### PR TITLE
CDRIVER-4317 Add support for clientEncryption entity in unified test runner

### DIFF
--- a/src/libmongoc/tests/bsonutil/bson-match.c
+++ b/src/libmongoc/tests/bsonutil/bson-match.c
@@ -60,6 +60,20 @@ is_special_match (const bson_t *bson)
    return true;
 }
 
+/* implements $$placeholder */
+static bool
+special_placeholder (bson_matcher_t *matcher,
+                     const bson_t *assertion,
+                     const bson_val_t *actual,
+                     void *ctx,
+                     const char *path,
+                     bson_error_t *error)
+{
+   /* Nothing to do (not an operator, just a reserved key value). The meaning
+    * and corresponding behavior of $$placeholder depends on context. */
+   return true;
+}
+
 /* implements $$exists */
 static bool
 special_exists (bson_matcher_t *matcher,
@@ -300,6 +314,8 @@ bson_matcher_new ()
 {
    bson_matcher_t *matcher = bson_malloc0 (sizeof (bson_matcher_t));
    /* Add default special functions. */
+   bson_matcher_add_special (
+      matcher, "$$placeholder", special_placeholder, NULL);
    bson_matcher_add_special (matcher, "$$exists", special_exists, NULL);
    bson_matcher_add_special (matcher, "$$type", special_type, NULL);
    bson_matcher_add_special (

--- a/src/libmongoc/tests/json/unified/kmsProviders-explicit_kms_credentials.json
+++ b/src/libmongoc/tests/json/unified/kmsProviders-explicit_kms_credentials.json
@@ -1,6 +1,11 @@
 {
   "description": "kmsProviders-explicit_kms_credentials",
   "schemaVersion": "1.8",
+  "runOnRequirements": [
+    {
+      "csfle": true
+    }
+  ],
   "createEntities": [
     {
       "client": {

--- a/src/libmongoc/tests/json/unified/kmsProviders-explicit_kms_credentials.json
+++ b/src/libmongoc/tests/json/unified/kmsProviders-explicit_kms_credentials.json
@@ -1,0 +1,47 @@
+{
+  "description": "kmsProviders-explicit_kms_credentials",
+  "schemaVersion": "1.8",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "clientEncryption": {
+        "id": "clientEncryption0",
+        "clientEncryptionOpts": {
+          "keyVaultClient": "client0",
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {
+            "aws": {
+              "accessKeyId": "accessKeyId",
+              "secretAccessKey": "secretAccessKey"
+            },
+            "azure": {
+              "tenantId": "tenantId",
+              "clientId": "clientId",
+              "clientSecret": "clientSecret"
+            },
+            "gcp": {
+              "email": "email",
+              "privateKey": "cHJpdmF0ZUtleQo="
+            },
+            "kmip": {
+              "endpoint": "endpoint"
+            },
+            "local": {
+              "key": "a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "",
+      "operations": []
+    }
+  ]
+}

--- a/src/libmongoc/tests/json/unified/kmsProviders-mixed_kms_credential_fields.json
+++ b/src/libmongoc/tests/json/unified/kmsProviders-mixed_kms_credential_fields.json
@@ -1,6 +1,11 @@
 {
   "description": "kmsProviders-mixed_kms_credential_fields",
   "schemaVersion": "1.8",
+  "runOnRequirements": [
+    {
+      "csfle": true
+    }
+  ],
   "createEntities": [
     {
       "client": {

--- a/src/libmongoc/tests/json/unified/kmsProviders-mixed_kms_credential_fields.json
+++ b/src/libmongoc/tests/json/unified/kmsProviders-mixed_kms_credential_fields.json
@@ -1,0 +1,49 @@
+{
+  "description": "kmsProviders-mixed_kms_credential_fields",
+  "schemaVersion": "1.8",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "clientEncryption": {
+        "id": "clientEncryption0",
+        "clientEncryptionOpts": {
+          "keyVaultClient": "client0",
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {
+            "aws": {
+              "accessKeyId": "accessKeyId",
+              "secretAccessKey": {
+                "$$placeholder": 1
+              }
+            },
+            "azure": {
+              "tenantId": "tenantId",
+              "clientId": {
+                "$$placeholder": 1
+              },
+              "clientSecret": {
+                "$$placeholder": 1
+              }
+            },
+            "gcp": {
+              "email": "email",
+              "privateKey": {
+                "$$placeholder": 1
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "",
+      "operations": []
+    }
+  ]
+}

--- a/src/libmongoc/tests/json/unified/kmsProviders-placeholder_kms_credentials.json
+++ b/src/libmongoc/tests/json/unified/kmsProviders-placeholder_kms_credentials.json
@@ -1,0 +1,65 @@
+{
+  "description": "kmsProviders-placeholder_kms_credentials",
+  "schemaVersion": "1.8",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "clientEncryption": {
+        "id": "clientEncryption0",
+        "clientEncryptionOpts": {
+          "keyVaultClient": "client0",
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {
+            "aws": {
+              "accessKeyId": {
+                "$$placeholder": 1
+              },
+              "secretAccessKey": {
+                "$$placeholder": 1
+              }
+            },
+            "azure": {
+              "tenantId": {
+                "$$placeholder": 1
+              },
+              "clientId": {
+                "$$placeholder": 1
+              },
+              "clientSecret": {
+                "$$placeholder": 1
+              }
+            },
+            "gcp": {
+              "email": {
+                "$$placeholder": 1
+              },
+              "privateKey": {
+                "$$placeholder": 1
+              }
+            },
+            "kmip": {
+              "endpoint": {
+                "$$placeholder": 1
+              }
+            },
+            "local": {
+              "key": {
+                "$$placeholder": 1
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "",
+      "operations": []
+    }
+  ]
+}

--- a/src/libmongoc/tests/json/unified/kmsProviders-placeholder_kms_credentials.json
+++ b/src/libmongoc/tests/json/unified/kmsProviders-placeholder_kms_credentials.json
@@ -1,6 +1,11 @@
 {
   "description": "kmsProviders-placeholder_kms_credentials",
   "schemaVersion": "1.8",
+  "runOnRequirements": [
+    {
+      "csfle": true
+    }
+  ],
   "createEntities": [
     {
       "client": {

--- a/src/libmongoc/tests/json/unified/kmsProviders-unconfigured_kms.json
+++ b/src/libmongoc/tests/json/unified/kmsProviders-unconfigured_kms.json
@@ -1,6 +1,11 @@
 {
   "description": "kmsProviders-unconfigured_kms",
   "schemaVersion": "1.8",
+  "runOnRequirements": [
+    {
+      "csfle": true
+    }
+  ],
   "createEntities": [
     {
       "client": {

--- a/src/libmongoc/tests/json/unified/kmsProviders-unconfigured_kms.json
+++ b/src/libmongoc/tests/json/unified/kmsProviders-unconfigured_kms.json
@@ -1,0 +1,33 @@
+{
+  "description": "kmsProviders-unconfigured_kms",
+  "schemaVersion": "1.8",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "clientEncryption": {
+        "id": "clientEncryption0",
+        "clientEncryptionOpts": {
+          "keyVaultClient": "client0",
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {
+            "aws": {},
+            "azure": {},
+            "gcp": {},
+            "kmip": {},
+            "local": {}
+          }
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "",
+      "operations": []
+    }
+  ]
+}

--- a/src/libmongoc/tests/unified/entity-map.c
+++ b/src/libmongoc/tests/unified/entity-map.c
@@ -677,24 +677,27 @@ _parse_kms_provider_kmip (bson_t *kms_providers,
          }
 
          /* Configure tlsOptions to enable KMIP TLS connections. */
-         BSON_APPEND_DOCUMENT_BEGIN (tls_opts, provider, &child);
-         if (!_append_kms_provider_value_or_getenv (
-                &child,
-                "tlsCAFile",
-                NULL,
-                "MONGOC_TEST_CSFLE_TLS_CA_FILE",
-                error)) {
-            return false;
+         {
+            bson_t tls_child;
+            BSON_APPEND_DOCUMENT_BEGIN (tls_opts, provider, &tls_child);
+            if (!_append_kms_provider_value_or_getenv (
+                   &tls_child,
+                   "tlsCAFile",
+                   NULL,
+                   "MONGOC_TEST_CSFLE_TLS_CA_FILE",
+                   error)) {
+               return false;
+            }
+            if (!_append_kms_provider_value_or_getenv (
+                   &tls_child,
+                   "tlsCertificateKeyFile",
+                   NULL,
+                   "MONGOC_TEST_CSFLE_TLS_CERTIFICATE_KEY_FILE",
+                   error)) {
+               return false;
+            }
+            bson_append_document_end (tls_opts, &tls_child);
          }
-         if (!_append_kms_provider_value_or_getenv (
-                &child,
-                "tlsCertificateKeyFile",
-                NULL,
-                "MONGOC_TEST_CSFLE_TLS_CERTIFICATE_KEY_FILE",
-                error)) {
-            return false;
-         }
-         bson_append_document_end (tls_opts, &child);
       } else {
          test_set_error (error, "unexpected field '%s'", value);
          return false;

--- a/src/libmongoc/tests/unified/entity-map.c
+++ b/src/libmongoc/tests/unified/entity-map.c
@@ -735,12 +735,14 @@ _parse_kms_provider_local (bson_t *kms_providers,
          } else {
             /* LOCAL_MASTERKEY in base64 encoding as defined in Client Side
              * Encryption Tests spec. */
-            const char key[] =
+            const char local_masterkey[] =
                "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6N"
                "mdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZG"
                "JkTXVyZG9uSjFk";
             uint8_t data[96];
-            BSON_ASSERT (mcommon_b64_pton (key, data, sizeof (data)) == 96);
+            BSON_ASSERT (mcommon_b64_pton (local_masterkey,
+                                           data,
+                                           sizeof (local_masterkey)) == 96);
             BSON_APPEND_BINARY (&child, "key", BSON_SUBTYPE_BINARY, data, 96);
          }
       } else {

--- a/src/libmongoc/tests/unified/entity-map.c
+++ b/src/libmongoc/tests/unified/entity-map.c
@@ -347,7 +347,7 @@ entity_client_new (entity_map_t *em, bson_t *bson, bson_error_t *error)
       }
    } else if (use_multiple_mongoses != NULL) {
       if (!test_framework_uri_apply_multi_mongos (
-               uri, *use_multiple_mongoses, error)) {
+             uri, *use_multiple_mongoses, error)) {
          goto done;
       }
    }
@@ -390,7 +390,8 @@ entity_client_new (entity_map_t *em, bson_t *bson, bson_error_t *error)
          } else if (0 == strcmp (event_type, "commandSucceededEvent")) {
             mongoc_apm_set_command_succeeded_cb (callbacks, command_succeeded);
          } else if (is_unsupported_event_type (event_type)) {
-            MONGOC_DEBUG ("Skipping observing unsupported event type: %s", event_type);
+            MONGOC_DEBUG ("Skipping observing unsupported event type: %s",
+                          event_type);
             continue;
          } else {
             test_set_error (error, "Unexpected event type: %s", event_type);

--- a/src/libmongoc/tests/unified/entity-map.c
+++ b/src/libmongoc/tests/unified/entity-map.c
@@ -870,8 +870,7 @@ entity_client_encryption_new (entity_map_t *entity_map,
             goto ce_opts_done;
          }
 
-         BSON_ASSERT (client =
-            (mongoc_client_t *) client_entity->value));
+         BSON_ASSERT ((client = (mongoc_client_t *) client_entity->value));
 
          mongoc_client_encryption_opts_set_keyvault_client (ce_opts, client);
       }

--- a/src/libmongoc/tests/unified/entity-map.c
+++ b/src/libmongoc/tests/unified/entity-map.c
@@ -634,7 +634,7 @@ _parse_kms_provider_gcp (bson_t *kms_providers,
          }
       } else if (strcmp (key, "endpoint") == 0) {
          if (value) {
-            BSON_APPEND_UTF8 (&child, key, value);
+            BSON_ASSERT (BSON_APPEND_UTF8 (&child, key, value));
          }
       } else {
          test_set_error (error, "unexpected field '%s'", value);
@@ -670,16 +670,17 @@ _parse_kms_provider_kmip (bson_t *kms_providers,
 
       if (strcmp (key, "endpoint") == 0) {
          if (value) {
-            BSON_APPEND_UTF8 (&child, key, value);
+            BSON_ASSERT (BSON_APPEND_UTF8 (&child, key, value));
          } else {
             /* Expect KMIP test server running on port 5698. */
-            BSON_APPEND_UTF8 (&child, key, "localhost:5698");
+            BSON_ASSERT (BSON_APPEND_UTF8 (&child, key, "localhost:5698"));
          }
 
          /* Configure tlsOptions to enable KMIP TLS connections. */
          {
             bson_t tls_child;
-            BSON_APPEND_DOCUMENT_BEGIN (tls_opts, provider, &tls_child);
+            BSON_ASSERT (
+               BSON_APPEND_DOCUMENT_BEGIN (tls_opts, provider, &tls_child));
             if (!_append_kms_provider_value_or_getenv (
                    &tls_child,
                    "tlsCAFile",
@@ -696,7 +697,7 @@ _parse_kms_provider_kmip (bson_t *kms_providers,
                    error)) {
                return false;
             }
-            bson_append_document_end (tls_opts, &tls_child);
+            BSON_ASSERT (bson_append_document_end (tls_opts, &tls_child));
          }
       } else {
          test_set_error (error, "unexpected field '%s'", value);
@@ -732,7 +733,7 @@ _parse_kms_provider_local (bson_t *kms_providers,
 
       if (strcmp (key, "key") == 0) {
          if (value) {
-            BSON_APPEND_UTF8 (&child, key, value);
+            BSON_ASSERT (BSON_APPEND_UTF8 (&child, key, value));
          } else {
             /* LOCAL_MASTERKEY in base64 encoding as defined in Client Side
              * Encryption Tests spec. */

--- a/src/libmongoc/tests/unified/entity-map.c
+++ b/src/libmongoc/tests/unified/entity-map.c
@@ -437,7 +437,7 @@ _entity_client_encryption_getenv (const char *name, bson_error_t *error)
 
    if (!(res = _mongoc_getenv (name))) {
       test_set_error (
-         error, "expected environment variable '%s' to be set", name);
+         error, "missing required environment variable '%s'", name);
    }
 
    return res;
@@ -469,9 +469,6 @@ _append_kms_provider_value_or_getenv (bson_t *bson,
          return true;
       }
    }
-
-   test_set_error (
-      error, "missing required environment variable '%s'", env_name);
 
    return false;
 }

--- a/src/libmongoc/tests/unified/entity-map.c
+++ b/src/libmongoc/tests/unified/entity-map.c
@@ -486,10 +486,11 @@ _validate_string_or_placeholder (const bson_iter_t *iter, bson_error_t *error)
       return true;
    }
 
-   /* Must be `{'$$placeholder': {}}` otherwise. */
+   /* Otherwise, must be a document with a single '$$placeholder' field. */
    if (BSON_ITER_HOLDS_DOCUMENT (iter)) {
       bson_val_t *const bson_val = bson_val_from_iter (iter);
-      bson_val_t *const expected = bson_val_from_json ("{'$$placeholder': {}}");
+      bson_val_t *const expected =
+         bson_val_from_json ("{'$$placeholder': { '$exists': true }}");
       bool is_match = false;
 
       BSON_ASSERT (bson_val);

--- a/src/libmongoc/tests/unified/entity-map.h
+++ b/src/libmongoc/tests/unified/entity-map.h
@@ -104,6 +104,11 @@ entity_map_get_client (entity_map_t *entity_map,
                        const char *id,
                        bson_error_t *error);
 
+mongoc_client_encryption_t *
+entity_map_get_client_encryption (entity_map_t *entity_map,
+                                  const char *id,
+                                  bson_error_t *error);
+
 mongoc_database_t *
 entity_map_get_database (entity_map_t *entity_map,
                          const char *id,

--- a/src/libmongoc/tests/unified/result.c
+++ b/src/libmongoc/tests/unified/result.c
@@ -363,8 +363,9 @@ result_check (result_t *result,
       }
       if (!entity_map_match (em, expect_result, result->value, false, error)) {
          test_set_error (error,
-                         "checking expectResult: %s",
-                         bson_val_to_json (expect_result));
+                         "expectResult mismatch:\nExpected: %s\nActual: %s\n",
+                         bson_val_to_json (expect_result),
+                         bson_val_to_json (result->value));
          goto done;
       }
    }
@@ -529,8 +530,9 @@ result_check (result_t *result,
 
          if (!bson_match (error_expect_result, result->value, true, error)) {
             test_diagnostics_error_info (
-               "checking error.expectResult: %s",
-               bson_val_to_json (error_expect_result));
+               "error.expectResult mismatch:\nExpected: %s\nActual: %s\n",
+               bson_val_to_json (error_expect_result),
+               bson_val_to_json (result->value));
             goto done;
          }
       }

--- a/src/libmongoc/tests/unified/runner.c
+++ b/src/libmongoc/tests/unified/runner.c
@@ -619,7 +619,7 @@ get_topology_type (mongoc_client_t *client)
 static void
 check_schema_version (test_file_t *test_file)
 {
-   const char *supported_version_strs[] = {"1.5"};
+   const char *supported_version_strs[] = {"1.8"};
    int i;
 
    for (i = 0; i < sizeof (supported_version_strs) /

--- a/src/libmongoc/tests/unified/runner.c
+++ b/src/libmongoc/tests/unified/runner.c
@@ -379,7 +379,8 @@ test_runner_new (void)
    callbacks = mongoc_apm_callbacks_new ();
    mongoc_apm_set_topology_changed_cb (callbacks, on_topology_changed);
    uri = test_framework_get_uri ();
-   /* In load balanced mode, the internal client must use the SINGLE_LB_MONGOS_URI. */
+   /* In load balanced mode, the internal client must use the
+    * SINGLE_LB_MONGOS_URI. */
    if (!test_framework_is_loadbalanced ()) {
       /* Always use multiple mongoses if speaking to a mongos.
        * Some test operations require communicating with all known mongos */
@@ -1104,12 +1105,13 @@ test_check_event (test_t *test,
       bool has_service_id = false;
 
       bson_oid_to_string (&actual->service_id, oid_str);
-      has_service_id = 0 != bson_oid_compare (&actual->service_id, &kZeroServiceId);
+      has_service_id =
+         0 != bson_oid_compare (&actual->service_id, &kZeroServiceId);
 
       if (*expected_has_service_id && !has_service_id) {
          test_error ("expected serviceId, but got none");
       }
-      
+
       if (!*expected_has_service_id && has_service_id) {
          test_error ("expected no serviceId, but got %s", oid_str);
       }

--- a/src/libmongoc/tests/unified/runner.c
+++ b/src/libmongoc/tests/unified/runner.c
@@ -774,6 +774,35 @@ check_run_on_requirement (test_runner_t *test_runner,
          return false;
       }
 
+#if defined(MONGOC_ENABLE_CLIENT_SIDE_ENCRYPTION)
+      if (0 == strcmp (key, "csfle")) {
+         const bool csfle_required = bson_iter_bool (&req_iter);
+
+         if (csfle_required) {
+            continue;
+         }
+
+         *fail_reason =
+            bson_strdup_printf ("CSFLE is not allowed but libmongoc was built "
+                                "with MONGOC_ENABLE_CLIENT_SIDE_ENCRYPTION=ON");
+
+         return false;
+#else
+      if (0 == strcmp (key, "csfle")) {
+         const bool csfle_required = bson_iter_bool (&req_iter);
+
+         if (!csfle_required) {
+            continue;
+         }
+
+         *fail_reason = bson_strdup_printf (
+            "CSFLE is required but libmongoc was built "
+            "without MONGOC_ENABLE_CLIENT_SIDE_ENCRYPTION=ON");
+
+         return false;
+#endif /* !defined(MONGOC_CLIENT_SIDE_ENCRYPTION) */
+      }
+
       test_error ("Unexpected runOnRequirement field: %s", key);
    }
    return true;


### PR DESCRIPTION
This PR is a part of CDRIVER-4317. It is being reviewed separately to unblock FLE 2 work.

This PR implements support for the new `clientEncryption` entity in unified tests. The JSON schema version is bumped from 1.5 to 1.8 to support running new unified test format valid-pass test files. This does _not_ indicate that the unified test runner supports JSON schema version 1.8 in its entirety (not all spec tests have been updated).

This PR includes a drive-by improvement to unified test runner error messages to support outputting the actual value of a BSON document when it differs from the expected value.

### PR Updates

- Add support for `runOnRequirement.csfle` to avoid test runner errors when built without CSFLE.