### PR TITLE
CDRIVER-4380 Update maxWireVersion for 6.0

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2202,6 +2202,144 @@ tasks:
       AUTH: noauth
       SSL: nossl
       VALGRIND: 'on'
+- name: test-valgrind-6.0-server-auth-nosasl-openssl
+  tags:
+  - '6.0'
+  - test-valgrind
+  exec_timeout_secs: 14400
+  depends_on:
+    name: debug-compile-valgrind
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-valgrind
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'on'
+- name: test-valgrind-6.0-server-noauth-nosasl-nossl
+  tags:
+  - '6.0'
+  - test-valgrind
+  exec_timeout_secs: 14400
+  depends_on:
+    name: debug-compile-valgrind
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-valgrind
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'on'
+- name: test-valgrind-6.0-replica-set-auth-nosasl-openssl
+  tags:
+  - '6.0'
+  - test-valgrind
+  exec_timeout_secs: 14400
+  depends_on:
+    name: debug-compile-valgrind
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-valgrind
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'on'
+- name: test-valgrind-6.0-replica-set-noauth-nosasl-nossl
+  tags:
+  - '6.0'
+  - test-valgrind
+  exec_timeout_secs: 14400
+  depends_on:
+    name: debug-compile-valgrind
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-valgrind
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'on'
+- name: test-valgrind-6.0-sharded-auth-nosasl-openssl
+  tags:
+  - '6.0'
+  - test-valgrind
+  exec_timeout_secs: 14400
+  depends_on:
+    name: debug-compile-valgrind
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-valgrind
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'on'
+- name: test-valgrind-6.0-sharded-noauth-nosasl-nossl
+  tags:
+  - '6.0'
+  - test-valgrind
+  exec_timeout_secs: 14400
+  depends_on:
+    name: debug-compile-valgrind
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-valgrind
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'on'
 - name: test-valgrind-5.0-server-auth-nosasl-openssl
   tags:
   - '5.0'
@@ -3078,6 +3216,198 @@ tasks:
       SSL: nossl
       TOPOLOGY: sharded_cluster
       VERSION: latest
+  - func: run tests
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+- name: test-asan-6.0-server-auth-nosasl-openssl-cse
+  tags:
+  - '6.0'
+  - client-side-encryption
+  - test-asan
+  exec_timeout_secs: 3600
+  depends_on:
+    name: debug-compile-asan-openssl-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-asan-openssl-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-asan-6.0-server-auth-nosasl-openssl
+  tags:
+  - '6.0'
+  - test-asan
+  exec_timeout_secs: 3600
+  depends_on:
+    name: debug-compile-asan-clang-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-asan-6.0-server-noauth-nosasl-nossl
+  tags:
+  - '6.0'
+  - test-asan
+  exec_timeout_secs: 3600
+  depends_on:
+    name: debug-compile-asan-clang
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-asan-clang
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+- name: test-asan-6.0-replica-set-auth-nosasl-openssl-cse
+  tags:
+  - '6.0'
+  - client-side-encryption
+  - test-asan
+  exec_timeout_secs: 3600
+  depends_on:
+    name: debug-compile-asan-openssl-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-asan-openssl-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-asan-6.0-replica-set-auth-nosasl-openssl
+  tags:
+  - '6.0'
+  - test-asan
+  exec_timeout_secs: 3600
+  depends_on:
+    name: debug-compile-asan-clang-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-asan-6.0-replica-set-noauth-nosasl-nossl
+  tags:
+  - '6.0'
+  - test-asan
+  exec_timeout_secs: 3600
+  depends_on:
+    name: debug-compile-asan-clang
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-asan-clang
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+- name: test-asan-6.0-sharded-auth-nosasl-openssl
+  tags:
+  - '6.0'
+  - test-asan
+  exec_timeout_secs: 3600
+  depends_on:
+    name: debug-compile-asan-clang-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-asan-6.0-sharded-noauth-nosasl-nossl
+  tags:
+  - '6.0'
+  - test-asan
+  exec_timeout_secs: 3600
+  depends_on:
+    name: debug-compile-asan-clang
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-asan-clang
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
     vars:
       ASAN: 'on'
