### PR TITLE
Disable ccache by default for versions older than 3.4.3

### DIFF
--- a/build/cmake/CCache.cmake
+++ b/build/cmake/CCache.cmake
@@ -8,31 +8,33 @@
     ON or OFF.
 ]]
 
-# Find and enable ccache for compiling
-find_program (CCACHE_EXECUTABLE ccache)
-if (CCACHE_EXECUTABLE)
-    message (STATUS "Found ccache: ${CCACHE_EXECUTABLE}")
+# Find and enable ccache for compiling if not already found.
+if (NOT DEFINED MONGO_USE_CCACHE)
+    find_program (CCACHE_EXECUTABLE ccache)
+    if (CCACHE_EXECUTABLE)
+        message (STATUS "Found ccache: ${CCACHE_EXECUTABLE}")
 
-    execute_process (
-        COMMAND ${CCACHE_EXECUTABLE} --version | perl -ne "print $1 if /^ccache version (.+)$/"
-        OUTPUT_VARIABLE CCACHE_VERSION
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
+        execute_process (
+            COMMAND ${CCACHE_EXECUTABLE} --version | perl -ne "print $1 if /^ccache version (.+)$/"
+            OUTPUT_VARIABLE CCACHE_VERSION
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
 
-    # Assume `ccache --version` mentions a simple version string, e.g. 1.2.3
-    set (SIMPLE_SEMVER_REGEX "([0-9]+)\.([0-9]+)\.([0-9]+)")
-    string (REGEX MATCH "${SIMPLE_SEMVER_REGEX}" CCACHE_VERSION ${CCACHE_VERSION})
+        # Assume `ccache --version` mentions a simple version string, e.g. 1.2.3
+        set (SIMPLE_SEMVER_REGEX "([0-9]+)\.([0-9]+)\.([0-9]+)")
+        string (REGEX MATCH "${SIMPLE_SEMVER_REGEX}" CCACHE_VERSION ${CCACHE_VERSION})
 
-    # Avoid spurious "ccache.conf: No such file or directory" errors due to ccache being invoked in parallel, which was patched in ccache version 3.4.3.
-    if (${CCACHE_VERSION} VERSION_LESS 3.4.3)
-        message (STATUS "Detected ccache version ${CCACHE_VERSION} is less than 3.4.3, which may lead to spurious failures when run in parallel. See https://github.com/ccache/ccache/issues/260 for more information.")
-        message (STATUS "Compiling with CCache disabled. Enable by setting MONGO_USE_CCACHE to ON")
-        option (MONGO_USE_CCACHE "Use CCache when compiling" OFF)
-    else ()
-        message (STATUS "Compiling with CCache enabled. Disable by setting MONGO_USE_CCACHE to OFF")
-        option (MONGO_USE_CCACHE "Use CCache when compiling" ON)
-    endif ()
-endif ()
+        # Avoid spurious "ccache.conf: No such file or directory" errors due to ccache being invoked in parallel, which was patched in ccache version 3.4.3.
+        if (${CCACHE_VERSION} VERSION_LESS 3.4.3)
+            message (STATUS "Detected ccache version ${CCACHE_VERSION} is less than 3.4.3, which may lead to spurious failures when run in parallel. See https://github.com/ccache/ccache/issues/260 for more information.")
+            message (STATUS "Compiling with CCache disabled. Enable by setting MONGO_USE_CCACHE to ON")
+            option (MONGO_USE_CCACHE "Use CCache when compiling" OFF)
+        else ()
+            message (STATUS "Compiling with CCache enabled. Disable by setting MONGO_USE_CCACHE to OFF")
+            option (MONGO_USE_CCACHE "Use CCache when compiling" ON)
+        endif ()
+    endif (CCACHE_EXECUTABLE)
+endif (NOT DEFINED MONGO_USE_CCACHE)
 
 if (MONGO_USE_CCACHE)
     set (CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_EXECUTABLE}")

--- a/build/cmake/CCache.cmake
+++ b/build/cmake/CCache.cmake
@@ -25,6 +25,13 @@ if (NOT DEFINED MONGO_USE_CCACHE)
         set (SIMPLE_SEMVER_REGEX "([0-9]+)\.([0-9]+)(\.([0-9]+))?")
         string (REGEX MATCH "${SIMPLE_SEMVER_REGEX}" CCACHE_VERSION ${CCACHE_VERSION})
 
+        if (CCACHE_VERSION)
+            message (STATUS "Detected ccache version: ${CCACHE_VERSION}")
+        else ()
+            message (WARNING "Could not obtain ccache version from `ccache --version`. Defaulting to 0.1.0.")
+            set (CCACHE_VERSION 0.1.0)
+        endif ()
+
         # Avoid spurious "ccache.conf: No such file or directory" errors due to ccache being invoked in parallel, which was patched in ccache version 3.4.3.
         if (${CCACHE_VERSION} VERSION_LESS 3.4.3)
             message (STATUS "Detected ccache version ${CCACHE_VERSION} is less than 3.4.3, which may lead to spurious failures when run in parallel. See https://github.com/ccache/ccache/issues/260 for more information.")

--- a/build/cmake/CCache.cmake
+++ b/build/cmake/CCache.cmake
@@ -20,8 +20,9 @@ if (NOT DEFINED MONGO_USE_CCACHE)
             OUTPUT_STRIP_TRAILING_WHITESPACE
         )
 
-        # Assume `ccache --version` mentions a simple version string, e.g. 1.2.3
-        set (SIMPLE_SEMVER_REGEX "([0-9]+)\.([0-9]+)\.([0-9]+)")
+        # Assume `ccache --version` mentions a simple version string, e.g. "1.2.3".
+        # Permit patch number to be omitted, e.g. "1.2".
+        set (SIMPLE_SEMVER_REGEX "([0-9]+)\.([0-9]+)(\.([0-9]+))?")
         string (REGEX MATCH "${SIMPLE_SEMVER_REGEX}" CCACHE_VERSION ${CCACHE_VERSION})
 
         # Avoid spurious "ccache.conf: No such file or directory" errors due to ccache being invoked in parallel, which was patched in ccache version 3.4.3.

--- a/build/cmake/CCache.cmake
+++ b/build/cmake/CCache.cmake
@@ -12,11 +12,29 @@
 find_program (CCACHE_EXECUTABLE ccache)
 if (CCACHE_EXECUTABLE)
     message (STATUS "Found ccache: ${CCACHE_EXECUTABLE}")
-    option (MONGO_USE_CCACHE "Use CCache when compiling" ON)
+
+    execute_process (
+        COMMAND ${CCACHE_EXECUTABLE} --version | perl -ne "print $1 if /^ccache version (.+)$/"
+        OUTPUT_VARIABLE CCACHE_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    # Assume `ccache --version` mentions a simple version string, e.g. 1.2.3
+    set (SIMPLE_SEMVER_REGEX "([0-9]+)\.([0-9]+)\.([0-9]+)")
+    string (REGEX MATCH "${SIMPLE_SEMVER_REGEX}" CCACHE_VERSION ${CCACHE_VERSION})
+
+    # Avoid spurious "ccache.conf: No such file or directory" errors due to ccache being invoked in parallel, which was patched in ccache version 3.4.3.
+    if (${CCACHE_VERSION} VERSION_LESS 3.4.3)
+        message (STATUS "Detected ccache version ${CCACHE_VERSION} is less than 3.4.3, which may lead to spurious failures when run in parallel. See https://github.com/ccache/ccache/issues/260 for more information.")
+        message (STATUS "Compiling with CCache disabled. Enable by setting MONGO_USE_CCACHE to ON")
+        option (MONGO_USE_CCACHE "Use CCache when compiling" OFF)
+    else ()
+        message (STATUS "Compiling with CCache enabled. Disable by setting MONGO_USE_CCACHE to OFF")
+        option (MONGO_USE_CCACHE "Use CCache when compiling" ON)
+    endif ()
 endif ()
 
 if (MONGO_USE_CCACHE)
-    message (STATUS "Compiling with CCache enabled. Disable by setting MONGO_USE_CCACHE to OFF")
     set (CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_EXECUTABLE}")
     set (CMAKE_C_COMPILER_LAUNCHER "${CCACHE_EXECUTABLE}")
 endif ()


### PR DESCRIPTION
### Description

This PR addresses the "ccache.conf: No such file or directory" spurious failures on Evergreen by conditionally disabling ccache by default given the detected ccache version is older than 3.4.3.

After further investigation, I found [this issue thread](https://gitlab.gnome.org/GNOME/gnome-build-meta/-/issues/35) which documented the same spurious failure being observed on Evergreen. Thread participants deduced the cause to be ccache being invoked in parallel, "which is problematic because ccache creates its configuration in `$HOME/.ccache/ccache.conf` on first run, but in non-atomic way, which breaks with error". This issue was then [reported and subsequently patched](https://github.com/ccache/ccache/issues/260) in ccache version 3.4.3.

As of time of writing, this condition to disable ccache by default should only affect Evergreen tests being run on the Ubuntu 18.04 variant, which uses ccache version 3.4.1.