### PR TITLE
BSON-as-JSON indented output

### DIFF
--- a/src/libbson/src/bson/bson-json-private.h
+++ b/src/libbson/src/bson/bson-json-private.h
@@ -23,6 +23,9 @@
 struct _bson_json_opts_t {
    bson_json_mode_t mode;
    int32_t max_len;
+   const char *initial_indent;
+   const char *subsequent_indent;
+   const char *level_indent;
 };
 
 

--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -387,13 +387,12 @@ _noop (void)
    }
 
 
-
 bson_json_opts_t *
 bson_json_opts_new (bson_json_mode_t mode, int32_t max_len)
 {
    bson_json_opts_t *opts;
 
-   opts = (bson_json_opts_t *) bson_malloc (sizeof *opts);
+   opts = (bson_json_opts_t *) bson_malloc0 (sizeof *opts);
    opts->mode = mode;
    opts->max_len = max_len;
 

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -2520,7 +2520,8 @@ _bson_json_newline_indent (const bson_json_state_t *state)
       bson_string_append (state->str, state->opts->subsequent_indent);
    }
    if (state->opts->level_indent) {
-      for (int i = 0; i < state->depth + 1; ++i) {
+      int i = 0;
+      for (i = 0; i < state->depth + 1; ++i) {
          bson_string_append (state->str, state->opts->level_indent);
       }
    }

--- a/src/libmongoc/tests/json-test-monitoring.c
+++ b/src/libmongoc/tests/json-test-monitoring.c
@@ -24,6 +24,7 @@
 #include "mongoc/mongoc-topology-private.h"
 #include "mongoc/mongoc-util-private.h"
 #include "mongoc/mongoc-util-private.h"
+#include <bson/bson-json-private.h>
 
 #include "TestSuite.h"
 #include "test-conveniences.h"
@@ -425,22 +426,33 @@ apm_match_visitor (match_ctx_t *ctx,
    return MATCH_ACTION_CONTINUE;
 }
 
+static void
+_print_bson_array_as_json (FILE *out, const bson_t *arr)
+{
+   bson_iter_t it;
+   for (bson_iter_init (&it, arr); bson_iter_next (&it);) {
+      bson_t elem;
+      bson_iter_bson (&it, &elem);
+
+      bson_json_opts_t opts = {};
+      opts.initial_indent = "";
+      opts.level_indent = "  ";
+      opts.subsequent_indent = "    ";
+      opts.mode = BSON_JSON_MODE_CANONICAL;
+      opts.max_len = BSON_MAX_LEN_UNLIMITED;
+      char *str = bson_as_json_with_opts (&elem, NULL, &opts);
+      fprintf (out, "  - %s\n", str);
+      bson_free (str);
+   }
+}
 
 static void
 _apm_match_error_context (const bson_t *actual, const bson_t *expectations)
 {
-   char *actual_str;
-   char *expectations_str;
-
-   actual_str = bson_as_canonical_extended_json (actual, NULL);
-   expectations_str = bson_as_canonical_extended_json (expectations, NULL);
-   fprintf (stderr,
-            "Error in APM matching\nFull list of captured events: %s\nFull "
-            "list of expectations: %s",
-            actual_str,
-            expectations_str);
-   bson_free (actual_str);
-   bson_free (expectations_str);
+   fprintf (stderr, "Error in APM matching.\nFull list of captured events:\n");
+   _print_bson_array_as_json (stderr, actual);
+   fprintf (stderr, "Expected events:\n");
+   _print_bson_array_as_json (stderr, expectations);
 }
 
 bool


### PR DESCRIPTION
This changeset adds options to bson_as_json that supports prettier-formatted output. Helpful when debugging differences between large documents side-by-side. These options are only exposed in the private API at the moment. It works like:

- `level_indent` - If `NULL`, all behaves as previously. If not-null, this string is inserted at the beginning of the line N times for a line at depth N.
- `initial_indent` - This is inserted before the opening brace.
- `subsequent_indent` - This is inserted before the `level_indent`s at the beginning of every line (except for the first line).

(This was useful while debugging csfle oddities.)