@@ -3987,6 +4317,138 @@ tasks:
       AUTH: noauth
       SSL: openssl
       VALGRIND: 'off'
+- name: test-tsan-6.0-server-auth-nosasl-openssl
+  tags:
+  - '6.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-6.0-server-noauth-nosasl-openssl
+  tags:
+  - '6.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-6.0-replica-set-auth-nosasl-openssl
+  tags:
+  - '6.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-6.0-replica-set-noauth-nosasl-openssl
+  tags:
+  - '6.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-6.0-sharded-auth-nosasl-openssl
+  tags:
+  - '6.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-tsan-6.0-sharded-noauth-nosasl-openssl
+  tags:
+  - '6.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-5.0-server-auth-nosasl-openssl
   tags:
   - '5.0'
@@ -4760,6 +5222,126 @@ tasks:
       SSL: nossl
       TOPOLOGY: sharded_cluster
       VERSION: latest
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+  - func: update codecov.io
+- name: test-coverage-6.0-server-auth-nosasl-openssl
+  tags:
+  - '6.0'
+  - test-coverage
+  exec_timeout_secs: 3600
+  commands:
+  - func: debug-compile-coverage-notest-nosasl-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+  - func: update codecov.io
+- name: test-coverage-6.0-server-noauth-nosasl-nossl
+  tags:
+  - '6.0'
+  - test-coverage
+  exec_timeout_secs: 3600
+  commands:
+  - func: debug-compile-coverage-notest-nosasl-nossl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+  - func: update codecov.io
+- name: test-coverage-6.0-replica-set-auth-nosasl-openssl
+  tags:
+  - '6.0'
+  - test-coverage
+  exec_timeout_secs: 3600
+  commands:
+  - func: debug-compile-coverage-notest-nosasl-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+  - func: update codecov.io
+- name: test-coverage-6.0-replica-set-noauth-nosasl-nossl
+  tags:
+  - '6.0'
+  - test-coverage
+  exec_timeout_secs: 3600
+  commands:
+  - func: debug-compile-coverage-notest-nosasl-nossl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+  - func: update codecov.io
+- name: test-coverage-6.0-sharded-auth-nosasl-openssl
+  tags:
+  - '6.0'
+  - test-coverage
+  exec_timeout_secs: 3600
+  commands:
+  - func: debug-compile-coverage-notest-nosasl-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+  - func: update codecov.io
+- name: test-coverage-6.0-sharded-noauth-nosasl-nossl
+  tags:
+  - '6.0'
+  - test-coverage
+  exec_timeout_secs: 3600
+  commands:
+  - func: debug-compile-coverage-notest-nosasl-nossl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
     vars:
       ASAN: 'off'
