### PR TITLE
Reduce expected removeKeyAltName operations to a single findOneAndUpdate

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
@@ -2358,11 +2358,34 @@ mongoc_client_encryption_remove_key_alt_name (
 
    _mongoc_bson_init_if_set (key_doc);
 
+
    {
       mongoc_find_and_modify_opts_t *const opts =
          mongoc_find_and_modify_opts_new ();
-      bson_t *const update =
-         BCON_NEW ("$pull", "{", "keyAltNames", BCON_UTF8 (keyaltname), "}");
+
+      /* clang-format off */
+      bson_t *const update = BCON_NEW (
+         "0", "{",
+            "$set", "{",
+               "keyAltNames", "{",
+                  "$cond", "[",
+                     "{",
+                        "$eq", "[", "$keyAltNames", "[", keyaltname, "]", "]",
+                     "}",
+                     "$$REMOVE",
+                     "{",
+                        "$filter", "{",
+                           "input", "$keyAltNames",
+                           "cond", "{",
+                              "$ne", "[", "$$this", keyaltname, "]",
+                           "}",
+                        "}",
+                     "}",
+                  "]",
+               "}",
+            "}",
+         "}");
+      /* clang-format on */
 
       BSON_ASSERT (mongoc_find_and_modify_opts_set_update (opts, update));
 
@@ -2373,85 +2396,28 @@ mongoc_client_encryption_remove_key_alt_name (
       mongoc_find_and_modify_opts_destroy (opts);
    }
 
-   /* Ensure keyAltNames field is removed if it would otherwise be empty. */
-   if (ret) {
+   if (ret && key_doc) {
       bson_iter_t iter;
-      bool should_remove = true;
 
-      BSON_ASSERT (bson_iter_init (&iter, &local_reply));
+      if (bson_iter_init_find (&iter, &local_reply, "value")) {
+         const bson_value_t *const value = bson_iter_value (&iter);
 
-      if (bson_iter_find_descendant (&iter, "value.keyAltNames", &iter)) {
-         if (!BSON_ITER_HOLDS_ARRAY (&iter)) {
+         if (value->value_type == BSON_TYPE_DOCUMENT) {
+            bson_t bson;
+            BSON_ASSERT (bson_init_static (
+               &bson, value->value.v_doc.data, value->value.v_doc.data_len));
+            bson_copy_to (&bson, key_doc);
+            bson_destroy (&bson);
+         } else if (value->value_type == BSON_TYPE_NULL) {
+            bson_t bson = BSON_INITIALIZER;
+            bson_copy_to (&bson, key_doc);
+            bson_destroy (&bson);
+         } else {
             bson_set_error (error,
                             MONGOC_ERROR_CLIENT,
                             MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_STATE,
-                            "expected keyAltNames to be an array of strings");
+                            "expected field value to be a document or null");
             ret = false;
-            GOTO (fail);
-         }
-
-         if (bson_iter_recurse (&iter, &iter)) {
-            while (bson_iter_next (&iter)) {
-               if (!BSON_ITER_HOLDS_UTF8 (&iter)) {
-                  bson_set_error (
-                     error,
-                     MONGOC_ERROR_CLIENT,
-                     MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_STATE,
-                     "expected keyAltNames to be an array of strings");
-                  ret = false;
-                  GOTO (fail);
-               }
-
-               if (strcmp (bson_iter_utf8 (&iter, NULL), keyaltname) != 0) {
-                  should_remove = false;
-                  break;
-               }
-            }
-         }
-      } else {
-         /* If keyAltNames does not exist, do not try to remove it. */
-         should_remove = false;
-      }
-
-      if (should_remove) {
-         bson_t *update =
-            BCON_NEW ("$unset", "{", "keyAltNames", BCON_BOOL (true), "}");
-         bson_t reply;
-
-         ret = mongoc_collection_update_one (client_encryption->keyvault_coll,
-                                             &query,
-                                             update,
-                                             NULL,
-                                             &reply,
-                                             error);
-
-         bson_destroy (update);
-         bson_destroy (&reply);
-      }
-
-      if (ret && key_doc) {
-         bson_iter_t iter;
-
-         if (bson_iter_init_find (&iter, &local_reply, "value")) {
-            const bson_value_t *const value = bson_iter_value (&iter);
-
-            if (value->value_type == BSON_TYPE_DOCUMENT) {
-               bson_t bson;
-               BSON_ASSERT (bson_init_static (
-                  &bson, value->value.v_doc.data, value->value.v_doc.data_len));
-               bson_copy_to (&bson, key_doc);
-               bson_destroy (&bson);
-            } else if (value->value_type == BSON_TYPE_NULL) {
-               bson_t bson = BSON_INITIALIZER;
-               bson_copy_to (&bson, key_doc);
-               bson_destroy (&bson);
-            } else {
-               bson_set_error (error,
-                               MONGOC_ERROR_CLIENT,
-                               MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_STATE,
-                               "expected field value to be a document or null");
-               ret = false;
-            }
          }
       }
    }

--- a/src/libmongoc/tests/json/client_side_encryption/unified/removeKeyAltName.json
+++ b/src/libmongoc/tests/json/client_side_encryption/unified/removeKeyAltName.json
@@ -118,11 +118,36 @@
                       }
                     }
                   },
-                  "update": {
-                    "$pull": {
-                      "keyAltNames": "does_not_exist"
+                  "update": [
+                    {
+                      "$set": {
+                        "keyAltNames": {
+                          "$cond": [
+                            {
+                              "$eq": [
+                                "$keyAltNames",
+                                [
+                                  "does_not_exist"
+                                ]
+                              ]
+                            },
+                            "$$REMOVE",
+                            {
+                              "$filter": {
+                                "input": "$keyAltNames",
+                                "cond": {
+                                  "$ne": [
+                                    "$$this",
+                                    "does_not_exist"
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
                     }
-                  },
+                  ],
                   "writeConcern": {
                     "w": "majority"
                   }
@@ -239,11 +264,36 @@
                       }
                     }
                   },
-                  "update": {
-                    "$pull": {
-                      "keyAltNames": "does_not_exist"
+                  "update": [
+                    {
+                      "$set": {
+                        "keyAltNames": {
+                          "$cond": [
+                            {
+                              "$eq": [
+                                "$keyAltNames",
+                                [
+                                  "does_not_exist"
+                                ]
+                              ]
+                            },
+                            "$$REMOVE",
+                            {
+                              "$filter": {
+                                "input": "$keyAltNames",
+                                "cond": {
+                                  "$ne": [
+                                    "$$this",
+                                    "does_not_exist"
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
                     }
-                  },
+                  ],
                   "writeConcern": {
                     "w": "majority"
                   }
@@ -378,11 +428,36 @@
                       }
                     }
                   },
-                  "update": {
-                    "$pull": {
-                      "keyAltNames": "alternate_name"
+                  "update": [
+                    {
+                      "$set": {
+                        "keyAltNames": {
+                          "$cond": [
+                            {
+                              "$eq": [
+                                "$keyAltNames",
+                                [
+                                  "alternate_name"
+                                ]
+                              ]
+                            },
+                            "$$REMOVE",
+                            {
+                              "$filter": {
+                                "input": "$keyAltNames",
+                                "cond": {
+                                  "$ne": [
+                                    "$$this",
+                                    "alternate_name"
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
                     }
-                  },
+                  ],
                   "writeConcern": {
                     "w": "majority"
                   }
@@ -501,11 +576,36 @@
                       }
                     }
                   },
-                  "update": {
-                    "$pull": {
-                      "keyAltNames": "alternate_name"
+                  "update": [
+                    {
+                      "$set": {
+                        "keyAltNames": {
+                          "$cond": [
+                            {
+                              "$eq": [
+                                "$keyAltNames",
+                                [
+                                  "alternate_name"
+                                ]
+                              ]
+                            },
+                            "$$REMOVE",
+                            {
+                              "$filter": {
+                                "input": "$keyAltNames",
+                                "cond": {
+                                  "$ne": [
+                                    "$$this",
+                                    "alternate_name"
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
                     }
-                  },
+                  ],
                   "writeConcern": {
                     "w": "majority"
                   }
@@ -525,42 +625,36 @@
                       }
                     }
                   },
-                  "update": {
-                    "$pull": {
-                      "keyAltNames": "local_key"
-                    }
-                  },
-                  "writeConcern": {
-                    "w": "majority"
-                  }
-                }
-              }
-            },
-            {
-              "commandStartedEvent": {
-                "databaseName": "keyvault",
-                "command": {
-                  "update": "datakeys",
-                  "updates": [
+                  "update": [
                     {
-                      "q": {
-                        "_id": {
-                          "$binary": {
-                            "base64": "bG9jYWxrZXlsb2NhbGtleQ==",
-                            "subType": "04"
-                          }
-                        }
-                      },
-                      "u": {
-                        "$unset": {
-                          "keyAltNames": true
+                      "$set": {
+                        "keyAltNames": {
+                          "$cond": [
+                            {
+                              "$eq": [
+                                "$keyAltNames",
+                                [
+                                  "local_key"
+                                ]
+                              ]
+                            },
+                            "$$REMOVE",
+                            {
+                              "$filter": {
+                                "input": "$keyAltNames",
+                                "cond": {
+                                  "$ne": [
+                                    "$$this",
+                                    "local_key"
+                                  ]
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     }
-                  ],
-                  "writeConcern": {
-                    "w": "majority"
-                  }
+                  ]
                 }
               }
             }

--- a/src/libmongoc/tests/unified/runner.c
+++ b/src/libmongoc/tests/unified/runner.c
@@ -1221,7 +1221,7 @@ test_check_expected_events_for_client (test_t *test,
    LL_COUNT (entity->events, eiter, actual_num_events);
    if (expected_num_events != actual_num_events) {
       bool too_many_events = actual_num_events > expected_num_events;
-      if (*ignore_extra_events) {
+      if (ignore_extra_events && *ignore_extra_events) {
          // We can never have too many events
          too_many_events = false;
       }


### PR DESCRIPTION
## Description

This PR implements the necessary changes to satisfy [DRIVERS-2356](https://jira.mongodb.org/browse/DRIVERS-2356).

It also includes a drive-by fix for a potential null pointer dereference of `ignore_extra_events` in the unified test runner given the optional `ignoreExtraEvents` option is not provided.