### PR TITLE
[CDRIVER-3380] Fixup JSON specials and decimal128 parsing

### DIFF
--- a/src/libbson/src/bson/bson-decimal128.c
+++ b/src/libbson/src/bson/bson-decimal128.c
@@ -542,7 +542,7 @@ bson_decimal128_from_string_w_len (const char *string,     /* IN */
          continue;
       }
 
-      if (ndigits_stored < 34) {
+      if (ndigits_stored < BSON_DECIMAL128_MAX_DIGITS) {
          if (*str_read != '0' || found_nonzero) {
             if (!found_nonzero) {
                first_nonzero = ndigits_read;
@@ -634,7 +634,7 @@ bson_decimal128_from_string_w_len (const char *string,     /* IN */
       /* Shift exponent to significand and decrease */
       last_digit++;
 
-      if (last_digit - first_digit > BSON_DECIMAL128_MAX_DIGITS) {
+      if (last_digit - first_digit >= BSON_DECIMAL128_MAX_DIGITS) {
          /* The exponent is too great to shift into the significand. */
          if (significant_digits == 0) {
             /* Value is zero, we are allowed to clamp the exponent. */

--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -1186,7 +1186,6 @@ _bson_json_read_start_map (bson_json_reader_t *reader) /* IN */
           * expected a legacy Binary format. now we see the second "{", so
           * backtrack and parse $type query operator. */
          bson->read_state = BSON_JSON_IN_START_MAP;
-         bson->read_state = BSON_JSON_IN_START_MAP;
          STACK_PUSH_DOC (bson_append_document_begin (
             STACK_BSON_PARENT, key, len, STACK_BSON_CHILD));
          _bson_json_save_map_key (bson, (const uint8_t *) "$type", 5);
@@ -1200,13 +1199,21 @@ _bson_json_read_start_map (bson_json_reader_t *reader) /* IN */
       case BSON_JSON_LF_MINKEY:
       case BSON_JSON_LF_OID:
       case BSON_JSON_LF_OPTIONS:
-      case BSON_JSON_LF_REGEX: // $regex lands here, but $regularExpression does
-                               // not
+      case BSON_JSON_LF_REGEX:
+      /**
+       * NOTE: A read_state of BSON_JSON_IN_BSON_TYPE is used when "$regex" is
+       * found, but BSON_JSON_IN_BSON_TYPE_REGEX_STARTMAP is used for
+       * "$regularExpression", which will instead go to a below 'if else' branch
+       * instead of this switch statement. They're both called "regex" in their
+       * respective enumerators, but they behave differently when parsing.
+       */
+      // fallthrough
       case BSON_JSON_LF_REGULAR_EXPRESSION_OPTIONS:
       case BSON_JSON_LF_REGULAR_EXPRESSION_PATTERN:
       case BSON_JSON_LF_SYMBOL:
       case BSON_JSON_LF_UNDEFINED:
       case BSON_JSON_LF_UUID:
+         // These special keys do not expect objects as their values. Fail.
          _bson_json_read_set_error (
             reader,
             "Unexpected nested object value for \"%s\" key",
@@ -1216,6 +1223,7 @@ _bson_json_read_start_map (bson_json_reader_t *reader) /* IN */
       case BSON_JSON_LF_SCOPE:
       case BSON_JSON_LF_TIMESTAMP_I:
       case BSON_JSON_LF_TIMESTAMP_T:
+         // These special LF keys aren't handled with BSON_JSON_IN_BSON_TYPE
          BSON_UNREACHABLE (
             "These LF values are handled with a different read_state");
       }

--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -1223,6 +1223,7 @@ _bson_json_read_start_map (bson_json_reader_t *reader) /* IN */
       case BSON_JSON_LF_SCOPE:
       case BSON_JSON_LF_TIMESTAMP_I:
       case BSON_JSON_LF_TIMESTAMP_T:
+      default:
          // These special LF keys aren't handled with BSON_JSON_IN_BSON_TYPE
          BSON_UNREACHABLE (
             "These LF values are handled with a different read_state");

--- a/src/libbson/src/jsonsl/jsonsl.c
+++ b/src/libbson/src/jsonsl/jsonsl.c
@@ -466,7 +466,7 @@ jsonsl_feed(jsonsl_t jsn, const jsonsl_char_t *bytes, size_t nbytes)
                       state->special_flags &= ~JSONSL_SPECIALf_NAN;
                    }
                    if (not_u && not_a) {
-                      /* This veryify will always fail, as we have an 'n'
+                      /* This verify will always fail, as we have an 'n'
                        * followed by a character that is neither 'a' nor 'u'
                        * (and hence cannot be "null"). The purpose of this
                        * VERIFY_SPECIAL is to generate an error in tokenization

--- a/src/libbson/src/jsonsl/jsonsl.c
+++ b/src/libbson/src/jsonsl/jsonsl.c
@@ -457,8 +457,8 @@ jsonsl_feed(jsonsl_t jsn, const jsonsl_char_t *bytes, size_t nbytes)
                 } else if (state->special_flags & JSONSL_SPECIALf_NULL ||
                            state->special_flags & JSONSL_SPECIALf_NAN) {
                    /* previous char was "n", are we parsing null or nan? */
-                   bool not_u = CUR_CHAR != 'u';
-                   bool not_a = tolower (CUR_CHAR) != 'a';
+                   const bool not_u = CUR_CHAR != 'u';
+                   const bool not_a = tolower (CUR_CHAR) != 'a';
                    if (not_u) {
                       state->special_flags &= ~JSONSL_SPECIALf_NULL;
                    }
@@ -466,6 +466,12 @@ jsonsl_feed(jsonsl_t jsn, const jsonsl_char_t *bytes, size_t nbytes)
                       state->special_flags &= ~JSONSL_SPECIALf_NAN;
                    }
                    if (not_u && not_a) {
+                      /* This veryify will always fail, as we have an 'n'
+                       * followed by a character that is neither 'a' nor 'u'
+                       * (and hence cannot be "null"). The purpose of this
+                       * VERIFY_SPECIAL is to generate an error in tokenization
+                       * that stops if a bare 'n' cannot possibly be a "nan" or
+                       * a "null". */
                       VERIFY_SPECIAL ("null", 4);
                    }
 #endif

--- a/src/libbson/src/jsonsl/jsonsl.c
+++ b/src/libbson/src/jsonsl/jsonsl.c
@@ -457,12 +457,16 @@ jsonsl_feed(jsonsl_t jsn, const jsonsl_char_t *bytes, size_t nbytes)
                 } else if (state->special_flags & JSONSL_SPECIALf_NULL ||
                            state->special_flags & JSONSL_SPECIALf_NAN) {
                    /* previous char was "n", are we parsing null or nan? */
-                   if (CUR_CHAR != 'u') {
+                   bool not_u = CUR_CHAR != 'u';
+                   bool not_a = tolower (CUR_CHAR) != 'a';
+                   if (not_u) {
                       state->special_flags &= ~JSONSL_SPECIALf_NULL;
                    }
-
-                   if (tolower(CUR_CHAR) != 'a') {
+                   if (not_a) {
                       state->special_flags &= ~JSONSL_SPECIALf_NAN;
+                   }
+                   if (not_u && not_a) {
+                      VERIFY_SPECIAL ("null", 4);
                    }
 #endif
                 }

--- a/src/libbson/tests/test-json.c
+++ b/src/libbson/tests/test-json.c
@@ -2727,6 +2727,7 @@ test_bson_json_errors (void)
        "Invalid read of boolean in state IN_BSON_TYPE"},
       {"{\"x\": {\"$dbPointer\": true}}",
        "Invalid read of boolean in state IN_BSON_TYPE_DBPOINTER_STARTMAP"},
+      {"[{\"$code\": {}}]", "Unexpected nested object value for \"$code\" key"},
       {"{\"x\": {\"$numberInt\": \"8589934592\"}}",
        "Invalid input string \"8589934592\", looking for INT32"},
       {0},


### PR DESCRIPTION
Certain token sequences leave the bson-from-json parser unhappy. This addresses those.