### PR TITLE
fix abi-compliance-check task

### DIFF
--- a/build/calc_release_version.py
+++ b/build/calc_release_version.py
@@ -38,7 +38,7 @@ PREVIOUS = len(sys.argv) > 1 and '-p' in sys.argv
 NEXT_MINOR = len(sys.argv) > 1 and '--next-minor' in sys.argv
 
 PREVIOUS_TAG_RE = re.compile('(?P<ver>(?P<vermaj>[0-9]+)\\.(?P<vermin>[0-9]+)'
-                             '\\.(?P<verpatch>[0-9]+))')
+                             '\\.(?P<verpatch>[0-9]+)(?:-(?P<verpre>.*))?)')
 RELEASE_TAG_RE = re.compile('(?P<ver>(?P<vermaj>[0-9]+)\\.(?P<vermin>[0-9]+)'
                             '\\.(?P<verpatch>[0-9]+)(?:-(?P<verpre>.*))?)')
 RELEASE_BRANCH_RE = re.compile('(?:(?:refs/remotes/)?origin/)?(?P<brname>r'
@@ -219,9 +219,8 @@ def previous(rel_ver):
             version_new['major'] = int(previous_tag_match.group('vermaj'))
             version_new['minor'] = int(previous_tag_match.group('vermin'))
             version_new['patch'] = int(previous_tag_match.group('verpatch'))
-            new_version_loose = LooseVersion(str(version_new['major']) + '.' +
-                                             str(version_new['minor']) + '.' +
-                                             str(version_new['patch']))
+            version_new['prerelease'] = previous_tag_match.group('verpre')
+            new_version_loose = LooseVersion(tag)
             if new_version_loose < rel_ver_loose and new_version_loose > version_loose:
                 version_loose = new_version_loose
                 if DEBUG:


### PR DESCRIPTION
# Summary
- Use prerelease marker when computing previous release version in calc_release_version.py

# Background & Motivation

This resolves recent failures of the [abi-compliance-check task](https://evergreen.mongodb.com/task/mongo_c_driver_releng_abi_compliance_check_72ca151532da0eaa7be39aea51b3b9d473612b20_22_06_14_19_21_58). The task compares the C driver from the most recent release tag. The most recent release tag is computed [here](https://github.com/mongodb/mongo-c-driver/blob/72ca151532da0eaa7be39aea51b3b9d473612b20/.evergreen/abi-compliance-check.sh#L14:L14) with:

```sh
echo $(python ./build/calc_release_version.py --next-minor -p) > VERSION_RELEASED
```

Before this change, a non-existent tag is output:
```
% python ./build/calc_release_version.py --next-minor -p
1.22.0
```

After this change, the 1.22.0-beta1 tag is output:
```
% python ./build/calc_release_version.py --next-minor -p
1.22.0-beta1
```
