### PR TITLE
CDRIVER-4309 document behavior for estimated_document_count

### DIFF
--- a/src/libmongoc/doc/mongoc_collection_estimated_document_count.rst
+++ b/src/libmongoc/doc/mongoc_collection_estimated_document_count.rst
@@ -40,6 +40,11 @@ This functions executes a count query on ``collection``. In contrast with :symbo
 
 .. include:: includes/retryable-read.txt
 
+Behavior
+^^^^^^^^
+
+This method is implemented using the `count <https://www.mongodb.com/docs/manual/reference/command/count/>`_ command. Due to an oversight in versions 5.0.0-5.0.8 of MongoDB, the ``count`` command was not included in version "1" of the Stable API. Applications using this method with the Stable API are recommended to upgrade their server version to 5.0.9+ or disable strict mode (via `:symbol:`mongoc_server_api_strict()`) to avoid encountering errors.
+
 Errors
 ------
 
@@ -80,4 +85,5 @@ Example
 .. seealso::
 
   | :symbol:`mongoc_collection_count_documents()`
+  | `Count: Behavior <https://www.mongodb.com/docs/manual/reference/command/count/#behavior>`_ in the MongoDB Manual
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-4309

Required documentation per the [CRUD spec](https://github.com/mongodb/specifications/blob/master/source/crud/crud.rst#estimateddocumentcount), which I missed in the [original PR](https://github.com/mongodb/mongo-c-driver/pull/984).