### PR TITLE
Improve clang-format friendliness of HANDLE_OPTION macro

### DIFF
--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -370,8 +370,9 @@ _noop (void)
                                  read_state_names[bson->read_state]);          \
       return;                                                                  \
    }
-#define HANDLE_OPTION(_key, _type, _state)                                     \
-   (len == strlen (_key) && strncmp ((const char *) val, (_key), len) == 0)    \
+#define HANDLE_OPTION(_selection_statement, _key, _type, _state)               \
+   _selection_statement (len == strlen (_key) &&                               \
+                         strncmp ((const char *) val, (_key), len) == 0)       \
    {                                                                           \
       if (bson->bson_type && bson->bson_type != (_type)) {                     \
          _bson_json_read_set_error (reader,                                    \
@@ -1368,98 +1369,98 @@ _bson_json_read_map_key (bson_json_reader_t *reader, /* IN */
       _bson_json_save_map_key (bson, val, len);
    }
 
-   /* clang-format off */
    if (bson->read_state == BSON_JSON_IN_BSON_TYPE) {
-      if
-         HANDLE_OPTION ("$regex", BSON_TYPE_REGEX, BSON_JSON_LF_REGEX)
-      else if
-         HANDLE_OPTION ("$options", BSON_TYPE_REGEX, BSON_JSON_LF_OPTIONS)
-      else if
-         HANDLE_OPTION ("$oid", BSON_TYPE_OID, BSON_JSON_LF_OID)
-      else if
-         HANDLE_OPTION ("$binary", BSON_TYPE_BINARY, BSON_JSON_LF_BINARY)
-      else if
-         HANDLE_OPTION ("$type", BSON_TYPE_BINARY, BSON_JSON_LF_TYPE)
-      else if
-         HANDLE_OPTION ("$uuid", BSON_TYPE_BINARY, BSON_JSON_LF_UUID)
-      else if
-         HANDLE_OPTION ("$date", BSON_TYPE_DATE_TIME, BSON_JSON_LF_DATE)
-      else if
-         HANDLE_OPTION (
-            "$undefined", BSON_TYPE_UNDEFINED, BSON_JSON_LF_UNDEFINED)
-      else if
-         HANDLE_OPTION ("$minKey", BSON_TYPE_MINKEY, BSON_JSON_LF_MINKEY)
-      else if
-         HANDLE_OPTION ("$maxKey", BSON_TYPE_MAXKEY, BSON_JSON_LF_MAXKEY)
-      else if
-         HANDLE_OPTION ("$numberInt", BSON_TYPE_INT32, BSON_JSON_LF_INT32)
-      else if
-         HANDLE_OPTION ("$numberLong", BSON_TYPE_INT64, BSON_JSON_LF_INT64)
-      else if
-         HANDLE_OPTION ("$numberDouble", BSON_TYPE_DOUBLE, BSON_JSON_LF_DOUBLE)
-      else if
-         HANDLE_OPTION ("$symbol", BSON_TYPE_SYMBOL, BSON_JSON_LF_SYMBOL)
-      else if
-         HANDLE_OPTION (
-            "$numberDecimal", BSON_TYPE_DECIMAL128, BSON_JSON_LF_DECIMAL128)
-      else if (!strcmp ("$timestamp", (const char *) val)) {
+      HANDLE_OPTION (if, "$regex", BSON_TYPE_REGEX, BSON_JSON_LF_REGEX)
+      HANDLE_OPTION (else if, "$options", BSON_TYPE_REGEX, BSON_JSON_LF_OPTIONS)
+      HANDLE_OPTION (else if, "$oid", BSON_TYPE_OID, BSON_JSON_LF_OID)
+      HANDLE_OPTION (else if, "$binary", BSON_TYPE_BINARY, BSON_JSON_LF_BINARY)
+      HANDLE_OPTION (else if, "$type", BSON_TYPE_BINARY, BSON_JSON_LF_TYPE)
+      HANDLE_OPTION (else if, "$uuid", BSON_TYPE_BINARY, BSON_JSON_LF_UUID)
+      HANDLE_OPTION (else if, "$date", BSON_TYPE_DATE_TIME, BSON_JSON_LF_DATE)
+      HANDLE_OPTION (
+         else if, "$undefined", BSON_TYPE_UNDEFINED, BSON_JSON_LF_UNDEFINED)
+      HANDLE_OPTION (else if, "$minKey", BSON_TYPE_MINKEY, BSON_JSON_LF_MINKEY)
+      HANDLE_OPTION (else if, "$maxKey", BSON_TYPE_MAXKEY, BSON_JSON_LF_MAXKEY)
+      HANDLE_OPTION (else if, "$numberInt", BSON_TYPE_INT32, BSON_JSON_LF_INT32)
+      HANDLE_OPTION (
+         else if, "$numberLong", BSON_TYPE_INT64, BSON_JSON_LF_INT64)
+      HANDLE_OPTION (
+         else if, "$numberDouble", BSON_TYPE_DOUBLE, BSON_JSON_LF_DOUBLE)
+      HANDLE_OPTION (else if, "$symbol", BSON_TYPE_SYMBOL, BSON_JSON_LF_SYMBOL)
+      HANDLE_OPTION (else if,
+                     "$numberDecimal",
+                     BSON_TYPE_DECIMAL128,
+                     BSON_JSON_LF_DECIMAL128)
+      else if (!strcmp ("$timestamp", (const char *) val))
+      {
          bson->bson_type = BSON_TYPE_TIMESTAMP;
          bson->read_state = BSON_JSON_IN_BSON_TYPE_TIMESTAMP_STARTMAP;
-      } else if (!strcmp ("$regularExpression", (const char *) val)) {
+      }
+      else if (!strcmp ("$regularExpression", (const char *) val))
+      {
          bson->bson_type = BSON_TYPE_REGEX;
          bson->read_state = BSON_JSON_IN_BSON_TYPE_REGEX_STARTMAP;
-      } else if (!strcmp ("$dbPointer", (const char *) val)) {
+      }
+      else if (!strcmp ("$dbPointer", (const char *) val))
+      {
          /* start parsing "key": {"$dbPointer": {...}}, save "key" for later */
          _bson_json_buf_set (
             &bson->dbpointer_key, bson->key_buf.buf, bson->key_buf.len);
 
          bson->bson_type = BSON_TYPE_DBPOINTER;
          bson->read_state = BSON_JSON_IN_BSON_TYPE_DBPOINTER_STARTMAP;
-      } else if (!strcmp ("$code", (const char *) val)) {
+      }
+      else if (!strcmp ("$code", (const char *) val))
+      {
          _bson_json_read_code_or_scope_key (
             bson, false /* is_scope */, val, len);
-      } else if (!strcmp ("$scope", (const char *) val)) {
+      }
+      else if (!strcmp ("$scope", (const char *) val))
+      {
          _bson_json_read_code_or_scope_key (
             bson, true /* is_scope */, val, len);
-      } else {
+      }
+      else
+      {
          _bson_json_bad_key_in_type (reader, val);
       }
    } else if (bson->read_state == BSON_JSON_IN_BSON_TYPE_DATE_NUMBERLONG) {
-      if
-         HANDLE_OPTION ("$numberLong", BSON_TYPE_DATE_TIME, BSON_JSON_LF_INT64)
-      else {
+      HANDLE_OPTION (if, "$numberLong", BSON_TYPE_DATE_TIME, BSON_JSON_LF_INT64)
+      else
+      {
          _bson_json_bad_key_in_type (reader, val);
       }
    } else if (bson->read_state == BSON_JSON_IN_BSON_TYPE_TIMESTAMP_VALUES) {
-      if
-         HANDLE_OPTION ("t", BSON_TYPE_TIMESTAMP, BSON_JSON_LF_TIMESTAMP_T)
-      else if
-         HANDLE_OPTION ("i", BSON_TYPE_TIMESTAMP, BSON_JSON_LF_TIMESTAMP_I)
-      else {
+      HANDLE_OPTION (if, "t", BSON_TYPE_TIMESTAMP, BSON_JSON_LF_TIMESTAMP_T)
+      HANDLE_OPTION (
+         else if, "i", BSON_TYPE_TIMESTAMP, BSON_JSON_LF_TIMESTAMP_I)
+      else
+      {
          _bson_json_bad_key_in_type (reader, val);
       }
    } else if (bson->read_state == BSON_JSON_IN_BSON_TYPE_REGEX_VALUES) {
-      if
-         HANDLE_OPTION (
-            "pattern", BSON_TYPE_REGEX, BSON_JSON_LF_REGULAR_EXPRESSION_PATTERN)
-      else if
-         HANDLE_OPTION (
-            "options", BSON_TYPE_REGEX, BSON_JSON_LF_REGULAR_EXPRESSION_OPTIONS)
-      else {
+      HANDLE_OPTION (if,
+                     "pattern",
+                     BSON_TYPE_REGEX,
+                     BSON_JSON_LF_REGULAR_EXPRESSION_PATTERN)
+      HANDLE_OPTION (else if,
+                     "options",
+                     BSON_TYPE_REGEX,
+                     BSON_JSON_LF_REGULAR_EXPRESSION_OPTIONS)
+      else
+      {
          _bson_json_bad_key_in_type (reader, val);
       }
    } else if (bson->read_state == BSON_JSON_IN_BSON_TYPE_BINARY_VALUES) {
-      if
-         HANDLE_OPTION ("base64", BSON_TYPE_BINARY, BSON_JSON_LF_BINARY)
-      else if
-         HANDLE_OPTION ("subType", BSON_TYPE_BINARY, BSON_JSON_LF_TYPE)
-      else {
+      HANDLE_OPTION (if, "base64", BSON_TYPE_BINARY, BSON_JSON_LF_BINARY)
+      HANDLE_OPTION (else if, "subType", BSON_TYPE_BINARY, BSON_JSON_LF_TYPE)
+      else
+      {
          _bson_json_bad_key_in_type (reader, val);
       }
    } else {
       _bson_json_save_map_key (bson, val, len);
    }
-   /* clang-format on */
 }
 
 


### PR DESCRIPTION
## Description

Motivated by the number of times this file has been attempted to be clang-formatted only for the `HANDLE_OPTION` blocks to be rendered utterly unreadable. Hopefully this is preferable to disabling clang-format for such a large block of code. Given how strange the `HANDLE_OPTION` macro is to begin with, I'm willing to accept the strangeness of the `_selection_statement` pattern. This code could use a refactor down the road to avoid these unusual patterns.