### PR TITLE
CDRIVER-4422 calc_release_version.py: remove --merged, plus improvements

### DIFF
--- a/build/calc_release_version.py
+++ b/build/calc_release_version.py
@@ -155,7 +155,7 @@ def get_branch_tags(active_branch_name):
     else:
         # Not a release branch, so look for the most recent tag in history
         commits = check_output(['git', 'log', '--pretty=format:%H',
-                                '--first-parent', '--no-merges'])
+                                '--no-merges'])
         if len(commits) > 0:
             for commit in commits.splitlines():
                 tags = check_output(['git', 'tag', '--points-at',

--- a/build/calc_release_version.py
+++ b/build/calc_release_version.py
@@ -79,6 +79,8 @@ def check_head_tag():
     # have git tell us if any tags that look like release tags point at HEAD;
     # based on our policy, a commit should never have more than one release tag
     tags = check_output(['git', 'tag', '--points-at', 'HEAD', '--list', '1.*']).split()
+    if len(tags) > 1:
+        raise Exception ('Expected 1 or 0 tags on HEAD, got: {}'.format(tags))
 
     tag = tags[0] if len(tags) > 0 else ''
     release_tag_match = RELEASE_TAG_RE.match(tag)

--- a/build/calc_release_version.py
+++ b/build/calc_release_version.py
@@ -59,9 +59,11 @@ def check_output(args):
             raise subprocess.CalledProcessError(ret, args[0], output=out)
 
     if type(out) is bytes:
-        # git isn't guaranteed to always return UTF-8, but for our purposes
-        # this should be fine as tags and hashes should be ASCII only.
-        out = out.decode('utf-8')
+       """
+       git isn't guaranteed to always return UTF-8, but for our purposes
+       this should be fine as tags and hashes should be ASCII only.
+       """
+       out = out.decode('utf-8')
 
     return out
 

--- a/build/calc_release_version.py
+++ b/build/calc_release_version.py
@@ -59,11 +59,9 @@ def check_output(args):
             raise subprocess.CalledProcessError(ret, args[0], output=out)
 
     if type(out) is bytes:
-       """
-       git isn't guaranteed to always return UTF-8, but for our purposes
-       this should be fine as tags and hashes should be ASCII only.
-       """
-       out = out.decode('utf-8')
+        # git isn't guaranteed to always return UTF-8, but for our purposes
+        # this should be fine as tags and hashes should be ASCII only.
+        out = out.decode('utf-8')
 
     return out
 
@@ -72,28 +70,25 @@ def check_head_tag():
     """
     Checks the current HEAD to see if it has been tagged with a tag that matches
     the pattern for a release tag.  Returns release version calculated from the
-    tag, or None if there is no matching tag associated with HEAD.  If there are
-    multiple release tags associated with HEAD, the one with the highest version
-    is returned.
+    tag, or None if there is no matching tag associated with HEAD.
     """
 
     found_tag = False
     version_loose = LooseVersion('0.0.0')
 
-    tags = check_output(['git', 'tag', '-l']).split()
-    head_commit = check_output(['git', 'rev-parse', '--revs-only',
-                                           'HEAD^{commit}']).strip()
-    for tag in tags:
-        release_tag_match = RELEASE_TAG_RE.match(tag)
-        tag_commit = check_output(['git', 'rev-parse', '--revs-only',
-                                              tag + '^{commit}']).strip()
-        if tag_commit == head_commit and release_tag_match:
-            new_version_loose = LooseVersion(release_tag_match.group('ver'))
-            if new_version_loose > version_loose:
-                if DEBUG:
-                    print('HEAD release tag: ' + release_tag_match.group('ver'))
-                version_loose = new_version_loose
-                found_tag = True
+    # have git tell us if any tags that look like release tags point at HEAD;
+    # based on our policy, a commit should never have more than one release tag
+    tags = check_output(['git', 'tag', '--points-at', 'HEAD', '--list', '1.*']).split()
+
+    tag = tags[0] if len(tags) > 0 else ''
+    release_tag_match = RELEASE_TAG_RE.match(tag)
+    if release_tag_match:
+        new_version_loose = LooseVersion(release_tag_match.group('ver'))
+        if new_version_loose > version_loose:
+            if DEBUG:
+                print('HEAD release tag: ' + release_tag_match.group('ver'))
+            version_loose = new_version_loose
+            found_tag = True
 
     if found_tag:
         if DEBUG:
@@ -102,13 +97,15 @@ def check_head_tag():
 
     return None
 
-def get_next_minor (prerelease_marker):
+def get_next_minor(prerelease_marker):
     """
     get_next_minor does the following:
-    Inspect the branches that fit the convention for a release branch.
-    Choose the latest increment the minor version. Append .0 to form the new version (e.g., r1.21 becomes 1.22.0)
-    Append a pre-release marker. (e.g. 1.22.0 becomes 1.22.0-20220201+gitf6e6a7025d)
+        - Inspect the branches that fit the convention for a release branch.
+        - Choose the latest and increment the minor version.
+        - Append .0 to form the new version (e.g., r1.21 becomes 1.22.0)
+        - Append a pre-release marker. (e.g. 1.22.0 becomes 1.22.0-20220201+gitf6e6a7025d)
     """
+
     version_loose = LooseVersion('0.0.0')
 
     version_new = {}
@@ -123,9 +120,9 @@ def get_next_minor (prerelease_marker):
             version_new['patch'] = 0
             version_new['prerelease'] = prerelease_marker
             new_version_loose = LooseVersion(str(version_new['major']) + '.' +
-                                                str(version_new['minor']) + '.' +
-                                                str(version_new['patch']) + '-' +
-                                                version_new['prerelease'])
+                                             str(version_new['minor']) + '.' +
+                                             str(version_new['patch']) + '-' +
+                                             version_new['prerelease'])
             if new_version_loose > version_loose:
                 version_loose = new_version_loose
                 if DEBUG:
@@ -133,6 +130,69 @@ def get_next_minor (prerelease_marker):
                             + '" based on branch "' \
                             + release_branch_match.group('brname') + '"')
     return str(version_loose)
