### PR TITLE
CDRIVER-4358 sync allowDiskUse CRUD spec tests

### DIFF
--- a/src/libmongoc/tests/json/crud/unified/aggregate-allowdiskuse.json
+++ b/src/libmongoc/tests/json/crud/unified/aggregate-allowdiskuse.json
@@ -1,11 +1,6 @@
 {
-  "description": "find-allowdiskuse",
+  "description": "aggregate-allowdiskuse",
   "schemaVersion": "1.0",
-  "runOnRequirements": [
-    {
-      "minServerVersion": "4.3.1"
-    }
-  ],
   "createEntities": [
     {
       "client": {
@@ -19,26 +14,37 @@
       "database": {
         "id": "database0",
         "client": "client0",
-        "databaseName": "crud-v2"
+        "databaseName": "crud-tests"
       }
     },
     {
       "collection": {
         "id": "collection0",
         "database": "database0",
-        "collectionName": "test_find_allowdiskuse"
+        "collectionName": "coll0"
       }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": []
     }
   ],
   "tests": [
     {
-      "description": "Find does not send allowDiskUse when value is not specified",
+      "description": "Aggregate does not send allowDiskUse when value is not specified",
       "operations": [
         {
           "object": "collection0",
-          "name": "find",
+          "name": "aggregate",
           "arguments": {
-            "filter": {}
+            "pipeline": [
+              {
+                "$match": {}
+              }
+            ]
           }
         }
       ],
@@ -49,11 +55,18 @@
             {
               "commandStartedEvent": {
                 "command": {
-                  "find": "test_find_allowdiskuse",
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {}
+                    }
+                  ],
                   "allowDiskUse": {
                     "$$exists": false
                   }
-                }
+                },
+                "commandName": "aggregate",
+                "databaseName": "crud-tests"
               }
             }
           ]
@@ -61,13 +74,17 @@
       ]
     },
     {
-      "description": "Find sends allowDiskUse false when false is specified",
+      "description": "Aggregate sends allowDiskUse false when false is specified",
       "operations": [
         {
           "object": "collection0",
-          "name": "find",
+          "name": "aggregate",
           "arguments": {
-            "filter": {},
+            "pipeline": [
+              {
+                "$match": {}
+              }
+            ],
             "allowDiskUse": false
           }
         }
@@ -79,9 +96,16 @@
             {
               "commandStartedEvent": {
                 "command": {
-                  "find": "test_find_allowdiskuse",
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {}
+                    }
+                  ],
                   "allowDiskUse": false
-                }
+                },
+                "commandName": "aggregate",
+                "databaseName": "crud-tests"
               }
             }
           ]
@@ -89,13 +113,17 @@
       ]
     },
     {
-      "description": "Find sends allowDiskUse true when true is specified",
+      "description": "Aggregate sends allowDiskUse true when true is specified",
       "operations": [
         {
           "object": "collection0",
-          "name": "find",
+          "name": "aggregate",
           "arguments": {
-            "filter": {},
+            "pipeline": [
+              {
+                "$match": {}
+              }
+            ],
             "allowDiskUse": true
           }
         }
@@ -107,9 +135,16 @@
             {
               "commandStartedEvent": {
                 "command": {
-                  "find": "test_find_allowdiskuse",
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {}
+                    }
+                  ],
                   "allowDiskUse": true
-                }
+                },
+                "commandName": "aggregate",
+                "databaseName": "crud-tests"
               }
             }
           ]


### PR DESCRIPTION
Full Evergreen patch build: https://spruce.mongodb.com/version/626c8db630661566a405605d/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

I synced all the spec tests associated with the `allowDiskUse` option and ran a patch build.  There were no failures present in the patch build that weren't in the base commit (except for one spurious TSAN failure).  I also checked to ensure that we aren't skipping any of the tests associated with `allowDiskUse`.  Apart from the spec tests themselves, there are only two mentions of `allowDiskUse` in the C driver code:

- in `test-mongoc-collection.c`, where it is set as an option as part of a specific test
- in `mongoc_collection_find_with_opts.rst` where its existence and type is documented

Neither of those occurrences appear to require a change as part of this ticket.