### PR TITLE
sync RPM spec file for 1.21.2 release

### DIFF
--- a/.evergreen/mongo-c-driver.spec
+++ b/.evergreen/mongo-c-driver.spec
@@ -10,7 +10,7 @@
 %global gh_project   mongo-c-driver
 %global libname      libmongoc
 %global libver       1.0
-%global up_version   1.21.1
+%global up_version   1.21.2
 #global up_prever    rc0
 # disabled as require a MongoDB server
 %bcond_with          tests
@@ -236,6 +236,9 @@ exit $ret
 
 
 %changelog
+* Wed Jun  8 2022 Remi Collet <remi@remirepo.net> - 1.21.2-1
+- update to 1.21.2 (no change)
+
 * Wed Mar  2 2022 Remi Collet <remi@remirepo.net> - 1.21.1-1
 - update to 1.21.1
 

--- a/.evergreen/spec.patch
+++ b/.evergreen/spec.patch
@@ -4,8 +4,8 @@
  %global gh_project   mongo-c-driver
  %global libname      libmongoc
  %global libver       1.0
--%global up_version   1.21.1
-+%global up_version   1.22.0
+-%global up_version   1.21.2
++%global up_version   1.23.0
  #global up_prever    rc0
  # disabled as require a MongoDB server
  %bcond_with          tests


### PR DESCRIPTION
Also use version 1.23.0 for the mock build, since that is what will be
calculate as the next version by the build based on the precense of the
1.22.0-beta0 release tag.

Patch build: https://spruce.mongodb.com/version/62a4b55b850e61511437f291/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Note that the patch build fails.  However, the failure is a result of C driver `master` branch requiring libmongocrypt 1.5.0 but Fedora only has 1.4.0 (since 1.5.0 isn't yet released).  The post-1.5.0 work to make sure this task returns to succeeding is captured in CDRIVER-4399.