+
+def get_branch_tags(active_branch_name):
+    """
+    Returns the tag or tags (as a single string with newlines between tags)
+    corresponding to the current branch, which must not be master.  If the
+    specified branch is a release branch then return all tags based on the
+    major/minor X.Y release version.  If the specified branch is neither master
+    nor a release branch, then walk backwards in history until the first tag
+    matching the glob '1.*' and return that tag.
+    """
+
+    if active_branch_name == 'master':
+        raise Exception('this method is not meant to be called while on "master"')
+    tags = ''
+    release_branch_match = RELEASE_BRANCH_RE.match(active_branch_name)
+    if release_branch_match:
+        # This is a release branch, so look for tags only on this branch
+        tag_glob = release_branch_match.group('vermaj') + '.' \
+                + release_branch_match.group('vermin') + '.*'
+        tags = check_output(['git', 'tag', '--list', tag_glob])
+    else:
+        # Not a release branch, so look for the most recent tag in history
+        commits = check_output(['git', 'log', '--pretty=format:%H',
+                                '--first-parent', '--no-merges'])
+        if len(commits) > 0:
+            for commit in commits.splitlines():
+                tags = check_output(['git', 'tag', '--points-at',
+                                     commit, '--list', '1.*'])
+                if len(tags) > 0:
+                    # found a tag, we should be done
+                    break
+
+    return tags
+
+def process_and_sort_tags(tags):
+    """
+    Given a string (as returned from get_branch_tags), return a sorted list of
+    zero or more tags (sorted based on the LooseVersion comparison) which meet
+    the following criteria:
+        - a final release tag (i.e., 1.x.y without any pre-release suffix)
+        - a pre-release tag which is not superseded by a release tag (i.e.,
+          1.x.y-preX iff 1.x.y does not already exist)
+    """
+
+    processed_and_sorted_tags = []
+    if not tags or len(tags) == 0:
+        return processed_and_sorted_tags
+
+    raw_tags = tags.splitlines()
+    # find all the final release tags
+    for tag in raw_tags:
+        release_tag_match = RELEASE_TAG_RE.match(tag)
+        if release_tag_match and not release_tag_match.group('verpre'):
+            processed_and_sorted_tags.append(tag)
+    # collect together final release tags and pre-release tags for
+    # versions that have not yet had a final release
+    for tag in raw_tags:
+        tag_parts = tag.split('-')
+        if len(tag_parts) >= 2 and tag_parts[0] not in processed_and_sorted_tags:
+            processed_and_sorted_tags.append(tag)
+    processed_and_sorted_tags.sort(key=LooseVersion)
+
+    return processed_and_sorted_tags
 
 def main():
     """
@@ -151,53 +211,50 @@ def main():
            patch version, and append a new pre-release marker
     """
 
