### PR TITLE
ignore dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ VERSION_RELEASED
 Debug
 install_manifest.txt
 x64
+
+# "dist" is produced during the release process
+dist


### PR DESCRIPTION
# Summary
- Add dist to gitignore

# Background & Motivation
The "dist" directory is created as part of the release process [here](https://github.com/10gen/mongo-c-driver-tools/blob/0f61287a1141eacb0d0be06f59c62d77e670c5c5/release.py#L397).