### PR TITLE
Enforce consistency across server support for hint errors

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-collection.c
+++ b/src/libmongoc/src/mongoc/mongoc-collection.c
@@ -3509,7 +3509,7 @@ mongoc_collection_find_and_modify_with_opts (
             error,
             MONGOC_ERROR_COMMAND,
             MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION,
-            "selected server does not support hint on findAndModify");
+            "The selected server does not support hint for findAndModify");
          GOTO (done);
       }
 

--- a/src/libmongoc/src/mongoc/mongoc-write-command.c
+++ b/src/libmongoc/src/mongoc/mongoc-write-command.c
@@ -1017,7 +1017,7 @@ _mongoc_write_command_execute_idl (mongoc_write_command_t *command,
          bson_set_error (
             &result->error,
             MONGOC_ERROR_COMMAND,
-            MONGOC_ERROR_COMMAND_INVALID_ARG,
+            MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION,
             "The selected server does not support hint for delete");
          result->failed = true;
          EXIT;

--- a/src/libmongoc/tests/test-mongoc-find-and-modify.c
+++ b/src/libmongoc/tests/test-mongoc-find-and-modify.c
@@ -537,7 +537,7 @@ test_find_and_modify_hint (void)
          error,
          MONGOC_ERROR_COMMAND,
          MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION,
-         "selected server does not support hint on findAndModify");
+         "The selected server does not support hint for findAndModify");
    }
 
    mongoc_find_and_modify_opts_destroy (opts);

--- a/src/libmongoc/tests/test-mongoc-server-stream.c
+++ b/src/libmongoc/tests/test-mongoc-server-stream.c
@@ -77,7 +77,7 @@ run_delete_with_hint_and_wc0 (bool expect_error,
       ASSERT_ERROR_CONTAINS (
          error,
          MONGOC_ERROR_COMMAND,
-         MONGOC_ERROR_COMMAND_INVALID_ARG,
+         MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION,
          "The selected server does not support hint for delete");
       ASSERT (!r);
    } else {


### PR DESCRIPTION
## Description

This PR resolves some discrepancies in how the client-side error reporting server incompatibility with the `hint` feature is communicated.

This PR ensure all related errors have:

- Domain: `MONGOC_ERROR_COMMAND`
- Code: `MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION`
- Message: "The selected server does not support hint for \<commandName\>"

This PR is also motivated by work being done on [CXX-2347](https://jira.mongodb.org/browse/CXX-2347) in light of [CXX-2377](https://jira.mongodb.org/browse/CXX-2377).