### PR TITLE
Inject our own project as the mongoc source for building libmongocrypt

### DIFF
--- a/.evergreen/compile-unix.sh
+++ b/.evergreen/compile-unix.sh
@@ -63,6 +63,9 @@ echo "ZSTD: $ZSTD"
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 echo "OS: $OS"
 
+# Assume we are running in the mongo-c-driver source root directory
+MONGOC_DIR="$PWD"
+
 # Since zstd inconsitently installed on macos-1014.
 # Remove this check in CDRIVER-3483.
 if [ "darwin" = "$OS" ]; then
@@ -234,7 +237,9 @@ if [ "$COMPILE_LIBMONGOCRYPT" = "ON" ]; then
 
    mkdir libmongocrypt/cmake-build
    cd libmongocrypt/cmake-build
-   $CMAKE -DENABLE_SHARED_BSON=ON -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" ../
+   $CMAKE -DENABLE_SHARED_BSON=ON -DCMAKE_BUILD_TYPE="Debug" \
+      -DMONGOCRYPT_MONGOC_DIR="$MONGOC_DIR" -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
+      -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH" -DBUILD_TESTING=OFF ../
    make install
    cd ../../
    else


### PR DESCRIPTION
libmongocrypt needs a copy of mongo-c-driver to build a libbson for itself. We are already such a mongo-c-driver, so send that to the libmongocrypt sub-build.