### PR TITLE
pin libmongocrypt to 1.5.0-alpha2

### DIFF
--- a/.evergreen/compile-unix.sh
+++ b/.evergreen/compile-unix.sh
@@ -227,7 +227,7 @@ pkg-config --modversion libssl || true
 
 if [ "$COMPILE_LIBMONGOCRYPT" = "ON" ]; then
    # Build libmongocrypt, using the previously fetched installed source.
-   git clone https://github.com/mongodb/libmongocrypt
+   git clone https://github.com/mongodb/libmongocrypt --branch 1.5.0-alpha2
    mkdir libmongocrypt/cmake-build
    cd libmongocrypt/cmake-build
    $CMAKE -DENABLE_SHARED_BSON=ON -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" ../

--- a/.evergreen/compile-windows.sh
+++ b/.evergreen/compile-windows.sh
@@ -115,7 +115,7 @@ fi
 
 if [ "$COMPILE_LIBMONGOCRYPT" = "ON" ]; then
    # Build libmongocrypt, using the previously fetched installed source.
-   git clone https://github.com/mongodb/libmongocrypt
+   git clone https://github.com/mongodb/libmongocrypt --branch 1.5.0-alpha2
    mkdir libmongocrypt/cmake-build
    cd libmongocrypt/cmake-build
    "$CMAKE" -G "$CC" "-DCMAKE_PREFIX_PATH=${INSTALL_DIR}/lib/cmake" -DENABLE_SHARED_BSON=ON -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" ../


### PR DESCRIPTION
Resolving MONGOCRYPT-434 may put the libmongocrypt master branch in a temporary breaking state until drivers update bindings and [SERVER-66771](https://jira.mongodb.org/browse/SERVER-66771) is released.