-
     version_loose = LooseVersion('0.0.0')
-    head_commit_short = check_output(['git', 'rev-parse',
-                                                 '--revs-only', '--short=10',
-                                                 'HEAD^{commit}']).strip()
+    head_commit_short = check_output(['git', 'rev-parse', '--revs-only',
+                                      '--short=10', 'HEAD^{commit}']).strip()
     prerelease_marker = datetime.date.today().strftime('%Y%m%d') \
             + '+git' + head_commit_short
 
     if NEXT_MINOR:
         if DEBUG:
             print('Calculating next minor release')
-        return get_next_minor (prerelease_marker)
+        return get_next_minor(prerelease_marker)
 
     head_tag_ver = check_head_tag()
     if head_tag_ver:
         return head_tag_ver
 
     active_branch_name = check_output(['git', 'rev-parse',
-                                                  '--abbrev-ref', 'HEAD']).strip()
+                                       '--abbrev-ref', 'HEAD']).strip()
     if DEBUG:
         print('Calculating release version for branch: ' + active_branch_name)
     if active_branch_name == 'master':
-        return get_next_minor (prerelease_marker)
+        return get_next_minor(prerelease_marker)
 
-    else:
-        tags = check_output(['git', 'tag',
-                                        '--merged', 'HEAD',
-                                        '--list', '1.*'])
-        if len(tags) > 0:
-            sorted_tags = tags.splitlines()
-            sorted_tags.sort(key=LooseVersion)
-            release_tag_match = RELEASE_TAG_RE.match(sorted_tags[-1])
-            if release_tag_match:
-                version_new = {}
-                version_new['major'] = int(release_tag_match.group('vermaj'))
-                version_new['minor'] = int(release_tag_match.group('vermin'))
-                version_new['patch'] = int(release_tag_match.group('verpatch')) + 1
-                version_new['prerelease'] = prerelease_marker
-                new_version_loose = LooseVersion(str(version_new['major']) + '.' +
-                                                 str(version_new['minor']) + '.' +
-                                                 str(version_new['patch']) + '-' +
-                                                 version_new['prerelease'])
-                if new_version_loose > version_loose:
-                    version_loose = new_version_loose
-                    if DEBUG:
-                        print('Found new best version "' + str(version_loose) \
-                                + '" from tag "' + release_tag_match.group('ver') + '"')
+    branch_tags = get_branch_tags(active_branch_name)
+    tags = process_and_sort_tags(branch_tags)
+
+    tag = tags[-1] if len(tags) > 0 else ''
+    # at this point the RE match is redundant, but convenient for accessing
+    # the components of the version string
+    release_tag_match = RELEASE_TAG_RE.match(tag)
+    if release_tag_match:
+        version_new = {}
+        version_new['major'] = int(release_tag_match.group('vermaj'))
+        version_new['minor'] = int(release_tag_match.group('vermin'))
+        version_new['patch'] = int(release_tag_match.group('verpatch')) + 1
+        version_new['prerelease'] = prerelease_marker
+        new_version_loose = LooseVersion(str(version_new['major']) + '.' +
+                                         str(version_new['minor']) + '.' +
+                                         str(version_new['patch']) + '-' +
+                                         version_new['prerelease'])
+        if new_version_loose > version_loose:
+            version_loose = new_version_loose
+            if DEBUG:
+                print('Found new best version "' + str(version_loose) \
+                        + '" from tag "' + release_tag_match.group('ver') + '"')
 
     return str(version_loose)
 
@@ -210,9 +267,9 @@ def previous(rel_ver):
         print('Calculating previous release version (option -p was specified).')
     version_loose = LooseVersion('0.0.0')
     rel_ver_loose = LooseVersion(rel_ver)
-    tags = check_output(['git', 'tag',
-                                    '--list', '1.*'])
-    for tag in tags.splitlines():
+    tags = check_output(['git', 'tag', '--list', '1.*'])
+    processed_and_sorted_tags = process_and_sort_tags(tags)
+    for tag in processed_and_sorted_tags:
         previous_tag_match = PREVIOUS_TAG_RE.match(tag)
         if previous_tag_match:
             version_new = {}

