### PR TITLE
CDRIVER-4085 fix docs for server_connection_id getters

### DIFF
--- a/src/libmongoc/doc/mongoc_apm_command_failed_get_server_connection_id.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_failed_get_server_connection_id.rst
@@ -8,11 +8,16 @@ Synopsis
 
 .. code-block:: c
 
-  void *
+  int32_t
   mongoc_apm_command_failed_get_server_connection_id (
      const mongoc_apm_command_failed_t *event);
 
 Returns this event's context.
+
+Returns the server connection ID for the command. The server connection ID is
+distinct from the server ID (:symbol:`mongoc_apm_command_failed_get_server_id`)
+and is returned by the hello or legacy hello response as "connectionId" from the
+server on 4.2+.
 
 Parameters
 ----------
@@ -22,7 +27,7 @@ Parameters
 Returns
 -------
 
-The pointer passed with :symbol:`mongoc_client_set_apm_callbacks` or :symbol:`mongoc_client_pool_set_apm_callbacks`.
+The server connection ID as a positive integer or -1 if it is not available.
 
 .. seealso::
 

--- a/src/libmongoc/doc/mongoc_apm_command_started_get_server_connection_id.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_started_get_server_connection_id.rst
@@ -8,11 +8,14 @@ Synopsis
 
 .. code-block:: c
 
-  void *
+  int32_t
   mongoc_apm_command_started_get_server_connection_id (
      const mongoc_apm_command_started_t *event);
 
-Returns this event's context.
+Returns the server connection ID for the command. The server connection ID is
+distinct from the server ID (:symbol:`mongoc_apm_command_started_get_server_id`)
+and is returned by the hello or legacy hello response as "connectionId" from the
+server on 4.2+.
 
 Parameters
 ----------
@@ -22,7 +25,7 @@ Parameters
 Returns
 -------
 
-The pointer passed with :symbol:`mongoc_client_set_apm_callbacks` or :symbol:`mongoc_client_pool_set_apm_callbacks`.
+The server connection ID as a positive integer or -1 if it is not available.
 
 .. seealso::
 

--- a/src/libmongoc/doc/mongoc_apm_command_succeeded_get_server_connection_id.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_succeeded_get_server_connection_id.rst
@@ -8,11 +8,14 @@ Synopsis
 
 .. code-block:: c
 
-  void *
+  int32_t
   mongoc_apm_command_succeeded_get_server_connection_id (
      const mongoc_apm_command_succeeded_t *event);
 
-Returns this event's context.
+Returns the server connection ID for the command. The server connection ID is
+distinct from the server ID
+(:symbol:`mongoc_apm_command_succeeded_get_server_id`) and is returned by the
+hello or legacy hello response as "connectionId" from the server on 4.2+.
 
 Parameters
 ----------
@@ -22,7 +25,7 @@ Parameters
 Returns
 -------
 
-The pointer passed with :symbol:`mongoc_client_set_apm_callbacks` or :symbol:`mongoc_client_pool_set_apm_callbacks`.
+The server connection ID as a positive integer or -1 if it is not available.
 
 .. seealso::
 


### PR DESCRIPTION
This removes copypasta that was missed in https://github.com/mongodb/mongo-c-driver/commit/ba73833f18191b34acc990bdca91bb9e68c90dfb (#972)