### PR TITLE
CDRIVER-4376 note that Visual Studio 2013 is required

### DIFF
--- a/src/libmongoc/doc/installing.rst
+++ b/src/libmongoc/doc/installing.rst
@@ -132,7 +132,7 @@ The ``cmake`` utility is also required. First `install Homebrew according to its
 Build environment on Windows with Visual Studio
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Building on Windows requires Windows Vista or newer and Visual Studio 2010 or newer. Additionally, ``cmake`` is required to generate Visual Studio project files.  Installation of these components on Windows is beyond the scope of this document.
+Building on Windows requires Windows Vista or newer and Visual Studio 2013 or newer. Additionally, ``cmake`` is required to generate Visual Studio project files.  Installation of these components on Windows is beyond the scope of this document.
 
 Build environment on Windows with MinGW-W64 and MSYS2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The C driver has not tested on Visual Studio < 2013 or since Visual Studio versions older than 2013 were removed from Evergreen (refer: CDRIVER-3593).

There is an incorrect note in [the public documentation](http://mongoc.org/libmongoc/current/installing.html#build-environment-on-windows-with-visual-studio) claiming to support back to 2010.