@@ -7125,6 +7707,1745 @@ tasks:
       SSL: nossl
       TOPOLOGY: sharded_cluster
       VERSION: latest
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+- name: test-6.0-server-auth-sasl-openssl-cse
+  tags:
+  - '6.0'
+  - auth
+  - client-side-encryption
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-6.0-server-auth-sasl-openssl
+  tags:
+  - '6.0'
+  - auth
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-6.0-server-auth-sasl-openssl-static-cse
+  tags:
+  - '6.0'
+  - auth
+  - client-side-encryption
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl-static
+      VALGRIND: 'off'
+- name: test-6.0-server-auth-sasl-openssl-static
+  tags:
+  - '6.0'
+  - auth
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
+- name: test-6.0-server-auth-sasl-darwinssl-cse
+  tags:
+  - '6.0'
+  - auth
+  - client-side-encryption
+  - darwinssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: darwinssl
+      VALGRIND: 'off'
+- name: test-6.0-server-auth-sasl-darwinssl
+  tags:
+  - '6.0'
+  - auth
+  - darwinssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
+- name: test-6.0-server-auth-sasl-winssl-cse
+  tags:
+  - '6.0'
+  - auth
+  - client-side-encryption
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: winssl
+      VALGRIND: 'off'
+- name: test-6.0-server-auth-sasl-winssl
+  tags:
+  - '6.0'
+  - auth
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
+- name: test-6.0-server-auth-nosasl-openssl
+  tags:
+  - '6.0'
+  - auth
+  - nosasl
+  - openssl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-6.0-server-auth-nosasl-openssl-static
+  tags:
+  - '6.0'
+  - auth
+  - nosasl
+  - openssl-static
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
+- name: test-6.0-server-auth-nosasl-darwinssl
+  tags:
+  - '6.0'
+  - auth
+  - darwinssl
+  - nosasl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
+- name: test-6.0-server-auth-nosasl-winssl
+  tags:
+  - '6.0'
+  - auth
+  - nosasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
+- name: test-6.0-server-noauth-sasl-openssl-cse
+  tags:
+  - '6.0'
+  - client-side-encryption
+  - noauth
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-6.0-server-noauth-sasl-openssl
+  tags:
+  - '6.0'
+  - noauth
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-6.0-server-noauth-sasl-openssl-static-cse
+  tags:
+  - '6.0'
+  - client-side-encryption
+  - noauth
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl-static
+      VALGRIND: 'off'
+- name: test-6.0-server-noauth-sasl-openssl-static
+  tags:
+  - '6.0'
+  - noauth
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
+- name: test-6.0-server-noauth-sasl-darwinssl-cse
+  tags:
+  - '6.0'
+  - client-side-encryption
+  - darwinssl
+  - noauth
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: darwinssl
+      VALGRIND: 'off'
+- name: test-6.0-server-noauth-sasl-darwinssl
+  tags:
+  - '6.0'
+  - darwinssl
+  - noauth
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
+- name: test-6.0-server-noauth-sasl-winssl-cse
+  tags:
+  - '6.0'
+  - client-side-encryption
+  - noauth
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: winssl
+      VALGRIND: 'off'
+- name: test-6.0-server-noauth-sasl-winssl
+  tags:
+  - '6.0'
+  - noauth
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
+- name: test-6.0-server-noauth-nosasl-openssl
+  tags:
+  - '6.0'
+  - noauth
+  - nosasl
+  - openssl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-6.0-server-noauth-nosasl-openssl-static
+  tags:
+  - '6.0'
+  - noauth
+  - nosasl
+  - openssl-static
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
+- name: test-6.0-server-noauth-nosasl-darwinssl
+  tags:
+  - '6.0'
+  - darwinssl
+  - noauth
+  - nosasl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
+- name: test-6.0-server-noauth-nosasl-winssl
+  tags:
+  - '6.0'
+  - noauth
+  - nosasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
+- name: test-6.0-server-noauth-nosasl-nossl
+  tags:
+  - '6.0'
+  - noauth
+  - nosasl
+  - nossl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-nossl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+- name: test-6.0-replica-set-auth-sasl-openssl-cse
+  tags:
+  - '6.0'
+  - auth
+  - client-side-encryption
+  - openssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-6.0-replica-set-auth-sasl-openssl
+  tags:
+  - '6.0'
+  - auth
+  - openssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-6.0-replica-set-auth-sasl-openssl-static-cse
+  tags:
+  - '6.0'
+  - auth
+  - client-side-encryption
+  - openssl-static
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-static-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl-static
+      VALGRIND: 'off'
+- name: test-6.0-replica-set-auth-sasl-openssl-static
+  tags:
+  - '6.0'
+  - auth
+  - openssl-static
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-static
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
+- name: test-6.0-replica-set-auth-sasl-darwinssl-cse
+  tags:
+  - '6.0'
+  - auth
+  - client-side-encryption
+  - darwinssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-darwinssl-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: darwinssl
+      VALGRIND: 'off'
+- name: test-6.0-replica-set-auth-sasl-darwinssl
+  tags:
+  - '6.0'
+  - auth
+  - darwinssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-darwinssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
+- name: test-6.0-replica-set-auth-sasl-winssl-cse
+  tags:
+  - '6.0'
+  - auth
+  - client-side-encryption
+  - replica_set
+  - sasl
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: winssl
+      VALGRIND: 'off'
+- name: test-6.0-replica-set-auth-sasl-winssl
+  tags:
+  - '6.0'
+  - auth
+  - replica_set
+  - sasl
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
+- name: test-6.0-replica-set-auth-nosasl-openssl
+  tags:
+  - '6.0'
+  - auth
+  - nosasl
+  - openssl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-6.0-replica-set-auth-nosasl-openssl-static
+  tags:
+  - '6.0'
+  - auth
+  - nosasl
+  - openssl-static
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
+- name: test-6.0-replica-set-auth-nosasl-darwinssl
+  tags:
+  - '6.0'
+  - auth
+  - darwinssl
+  - nosasl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
+- name: test-6.0-replica-set-auth-nosasl-winssl
+  tags:
+  - '6.0'
+  - auth
+  - nosasl
+  - replica_set
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
+- name: test-6.0-replica-set-noauth-sasl-openssl-cse
+  tags:
+  - '6.0'
+  - client-side-encryption
+  - noauth
+  - openssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-6.0-replica-set-noauth-sasl-openssl
+  tags:
+  - '6.0'
+  - noauth
+  - openssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-6.0-replica-set-noauth-sasl-openssl-static-cse
+  tags:
+  - '6.0'
+  - client-side-encryption
+  - noauth
+  - openssl-static
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-static-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl-static
+      VALGRIND: 'off'
+- name: test-6.0-replica-set-noauth-sasl-openssl-static
+  tags:
+  - '6.0'
+  - noauth
+  - openssl-static
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-static
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
+- name: test-6.0-replica-set-noauth-sasl-darwinssl-cse
+  tags:
+  - '6.0'
+  - client-side-encryption
+  - darwinssl
+  - noauth
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-darwinssl-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: darwinssl
+      VALGRIND: 'off'
+- name: test-6.0-replica-set-noauth-sasl-darwinssl
+  tags:
+  - '6.0'
+  - darwinssl
+  - noauth
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-darwinssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
+- name: test-6.0-replica-set-noauth-sasl-winssl-cse
+  tags:
+  - '6.0'
+  - client-side-encryption
+  - noauth
+  - replica_set
+  - sasl
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl-cse
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl-cse
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: winssl
+      VALGRIND: 'off'
+- name: test-6.0-replica-set-noauth-sasl-winssl
+  tags:
+  - '6.0'
+  - noauth
+  - replica_set
+  - sasl
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
+- name: test-6.0-replica-set-noauth-nosasl-openssl
+  tags:
+  - '6.0'
+  - noauth
+  - nosasl
+  - openssl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-6.0-replica-set-noauth-nosasl-openssl-static
+  tags:
+  - '6.0'
+  - noauth
+  - nosasl
+  - openssl-static
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
+- name: test-6.0-replica-set-noauth-nosasl-darwinssl
+  tags:
+  - '6.0'
+  - darwinssl
+  - noauth
+  - nosasl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
+- name: test-6.0-replica-set-noauth-nosasl-winssl
+  tags:
+  - '6.0'
+  - noauth
+  - nosasl
+  - replica_set
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
+- name: test-6.0-replica-set-noauth-nosasl-nossl
+  tags:
+  - '6.0'
+  - noauth
+  - nosasl
+  - nossl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-nossl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+- name: test-6.0-sharded-auth-sasl-openssl
+  tags:
+  - '6.0'
+  - auth
+  - openssl
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-6.0-sharded-auth-sasl-openssl-static
+  tags:
+  - '6.0'
+  - auth
+  - openssl-static
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl-static
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
+- name: test-6.0-sharded-auth-sasl-darwinssl
+  tags:
+  - '6.0'
+  - auth
+  - darwinssl
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-darwinssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
+- name: test-6.0-sharded-auth-sasl-winssl
+  tags:
+  - '6.0'
+  - auth
+  - sasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
+- name: test-6.0-sharded-auth-nosasl-openssl
+  tags:
+  - '6.0'
+  - auth
+  - nosasl
+  - openssl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-6.0-sharded-auth-nosasl-openssl-static
+  tags:
+  - '6.0'
+  - auth
+  - nosasl
+  - openssl-static
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
+- name: test-6.0-sharded-auth-nosasl-darwinssl
+  tags:
+  - '6.0'
+  - auth
+  - darwinssl
+  - nosasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
+- name: test-6.0-sharded-auth-nosasl-winssl
+  tags:
+  - '6.0'
+  - auth
+  - nosasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
+- name: test-6.0-sharded-noauth-sasl-openssl
+  tags:
+  - '6.0'
+  - noauth
+  - openssl
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-6.0-sharded-noauth-sasl-openssl-static
+  tags:
+  - '6.0'
+  - noauth
+  - openssl-static
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl-static
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
+- name: test-6.0-sharded-noauth-sasl-darwinssl
+  tags:
+  - '6.0'
+  - darwinssl
+  - noauth
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-darwinssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
+- name: test-6.0-sharded-noauth-sasl-winssl
+  tags:
+  - '6.0'
+  - noauth
+  - sasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
+- name: test-6.0-sharded-noauth-nosasl-openssl
+  tags:
+  - '6.0'
+  - noauth
+  - nosasl
+  - openssl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
+- name: test-6.0-sharded-noauth-nosasl-openssl-static
+  tags:
+  - '6.0'
+  - noauth
+  - nosasl
+  - openssl-static
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
+- name: test-6.0-sharded-noauth-nosasl-darwinssl
+  tags:
+  - '6.0'
+  - darwinssl
+  - noauth
+  - nosasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
+- name: test-6.0-sharded-noauth-nosasl-winssl
+  tags:
+  - '6.0'
+  - noauth
+  - nosasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
+  - func: run tests
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
+- name: test-6.0-sharded-noauth-nosasl-nossl
+  tags:
+  - '6.0'
+  - noauth
+  - nosasl
+  - nossl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-nossl
+  commands:
+  - func: fetch build
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
+  - func: bootstrap mongo-orchestration
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
     vars:
       ASAN: 'off'

