### PR TITLE
Set MONGO_USE_CCACHE to OFF by default

### DIFF
--- a/build/cmake/CCache.cmake
+++ b/build/cmake/CCache.cmake
@@ -12,7 +12,7 @@
 find_program (CCACHE_EXECUTABLE ccache)
 if (CCACHE_EXECUTABLE)
     message (STATUS "Found ccache: ${CCACHE_EXECUTABLE}")
-    option (MONGO_USE_CCACHE "Use CCache when compiling" ON)
+    option (MONGO_USE_CCACHE "Use CCache when compiling" OFF)
 endif ()
 
 if (MONGO_USE_CCACHE)


### PR DESCRIPTION
### Description

```
ccache: error: /home/ubuntu/.ccache/ccache.conf: No such file or directory
```

Various Evergreen tasks are failing spuriously due to the above ccache error frequently enough that I would like to suggest the option be disabled by default until the issue is properly tested and addressed.