### PR TITLE
Fix printing location of libmongocrypt with invalid version

### DIFF
--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -442,7 +442,7 @@ elseif (NOT ENABLE_CLIENT_SIDE_ENCRYPTION STREQUAL OFF)
    endif ()
 
    if (mongocrypt_FOUND AND "${mongocrypt_VERSION}" VERSION_LESS 1.5.0)
-      message ("--   libmongocrypt found at ${LIBMONGOCRYPT_LIBRARY}")
+      message ("--   libmongocrypt found at ${mongocrypt_DIR}")
       message ("--   libmongocrypt version ${mongocrypt_VERSION} found")
       message ("--   libmongocrypt version 1.5.0 is required to enable Client-Side Field Level Encryption Support.")
       set (REQUIRED_MONGOCRYPT_VERSION_FOUND OFF)


### PR DESCRIPTION
Current implementation results in the following error message (note the missing location of the candidate):
```
Searching for libmongocrypt
--   libmongocrypt found at
--   libmongocrypt version 1.3.0 found
--   libmongocrypt version 1.5.0 is required to enable Client-Side Field Level Encryption Support.
CMake Error at src/libmongoc/CMakeLists.txt:466 (message):
  Required library (libmongocrypt) not found.
```

This PR addresses this issue by using [`${mongocrypt_DIR}`](https://cmake.org/cmake/help/v3.1/command/find_package.html) instead of the not-yet-defined `${LIBMONGOCRYPT_LIBRARY}` on [line 459](https://github.com/eramongodb/mongo-c-driver/blob/62fc65d20ad90b76052775f1b720e36945984f81/src/libmongoc/CMakeLists.txt#L459):
```
 Searching for libmongocrypt
 --   libmongocrypt found at /mnt/c/Users/eramongodb/Projects/libmongocrypt/local-install/lib/cmake/mongocrypt
 --   libmongocrypt version 1.3.0 found
 --   libmongocrypt version 1.5.0 is required to enable Client-Side Field Level Encryption Support.
 CMake Error at src/libmongoc/CMakeLists.txt:466 (message):
   Required library (libmongocrypt) not found.
```