### PR TITLE
CDRIVER-4305: 'fullDocument' may be null/omitted

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-change-stream.c
+++ b/src/libmongoc/src/mongoc/mongoc-change-stream.c
@@ -123,7 +123,9 @@ _make_command (mongoc_change_stream_t *stream, bson_t *command)
    bson_append_document_begin (&pipeline, "0", 1, &change_stream_stage);
    bson_append_document_begin (
       &change_stream_stage, "$changeStream", 13, &change_stream_doc);
-   bson_concat (&change_stream_doc, stream->full_document);
+   if (stream->full_document) {
+      bson_concat (&change_stream_doc, stream->full_document);
+   }
 
    if (stream->resumed) {
       /* Change stream spec: Resume Process */
@@ -412,7 +414,12 @@ _change_stream_init (mongoc_change_stream_t *stream,
       return;
    }
 
-   stream->full_document = BCON_NEW ("fullDocument", stream->opts.fullDocument);
+   if (stream->opts.fullDocument) {
+      stream->full_document =
+         BCON_NEW ("fullDocument", stream->opts.fullDocument);
+   } else {
+      stream->full_document = NULL;
+   }
 
    _mongoc_timestamp_set (&stream->operation_time,
                           &stream->opts.startAtOperationTime);

--- a/src/libmongoc/src/mongoc/mongoc-opts.c
+++ b/src/libmongoc/src/mongoc/mongoc-opts.c
@@ -1581,7 +1581,7 @@ _mongoc_change_stream_opts_parse (
    bson_init (&mongoc_change_stream_opts->startAfter);
    memset (&mongoc_change_stream_opts->startAtOperationTime, 0, sizeof (mongoc_timestamp_t));
    mongoc_change_stream_opts->maxAwaitTimeMS = 0;
-   mongoc_change_stream_opts->fullDocument = "default";
+   mongoc_change_stream_opts->fullDocument = NULL;
    memset (&mongoc_change_stream_opts->comment, 0, sizeof (bson_value_t));
    bson_init (&mongoc_change_stream_opts->extra);
 

--- a/src/libmongoc/tests/test-mongoc-change-stream.c
+++ b/src/libmongoc/tests/test-mongoc-change-stream.c
@@ -130,7 +130,7 @@ test_change_stream_pipeline (void)
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'db',"
                 " 'aggregate': 'coll',"
-                " 'pipeline': [{'$changeStream': {'fullDocument': 'default'}}],"
+                " 'pipeline': [{'$changeStream': {}}],"
                 " 'cursor': {}}"));
 
    mock_server_replies_simple (
@@ -180,15 +180,15 @@ test_change_stream_pipeline (void)
    /* Test non-empty pipeline */
    future = future_collection_watch (coll, nonempty_pipeline, NULL);
 
-   request = mock_server_receives_msg (
-      server,
-      MONGOC_MSG_NONE,
-      tmp_bson ("{'$db': 'db',"
-                " 'aggregate': 'coll',"
-                " 'pipeline': ["
-                "   {'$changeStream': {'fullDocument': 'default'}},"
-                "   {'$project': {'ns': false}}],"
-                " 'cursor': {}}"));
+   request =
+      mock_server_receives_msg (server,
+                                MONGOC_MSG_NONE,
+                                tmp_bson ("{'$db': 'db',"
+                                          " 'aggregate': 'coll',"
+                                          " 'pipeline': ["
+                                          "   {'$changeStream': {}},"
+                                          "   {'$project': {'ns': false}}],"
+                                          " 'cursor': {}}"));
    mock_server_replies_simple (
       request,
       "{'cursor': {'id': 123, 'ns': 'db.coll','firstBatch': []},'ok': 1}");
@@ -739,11 +739,10 @@ test_change_stream_resumable_error (void)
       "{ 'code': 10107, 'errmsg': 'not primary', 'ok': 0 }";
    const char *interrupted_err =
       "{ 'code': 11601, 'errmsg': 'interrupted', 'ok': 0 }";
-   const bson_t *watch_cmd =
-      tmp_bson ("{'$db': 'db',"
-                " 'aggregate': 'coll',"
-                " 'pipeline': [{'$changeStream': {'fullDocument': 'default'}}],"
-                " 'cursor': {}}");
+   const bson_t *watch_cmd = tmp_bson ("{'$db': 'db',"
+                                       " 'aggregate': 'coll',"
+                                       " 'pipeline': [{'$changeStream': {}}],"
+                                       " 'cursor': {}}");
    const char *expected_msg =
       "{'$db': 'db', 'getMore': {'$numberLong': '%d'}, 'collection': 'coll' }";
 
@@ -1825,7 +1824,7 @@ _test_resume (const char *opts,
       server,
       MONGOC_QUERY_NONE,
       tmp_bson ("{ 'aggregate': 'coll', 'pipeline' : [ { '$changeStream': { %s "
-                "'fullDocument': 'default' } } ], 'cursor': {  } }",
+                " 'fullDocument': null } } ], 'cursor': {  } }",
                 expected_change_stream_opts));
    msg = bson_strdup_printf ("{'cursor': {'id': 123, 'ns': 'db.coll',"
                              "'firstBatch': [%s]%s }, 'operationTime': "
@@ -1855,7 +1854,7 @@ _test_resume (const char *opts,
       server,
       MONGOC_QUERY_NONE,
       tmp_bson ("{ 'aggregate': 'coll', 'pipeline' : [ { '$changeStream': { %s "
-                "'fullDocument': 'default' }} ], 'cursor': {  } }",
+                " 'fullDocument': null }} ], 'cursor': {  } }",
                 expected_resume_change_stream_opts));
    mock_server_replies_simple (
       request,


### PR DESCRIPTION
This commit implements CDRIVER-4305, which allows fullDocument to be
NULL equivalent to a literal "default" string. This is permitted in
server 3.6+, and this change makes that the preferred and default
behavior.

This driver already requires 3.6 or newer (as per minWireVersion)

This changeset does not introduce new tests, but it was tested locally against the change_streams unified tests, which rely on `fullDocument` being nullable. Additional changes are required before the change_streams unified tests can be enabled.