--- a/build/evergreen_config_lib/tasks.py
+++ b/build/evergreen_config_lib/tasks.py
@@ -464,7 +464,7 @@ class IntegrationTask(MatrixTask):
     axes = OD([('valgrind', ['valgrind', False]),
                ('sanitizer', ['asan', 'tsan', False]),
                ('coverage', ['coverage', False]),
-               ('version', ['latest', '5.0', '4.4', '4.2', '4.0', '3.6']),
+               ('version', ['latest', '6.0', '5.0', '4.4', '4.2', '4.0', '3.6']),
                ('topology', ['server', 'replica_set', 'sharded_cluster']),
                ('auth', [True, False]),
                ('sasl', ['sasl', 'sspi', False]),

--- a/src/libmongoc/src/mongoc/mongoc-client-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-private.h
@@ -45,7 +45,7 @@ BSON_BEGIN_DECLS
  * WIRE_VERSION_MAX must be accompanied by an update to
  * `_mongoc_wire_version_to_server_version`. */
 #define WIRE_VERSION_MIN 6  /* a.k.a. minWireVersion */
-#define WIRE_VERSION_MAX 15 /* a.k.a. maxWireVersion */
+#define WIRE_VERSION_MAX 17 /* a.k.a. maxWireVersion */
 
 /* first version that supported "find" and "getMore" commands */
 #define WIRE_VERSION_FIND_CMD 4

--- a/src/libmongoc/src/mongoc/mongoc-util.c
+++ b/src/libmongoc/src/mongoc/mongoc-util.c
@@ -306,6 +306,10 @@ _mongoc_wire_version_to_server_version (int32_t version)
       return "5.1";
    case 15:
       return "5.2";
+   case 16:
+      return "5.3";
+   case 17:
+      return "6.0";
    default:
       return "Unknown";
    }


### PR DESCRIPTION
Addresses CDRIVER-4380 

I've added a set of tasks for `6.0` integration testing in this PR. Also we seem to have jumped over wire version 16, which I believe corresponds to server version 5.3 based on digging in the code.