### PR TITLE
Do not elide find_package() if MONGO_USE_CCACHE is set

### DIFF
--- a/build/cmake/CCache.cmake
+++ b/build/cmake/CCache.cmake
@@ -8,41 +8,40 @@
     ON or OFF.
 ]]
 
-# Find and enable ccache for compiling if not already found.
-if (NOT DEFINED MONGO_USE_CCACHE)
-    find_program (CCACHE_EXECUTABLE ccache)
-    if (CCACHE_EXECUTABLE)
-        message (STATUS "Found ccache: ${CCACHE_EXECUTABLE}")
+find_program (CCACHE_EXECUTABLE ccache)
 
-        execute_process (
-            COMMAND ${CCACHE_EXECUTABLE} --version | perl -ne "print $1 if /^ccache version (.+)$/"
-            OUTPUT_VARIABLE CCACHE_VERSION
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-        )
+# Enable ccache for compiling if not already configured.
+if (CCACHE_EXECUTABLE AND NOT DEFINED MONGO_USE_CCACHE)
+    message (STATUS "Found ccache: ${CCACHE_EXECUTABLE}")
 
-        # Assume `ccache --version` mentions a simple version string, e.g. "1.2.3".
-        # Permit patch number to be omitted, e.g. "1.2".
-        set (SIMPLE_SEMVER_REGEX "([0-9]+)\.([0-9]+)(\.([0-9]+))?")
-        string (REGEX MATCH "${SIMPLE_SEMVER_REGEX}" CCACHE_VERSION ${CCACHE_VERSION})
+    execute_process (
+        COMMAND ${CCACHE_EXECUTABLE} --version | perl -ne "print $1 if /^ccache version (.+)$/"
+        OUTPUT_VARIABLE CCACHE_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
 
-        if (CCACHE_VERSION)
-            message (STATUS "Detected ccache version: ${CCACHE_VERSION}")
-        else ()
-            message (WARNING "Could not obtain ccache version from `ccache --version`. Defaulting to 0.1.0.")
-            set (CCACHE_VERSION 0.1.0)
-        endif ()
+    # Assume `ccache --version` mentions a simple version string, e.g. "1.2.3".
+    # Permit patch number to be omitted, e.g. "1.2".
+    set (SIMPLE_SEMVER_REGEX "([0-9]+)\.([0-9]+)(\.([0-9]+))?")
+    string (REGEX MATCH "${SIMPLE_SEMVER_REGEX}" CCACHE_VERSION ${CCACHE_VERSION})
 
-        # Avoid spurious "ccache.conf: No such file or directory" errors due to ccache being invoked in parallel, which was patched in ccache version 3.4.3.
-        if (${CCACHE_VERSION} VERSION_LESS 3.4.3)
-            message (STATUS "Detected ccache version ${CCACHE_VERSION} is less than 3.4.3, which may lead to spurious failures when run in parallel. See https://github.com/ccache/ccache/issues/260 for more information.")
-            message (STATUS "Compiling with CCache disabled. Enable by setting MONGO_USE_CCACHE to ON")
-            option (MONGO_USE_CCACHE "Use CCache when compiling" OFF)
-        else ()
-            message (STATUS "Compiling with CCache enabled. Disable by setting MONGO_USE_CCACHE to OFF")
-            option (MONGO_USE_CCACHE "Use CCache when compiling" ON)
-        endif ()
-    endif (CCACHE_EXECUTABLE)
-endif (NOT DEFINED MONGO_USE_CCACHE)
+    if (CCACHE_VERSION)
+        message (STATUS "Detected ccache version: ${CCACHE_VERSION}")
+    else ()
+        message (WARNING "Could not obtain ccache version from `ccache --version`. Defaulting to 0.1.0.")
+        set (CCACHE_VERSION 0.1.0)
+    endif ()
+
+    # Avoid spurious "ccache.conf: No such file or directory" errors due to ccache being invoked in parallel, which was patched in ccache version 3.4.3.
+    if (${CCACHE_VERSION} VERSION_LESS 3.4.3)
+        message (STATUS "Detected ccache version ${CCACHE_VERSION} is less than 3.4.3, which may lead to spurious failures when run in parallel. See https://github.com/ccache/ccache/issues/260 for more information.")
+        message (STATUS "Compiling with CCache disabled. Enable by setting MONGO_USE_CCACHE to ON")
+        option (MONGO_USE_CCACHE "Use CCache when compiling" OFF)
+    else ()
+        message (STATUS "Compiling with CCache enabled. Disable by setting MONGO_USE_CCACHE to OFF")
+        option (MONGO_USE_CCACHE "Use CCache when compiling" ON)
+    endif ()
+endif (CCACHE_EXECUTABLE AND NOT DEFINED MONGO_USE_CCACHE)
 
 if (MONGO_USE_CCACHE)
     set (CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_EXECUTABLE}")

--- a/build/cmake/CCache.cmake
+++ b/build/cmake/CCache.cmake
@@ -33,7 +33,7 @@ if (CCACHE_EXECUTABLE AND NOT DEFINED MONGO_USE_CCACHE)
     endif ()
 
     # Avoid spurious "ccache.conf: No such file or directory" errors due to ccache being invoked in parallel, which was patched in ccache version 3.4.3.
-    if (${CCACHE_VERSION} VERSION_LESS 3.4.3)
+    if (CCACHE_VERSION VERSION_LESS "3.4.3")
         message (STATUS "Detected ccache version ${CCACHE_VERSION} is less than 3.4.3, which may lead to spurious failures when run in parallel. See https://github.com/ccache/ccache/issues/260 for more information.")
         message (STATUS "Compiling with CCache disabled. Enable by setting MONGO_USE_CCACHE to ON")
         option (MONGO_USE_CCACHE "Use CCache when compiling" OFF)


### PR DESCRIPTION
### Description

Fix overzealous elison of call to ~`find_package()`~ `find_program()` introduced in https://github.com/mongodb/mongo-c-driver/pull/1029 when `MONGO_USE_CCACHE` is set. `CCACHE_EXECUTABLE` still needs to be found and set when `MONGO_USE_CCACHE` is manually set by the user on initial configuration, not just post-configuration.