### PR TITLE
(QoL) Enable cross-config if we are the top-level project in a ninja-multiconf build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -541,3 +541,7 @@ if (TARGET test-libmongoc)
          TEST_INCLUDE_FILES "${PROJECT_BINARY_DIR}/LoadTests-${CMAKE_BUILD_TYPE}.cmake")
    endif ()
 endif ()
+
+if (CMAKE_GENERATOR STREQUAL "Ninja Multi-Config" AND PROJECT_IS_TOP_LEVEL)
+   set (CMAKE_CROSS_CONFIGS "all")
+endif ()


### PR DESCRIPTION
The `Ninja Multi-Config` generator permits building arbitrary configurations without rerunning CMake. This PR enables the special "colon-suffix" cross-config targets in the generated Ninja files. i.e. one can build `all:Debug` to build the project in `Debug`, `all:Release` to build the project in release, and `all:all` to build all enabled configurations simultaneously.