### PR TITLE
Update mongoc-socket.c

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-socket.c
+++ b/src/libmongoc/src/mongoc/mongoc-socket.c
@@ -27,6 +27,11 @@
 #ifdef _WIN32
 #include <Mstcpip.h>
 #include <process.h>
+
+#if (defined (_MSCVER)
+#pragma comment(lib, "Advapi32.lib")
+#endif
+
 #endif
 
 #undef MONGOC_LOG_DOMAIN


### PR DESCRIPTION
added #pragma, so the Microsoft C Compiler can add the Advapi32.lib as import library and the library compiles here for Windows.