### PR TITLE
Fix leak of test context when test registration is skipped

### DIFF
--- a/src/libmongoc/tests/TestSuite.c
+++ b/src/libmongoc/tests/TestSuite.c
@@ -319,6 +319,9 @@ _V_TestSuite_AddFull (TestSuite *suite,
    Test *iter;
 
    if (suite->ctest_run && (0 != strcmp (suite->ctest_run, name))) {
+      if (dtor) {
+         dtor (ctx);
+      }
       return NULL;
    }
 


### PR DESCRIPTION
I was scratching my head about LeakSanitizer warnings I was only seeing on my own box, until I realized that I use CTest and Evergreen does not.