--- a/build/calc_release_version.py
+++ b/build/calc_release_version.py
@@ -81,10 +81,12 @@ def check_head_tag():
     # have git tell us if any tags that look like release tags point at HEAD;
     # based on our policy, a commit should never have more than one release tag
     tags = check_output(['git', 'tag', '--points-at', 'HEAD', '--list', '1.*']).split()
-    if len(tags) > 1:
+    tag = ''
+    if len(tags) == 1:
+        tag = tags[0]
+    elif len(tags) > 1:
         raise Exception ('Expected 1 or 0 tags on HEAD, got: {}'.format(tags))
 
-    tag = tags[0] if len(tags) > 0 else ''
     release_tag_match = RELEASE_TAG_RE.match(tag)
     if release_tag_match:
         new_version_loose = LooseVersion(release_tag_match.group('ver'))


### PR DESCRIPTION
Detail of changes:
 * remove --merged option for compatibility with older versions of 'git'
 * fix bug that considered pre-release tags as higher than their
   succeeding releases (e.g., 1.22.0-beta0 was treated as a higher
   version tag than 1.22.0)
 * formatting fixes
 * refactor to reduce code duplication, increase readability, and
   improve maintainability

Patch builds are not a good reflection of whether or not this will work as intended, so here is a console transcript showing the behavior.  This was done on a Debian 8 system (Git version 2.1.4, Python 2.7.9/3.4.2) as well as on a Debian 7 system (Git 1.7.10.4, Python 2.7.3):

```
root@debian:~/mongo-c-driver.git# git checkout master
M	build/calc_release_version.py
Switched to branch 'master'
Your branch is up-to-date with 'origin/master'.
root@debian:~/mongo-c-driver.git# python3 build/calc_release_version.py 
1.23.0-20220707+git5b91ef0fad
root@debian:~/mongo-c-driver.git# python3 build/calc_release_version.py -p
1.22.0
root@debian:~/mongo-c-driver.git# python3 build/calc_release_version.py --next-minor
1.23.0-20220707+git5b91ef0fad
root@debian:~/mongo-c-driver.git# git checkout r1.22
M	build/calc_release_version.py
Switched to branch 'r1.22'
Your branch is up-to-date with 'origin/r1.22'.
root@debian:~/mongo-c-driver.git# python3 build/calc_release_version.py 
1.22.1-20220707+gitf9cd3dd347
root@debian:~/mongo-c-driver.git# python3 build/calc_release_version.py -p
1.22.0
root@debian:~/mongo-c-driver.git# python3 build/calc_release_version.py --next-minor
1.23.0-20220707+gitf9cd3dd347
root@debian:~/mongo-c-driver.git# git log --oneline -n2                  
f9cd3dd Inject our own project as the mongoc source for building libmongocrypt (#1059)
629d5ae fix abi-compliance-check task (#1039)
root@debian:~/mongo-c-driver.git# git tag 1.22.1-beta0 629d5ae
root@debian:~/mongo-c-driver.git# python3 build/calc_release_version.py 
1.22.2-20220707+gitf9cd3dd347
root@debian:~/mongo-c-driver.git# python3 build/calc_release_version.py -p
1.22.1-beta0
root@debian:~/mongo-c-driver.git# python3 build/calc_release_version.py --next-minor
1.23.0-20220707+gitf9cd3dd347
root@debian:~/mongo-c-driver.git# git tag -d 1.22.1-beta0
Deleted tag '1.22.1-beta0' (was 629d5ae)
root@debian:~/mongo-c-driver.git# git checkout -b extra_branch_test r1.22
M	build/calc_release_version.py
Switched to a new branch 'extra_branch_test'
root@debian:~/mongo-c-driver.git# python3 build/calc_release_version.py 
1.22.1-20220707+gitf9cd3dd347
root@debian:~/mongo-c-driver.git# python3 build/calc_release_version.py -p
1.22.0
root@debian:~/mongo-c-driver.git# python3 build/calc_release_version.py --next-minor
1.23.0-20220707+gitf9cd3dd347
root@debian:~/mongo-c-driver.git# git checkout master
M	build/calc_release_version.py
Switched to branch 'master'
Your branch is up-to-date with 'origin/master'.
root@debian:~/mongo-c-driver.git# git branch -D extra_branch_test
Deleted branch extra_branch_test (was f9cd3dd).
```