### PR TITLE
CDRIVER-4199: Add comment to change stream getMore commands

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-change-stream.c
+++ b/src/libmongoc/src/mongoc/mongoc-change-stream.c
@@ -247,6 +247,7 @@ _make_cursor (mongoc_change_stream_t *stream)
 
    if (stream->opts.comment.value_type != BSON_TYPE_EOD) {
       bson_append_value (&command_opts, "comment", 7, &stream->opts.comment);
+      bson_append_value (&getmore_opts, "comment", 7, &stream->opts.comment);
    }
 
    if (bson_iter_init_find (&iter, &command_opts, "sessionId")) {


### PR DESCRIPTION
This adds a missing "comment" value to getMore for changestreams. This
fixes test failures in the changestreams tests, which are not yet
enabled in this branch but has been manually validated locally.