### PR TITLE
CDRIVER-4408 require 4.2.0 server for csfle tests

### DIFF
--- a/src/libmongoc/tests/unified/runner.c
+++ b/src/libmongoc/tests/unified/runner.c
@@ -782,7 +782,7 @@ check_run_on_requirement (test_runner_t *test_runner,
          semver_parse ("4.2.0", &min_server_version);
          if (semver_cmp (server_version, &min_server_version) < 0) {
             *fail_reason = bson_strdup_printf (
-               "Server version(%s) is lower than minServerVersion(%s) for CSFLE",
+               "Server version %s is lower than minServerVersion %s required by CSFLE",
                semver_to_string (server_version),
                semver_to_string (&min_server_version));
             return false;

--- a/src/libmongoc/tests/unified/runner.c
+++ b/src/libmongoc/tests/unified/runner.c
@@ -777,6 +777,16 @@ check_run_on_requirement (test_runner_t *test_runner,
 #if defined(MONGOC_ENABLE_CLIENT_SIDE_ENCRYPTION)
       if (0 == strcmp (key, "csfle")) {
          const bool csfle_required = bson_iter_bool (&req_iter);
+         semver_t min_server_version;
+         
+         semver_parse ("4.2.0", &min_server_version);
+         if (semver_cmp (server_version, &min_server_version) < 0) {
+            *fail_reason = bson_strdup_printf (
+               "Server version(%s) is lower than minServerVersion(%s) for CSFLE",
+               semver_to_string (server_version),
+               semver_to_string (&min_server_version));
+            return false;
+         }
 
          if (csfle_required) {
             continue;


### PR DESCRIPTION
This PR validates changes proposed in DRIVERS-2359.

There are no tests on Evergreen with `*-cse` running against servers older than 4.2.

Running locally with a 3.6 server before this change:
```
% ./cmake-build/src/libmongoc/test-libmongoc -l "/client_side_encryption/unified/removeKeyAltName"
...
error: expected result, but got error: The dollar ($) prefixed field '$set' in '0.$set' is not valid for storage.
{ "status": "fail", "test_file": "/client_side_encryption/unified/removeKeyAltName", "seed": "1458558547", "start": 884.901830, "end": 886.010523, "elapsed": 1.108693  }
```

After this change:
```
./cmake-build/src/libmongoc/test-libmongoc -l "/client_side_encryption/unified/removeKeyAltName"
...
Requirement 0 failed because: Server version(3.6.21) is lower than minServerVersion(4.2.0) for CSFLE
{ "status": "pass", "test_file": "/client_side_encryption/unified/removeKeyAltName", "seed": "3305432147", "start": 762.108535, "end": 762.138667, "elapsed": 0.030132  }
```