### PR TITLE
Fix SANITIZE arg shell quoting

### DIFF
--- a/.evergreen/compile-unix.sh
+++ b/.evergreen/compile-unix.sh
@@ -200,7 +200,8 @@ esac
 if [ "darwin" = "$OS" -a "arm64" = "$MARCH" ]; then
    CONFIGURE_FLAGS="$CONFIGURE_FLAGS -DCMAKE_OSX_ARCHITECTURES=arm64"
 fi
-CONFIGURE_FLAGS="$CONFIGURE_FLAGS \"-DMONGO_SANITIZE=${SANITIZE}\""
+
+CONFIGURE_FLAGS="$CONFIGURE_FLAGS -DMONGO_SANITIZE=$SANITIZE"
 
 if ! python3 build/mongodl.py --test -C csfle -V 5.3.1 -o . > /dev/null; then
    echo "No csfle detected for this platform. Disabling MONGOC_TEST_USE_CSFLE."


### PR DESCRIPTION
The current build is not building with sanitizers enabled. The escaped quotes around `MONGO_SANITIZE` are passed through literally, and CMake just discards the argument and doesn't mention it. The quotes are not required as the argument should be shell-safe.