### PR TITLE
CDRIVER-4365 support encryptedFields in collection create and drop

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2916,6 +2916,33 @@ tasks:
       AUTH: noauth
       SSL: nossl
       VALGRIND: 'off'
+- name: test-asan-latest-replica-set-auth-nosasl-openssl-cse
+  tags:
+  - client-side-encryption
+  - latest
+  - test-asan
+  exec_timeout_secs: 3600
+  depends_on:
+    name: debug-compile-asan-openssl-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-asan-openssl-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-latest-replica-set-auth-nosasl-openssl
   tags:
   - latest
@@ -5973,6 +6000,35 @@ tasks:
       AUTH: noauth
       SSL: nossl
       VALGRIND: 'off'
+- name: test-latest-replica-set-auth-sasl-openssl-cse
+  tags:
+  - auth
+  - client-side-encryption
+  - latest
+  - openssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-latest-replica-set-auth-sasl-openssl
   tags:
   - auth
@@ -5997,6 +6053,35 @@ tasks:
       ASAN: 'off'
       AUTH: auth
       SSL: openssl
+      VALGRIND: 'off'
+- name: test-latest-replica-set-auth-sasl-openssl-static-cse
+  tags:
+  - auth
+  - client-side-encryption
+  - latest
+  - openssl-static
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-static-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl-static
       VALGRIND: 'off'
 - name: test-latest-replica-set-auth-sasl-openssl-static
   tags:
@@ -6023,6 +6108,35 @@ tasks:
       AUTH: auth
       SSL: openssl-static
       VALGRIND: 'off'
+- name: test-latest-replica-set-auth-sasl-darwinssl-cse
+  tags:
+  - auth
+  - client-side-encryption
+  - darwinssl
+  - latest
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-darwinssl-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-latest-replica-set-auth-sasl-darwinssl
   tags:
   - auth
@@ -6047,6 +6161,35 @@ tasks:
       ASAN: 'off'
       AUTH: auth
       SSL: darwinssl
+      VALGRIND: 'off'
+- name: test-latest-replica-set-auth-sasl-winssl-cse
+  tags:
+  - auth
+  - client-side-encryption
+  - latest
+  - replica_set
+  - sasl
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: winssl
       VALGRIND: 'off'
 - name: test-latest-replica-set-auth-sasl-winssl
   tags:
@@ -6173,6 +6316,35 @@ tasks:
       AUTH: auth
       SSL: winssl
       VALGRIND: 'off'
+- name: test-latest-replica-set-noauth-sasl-openssl-cse
+  tags:
+  - client-side-encryption
+  - latest
+  - noauth
+  - openssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-latest-replica-set-noauth-sasl-openssl
   tags:
   - latest
@@ -6197,6 +6369,35 @@ tasks:
       ASAN: 'off'
       AUTH: noauth
       SSL: openssl
+      VALGRIND: 'off'
+- name: test-latest-replica-set-noauth-sasl-openssl-static-cse
+  tags:
+  - client-side-encryption
+  - latest
+  - noauth
+  - openssl-static
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-static-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl-static
       VALGRIND: 'off'
 - name: test-latest-replica-set-noauth-sasl-openssl-static
   tags:
@@ -6223,6 +6424,35 @@ tasks:
       AUTH: noauth
       SSL: openssl-static
       VALGRIND: 'off'
+- name: test-latest-replica-set-noauth-sasl-darwinssl-cse
+  tags:
+  - client-side-encryption
+  - darwinssl
+  - latest
+  - noauth
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-darwinssl-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-latest-replica-set-noauth-sasl-darwinssl
   tags:
   - darwinssl
@@ -6247,6 +6477,35 @@ tasks:
       ASAN: 'off'
       AUTH: noauth
       SSL: darwinssl
+      VALGRIND: 'off'
+- name: test-latest-replica-set-noauth-sasl-winssl-cse
+  tags:
+  - client-side-encryption
+  - latest
+  - noauth
+  - replica_set
+  - sasl
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: winssl
       VALGRIND: 'off'
 - name: test-latest-replica-set-noauth-sasl-winssl
   tags:

--- a/build/evergreen_config_lib/tasks.py
+++ b/build/evergreen_config_lib/tasks.py
@@ -606,7 +606,7 @@ class IntegrationTask(MatrixTask):
             require(self.version == 'latest' or parse_version(self.version) >= parse_version("4.2"))
             if self.version == 'latest' or parse_version(self.version) >= parse_version("6.0"):
                 # FLE 2.0 Client-Side Encryption tasks on 6.0 require a non-standalone topology.
-                require(self.topology == 'server' or self.topology == 'replica_set')
+                require(self.topology in ('server', 'replica_set'))
             else:
                 require(self.topology == 'server')
             if self.sanitizer != "asan":

--- a/build/evergreen_config_lib/tasks.py
+++ b/build/evergreen_config_lib/tasks.py
@@ -604,7 +604,11 @@ class IntegrationTask(MatrixTask):
 
         if self.cse:
             require(self.version == 'latest' or parse_version(self.version) >= parse_version("4.2"))
