### PR TITLE
Fix fallback for missing stdbool.h

### DIFF
--- a/src/kms-message/src/kms_crypto.h
+++ b/src/kms-message/src/kms_crypto.h
@@ -17,8 +17,7 @@
 #ifndef KMS_MESSAGE_KMS_CRYPTO_H
 #define KMS_MESSAGE_KMS_CRYPTO_H
 
-#include <stdbool.h>
-#include <stdlib.h>
+#include "bson-compat.h"
 
 typedef struct {
    bool (*sha256) (void *ctx,

--- a/src/kms-message/src/kms_kv_list.h
+++ b/src/kms-message/src/kms_kv_list.h
@@ -17,12 +17,9 @@
 #ifndef KMS_KV_LIST_H
 #define KMS_KV_LIST_H
 
+#include "bson-compat.h"
 #include "kms_message/kms_message.h"
 #include "kms_request_str.h"
-
-#include <stdbool.h>
-#include <stdint.h>
-#include <stdlib.h>
 
 /* key-value pair */
 typedef struct {

--- a/src/kms-message/src/kms_message/kms_request.h
+++ b/src/kms-message/src/kms_message/kms_request.h
@@ -17,12 +17,8 @@
 #ifndef KMS_REQUEST_H
 #define KMS_REQUEST_H
 
+#include "bson-compat.h"
 #include "kms_message.h"
-
-#include <stdbool.h>
-#include <stdint.h>
-#include <stdlib.h>
-#include <time.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/kms-message/src/kms_message/kms_request_opt.h
+++ b/src/kms-message/src/kms_message/kms_request_opt.h
@@ -17,10 +17,8 @@
 #ifndef KMS_REQUEST_OPT_H
 #define KMS_REQUEST_OPT_H
 
+#include "bson-compat.h"
 #include "kms_message_defines.h"
-
-#include <stdbool.h>
-#include <stdlib.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/kms-message/src/kms_request_opt_private.h
+++ b/src/kms-message/src/kms_request_opt_private.h
@@ -17,11 +17,10 @@
 #ifndef KMS_REQUEST_OPT_PRIVATE_H
 #define KMS_REQUEST_OPT_PRIVATE_H
 
+#include "bson-compat.h"
 #include "kms_message/kms_message_defines.h"
 #include "kms_message/kms_request_opt.h"
 #include "kms_crypto.h"
-
-#include <stdbool.h>
 
 struct _kms_request_opt_t {
    bool connection_close;

--- a/src/kms-message/src/kms_request_str.c
+++ b/src/kms-message/src/kms_request_str.c
@@ -14,17 +14,13 @@
  * limitations under the License.
  */
 
+#include "bson-compat.h"
 #include "hexlify.h"
 #include "kms_crypto.h"
 #include "kms_message/kms_message.h"
 #include "kms_message_private.h"
 #include "kms_request_str.h"
 #include "kms_port.h"
-
-#include <stdio.h>
-#include <ctype.h>
-#include <stdbool.h>
-#include <stdlib.h>
 
 bool rfc_3986_tab[256] = {0};
 bool kms_initialized = false;

--- a/src/kms-message/src/kms_request_str.h
+++ b/src/kms-message/src/kms_request_str.h
@@ -17,13 +17,9 @@
 #ifndef KMS_MESSAGE_KMS_REQUEST_STR_H
 #define KMS_MESSAGE_KMS_REQUEST_STR_H
 
+#include "bson-compat.h"
 #include "kms_message/kms_message.h"
 #include "kms_crypto.h"
-
-#include <stdarg.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <string.h>
 
 typedef struct {
    char *str;

--- a/src/libbson/CMakeLists.txt
+++ b/src/libbson/CMakeLists.txt
@@ -98,6 +98,9 @@ else ()
 endif ()
 
 CHECK_INCLUDE_FILE (stdbool.h BSON_HAVE_STDBOOL_H)
+if (NOT BSON_HAVE_STDBOOL_H)
+   set (BSON_HAVE_STDBOOL_H 0)
+endif ()
 
 if (MSVC)
    set (BSON_HAVE_CLOCK_GETTIME 0)

--- a/src/libbson/src/bson/bson-cmp.h
+++ b/src/libbson/src/bson/bson-cmp.h
@@ -21,12 +21,8 @@
 #define BSON_CMP_H
 
 
-#include "bson-compat.h" /* ssize_t */
+#include "bson-compat.h" /* limits, ssize_t, stdbool, stdint */
 #include "bson-macros.h" /* BSON_CONCAT */
-
-#include <limits.h>
-#include <stdbool.h>
-#include <stdint.h>
 
 
 BSON_BEGIN_DECLS

--- a/src/libmongoc/src/mongoc/mongoc-timeout-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-timeout-private.h
@@ -19,8 +19,7 @@
 #ifndef MONGOC_TIMEOUT_PRIVATE_H
 #define MONGOC_TIMEOUT_PRIVATE_H
 
-#include <stdint.h>
-#include <stdbool.h>
+#include "bson-compat.h"
 
 typedef struct _mongoc_timeout_t mongoc_timeout_t;
 


### PR DESCRIPTION
I've noticed that if `stdbool.h` is missing (not supported by the compiler), the existing fallback is not correctly called.
This used to work in version 1.14.1.

The first part of the issue is in `src/libbson/CMakeLists.txt`.
If the check finds no `stdbool.h`, the `BSON_HAVE_STDBOOL_H` macro was not initialized to 0.

The other part of the issue is that `stdbool.h` is being included directly rather than via `bson-compat.h`, which provides a fallback if `stdbool.h` is missing, along with other commonly used headers.