### PR TITLE
Update bson-iter.c

### DIFF
--- a/src/libbson/src/bson/bson-iter.c
+++ b/src/libbson/src/bson/bson-iter.c
@@ -1894,8 +1894,8 @@ bson_iter_visit_all (bson_iter_t *iter,             /* INOUT */
                      const bson_visitor_t *visitor, /* IN */
                      void *data)                    /* IN */
 {
-   uint32_t bson_type;
-   const char *key;
+   uint32_t bson_type = 0;
+   const char *key = NULL;
    bool unsupported;
 
    BSON_ASSERT (iter);


### PR DESCRIPTION
This fixed compiler warning about uninitialized variable in call to bson_iter_visit_all for line 2145

```
mongo-c-driver/src/libbson/src/bson/bson-iter.c: In function ‘bson_iter_visit_all’:
mongo-c-driver/src/libbson/src/bson/bson-iter.c:2145:42: error: ‘key’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
          visitor->visit_unsupported_type (iter, key, bson_type, data);
                                          ^
mongo-c-driver/src/libbson/src/bson/bson-iter.c:2145:42: error: ‘bson_type’ may be used uninitialized in this function [-Werror=maybe-uninitialized]

```