-            require(self.topology == 'server')
+            if self.version == 'latest' or parse_version(self.version) >= parse_version("6.0"):
+                # FLE 2.0 Client-Side Encryption tasks on 6.0 require a non-standalone topology.
+                require(self.topology == 'server' or self.topology == 'replica_set')
+            else:
+                require(self.topology == 'server')
             if self.sanitizer != "asan":
                 # limit to SASL=AUTO to reduce redundant tasks.
                 require(self.sasl)

--- a/src/libmongoc/doc/mongoc_auto_encryption_opts_set_encrypted_fields_map.rst
+++ b/src/libmongoc/doc/mongoc_auto_encryption_opts_set_encrypted_fields_map.rst
@@ -1,0 +1,29 @@
+:man_page: mongoc_auto_encryption_opts_set_encrypted_fields_map
+
+mongoc_auto_encryption_opts_set_encrypted_fields_map()
+======================================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_auto_encryption_opts_set_encrypted_fields_map (
+      mongoc_auto_encryption_opts_t *opts, const bson_t *encrypted_fields_map);
+
+
+Parameters
+----------
+
+* ``opts``: The :symbol:`mongoc_auto_encryption_opts_t`
+* ``encrypted_fields_map``: A :symbol:`bson_t` where keys are collection namespaces and values are encrypted fields documents.
+
+Supplying an ``encrypted_fields_map`` provides more security than relying on an ``encryptedFields`` obtained from the server. It protects against a malicious server advertising a false ``encryptedFields``.
+
+.. seealso::
+
+  | :symbol:`mongoc_client_enable_auto_encryption()`
+
+  | The guide for :doc:`Using Client-Side Field Level Encryption <using_client_side_encryption>`
+

--- a/src/libmongoc/doc/mongoc_auto_encryption_opts_t.rst
+++ b/src/libmongoc/doc/mongoc_auto_encryption_opts_t.rst
@@ -35,4 +35,5 @@ Synopsis
     mongoc_auto_encryption_opts_set_bypass_auto_encryption
     mongoc_auto_encryption_opts_set_extra
     mongoc_auto_encryption_opts_set_tls_opts
+    mongoc_auto_encryption_opts_set_encrypted_fields_map
 

--- a/src/libmongoc/doc/mongoc_database_create_collection.rst
+++ b/src/libmongoc/doc/mongoc_database_create_collection.rst
@@ -30,6 +30,8 @@ This function creates a :symbol:`mongoc_collection_t` from the given :symbol:`mo
 
 If no write concern is provided in ``opts``, the database's write concern is used.
 
+The ``encryptedFields`` document in ``opts`` may be used to create a collection used for :doc:`Using Client-Side Field Level Encryption <using_client_side_encryption>`.
+
 For a list of all options, see `the MongoDB Manual entry on the create command <https://docs.mongodb.org/manual/reference/command/create/>`_.
 
 Errors

--- a/src/libmongoc/doc/mongoc_database_drop_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_database_drop_with_opts.rst
@@ -30,6 +30,8 @@ This function attempts to drop a database on the MongoDB server.
 
 If no write concern is provided in ``opts``, the database's write concern is used.
 
+The ``encryptedFields`` document in ``opts`` may be used to drop a collection used for :doc:`Using Client-Side Field Level Encryption <using_client_side_encryption>`.
+
 Errors
 ------
 

--- a/src/libmongoc/src/mongoc/mongoc-client-side-encryption.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-side-encryption.h
@@ -65,6 +65,10 @@ mongoc_auto_encryption_opts_set_schema_map (mongoc_auto_encryption_opts_t *opts,
                                             const bson_t *schema_map);
 
 MONGOC_EXPORT (void)
+mongoc_auto_encryption_opts_set_encrypted_fields_map (
+   mongoc_auto_encryption_opts_t *opts, const bson_t *encrypted_fields_map);
+
+MONGOC_EXPORT (void)
 mongoc_auto_encryption_opts_set_bypass_auto_encryption (
    mongoc_auto_encryption_opts_t *opts, bool bypass_auto_encryption);
 

--- a/src/libmongoc/src/mongoc/mongoc-database-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-database-private.h
@@ -45,6 +45,37 @@ _mongoc_database_new (mongoc_client_t *client,
                       const mongoc_read_concern_t *read_concern,
                       const mongoc_write_concern_t *write_concern);
 
+/* _mongoc_get_encryptedFields_from_map checks the collection has an
+ * encryptedFields set on the client encryptedFieldsMap.
+ * encryptedFields is always initialized on return.
+ */
+bool
+_mongoc_get_encryptedFields_from_map (mongoc_client_t *client,
+                                      const char *dbName,
+                                      const char *collName,
+                                      bson_t *encryptedFields,
+                                      bson_error_t *error);
+
+/* _mongoc_get_encryptedFields_from_map checks the collection has an
+ * encryptedFields by running listCollections.
+ * encryptedFields is always initialized on return.
+ */
+bool
+_mongoc_get_encryptedFields_from_server (mongoc_client_t *client,
+                                         const char *dbName,
+                                         const char *collName,
+                                         bson_t *encryptedFields,
+                                         bson_error_t *error);
+
+/* _mongoc_get_encryptedField_state_collection returns the state collection
+ * name. Returns NULL on error. */
+char *
+_mongoc_get_encryptedField_state_collection (
+   const bson_t *encryptedFields,
+   const char *data_collection,
+   const char *state_collection_suffix,
+   bson_error_t *error);
+
 BSON_END_DECLS
 
 

--- a/src/libmongoc/src/mongoc/mongoc-database.c
+++ b/src/libmongoc/src/mongoc/mongoc-database.c
@@ -853,9 +853,8 @@ mongoc_database_get_collection_names_with_opts (mongoc_database_t *database,
    return ret;
 }
 
-
-mongoc_collection_t *
-mongoc_database_create_collection (mongoc_database_t *database,
+static mongoc_collection_t *
+create_collection (mongoc_database_t *database,
                                    const char *name,
                                    const bson_t *opts,
                                    bson_error_t *error)
@@ -994,6 +993,293 @@ mongoc_database_create_collection (mongoc_database_t *database,
    bson_destroy (&cmd);
 
    return collection;
+}
+
+char *
+_mongoc_get_encryptedField_state_collection (
+   const bson_t *encryptedFields,
+   const char *data_collection,
+   const char *state_collection_suffix,
+   bson_error_t *error)
+{
+   bson_iter_t iter;
+   const char *fieldName = NULL;
+
+   if (0 == strcmp (state_collection_suffix, "esc")) {
+      fieldName = "escCollection";
+   } else if (0 == strcmp (state_collection_suffix, "ecc")) {
+      fieldName = "eccCollection";
+   } else if (0 == strcmp (state_collection_suffix, "ecoc")) {
+      fieldName = "ecocCollection";
+   } else {
+      bson_set_error (error,
+                      MONGOC_ERROR_COMMAND,
+                      MONGOC_ERROR_COMMAND_INVALID_ARG,
+                      "expected state_collection_suffix to be 'esc', 'ecc', or "
+                      "'ecoc', got: %s",
+                      state_collection_suffix);
+      return NULL;
+   }
+
+   if (bson_iter_init_find (&iter, encryptedFields, fieldName)) {
+      if (!BSON_ITER_HOLDS_UTF8 (&iter)) {
+         bson_set_error (error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "expected encryptedFields.%s to be UTF-8",
+                         fieldName);
+         return NULL;
+      }
+      return bson_strdup (bson_iter_utf8 (&iter, NULL));
+   }
+   return bson_strdup_printf (
+      "enxcol_.%s.%s", data_collection, state_collection_suffix);
+}
+
+static mongoc_collection_t *
+create_collection_with_encryptedFields (mongoc_database_t *database,
+                                        const char *name,
+                                        const bson_t *opts,
+                                        const bson_t *encryptedFields,
+                                        bson_error_t *error)
+{
+   char *escName = NULL;
+   char *eccName = NULL;
+   char *ecocName = NULL;
+   mongoc_collection_t *escCollection = NULL;
+   mongoc_collection_t *eccCollection = NULL;
+   mongoc_collection_t *ecocCollection = NULL;
+   mongoc_collection_t *dataCollection = NULL;
+   bool ok = false;
+   bson_t *cc_opts = NULL;
+   
+   /* Create ESC collection. */
+   escName = _mongoc_get_encryptedField_state_collection (
+      encryptedFields, name, "esc", error);
+   if (!escName) {
+      goto fail;
+   }
+
+   escCollection = create_collection (database, escName, NULL /* opts */, error);
+   if (!escCollection) {
+      goto fail;
+   }
+
+   /* Create ECC collection. */
+   eccName = _mongoc_get_encryptedField_state_collection (
+      encryptedFields, name, "ecc", error);
+   if (!eccName) {
+      goto fail;
+   }
+
+   eccCollection = create_collection (database, eccName, NULL /* opts */, error);
+   if (!eccCollection) {
+      goto fail;
+   }
+
+   /* Create ECOC collection. */
+   ecocName = _mongoc_get_encryptedField_state_collection (
+      encryptedFields, name, "ecoc", error);
+   if (!ecocName) {
+      goto fail;
+   }
+
+   ecocCollection = create_collection (database, ecocName, NULL /* opts */, error);
+   if (!ecocCollection) {
+      goto fail;
+   }
+
+   /* Create data collection. */
+   cc_opts = bson_copy (opts);
+   if (!BSON_APPEND_DOCUMENT (cc_opts, "encryptedFields", encryptedFields)) {
+      bson_set_error (error,
+                        MONGOC_ERROR_COMMAND,
+                        MONGOC_ERROR_COMMAND_INVALID_ARG,
+                        "unable to append encryptedFields");
+      goto fail;
+   }
+   dataCollection = create_collection (database, name, cc_opts, error);
+   if (!dataCollection) {
+      goto fail;
+   }
+
+   /* Create index on __safeContent__. */
+   {
+      bson_t *keys = BCON_NEW ("__safeContent__", BCON_INT32 (1));
+      char *index_name;
+      bson_t *create_indexes;
+
+      index_name = mongoc_collection_keys_to_index_string (keys);
+      create_indexes = BCON_NEW ("createIndexes",
+                                 BCON_UTF8 (name),
+                                 "indexes",
+                                 "[",
+                                 "{",
+                                 "key",
+                                 BCON_DOCUMENT (keys),
+                                 "name",
+                                 BCON_UTF8 (index_name),
+                                 "}",
+                                 "]");
+
+      if (!mongoc_database_write_command_with_opts (database,
+                                                    create_indexes,
+                                                    NULL /* opts */,
+                                                    NULL /* reply */,
+                                                    error)) {
+         bson_destroy (create_indexes);
+         bson_free (index_name);
+         bson_destroy (keys);
+         goto fail;
+      }
+      bson_destroy (create_indexes);
+      bson_free (index_name);
+      bson_destroy (keys);
+   }
+
+   ok = true;
+fail:
+   bson_destroy (cc_opts);
+   mongoc_collection_destroy (ecocCollection);
+   bson_free (ecocName);
+   mongoc_collection_destroy (eccCollection);
+   bson_free (eccName);
+   mongoc_collection_destroy (escCollection);
+   bson_free (escName);
+   if (ok) {
+      return dataCollection;
+   } else {
+      mongoc_collection_destroy (dataCollection);
+      return NULL;
+   }
+}
+
+bool
+_mongoc_get_encryptedFields_from_map (mongoc_client_t *client,
+                                      const char *dbName,
+                                      const char *collName,
+                                      bson_t *encryptedFields,
+                                      bson_error_t *error)
+{
+   const bson_t *efMap = client->topology->encrypted_fields_map;
+
+   bson_init (encryptedFields);
+
+   if (bson_empty0 (efMap)) {
+      return true;
+   }
+
+   char* ns = bson_strdup_printf ("%s.%s", dbName, collName);
+   bson_iter_t iter;
+   if (!bson_iter_init_find (&iter, efMap, ns)) {
+      bson_free (ns);
+      return true;
+   }
+
+   if (!_mongoc_iter_document_as_bson (&iter, encryptedFields, error)) {
+      bson_free (ns);
+      return false;
+   }
+
+   bson_free (ns);
+   return true;
+}
+
+bool
+_mongoc_get_encryptedFields_from_server (mongoc_client_t *client,
+                                         const char *dbName,
+                                         const char *collName,
+                                         bson_t *encryptedFields,
+                                         bson_error_t *error)
+{
+   mongoc_database_t *db = mongoc_client_get_database (client, dbName);
+   bson_t *opts = BCON_NEW ("filter", "{", "name", BCON_UTF8 (collName), "}");
+   mongoc_cursor_t *cursor;
+   bool ret = false;
+   const bson_t *collInfo;
+
+   bson_init (encryptedFields);
+
+   cursor = mongoc_database_find_collections_with_opts (db, opts);
+   if (mongoc_cursor_error (cursor, error)) {
+      goto fail;
+   }
+
+   if (mongoc_cursor_next (cursor, &collInfo)) {
+      /* Check if the collInfo has options.encryptedFields. */
+      bson_iter_t iter;
+      if (!bson_iter_init (&iter, collInfo)) {
+         bson_set_error (error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "unable to iterate listCollections result");
+         goto fail;
+      }
+
+      if (bson_iter_find_descendant (&iter, "options.encryptedFields", &iter)) {
+         bson_t tmp;
+         if (!_mongoc_iter_document_as_bson (&iter, &tmp, error)) {
+            goto fail;
+         }
+         bson_copy_to (&tmp, encryptedFields);
+      }
+   }
+
+   if (mongoc_cursor_error (cursor, error)) {
+      goto fail;
+   }
+
+   ret = true;
+fail:
+   mongoc_cursor_destroy (cursor);
+   bson_destroy (opts);
+   mongoc_database_destroy (db);
+   return ret;
+}
+
+mongoc_collection_t *
+mongoc_database_create_collection (mongoc_database_t *database,
+                                   const char *name,
+                                   const bson_t *opts,
+                                   bson_error_t *error)
+{
+   bson_iter_t iter;
+   bson_t encryptedFields = BSON_INITIALIZER;
+
+   if (opts && bson_iter_init_find (&iter, opts, "encryptedFields")) {
+      if (!_mongoc_iter_document_as_bson (&iter, &encryptedFields, error)) {
+         return NULL;
+      }
+   }
+
+   if (bson_empty (&encryptedFields)) {
+      if (!_mongoc_get_encryptedFields_from_map (
+             database->client,
+             mongoc_database_get_name (database),
+             name,
+             &encryptedFields,
+             error)) {
+         return NULL;
+      }
+   }
+
+   if (!bson_empty (&encryptedFields)) {
+      bson_t opts_without_encryptedFields = BSON_INITIALIZER;
+
+      if (opts) {
+         bson_copy_to_excluding_noinit (
+            opts, &opts_without_encryptedFields, "encryptedFields", NULL);
+      }
+
+      mongoc_collection_t *ret = create_collection_with_encryptedFields (
+         database, name, &opts_without_encryptedFields, &encryptedFields, error);
+
+      bson_destroy (&opts_without_encryptedFields);
+      bson_destroy (&encryptedFields);
+      return ret;
+   }
+
+   return create_collection (database, name, opts, error);
 }
 
 

--- a/src/libmongoc/src/mongoc/mongoc-database.c
+++ b/src/libmongoc/src/mongoc/mongoc-database.c
@@ -855,9 +855,9 @@ mongoc_database_get_collection_names_with_opts (mongoc_database_t *database,
 
 static mongoc_collection_t *
 create_collection (mongoc_database_t *database,
-                                   const char *name,
-                                   const bson_t *opts,
-                                   bson_error_t *error)
+                   const char *name,
+                   const bson_t *opts,
+                   bson_error_t *error)
 {
    mongoc_collection_t *collection = NULL;
    bson_iter_t iter;
@@ -1052,7 +1052,7 @@ create_collection_with_encryptedFields (mongoc_database_t *database,
    mongoc_collection_t *dataCollection = NULL;
    bool ok = false;
    bson_t *cc_opts = NULL;
-   
+
    /* Create ESC collection. */
    escName = _mongoc_get_encryptedField_state_collection (
       encryptedFields, name, "esc", error);
@@ -1060,7 +1060,8 @@ create_collection_with_encryptedFields (mongoc_database_t *database,
       goto fail;
    }
 
-   escCollection = create_collection (database, escName, NULL /* opts */, error);
+   escCollection =
+      create_collection (database, escName, NULL /* opts */, error);
    if (!escCollection) {
       goto fail;
    }
@@ -1072,7 +1073,8 @@ create_collection_with_encryptedFields (mongoc_database_t *database,
       goto fail;
    }
 
-   eccCollection = create_collection (database, eccName, NULL /* opts */, error);
+   eccCollection =
+      create_collection (database, eccName, NULL /* opts */, error);
    if (!eccCollection) {
       goto fail;
    }
@@ -1084,7 +1086,8 @@ create_collection_with_encryptedFields (mongoc_database_t *database,
       goto fail;
    }
 
-   ecocCollection = create_collection (database, ecocName, NULL /* opts */, error);
+   ecocCollection =
+      create_collection (database, ecocName, NULL /* opts */, error);
    if (!ecocCollection) {
       goto fail;
    }
@@ -1093,9 +1096,9 @@ create_collection_with_encryptedFields (mongoc_database_t *database,
    cc_opts = bson_copy (opts);
    if (!BSON_APPEND_DOCUMENT (cc_opts, "encryptedFields", encryptedFields)) {
       bson_set_error (error,
-                        MONGOC_ERROR_COMMAND,
-                        MONGOC_ERROR_COMMAND_INVALID_ARG,
-                        "unable to append encryptedFields");
+                      MONGOC_ERROR_COMMAND,
+                      MONGOC_ERROR_COMMAND_INVALID_ARG,
+                      "unable to append encryptedFields");
       goto fail;
    }
    dataCollection = create_collection (database, name, cc_opts, error);
@@ -1169,7 +1172,7 @@ _mongoc_get_encryptedFields_from_map (mongoc_client_t *client,
       return true;
    }
 
-   char* ns = bson_strdup_printf ("%s.%s", dbName, collName);
+   char *ns = bson_strdup_printf ("%s.%s", dbName, collName);
    bson_iter_t iter;
    if (!bson_iter_init_find (&iter, efMap, ns)) {
       bson_free (ns);
@@ -1271,8 +1274,12 @@ mongoc_database_create_collection (mongoc_database_t *database,
             opts, &opts_without_encryptedFields, "encryptedFields", NULL);
       }
 
-      mongoc_collection_t *ret = create_collection_with_encryptedFields (
-         database, name, &opts_without_encryptedFields, &encryptedFields, error);
+      mongoc_collection_t *ret =
+         create_collection_with_encryptedFields (database,
+                                                 name,
+                                                 &opts_without_encryptedFields,
+                                                 &encryptedFields,
+                                                 error);
 
       bson_destroy (&opts_without_encryptedFields);
       bson_destroy (&encryptedFields);

--- a/src/libmongoc/src/mongoc/mongoc-database.c
+++ b/src/libmongoc/src/mongoc/mongoc-database.c
@@ -1162,14 +1162,13 @@ _mongoc_get_encryptedFields_from_map (mongoc_client_t *client,
       bson_free (ns);
       return true;
    }
+   bson_free (ns);
 
    if (!_mongoc_iter_document_as_bson (&iter, encryptedFields, error)) {
       /* The efMap entry should always be a document. */
-      bson_free (ns);
       return false;
    }
 
-   bson_free (ns);
    return true;
 }
 

--- a/src/libmongoc/src/mongoc/mongoc-database.c
+++ b/src/libmongoc/src/mongoc/mongoc-database.c
@@ -1121,16 +1121,8 @@ create_collection_with_encryptedFields (mongoc_database_t *database,
                                  "}",
                                  "]");
 
-      if (!mongoc_database_write_command_with_opts (database,
-                                                    create_indexes,
-                                                    NULL /* opts */,
-                                                    NULL /* reply */,
-                                                    error)) {
-         bson_destroy (create_indexes);
-         bson_free (index_name);
-         bson_destroy (keys);
-         goto fail;
-      }
+      ok = mongoc_database_write_command_with_opts (
+         database, create_indexes, NULL /* opts */, NULL /* reply */, error);
       bson_destroy (create_indexes);
       bson_free (index_name);
       bson_destroy (keys);

--- a/src/libmongoc/src/mongoc/mongoc-database.c
+++ b/src/libmongoc/src/mongoc/mongoc-database.c
@@ -1151,17 +1151,20 @@ _mongoc_get_encryptedFields_from_map (mongoc_client_t *client,
    bson_init (encryptedFields);
 
    if (bson_empty0 (efMap)) {
+      /* Unset or empty efMap will have no encrypted fields */
       return true;
    }
 
    char *ns = bson_strdup_printf ("%s.%s", dbName, collName);
    bson_iter_t iter;
    if (!bson_iter_init_find (&iter, efMap, ns)) {
+      /* No efMap entry for this database+collection. */
       bson_free (ns);
       return true;
    }
 
    if (!_mongoc_iter_document_as_bson (&iter, encryptedFields, error)) {
+      /* The efMap entry should always be a document. */
       bson_free (ns);
       return false;
    }

--- a/src/libmongoc/src/mongoc/mongoc-topology-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-private.h
@@ -191,6 +191,8 @@ typedef struct _mongoc_topology_t {
    char *csfle_override_path;
    // Corresponds to extraOptions.csfleRequired
    bool csfle_required;
+   // Corresponds to AutoEncryptionOpts.encryptedFieldsMap.
+   bson_t *encrypted_fields_map;
 
    /* For background monitoring. */
    mongoc_set_t *server_monitors;

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -701,6 +701,8 @@ mongoc_topology_destroy (mongoc_topology_t *topology)
    mongoc_cond_destroy (&topology->cond_client);
    bson_mutex_destroy (&topology->tpld_modification_mtx);
 
+   bson_destroy (topology->encrypted_fields_map);
+
    bson_free (topology);
 }
 

--- a/src/libmongoc/src/mongoc/mongoc-util-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-util-private.h
@@ -234,6 +234,13 @@ _mongoc_rand_uint64_t (uint64_t min, uint64_t max, uint64_t (*rand) (void));
 size_t
 _mongoc_rand_size_t (size_t min, size_t max, size_t (*rand) (void));
 
+/* _mongoc_iter_document_as_bson attempts to read the document from @iter into 
+ * @bson. */
+bool
+_mongoc_iter_document_as_bson (const bson_iter_t *iter,
+                               bson_t *bson,
+                               bson_error_t *error);
+
 BSON_END_DECLS
 
 #endif /* MONGOC_UTIL_PRIVATE_H */

--- a/src/libmongoc/src/mongoc/mongoc-util-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-util-private.h
@@ -234,7 +234,7 @@ _mongoc_rand_uint64_t (uint64_t min, uint64_t max, uint64_t (*rand) (void));
 size_t
 _mongoc_rand_size_t (size_t min, size_t max, size_t (*rand) (void));
 
-/* _mongoc_iter_document_as_bson attempts to read the document from @iter into 
+/* _mongoc_iter_document_as_bson attempts to read the document from @iter into
  * @bson. */
 bool
 _mongoc_iter_document_as_bson (const bson_iter_t *iter,

--- a/src/libmongoc/src/mongoc/mongoc-util.c
+++ b/src/libmongoc/src/mongoc/mongoc-util.c
@@ -863,3 +863,33 @@ _mongoc_rand_size_t (size_t min, size_t max, size_t (*rand) (void))
    "Implementation of _mongoc_simple_rand_size_t() requires size_t be exactly 32-bit or 64-bit"
 
 #endif
+
+bool
+_mongoc_iter_document_as_bson (const bson_iter_t *iter,
+                               bson_t *bson,
+                               bson_error_t *error)
+{
+   uint32_t len;
+   const uint8_t *data;
+
+   if (!BSON_ITER_HOLDS_DOCUMENT (iter)) {
+      bson_set_error (error,
+                      MONGOC_ERROR_COMMAND,
+                      MONGOC_ERROR_COMMAND_INVALID_ARG,
+                      "expected BSON document for field: %s",
+                      bson_iter_key (iter));
+      return false;
+   }
+
+   bson_iter_document (iter, &len, &data);
+   if (!bson_init_static (bson, data, len)) {
+      bson_set_error (error,
+                      MONGOC_ERROR_COMMAND,
+                      MONGOC_ERROR_COMMAND_INVALID_ARG,
+                      "unable to initialize BSON document from field: %s",
+                      bson_iter_key (iter));
+      return false;
+   }
+
+   return true;
+}

--- a/src/libmongoc/tests/json-test.c
+++ b/src/libmongoc/tests/json-test.c
@@ -1596,6 +1596,15 @@ set_auto_encryption_opts (mongoc_client_t *client, bson_t *test)
       bson_init (&extra);
    }
 
+   if (bson_iter_init_find (&iter, &opts, "encryptedFieldsMap")) {
+      BSON_ASSERT (BSON_ITER_HOLDS_DOCUMENT (&iter));
+      bson_t efm;
+
+      bson_iter_bson (&iter, &efm);
+      mongoc_auto_encryption_opts_set_encrypted_fields_map (auto_encryption_opts, &efm);
+      bson_destroy (&efm);
+   }
+
    if (test_framework_getenv_bool ("MONGOC_TEST_MONGOCRYPTD_BYPASS_SPAWN") &&
        !bson_iter_init_find (&iter, &extra, "mongocryptdBypassSpawn")) {
       /* forking is disallowed in test runner, bypass spawning mongocryptd and

--- a/src/libmongoc/tests/json-test.c
+++ b/src/libmongoc/tests/json-test.c
@@ -1601,7 +1601,8 @@ set_auto_encryption_opts (mongoc_client_t *client, bson_t *test)
       bson_t efm;
 
       bson_iter_bson (&iter, &efm);
-      mongoc_auto_encryption_opts_set_encrypted_fields_map (auto_encryption_opts, &efm);
+      mongoc_auto_encryption_opts_set_encrypted_fields_map (
+         auto_encryption_opts, &efm);
       bson_destroy (&efm);
    }
 

--- a/src/libmongoc/tests/json/client_side_encryption/fle2-CreateCollection.json
+++ b/src/libmongoc/tests/json/client_side_encryption/fle2-CreateCollection.json
@@ -1,0 +1,2059 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "6.0.0",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "default",
+  "collection_name": "default",
+  "tests": [
+    {
+      "description": "state collections and index are created",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "escCollection": "encryptedCollection.esc",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection",
+            "index": "__safeContent___1"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.esc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.esc"
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.ecc"
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.ecoc"
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection",
+              "encryptedFields": {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                  {
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "keyId": {
+                      "$binary": {
+                        "subType": "04",
+                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "__safeContent___1",
+                  "key": {
+                    "__safeContent__": 1
+                  }
+                }
+              ]
+            },
+            "command_name": "createIndexes",
+            "database_name": "default"
+          }
+        }
+      ]
+    },
+    {
+      "description": "default state collection names are applied",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  },
+                  "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                      "$numberLong": "0"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection",
+            "index": "__safeContent___1"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "enxcol_.encryptedCollection.esc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "enxcol_.encryptedCollection.ecc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "enxcol_.encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "enxcol_.encryptedCollection.esc"
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "enxcol_.encryptedCollection.ecc"
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "enxcol_.encryptedCollection.ecoc"
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection",
+              "encryptedFields": {
+                "fields": [
+                  {
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "keyId": {
+                      "$binary": {
+                        "subType": "04",
+                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                      }
+                    },
+                    "queries": {
+                      "queryType": "equality",
+                      "contention": {
+                        "$numberLong": "0"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "__safeContent___1",
+                  "key": {
+                    "__safeContent__": 1
+                  }
+                }
+              ]
+            },
+            "command_name": "createIndexes",
+            "database_name": "default"
+          }
+        }
+      ]
+    },
+    {
+      "description": "drop removes all state collections",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  },
+                  "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                      "$numberLong": "0"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection",
+            "index": "__safeContent___1"
+          }
+        },
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertIndexNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection",
+            "index": "__safeContent___1"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "enxcol_.encryptedCollection.esc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "enxcol_.encryptedCollection.ecc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "enxcol_.encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "enxcol_.encryptedCollection.esc"
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "enxcol_.encryptedCollection.ecc"
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "enxcol_.encryptedCollection.ecoc"
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection",
+              "encryptedFields": {
+                "fields": [
+                  {
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "keyId": {
+                      "$binary": {
+                        "subType": "04",
+                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                      }
+                    },
+                    "queries": {
+                      "queryType": "equality",
+                      "contention": {
+                        "$numberLong": "0"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "__safeContent___1",
+                  "key": {
+                    "__safeContent__": 1
+                  }
+                }
+              ]
+            },
+            "command_name": "createIndexes",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "enxcol_.encryptedCollection.esc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "enxcol_.encryptedCollection.ecc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "enxcol_.encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        }
+      ]
+    },
+    {
+      "description": "encryptedFieldsMap with cyclic entries does not loop",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "escCollection": "encryptedCollection.esc",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            },
+            "default.encryptedCollection.esc": {
+              "escCollection": "encryptedCollection",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection",
+            "index": "__safeContent___1"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.esc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.esc"
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.ecc"
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.ecoc"
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection",
+              "encryptedFields": {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                  {
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "keyId": {
+                      "$binary": {
+                        "subType": "04",
+                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "__safeContent___1",
+                  "key": {
+                    "__safeContent__": 1
+                  }
+                }
+              ]
+            },
+            "command_name": "createIndexes",
+            "database_name": "default"
+          }
+        }
+      ]
+    },
+    {
+      "description": "CreateCollection without encryptedFields.",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "escCollection": "encryptedCollection.esc",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "plaintextCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "plaintextCollection"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "plaintextCollection"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "listCollections": 1,
+              "filter": {
+                "name": "plaintextCollection"
+              }
+            },
+            "command_name": "listCollections",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "plaintextCollection"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "plaintextCollection"
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        }
+      ]
+    },
+    {
+      "description": "CreateCollection from encryptedFieldsMap.",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "escCollection": "encryptedCollection.esc",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection",
+            "index": "__safeContent___1"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.esc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.esc"
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.ecc"
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.ecoc"
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection",
+              "encryptedFields": {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                  {
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "keyId": {
+                      "$binary": {
+                        "subType": "04",
+                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "__safeContent___1",
+                  "key": {
+                    "__safeContent__": 1
+                  }
+                }
+              ]
+            },
+            "command_name": "createIndexes",
+            "database_name": "default"
+          }
+        }
+      ]
+    },
+    {
+      "description": "CreateCollection from encryptedFields.",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection",
+            "encryptedFields": {
+              "escCollection": "encryptedCollection.esc",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection",
+            "encryptedFields": {
+              "escCollection": "encryptedCollection.esc",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection",
+            "index": "__safeContent___1"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.esc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.esc"
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.ecc"
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.ecoc"
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection",
+              "encryptedFields": {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                  {
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "keyId": {
+                      "$binary": {
+                        "subType": "04",
+                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "__safeContent___1",
+                  "key": {
+                    "__safeContent__": 1
+                  }
+                }
+              ]
+            },
+            "command_name": "createIndexes",
+            "database_name": "default"
+          }
+        }
+      ]
+    },
+    {
+      "description": "DropCollection from encryptedFieldsMap",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "escCollection": "encryptedCollection.esc",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.esc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        }
+      ]
+    },
+    {
+      "description": "DropCollection from encryptedFields",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          },
+          "encryptedFieldsMap": {}
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection",
+            "encryptedFields": {
+              "escCollection": "encryptedCollection.esc",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection",
+            "encryptedFields": {
+              "escCollection": "encryptedCollection.esc",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection",
+            "index": "__safeContent___1"
+          }
+        },
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection",
+            "encryptedFields": {
+              "escCollection": "encryptedCollection.esc",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.esc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.esc"
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.ecc"
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.ecoc"
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection",
+              "encryptedFields": {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                  {
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "keyId": {
+                      "$binary": {
+                        "subType": "04",
+                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "__safeContent___1",
+                  "key": {
+                    "__safeContent__": 1
+                  }
+                }
+              ]
+            },
+            "command_name": "createIndexes",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.esc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        }
+      ]
+    },
+    {
+      "description": "DropCollection from remote encryptedFields",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          },
+          "encryptedFieldsMap": {}
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection",
+            "encryptedFields": {
+              "escCollection": "encryptedCollection.esc",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection",
+            "encryptedFields": {
+              "escCollection": "encryptedCollection.esc",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection",
+            "index": "__safeContent___1"
+          }
+        },
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.esc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.esc"
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.ecc"
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.ecoc"
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection",
+              "encryptedFields": {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                  {
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "keyId": {
+                      "$binary": {
+                        "subType": "04",
+                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "__safeContent___1",
+                  "key": {
+                    "__safeContent__": 1
+                  }
+                }
+              ]
+            },
+            "command_name": "createIndexes",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "listCollections": 1,
+              "filter": {
+                "name": "encryptedCollection"
+              }
+            },
+            "command_name": "listCollections",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.esc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

- Add `mongoc_auto_encryption_opts_set_encrypted_fields_map`
- Add `encryptedFields` required behavior to create and drop collection helpers.
- Run "*-cse" tasks on replica set for server 6.0+.
    - Add "majority" write concern to key vault operations in CSFLE tests.
- Add `_mongoc_iter_document_as_bson` utility to convert a `bson_iter_t` to `bson_t`.

# Background & Motivation

Please see https://github.com/mongodb/specifications/pull/1183/ for the specification changes.

FLE 2.0 requires a non-standalone server topology. Tests need to apply write concern majority on key vault operations, as noted in the [specification test README](https://github.com/mongodb/specifications/blob/c5067286cf05f741660c05e1fe5fc66144fef76d/source/client-side-encryption/tests/README.rst#prose-tests)

> Perform all applicable operations on key vault collections (e.g. inserting an example data key, or running a find command) with readConcern/writeConcern "majority".

That is because the key vault is queried with readConcern "majority". If keys are inserted without writeConcern "majority", some tests fail to find the key if it the insert is not majority committed before it is queried.

Because the name of FLE 2.0 is still [being decided](https://jira.mongodb.org/browse/WRITING-10860), the documentation for `mongoc_auto_encryption_opts_set_encrypted_fields_map` is brief.