### PR TITLE
Update generated files for Evergreen config and future functions

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -13,7 +13,8 @@ exec_timeout_secs: 2400
 functions:
   fetch source:
   - command: git.get_project
-    params: {directory: mongoc}
+    params:
+      directory: mongoc
   - command: shell.exec
     params:
       working_dir: mongoc
@@ -29,7 +30,8 @@ functions:
         fi
         echo "CURRENT_VERSION: $VERSION" > expansion.yml
   - command: expansions.update
-    params: {file: mongoc/expansion.yml}
+    params:
+      file: mongoc/expansion.yml
   - command: shell.exec
     params:
       continue_on_err: true
@@ -40,21 +42,35 @@ functions:
         curl --retry 5 https://s3.amazonaws.com/mciuploads/${project}/${branch_name}/mongo-c-driver-${CURRENT_VERSION}.tar.gz --output mongoc.tar.gz -sS --max-time 120
   upload release:
   - command: shell.exec
-    params: {shell: bash, script: '[ -f mongoc/cmake_build/mongo*gz ] && mv mongoc/cmake_build/mongo*gz
-        mongoc.tar.gz'}
+    params:
+      shell: bash
+      script: '[ -f mongoc/cmake_build/mongo*gz ] && mv mongoc/cmake_build/mongo*gz
+        mongoc.tar.gz'
   - command: s3.put
-    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${branch_name}/mongo-c-driver-${CURRENT_VERSION}.tar.gz',
-      bucket: mciuploads, permissions: public-read, local_file: mongoc.tar.gz, content_type: '${content_type|application/x-gzip}'}
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/${branch_name}/mongo-c-driver-${CURRENT_VERSION}.tar.gz
+      bucket: mciuploads
+      permissions: public-read
+      local_file: mongoc.tar.gz
+      content_type: ${content_type|application/x-gzip}
   upload build:
   - command: archive.targz_pack
     params:
       target: ${build_id}.tar.gz
       source_dir: mongoc
-      include: [./**]
+      include:
+      - ./**
   - command: s3.put
-    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${build_variant}/${revision}/${task_name}/${build_id}.tar.gz',
-      bucket: mciuploads, permissions: public-read, local_file: '${build_id}.tar.gz',
-      content_type: '${content_type|application/x-gzip}'}
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/${build_variant}/${revision}/${task_name}/${build_id}.tar.gz
+      bucket: mciuploads
+      permissions: public-read
+      local_file: ${build_id}.tar.gz
+      content_type: ${content_type|application/x-gzip}
   release archive:
   - command: shell.exec
     type: test
@@ -90,8 +106,12 @@ functions:
         set -o errexit
         rm -rf mongoc
   - command: s3.get
-    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${build_variant}/${revision}/${BUILD_NAME}/${build_id}.tar.gz',
-      bucket: mciuploads, local_file: build.tar.gz}
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/${build_variant}/${revision}/${BUILD_NAME}/${build_id}.tar.gz
+      bucket: mciuploads
+      local_file: build.tar.gz
   - command: shell.exec
     params:
       continue_on_err: true
@@ -117,9 +137,15 @@ functions:
         export AWS_SECRET_ACCESS_KEY=${aws_secret}
         aws s3 cp doc/html s3://mciuploads/${project}/docs/libbson/${CURRENT_VERSION} --recursive --acl public-read --region us-east-1
   - command: s3.put
-    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/docs/libbson/${CURRENT_VERSION}/index.html',
-      bucket: mciuploads, permissions: public-read, local_file: mongoc/cmake_build/src/libbson/doc/html/index.html,
-      content_type: text/html, display_name: libbson docs}
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/docs/libbson/${CURRENT_VERSION}/index.html
+      bucket: mciuploads
+      permissions: public-read
+      local_file: mongoc/cmake_build/src/libbson/doc/html/index.html
+      content_type: text/html
+      display_name: libbson docs
   - command: shell.exec
     params:
       silent: true
@@ -131,9 +157,15 @@ functions:
         export AWS_SECRET_ACCESS_KEY=${aws_secret}
         aws s3 cp doc/html s3://mciuploads/${project}/docs/libmongoc/${CURRENT_VERSION} --recursive --acl public-read --region us-east-1
   - command: s3.put
-    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/docs/libmongoc/${CURRENT_VERSION}/index.html',
-      bucket: mciuploads, permissions: public-read, local_file: mongoc/cmake_build/src/libmongoc/doc/html/index.html,
-      content_type: text/html, display_name: libmongoc docs}
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/docs/libmongoc/${CURRENT_VERSION}/index.html
+      bucket: mciuploads
+      permissions: public-read
+      local_file: mongoc/cmake_build/src/libmongoc/doc/html/index.html
+      content_type: text/html
+      display_name: libmongoc docs
   upload man pages:
   - command: shell.exec
     params:
@@ -151,13 +183,25 @@ functions:
         sh .evergreen/man-pages-to-html.sh libbson cmake_build/src/libbson/doc/man > bson-man-pages.html
         sh .evergreen/man-pages-to-html.sh libmongoc cmake_build/src/libmongoc/doc/man > mongoc-man-pages.html
   - command: s3.put
-    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/man-pages/libbson/${CURRENT_VERSION}/index.html',
-      bucket: mciuploads, permissions: public-read, local_file: mongoc/bson-man-pages.html,
-      content_type: text/html, display_name: libbson man pages}
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/man-pages/libbson/${CURRENT_VERSION}/index.html
+      bucket: mciuploads
+      permissions: public-read
+      local_file: mongoc/bson-man-pages.html
+      content_type: text/html
+      display_name: libbson man pages
   - command: s3.put
-    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/man-pages/libmongoc/${CURRENT_VERSION}/index.html',
-      bucket: mciuploads, permissions: public-read, local_file: mongoc/mongoc-man-pages.html,
-      content_type: text/html, display_name: libmongoc man pages}
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/man-pages/libmongoc/${CURRENT_VERSION}/index.html
+      bucket: mciuploads
+      permissions: public-read
+      local_file: mongoc/mongoc-man-pages.html
+      content_type: text/html
+      display_name: libmongoc man pages
   upload coverage:
   - command: shell.exec
     params:
@@ -170,9 +214,15 @@ functions:
         export AWS_SECRET_ACCESS_KEY=${aws_secret}
         aws s3 cp coverage s3://mciuploads/${project}/${build_variant}/${revision}/${version_id}/${build_id}/coverage/ --recursive --acl public-read --region us-east-1
   - command: s3.put
-    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${build_variant}/${revision}/${version_id}/${build_id}/coverage/index.html',
-      bucket: mciuploads, permissions: public-read, local_file: mongoc/coverage/index.html,
-      content_type: text/html, display_name: Coverage Report}
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/${build_variant}/${revision}/${version_id}/${build_id}/coverage/index.html
+      bucket: mciuploads
+      permissions: public-read
+      local_file: mongoc/coverage/index.html
+      content_type: text/html
+      display_name: Coverage Report
   abi report:
   - command: shell.exec
     params:
@@ -197,9 +247,15 @@ functions:
           exit 0
         fi
   - command: s3.put
-    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${build_variant}/${revision}/${version_id}/${build_id}/abi-compliance/compat_report.html',
-      bucket: mciuploads, permissions: public-read, local_files_include_filter: mongoc/abi-compliance/compat_reports/**/*.html,
-      content_type: text/html, display_name: 'ABI Report:'}
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/${build_variant}/${revision}/${version_id}/${build_id}/abi-compliance/compat_report.html
+      bucket: mciuploads
+      permissions: public-read
+      local_files_include_filter: mongoc/abi-compliance/compat_reports/**/*.html
+      content_type: text/html
+      display_name: 'ABI Report:'
   upload scan artifacts:
   - command: shell.exec
     type: test
@@ -224,9 +280,15 @@ functions:
         export AWS_SECRET_ACCESS_KEY=${aws_secret}
         aws s3 cp scan s3://mciuploads/${project}/${build_variant}/${revision}/${version_id}/${build_id}/scan/ --recursive --acl public-read --region us-east-1
   - command: s3.put
-    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${build_variant}/${revision}/${version_id}/${build_id}/scan/index.html',
-      bucket: mciuploads, permissions: public-read, local_file: mongoc/scan.html,
-      content_type: text/html, display_name: Scan Build Report}
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/${build_variant}/${revision}/${version_id}/${build_id}/scan/index.html
+      bucket: mciuploads
+      permissions: public-read
+      local_file: mongoc/scan.html
+      content_type: text/html
+      display_name: Scan Build Report
   upload mo artifacts:
   - command: shell.exec
     params:
@@ -238,13 +300,25 @@ functions:
         [ -d "/cygdrive/c/data/mo" ] && DIR="/cygdrive/c/data/mo"
         [ -d $DIR ] && find $DIR -name \*.log | xargs tar czf mongodb-logs.tar.gz
   - command: s3.put
-    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${build_variant}/${revision}/${version_id}/${build_id}/logs/${task_id}-${execution}-mongodb-logs.tar.gz',
-      bucket: mciuploads, permissions: public-read, local_file: mongoc/mongodb-logs.tar.gz,
-      content_type: '${content_type|application/x-gzip}', display_name: mongodb-logs.tar.gz}
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/${build_variant}/${revision}/${version_id}/${build_id}/logs/${task_id}-${execution}-mongodb-logs.tar.gz
+      bucket: mciuploads
+      permissions: public-read
+      local_file: mongoc/mongodb-logs.tar.gz
+      content_type: ${content_type|application/x-gzip}
+      display_name: mongodb-logs.tar.gz
   - command: s3.put
-    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${build_variant}/${revision}/${version_id}/${build_id}/logs/${task_id}-${execution}-orchestration.log',
-      bucket: mciuploads, permissions: public-read, local_file: mongoc/MO/server.log,
-      content_type: '${content_type|text/plain}', display_name: orchestration.log}
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/${build_variant}/${revision}/${version_id}/${build_id}/logs/${task_id}-${execution}-orchestration.log
+      bucket: mciuploads
+      permissions: public-read
+      local_file: mongoc/MO/server.log
+      content_type: ${content_type|text/plain}
+      display_name: orchestration.log
   - command: shell.exec
     params:
       working_dir: mongoc
@@ -269,12 +343,20 @@ functions:
     params:
       target: mongo-coredumps.tgz
       source_dir: mongoc
-      include: [./**.core, ./**.mdmp]
+      include:
+      - ./**.core
+      - ./**.mdmp
   - command: s3.put
-    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${build_variant}/${revision}/${version_id}/${build_id}/coredumps/${task_id}-${execution}-coredumps.log',
-      bucket: mciuploads, permissions: public-read, local_file: mongo-coredumps.tgz,
-      content_type: '${content_type|application/x-gzip}', display_name: 'Core Dumps
-        - Execution ${execution}', optional: 'True'}
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/${build_variant}/${revision}/${version_id}/${build_id}/coredumps/${task_id}-${execution}-coredumps.log
+      bucket: mciuploads
+      permissions: public-read
+      local_file: mongo-coredumps.tgz
+      content_type: ${content_type|application/x-gzip}
+      display_name: Core Dumps - Execution ${execution}
+      optional: 'True'
   backtrace:
   - command: shell.exec
     params:
@@ -288,14 +370,22 @@ functions:
     params:
       target: working-dir.tar.gz
       source_dir: mongoc
-      include: [./**]
+      include:
+      - ./**
   - command: s3.put
-    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${build_variant}/${revision}/${version_id}/${build_id}/artifacts/${task_id}-${execution}-working-dir.tar.gz',
-      bucket: mciuploads, permissions: public-read, local_file: working-dir.tar.gz,
-      content_type: '${content_type|application/x-gzip}', display_name: working-dir.tar.gz}
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/${build_variant}/${revision}/${version_id}/${build_id}/artifacts/${task_id}-${execution}-working-dir.tar.gz
+      bucket: mciuploads
+      permissions: public-read
+      local_file: working-dir.tar.gz
+      content_type: ${content_type|application/x-gzip}
+      display_name: working-dir.tar.gz
   upload test results:
   - command: attach.results
-    params: {file_location: mongoc/test-results.json}
+    params:
+      file_location: mongoc/test-results.json
   bootstrap mongo-orchestration:
   - command: shell.exec
     params:
@@ -704,7 +794,8 @@ functions:
         export MONGODB_URI="${MONGODB_URI}"
         bash $DRIVERS_TOOLS/.evergreen/run-load-balancer.sh start
   - command: expansions.update
-    params: {file: lb-expansion.yml}
+    params:
+      file: lb-expansion.yml
   stop load balancer:
   - command: shell.exec
     params:
@@ -720,19 +811,19 @@ functions:
         export MONGODB_URI="foo" # TODO: DRIVERS-1833 remove this.
         $DRIVERS_TOOLS/.evergreen/run-load-balancer.sh stop
 pre:
-- {func: fetch source}
-- {func: windows fix}
-- {func: make files executable}
-- {func: prepare kerberos}
+- func: fetch source
+- func: windows fix
+- func: make files executable
+- func: prepare kerberos
 post:
-- {func: backtrace}
-- {func: upload working dir}
-- {func: upload mo artifacts}
-- {func: upload test results}
-- {func: cleanup}
-- {func: stop load balancer}
+- func: backtrace
+- func: upload working dir
+- func: upload mo artifacts
+- func: upload test results
+- func: cleanup
+- func: stop load balancer
 timeout:
-- {func: backtrace}
+- func: backtrace
 tasks:
 - name: check-headers
   commands:
@@ -754,13 +845,14 @@ tasks:
         python ./.evergreen/check-preludes.py .
 - name: make-release-archive
   commands:
-  - {func: release archive}
-  - {func: upload docs}
-  - {func: upload man pages}
-  - {func: upload release}
-  - {func: upload build}
+  - func: release archive
+  - func: upload docs
+  - func: upload man pages
+  - func: upload release
+  - func: upload build
 - name: hardened-compile
-  tags: [hardened]
+  tags:
+  - hardened
   commands:
   - command: shell.exec
     type: test
@@ -777,12 +869,14 @@ tasks:
         export ZLIB="OFF"
         export ZSTD="OFF"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: abi-compliance-check
   commands:
-  - {func: abi report}
+  - func: abi report
 - name: debug-compile-compression-zlib
-  tags: [compression, zlib]
+  tags:
+  - compression
+  - zlib
   commands:
   - command: shell.exec
     type: test
@@ -797,9 +891,11 @@ tasks:
         export ZLIB="BUNDLED"
         export ZSTD="OFF"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-compression-snappy
-  tags: [compression, snappy]
+  tags:
+  - compression
+  - snappy
   commands:
   - command: shell.exec
     type: test
@@ -814,9 +910,11 @@ tasks:
         export ZLIB="OFF"
         export ZSTD="OFF"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-compression-zstd
-  tags: [compression, zstd]
+  tags:
+  - compression
+  - zstd
   commands:
   - command: shell.exec
     type: test
@@ -831,9 +929,13 @@ tasks:
         export ZLIB="OFF"
         export ZSTD="ON"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-compression
-  tags: [compression, snappy, zlib, zstd]
+  tags:
+  - compression
+  - snappy
+  - zlib
+  - zstd
   commands:
   - command: shell.exec
     type: test
@@ -848,9 +950,10 @@ tasks:
         export ZLIB="BUNDLED"
         export ZSTD="ON"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-no-align
-  tags: [debug-compile]
+  tags:
+  - debug-compile
   commands:
   - command: shell.exec
     type: test
@@ -866,9 +969,12 @@ tasks:
         export ZLIB="BUNDLED"
         export ZSTD="OFF"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-nosasl-nossl
-  tags: [debug-compile, nosasl, nossl]
+  tags:
+  - debug-compile
+  - nosasl
+  - nossl
   commands:
   - command: shell.exec
     type: test
@@ -881,7 +987,7 @@ tasks:
         export SANITIZE=""
         export SSL="OFF"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-lto
   commands:
   - command: shell.exec
@@ -895,7 +1001,7 @@ tasks:
         export DEBUG="ON"
         export SANITIZE=""
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-lto-thin
   commands:
   - command: shell.exec
@@ -909,9 +1015,13 @@ tasks:
         export DEBUG="ON"
         export SANITIZE=""
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-c11
-  tags: [c11, debug-compile, special, stdflags]
+  tags:
+  - c11
+  - debug-compile
+  - special
+  - stdflags
   commands:
   - command: shell.exec
     type: test
@@ -924,9 +1034,13 @@ tasks:
         export DEBUG="ON"
         export SANITIZE=""
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-c99
-  tags: [c99, debug-compile, special, stdflags]
+  tags:
+  - c99
+  - debug-compile
+  - special
+  - stdflags
   commands:
   - command: shell.exec
     type: test
@@ -939,9 +1053,12 @@ tasks:
         export DEBUG="ON"
         export SANITIZE=""
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-valgrind
-  tags: [debug-compile, special, valgrind]
+  tags:
+  - debug-compile
+  - special
+  - valgrind
   commands:
   - command: shell.exec
     type: test
@@ -956,9 +1073,12 @@ tasks:
         export SSL="OPENSSL"
         export VALGRIND="ON"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-coverage
-  tags: [coverage, debug-compile, special]
+  tags:
+  - coverage
+  - debug-compile
+  - special
   commands:
   - command: shell.exec
     type: test
@@ -971,10 +1091,12 @@ tasks:
         export DEBUG="ON"
         export SANITIZE=""
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
-  - {func: upload coverage}
+  - func: upload build
+  - func: upload coverage
 - name: debug-compile-no-counters
-  tags: [debug-compile, no-counters]
+  tags:
+  - debug-compile
+  - no-counters
   commands:
   - command: shell.exec
     type: test
@@ -987,9 +1109,12 @@ tasks:
         export ENABLE_SHM_COUNTERS="OFF"
         export SANITIZE=""
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-asan-clang
-  tags: [asan-clang, debug-compile, special]
+  tags:
+  - asan-clang
+  - debug-compile
+  - special
   commands:
   - command: shell.exec
     type: test
@@ -1009,9 +1134,10 @@ tasks:
         export ZLIB="BUNDLED"
         export ZSTD="OFF"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-asan-gcc
-  tags: [special]
+  tags:
+  - special
   commands:
   - command: shell.exec
     type: test
@@ -1029,9 +1155,12 @@ tasks:
         export ZLIB="BUNDLED"
         export ZSTD="OFF"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-asan-clang-openssl
-  tags: [asan-clang, debug-compile, special]
+  tags:
+  - asan-clang
+  - debug-compile
+  - special
   commands:
   - command: shell.exec
     type: test
@@ -1052,9 +1181,10 @@ tasks:
         export ZLIB="BUNDLED"
         export ZSTD="OFF"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-ubsan
-  tags: [special]
+  tags:
+  - special
   commands:
   - command: shell.exec
     type: test
@@ -1074,9 +1204,13 @@ tasks:
         export ZLIB="BUNDLED"
         export ZSTD="OFF"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-scan-build
-  tags: [clang, debug-compile, scan-build, special]
+  tags:
+  - clang
+  - debug-compile
+  - scan-build
+  - special
   commands:
   - command: shell.exec
     type: test
@@ -1090,8 +1224,8 @@ tasks:
         export DEBUG="ON"
         export SANITIZE=""
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
-  - {func: upload scan artifacts}
+  - func: upload build
+  - func: upload scan artifacts
   - command: shell.exec
     type: test
     params:
@@ -1116,9 +1250,11 @@ tasks:
         export SANITIZE=""
         export TRACING="ON"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: release-compile
-  depends_on: {name: make-release-archive, variant: releng}
+  depends_on:
+    name: make-release-archive
+    variant: releng
   commands:
   - command: shell.exec
     type: test
@@ -1130,9 +1266,12 @@ tasks:
         export RELEASE="ON"
         export SANITIZE=""
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-nosasl-openssl
-  tags: [debug-compile, nosasl, openssl]
+  tags:
+  - debug-compile
+  - nosasl
+  - openssl
   commands:
   - command: shell.exec
     type: test
@@ -1145,9 +1284,12 @@ tasks:
         export SANITIZE=""
         export SSL="OPENSSL"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-nosasl-openssl-static
-  tags: [debug-compile, nosasl, openssl-static]
+  tags:
+  - debug-compile
+  - nosasl
+  - openssl-static
   commands:
   - command: shell.exec
     type: test
@@ -1160,9 +1302,12 @@ tasks:
         export SANITIZE=""
         export SSL="OPENSSL_STATIC"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-nosasl-darwinssl
-  tags: [darwinssl, debug-compile, nosasl]
+  tags:
+  - darwinssl
+  - debug-compile
+  - nosasl
   commands:
   - command: shell.exec
     type: test
@@ -1175,9 +1320,12 @@ tasks:
         export SANITIZE=""
         export SSL="DARWIN"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-nosasl-winssl
-  tags: [debug-compile, nosasl, winssl]
+  tags:
+  - debug-compile
+  - nosasl
+  - winssl
   commands:
   - command: shell.exec
     type: test
@@ -1190,9 +1338,12 @@ tasks:
         export SANITIZE=""
         export SSL="WINDOWS"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-sasl-nossl
-  tags: [debug-compile, nossl, sasl]
+  tags:
+  - debug-compile
+  - nossl
+  - sasl
   commands:
   - command: shell.exec
     type: test
@@ -1206,9 +1357,12 @@ tasks:
         export SASL="AUTO"
         export SSL="OFF"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-sasl-openssl
-  tags: [debug-compile, openssl, sasl]
+  tags:
+  - debug-compile
+  - openssl
+  - sasl
   commands:
   - command: shell.exec
     type: test
@@ -1222,9 +1376,12 @@ tasks:
         export SASL="AUTO"
         export SSL="OPENSSL"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-sasl-openssl-static
-  tags: [debug-compile, openssl-static, sasl]
+  tags:
+  - debug-compile
+  - openssl-static
+  - sasl
   commands:
   - command: shell.exec
     type: test
@@ -1238,9 +1395,12 @@ tasks:
         export SASL="AUTO"
         export SSL="OPENSSL_STATIC"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-sasl-darwinssl
-  tags: [darwinssl, debug-compile, sasl]
+  tags:
+  - darwinssl
+  - debug-compile
+  - sasl
   commands:
   - command: shell.exec
     type: test
@@ -1254,9 +1414,12 @@ tasks:
         export SASL="AUTO"
         export SSL="DARWIN"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-sasl-winssl
-  tags: [debug-compile, sasl, winssl]
+  tags:
+  - debug-compile
+  - sasl
+  - winssl
   commands:
   - command: shell.exec
     type: test
@@ -1270,9 +1433,12 @@ tasks:
         export SASL="CYRUS"
         export SSL="WINDOWS"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-sspi-nossl
-  tags: [debug-compile, nossl, sspi]
+  tags:
+  - debug-compile
+  - nossl
+  - sspi
   commands:
   - command: shell.exec
     type: test
@@ -1286,9 +1452,12 @@ tasks:
         export SASL="SSPI"
         export SSL="OFF"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-sspi-openssl
-  tags: [debug-compile, openssl, sspi]
+  tags:
+  - debug-compile
+  - openssl
+  - sspi
   commands:
   - command: shell.exec
     type: test
@@ -1302,9 +1471,12 @@ tasks:
         export SASL="SSPI"
         export SSL="OPENSSL"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-sspi-openssl-static
-  tags: [debug-compile, openssl-static, sspi]
+  tags:
+  - debug-compile
+  - openssl-static
+  - sspi
   commands:
   - command: shell.exec
     type: test
@@ -1318,7 +1490,7 @@ tasks:
         export SASL="SSPI"
         export SSL="OPENSSL_STATIC"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-rdtscp
   commands:
   - command: shell.exec
@@ -1332,9 +1504,12 @@ tasks:
         export ENABLE_RDTSCP="ON"
         export SANITIZE=""
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-sspi-winssl
-  tags: [debug-compile, sspi, winssl]
+  tags:
+  - debug-compile
+  - sspi
+  - winssl
   commands:
   - command: shell.exec
     type: test
@@ -1348,9 +1523,10 @@ tasks:
         export SASL="SSPI"
         export SSL="WINDOWS"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-nosrv
-  tags: [debug-compile]
+  tags:
+  - debug-compile
   commands:
   - command: shell.exec
     type: test
@@ -1363,124 +1539,197 @@ tasks:
         export SANITIZE=""
         export SRV="OFF"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: link-with-cmake
-  depends_on: {name: make-release-archive, variant: releng}
+  depends_on:
+    name: make-release-archive
+    variant: releng
   commands:
   - func: bootstrap mongo-orchestration
-    vars: {VERSION: latest}
+    vars:
+      VERSION: latest
   - func: link sample program
-    vars: {BUILD_SAMPLE_WITH_CMAKE: 1}
+    vars:
+      BUILD_SAMPLE_WITH_CMAKE: 1
 - name: link-with-cmake-ssl
-  depends_on: {name: make-release-archive, variant: releng}
+  depends_on:
+    name: make-release-archive
+    variant: releng
   commands:
   - func: bootstrap mongo-orchestration
-    vars: {VERSION: latest}
+    vars:
+      VERSION: latest
   - func: link sample program
-    vars: {BUILD_SAMPLE_WITH_CMAKE: 1, ENABLE_SSL: 1}
+    vars:
+      BUILD_SAMPLE_WITH_CMAKE: 1
+      ENABLE_SSL: 1
 - name: link-with-cmake-snappy
-  depends_on: {name: make-release-archive, variant: releng}
+  depends_on:
+    name: make-release-archive
+    variant: releng
   commands:
   - func: bootstrap mongo-orchestration
-    vars: {VERSION: latest}
+    vars:
+      VERSION: latest
   - func: link sample program
-    vars: {BUILD_SAMPLE_WITH_CMAKE: 1, ENABLE_SNAPPY: 1}
+    vars:
+      BUILD_SAMPLE_WITH_CMAKE: 1
+      ENABLE_SNAPPY: 1
 - name: link-with-cmake-mac
-  depends_on: {name: make-release-archive, variant: releng}
+  depends_on:
+    name: make-release-archive
+    variant: releng
   commands:
   - func: bootstrap mongo-orchestration
-    vars: {VERSION: latest}
+    vars:
+      VERSION: latest
   - func: link sample program
-    vars: {BUILD_SAMPLE_WITH_CMAKE: 1}
+    vars:
+      BUILD_SAMPLE_WITH_CMAKE: 1
 - name: link-with-cmake-deprecated
-  depends_on: {name: make-release-archive, variant: releng}
+  depends_on:
+    name: make-release-archive
+    variant: releng
   commands:
   - func: bootstrap mongo-orchestration
-    vars: {VERSION: latest}
+    vars:
+      VERSION: latest
   - func: link sample program
-    vars: {BUILD_SAMPLE_WITH_CMAKE: 1, BUILD_SAMPLE_WITH_CMAKE_DEPRECATED: 1}
+    vars:
+      BUILD_SAMPLE_WITH_CMAKE: 1
+      BUILD_SAMPLE_WITH_CMAKE_DEPRECATED: 1
 - name: link-with-cmake-ssl-deprecated
-  depends_on: {name: make-release-archive, variant: releng}
+  depends_on:
+    name: make-release-archive
+    variant: releng
   commands:
   - func: bootstrap mongo-orchestration
-    vars: {VERSION: latest}
+    vars:
+      VERSION: latest
   - func: link sample program
-    vars: {BUILD_SAMPLE_WITH_CMAKE: 1, BUILD_SAMPLE_WITH_CMAKE_DEPRECATED: 1, ENABLE_SSL: 1}
+    vars:
+      BUILD_SAMPLE_WITH_CMAKE: 1
+      BUILD_SAMPLE_WITH_CMAKE_DEPRECATED: 1
+      ENABLE_SSL: 1
 - name: link-with-cmake-snappy-deprecated
-  depends_on: {name: make-release-archive, variant: releng}
+  depends_on:
+    name: make-release-archive
+    variant: releng
   commands:
   - func: bootstrap mongo-orchestration
-    vars: {VERSION: latest}
+    vars:
+      VERSION: latest
   - func: link sample program
-    vars: {BUILD_SAMPLE_WITH_CMAKE: 1, BUILD_SAMPLE_WITH_CMAKE_DEPRECATED: 1, ENABLE_SNAPPY: 1}
+    vars:
+      BUILD_SAMPLE_WITH_CMAKE: 1
+      BUILD_SAMPLE_WITH_CMAKE_DEPRECATED: 1
+      ENABLE_SNAPPY: 1
 - name: link-with-cmake-mac-deprecated
-  depends_on: {name: make-release-archive, variant: releng}
+  depends_on:
+    name: make-release-archive
+    variant: releng
   commands:
   - func: bootstrap mongo-orchestration
-    vars: {VERSION: latest}
+    vars:
+      VERSION: latest
   - func: link sample program
-    vars: {BUILD_SAMPLE_WITH_CMAKE: 1, BUILD_SAMPLE_WITH_CMAKE_DEPRECATED: 1}
+    vars:
+      BUILD_SAMPLE_WITH_CMAKE: 1
+      BUILD_SAMPLE_WITH_CMAKE_DEPRECATED: 1
 - name: link-with-cmake-windows
-  depends_on: {name: make-release-archive, variant: releng}
+  depends_on:
+    name: make-release-archive
+    variant: releng
   commands:
   - func: bootstrap mongo-orchestration
-    vars: {VERSION: latest}
-  - {func: link sample program MSVC}
+    vars:
+      VERSION: latest
+  - func: link sample program MSVC
 - name: link-with-cmake-windows-ssl
-  depends_on: {name: make-release-archive, variant: releng}
+  depends_on:
+    name: make-release-archive
+    variant: releng
   commands:
   - func: bootstrap mongo-orchestration
-    vars: {SSL: 1, VERSION: latest}
+    vars:
+      SSL: 1
+      VERSION: latest
   - func: link sample program MSVC
-    vars: {ENABLE_SSL: 1}
+    vars:
+      ENABLE_SSL: 1
 - name: link-with-cmake-windows-snappy
-  depends_on: {name: make-release-archive, variant: releng}
+  depends_on:
+    name: make-release-archive
+    variant: releng
   commands:
   - func: bootstrap mongo-orchestration
-    vars: {VERSION: latest}
+    vars:
+      VERSION: latest
   - func: link sample program MSVC
-    vars: {ENABLE_SNAPPY: 1}
+    vars:
+      ENABLE_SNAPPY: 1
 - name: link-with-cmake-mingw
-  depends_on: {name: make-release-archive, variant: releng}
+  depends_on:
+    name: make-release-archive
+    variant: releng
   commands:
   - func: bootstrap mongo-orchestration
-    vars: {VERSION: latest}
-  - {func: link sample program mingw}
+    vars:
+      VERSION: latest
+  - func: link sample program mingw
 - name: link-with-pkg-config
-  depends_on: {name: make-release-archive, variant: releng}
+  depends_on:
+    name: make-release-archive
+    variant: releng
   commands:
   - func: bootstrap mongo-orchestration
-    vars: {VERSION: latest}
-  - {func: link sample program}
-- name: link-with-pkg-config-mac
-  depends_on: {name: make-release-archive, variant: releng}
-  commands:
-  - func: bootstrap mongo-orchestration
-    vars: {VERSION: latest}
-  - {func: link sample program}
-- name: link-with-pkg-config-ssl
-  depends_on: {name: make-release-archive, variant: releng}
-  commands:
-  - func: bootstrap mongo-orchestration
-    vars: {VERSION: latest}
+    vars:
+      VERSION: latest
   - func: link sample program
-    vars: {ENABLE_SSL: 1}
+- name: link-with-pkg-config-mac
+  depends_on:
+    name: make-release-archive
+    variant: releng
+  commands:
+  - func: bootstrap mongo-orchestration
+    vars:
+      VERSION: latest
+  - func: link sample program
+- name: link-with-pkg-config-ssl
+  depends_on:
+    name: make-release-archive
+    variant: releng
+  commands:
+  - func: bootstrap mongo-orchestration
+    vars:
+      VERSION: latest
+  - func: link sample program
+    vars:
+      ENABLE_SSL: 1
 - name: link-with-bson
-  depends_on: {name: make-release-archive, variant: releng}
+  depends_on:
+    name: make-release-archive
+    variant: releng
   commands:
-  - {func: link sample program bson}
+  - func: link sample program bson
 - name: link-with-bson-mac
-  depends_on: {name: make-release-archive, variant: releng}
+  depends_on:
+    name: make-release-archive
+    variant: releng
   commands:
-  - {func: link sample program bson}
+  - func: link sample program bson
 - name: link-with-bson-windows
-  depends_on: {name: make-release-archive, variant: releng}
+  depends_on:
+    name: make-release-archive
+    variant: releng
   commands:
-  - {func: link sample program MSVC bson}
+  - func: link sample program MSVC bson
 - name: link-with-bson-mingw
-  depends_on: {name: make-release-archive, variant: releng}
+  depends_on:
+    name: make-release-archive
+    variant: releng
   commands:
-  - {func: link sample program mingw bson}
+  - func: link sample program mingw bson
 - name: debian-package-build
   commands:
   - command: shell.exec
@@ -1493,11 +1742,23 @@ tasks:
         export IS_PATCH="${is_patch}"
         sh .evergreen/debian_package_build.sh
   - command: s3.put
-    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${branch_name}/mongo-c-driver-debian-packages-${CURRENT_VERSION}.tar.gz',
-      bucket: mciuploads, permissions: public-read, local_file: deb.tar.gz, content_type: '${content_type|application/x-gzip}'}
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/${branch_name}/mongo-c-driver-debian-packages-${CURRENT_VERSION}.tar.gz
+      bucket: mciuploads
+      permissions: public-read
+      local_file: deb.tar.gz
+      content_type: ${content_type|application/x-gzip}
   - command: s3.put
-    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${branch_name}/${revision}/${version_id}/${build_id}/${execution}/mongo-c-driver-debian-packages.tar.gz',
-      bucket: mciuploads, permissions: public-read, local_file: deb.tar.gz, content_type: '${content_type|application/x-gzip}'}
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/${branch_name}/${revision}/${version_id}/${build_id}/${execution}/mongo-c-driver-debian-packages.tar.gz
+      bucket: mciuploads
+      permissions: public-read
+      local_file: deb.tar.gz
+      content_type: ${content_type|application/x-gzip}
 - name: rpm-package-build
   commands:
   - command: shell.exec
@@ -1509,13 +1770,27 @@ tasks:
         set -o errexit
         sh .evergreen/build_snapshot_rpm.sh
   - command: s3.put
-    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${branch_name}/mongo-c-driver-rpm-packages-${CURRENT_VERSION}.tar.gz',
-      bucket: mciuploads, permissions: public-read, local_file: rpm.tar.gz, content_type: '${content_type|application/x-gzip}'}
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/${branch_name}/mongo-c-driver-rpm-packages-${CURRENT_VERSION}.tar.gz
+      bucket: mciuploads
+      permissions: public-read
+      local_file: rpm.tar.gz
+      content_type: ${content_type|application/x-gzip}
   - command: s3.put
-    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${branch_name}/${revision}/${version_id}/${build_id}/${execution}/mongo-c-driver-rpm-packages.tar.gz',
-      bucket: mciuploads, permissions: public-read, local_file: rpm.tar.gz, content_type: '${content_type|application/x-gzip}'}
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/${branch_name}/${revision}/${version_id}/${build_id}/${execution}/mongo-c-driver-rpm-packages.tar.gz
+      bucket: mciuploads
+      permissions: public-read
+      local_file: rpm.tar.gz
+      content_type: ${content_type|application/x-gzip}
 - name: install-uninstall-check-mingw
-  depends_on: {name: make-release-archive, variant: releng}
+  depends_on:
+    name: make-release-archive
+    variant: releng
   commands:
   - command: shell.exec
     type: test
@@ -1528,7 +1803,9 @@ tasks:
         BSON_ONLY=1 cmd.exe /c .\\.evergreen\\install-uninstall-check-windows.cmd
         cmd.exe /c .\\.evergreen\\install-uninstall-check-windows.cmd
 - name: install-uninstall-check-msvc
-  depends_on: {name: make-release-archive, variant: releng}
+  depends_on:
+    name: make-release-archive
+    variant: releng
   commands:
   - command: shell.exec
     type: test
@@ -1541,7 +1818,9 @@ tasks:
         BSON_ONLY=1 cmd.exe /c .\\.evergreen\\install-uninstall-check-windows.cmd
         cmd.exe /c .\\.evergreen\\install-uninstall-check-windows.cmd
 - name: install-uninstall-check
-  depends_on: {name: make-release-archive, variant: releng}
+  depends_on:
+    name: make-release-archive
+    variant: releng
   commands:
   - command: shell.exec
     type: test
@@ -1566,9 +1845,14 @@ tasks:
         export DEBUG="ON"
         export SANITIZE=""
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-sasl-openssl-cse
-  tags: [client-side-encryption, debug-compile, openssl, sasl, special]
+  tags:
+  - client-side-encryption
+  - debug-compile
+  - openssl
+  - sasl
+  - special
   commands:
   - command: shell.exec
     type: test
@@ -1594,9 +1878,14 @@ tasks:
         export SASL="AUTO"
         export SSL="OPENSSL"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-sasl-openssl-static-cse
-  tags: [client-side-encryption, debug-compile, openssl-static, sasl, special]
+  tags:
+  - client-side-encryption
+  - debug-compile
+  - openssl-static
+  - sasl
+  - special
   commands:
   - command: shell.exec
     type: test
@@ -1622,9 +1911,14 @@ tasks:
         export SASL="AUTO"
         export SSL="OPENSSL_STATIC"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-sasl-darwinssl-cse
-  tags: [client-side-encryption, darwinssl, debug-compile, sasl, special]
+  tags:
+  - client-side-encryption
+  - darwinssl
+  - debug-compile
+  - sasl
+  - special
   commands:
   - command: shell.exec
     type: test
@@ -1650,9 +1944,14 @@ tasks:
         export SASL="AUTO"
         export SSL="DARWIN"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-sasl-winssl-cse
-  tags: [client-side-encryption, debug-compile, sasl, special, winssl]
+  tags:
+  - client-side-encryption
+  - debug-compile
+  - sasl
+  - special
+  - winssl
   commands:
   - command: shell.exec
     type: test
@@ -1678,9 +1977,12 @@ tasks:
         export SASL="AUTO"
         export SSL="WINDOWS"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-asan-openssl-cse
-  tags: [asan-clang, client-side-encryption, debug-compile]
+  tags:
+  - asan-clang
+  - client-side-encryption
+  - debug-compile
   commands:
   - command: shell.exec
     type: test
@@ -1710,11 +2012,12 @@ tasks:
         export SANITIZE="address"
         export SSL="OPENSSL"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: install ssl
-    vars: {SSL: openssl-1.0.1u}
+    vars:
+      SSL: openssl-1.0.1u
   - command: shell.exec
     type: test
     params:
@@ -1728,9 +2031,11 @@ tasks:
         export SASL="OFF"
         export SSL="OPENSSL"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: debug-compile-tsan-openssl
-  tags: [special, tsan]
+  tags:
+  - special
+  - tsan
   commands:
   - command: shell.exec
     type: test
@@ -1746,13 +2051,16 @@ tasks:
         export SANITIZE="thread"
         export SSL="OPENSSL"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - {func: upload build}
+  - func: upload build
 - name: build-and-test-with-toolchain
   commands:
   - command: s3.get
-    params: {aws_key: '${toolchain_aws_key}', aws_secret: '${toolchain_aws_secret}',
-      remote_file: 'mongo-c-toolchain/${distro_id}/mongo-c-toolchain.tar.gz', bucket: mongo-c-toolchain,
-      local_file: mongo-c-toolchain.tar.gz}
+    params:
+      aws_key: ${toolchain_aws_key}
+      aws_secret: ${toolchain_aws_secret}
+      remote_file: mongo-c-toolchain/${distro_id}/mongo-c-toolchain.tar.gz
+      bucket: mongo-c-toolchain
+      local_file: mongo-c-toolchain.tar.gz
   - command: shell.exec
     type: test
     params:
@@ -1762,6349 +2070,14843 @@ tasks:
         set -o errexit
         sh ./.evergreen/build-and-test-with-toolchain.sh
 - name: test-valgrind-latest-server-auth-nosasl-openssl
-  tags: [latest, test-valgrind]
+  tags:
+  - latest
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'on'
 - name: test-valgrind-latest-server-noauth-nosasl-nossl
-  tags: [latest, test-valgrind]
+  tags:
+  - latest
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'on'
 - name: test-valgrind-latest-replica-set-auth-nosasl-openssl
-  tags: [latest, test-valgrind]
+  tags:
+  - latest
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'on'
 - name: test-valgrind-latest-replica-set-noauth-nosasl-nossl
-  tags: [latest, test-valgrind]
+  tags:
+  - latest
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'on'
 - name: test-valgrind-latest-sharded-auth-nosasl-openssl
-  tags: [latest, test-valgrind]
+  tags:
+  - latest
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'on'
 - name: test-valgrind-latest-sharded-noauth-nosasl-nossl
-  tags: [latest, test-valgrind]
+  tags:
+  - latest
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'on'
 - name: test-valgrind-6.0-server-auth-nosasl-openssl
-  tags: ['6.0', test-valgrind]
+  tags:
+  - '6.0'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'on'
 - name: test-valgrind-6.0-server-noauth-nosasl-nossl
-  tags: ['6.0', test-valgrind]
+  tags:
+  - '6.0'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'on'
 - name: test-valgrind-6.0-replica-set-auth-nosasl-openssl
-  tags: ['6.0', test-valgrind]
+  tags:
+  - '6.0'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'on'
 - name: test-valgrind-6.0-replica-set-noauth-nosasl-nossl
-  tags: ['6.0', test-valgrind]
+  tags:
+  - '6.0'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'on'
 - name: test-valgrind-6.0-sharded-auth-nosasl-openssl
-  tags: ['6.0', test-valgrind]
+  tags:
+  - '6.0'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'on'
 - name: test-valgrind-6.0-sharded-noauth-nosasl-nossl
-  tags: ['6.0', test-valgrind]
+  tags:
+  - '6.0'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'on'
 - name: test-valgrind-5.0-server-auth-nosasl-openssl
-  tags: ['5.0', test-valgrind]
+  tags:
+  - '5.0'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'on'
 - name: test-valgrind-5.0-server-noauth-nosasl-nossl
-  tags: ['5.0', test-valgrind]
+  tags:
+  - '5.0'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'on'
 - name: test-valgrind-5.0-replica-set-auth-nosasl-openssl
-  tags: ['5.0', test-valgrind]
+  tags:
+  - '5.0'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'on'
 - name: test-valgrind-5.0-replica-set-noauth-nosasl-nossl
-  tags: ['5.0', test-valgrind]
+  tags:
+  - '5.0'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'on'
 - name: test-valgrind-5.0-sharded-auth-nosasl-openssl
-  tags: ['5.0', test-valgrind]
+  tags:
+  - '5.0'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'on'
 - name: test-valgrind-5.0-sharded-noauth-nosasl-nossl
-  tags: ['5.0', test-valgrind]
+  tags:
+  - '5.0'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'on'
 - name: test-valgrind-4.4-server-auth-nosasl-openssl
-  tags: ['4.4', test-valgrind]
+  tags:
+  - '4.4'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'on'
 - name: test-valgrind-4.4-server-noauth-nosasl-nossl
-  tags: ['4.4', test-valgrind]
+  tags:
+  - '4.4'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'on'
 - name: test-valgrind-4.4-replica-set-auth-nosasl-openssl
-  tags: ['4.4', test-valgrind]
+  tags:
+  - '4.4'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'on'
 - name: test-valgrind-4.4-replica-set-noauth-nosasl-nossl
-  tags: ['4.4', test-valgrind]
+  tags:
+  - '4.4'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'on'
 - name: test-valgrind-4.4-sharded-auth-nosasl-openssl
-  tags: ['4.4', test-valgrind]
+  tags:
+  - '4.4'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'on'
 - name: test-valgrind-4.4-sharded-noauth-nosasl-nossl
-  tags: ['4.4', test-valgrind]
+  tags:
+  - '4.4'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'on'
 - name: test-valgrind-4.2-server-auth-nosasl-openssl
-  tags: ['4.2', test-valgrind]
+  tags:
+  - '4.2'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'on'
 - name: test-valgrind-4.2-server-noauth-nosasl-nossl
-  tags: ['4.2', test-valgrind]
+  tags:
+  - '4.2'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'on'
 - name: test-valgrind-4.2-replica-set-auth-nosasl-openssl
-  tags: ['4.2', test-valgrind]
+  tags:
+  - '4.2'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'on'
 - name: test-valgrind-4.2-replica-set-noauth-nosasl-nossl
-  tags: ['4.2', test-valgrind]
+  tags:
+  - '4.2'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'on'
 - name: test-valgrind-4.2-sharded-auth-nosasl-openssl
-  tags: ['4.2', test-valgrind]
+  tags:
+  - '4.2'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'on'
 - name: test-valgrind-4.2-sharded-noauth-nosasl-nossl
-  tags: ['4.2', test-valgrind]
+  tags:
+  - '4.2'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'on'
 - name: test-valgrind-4.0-server-auth-nosasl-openssl
-  tags: ['4.0', test-valgrind]
+  tags:
+  - '4.0'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'on'
 - name: test-valgrind-4.0-server-noauth-nosasl-nossl
-  tags: ['4.0', test-valgrind]
+  tags:
+  - '4.0'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'on'
 - name: test-valgrind-4.0-replica-set-auth-nosasl-openssl
-  tags: ['4.0', test-valgrind]
+  tags:
+  - '4.0'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'on'
 - name: test-valgrind-4.0-replica-set-noauth-nosasl-nossl
-  tags: ['4.0', test-valgrind]
+  tags:
+  - '4.0'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'on'
 - name: test-valgrind-4.0-sharded-auth-nosasl-openssl
-  tags: ['4.0', test-valgrind]
+  tags:
+  - '4.0'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'on'
 - name: test-valgrind-4.0-sharded-noauth-nosasl-nossl
-  tags: ['4.0', test-valgrind]
+  tags:
+  - '4.0'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'on'
 - name: test-valgrind-3.6-server-auth-nosasl-openssl
-  tags: ['3.6', test-valgrind]
+  tags:
+  - '3.6'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'on'
 - name: test-valgrind-3.6-server-noauth-nosasl-nossl
-  tags: ['3.6', test-valgrind]
+  tags:
+  - '3.6'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'on'
 - name: test-valgrind-3.6-replica-set-auth-nosasl-openssl
-  tags: ['3.6', test-valgrind]
+  tags:
+  - '3.6'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'on'
 - name: test-valgrind-3.6-replica-set-noauth-nosasl-nossl
-  tags: ['3.6', test-valgrind]
+  tags:
+  - '3.6'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'on'
 - name: test-valgrind-3.6-sharded-auth-nosasl-openssl
-  tags: ['3.6', test-valgrind]
+  tags:
+  - '3.6'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'on'
 - name: test-valgrind-3.6-sharded-noauth-nosasl-nossl
-  tags: ['3.6', test-valgrind]
+  tags:
+  - '3.6'
+  - test-valgrind
   exec_timeout_secs: 14400
-  depends_on: {name: debug-compile-valgrind}
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'on'
 - name: test-asan-latest-server-auth-nosasl-openssl-cse
-  tags: [client-side-encryption, latest, test-asan]
+  tags:
+  - client-side-encryption
+  - latest
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-openssl-cse}
+  depends_on:
+    name: debug-compile-asan-openssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-openssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-asan-openssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: latest}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-latest-server-auth-nosasl-openssl
-  tags: [latest, test-asan]
+  tags:
+  - latest
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang-openssl}
+  depends_on:
+    name: debug-compile-asan-clang-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-latest-server-noauth-nosasl-nossl
-  tags: [latest, test-asan]
+  tags:
+  - latest
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang}
+  depends_on:
+    name: debug-compile-asan-clang
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-asan-latest-replica-set-auth-nosasl-openssl-cse
-  tags: [client-side-encryption, latest, test-asan]
+  tags:
+  - client-side-encryption
+  - latest
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-openssl-cse}
+  depends_on:
+    name: debug-compile-asan-openssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-openssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-asan-openssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: latest}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-latest-replica-set-auth-nosasl-openssl
-  tags: [latest, test-asan]
+  tags:
+  - latest
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang-openssl}
+  depends_on:
+    name: debug-compile-asan-clang-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-latest-replica-set-noauth-nosasl-nossl
-  tags: [latest, test-asan]
+  tags:
+  - latest
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang}
+  depends_on:
+    name: debug-compile-asan-clang
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-asan-latest-sharded-auth-nosasl-openssl
-  tags: [latest, test-asan]
+  tags:
+  - latest
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang-openssl}
+  depends_on:
+    name: debug-compile-asan-clang-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-latest-sharded-noauth-nosasl-nossl
-  tags: [latest, test-asan]
+  tags:
+  - latest
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang}
+  depends_on:
+    name: debug-compile-asan-clang
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-asan-6.0-server-auth-nosasl-openssl-cse
-  tags: ['6.0', client-side-encryption, test-asan]
+  tags:
+  - '6.0'
+  - client-side-encryption
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-openssl-cse}
+  depends_on:
+    name: debug-compile-asan-openssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-openssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-asan-openssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '6.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-6.0-server-auth-nosasl-openssl
-  tags: ['6.0', test-asan]
+  tags:
+  - '6.0'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang-openssl}
+  depends_on:
+    name: debug-compile-asan-clang-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-6.0-server-noauth-nosasl-nossl
-  tags: ['6.0', test-asan]
+  tags:
+  - '6.0'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang}
+  depends_on:
+    name: debug-compile-asan-clang
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-asan-6.0-replica-set-auth-nosasl-openssl-cse
-  tags: ['6.0', client-side-encryption, test-asan]
+  tags:
+  - '6.0'
+  - client-side-encryption
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-openssl-cse}
+  depends_on:
+    name: debug-compile-asan-openssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-openssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-asan-openssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '6.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-6.0-replica-set-auth-nosasl-openssl
-  tags: ['6.0', test-asan]
+  tags:
+  - '6.0'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang-openssl}
+  depends_on:
+    name: debug-compile-asan-clang-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-6.0-replica-set-noauth-nosasl-nossl
-  tags: ['6.0', test-asan]
+  tags:
+  - '6.0'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang}
+  depends_on:
+    name: debug-compile-asan-clang
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-asan-6.0-sharded-auth-nosasl-openssl
-  tags: ['6.0', test-asan]
+  tags:
+  - '6.0'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang-openssl}
+  depends_on:
+    name: debug-compile-asan-clang-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-6.0-sharded-noauth-nosasl-nossl
-  tags: ['6.0', test-asan]
+  tags:
+  - '6.0'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang}
+  depends_on:
+    name: debug-compile-asan-clang
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-asan-5.0-server-auth-nosasl-openssl-cse
-  tags: ['5.0', client-side-encryption, test-asan]
+  tags:
+  - '5.0'
+  - client-side-encryption
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-openssl-cse}
+  depends_on:
+    name: debug-compile-asan-openssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-openssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-asan-openssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '5.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '5.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-5.0-server-auth-nosasl-openssl
-  tags: ['5.0', test-asan]
+  tags:
+  - '5.0'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang-openssl}
+  depends_on:
+    name: debug-compile-asan-clang-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-5.0-server-noauth-nosasl-nossl
-  tags: ['5.0', test-asan]
+  tags:
+  - '5.0'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang}
+  depends_on:
+    name: debug-compile-asan-clang
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-asan-5.0-replica-set-auth-nosasl-openssl
-  tags: ['5.0', test-asan]
+  tags:
+  - '5.0'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang-openssl}
+  depends_on:
+    name: debug-compile-asan-clang-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-5.0-replica-set-noauth-nosasl-nossl
-  tags: ['5.0', test-asan]
+  tags:
+  - '5.0'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang}
+  depends_on:
+    name: debug-compile-asan-clang
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-asan-5.0-sharded-auth-nosasl-openssl
-  tags: ['5.0', test-asan]
+  tags:
+  - '5.0'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang-openssl}
+  depends_on:
+    name: debug-compile-asan-clang-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-5.0-sharded-noauth-nosasl-nossl
-  tags: ['5.0', test-asan]
+  tags:
+  - '5.0'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang}
+  depends_on:
+    name: debug-compile-asan-clang
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-asan-4.4-server-auth-nosasl-openssl-cse
-  tags: ['4.4', client-side-encryption, test-asan]
+  tags:
+  - '4.4'
+  - client-side-encryption
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-openssl-cse}
+  depends_on:
+    name: debug-compile-asan-openssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-openssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-asan-openssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.4'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.4'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-4.4-server-auth-nosasl-openssl
-  tags: ['4.4', test-asan]
+  tags:
+  - '4.4'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang-openssl}
+  depends_on:
+    name: debug-compile-asan-clang-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-4.4-server-noauth-nosasl-nossl
-  tags: ['4.4', test-asan]
+  tags:
+  - '4.4'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang}
+  depends_on:
+    name: debug-compile-asan-clang
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-asan-4.4-replica-set-auth-nosasl-openssl
-  tags: ['4.4', test-asan]
+  tags:
+  - '4.4'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang-openssl}
+  depends_on:
+    name: debug-compile-asan-clang-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-4.4-replica-set-noauth-nosasl-nossl
-  tags: ['4.4', test-asan]
+  tags:
+  - '4.4'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang}
+  depends_on:
+    name: debug-compile-asan-clang
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-asan-4.4-sharded-auth-nosasl-openssl
-  tags: ['4.4', test-asan]
+  tags:
+  - '4.4'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang-openssl}
+  depends_on:
+    name: debug-compile-asan-clang-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-4.4-sharded-noauth-nosasl-nossl
-  tags: ['4.4', test-asan]
+  tags:
+  - '4.4'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang}
+  depends_on:
+    name: debug-compile-asan-clang
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-asan-4.2-server-auth-nosasl-openssl-cse
-  tags: ['4.2', client-side-encryption, test-asan]
+  tags:
+  - '4.2'
+  - client-side-encryption
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-openssl-cse}
+  depends_on:
+    name: debug-compile-asan-openssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-openssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-asan-openssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.2'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.2'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-4.2-server-auth-nosasl-openssl
-  tags: ['4.2', test-asan]
+  tags:
+  - '4.2'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang-openssl}
+  depends_on:
+    name: debug-compile-asan-clang-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-4.2-server-noauth-nosasl-nossl
-  tags: ['4.2', test-asan]
+  tags:
+  - '4.2'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang}
+  depends_on:
+    name: debug-compile-asan-clang
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-asan-4.2-replica-set-auth-nosasl-openssl
-  tags: ['4.2', test-asan]
+  tags:
+  - '4.2'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang-openssl}
+  depends_on:
+    name: debug-compile-asan-clang-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-4.2-replica-set-noauth-nosasl-nossl
-  tags: ['4.2', test-asan]
+  tags:
+  - '4.2'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang}
+  depends_on:
+    name: debug-compile-asan-clang
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-asan-4.2-sharded-auth-nosasl-openssl
-  tags: ['4.2', test-asan]
+  tags:
+  - '4.2'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang-openssl}
+  depends_on:
+    name: debug-compile-asan-clang-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-4.2-sharded-noauth-nosasl-nossl
-  tags: ['4.2', test-asan]
+  tags:
+  - '4.2'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang}
+  depends_on:
+    name: debug-compile-asan-clang
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-asan-4.0-server-auth-nosasl-openssl
-  tags: ['4.0', test-asan]
+  tags:
+  - '4.0'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang-openssl}
+  depends_on:
+    name: debug-compile-asan-clang-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-4.0-server-noauth-nosasl-nossl
-  tags: ['4.0', test-asan]
+  tags:
+  - '4.0'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang}
+  depends_on:
+    name: debug-compile-asan-clang
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-asan-4.0-replica-set-auth-nosasl-openssl
-  tags: ['4.0', test-asan]
+  tags:
+  - '4.0'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang-openssl}
+  depends_on:
+    name: debug-compile-asan-clang-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-4.0-replica-set-noauth-nosasl-nossl
-  tags: ['4.0', test-asan]
+  tags:
+  - '4.0'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang}
+  depends_on:
+    name: debug-compile-asan-clang
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-asan-4.0-sharded-auth-nosasl-openssl
-  tags: ['4.0', test-asan]
+  tags:
+  - '4.0'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang-openssl}
+  depends_on:
+    name: debug-compile-asan-clang-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-4.0-sharded-noauth-nosasl-nossl
-  tags: ['4.0', test-asan]
+  tags:
+  - '4.0'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang}
+  depends_on:
+    name: debug-compile-asan-clang
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-asan-3.6-server-auth-nosasl-openssl
-  tags: ['3.6', test-asan]
+  tags:
+  - '3.6'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang-openssl}
+  depends_on:
+    name: debug-compile-asan-clang-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-3.6-server-noauth-nosasl-nossl
-  tags: ['3.6', test-asan]
+  tags:
+  - '3.6'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang}
+  depends_on:
+    name: debug-compile-asan-clang
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-asan-3.6-replica-set-auth-nosasl-openssl
-  tags: ['3.6', test-asan]
+  tags:
+  - '3.6'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang-openssl}
+  depends_on:
+    name: debug-compile-asan-clang-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-3.6-replica-set-noauth-nosasl-nossl
-  tags: ['3.6', test-asan]
+  tags:
+  - '3.6'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang}
+  depends_on:
+    name: debug-compile-asan-clang
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-asan-3.6-sharded-auth-nosasl-openssl
-  tags: ['3.6', test-asan]
+  tags:
+  - '3.6'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang-openssl}
+  depends_on:
+    name: debug-compile-asan-clang-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-asan-3.6-sharded-noauth-nosasl-nossl
-  tags: ['3.6', test-asan]
+  tags:
+  - '3.6'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang}
+  depends_on:
+    name: debug-compile-asan-clang
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-tsan-latest-server-auth-nosasl-openssl
-  tags: [latest, tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - latest
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-latest-server-noauth-nosasl-openssl
-  tags: [latest, tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - latest
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-latest-replica-set-auth-nosasl-openssl
-  tags: [latest, tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - latest
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-latest-replica-set-noauth-nosasl-openssl
-  tags: [latest, tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - latest
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-latest-sharded-auth-nosasl-openssl
-  tags: [latest, tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - latest
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-latest-sharded-noauth-nosasl-openssl
-  tags: [latest, tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - latest
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-6.0-server-auth-nosasl-openssl
-  tags: ['6.0', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '6.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-6.0-server-noauth-nosasl-openssl
-  tags: ['6.0', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '6.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-6.0-replica-set-auth-nosasl-openssl
-  tags: ['6.0', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '6.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-6.0-replica-set-noauth-nosasl-openssl
-  tags: ['6.0', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '6.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-6.0-sharded-auth-nosasl-openssl
-  tags: ['6.0', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '6.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-6.0-sharded-noauth-nosasl-openssl
-  tags: ['6.0', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '6.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-5.0-server-auth-nosasl-openssl
-  tags: ['5.0', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '5.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-5.0-server-noauth-nosasl-openssl
-  tags: ['5.0', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '5.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-5.0-replica-set-auth-nosasl-openssl
-  tags: ['5.0', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '5.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-5.0-replica-set-noauth-nosasl-openssl
-  tags: ['5.0', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '5.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-5.0-sharded-auth-nosasl-openssl
-  tags: ['5.0', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '5.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-5.0-sharded-noauth-nosasl-openssl
-  tags: ['5.0', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '5.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-4.4-server-auth-nosasl-openssl
-  tags: ['4.4', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '4.4'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-4.4-server-noauth-nosasl-openssl
-  tags: ['4.4', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '4.4'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-4.4-replica-set-auth-nosasl-openssl
-  tags: ['4.4', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '4.4'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-4.4-replica-set-noauth-nosasl-openssl
-  tags: ['4.4', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '4.4'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-4.4-sharded-auth-nosasl-openssl
-  tags: ['4.4', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '4.4'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-4.4-sharded-noauth-nosasl-openssl
-  tags: ['4.4', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '4.4'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-4.2-server-auth-nosasl-openssl
-  tags: ['4.2', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '4.2'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-4.2-server-noauth-nosasl-openssl
-  tags: ['4.2', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '4.2'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-4.2-replica-set-auth-nosasl-openssl
-  tags: ['4.2', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '4.2'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-4.2-replica-set-noauth-nosasl-openssl
-  tags: ['4.2', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '4.2'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-4.2-sharded-auth-nosasl-openssl
-  tags: ['4.2', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '4.2'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-4.2-sharded-noauth-nosasl-openssl
-  tags: ['4.2', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '4.2'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-4.0-server-auth-nosasl-openssl
-  tags: ['4.0', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '4.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-4.0-server-noauth-nosasl-openssl
-  tags: ['4.0', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '4.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-4.0-replica-set-auth-nosasl-openssl
-  tags: ['4.0', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '4.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-4.0-replica-set-noauth-nosasl-openssl
-  tags: ['4.0', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '4.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-4.0-sharded-auth-nosasl-openssl
-  tags: ['4.0', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '4.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-4.0-sharded-noauth-nosasl-openssl
-  tags: ['4.0', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '4.0'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-3.6-server-auth-nosasl-openssl
-  tags: ['3.6', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '3.6'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-3.6-server-noauth-nosasl-openssl
-  tags: ['3.6', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '3.6'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-3.6-replica-set-auth-nosasl-openssl
-  tags: ['3.6', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '3.6'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-3.6-replica-set-noauth-nosasl-openssl
-  tags: ['3.6', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '3.6'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-3.6-sharded-auth-nosasl-openssl
-  tags: ['3.6', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '3.6'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-tsan-3.6-sharded-noauth-nosasl-openssl
-  tags: ['3.6', tsan]
-  depends_on: {name: debug-compile-tsan-openssl}
+  tags:
+  - '3.6'
+  - tsan
+  depends_on:
+    name: debug-compile-tsan-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-tsan-openssl}
+    vars:
+      BUILD_NAME: debug-compile-tsan-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-coverage-latest-server-auth-nosasl-openssl
-  tags: [latest, test-coverage]
+  tags:
+  - latest
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-openssl}
+  - func: debug-compile-coverage-notest-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-latest-server-noauth-nosasl-nossl
-  tags: [latest, test-coverage]
+  tags:
+  - latest
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-nossl}
+  - func: debug-compile-coverage-notest-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-latest-replica-set-auth-nosasl-openssl
-  tags: [latest, test-coverage]
+  tags:
+  - latest
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-openssl}
+  - func: debug-compile-coverage-notest-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-latest-replica-set-noauth-nosasl-nossl
-  tags: [latest, test-coverage]
+  tags:
+  - latest
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-nossl}
+  - func: debug-compile-coverage-notest-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-latest-sharded-auth-nosasl-openssl
-  tags: [latest, test-coverage]
+  tags:
+  - latest
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-openssl}
+  - func: debug-compile-coverage-notest-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-latest-sharded-noauth-nosasl-nossl
-  tags: [latest, test-coverage]
+  tags:
+  - latest
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-nossl}
+  - func: debug-compile-coverage-notest-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-6.0-server-auth-nosasl-openssl
-  tags: ['6.0', test-coverage]
+  tags:
+  - '6.0'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-openssl}
+  - func: debug-compile-coverage-notest-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-6.0-server-noauth-nosasl-nossl
-  tags: ['6.0', test-coverage]
+  tags:
+  - '6.0'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-nossl}
+  - func: debug-compile-coverage-notest-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-6.0-replica-set-auth-nosasl-openssl
-  tags: ['6.0', test-coverage]
+  tags:
+  - '6.0'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-openssl}
+  - func: debug-compile-coverage-notest-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-6.0-replica-set-noauth-nosasl-nossl
-  tags: ['6.0', test-coverage]
+  tags:
+  - '6.0'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-nossl}
+  - func: debug-compile-coverage-notest-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-6.0-sharded-auth-nosasl-openssl
-  tags: ['6.0', test-coverage]
+  tags:
+  - '6.0'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-openssl}
+  - func: debug-compile-coverage-notest-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-6.0-sharded-noauth-nosasl-nossl
-  tags: ['6.0', test-coverage]
+  tags:
+  - '6.0'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-nossl}
+  - func: debug-compile-coverage-notest-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-5.0-server-auth-nosasl-openssl
-  tags: ['5.0', test-coverage]
+  tags:
+  - '5.0'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-openssl}
+  - func: debug-compile-coverage-notest-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-5.0-server-noauth-nosasl-nossl
-  tags: ['5.0', test-coverage]
+  tags:
+  - '5.0'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-nossl}
+  - func: debug-compile-coverage-notest-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-5.0-replica-set-auth-nosasl-openssl
-  tags: ['5.0', test-coverage]
+  tags:
+  - '5.0'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-openssl}
+  - func: debug-compile-coverage-notest-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-5.0-replica-set-noauth-nosasl-nossl
-  tags: ['5.0', test-coverage]
+  tags:
+  - '5.0'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-nossl}
+  - func: debug-compile-coverage-notest-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-5.0-sharded-auth-nosasl-openssl
-  tags: ['5.0', test-coverage]
+  tags:
+  - '5.0'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-openssl}
+  - func: debug-compile-coverage-notest-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-5.0-sharded-noauth-nosasl-nossl
-  tags: ['5.0', test-coverage]
+  tags:
+  - '5.0'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-nossl}
+  - func: debug-compile-coverage-notest-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-4.4-server-auth-nosasl-openssl
-  tags: ['4.4', test-coverage]
+  tags:
+  - '4.4'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-openssl}
+  - func: debug-compile-coverage-notest-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-4.4-server-noauth-nosasl-nossl
-  tags: ['4.4', test-coverage]
+  tags:
+  - '4.4'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-nossl}
+  - func: debug-compile-coverage-notest-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-4.4-replica-set-auth-nosasl-openssl
-  tags: ['4.4', test-coverage]
+  tags:
+  - '4.4'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-openssl}
+  - func: debug-compile-coverage-notest-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-4.4-replica-set-noauth-nosasl-nossl
-  tags: ['4.4', test-coverage]
+  tags:
+  - '4.4'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-nossl}
+  - func: debug-compile-coverage-notest-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-4.4-sharded-auth-nosasl-openssl
-  tags: ['4.4', test-coverage]
+  tags:
+  - '4.4'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-openssl}
+  - func: debug-compile-coverage-notest-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-4.4-sharded-noauth-nosasl-nossl
-  tags: ['4.4', test-coverage]
+  tags:
+  - '4.4'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-nossl}
+  - func: debug-compile-coverage-notest-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-4.2-server-auth-nosasl-openssl
-  tags: ['4.2', test-coverage]
+  tags:
+  - '4.2'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-openssl}
+  - func: debug-compile-coverage-notest-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-4.2-server-noauth-nosasl-nossl
-  tags: ['4.2', test-coverage]
+  tags:
+  - '4.2'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-nossl}
+  - func: debug-compile-coverage-notest-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-4.2-replica-set-auth-nosasl-openssl
-  tags: ['4.2', test-coverage]
+  tags:
+  - '4.2'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-openssl}
+  - func: debug-compile-coverage-notest-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-4.2-replica-set-noauth-nosasl-nossl
-  tags: ['4.2', test-coverage]
+  tags:
+  - '4.2'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-nossl}
+  - func: debug-compile-coverage-notest-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-4.2-sharded-auth-nosasl-openssl
-  tags: ['4.2', test-coverage]
+  tags:
+  - '4.2'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-openssl}
+  - func: debug-compile-coverage-notest-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-4.2-sharded-noauth-nosasl-nossl
-  tags: ['4.2', test-coverage]
+  tags:
+  - '4.2'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-nossl}
+  - func: debug-compile-coverage-notest-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-4.0-server-auth-nosasl-openssl
-  tags: ['4.0', test-coverage]
+  tags:
+  - '4.0'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-openssl}
+  - func: debug-compile-coverage-notest-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-4.0-server-noauth-nosasl-nossl
-  tags: ['4.0', test-coverage]
+  tags:
+  - '4.0'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-nossl}
+  - func: debug-compile-coverage-notest-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-4.0-replica-set-auth-nosasl-openssl
-  tags: ['4.0', test-coverage]
+  tags:
+  - '4.0'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-openssl}
+  - func: debug-compile-coverage-notest-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-4.0-replica-set-noauth-nosasl-nossl
-  tags: ['4.0', test-coverage]
+  tags:
+  - '4.0'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-nossl}
+  - func: debug-compile-coverage-notest-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-4.0-sharded-auth-nosasl-openssl
-  tags: ['4.0', test-coverage]
+  tags:
+  - '4.0'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-openssl}
+  - func: debug-compile-coverage-notest-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-4.0-sharded-noauth-nosasl-nossl
-  tags: ['4.0', test-coverage]
+  tags:
+  - '4.0'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-nossl}
+  - func: debug-compile-coverage-notest-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-3.6-server-auth-nosasl-openssl
-  tags: ['3.6', test-coverage]
+  tags:
+  - '3.6'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-openssl}
+  - func: debug-compile-coverage-notest-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-3.6-server-noauth-nosasl-nossl
-  tags: ['3.6', test-coverage]
+  tags:
+  - '3.6'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-nossl}
+  - func: debug-compile-coverage-notest-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-3.6-replica-set-auth-nosasl-openssl
-  tags: ['3.6', test-coverage]
+  tags:
+  - '3.6'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-openssl}
+  - func: debug-compile-coverage-notest-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-3.6-replica-set-noauth-nosasl-nossl
-  tags: ['3.6', test-coverage]
+  tags:
+  - '3.6'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-nossl}
+  - func: debug-compile-coverage-notest-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-3.6-sharded-auth-nosasl-openssl
-  tags: ['3.6', test-coverage]
+  tags:
+  - '3.6'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-openssl}
+  - func: debug-compile-coverage-notest-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-coverage-3.6-sharded-noauth-nosasl-nossl
-  tags: ['3.6', test-coverage]
+  tags:
+  - '3.6'
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-nossl}
+  - func: debug-compile-coverage-notest-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
-  - {func: update codecov.io}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
+  - func: update codecov.io
 - name: test-latest-server-auth-sasl-openssl-cse
-  tags: [auth, client-side-encryption, latest, openssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-cse}
+  tags:
+  - auth
+  - client-side-encryption
+  - latest
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: latest}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-latest-server-auth-sasl-openssl
-  tags: [auth, latest, openssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - auth
+  - latest
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-latest-server-auth-sasl-openssl-static-cse
-  tags: [auth, client-side-encryption, latest, openssl-static, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-static-cse}
+  tags:
+  - auth
+  - client-side-encryption
+  - latest
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: latest}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-latest-server-auth-sasl-openssl-static
-  tags: [auth, latest, openssl-static, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - auth
+  - latest
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-latest-server-auth-sasl-darwinssl-cse
-  tags: [auth, client-side-encryption, darwinssl, latest, sasl, server]
-  depends_on: {name: debug-compile-sasl-darwinssl-cse}
+  tags:
+  - auth
+  - client-side-encryption
+  - darwinssl
+  - latest
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: latest}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-latest-server-auth-sasl-darwinssl
-  tags: [auth, darwinssl, latest, sasl, server]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - auth
+  - darwinssl
+  - latest
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-latest-server-auth-sasl-winssl-cse
-  tags: [auth, client-side-encryption, latest, sasl, server, winssl]
-  depends_on: {name: debug-compile-sasl-winssl-cse}
+  tags:
+  - auth
+  - client-side-encryption
+  - latest
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: latest}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-latest-server-auth-sasl-winssl
-  tags: [auth, latest, sasl, server, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - auth
+  - latest
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-latest-server-auth-sspi-winssl
-  tags: [auth, latest, server, sspi, winssl]
-  depends_on: {name: debug-compile-sspi-winssl}
+  tags:
+  - auth
+  - latest
+  - server
+  - sspi
+  - winssl
+  depends_on:
+    name: debug-compile-sspi-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sspi-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sspi-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-latest-server-auth-nosasl-openssl
-  tags: [auth, latest, nosasl, openssl, server]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - auth
+  - latest
+  - nosasl
+  - openssl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-latest-server-auth-nosasl-openssl-static
-  tags: [auth, latest, nosasl, openssl-static, server]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - auth
+  - latest
+  - nosasl
+  - openssl-static
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-latest-server-auth-nosasl-darwinssl
-  tags: [auth, darwinssl, latest, nosasl, server]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - auth
+  - darwinssl
+  - latest
+  - nosasl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-latest-server-auth-nosasl-winssl
-  tags: [auth, latest, nosasl, server, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - auth
+  - latest
+  - nosasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-latest-server-noauth-sasl-openssl-cse
-  tags: [client-side-encryption, latest, noauth, openssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-cse}
+  tags:
+  - client-side-encryption
+  - latest
+  - noauth
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: latest}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-latest-server-noauth-sasl-openssl
-  tags: [latest, noauth, openssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - latest
+  - noauth
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-latest-server-noauth-sasl-openssl-static-cse
-  tags: [client-side-encryption, latest, noauth, openssl-static, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-static-cse}
+  tags:
+  - client-side-encryption
+  - latest
+  - noauth
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: latest}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-latest-server-noauth-sasl-openssl-static
-  tags: [latest, noauth, openssl-static, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - latest
+  - noauth
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-latest-server-noauth-sasl-darwinssl-cse
-  tags: [client-side-encryption, darwinssl, latest, noauth, sasl, server]
-  depends_on: {name: debug-compile-sasl-darwinssl-cse}
+  tags:
+  - client-side-encryption
+  - darwinssl
+  - latest
+  - noauth
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: latest}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-latest-server-noauth-sasl-darwinssl
-  tags: [darwinssl, latest, noauth, sasl, server]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - darwinssl
+  - latest
+  - noauth
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-latest-server-noauth-sasl-winssl-cse
-  tags: [client-side-encryption, latest, noauth, sasl, server, winssl]
-  depends_on: {name: debug-compile-sasl-winssl-cse}
+  tags:
+  - client-side-encryption
+  - latest
+  - noauth
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: latest}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-latest-server-noauth-sasl-winssl
-  tags: [latest, noauth, sasl, server, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - latest
+  - noauth
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-latest-server-noauth-nosasl-openssl
-  tags: [latest, noauth, nosasl, openssl, server]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - latest
+  - noauth
+  - nosasl
+  - openssl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-latest-server-noauth-nosasl-openssl-static
-  tags: [latest, noauth, nosasl, openssl-static, server]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - latest
+  - noauth
+  - nosasl
+  - openssl-static
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-latest-server-noauth-nosasl-darwinssl
-  tags: [darwinssl, latest, noauth, nosasl, server]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - darwinssl
+  - latest
+  - noauth
+  - nosasl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-latest-server-noauth-nosasl-winssl
-  tags: [latest, noauth, nosasl, server, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - latest
+  - noauth
+  - nosasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-latest-server-noauth-nosasl-nossl
-  tags: [latest, noauth, nosasl, nossl, server]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - latest
+  - noauth
+  - nosasl
+  - nossl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-latest-replica-set-auth-sasl-openssl-cse
-  tags: [auth, client-side-encryption, latest, openssl, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl-cse}
+  tags:
+  - auth
+  - client-side-encryption
+  - latest
+  - openssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: latest}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-latest-replica-set-auth-sasl-openssl
-  tags: [auth, latest, openssl, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - auth
+  - latest
+  - openssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-latest-replica-set-auth-sasl-openssl-static-cse
-  tags: [auth, client-side-encryption, latest, openssl-static, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl-static-cse}
+  tags:
+  - auth
+  - client-side-encryption
+  - latest
+  - openssl-static
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-static-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: latest}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-latest-replica-set-auth-sasl-openssl-static
-  tags: [auth, latest, openssl-static, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - auth
+  - latest
+  - openssl-static
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-latest-replica-set-auth-sasl-darwinssl-cse
-  tags: [auth, client-side-encryption, darwinssl, latest, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-darwinssl-cse}
+  tags:
+  - auth
+  - client-side-encryption
+  - darwinssl
+  - latest
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-darwinssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: latest}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-latest-replica-set-auth-sasl-darwinssl
-  tags: [auth, darwinssl, latest, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - auth
+  - darwinssl
+  - latest
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-latest-replica-set-auth-sasl-winssl-cse
-  tags: [auth, client-side-encryption, latest, replica_set, sasl, winssl]
-  depends_on: {name: debug-compile-sasl-winssl-cse}
+  tags:
+  - auth
+  - client-side-encryption
+  - latest
+  - replica_set
+  - sasl
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: latest}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-latest-replica-set-auth-sasl-winssl
-  tags: [auth, latest, replica_set, sasl, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - auth
+  - latest
+  - replica_set
+  - sasl
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-latest-replica-set-auth-nosasl-openssl
-  tags: [auth, latest, nosasl, openssl, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - auth
+  - latest
+  - nosasl
+  - openssl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-latest-replica-set-auth-nosasl-openssl-static
-  tags: [auth, latest, nosasl, openssl-static, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - auth
+  - latest
+  - nosasl
+  - openssl-static
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-latest-replica-set-auth-nosasl-darwinssl
-  tags: [auth, darwinssl, latest, nosasl, replica_set]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - auth
+  - darwinssl
+  - latest
+  - nosasl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-latest-replica-set-auth-nosasl-winssl
-  tags: [auth, latest, nosasl, replica_set, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - auth
+  - latest
+  - nosasl
+  - replica_set
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-latest-replica-set-noauth-sasl-openssl-cse
-  tags: [client-side-encryption, latest, noauth, openssl, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl-cse}
+  tags:
+  - client-side-encryption
+  - latest
+  - noauth
+  - openssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: latest}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-latest-replica-set-noauth-sasl-openssl
-  tags: [latest, noauth, openssl, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - latest
+  - noauth
+  - openssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-latest-replica-set-noauth-sasl-openssl-static-cse
-  tags: [client-side-encryption, latest, noauth, openssl-static, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl-static-cse}
+  tags:
+  - client-side-encryption
+  - latest
+  - noauth
+  - openssl-static
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-static-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: latest}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-latest-replica-set-noauth-sasl-openssl-static
-  tags: [latest, noauth, openssl-static, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - latest
+  - noauth
+  - openssl-static
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-latest-replica-set-noauth-sasl-darwinssl-cse
-  tags: [client-side-encryption, darwinssl, latest, noauth, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-darwinssl-cse}
+  tags:
+  - client-side-encryption
+  - darwinssl
+  - latest
+  - noauth
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-darwinssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: latest}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-latest-replica-set-noauth-sasl-darwinssl
-  tags: [darwinssl, latest, noauth, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - darwinssl
+  - latest
+  - noauth
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-latest-replica-set-noauth-sasl-winssl-cse
-  tags: [client-side-encryption, latest, noauth, replica_set, sasl, winssl]
-  depends_on: {name: debug-compile-sasl-winssl-cse}
+  tags:
+  - client-side-encryption
+  - latest
+  - noauth
+  - replica_set
+  - sasl
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: latest}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-latest-replica-set-noauth-sasl-winssl
-  tags: [latest, noauth, replica_set, sasl, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - latest
+  - noauth
+  - replica_set
+  - sasl
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-latest-replica-set-noauth-nosasl-openssl
-  tags: [latest, noauth, nosasl, openssl, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - latest
+  - noauth
+  - nosasl
+  - openssl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-latest-replica-set-noauth-nosasl-openssl-static
-  tags: [latest, noauth, nosasl, openssl-static, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - latest
+  - noauth
+  - nosasl
+  - openssl-static
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-latest-replica-set-noauth-nosasl-darwinssl
-  tags: [darwinssl, latest, noauth, nosasl, replica_set]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - darwinssl
+  - latest
+  - noauth
+  - nosasl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-latest-replica-set-noauth-nosasl-winssl
-  tags: [latest, noauth, nosasl, replica_set, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - latest
+  - noauth
+  - nosasl
+  - replica_set
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-latest-replica-set-noauth-nosasl-nossl
-  tags: [latest, noauth, nosasl, nossl, replica_set]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - latest
+  - noauth
+  - nosasl
+  - nossl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-latest-sharded-auth-sasl-openssl
-  tags: [auth, latest, openssl, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - auth
+  - latest
+  - openssl
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-latest-sharded-auth-sasl-openssl-static
-  tags: [auth, latest, openssl-static, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - auth
+  - latest
+  - openssl-static
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-latest-sharded-auth-sasl-darwinssl
-  tags: [auth, darwinssl, latest, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - auth
+  - darwinssl
+  - latest
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-latest-sharded-auth-sasl-winssl
-  tags: [auth, latest, sasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - auth
+  - latest
+  - sasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-latest-sharded-auth-nosasl-openssl
-  tags: [auth, latest, nosasl, openssl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - auth
+  - latest
+  - nosasl
+  - openssl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-latest-sharded-auth-nosasl-openssl-static
-  tags: [auth, latest, nosasl, openssl-static, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - auth
+  - latest
+  - nosasl
+  - openssl-static
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-latest-sharded-auth-nosasl-darwinssl
-  tags: [auth, darwinssl, latest, nosasl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - auth
+  - darwinssl
+  - latest
+  - nosasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-latest-sharded-auth-nosasl-winssl
-  tags: [auth, latest, nosasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - auth
+  - latest
+  - nosasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-latest-sharded-noauth-sasl-openssl
-  tags: [latest, noauth, openssl, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - latest
+  - noauth
+  - openssl
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-latest-sharded-noauth-sasl-openssl-static
-  tags: [latest, noauth, openssl-static, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - latest
+  - noauth
+  - openssl-static
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-latest-sharded-noauth-sasl-darwinssl
-  tags: [darwinssl, latest, noauth, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - darwinssl
+  - latest
+  - noauth
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-latest-sharded-noauth-sasl-winssl
-  tags: [latest, noauth, sasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - latest
+  - noauth
+  - sasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-latest-sharded-noauth-nosasl-openssl
-  tags: [latest, noauth, nosasl, openssl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - latest
+  - noauth
+  - nosasl
+  - openssl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-latest-sharded-noauth-nosasl-openssl-static
-  tags: [latest, noauth, nosasl, openssl-static, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - latest
+  - noauth
+  - nosasl
+  - openssl-static
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-latest-sharded-noauth-nosasl-darwinssl
-  tags: [darwinssl, latest, noauth, nosasl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - darwinssl
+  - latest
+  - noauth
+  - nosasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-latest-sharded-noauth-nosasl-winssl
-  tags: [latest, noauth, nosasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - latest
+  - noauth
+  - nosasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-latest-sharded-noauth-nosasl-nossl
-  tags: [latest, noauth, nosasl, nossl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - latest
+  - noauth
+  - nosasl
+  - nossl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-6.0-server-auth-sasl-openssl-cse
-  tags: ['6.0', auth, client-side-encryption, openssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-cse}
+  tags:
+  - '6.0'
+  - auth
+  - client-side-encryption
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '6.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-6.0-server-auth-sasl-openssl
-  tags: ['6.0', auth, openssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '6.0'
+  - auth
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-6.0-server-auth-sasl-openssl-static-cse
-  tags: ['6.0', auth, client-side-encryption, openssl-static, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-static-cse}
+  tags:
+  - '6.0'
+  - auth
+  - client-side-encryption
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '6.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-6.0-server-auth-sasl-openssl-static
-  tags: ['6.0', auth, openssl-static, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '6.0'
+  - auth
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-6.0-server-auth-sasl-darwinssl-cse
-  tags: ['6.0', auth, client-side-encryption, darwinssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-darwinssl-cse}
+  tags:
+  - '6.0'
+  - auth
+  - client-side-encryption
+  - darwinssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '6.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-6.0-server-auth-sasl-darwinssl
-  tags: ['6.0', auth, darwinssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '6.0'
+  - auth
+  - darwinssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-6.0-server-auth-sasl-winssl-cse
-  tags: ['6.0', auth, client-side-encryption, sasl, server, winssl]
-  depends_on: {name: debug-compile-sasl-winssl-cse}
+  tags:
+  - '6.0'
+  - auth
+  - client-side-encryption
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '6.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-6.0-server-auth-sasl-winssl
-  tags: ['6.0', auth, sasl, server, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '6.0'
+  - auth
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-6.0-server-auth-nosasl-openssl
-  tags: ['6.0', auth, nosasl, openssl, server]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '6.0'
+  - auth
+  - nosasl
+  - openssl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-6.0-server-auth-nosasl-openssl-static
-  tags: ['6.0', auth, nosasl, openssl-static, server]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '6.0'
+  - auth
+  - nosasl
+  - openssl-static
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-6.0-server-auth-nosasl-darwinssl
-  tags: ['6.0', auth, darwinssl, nosasl, server]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '6.0'
+  - auth
+  - darwinssl
+  - nosasl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-6.0-server-auth-nosasl-winssl
-  tags: ['6.0', auth, nosasl, server, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '6.0'
+  - auth
+  - nosasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-6.0-server-noauth-sasl-openssl-cse
-  tags: ['6.0', client-side-encryption, noauth, openssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-cse}
+  tags:
+  - '6.0'
+  - client-side-encryption
+  - noauth
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '6.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-6.0-server-noauth-sasl-openssl
-  tags: ['6.0', noauth, openssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '6.0'
+  - noauth
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-6.0-server-noauth-sasl-openssl-static-cse
-  tags: ['6.0', client-side-encryption, noauth, openssl-static, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-static-cse}
+  tags:
+  - '6.0'
+  - client-side-encryption
+  - noauth
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '6.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-6.0-server-noauth-sasl-openssl-static
-  tags: ['6.0', noauth, openssl-static, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '6.0'
+  - noauth
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-6.0-server-noauth-sasl-darwinssl-cse
-  tags: ['6.0', client-side-encryption, darwinssl, noauth, sasl, server]
-  depends_on: {name: debug-compile-sasl-darwinssl-cse}
+  tags:
+  - '6.0'
+  - client-side-encryption
+  - darwinssl
+  - noauth
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '6.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-6.0-server-noauth-sasl-darwinssl
-  tags: ['6.0', darwinssl, noauth, sasl, server]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '6.0'
+  - darwinssl
+  - noauth
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-6.0-server-noauth-sasl-winssl-cse
-  tags: ['6.0', client-side-encryption, noauth, sasl, server, winssl]
-  depends_on: {name: debug-compile-sasl-winssl-cse}
+  tags:
+  - '6.0'
+  - client-side-encryption
+  - noauth
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '6.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-6.0-server-noauth-sasl-winssl
-  tags: ['6.0', noauth, sasl, server, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '6.0'
+  - noauth
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-6.0-server-noauth-nosasl-openssl
-  tags: ['6.0', noauth, nosasl, openssl, server]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '6.0'
+  - noauth
+  - nosasl
+  - openssl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-6.0-server-noauth-nosasl-openssl-static
-  tags: ['6.0', noauth, nosasl, openssl-static, server]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '6.0'
+  - noauth
+  - nosasl
+  - openssl-static
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-6.0-server-noauth-nosasl-darwinssl
-  tags: ['6.0', darwinssl, noauth, nosasl, server]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '6.0'
+  - darwinssl
+  - noauth
+  - nosasl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-6.0-server-noauth-nosasl-winssl
-  tags: ['6.0', noauth, nosasl, server, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '6.0'
+  - noauth
+  - nosasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-6.0-server-noauth-nosasl-nossl
-  tags: ['6.0', noauth, nosasl, nossl, server]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - '6.0'
+  - noauth
+  - nosasl
+  - nossl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-6.0-replica-set-auth-sasl-openssl-cse
-  tags: ['6.0', auth, client-side-encryption, openssl, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl-cse}
+  tags:
+  - '6.0'
+  - auth
+  - client-side-encryption
+  - openssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '6.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-6.0-replica-set-auth-sasl-openssl
-  tags: ['6.0', auth, openssl, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '6.0'
+  - auth
+  - openssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-6.0-replica-set-auth-sasl-openssl-static-cse
-  tags: ['6.0', auth, client-side-encryption, openssl-static, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl-static-cse}
+  tags:
+  - '6.0'
+  - auth
+  - client-side-encryption
+  - openssl-static
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-static-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '6.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-6.0-replica-set-auth-sasl-openssl-static
-  tags: ['6.0', auth, openssl-static, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '6.0'
+  - auth
+  - openssl-static
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-6.0-replica-set-auth-sasl-darwinssl-cse
-  tags: ['6.0', auth, client-side-encryption, darwinssl, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-darwinssl-cse}
+  tags:
+  - '6.0'
+  - auth
+  - client-side-encryption
+  - darwinssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-darwinssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '6.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-6.0-replica-set-auth-sasl-darwinssl
-  tags: ['6.0', auth, darwinssl, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '6.0'
+  - auth
+  - darwinssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-6.0-replica-set-auth-sasl-winssl-cse
-  tags: ['6.0', auth, client-side-encryption, replica_set, sasl, winssl]
-  depends_on: {name: debug-compile-sasl-winssl-cse}
+  tags:
+  - '6.0'
+  - auth
+  - client-side-encryption
+  - replica_set
+  - sasl
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '6.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-6.0-replica-set-auth-sasl-winssl
-  tags: ['6.0', auth, replica_set, sasl, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '6.0'
+  - auth
+  - replica_set
+  - sasl
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-6.0-replica-set-auth-nosasl-openssl
-  tags: ['6.0', auth, nosasl, openssl, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '6.0'
+  - auth
+  - nosasl
+  - openssl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-6.0-replica-set-auth-nosasl-openssl-static
-  tags: ['6.0', auth, nosasl, openssl-static, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '6.0'
+  - auth
+  - nosasl
+  - openssl-static
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-6.0-replica-set-auth-nosasl-darwinssl
-  tags: ['6.0', auth, darwinssl, nosasl, replica_set]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '6.0'
+  - auth
+  - darwinssl
+  - nosasl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-6.0-replica-set-auth-nosasl-winssl
-  tags: ['6.0', auth, nosasl, replica_set, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '6.0'
+  - auth
+  - nosasl
+  - replica_set
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-6.0-replica-set-noauth-sasl-openssl-cse
-  tags: ['6.0', client-side-encryption, noauth, openssl, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl-cse}
+  tags:
+  - '6.0'
+  - client-side-encryption
+  - noauth
+  - openssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '6.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-6.0-replica-set-noauth-sasl-openssl
-  tags: ['6.0', noauth, openssl, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '6.0'
+  - noauth
+  - openssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-6.0-replica-set-noauth-sasl-openssl-static-cse
-  tags: ['6.0', client-side-encryption, noauth, openssl-static, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl-static-cse}
+  tags:
+  - '6.0'
+  - client-side-encryption
+  - noauth
+  - openssl-static
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-static-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '6.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-6.0-replica-set-noauth-sasl-openssl-static
-  tags: ['6.0', noauth, openssl-static, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '6.0'
+  - noauth
+  - openssl-static
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-6.0-replica-set-noauth-sasl-darwinssl-cse
-  tags: ['6.0', client-side-encryption, darwinssl, noauth, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-darwinssl-cse}
+  tags:
+  - '6.0'
+  - client-side-encryption
+  - darwinssl
+  - noauth
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-darwinssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '6.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-6.0-replica-set-noauth-sasl-darwinssl
-  tags: ['6.0', darwinssl, noauth, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '6.0'
+  - darwinssl
+  - noauth
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-6.0-replica-set-noauth-sasl-winssl-cse
-  tags: ['6.0', client-side-encryption, noauth, replica_set, sasl, winssl]
-  depends_on: {name: debug-compile-sasl-winssl-cse}
+  tags:
+  - '6.0'
+  - client-side-encryption
+  - noauth
+  - replica_set
+  - sasl
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '6.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-6.0-replica-set-noauth-sasl-winssl
-  tags: ['6.0', noauth, replica_set, sasl, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '6.0'
+  - noauth
+  - replica_set
+  - sasl
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-6.0-replica-set-noauth-nosasl-openssl
-  tags: ['6.0', noauth, nosasl, openssl, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '6.0'
+  - noauth
+  - nosasl
+  - openssl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-6.0-replica-set-noauth-nosasl-openssl-static
-  tags: ['6.0', noauth, nosasl, openssl-static, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '6.0'
+  - noauth
+  - nosasl
+  - openssl-static
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-6.0-replica-set-noauth-nosasl-darwinssl
-  tags: ['6.0', darwinssl, noauth, nosasl, replica_set]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '6.0'
+  - darwinssl
+  - noauth
+  - nosasl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-6.0-replica-set-noauth-nosasl-winssl
-  tags: ['6.0', noauth, nosasl, replica_set, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '6.0'
+  - noauth
+  - nosasl
+  - replica_set
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-6.0-replica-set-noauth-nosasl-nossl
-  tags: ['6.0', noauth, nosasl, nossl, replica_set]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - '6.0'
+  - noauth
+  - nosasl
+  - nossl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-6.0-sharded-auth-sasl-openssl
-  tags: ['6.0', auth, openssl, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '6.0'
+  - auth
+  - openssl
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-6.0-sharded-auth-sasl-openssl-static
-  tags: ['6.0', auth, openssl-static, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '6.0'
+  - auth
+  - openssl-static
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-6.0-sharded-auth-sasl-darwinssl
-  tags: ['6.0', auth, darwinssl, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '6.0'
+  - auth
+  - darwinssl
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-6.0-sharded-auth-sasl-winssl
-  tags: ['6.0', auth, sasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '6.0'
+  - auth
+  - sasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-6.0-sharded-auth-nosasl-openssl
-  tags: ['6.0', auth, nosasl, openssl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '6.0'
+  - auth
+  - nosasl
+  - openssl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-6.0-sharded-auth-nosasl-openssl-static
-  tags: ['6.0', auth, nosasl, openssl-static, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '6.0'
+  - auth
+  - nosasl
+  - openssl-static
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-6.0-sharded-auth-nosasl-darwinssl
-  tags: ['6.0', auth, darwinssl, nosasl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '6.0'
+  - auth
+  - darwinssl
+  - nosasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-6.0-sharded-auth-nosasl-winssl
-  tags: ['6.0', auth, nosasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '6.0'
+  - auth
+  - nosasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-6.0-sharded-noauth-sasl-openssl
-  tags: ['6.0', noauth, openssl, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '6.0'
+  - noauth
+  - openssl
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-6.0-sharded-noauth-sasl-openssl-static
-  tags: ['6.0', noauth, openssl-static, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '6.0'
+  - noauth
+  - openssl-static
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-6.0-sharded-noauth-sasl-darwinssl
-  tags: ['6.0', darwinssl, noauth, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '6.0'
+  - darwinssl
+  - noauth
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-6.0-sharded-noauth-sasl-winssl
-  tags: ['6.0', noauth, sasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '6.0'
+  - noauth
+  - sasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-6.0-sharded-noauth-nosasl-openssl
-  tags: ['6.0', noauth, nosasl, openssl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '6.0'
+  - noauth
+  - nosasl
+  - openssl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-6.0-sharded-noauth-nosasl-openssl-static
-  tags: ['6.0', noauth, nosasl, openssl-static, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '6.0'
+  - noauth
+  - nosasl
+  - openssl-static
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-6.0-sharded-noauth-nosasl-darwinssl
-  tags: ['6.0', darwinssl, noauth, nosasl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '6.0'
+  - darwinssl
+  - noauth
+  - nosasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-6.0-sharded-noauth-nosasl-winssl
-  tags: ['6.0', noauth, nosasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '6.0'
+  - noauth
+  - nosasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-6.0-sharded-noauth-nosasl-nossl
-  tags: ['6.0', noauth, nosasl, nossl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - '6.0'
+  - noauth
+  - nosasl
+  - nossl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '6.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-5.0-server-auth-sasl-openssl-cse
-  tags: ['5.0', auth, client-side-encryption, openssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-cse}
+  tags:
+  - '5.0'
+  - auth
+  - client-side-encryption
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '5.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '5.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-5.0-server-auth-sasl-openssl
-  tags: ['5.0', auth, openssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '5.0'
+  - auth
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-5.0-server-auth-sasl-openssl-static-cse
-  tags: ['5.0', auth, client-side-encryption, openssl-static, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-static-cse}
+  tags:
+  - '5.0'
+  - auth
+  - client-side-encryption
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '5.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '5.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-5.0-server-auth-sasl-openssl-static
-  tags: ['5.0', auth, openssl-static, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '5.0'
+  - auth
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-5.0-server-auth-sasl-darwinssl-cse
-  tags: ['5.0', auth, client-side-encryption, darwinssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-darwinssl-cse}
+  tags:
+  - '5.0'
+  - auth
+  - client-side-encryption
+  - darwinssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '5.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '5.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-5.0-server-auth-sasl-darwinssl
-  tags: ['5.0', auth, darwinssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '5.0'
+  - auth
+  - darwinssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-5.0-server-auth-sasl-winssl-cse
-  tags: ['5.0', auth, client-side-encryption, sasl, server, winssl]
-  depends_on: {name: debug-compile-sasl-winssl-cse}
+  tags:
+  - '5.0'
+  - auth
+  - client-side-encryption
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '5.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '5.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-5.0-server-auth-sasl-winssl
-  tags: ['5.0', auth, sasl, server, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '5.0'
+  - auth
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-5.0-server-auth-nosasl-openssl
-  tags: ['5.0', auth, nosasl, openssl, server]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '5.0'
+  - auth
+  - nosasl
+  - openssl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-5.0-server-auth-nosasl-openssl-static
-  tags: ['5.0', auth, nosasl, openssl-static, server]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '5.0'
+  - auth
+  - nosasl
+  - openssl-static
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-5.0-server-auth-nosasl-darwinssl
-  tags: ['5.0', auth, darwinssl, nosasl, server]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '5.0'
+  - auth
+  - darwinssl
+  - nosasl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-5.0-server-auth-nosasl-winssl
-  tags: ['5.0', auth, nosasl, server, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '5.0'
+  - auth
+  - nosasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-5.0-server-noauth-sasl-openssl-cse
-  tags: ['5.0', client-side-encryption, noauth, openssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-cse}
+  tags:
+  - '5.0'
+  - client-side-encryption
+  - noauth
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '5.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '5.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-5.0-server-noauth-sasl-openssl
-  tags: ['5.0', noauth, openssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '5.0'
+  - noauth
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-5.0-server-noauth-sasl-openssl-static-cse
-  tags: ['5.0', client-side-encryption, noauth, openssl-static, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-static-cse}
+  tags:
+  - '5.0'
+  - client-side-encryption
+  - noauth
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '5.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '5.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-5.0-server-noauth-sasl-openssl-static
-  tags: ['5.0', noauth, openssl-static, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '5.0'
+  - noauth
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-5.0-server-noauth-sasl-darwinssl-cse
-  tags: ['5.0', client-side-encryption, darwinssl, noauth, sasl, server]
-  depends_on: {name: debug-compile-sasl-darwinssl-cse}
+  tags:
+  - '5.0'
+  - client-side-encryption
+  - darwinssl
+  - noauth
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '5.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '5.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-5.0-server-noauth-sasl-darwinssl
-  tags: ['5.0', darwinssl, noauth, sasl, server]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '5.0'
+  - darwinssl
+  - noauth
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-5.0-server-noauth-sasl-winssl-cse
-  tags: ['5.0', client-side-encryption, noauth, sasl, server, winssl]
-  depends_on: {name: debug-compile-sasl-winssl-cse}
+  tags:
+  - '5.0'
+  - client-side-encryption
+  - noauth
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '5.0'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '5.0'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-5.0-server-noauth-sasl-winssl
-  tags: ['5.0', noauth, sasl, server, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '5.0'
+  - noauth
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-5.0-server-noauth-nosasl-openssl
-  tags: ['5.0', noauth, nosasl, openssl, server]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '5.0'
+  - noauth
+  - nosasl
+  - openssl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-5.0-server-noauth-nosasl-openssl-static
-  tags: ['5.0', noauth, nosasl, openssl-static, server]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '5.0'
+  - noauth
+  - nosasl
+  - openssl-static
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-5.0-server-noauth-nosasl-darwinssl
-  tags: ['5.0', darwinssl, noauth, nosasl, server]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '5.0'
+  - darwinssl
+  - noauth
+  - nosasl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-5.0-server-noauth-nosasl-winssl
-  tags: ['5.0', noauth, nosasl, server, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '5.0'
+  - noauth
+  - nosasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-5.0-server-noauth-nosasl-nossl
-  tags: ['5.0', noauth, nosasl, nossl, server]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - '5.0'
+  - noauth
+  - nosasl
+  - nossl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-5.0-replica-set-auth-sasl-openssl
-  tags: ['5.0', auth, openssl, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '5.0'
+  - auth
+  - openssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-5.0-replica-set-auth-sasl-openssl-static
-  tags: ['5.0', auth, openssl-static, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '5.0'
+  - auth
+  - openssl-static
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-5.0-replica-set-auth-sasl-darwinssl
-  tags: ['5.0', auth, darwinssl, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '5.0'
+  - auth
+  - darwinssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-5.0-replica-set-auth-sasl-winssl
-  tags: ['5.0', auth, replica_set, sasl, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '5.0'
+  - auth
+  - replica_set
+  - sasl
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-5.0-replica-set-auth-nosasl-openssl
-  tags: ['5.0', auth, nosasl, openssl, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '5.0'
+  - auth
+  - nosasl
+  - openssl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-5.0-replica-set-auth-nosasl-openssl-static
-  tags: ['5.0', auth, nosasl, openssl-static, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '5.0'
+  - auth
+  - nosasl
+  - openssl-static
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-5.0-replica-set-auth-nosasl-darwinssl
-  tags: ['5.0', auth, darwinssl, nosasl, replica_set]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '5.0'
+  - auth
+  - darwinssl
+  - nosasl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-5.0-replica-set-auth-nosasl-winssl
-  tags: ['5.0', auth, nosasl, replica_set, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '5.0'
+  - auth
+  - nosasl
+  - replica_set
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-5.0-replica-set-noauth-sasl-openssl
-  tags: ['5.0', noauth, openssl, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '5.0'
+  - noauth
+  - openssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-5.0-replica-set-noauth-sasl-openssl-static
-  tags: ['5.0', noauth, openssl-static, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '5.0'
+  - noauth
+  - openssl-static
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-5.0-replica-set-noauth-sasl-darwinssl
-  tags: ['5.0', darwinssl, noauth, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '5.0'
+  - darwinssl
+  - noauth
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-5.0-replica-set-noauth-sasl-winssl
-  tags: ['5.0', noauth, replica_set, sasl, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '5.0'
+  - noauth
+  - replica_set
+  - sasl
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-5.0-replica-set-noauth-nosasl-openssl
-  tags: ['5.0', noauth, nosasl, openssl, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '5.0'
+  - noauth
+  - nosasl
+  - openssl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-5.0-replica-set-noauth-nosasl-openssl-static
-  tags: ['5.0', noauth, nosasl, openssl-static, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '5.0'
+  - noauth
+  - nosasl
+  - openssl-static
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-5.0-replica-set-noauth-nosasl-darwinssl
-  tags: ['5.0', darwinssl, noauth, nosasl, replica_set]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '5.0'
+  - darwinssl
+  - noauth
+  - nosasl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-5.0-replica-set-noauth-nosasl-winssl
-  tags: ['5.0', noauth, nosasl, replica_set, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '5.0'
+  - noauth
+  - nosasl
+  - replica_set
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-5.0-replica-set-noauth-nosasl-nossl
-  tags: ['5.0', noauth, nosasl, nossl, replica_set]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - '5.0'
+  - noauth
+  - nosasl
+  - nossl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-5.0-sharded-auth-sasl-openssl
-  tags: ['5.0', auth, openssl, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '5.0'
+  - auth
+  - openssl
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-5.0-sharded-auth-sasl-openssl-static
-  tags: ['5.0', auth, openssl-static, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '5.0'
+  - auth
+  - openssl-static
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-5.0-sharded-auth-sasl-darwinssl
-  tags: ['5.0', auth, darwinssl, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '5.0'
+  - auth
+  - darwinssl
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-5.0-sharded-auth-sasl-winssl
-  tags: ['5.0', auth, sasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '5.0'
+  - auth
+  - sasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-5.0-sharded-auth-nosasl-openssl
-  tags: ['5.0', auth, nosasl, openssl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '5.0'
+  - auth
+  - nosasl
+  - openssl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-5.0-sharded-auth-nosasl-openssl-static
-  tags: ['5.0', auth, nosasl, openssl-static, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '5.0'
+  - auth
+  - nosasl
+  - openssl-static
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-5.0-sharded-auth-nosasl-darwinssl
-  tags: ['5.0', auth, darwinssl, nosasl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '5.0'
+  - auth
+  - darwinssl
+  - nosasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-5.0-sharded-auth-nosasl-winssl
-  tags: ['5.0', auth, nosasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '5.0'
+  - auth
+  - nosasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-5.0-sharded-noauth-sasl-openssl
-  tags: ['5.0', noauth, openssl, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '5.0'
+  - noauth
+  - openssl
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-5.0-sharded-noauth-sasl-openssl-static
-  tags: ['5.0', noauth, openssl-static, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '5.0'
+  - noauth
+  - openssl-static
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-5.0-sharded-noauth-sasl-darwinssl
-  tags: ['5.0', darwinssl, noauth, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '5.0'
+  - darwinssl
+  - noauth
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-5.0-sharded-noauth-sasl-winssl
-  tags: ['5.0', noauth, sasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '5.0'
+  - noauth
+  - sasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-5.0-sharded-noauth-nosasl-openssl
-  tags: ['5.0', noauth, nosasl, openssl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '5.0'
+  - noauth
+  - nosasl
+  - openssl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-5.0-sharded-noauth-nosasl-openssl-static
-  tags: ['5.0', noauth, nosasl, openssl-static, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '5.0'
+  - noauth
+  - nosasl
+  - openssl-static
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-5.0-sharded-noauth-nosasl-darwinssl
-  tags: ['5.0', darwinssl, noauth, nosasl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '5.0'
+  - darwinssl
+  - noauth
+  - nosasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-5.0-sharded-noauth-nosasl-winssl
-  tags: ['5.0', noauth, nosasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '5.0'
+  - noauth
+  - nosasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-5.0-sharded-noauth-nosasl-nossl
-  tags: ['5.0', noauth, nosasl, nossl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - '5.0'
+  - noauth
+  - nosasl
+  - nossl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-4.4-server-auth-sasl-openssl-cse
-  tags: ['4.4', auth, client-side-encryption, openssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-cse}
+  tags:
+  - '4.4'
+  - auth
+  - client-side-encryption
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.4'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.4'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.4-server-auth-sasl-openssl
-  tags: ['4.4', auth, openssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '4.4'
+  - auth
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.4-server-auth-sasl-openssl-static-cse
-  tags: ['4.4', auth, client-side-encryption, openssl-static, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-static-cse}
+  tags:
+  - '4.4'
+  - auth
+  - client-side-encryption
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.4'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '4.4'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.4-server-auth-sasl-openssl-static
-  tags: ['4.4', auth, openssl-static, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '4.4'
+  - auth
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.4-server-auth-sasl-darwinssl-cse
-  tags: ['4.4', auth, client-side-encryption, darwinssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-darwinssl-cse}
+  tags:
+  - '4.4'
+  - auth
+  - client-side-encryption
+  - darwinssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.4'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '4.4'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.4-server-auth-sasl-darwinssl
-  tags: ['4.4', auth, darwinssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '4.4'
+  - auth
+  - darwinssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.4-server-auth-sasl-winssl-cse
-  tags: ['4.4', auth, client-side-encryption, sasl, server, winssl]
-  depends_on: {name: debug-compile-sasl-winssl-cse}
+  tags:
+  - '4.4'
+  - auth
+  - client-side-encryption
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '4.4'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '4.4'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.4-server-auth-sasl-winssl
-  tags: ['4.4', auth, sasl, server, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '4.4'
+  - auth
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.4-server-auth-nosasl-openssl
-  tags: ['4.4', auth, nosasl, openssl, server]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '4.4'
+  - auth
+  - nosasl
+  - openssl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.4-server-auth-nosasl-openssl-static
-  tags: ['4.4', auth, nosasl, openssl-static, server]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '4.4'
+  - auth
+  - nosasl
+  - openssl-static
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.4-server-auth-nosasl-darwinssl
-  tags: ['4.4', auth, darwinssl, nosasl, server]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '4.4'
+  - auth
+  - darwinssl
+  - nosasl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.4-server-auth-nosasl-winssl
-  tags: ['4.4', auth, nosasl, server, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '4.4'
+  - auth
+  - nosasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.4-server-noauth-sasl-openssl-cse
-  tags: ['4.4', client-side-encryption, noauth, openssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-cse}
+  tags:
+  - '4.4'
+  - client-side-encryption
+  - noauth
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '4.4'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.4'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.4-server-noauth-sasl-openssl
-  tags: ['4.4', noauth, openssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '4.4'
+  - noauth
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.4-server-noauth-sasl-openssl-static-cse
-  tags: ['4.4', client-side-encryption, noauth, openssl-static, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-static-cse}
+  tags:
+  - '4.4'
+  - client-side-encryption
+  - noauth
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.4'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '4.4'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.4-server-noauth-sasl-openssl-static
-  tags: ['4.4', noauth, openssl-static, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '4.4'
+  - noauth
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.4-server-noauth-sasl-darwinssl-cse
-  tags: ['4.4', client-side-encryption, darwinssl, noauth, sasl, server]
-  depends_on: {name: debug-compile-sasl-darwinssl-cse}
+  tags:
+  - '4.4'
+  - client-side-encryption
+  - darwinssl
+  - noauth
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.4'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '4.4'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.4-server-noauth-sasl-darwinssl
-  tags: ['4.4', darwinssl, noauth, sasl, server]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '4.4'
+  - darwinssl
+  - noauth
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.4-server-noauth-sasl-winssl-cse
-  tags: ['4.4', client-side-encryption, noauth, sasl, server, winssl]
-  depends_on: {name: debug-compile-sasl-winssl-cse}
+  tags:
+  - '4.4'
+  - client-side-encryption
+  - noauth
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '4.4'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '4.4'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.4-server-noauth-sasl-winssl
-  tags: ['4.4', noauth, sasl, server, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '4.4'
+  - noauth
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.4-server-noauth-nosasl-openssl
-  tags: ['4.4', noauth, nosasl, openssl, server]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '4.4'
+  - noauth
+  - nosasl
+  - openssl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.4-server-noauth-nosasl-openssl-static
-  tags: ['4.4', noauth, nosasl, openssl-static, server]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '4.4'
+  - noauth
+  - nosasl
+  - openssl-static
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.4-server-noauth-nosasl-darwinssl
-  tags: ['4.4', darwinssl, noauth, nosasl, server]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '4.4'
+  - darwinssl
+  - noauth
+  - nosasl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.4-server-noauth-nosasl-winssl
-  tags: ['4.4', noauth, nosasl, server, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '4.4'
+  - noauth
+  - nosasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.4-server-noauth-nosasl-nossl
-  tags: ['4.4', noauth, nosasl, nossl, server]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - '4.4'
+  - noauth
+  - nosasl
+  - nossl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-4.4-replica-set-auth-sasl-openssl
-  tags: ['4.4', auth, openssl, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '4.4'
+  - auth
+  - openssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.4-replica-set-auth-sasl-openssl-static
-  tags: ['4.4', auth, openssl-static, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '4.4'
+  - auth
+  - openssl-static
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.4-replica-set-auth-sasl-darwinssl
-  tags: ['4.4', auth, darwinssl, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '4.4'
+  - auth
+  - darwinssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.4-replica-set-auth-sasl-winssl
-  tags: ['4.4', auth, replica_set, sasl, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '4.4'
+  - auth
+  - replica_set
+  - sasl
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.4-replica-set-auth-nosasl-openssl
-  tags: ['4.4', auth, nosasl, openssl, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '4.4'
+  - auth
+  - nosasl
+  - openssl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.4-replica-set-auth-nosasl-openssl-static
-  tags: ['4.4', auth, nosasl, openssl-static, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '4.4'
+  - auth
+  - nosasl
+  - openssl-static
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.4-replica-set-auth-nosasl-darwinssl
-  tags: ['4.4', auth, darwinssl, nosasl, replica_set]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '4.4'
+  - auth
+  - darwinssl
+  - nosasl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.4-replica-set-auth-nosasl-winssl
-  tags: ['4.4', auth, nosasl, replica_set, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '4.4'
+  - auth
+  - nosasl
+  - replica_set
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.4-replica-set-noauth-sasl-openssl
-  tags: ['4.4', noauth, openssl, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '4.4'
+  - noauth
+  - openssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.4-replica-set-noauth-sasl-openssl-static
-  tags: ['4.4', noauth, openssl-static, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '4.4'
+  - noauth
+  - openssl-static
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.4-replica-set-noauth-sasl-darwinssl
-  tags: ['4.4', darwinssl, noauth, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '4.4'
+  - darwinssl
+  - noauth
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.4-replica-set-noauth-sasl-winssl
-  tags: ['4.4', noauth, replica_set, sasl, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '4.4'
+  - noauth
+  - replica_set
+  - sasl
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.4-replica-set-noauth-nosasl-openssl
-  tags: ['4.4', noauth, nosasl, openssl, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '4.4'
+  - noauth
+  - nosasl
+  - openssl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.4-replica-set-noauth-nosasl-openssl-static
-  tags: ['4.4', noauth, nosasl, openssl-static, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '4.4'
+  - noauth
+  - nosasl
+  - openssl-static
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.4-replica-set-noauth-nosasl-darwinssl
-  tags: ['4.4', darwinssl, noauth, nosasl, replica_set]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '4.4'
+  - darwinssl
+  - noauth
+  - nosasl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.4-replica-set-noauth-nosasl-winssl
-  tags: ['4.4', noauth, nosasl, replica_set, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '4.4'
+  - noauth
+  - nosasl
+  - replica_set
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.4-replica-set-noauth-nosasl-nossl
-  tags: ['4.4', noauth, nosasl, nossl, replica_set]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - '4.4'
+  - noauth
+  - nosasl
+  - nossl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-4.4-sharded-auth-sasl-openssl
-  tags: ['4.4', auth, openssl, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '4.4'
+  - auth
+  - openssl
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.4-sharded-auth-sasl-openssl-static
-  tags: ['4.4', auth, openssl-static, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '4.4'
+  - auth
+  - openssl-static
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.4-sharded-auth-sasl-darwinssl
-  tags: ['4.4', auth, darwinssl, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '4.4'
+  - auth
+  - darwinssl
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.4-sharded-auth-sasl-winssl
-  tags: ['4.4', auth, sasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '4.4'
+  - auth
+  - sasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.4-sharded-auth-nosasl-openssl
-  tags: ['4.4', auth, nosasl, openssl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '4.4'
+  - auth
+  - nosasl
+  - openssl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.4-sharded-auth-nosasl-openssl-static
-  tags: ['4.4', auth, nosasl, openssl-static, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '4.4'
+  - auth
+  - nosasl
+  - openssl-static
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.4-sharded-auth-nosasl-darwinssl
-  tags: ['4.4', auth, darwinssl, nosasl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '4.4'
+  - auth
+  - darwinssl
+  - nosasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.4-sharded-auth-nosasl-winssl
-  tags: ['4.4', auth, nosasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '4.4'
+  - auth
+  - nosasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.4-sharded-noauth-sasl-openssl
-  tags: ['4.4', noauth, openssl, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '4.4'
+  - noauth
+  - openssl
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.4-sharded-noauth-sasl-openssl-static
-  tags: ['4.4', noauth, openssl-static, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '4.4'
+  - noauth
+  - openssl-static
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.4-sharded-noauth-sasl-darwinssl
-  tags: ['4.4', darwinssl, noauth, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '4.4'
+  - darwinssl
+  - noauth
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.4-sharded-noauth-sasl-winssl
-  tags: ['4.4', noauth, sasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '4.4'
+  - noauth
+  - sasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.4-sharded-noauth-nosasl-openssl
-  tags: ['4.4', noauth, nosasl, openssl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '4.4'
+  - noauth
+  - nosasl
+  - openssl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.4-sharded-noauth-nosasl-openssl-static
-  tags: ['4.4', noauth, nosasl, openssl-static, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '4.4'
+  - noauth
+  - nosasl
+  - openssl-static
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.4-sharded-noauth-nosasl-darwinssl
-  tags: ['4.4', darwinssl, noauth, nosasl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '4.4'
+  - darwinssl
+  - noauth
+  - nosasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.4-sharded-noauth-nosasl-winssl
-  tags: ['4.4', noauth, nosasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '4.4'
+  - noauth
+  - nosasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.4-sharded-noauth-nosasl-nossl
-  tags: ['4.4', noauth, nosasl, nossl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - '4.4'
+  - noauth
+  - nosasl
+  - nossl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.4'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-4.2-server-auth-sasl-openssl-cse
-  tags: ['4.2', auth, client-side-encryption, openssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-cse}
+  tags:
+  - '4.2'
+  - auth
+  - client-side-encryption
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.2'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.2'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.2-server-auth-sasl-openssl
-  tags: ['4.2', auth, openssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '4.2'
+  - auth
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.2-server-auth-sasl-openssl-static-cse
-  tags: ['4.2', auth, client-side-encryption, openssl-static, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-static-cse}
+  tags:
+  - '4.2'
+  - auth
+  - client-side-encryption
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.2'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '4.2'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.2-server-auth-sasl-openssl-static
-  tags: ['4.2', auth, openssl-static, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '4.2'
+  - auth
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.2-server-auth-sasl-darwinssl-cse
-  tags: ['4.2', auth, client-side-encryption, darwinssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-darwinssl-cse}
+  tags:
+  - '4.2'
+  - auth
+  - client-side-encryption
+  - darwinssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.2'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '4.2'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.2-server-auth-sasl-darwinssl
-  tags: ['4.2', auth, darwinssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '4.2'
+  - auth
+  - darwinssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.2-server-auth-sasl-winssl-cse
-  tags: ['4.2', auth, client-side-encryption, sasl, server, winssl]
-  depends_on: {name: debug-compile-sasl-winssl-cse}
+  tags:
+  - '4.2'
+  - auth
+  - client-side-encryption
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '4.2'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '4.2'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.2-server-auth-sasl-winssl
-  tags: ['4.2', auth, sasl, server, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '4.2'
+  - auth
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.2-server-auth-nosasl-openssl
-  tags: ['4.2', auth, nosasl, openssl, server]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '4.2'
+  - auth
+  - nosasl
+  - openssl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.2-server-auth-nosasl-openssl-static
-  tags: ['4.2', auth, nosasl, openssl-static, server]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '4.2'
+  - auth
+  - nosasl
+  - openssl-static
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.2-server-auth-nosasl-darwinssl
-  tags: ['4.2', auth, darwinssl, nosasl, server]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '4.2'
+  - auth
+  - darwinssl
+  - nosasl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.2-server-auth-nosasl-winssl
-  tags: ['4.2', auth, nosasl, server, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '4.2'
+  - auth
+  - nosasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.2-server-noauth-sasl-openssl-cse
-  tags: ['4.2', client-side-encryption, noauth, openssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-cse}
+  tags:
+  - '4.2'
+  - client-side-encryption
+  - noauth
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '4.2'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.2'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.2-server-noauth-sasl-openssl
-  tags: ['4.2', noauth, openssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '4.2'
+  - noauth
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.2-server-noauth-sasl-openssl-static-cse
-  tags: ['4.2', client-side-encryption, noauth, openssl-static, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-static-cse}
+  tags:
+  - '4.2'
+  - client-side-encryption
+  - noauth
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.2'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '4.2'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.2-server-noauth-sasl-openssl-static
-  tags: ['4.2', noauth, openssl-static, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '4.2'
+  - noauth
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.2-server-noauth-sasl-darwinssl-cse
-  tags: ['4.2', client-side-encryption, darwinssl, noauth, sasl, server]
-  depends_on: {name: debug-compile-sasl-darwinssl-cse}
+  tags:
+  - '4.2'
+  - client-side-encryption
+  - darwinssl
+  - noauth
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.2'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '4.2'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
-      VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.2-server-noauth-sasl-darwinssl
-  tags: ['4.2', darwinssl, noauth, sasl, server]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '4.2'
+  - darwinssl
+  - noauth
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.2-server-noauth-sasl-winssl-cse
-  tags: ['4.2', client-side-encryption, noauth, sasl, server, winssl]
-  depends_on: {name: debug-compile-sasl-winssl-cse}
+  tags:
+  - '4.2'
+  - client-side-encryption
+  - noauth
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl-cse
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl-cse
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '4.2'}
-  - {func: clone drivers-evergreen-tools}
-  - {func: run kms servers}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '4.2'
+  - func: clone drivers-evergreen-tools
+  - func: run kms servers
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      CLIENT_SIDE_ENCRYPTION: 'on'
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.2-server-noauth-sasl-winssl
-  tags: ['4.2', noauth, sasl, server, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '4.2'
+  - noauth
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.2-server-noauth-nosasl-openssl
-  tags: ['4.2', noauth, nosasl, openssl, server]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '4.2'
+  - noauth
+  - nosasl
+  - openssl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.2-server-noauth-nosasl-openssl-static
-  tags: ['4.2', noauth, nosasl, openssl-static, server]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '4.2'
+  - noauth
+  - nosasl
+  - openssl-static
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.2-server-noauth-nosasl-darwinssl
-  tags: ['4.2', darwinssl, noauth, nosasl, server]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '4.2'
+  - darwinssl
+  - noauth
+  - nosasl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.2-server-noauth-nosasl-winssl
-  tags: ['4.2', noauth, nosasl, server, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '4.2'
+  - noauth
+  - nosasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.2-server-noauth-nosasl-nossl
-  tags: ['4.2', noauth, nosasl, nossl, server]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - '4.2'
+  - noauth
+  - nosasl
+  - nossl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-4.2-replica-set-auth-sasl-openssl
-  tags: ['4.2', auth, openssl, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '4.2'
+  - auth
+  - openssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.2-replica-set-auth-sasl-openssl-static
-  tags: ['4.2', auth, openssl-static, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '4.2'
+  - auth
+  - openssl-static
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.2-replica-set-auth-sasl-darwinssl
-  tags: ['4.2', auth, darwinssl, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '4.2'
+  - auth
+  - darwinssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.2-replica-set-auth-sasl-winssl
-  tags: ['4.2', auth, replica_set, sasl, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '4.2'
+  - auth
+  - replica_set
+  - sasl
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.2-replica-set-auth-nosasl-openssl
-  tags: ['4.2', auth, nosasl, openssl, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '4.2'
+  - auth
+  - nosasl
+  - openssl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.2-replica-set-auth-nosasl-openssl-static
-  tags: ['4.2', auth, nosasl, openssl-static, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '4.2'
+  - auth
+  - nosasl
+  - openssl-static
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.2-replica-set-auth-nosasl-darwinssl
-  tags: ['4.2', auth, darwinssl, nosasl, replica_set]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '4.2'
+  - auth
+  - darwinssl
+  - nosasl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.2-replica-set-auth-nosasl-winssl
-  tags: ['4.2', auth, nosasl, replica_set, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '4.2'
+  - auth
+  - nosasl
+  - replica_set
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.2-replica-set-noauth-sasl-openssl
-  tags: ['4.2', noauth, openssl, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '4.2'
+  - noauth
+  - openssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.2-replica-set-noauth-sasl-openssl-static
-  tags: ['4.2', noauth, openssl-static, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '4.2'
+  - noauth
+  - openssl-static
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.2-replica-set-noauth-sasl-darwinssl
-  tags: ['4.2', darwinssl, noauth, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '4.2'
+  - darwinssl
+  - noauth
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.2-replica-set-noauth-sasl-winssl
-  tags: ['4.2', noauth, replica_set, sasl, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '4.2'
+  - noauth
+  - replica_set
+  - sasl
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.2-replica-set-noauth-nosasl-openssl
-  tags: ['4.2', noauth, nosasl, openssl, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '4.2'
+  - noauth
+  - nosasl
+  - openssl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.2-replica-set-noauth-nosasl-openssl-static
-  tags: ['4.2', noauth, nosasl, openssl-static, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '4.2'
+  - noauth
+  - nosasl
+  - openssl-static
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.2-replica-set-noauth-nosasl-darwinssl
-  tags: ['4.2', darwinssl, noauth, nosasl, replica_set]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '4.2'
+  - darwinssl
+  - noauth
+  - nosasl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.2-replica-set-noauth-nosasl-winssl
-  tags: ['4.2', noauth, nosasl, replica_set, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '4.2'
+  - noauth
+  - nosasl
+  - replica_set
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.2-replica-set-noauth-nosasl-nossl
-  tags: ['4.2', noauth, nosasl, nossl, replica_set]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - '4.2'
+  - noauth
+  - nosasl
+  - nossl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-4.2-sharded-auth-sasl-openssl
-  tags: ['4.2', auth, openssl, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '4.2'
+  - auth
+  - openssl
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.2-sharded-auth-sasl-openssl-static
-  tags: ['4.2', auth, openssl-static, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '4.2'
+  - auth
+  - openssl-static
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.2-sharded-auth-sasl-darwinssl
-  tags: ['4.2', auth, darwinssl, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '4.2'
+  - auth
+  - darwinssl
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.2-sharded-auth-sasl-winssl
-  tags: ['4.2', auth, sasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '4.2'
+  - auth
+  - sasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.2-sharded-auth-nosasl-openssl
-  tags: ['4.2', auth, nosasl, openssl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '4.2'
+  - auth
+  - nosasl
+  - openssl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.2-sharded-auth-nosasl-openssl-static
-  tags: ['4.2', auth, nosasl, openssl-static, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '4.2'
+  - auth
+  - nosasl
+  - openssl-static
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.2-sharded-auth-nosasl-darwinssl
-  tags: ['4.2', auth, darwinssl, nosasl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '4.2'
+  - auth
+  - darwinssl
+  - nosasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.2-sharded-auth-nosasl-winssl
-  tags: ['4.2', auth, nosasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '4.2'
+  - auth
+  - nosasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.2-sharded-noauth-sasl-openssl
-  tags: ['4.2', noauth, openssl, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '4.2'
+  - noauth
+  - openssl
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.2-sharded-noauth-sasl-openssl-static
-  tags: ['4.2', noauth, openssl-static, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '4.2'
+  - noauth
+  - openssl-static
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.2-sharded-noauth-sasl-darwinssl
-  tags: ['4.2', darwinssl, noauth, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '4.2'
+  - darwinssl
+  - noauth
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.2-sharded-noauth-sasl-winssl
-  tags: ['4.2', noauth, sasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '4.2'
+  - noauth
+  - sasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.2-sharded-noauth-nosasl-openssl
-  tags: ['4.2', noauth, nosasl, openssl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '4.2'
+  - noauth
+  - nosasl
+  - openssl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.2-sharded-noauth-nosasl-openssl-static
-  tags: ['4.2', noauth, nosasl, openssl-static, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '4.2'
+  - noauth
+  - nosasl
+  - openssl-static
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.2-sharded-noauth-nosasl-darwinssl
-  tags: ['4.2', darwinssl, noauth, nosasl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '4.2'
+  - darwinssl
+  - noauth
+  - nosasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.2-sharded-noauth-nosasl-winssl
-  tags: ['4.2', noauth, nosasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '4.2'
+  - noauth
+  - nosasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.2-sharded-noauth-nosasl-nossl
-  tags: ['4.2', noauth, nosasl, nossl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - '4.2'
+  - noauth
+  - nosasl
+  - nossl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.2'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-4.0-server-auth-sasl-openssl
-  tags: ['4.0', auth, openssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '4.0'
+  - auth
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.0-server-auth-sasl-openssl-static
-  tags: ['4.0', auth, openssl-static, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '4.0'
+  - auth
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.0-server-auth-sasl-darwinssl
-  tags: ['4.0', auth, darwinssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '4.0'
+  - auth
+  - darwinssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.0-server-auth-sasl-winssl
-  tags: ['4.0', auth, sasl, server, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '4.0'
+  - auth
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.0-server-auth-nosasl-openssl
-  tags: ['4.0', auth, nosasl, openssl, server]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '4.0'
+  - auth
+  - nosasl
+  - openssl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.0-server-auth-nosasl-openssl-static
-  tags: ['4.0', auth, nosasl, openssl-static, server]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '4.0'
+  - auth
+  - nosasl
+  - openssl-static
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.0-server-auth-nosasl-darwinssl
-  tags: ['4.0', auth, darwinssl, nosasl, server]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '4.0'
+  - auth
+  - darwinssl
+  - nosasl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.0-server-auth-nosasl-winssl
-  tags: ['4.0', auth, nosasl, server, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '4.0'
+  - auth
+  - nosasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.0-server-noauth-sasl-openssl
-  tags: ['4.0', noauth, openssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '4.0'
+  - noauth
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.0-server-noauth-sasl-openssl-static
-  tags: ['4.0', noauth, openssl-static, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '4.0'
+  - noauth
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.0-server-noauth-sasl-darwinssl
-  tags: ['4.0', darwinssl, noauth, sasl, server]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '4.0'
+  - darwinssl
+  - noauth
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.0-server-noauth-sasl-winssl
-  tags: ['4.0', noauth, sasl, server, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '4.0'
+  - noauth
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.0-server-noauth-nosasl-openssl
-  tags: ['4.0', noauth, nosasl, openssl, server]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '4.0'
+  - noauth
+  - nosasl
+  - openssl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.0-server-noauth-nosasl-openssl-static
-  tags: ['4.0', noauth, nosasl, openssl-static, server]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '4.0'
+  - noauth
+  - nosasl
+  - openssl-static
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.0-server-noauth-nosasl-darwinssl
-  tags: ['4.0', darwinssl, noauth, nosasl, server]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '4.0'
+  - darwinssl
+  - noauth
+  - nosasl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.0-server-noauth-nosasl-winssl
-  tags: ['4.0', noauth, nosasl, server, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '4.0'
+  - noauth
+  - nosasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.0-server-noauth-nosasl-nossl
-  tags: ['4.0', noauth, nosasl, nossl, server]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - '4.0'
+  - noauth
+  - nosasl
+  - nossl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-4.0-replica-set-auth-sasl-openssl
-  tags: ['4.0', auth, openssl, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '4.0'
+  - auth
+  - openssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.0-replica-set-auth-sasl-openssl-static
-  tags: ['4.0', auth, openssl-static, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '4.0'
+  - auth
+  - openssl-static
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.0-replica-set-auth-sasl-darwinssl
-  tags: ['4.0', auth, darwinssl, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '4.0'
+  - auth
+  - darwinssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.0-replica-set-auth-sasl-winssl
-  tags: ['4.0', auth, replica_set, sasl, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '4.0'
+  - auth
+  - replica_set
+  - sasl
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.0-replica-set-auth-nosasl-openssl
-  tags: ['4.0', auth, nosasl, openssl, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '4.0'
+  - auth
+  - nosasl
+  - openssl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.0-replica-set-auth-nosasl-openssl-static
-  tags: ['4.0', auth, nosasl, openssl-static, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '4.0'
+  - auth
+  - nosasl
+  - openssl-static
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.0-replica-set-auth-nosasl-darwinssl
-  tags: ['4.0', auth, darwinssl, nosasl, replica_set]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '4.0'
+  - auth
+  - darwinssl
+  - nosasl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.0-replica-set-auth-nosasl-winssl
-  tags: ['4.0', auth, nosasl, replica_set, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '4.0'
+  - auth
+  - nosasl
+  - replica_set
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.0-replica-set-noauth-sasl-openssl
-  tags: ['4.0', noauth, openssl, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '4.0'
+  - noauth
+  - openssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.0-replica-set-noauth-sasl-openssl-static
-  tags: ['4.0', noauth, openssl-static, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '4.0'
+  - noauth
+  - openssl-static
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.0-replica-set-noauth-sasl-darwinssl
-  tags: ['4.0', darwinssl, noauth, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '4.0'
+  - darwinssl
+  - noauth
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.0-replica-set-noauth-sasl-winssl
-  tags: ['4.0', noauth, replica_set, sasl, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '4.0'
+  - noauth
+  - replica_set
+  - sasl
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.0-replica-set-noauth-nosasl-openssl
-  tags: ['4.0', noauth, nosasl, openssl, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '4.0'
+  - noauth
+  - nosasl
+  - openssl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.0-replica-set-noauth-nosasl-openssl-static
-  tags: ['4.0', noauth, nosasl, openssl-static, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '4.0'
+  - noauth
+  - nosasl
+  - openssl-static
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.0-replica-set-noauth-nosasl-darwinssl
-  tags: ['4.0', darwinssl, noauth, nosasl, replica_set]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '4.0'
+  - darwinssl
+  - noauth
+  - nosasl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.0-replica-set-noauth-nosasl-winssl
-  tags: ['4.0', noauth, nosasl, replica_set, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '4.0'
+  - noauth
+  - nosasl
+  - replica_set
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.0-replica-set-noauth-nosasl-nossl
-  tags: ['4.0', noauth, nosasl, nossl, replica_set]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - '4.0'
+  - noauth
+  - nosasl
+  - nossl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-4.0-sharded-auth-sasl-openssl
-  tags: ['4.0', auth, openssl, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '4.0'
+  - auth
+  - openssl
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.0-sharded-auth-sasl-openssl-static
-  tags: ['4.0', auth, openssl-static, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '4.0'
+  - auth
+  - openssl-static
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.0-sharded-auth-sasl-darwinssl
-  tags: ['4.0', auth, darwinssl, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '4.0'
+  - auth
+  - darwinssl
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.0-sharded-auth-sasl-winssl
-  tags: ['4.0', auth, sasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '4.0'
+  - auth
+  - sasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.0-sharded-auth-nosasl-openssl
-  tags: ['4.0', auth, nosasl, openssl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '4.0'
+  - auth
+  - nosasl
+  - openssl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.0-sharded-auth-nosasl-openssl-static
-  tags: ['4.0', auth, nosasl, openssl-static, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '4.0'
+  - auth
+  - nosasl
+  - openssl-static
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.0-sharded-auth-nosasl-darwinssl
-  tags: ['4.0', auth, darwinssl, nosasl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '4.0'
+  - auth
+  - darwinssl
+  - nosasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.0-sharded-auth-nosasl-winssl
-  tags: ['4.0', auth, nosasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '4.0'
+  - auth
+  - nosasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.0-sharded-noauth-sasl-openssl
-  tags: ['4.0', noauth, openssl, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '4.0'
+  - noauth
+  - openssl
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.0-sharded-noauth-sasl-openssl-static
-  tags: ['4.0', noauth, openssl-static, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '4.0'
+  - noauth
+  - openssl-static
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.0-sharded-noauth-sasl-darwinssl
-  tags: ['4.0', darwinssl, noauth, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '4.0'
+  - darwinssl
+  - noauth
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.0-sharded-noauth-sasl-winssl
-  tags: ['4.0', noauth, sasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '4.0'
+  - noauth
+  - sasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.0-sharded-noauth-nosasl-openssl
-  tags: ['4.0', noauth, nosasl, openssl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '4.0'
+  - noauth
+  - nosasl
+  - openssl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-4.0-sharded-noauth-nosasl-openssl-static
-  tags: ['4.0', noauth, nosasl, openssl-static, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '4.0'
+  - noauth
+  - nosasl
+  - openssl-static
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-4.0-sharded-noauth-nosasl-darwinssl
-  tags: ['4.0', darwinssl, noauth, nosasl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '4.0'
+  - darwinssl
+  - noauth
+  - nosasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-4.0-sharded-noauth-nosasl-winssl
-  tags: ['4.0', noauth, nosasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '4.0'
+  - noauth
+  - nosasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-4.0-sharded-noauth-nosasl-nossl
-  tags: ['4.0', noauth, nosasl, nossl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - '4.0'
+  - noauth
+  - nosasl
+  - nossl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '4.0'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-3.6-server-auth-sasl-openssl
-  tags: ['3.6', auth, openssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '3.6'
+  - auth
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-3.6-server-auth-sasl-openssl-static
-  tags: ['3.6', auth, openssl-static, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '3.6'
+  - auth
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-3.6-server-auth-sasl-darwinssl
-  tags: ['3.6', auth, darwinssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '3.6'
+  - auth
+  - darwinssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-3.6-server-auth-sasl-winssl
-  tags: ['3.6', auth, sasl, server, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '3.6'
+  - auth
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-3.6-server-auth-nosasl-openssl
-  tags: ['3.6', auth, nosasl, openssl, server]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '3.6'
+  - auth
+  - nosasl
+  - openssl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-3.6-server-auth-nosasl-openssl-static
-  tags: ['3.6', auth, nosasl, openssl-static, server]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '3.6'
+  - auth
+  - nosasl
+  - openssl-static
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-3.6-server-auth-nosasl-darwinssl
-  tags: ['3.6', auth, darwinssl, nosasl, server]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '3.6'
+  - auth
+  - darwinssl
+  - nosasl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-3.6-server-auth-nosasl-winssl
-  tags: ['3.6', auth, nosasl, server, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '3.6'
+  - auth
+  - nosasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-3.6-server-noauth-sasl-openssl
-  tags: ['3.6', noauth, openssl, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '3.6'
+  - noauth
+  - openssl
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-3.6-server-noauth-sasl-openssl-static
-  tags: ['3.6', noauth, openssl-static, sasl, server]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '3.6'
+  - noauth
+  - openssl-static
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-3.6-server-noauth-sasl-darwinssl
-  tags: ['3.6', darwinssl, noauth, sasl, server]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '3.6'
+  - darwinssl
+  - noauth
+  - sasl
+  - server
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-3.6-server-noauth-sasl-winssl
-  tags: ['3.6', noauth, sasl, server, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '3.6'
+  - noauth
+  - sasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-3.6-server-noauth-nosasl-openssl
-  tags: ['3.6', noauth, nosasl, openssl, server]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '3.6'
+  - noauth
+  - nosasl
+  - openssl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: server
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-3.6-server-noauth-nosasl-openssl-static
-  tags: ['3.6', noauth, nosasl, openssl-static, server]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '3.6'
+  - noauth
+  - nosasl
+  - openssl-static
+  - server
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: server
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-3.6-server-noauth-nosasl-darwinssl
-  tags: ['3.6', darwinssl, noauth, nosasl, server]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '3.6'
+  - darwinssl
+  - noauth
+  - nosasl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: server
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-3.6-server-noauth-nosasl-winssl
-  tags: ['3.6', noauth, nosasl, server, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '3.6'
+  - noauth
+  - nosasl
+  - server
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: server
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-3.6-server-noauth-nosasl-nossl
-  tags: ['3.6', noauth, nosasl, nossl, server]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - '3.6'
+  - noauth
+  - nosasl
+  - nossl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-3.6-replica-set-auth-sasl-openssl
-  tags: ['3.6', auth, openssl, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '3.6'
+  - auth
+  - openssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-3.6-replica-set-auth-sasl-openssl-static
-  tags: ['3.6', auth, openssl-static, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '3.6'
+  - auth
+  - openssl-static
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-3.6-replica-set-auth-sasl-darwinssl
-  tags: ['3.6', auth, darwinssl, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '3.6'
+  - auth
+  - darwinssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-3.6-replica-set-auth-sasl-winssl
-  tags: ['3.6', auth, replica_set, sasl, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '3.6'
+  - auth
+  - replica_set
+  - sasl
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-3.6-replica-set-auth-nosasl-openssl
-  tags: ['3.6', auth, nosasl, openssl, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '3.6'
+  - auth
+  - nosasl
+  - openssl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-3.6-replica-set-auth-nosasl-openssl-static
-  tags: ['3.6', auth, nosasl, openssl-static, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '3.6'
+  - auth
+  - nosasl
+  - openssl-static
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-3.6-replica-set-auth-nosasl-darwinssl
-  tags: ['3.6', auth, darwinssl, nosasl, replica_set]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '3.6'
+  - auth
+  - darwinssl
+  - nosasl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-3.6-replica-set-auth-nosasl-winssl
-  tags: ['3.6', auth, nosasl, replica_set, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '3.6'
+  - auth
+  - nosasl
+  - replica_set
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-3.6-replica-set-noauth-sasl-openssl
-  tags: ['3.6', noauth, openssl, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '3.6'
+  - noauth
+  - openssl
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-3.6-replica-set-noauth-sasl-openssl-static
-  tags: ['3.6', noauth, openssl-static, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '3.6'
+  - noauth
+  - openssl-static
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-3.6-replica-set-noauth-sasl-darwinssl
-  tags: ['3.6', darwinssl, noauth, replica_set, sasl]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '3.6'
+  - darwinssl
+  - noauth
+  - replica_set
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-3.6-replica-set-noauth-sasl-winssl
-  tags: ['3.6', noauth, replica_set, sasl, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '3.6'
+  - noauth
+  - replica_set
+  - sasl
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-3.6-replica-set-noauth-nosasl-openssl
-  tags: ['3.6', noauth, nosasl, openssl, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '3.6'
+  - noauth
+  - nosasl
+  - openssl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-3.6-replica-set-noauth-nosasl-openssl-static
-  tags: ['3.6', noauth, nosasl, openssl-static, replica_set]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '3.6'
+  - noauth
+  - nosasl
+  - openssl-static
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-3.6-replica-set-noauth-nosasl-darwinssl
-  tags: ['3.6', darwinssl, noauth, nosasl, replica_set]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '3.6'
+  - darwinssl
+  - noauth
+  - nosasl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-3.6-replica-set-noauth-nosasl-winssl
-  tags: ['3.6', noauth, nosasl, replica_set, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '3.6'
+  - noauth
+  - nosasl
+  - replica_set
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-3.6-replica-set-noauth-nosasl-nossl
-  tags: ['3.6', noauth, nosasl, nossl, replica_set]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - '3.6'
+  - noauth
+  - nosasl
+  - nossl
+  - replica_set
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: replica_set
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-3.6-sharded-auth-sasl-openssl
-  tags: ['3.6', auth, openssl, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '3.6'
+  - auth
+  - openssl
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-3.6-sharded-auth-sasl-openssl-static
-  tags: ['3.6', auth, openssl-static, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '3.6'
+  - auth
+  - openssl-static
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-3.6-sharded-auth-sasl-darwinssl
-  tags: ['3.6', auth, darwinssl, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '3.6'
+  - auth
+  - darwinssl
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-3.6-sharded-auth-sasl-winssl
-  tags: ['3.6', auth, sasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '3.6'
+  - auth
+  - sasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-3.6-sharded-auth-nosasl-openssl
-  tags: ['3.6', auth, nosasl, openssl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '3.6'
+  - auth
+  - nosasl
+  - openssl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-3.6-sharded-auth-nosasl-openssl-static
-  tags: ['3.6', auth, nosasl, openssl-static, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '3.6'
+  - auth
+  - nosasl
+  - openssl-static
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-3.6-sharded-auth-nosasl-darwinssl
-  tags: ['3.6', auth, darwinssl, nosasl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '3.6'
+  - auth
+  - darwinssl
+  - nosasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-3.6-sharded-auth-nosasl-winssl
-  tags: ['3.6', auth, nosasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '3.6'
+  - auth
+  - nosasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
+    vars:
+      AUTH: auth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: auth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-3.6-sharded-noauth-sasl-openssl
-  tags: ['3.6', noauth, openssl, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - '3.6'
+  - noauth
+  - openssl
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-3.6-sharded-noauth-sasl-openssl-static
-  tags: ['3.6', noauth, openssl-static, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - '3.6'
+  - noauth
+  - openssl-static
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-3.6-sharded-noauth-sasl-darwinssl
-  tags: ['3.6', darwinssl, noauth, sasl, sharded_cluster]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - '3.6'
+  - darwinssl
+  - noauth
+  - sasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-3.6-sharded-noauth-sasl-winssl
-  tags: ['3.6', noauth, sasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-sasl-winssl}
+  tags:
+  - '3.6'
+  - noauth
+  - sasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-sasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-3.6-sharded-noauth-nosasl-openssl
-  tags: ['3.6', noauth, nosasl, openssl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - '3.6'
+  - noauth
+  - nosasl
+  - openssl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: openssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl
+      VALGRIND: 'off'
 - name: test-3.6-sharded-noauth-nosasl-openssl-static
-  tags: ['3.6', noauth, nosasl, openssl-static, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-openssl-static}
+  tags:
+  - '3.6'
+  - noauth
+  - nosasl
+  - openssl-static
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-static
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: openssl-static
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: openssl-static
+      VALGRIND: 'off'
 - name: test-3.6-sharded-noauth-nosasl-darwinssl
-  tags: ['3.6', darwinssl, noauth, nosasl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - '3.6'
+  - darwinssl
+  - noauth
+  - nosasl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: darwinssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: darwinssl
+      VALGRIND: 'off'
 - name: test-3.6-sharded-noauth-nosasl-winssl
-  tags: ['3.6', noauth, nosasl, sharded_cluster, winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - '3.6'
+  - noauth
+  - nosasl
+  - sharded_cluster
+  - winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: winssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: winssl
+      VALGRIND: 'off'
 - name: test-3.6-sharded-noauth-nosasl-nossl
-  tags: ['3.6', noauth, nosasl, nossl, sharded_cluster]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - '3.6'
+  - noauth
+  - nosasl
+  - nossl
+  - sharded_cluster
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '3.6'
   - func: run tests
-    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+    vars:
+      ASAN: 'off'
+      AUTH: noauth
+      SSL: nossl
+      VALGRIND: 'off'
 - name: test-dns-openssl
-  depends_on: {name: debug-compile-sasl-openssl}
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: ssl, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: ssl
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {AUTH: noauth, DNS: 'on', SSL: ssl}
+    vars:
+      AUTH: noauth
+      DNS: 'on'
+      SSL: ssl
 - name: test-dns-winssl
-  depends_on: {name: debug-compile-sspi-winssl}
+  depends_on:
+    name: debug-compile-sspi-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sspi-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sspi-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: ssl, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: ssl
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {AUTH: noauth, DNS: 'on', SSL: ssl}
+    vars:
+      AUTH: noauth
+      DNS: 'on'
+      SSL: ssl
 - name: test-dns-darwinssl
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: ssl, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: noauth
+      SSL: ssl
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {AUTH: noauth, DNS: 'on', SSL: ssl}
+    vars:
+      AUTH: noauth
+      DNS: 'on'
+      SSL: ssl
 - name: test-dns-loadbalanced-openssl
-  depends_on: {name: debug-compile-sasl-openssl}
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: ssl, TOPOLOGY: sharded_cluster, VERSION: latest}
-  - {func: clone drivers-evergreen-tools}
+    vars:
+      AUTH: noauth
+      SSL: ssl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
   - func: start load balancer
-    vars: {MONGODB_URI: 'mongodb://localhost:27017,localhost:27018'}
+    vars:
+      MONGODB_URI: mongodb://localhost:27017,localhost:27018
   - func: run tests
-    vars: {AUTH: noauth, DNS: loadbalanced, SSL: ssl}
+    vars:
+      AUTH: noauth
+      DNS: loadbalanced
+      SSL: ssl
 - name: test-dns-auth-openssl
-  depends_on: {name: debug-compile-sasl-openssl}
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: ssl, TOPOLOGY: replica_set, VERSION: latest, AUTHSOURCE: thisDB}
+    vars:
+      AUTH: auth
+      SSL: ssl
+      TOPOLOGY: replica_set
+      VERSION: latest
+      AUTHSOURCE: thisDB
   - func: run tests
-    vars: {AUTH: auth, DNS: dns-auth, SSL: ssl}
+    vars:
+      AUTH: auth
+      DNS: dns-auth
+      SSL: ssl
 - name: test-dns-auth-winssl
-  depends_on: {name: debug-compile-sspi-winssl}
+  depends_on:
+    name: debug-compile-sspi-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sspi-winssl}
+    vars:
+      BUILD_NAME: debug-compile-sspi-winssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: ssl, TOPOLOGY: replica_set, VERSION: latest, AUTHSOURCE: thisDB}
+    vars:
+      AUTH: auth
+      SSL: ssl
+      TOPOLOGY: replica_set
+      VERSION: latest
+      AUTHSOURCE: thisDB
   - func: run tests
-    vars: {AUTH: auth, DNS: dns-auth, SSL: ssl}
+    vars:
+      AUTH: auth
+      DNS: dns-auth
+      SSL: ssl
 - name: test-dns-auth-darwinssl
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: ssl, TOPOLOGY: replica_set, VERSION: latest, AUTHSOURCE: thisDB}
+    vars:
+      AUTH: auth
+      SSL: ssl
+      TOPOLOGY: replica_set
+      VERSION: latest
+      AUTHSOURCE: thisDB
   - func: run tests
-    vars: {AUTH: auth, DNS: dns-auth, SSL: ssl}
+    vars:
+      AUTH: auth
+      DNS: dns-auth
+      SSL: ssl
 - name: test-latest-server-compression-zlib
-  tags: [compression, latest, zlib]
-  depends_on: {name: debug-compile-compression-zlib}
+  tags:
+  - compression
+  - latest
+  - zlib
+  depends_on:
+    name: debug-compile-compression-zlib
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-compression-zlib}
+    vars:
+      BUILD_NAME: debug-compile-compression-zlib
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, ORCHESTRATION_FILE: zlib, SSL: nossl, VERSION: latest}
+    vars:
+      AUTH: noauth
+      ORCHESTRATION_FILE: zlib
+      SSL: nossl
+      VERSION: latest
   - func: run tests
-    vars: {AUTH: noauth, COMPRESSORS: zlib, SSL: nossl}
+    vars:
+      AUTH: noauth
+      COMPRESSORS: zlib
+      SSL: nossl
 - name: test-latest-server-compression-snappy
-  tags: [compression, latest, snappy]
-  depends_on: {name: debug-compile-compression-snappy}
+  tags:
+  - compression
+  - latest
+  - snappy
+  depends_on:
+    name: debug-compile-compression-snappy
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-compression-snappy}
+    vars:
+      BUILD_NAME: debug-compile-compression-snappy
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, ORCHESTRATION_FILE: snappy, SSL: nossl, VERSION: latest}
+    vars:
+      AUTH: noauth
+      ORCHESTRATION_FILE: snappy
+      SSL: nossl
+      VERSION: latest
   - func: run tests
-    vars: {AUTH: noauth, COMPRESSORS: snappy, SSL: nossl}
+    vars:
+      AUTH: noauth
+      COMPRESSORS: snappy
+      SSL: nossl
 - name: test-latest-server-compression-zstd
-  tags: [compression, latest, zstd]
-  depends_on: {name: debug-compile-compression-zstd}
+  tags:
+  - compression
+  - latest
+  - zstd
+  depends_on:
+    name: debug-compile-compression-zstd
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-compression-zstd}
+    vars:
+      BUILD_NAME: debug-compile-compression-zstd
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, ORCHESTRATION_FILE: zstd, SSL: nossl, VERSION: latest}
+    vars:
+      AUTH: noauth
+      ORCHESTRATION_FILE: zstd
+      SSL: nossl
+      VERSION: latest
   - func: run tests
-    vars: {AUTH: noauth, COMPRESSORS: zstd, SSL: nossl}
+    vars:
+      AUTH: noauth
+      COMPRESSORS: zstd
+      SSL: nossl
 - name: test-latest-server-compression
-  tags: [compression, latest, snappy, zlib, zstd]
-  depends_on: {name: debug-compile-compression}
+  tags:
+  - compression
+  - latest
+  - snappy
+  - zlib
+  - zstd
+  depends_on:
+    name: debug-compile-compression
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-compression}
+    vars:
+      BUILD_NAME: debug-compile-compression
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, ORCHESTRATION_FILE: snappy-zlib-zstd, SSL: nossl, VERSION: latest}
+    vars:
+      AUTH: noauth
+      ORCHESTRATION_FILE: snappy-zlib-zstd
+      SSL: nossl
+      VERSION: latest
   - func: run tests
-    vars: {AUTH: noauth, COMPRESSORS: 'snappy,zlib,zstd', SSL: nossl}
+    vars:
+      AUTH: noauth
+      COMPRESSORS: snappy,zlib,zstd
+      SSL: nossl
 - name: retry-true-latest-server
-  depends_on: {name: debug-compile-sasl-openssl}
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {TOPOLOGY: server, VERSION: latest}
+    vars:
+      TOPOLOGY: server
+      VERSION: latest
   - func: run tests
-    vars: {URI: 'mongodb://localhost/?retryWrites=true'}
+    vars:
+      URI: mongodb://localhost/?retryWrites=true
 - name: test-latest-server-hardened
-  tags: [hardened, latest]
-  depends_on: {name: hardened-compile}
+  tags:
+  - hardened
+  - latest
+  depends_on:
+    name: hardened-compile
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: hardened-compile}
+    vars:
+      BUILD_NAME: hardened-compile
   - func: bootstrap mongo-orchestration
-    vars: {TOPOLOGY: server, VERSION: latest}
-  - {func: run tests}
+    vars:
+      TOPOLOGY: server
+      VERSION: latest
+  - func: run tests
 - name: authentication-tests-openssl
-  tags: [authentication-tests, openssl, sasl]
-  depends_on: {name: debug-compile-sasl-openssl}
+  tags:
+  - authentication-tests
+  - openssl
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
-  - {func: run auth tests}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
+  - func: run auth tests
 - name: authentication-tests-openssl-static
-  tags: [authentication-tests, openssl-static, sasl]
-  depends_on: {name: debug-compile-sasl-openssl-static}
+  tags:
+  - authentication-tests
+  - openssl-static
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-openssl-static
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
-  - {func: run auth tests}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl-static
+  - func: run auth tests
 - name: authentication-tests-darwinssl
-  tags: [authentication-tests, darwinssl, sasl]
-  depends_on: {name: debug-compile-sasl-darwinssl}
+  tags:
+  - authentication-tests
+  - darwinssl
+  - sasl
+  depends_on:
+    name: debug-compile-sasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
-  - {func: run auth tests}
+    vars:
+      BUILD_NAME: debug-compile-sasl-darwinssl
+  - func: run auth tests
 - name: authentication-tests-winssl
-  tags: [authentication-tests, sspi, winssl]
-  depends_on: {name: debug-compile-sspi-winssl}
+  tags:
+  - authentication-tests
+  - sspi
+  - winssl
+  depends_on:
+    name: debug-compile-sspi-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sspi-winssl}
-  - {func: run auth tests}
+    vars:
+      BUILD_NAME: debug-compile-sspi-winssl
+  - func: run auth tests
 - name: authentication-tests-openssl-nosasl
-  tags: [authentication-tests, nosasl, openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - authentication-tests
+  - nosasl
+  - openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
-  - {func: run auth tests}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
+  - func: run auth tests
 - name: test-valgrind-memcheck-mock-server
-  tags: [test-valgrind]
-  depends_on: {name: debug-compile-valgrind}
+  tags:
+  - test-valgrind
+  depends_on:
+    name: debug-compile-valgrind
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-valgrind}
+    vars:
+      BUILD_NAME: debug-compile-valgrind
   - func: run mock server tests
-    vars: {SSL: ssl, VALGRIND: 'on'}
+    vars:
+      SSL: ssl
+      VALGRIND: 'on'
 - name: test-asan-memcheck-mock-server
-  tags: [test-asan]
-  depends_on: {name: debug-compile-asan-clang}
+  tags:
+  - test-asan
+  depends_on:
+    name: debug-compile-asan-clang
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang
   - func: run mock server tests
-    vars: {ASAN: 'on', SSL: ssl}
+    vars:
+      ASAN: 'on'
+      SSL: ssl
 - name: test-mongohouse
-  depends_on: {name: debug-compile-sasl-openssl}
+  depends_on:
+    name: debug-compile-sasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-sasl-openssl}
-  - {func: build mongohouse}
-  - {func: run mongohouse}
-  - {func: test mongohouse}
+    vars:
+      BUILD_NAME: debug-compile-sasl-openssl
+  - func: build mongohouse
+  - func: run mongohouse
+  - func: test mongohouse
 - name: test-coverage-mock-server
-  tags: [test-coverage]
+  tags:
+  - test-coverage
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-openssl}
+  - func: debug-compile-coverage-notest-nosasl-openssl
   - func: run mock server tests
-    vars: {SSL: ssl}
-  - {func: update codecov.io}
+    vars:
+      SSL: ssl
+  - func: update codecov.io
 - name: test-coverage-latest-server-dns
-  tags: [test-coverage]
+  tags:
+  - test-coverage
   exec_timeout_secs: 3600
   commands:
-  - {func: debug-compile-coverage-notest-nosasl-openssl}
+  - func: debug-compile-coverage-notest-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: ssl, TOPOLOGY: replica_set, VERSION: latest}
+    vars:
+      AUTH: auth
+      SSL: ssl
+      TOPOLOGY: replica_set
+      VERSION: latest
   - func: run tests
-    vars: {AUTH: auth, DNS: 'on', SSL: ssl}
-  - {func: update codecov.io}
+    vars:
+      AUTH: auth
+      DNS: 'on'
+      SSL: ssl
+  - func: update codecov.io
 - name: authentication-tests-memcheck
-  tags: [authentication-tests, valgrind]
+  tags:
+  - authentication-tests
+  - valgrind
   commands:
   - command: shell.exec
     type: test
@@ -8115,32 +16917,53 @@ tasks:
         set -o errexit
         VALGRIND=ON DEBUG=ON CC='${CC}' MARCH='${MARCH}' SASL=AUTO                   SSL=OPENSSL sh .evergreen/compile.sh
   - func: run auth tests
-    vars: {valgrind: 'true'}
+    vars:
+      valgrind: 'true'
 - name: test-versioned-api
-  tags: [versioned-api]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - versioned-api
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, REQUIRE_API_VERSION: 'true', SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      REQUIRE_API_VERSION: 'true'
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: test versioned api
-    vars: {AUTH: auth, SSL: ssl}
+    vars:
+      AUTH: auth
+      SSL: ssl
 - name: test-versioned-api-accept-version-two
-  tags: [versioned-api]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - versioned-api
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, ORCHESTRATION_FILE: versioned-api-testing, SSL: nossl, TOPOLOGY: server,
-      VERSION: '5.0'}
+    vars:
+      AUTH: noauth
+      ORCHESTRATION_FILE: versioned-api-testing
+      SSL: nossl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: test versioned api
-    vars: {AUTH: noauth, SSL: nossl}
+    vars:
+      AUTH: noauth
+      SSL: nossl
 - name: build-and-run-authentication-tests-openssl-0.9.8
   commands:
   - func: install ssl
-    vars: {SSL: openssl-0.9.8zh}
+    vars:
+      SSL: openssl-0.9.8zh
   - command: shell.exec
     type: test
     params:
@@ -8150,12 +16973,14 @@ tasks:
         set -o errexit
         DEBUG=ON CC='${CC}' MARCH='${MARCH}' SASL=OFF SSL=OPENSSL sh .evergreen/compile.sh
   - func: run auth tests
-    vars: {obsolete_tls: true}
-  - {func: upload build}
+    vars:
+      obsolete_tls: true
+  - func: upload build
 - name: build-and-run-authentication-tests-openssl-1.0.0
   commands:
   - func: install ssl
-    vars: {SSL: openssl-1.0.0t}
+    vars:
+      SSL: openssl-1.0.0t
   - command: shell.exec
     type: test
     params:
@@ -8165,12 +16990,14 @@ tasks:
         set -o errexit
         DEBUG=ON CC='${CC}' MARCH='${MARCH}' SASL=OFF SSL=OPENSSL sh .evergreen/compile.sh
   - func: run auth tests
-    vars: {obsolete_tls: true}
-  - {func: upload build}
+    vars:
+      obsolete_tls: true
+  - func: upload build
 - name: build-and-run-authentication-tests-openssl-1.0.1
   commands:
   - func: install ssl
-    vars: {SSL: openssl-1.0.1u}
+    vars:
+      SSL: openssl-1.0.1u
   - command: shell.exec
     type: test
     params:
@@ -8180,12 +17007,13 @@ tasks:
         set -o errexit
         export CFLAGS=-Wno-redundant-decls
         DEBUG=ON CC='${CC}' MARCH='${MARCH}' SASL=OFF SSL=OPENSSL sh .evergreen/compile.sh
-  - {func: run auth tests}
-  - {func: upload build}
+  - func: run auth tests
+  - func: upload build
 - name: build-and-run-authentication-tests-openssl-1.0.1-fips
   commands:
   - func: install ssl
-    vars: {SSL: openssl-1.0.1u-fips}
+    vars:
+      SSL: openssl-1.0.1u-fips
   - command: shell.exec
     type: test
     params:
@@ -8195,12 +17023,13 @@ tasks:
         set -o errexit
         export CFLAGS=-Wno-redundant-decls
         DEBUG=ON CC='${CC}' MARCH='${MARCH}' SASL=OFF SSL=OPENSSL OPENSSL_FIPS=1 sh .evergreen/compile.sh
-  - {func: run auth tests}
-  - {func: upload build}
+  - func: run auth tests
+  - func: upload build
 - name: build-and-run-authentication-tests-openssl-1.0.2
   commands:
   - func: install ssl
-    vars: {SSL: openssl-1.0.2l}
+    vars:
+      SSL: openssl-1.0.2l
   - command: shell.exec
     type: test
     params:
@@ -8209,12 +17038,13 @@ tasks:
       script: |-
         set -o errexit
         DEBUG=ON CC='${CC}' MARCH='${MARCH}' SASL=OFF SSL=OPENSSL sh .evergreen/compile.sh
-  - {func: run auth tests}
-  - {func: upload build}
+  - func: run auth tests
+  - func: upload build
 - name: build-and-run-authentication-tests-openssl-1.1.0
   commands:
   - func: install ssl
-    vars: {SSL: openssl-1.1.0f}
+    vars:
+      SSL: openssl-1.1.0f
   - command: shell.exec
     type: test
     params:
@@ -8223,12 +17053,13 @@ tasks:
       script: |-
         set -o errexit
         DEBUG=ON CC='${CC}' MARCH='${MARCH}' SASL=OFF SSL=OPENSSL sh .evergreen/compile.sh
-  - {func: run auth tests}
-  - {func: upload build}
+  - func: run auth tests
+  - func: upload build
 - name: build-and-run-authentication-tests-libressl-2.5
   commands:
   - func: install ssl
-    vars: {SSL: libressl-2.5.2}
+    vars:
+      SSL: libressl-2.5.2
   - command: shell.exec
     type: test
     params:
@@ -8238,12 +17069,14 @@ tasks:
         set -o errexit
         DEBUG=ON CC='${CC}' MARCH='${MARCH}' SASL=OFF SSL=LIBRESSL sh .evergreen/compile.sh
   - func: run auth tests
-    vars: {require_tls12: true}
-  - {func: upload build}
+    vars:
+      require_tls12: true
+  - func: upload build
 - name: build-and-run-authentication-tests-libressl-3.0-auto
   commands:
   - func: install ssl
-    vars: {SSL: libressl-3.0.2}
+    vars:
+      SSL: libressl-3.0.2
   - command: shell.exec
     type: test
     params:
@@ -8254,12 +17087,14 @@ tasks:
         export CFLAGS=-Wno-redundant-decls
         DEBUG=ON CC='${CC}' MARCH='${MARCH}' SASL=OFF SSL=AUTO sh .evergreen/compile.sh
   - func: run auth tests
-    vars: {require_tls12: true}
-  - {func: upload build}
+    vars:
+      require_tls12: true
+  - func: upload build
 - name: build-and-run-authentication-tests-libressl-3.0
   commands:
   - func: install ssl
-    vars: {SSL: libressl-3.0.2}
+    vars:
+      SSL: libressl-3.0.2
   - command: shell.exec
     type: test
     params:
@@ -8269,48 +17104,93 @@ tasks:
         set -o errexit
         DEBUG=ON CC='${CC}' MARCH='${MARCH}' SASL=OFF SSL=LIBRESSL sh .evergreen/compile.sh
   - func: run auth tests
-    vars: {require_tls12: true}
-  - {func: upload build}
+    vars:
+      require_tls12: true
+  - func: upload build
 - name: test-latest-server-ipv6-client-ipv6-noauth-nosasl-nossl
-  tags: [ipv4-ipv6, latest, nosasl, nossl, server]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - ipv4-ipv6
+  - latest
+  - nosasl
+  - nossl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {IPV4_ONLY: 'off', VERSION: latest}
+    vars:
+      IPV4_ONLY: 'off'
+      VERSION: latest
   - func: run tests
-    vars: {IPV4_ONLY: 'off', URI: 'mongodb://[::1]/'}
+    vars:
+      IPV4_ONLY: 'off'
+      URI: mongodb://[::1]/
 - name: test-latest-server-ipv6-client-ipv4-noauth-nosasl-nossl
-  tags: [ipv4-ipv6, latest, nosasl, nossl, server]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - ipv4-ipv6
+  - latest
+  - nosasl
+  - nossl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {IPV4_ONLY: 'off', VERSION: latest}
+    vars:
+      IPV4_ONLY: 'off'
+      VERSION: latest
   - func: run tests
-    vars: {IPV4_ONLY: 'off', URI: 'mongodb://127.0.0.1/'}
+    vars:
+      IPV4_ONLY: 'off'
+      URI: mongodb://127.0.0.1/
 - name: test-latest-server-ipv4-client-ipv4-noauth-nosasl-nossl
-  tags: [ipv4-ipv6, latest, nosasl, nossl, server]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - ipv4-ipv6
+  - latest
+  - nosasl
+  - nossl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {IPV4_ONLY: 'on', VERSION: latest}
+    vars:
+      IPV4_ONLY: 'on'
+      VERSION: latest
   - func: run tests
-    vars: {IPV4_ONLY: 'on', URI: 'mongodb://127.0.0.1/'}
+    vars:
+      IPV4_ONLY: 'on'
+      URI: mongodb://127.0.0.1/
 - name: test-latest-server-ipv4-client-localhost-noauth-nosasl-nossl
-  tags: [ipv4-ipv6, latest, nosasl, nossl, server]
-  depends_on: {name: debug-compile-nosasl-nossl}
+  tags:
+  - ipv4-ipv6
+  - latest
+  - nosasl
+  - nossl
+  - server
+  depends_on:
+    name: debug-compile-nosasl-nossl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-nossl
   - func: bootstrap mongo-orchestration
-    vars: {IPV4_ONLY: 'on', VERSION: latest}
+    vars:
+      IPV4_ONLY: 'on'
+      VERSION: latest
   - func: run tests
-    vars: {IPV4_ONLY: 'on', URI: 'mongodb://localhost/'}
+    vars:
+      IPV4_ONLY: 'on'
+      URI: mongodb://localhost/
 - name: debug-compile-aws
   commands:
   - command: shell.exec
@@ -8325,148 +17205,256 @@ tasks:
         export CC='${CC}'
         $CMAKE -DENABLE_SASL=OFF -DENABLE_SNAPPY=OFF -DENABLE_ZSTD=OFF -DENABLE_CLIENT_SIDE_ENCRYPTION=OFF .
         $CMAKE --build . --target mongoc-ping
-  - {func: upload build}
+  - func: upload build
 - name: test-aws-openssl-regular-latest
-  depends_on: {name: debug-compile-aws}
+  depends_on:
+    name: debug-compile-aws
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-aws}
+    vars:
+      BUILD_NAME: debug-compile-aws
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: auth
+      ORCHESTRATION_FILE: auth-aws
+      TOPOLOGY: server
+      VERSION: latest
   - func: run aws tests
-    vars: {TESTCASE: REGULAR}
+    vars:
+      TESTCASE: REGULAR
 - name: test-aws-openssl-regular-5.0
-  depends_on: {name: debug-compile-aws}
+  depends_on:
+    name: debug-compile-aws
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-aws}
+    vars:
+      BUILD_NAME: debug-compile-aws
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      ORCHESTRATION_FILE: auth-aws
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run aws tests
-    vars: {TESTCASE: REGULAR}
+    vars:
+      TESTCASE: REGULAR
 - name: test-aws-openssl-regular-4.4
-  depends_on: {name: debug-compile-aws}
+  depends_on:
+    name: debug-compile-aws
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-aws}
+    vars:
+      BUILD_NAME: debug-compile-aws
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      ORCHESTRATION_FILE: auth-aws
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run aws tests
-    vars: {TESTCASE: REGULAR}
+    vars:
+      TESTCASE: REGULAR
 - name: test-aws-openssl-ec2-latest
-  depends_on: {name: debug-compile-aws}
+  depends_on:
+    name: debug-compile-aws
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-aws}
+    vars:
+      BUILD_NAME: debug-compile-aws
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: auth
+      ORCHESTRATION_FILE: auth-aws
+      TOPOLOGY: server
+      VERSION: latest
   - func: run aws tests
-    vars: {TESTCASE: EC2}
+    vars:
+      TESTCASE: EC2
 - name: test-aws-openssl-ec2-5.0
-  depends_on: {name: debug-compile-aws}
+  depends_on:
+    name: debug-compile-aws
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-aws}
+    vars:
+      BUILD_NAME: debug-compile-aws
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      ORCHESTRATION_FILE: auth-aws
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run aws tests
-    vars: {TESTCASE: EC2}
+    vars:
+      TESTCASE: EC2
 - name: test-aws-openssl-ec2-4.4
-  depends_on: {name: debug-compile-aws}
+  depends_on:
+    name: debug-compile-aws
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-aws}
+    vars:
+      BUILD_NAME: debug-compile-aws
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      ORCHESTRATION_FILE: auth-aws
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run aws tests
-    vars: {TESTCASE: EC2}
+    vars:
+      TESTCASE: EC2
 - name: test-aws-openssl-ecs-latest
-  depends_on: {name: debug-compile-aws}
+  depends_on:
+    name: debug-compile-aws
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-aws}
+    vars:
+      BUILD_NAME: debug-compile-aws
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: auth
+      ORCHESTRATION_FILE: auth-aws
+      TOPOLOGY: server
+      VERSION: latest
   - func: run aws tests
-    vars: {TESTCASE: ECS}
+    vars:
+      TESTCASE: ECS
 - name: test-aws-openssl-ecs-5.0
-  depends_on: {name: debug-compile-aws}
+  depends_on:
+    name: debug-compile-aws
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-aws}
+    vars:
+      BUILD_NAME: debug-compile-aws
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      ORCHESTRATION_FILE: auth-aws
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run aws tests
-    vars: {TESTCASE: ECS}
+    vars:
+      TESTCASE: ECS
 - name: test-aws-openssl-ecs-4.4
-  depends_on: {name: debug-compile-aws}
+  depends_on:
+    name: debug-compile-aws
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-aws}
+    vars:
+      BUILD_NAME: debug-compile-aws
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      ORCHESTRATION_FILE: auth-aws
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run aws tests
-    vars: {TESTCASE: ECS}
+    vars:
+      TESTCASE: ECS
 - name: test-aws-openssl-lambda-latest
-  depends_on: {name: debug-compile-aws}
+  depends_on:
+    name: debug-compile-aws
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-aws}
+    vars:
+      BUILD_NAME: debug-compile-aws
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: auth
+      ORCHESTRATION_FILE: auth-aws
+      TOPOLOGY: server
+      VERSION: latest
   - func: run aws tests
-    vars: {TESTCASE: LAMBDA}
+    vars:
+      TESTCASE: LAMBDA
 - name: test-aws-openssl-lambda-5.0
-  depends_on: {name: debug-compile-aws}
+  depends_on:
+    name: debug-compile-aws
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-aws}
+    vars:
+      BUILD_NAME: debug-compile-aws
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      ORCHESTRATION_FILE: auth-aws
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run aws tests
-    vars: {TESTCASE: LAMBDA}
+    vars:
+      TESTCASE: LAMBDA
 - name: test-aws-openssl-lambda-4.4
-  depends_on: {name: debug-compile-aws}
+  depends_on:
+    name: debug-compile-aws
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-aws}
+    vars:
+      BUILD_NAME: debug-compile-aws
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      ORCHESTRATION_FILE: auth-aws
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run aws tests
-    vars: {TESTCASE: LAMBDA}
+    vars:
+      TESTCASE: LAMBDA
 - name: test-aws-openssl-assume_role-latest
-  depends_on: {name: debug-compile-aws}
+  depends_on:
+    name: debug-compile-aws
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-aws}
+    vars:
+      BUILD_NAME: debug-compile-aws
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: latest}
+    vars:
+      AUTH: auth
+      ORCHESTRATION_FILE: auth-aws
+      TOPOLOGY: server
+      VERSION: latest
   - func: run aws tests
-    vars: {TESTCASE: ASSUME_ROLE}
+    vars:
+      TESTCASE: ASSUME_ROLE
 - name: test-aws-openssl-assume_role-5.0
-  depends_on: {name: debug-compile-aws}
+  depends_on:
+    name: debug-compile-aws
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-aws}
+    vars:
+      BUILD_NAME: debug-compile-aws
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      AUTH: auth
+      ORCHESTRATION_FILE: auth-aws
+      TOPOLOGY: server
+      VERSION: '5.0'
   - func: run aws tests
-    vars: {TESTCASE: ASSUME_ROLE}
+    vars:
+      TESTCASE: ASSUME_ROLE
 - name: test-aws-openssl-assume_role-4.4
-  depends_on: {name: debug-compile-aws}
+  depends_on:
+    name: debug-compile-aws
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-aws}
+    vars:
+      BUILD_NAME: debug-compile-aws
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      AUTH: auth
+      ORCHESTRATION_FILE: auth-aws
+      TOPOLOGY: server
+      VERSION: '4.4'
   - func: run aws tests
-    vars: {TESTCASE: ASSUME_ROLE}
+    vars:
+      TESTCASE: ASSUME_ROLE
 - name: ocsp-openssl-test_1-rsa-delegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -8476,8 +17464,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -8487,11 +17479,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_1-rsa-delegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -8501,8 +17496,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -8512,11 +17511,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_1-rsa-delegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -8526,8 +17528,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -8537,11 +17543,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_1-rsa-delegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -8551,8 +17560,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -8563,11 +17576,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_1-rsa-delegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -8577,8 +17593,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -8589,11 +17609,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_1-rsa-delegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -8603,8 +17626,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -8615,11 +17642,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_1-ecdsa-delegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -8629,8 +17659,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -8640,11 +17674,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_1-ecdsa-delegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -8654,8 +17691,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -8665,11 +17706,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_1-ecdsa-delegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -8679,8 +17723,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -8690,11 +17738,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_1-ecdsa-delegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -8704,8 +17755,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -8716,11 +17771,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_1-ecdsa-delegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -8730,8 +17788,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -8742,11 +17804,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_1-ecdsa-delegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -8756,8 +17821,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -8768,11 +17837,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_1-rsa-nodelegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -8782,8 +17854,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -8793,11 +17869,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_1-rsa-nodelegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -8807,8 +17886,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -8818,11 +17901,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_1-rsa-nodelegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -8832,8 +17918,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -8843,11 +17933,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_1-rsa-nodelegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -8857,8 +17950,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -8869,11 +17966,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_1-rsa-nodelegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -8883,8 +17983,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -8895,11 +17999,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_1-rsa-nodelegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -8909,8 +18016,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -8921,11 +18032,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_1-ecdsa-nodelegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -8935,8 +18049,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -8946,11 +18064,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_1-ecdsa-nodelegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -8960,8 +18081,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -8971,11 +18096,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_1-ecdsa-nodelegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -8985,8 +18113,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -8996,11 +18128,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_1-ecdsa-nodelegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -9010,8 +18145,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -9022,11 +18161,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_1-ecdsa-nodelegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -9036,8 +18178,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -9048,11 +18194,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_1-ecdsa-nodelegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -9062,8 +18211,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -9074,11 +18227,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_2-rsa-delegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -9088,8 +18244,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -9099,11 +18259,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_2-rsa-delegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -9113,8 +18276,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -9124,11 +18291,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_2-rsa-delegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -9138,8 +18308,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -9149,11 +18323,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_2-rsa-delegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -9163,8 +18340,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -9175,11 +18356,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_2-rsa-delegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -9189,8 +18373,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -9201,11 +18389,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_2-rsa-delegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -9215,8 +18406,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -9227,11 +18422,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_2-ecdsa-delegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -9241,8 +18439,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -9252,11 +18454,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_2-ecdsa-delegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -9266,8 +18471,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -9277,11 +18486,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_2-ecdsa-delegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -9291,8 +18503,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -9302,11 +18518,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_2-ecdsa-delegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -9316,8 +18535,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -9328,11 +18551,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_2-ecdsa-delegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -9342,8 +18568,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -9354,11 +18584,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_2-ecdsa-delegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -9368,8 +18601,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -9380,11 +18617,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_2-rsa-nodelegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -9394,8 +18634,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -9405,11 +18649,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_2-rsa-nodelegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -9419,8 +18666,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -9430,11 +18681,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_2-rsa-nodelegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -9444,8 +18698,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -9455,11 +18713,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_2-rsa-nodelegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -9469,8 +18730,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -9481,11 +18746,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_2-rsa-nodelegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -9495,8 +18763,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -9507,11 +18779,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_2-rsa-nodelegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -9521,8 +18796,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -9533,11 +18812,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_2-ecdsa-nodelegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -9547,8 +18829,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -9558,11 +18844,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_2-ecdsa-nodelegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -9572,8 +18861,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -9583,11 +18876,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_2-ecdsa-nodelegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -9597,8 +18893,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -9608,11 +18908,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_2-ecdsa-nodelegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -9622,8 +18925,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -9634,11 +18941,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_2-ecdsa-nodelegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -9648,8 +18958,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -9660,11 +18974,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_2-ecdsa-nodelegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -9674,8 +18991,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -9686,11 +19007,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-rsa-delegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -9700,8 +19024,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -9711,11 +19039,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-rsa-delegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -9725,8 +19056,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -9736,11 +19071,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-rsa-delegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -9750,8 +19088,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -9761,11 +19103,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_3-rsa-delegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -9775,8 +19120,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -9787,11 +19136,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_3-rsa-delegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -9801,8 +19153,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -9813,11 +19169,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_3-rsa-delegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -9827,8 +19186,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -9839,11 +19202,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-test_3-rsa-delegate-latest
-  tags: [ocsp-darwinssl]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - command: shell.exec
     type: test
     params:
@@ -9853,8 +19219,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -9864,11 +19234,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-test_3-rsa-delegate-5.0
-  tags: [ocsp-darwinssl]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - command: shell.exec
     type: test
     params:
@@ -9878,8 +19251,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -9889,11 +19266,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-test_3-rsa-delegate-4.4
-  tags: [ocsp-darwinssl]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - command: shell.exec
     type: test
     params:
@@ -9903,8 +19283,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -9914,11 +19298,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-test_3-rsa-delegate-latest
-  tags: [ocsp-winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - ocsp-winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - command: shell.exec
     type: test
     params:
@@ -9928,8 +19315,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -9939,11 +19330,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-test_3-rsa-delegate-5.0
-  tags: [ocsp-winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - ocsp-winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - command: shell.exec
     type: test
     params:
@@ -9953,8 +19347,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -9964,11 +19362,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-test_3-rsa-delegate-4.4
-  tags: [ocsp-winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - ocsp-winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - command: shell.exec
     type: test
     params:
@@ -9978,8 +19379,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -9989,11 +19394,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-ecdsa-delegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -10003,8 +19411,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -10014,11 +19426,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-ecdsa-delegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -10028,8 +19443,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -10039,11 +19458,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-ecdsa-delegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -10053,8 +19475,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -10064,11 +19490,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_3-ecdsa-delegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -10078,8 +19507,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -10090,11 +19523,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_3-ecdsa-delegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -10104,8 +19540,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -10116,11 +19556,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_3-ecdsa-delegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -10130,8 +19573,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -10142,11 +19589,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-rsa-nodelegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -10156,8 +19606,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -10167,11 +19621,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-rsa-nodelegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -10181,8 +19638,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -10192,11 +19653,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-rsa-nodelegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -10206,8 +19670,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -10217,11 +19685,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_3-rsa-nodelegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -10231,8 +19702,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -10243,11 +19718,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_3-rsa-nodelegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -10257,8 +19735,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -10269,11 +19751,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_3-rsa-nodelegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -10283,8 +19768,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -10295,11 +19784,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-test_3-rsa-nodelegate-latest
-  tags: [ocsp-darwinssl]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - command: shell.exec
     type: test
     params:
@@ -10309,8 +19801,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -10320,11 +19816,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-test_3-rsa-nodelegate-5.0
-  tags: [ocsp-darwinssl]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - command: shell.exec
     type: test
     params:
@@ -10334,8 +19833,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -10345,11 +19848,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-test_3-rsa-nodelegate-4.4
-  tags: [ocsp-darwinssl]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - command: shell.exec
     type: test
     params:
@@ -10359,8 +19865,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -10370,11 +19880,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-test_3-rsa-nodelegate-latest
-  tags: [ocsp-winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - ocsp-winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - command: shell.exec
     type: test
     params:
@@ -10384,8 +19897,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -10395,11 +19912,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-test_3-rsa-nodelegate-5.0
-  tags: [ocsp-winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - ocsp-winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - command: shell.exec
     type: test
     params:
@@ -10409,8 +19929,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -10420,11 +19944,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-test_3-rsa-nodelegate-4.4
-  tags: [ocsp-winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - ocsp-winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - command: shell.exec
     type: test
     params:
@@ -10434,8 +19961,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -10445,11 +19976,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-ecdsa-nodelegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -10459,8 +19993,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -10470,11 +20008,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-ecdsa-nodelegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -10484,8 +20025,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -10495,11 +20040,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-ecdsa-nodelegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -10509,8 +20057,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -10520,11 +20072,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_3-ecdsa-nodelegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -10534,8 +20089,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -10546,11 +20105,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_3-ecdsa-nodelegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -10560,8 +20122,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -10572,11 +20138,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_3-ecdsa-nodelegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -10586,8 +20155,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -10598,11 +20171,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_4-rsa-delegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -10612,8 +20188,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -10623,11 +20203,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_4-rsa-delegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -10637,8 +20220,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -10648,11 +20235,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_4-rsa-delegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -10662,8 +20252,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -10673,11 +20267,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_4-rsa-delegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -10687,8 +20284,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -10699,11 +20300,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_4-rsa-delegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -10713,8 +20317,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -10725,11 +20333,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_4-rsa-delegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -10739,8 +20350,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -10751,11 +20366,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-test_4-rsa-delegate-latest
-  tags: [ocsp-darwinssl]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - command: shell.exec
     type: test
     params:
@@ -10765,8 +20383,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -10776,11 +20398,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-test_4-rsa-delegate-5.0
-  tags: [ocsp-darwinssl]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - command: shell.exec
     type: test
     params:
@@ -10790,8 +20415,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -10801,11 +20430,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-test_4-rsa-delegate-4.4
-  tags: [ocsp-darwinssl]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - command: shell.exec
     type: test
     params:
@@ -10815,8 +20447,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -10826,11 +20462,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-test_4-rsa-delegate-latest
-  tags: [ocsp-winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - ocsp-winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - command: shell.exec
     type: test
     params:
@@ -10840,8 +20479,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -10851,11 +20494,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-test_4-rsa-delegate-5.0
-  tags: [ocsp-winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - ocsp-winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - command: shell.exec
     type: test
     params:
@@ -10865,8 +20511,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -10876,11 +20526,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-test_4-rsa-delegate-4.4
-  tags: [ocsp-winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - ocsp-winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - command: shell.exec
     type: test
     params:
@@ -10890,8 +20543,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -10901,11 +20558,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_4-ecdsa-delegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -10915,8 +20575,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -10926,11 +20590,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_4-ecdsa-delegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -10940,8 +20607,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -10951,11 +20622,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_4-ecdsa-delegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -10965,8 +20639,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -10976,11 +20654,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_4-ecdsa-delegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -10990,8 +20671,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -11002,11 +20687,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_4-ecdsa-delegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -11016,8 +20704,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -11028,11 +20720,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_4-ecdsa-delegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -11042,8 +20737,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -11054,11 +20753,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_4-rsa-nodelegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -11068,8 +20770,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -11079,11 +20785,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_4-rsa-nodelegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -11093,8 +20802,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -11104,11 +20817,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_4-rsa-nodelegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -11118,8 +20834,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -11129,11 +20849,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_4-rsa-nodelegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -11143,8 +20866,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -11155,11 +20882,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_4-rsa-nodelegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -11169,8 +20899,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -11181,11 +20915,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_4-rsa-nodelegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -11195,8 +20932,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -11207,11 +20948,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-test_4-rsa-nodelegate-latest
-  tags: [ocsp-darwinssl]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - command: shell.exec
     type: test
     params:
@@ -11221,8 +20965,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -11232,11 +20980,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-test_4-rsa-nodelegate-5.0
-  tags: [ocsp-darwinssl]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - command: shell.exec
     type: test
     params:
@@ -11246,8 +20997,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -11257,11 +21012,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-test_4-rsa-nodelegate-4.4
-  tags: [ocsp-darwinssl]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - command: shell.exec
     type: test
     params:
@@ -11271,8 +21029,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -11282,11 +21044,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-test_4-rsa-nodelegate-latest
-  tags: [ocsp-winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - ocsp-winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - command: shell.exec
     type: test
     params:
@@ -11296,8 +21061,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -11307,11 +21076,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-test_4-rsa-nodelegate-5.0
-  tags: [ocsp-winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - ocsp-winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - command: shell.exec
     type: test
     params:
@@ -11321,8 +21093,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -11332,11 +21108,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-test_4-rsa-nodelegate-4.4
-  tags: [ocsp-winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - ocsp-winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - command: shell.exec
     type: test
     params:
@@ -11346,8 +21125,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -11357,11 +21140,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_4-ecdsa-nodelegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -11371,8 +21157,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -11382,11 +21172,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_4-ecdsa-nodelegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -11396,8 +21189,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -11407,11 +21204,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_4-ecdsa-nodelegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -11421,8 +21221,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -11432,11 +21236,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_4-ecdsa-nodelegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -11446,8 +21253,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -11458,11 +21269,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_4-ecdsa-nodelegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -11472,8 +21286,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -11484,11 +21302,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_4-ecdsa-nodelegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -11498,8 +21319,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -11510,11 +21335,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-soft_fail_test-rsa-nodelegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -11524,8 +21352,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -11535,11 +21367,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-soft_fail_test-rsa-nodelegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -11549,8 +21384,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -11560,11 +21399,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-soft_fail_test-rsa-nodelegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -11574,8 +21416,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -11585,11 +21431,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-soft_fail_test-rsa-nodelegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -11599,8 +21448,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -11611,11 +21464,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-soft_fail_test-rsa-nodelegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -11625,8 +21481,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -11637,11 +21497,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-soft_fail_test-rsa-nodelegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -11651,8 +21514,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -11663,11 +21530,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-soft_fail_test-rsa-nodelegate-latest
-  tags: [ocsp-darwinssl]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - command: shell.exec
     type: test
     params:
@@ -11677,8 +21547,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -11688,11 +21562,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-soft_fail_test-rsa-nodelegate-5.0
-  tags: [ocsp-darwinssl]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - command: shell.exec
     type: test
     params:
@@ -11702,8 +21579,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -11713,11 +21594,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-soft_fail_test-rsa-nodelegate-4.4
-  tags: [ocsp-darwinssl]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - command: shell.exec
     type: test
     params:
@@ -11727,8 +21611,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -11738,11 +21626,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-soft_fail_test-rsa-nodelegate-latest
-  tags: [ocsp-winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - ocsp-winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - command: shell.exec
     type: test
     params:
@@ -11752,8 +21643,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -11763,11 +21658,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-soft_fail_test-rsa-nodelegate-5.0
-  tags: [ocsp-winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - ocsp-winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - command: shell.exec
     type: test
     params:
@@ -11777,8 +21675,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -11788,11 +21690,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-soft_fail_test-rsa-nodelegate-4.4
-  tags: [ocsp-winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - ocsp-winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - command: shell.exec
     type: test
     params:
@@ -11802,8 +21707,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -11813,11 +21722,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-soft_fail_test-ecdsa-nodelegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -11827,8 +21739,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -11838,11 +21754,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-soft_fail_test-ecdsa-nodelegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -11852,8 +21771,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -11863,11 +21786,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-soft_fail_test-ecdsa-nodelegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -11877,8 +21803,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -11888,11 +21818,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-soft_fail_test-ecdsa-nodelegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -11902,8 +21835,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -11914,11 +21851,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-soft_fail_test-ecdsa-nodelegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -11928,8 +21868,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -11940,11 +21884,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-soft_fail_test-ecdsa-nodelegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -11954,8 +21901,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -11966,11 +21917,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_1-rsa-delegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -11980,8 +21934,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -11991,11 +21949,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_1-rsa-delegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -12005,8 +21966,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -12016,11 +21981,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_1-rsa-delegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -12030,8 +21998,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -12041,11 +22013,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_1-rsa-delegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -12055,8 +22030,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -12067,11 +22046,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_1-rsa-delegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -12081,8 +22063,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -12093,11 +22079,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_1-rsa-delegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -12107,8 +22096,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -12119,11 +22112,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-malicious_server_test_1-rsa-delegate-latest
-  tags: [ocsp-darwinssl]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - command: shell.exec
     type: test
     params:
@@ -12133,8 +22129,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -12144,11 +22144,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-malicious_server_test_1-rsa-delegate-5.0
-  tags: [ocsp-darwinssl]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - command: shell.exec
     type: test
     params:
@@ -12158,8 +22161,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -12169,11 +22176,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-malicious_server_test_1-rsa-delegate-4.4
-  tags: [ocsp-darwinssl]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - command: shell.exec
     type: test
     params:
@@ -12183,8 +22193,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -12194,11 +22208,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-malicious_server_test_1-rsa-delegate-latest
-  tags: [ocsp-winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - ocsp-winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - command: shell.exec
     type: test
     params:
@@ -12208,8 +22225,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -12219,11 +22240,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-malicious_server_test_1-rsa-delegate-5.0
-  tags: [ocsp-winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - ocsp-winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - command: shell.exec
     type: test
     params:
@@ -12233,8 +22257,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -12244,11 +22272,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-malicious_server_test_1-rsa-delegate-4.4
-  tags: [ocsp-winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - ocsp-winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - command: shell.exec
     type: test
     params:
@@ -12258,8 +22289,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -12269,11 +22304,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_1-ecdsa-delegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -12283,8 +22321,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -12294,11 +22336,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_1-ecdsa-delegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -12308,8 +22353,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -12319,11 +22368,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_1-ecdsa-delegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -12333,8 +22385,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -12344,11 +22400,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_1-ecdsa-delegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -12358,8 +22417,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -12370,11 +22433,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_1-ecdsa-delegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -12384,8 +22450,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -12396,11 +22466,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_1-ecdsa-delegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -12410,8 +22483,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -12422,11 +22499,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_1-rsa-nodelegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -12436,8 +22516,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -12447,11 +22531,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_1-rsa-nodelegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -12461,8 +22548,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -12472,11 +22563,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_1-rsa-nodelegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -12486,8 +22580,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -12497,11 +22595,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_1-rsa-nodelegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -12511,8 +22612,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -12523,11 +22628,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_1-rsa-nodelegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -12537,8 +22645,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -12549,11 +22661,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_1-rsa-nodelegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -12563,8 +22678,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -12575,11 +22694,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-malicious_server_test_1-rsa-nodelegate-latest
-  tags: [ocsp-darwinssl]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - command: shell.exec
     type: test
     params:
@@ -12589,8 +22711,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -12600,11 +22726,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-malicious_server_test_1-rsa-nodelegate-5.0
-  tags: [ocsp-darwinssl]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - command: shell.exec
     type: test
     params:
@@ -12614,8 +22743,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -12625,11 +22758,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-malicious_server_test_1-rsa-nodelegate-4.4
-  tags: [ocsp-darwinssl]
-  depends_on: {name: debug-compile-nosasl-darwinssl}
+  tags:
+  - ocsp-darwinssl
+  depends_on:
+    name: debug-compile-nosasl-darwinssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-darwinssl
   - command: shell.exec
     type: test
     params:
@@ -12639,8 +22775,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -12650,11 +22790,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-malicious_server_test_1-rsa-nodelegate-latest
-  tags: [ocsp-winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - ocsp-winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - command: shell.exec
     type: test
     params:
@@ -12664,8 +22807,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -12675,11 +22822,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-malicious_server_test_1-rsa-nodelegate-5.0
-  tags: [ocsp-winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - ocsp-winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - command: shell.exec
     type: test
     params:
@@ -12689,8 +22839,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -12700,11 +22854,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-malicious_server_test_1-rsa-nodelegate-4.4
-  tags: [ocsp-winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - ocsp-winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - command: shell.exec
     type: test
     params:
@@ -12714,8 +22871,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -12725,11 +22886,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_1-ecdsa-nodelegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -12739,8 +22903,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -12750,11 +22918,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_1-ecdsa-nodelegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -12764,8 +22935,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -12775,11 +22950,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_1-ecdsa-nodelegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -12789,8 +22967,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -12800,11 +22982,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_1-ecdsa-nodelegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -12814,8 +22999,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -12826,11 +23015,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_1-ecdsa-nodelegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -12840,8 +23032,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -12852,11 +23048,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_1-ecdsa-nodelegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -12866,8 +23065,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -12878,11 +23081,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_2-rsa-nodelegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -12892,8 +23098,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -12903,11 +23113,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_2-rsa-nodelegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -12917,8 +23130,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -12928,11 +23145,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_2-rsa-nodelegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -12942,8 +23162,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -12953,11 +23177,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_2-rsa-nodelegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -12967,8 +23194,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -12979,11 +23210,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_2-rsa-nodelegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -12993,8 +23227,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -13005,11 +23243,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_2-rsa-nodelegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -13019,8 +23260,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -13031,11 +23276,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-malicious_server_test_2-rsa-nodelegate-latest
-  tags: [ocsp-winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - ocsp-winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - command: shell.exec
     type: test
     params:
@@ -13045,8 +23293,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -13056,11 +23308,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-malicious_server_test_2-rsa-nodelegate-5.0
-  tags: [ocsp-winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - ocsp-winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - command: shell.exec
     type: test
     params:
@@ -13070,8 +23325,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -13081,11 +23340,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-malicious_server_test_2-rsa-nodelegate-4.4
-  tags: [ocsp-winssl]
-  depends_on: {name: debug-compile-nosasl-winssl}
+  tags:
+  - ocsp-winssl
+  depends_on:
+    name: debug-compile-nosasl-winssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-winssl
   - command: shell.exec
     type: test
     params:
@@ -13095,8 +23357,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -13106,11 +23372,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_2-ecdsa-nodelegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -13120,8 +23389,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -13131,11 +23404,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_2-ecdsa-nodelegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -13145,8 +23421,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -13156,11 +23436,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_2-ecdsa-nodelegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -13170,8 +23453,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -13181,11 +23468,14 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_2-ecdsa-nodelegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -13195,8 +23485,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -13207,11 +23501,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_2-ecdsa-nodelegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -13221,8 +23518,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -13233,11 +23534,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_2-ecdsa-nodelegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -13247,8 +23551,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
-      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -13259,11 +23567,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-cache-rsa-nodelegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -13273,8 +23584,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -13284,11 +23599,14 @@ tasks:
         set -o errexit
         CERT_TYPE=rsa .evergreen/run-ocsp-cache-test.sh
 - name: ocsp-openssl-cache-rsa-nodelegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -13298,8 +23616,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -13309,11 +23631,14 @@ tasks:
         set -o errexit
         CERT_TYPE=rsa .evergreen/run-ocsp-cache-test.sh
 - name: ocsp-openssl-cache-rsa-nodelegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -13323,8 +23648,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -13334,11 +23663,14 @@ tasks:
         set -o errexit
         CERT_TYPE=rsa .evergreen/run-ocsp-cache-test.sh
 - name: ocsp-openssl-1.0.1-cache-rsa-nodelegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -13348,8 +23680,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -13360,11 +23696,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         CERT_TYPE=rsa .evergreen/run-ocsp-cache-test.sh
 - name: ocsp-openssl-1.0.1-cache-rsa-nodelegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -13374,8 +23713,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -13386,11 +23729,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         CERT_TYPE=rsa .evergreen/run-ocsp-cache-test.sh
 - name: ocsp-openssl-1.0.1-cache-rsa-nodelegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -13400,8 +23746,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -13412,11 +23762,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         CERT_TYPE=rsa .evergreen/run-ocsp-cache-test.sh
 - name: ocsp-openssl-cache-ecdsa-nodelegate-latest
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -13426,8 +23779,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -13437,11 +23794,14 @@ tasks:
         set -o errexit
         CERT_TYPE=ecdsa .evergreen/run-ocsp-cache-test.sh
 - name: ocsp-openssl-cache-ecdsa-nodelegate-5.0
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -13451,8 +23811,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -13462,11 +23826,14 @@ tasks:
         set -o errexit
         CERT_TYPE=ecdsa .evergreen/run-ocsp-cache-test.sh
 - name: ocsp-openssl-cache-ecdsa-nodelegate-4.4
-  tags: [ocsp-openssl]
-  depends_on: {name: debug-compile-nosasl-openssl}
+  tags:
+  - ocsp-openssl
+  depends_on:
+    name: debug-compile-nosasl-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl
   - command: shell.exec
     type: test
     params:
@@ -13476,8 +23843,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -13487,11 +23858,14 @@ tasks:
         set -o errexit
         CERT_TYPE=ecdsa .evergreen/run-ocsp-cache-test.sh
 - name: ocsp-openssl-1.0.1-cache-ecdsa-nodelegate-latest
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -13501,8 +23875,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: latest}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
   - command: shell.exec
     type: test
     params:
@@ -13513,11 +23891,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         CERT_TYPE=ecdsa .evergreen/run-ocsp-cache-test.sh
 - name: ocsp-openssl-1.0.1-cache-ecdsa-nodelegate-5.0
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -13527,8 +23908,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '5.0'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '5.0'
   - command: shell.exec
     type: test
     params:
@@ -13539,11 +23924,14 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         CERT_TYPE=ecdsa .evergreen/run-ocsp-cache-test.sh
 - name: ocsp-openssl-1.0.1-cache-ecdsa-nodelegate-4.4
-  tags: [ocsp-openssl-1.0.1]
-  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
+  tags:
+  - ocsp-openssl-1.0.1
+  depends_on:
+    name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
+    vars:
+      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
   - command: shell.exec
     type: test
     params:
@@ -13553,8 +23941,12 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
-      TOPOLOGY: server, VERSION: '4.4'}
+    vars:
+      OCSP: 'on'
+      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: '4.4'
   - command: shell.exec
     type: test
     params:
@@ -13565,61 +23957,113 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         CERT_TYPE=ecdsa .evergreen/run-ocsp-cache-test.sh
 - name: test-loadbalanced-asan-auth-openssl-5.0
-  tags: ['5.0', test-asan]
+  tags:
+  - '5.0'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang-openssl}
+  depends_on:
+    name: debug-compile-asan-clang-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: ssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
-  - {func: clone drivers-evergreen-tools}
+    vars:
+      AUTH: auth
+      SSL: ssl
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
+  - func: clone drivers-evergreen-tools
   - func: start load balancer
-    vars: {MONGODB_URI: 'mongodb://localhost:27017,localhost:27018'}
+    vars:
+      MONGODB_URI: mongodb://localhost:27017,localhost:27018
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, LOADBALANCED: loadbalanced, SSL: ssl}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      LOADBALANCED: loadbalanced
+      SSL: ssl
 - name: test-loadbalanced-asan-auth-openssl-latest
-  tags: [latest, test-asan]
+  tags:
+  - latest
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang-openssl}
+  depends_on:
+    name: debug-compile-asan-clang-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: auth, SSL: ssl, TOPOLOGY: sharded_cluster, VERSION: latest}
-  - {func: clone drivers-evergreen-tools}
+    vars:
+      AUTH: auth
+      SSL: ssl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
   - func: start load balancer
-    vars: {MONGODB_URI: 'mongodb://localhost:27017,localhost:27018'}
+    vars:
+      MONGODB_URI: mongodb://localhost:27017,localhost:27018
   - func: run tests
-    vars: {ASAN: 'on', AUTH: auth, LOADBALANCED: loadbalanced, SSL: ssl}
+    vars:
+      ASAN: 'on'
+      AUTH: auth
+      LOADBALANCED: loadbalanced
+      SSL: ssl
 - name: test-loadbalanced-asan-noauth-nossl-5.0
-  tags: ['5.0', test-asan]
+  tags:
+  - '5.0'
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang-openssl}
+  depends_on:
+    name: debug-compile-asan-clang-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
-  - {func: clone drivers-evergreen-tools}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: '5.0'
+  - func: clone drivers-evergreen-tools
   - func: start load balancer
-    vars: {MONGODB_URI: 'mongodb://localhost:27017,localhost:27018'}
+    vars:
+      MONGODB_URI: mongodb://localhost:27017,localhost:27018
   - func: run tests
-    vars: {ASAN: 'on', AUTH: noauth, LOADBALANCED: loadbalanced, SSL: nossl}
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      LOADBALANCED: loadbalanced
+      SSL: nossl
 - name: test-loadbalanced-asan-noauth-nossl-latest
-  tags: [latest, test-asan]
+  tags:
+  - latest
+  - test-asan
   exec_timeout_secs: 3600
-  depends_on: {name: debug-compile-asan-clang-openssl}
+  depends_on:
+    name: debug-compile-asan-clang-openssl
   commands:
   - func: fetch build
-    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
+    vars:
+      BUILD_NAME: debug-compile-asan-clang-openssl
   - func: bootstrap mongo-orchestration
-    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: latest}
-  - {func: clone drivers-evergreen-tools}
+    vars:
+      AUTH: noauth
+      SSL: nossl
+      TOPOLOGY: sharded_cluster
+      VERSION: latest
+  - func: clone drivers-evergreen-tools
   - func: start load balancer
-    vars: {MONGODB_URI: 'mongodb://localhost:27017,localhost:27018'}
+    vars:
+      MONGODB_URI: mongodb://localhost:27017,localhost:27018
   - func: run tests
-    vars: {ASAN: 'on', AUTH: noauth, LOADBALANCED: loadbalanced, SSL: nossl}
+    vars:
+      ASAN: 'on'
+      AUTH: noauth
+      LOADBALANCED: loadbalanced
+      SSL: nossl
 buildvariants:
 - name: releng
   display_name: '**Release Archive Creator'
@@ -13631,9 +24075,11 @@ buildvariants:
   - .debug-compile .stdflags
   - .debug-compile !.sspi .openssl !.asan-clang
   - name: debug-compile-sasl-openssl-static
-    distros: [ubuntu1804-build]
+    distros:
+    - ubuntu1804-build
   - name: debug-compile-nosasl-openssl-static
-    distros: [ubuntu1804-build]
+    distros:
+    - ubuntu1804-build
   - .debug-compile !.sspi .nossl
   - debug-compile-valgrind
   - debug-compile-no-counters
@@ -13646,361 +24092,681 @@ buildvariants:
   - link-with-cmake-snappy
   - link-with-cmake-snappy-deprecated
   - name: link-with-cmake-mac
-    distros: [macos-1014]
+    distros:
+    - macos-1014
   - name: link-with-cmake-mac-deprecated
-    distros: [macos-1014]
+    distros:
+    - macos-1014
   - name: link-with-cmake-windows
-    distros: [windows-64-vs2017-test]
+    distros:
+    - windows-64-vs2017-test
   - name: link-with-cmake-windows-ssl
-    distros: [windows-64-vs2017-test]
+    distros:
+    - windows-64-vs2017-test
   - name: link-with-cmake-windows-snappy
-    distros: [windows-64-vs2017-test]
+    distros:
+    - windows-64-vs2017-test
   - name: link-with-cmake-mingw
-    distros: [windows-64-vs2017-test]
+    distros:
+    - windows-64-vs2017-test
   - name: link-with-pkg-config
-    distros: [ubuntu1804-test]
+    distros:
+    - ubuntu1804-test
   - name: link-with-pkg-config-mac
-    distros: [macos-1014]
+    distros:
+    - macos-1014
   - link-with-pkg-config-ssl
   - link-with-bson
   - name: link-with-bson-windows
-    distros: [windows-64-vs2017-test]
+    distros:
+    - windows-64-vs2017-test
   - name: link-with-bson-mac
-    distros: [macos-1014]
+    distros:
+    - macos-1014
   - name: link-with-bson-mingw
-    distros: [windows-64-vs2013-compile]
+    distros:
+    - windows-64-vs2013-compile
   - check-headers
   - install-uninstall-check
   - name: install-uninstall-check-mingw
-    distros: [windows-64-vs2017-test]
+    distros:
+    - windows-64-vs2017-test
   - name: install-uninstall-check-msvc
-    distros: [windows-64-vs2017-test]
+    distros:
+    - windows-64-vs2017-test
   - debug-compile-with-warnings
   - name: build-and-test-with-toolchain
-    distros: [debian10-small]
+    distros:
+    - debian10-small
 - name: clang34ubuntu
   display_name: clang 3.4 (Ubuntu 14.04)
-  expansions: {CC: clang}
+  expansions:
+    CC: clang
   run_on: ubuntu1404-build
-  tasks: [debug-compile-scan-build, release-compile, debug-compile-nosasl-nossl, debug-compile-rdtscp,
-    .debug-compile !.sspi .openssl, .debug-compile !.sspi .nossl, .authentication-tests
-      .openssl, .4.0 .openssl !.nosasl .server, .3.6 .openssl !.nosasl .server]
+  tasks:
+  - debug-compile-scan-build
+  - release-compile
+  - debug-compile-nosasl-nossl
+  - debug-compile-rdtscp
+  - .debug-compile !.sspi .openssl
+  - .debug-compile !.sspi .nossl
+  - .authentication-tests .openssl
+  - .4.0 .openssl !.nosasl .server
+  - .3.6 .openssl !.nosasl .server
 - name: clang35
   display_name: clang 3.5 (Debian 8.1)
-  expansions: {CC: clang}
+  expansions:
+    CC: clang
   run_on: debian81-test
-  tasks: [release-compile, debug-compile-nosasl-nossl, .debug-compile .stdflags, .debug-compile
-      !.sspi .openssl, .debug-compile !.sspi .nossl, .authentication-tests .openssl,
-    .4.0 .openssl !.nosasl .server]
+  tasks:
+  - release-compile
+  - debug-compile-nosasl-nossl
+  - .debug-compile .stdflags
+  - .debug-compile !.sspi .openssl
+  - .debug-compile !.sspi .nossl
+  - .authentication-tests .openssl
+  - .4.0 .openssl !.nosasl .server
 - name: clang38
   display_name: clang 3.8 (Debian 9.2)
-  expansions: {CC: clang}
+  expansions:
+    CC: clang
   run_on: debian92-test
-  tasks: [release-compile, debug-compile-nosasl-nossl, .debug-compile .stdflags, .debug-compile
-      !.sspi .openssl, .debug-compile !.sspi .openssl-static, .debug-compile !.sspi
-      .nossl, .latest .openssl !.nosasl .server, .latest .openssl-static !.nosasl
-      .server, .latest .nossl, .5.0 .openssl !.nosasl .server, .4.4 .openssl !.nosasl
-      .server, .4.2 .openssl !.nosasl .server]
+  tasks:
+  - release-compile
+  - debug-compile-nosasl-nossl
+  - .debug-compile .stdflags
+  - .debug-compile !.sspi .openssl
+  - .debug-compile !.sspi .openssl-static
+  - .debug-compile !.sspi .nossl
+  - .latest .openssl !.nosasl .server
+  - .latest .openssl-static !.nosasl .server
+  - .latest .nossl
+  - .5.0 .openssl !.nosasl .server
+  - .4.4 .openssl !.nosasl .server
+  - .4.2 .openssl !.nosasl .server
 - name: openssl
   display_name: OpenSSL / LibreSSL
   run_on: archlinux-build
-  tasks: [build-and-run-authentication-tests-openssl-0.9.8, build-and-run-authentication-tests-openssl-1.0.0,
-    build-and-run-authentication-tests-openssl-1.0.1, build-and-run-authentication-tests-openssl-1.0.2,
-    build-and-run-authentication-tests-openssl-1.1.0, build-and-run-authentication-tests-openssl-1.0.1-fips,
-    build-and-run-authentication-tests-libressl-2.5, build-and-run-authentication-tests-libressl-3.0-auto,
-    build-and-run-authentication-tests-libressl-3.0]
+  tasks:
+  - build-and-run-authentication-tests-openssl-0.9.8
+  - build-and-run-authentication-tests-openssl-1.0.0
+  - build-and-run-authentication-tests-openssl-1.0.1
+  - build-and-run-authentication-tests-openssl-1.0.2
+  - build-and-run-authentication-tests-openssl-1.1.0
+  - build-and-run-authentication-tests-openssl-1.0.1-fips
+  - build-and-run-authentication-tests-libressl-2.5
+  - build-and-run-authentication-tests-libressl-3.0-auto
+  - build-and-run-authentication-tests-libressl-3.0
 - name: clang37
   display_name: clang 3.7 (Archlinux)
-  expansions: {CC: clang}
+  expansions:
+    CC: clang
   run_on: archlinux-test
-  tasks: [release-compile, debug-compile-nosasl-nossl, .debug-compile .stdflags, .debug-compile
-      !.sspi .openssl, .debug-compile !.sspi .nossl, .authentication-tests .openssl,
-    .4.0 .nossl, .3.6 .nossl]
+  tasks:
+  - release-compile
+  - debug-compile-nosasl-nossl
+  - .debug-compile .stdflags
+  - .debug-compile !.sspi .openssl
+  - .debug-compile !.sspi .nossl
+  - .authentication-tests .openssl
+  - .4.0 .nossl
+  - .3.6 .nossl
 - name: clang60-i686
   display_name: clang 6.0 (i686) (Ubuntu 18.04)
-  expansions: {CC: clang, MARCH: i686}
+  expansions:
+    CC: clang
+    MARCH: i686
   run_on: ubuntu1804-test
-  tasks: [debug-compile-scan-build, release-compile, debug-compile-nosasl-nossl, debug-compile-no-align,
-    .debug-compile .stdflags, .debug-compile !.sspi .nossl .nosasl, .latest .nossl
-      .nosasl, .5.0 .nossl .nosasl, .4.4 .nossl .nosasl, .4.2 .nossl .nosasl, .4.0
-      .nossl .nosasl]
+  tasks:
+  - debug-compile-scan-build
+  - release-compile
+  - debug-compile-nosasl-nossl
+  - debug-compile-no-align
+  - .debug-compile .stdflags
+  - .debug-compile !.sspi .nossl .nosasl
+  - .latest .nossl .nosasl
+  - .5.0 .nossl .nosasl
+  - .4.4 .nossl .nosasl
+  - .4.2 .nossl .nosasl
+  - .4.0 .nossl .nosasl
 - name: clang38-i686
   display_name: clang 3.8 (i686) (Ubuntu 16.04)
-  expansions: {CC: clang, MARCH: i686}
+  expansions:
+    CC: clang
+    MARCH: i686
   run_on: ubuntu1604-test
-  tasks: [debug-compile-scan-build, release-compile, debug-compile-nosasl-nossl, debug-compile-no-align,
-    .debug-compile .stdflags, .debug-compile !.sspi .nossl .nosasl, .3.6 .nossl .nosasl]
+  tasks:
+  - debug-compile-scan-build
+  - release-compile
+  - debug-compile-nosasl-nossl
+  - debug-compile-no-align
+  - .debug-compile .stdflags
+  - .debug-compile !.sspi .nossl .nosasl
+  - .3.6 .nossl .nosasl
 - name: clang38ubuntu
   display_name: clang 3.8 (Ubuntu 16.04)
-  expansions: {CC: clang}
+  expansions:
+    CC: clang
   run_on: ubuntu1604-test
-  tasks: [.compression !.zstd, debug-compile-scan-build, debug-compile-asan-clang,
-    debug-compile-ubsan, release-compile, debug-compile-nosasl-nossl, debug-compile-no-align,
-    .debug-compile .stdflags, .debug-compile !.sspi .openssl, .debug-compile !.sspi
-      .nossl, .authentication-tests .openssl, .authentication-tests .valgrind, .4.4
-      .openssl !.nosasl .server, .4.2 .openssl !.nosasl .server, .4.0 .openssl !.nosasl
-      .server, .3.6 .openssl !.nosasl .server, .test-coverage .3.6]
+  tasks:
+  - .compression !.zstd
+  - debug-compile-scan-build
+  - debug-compile-asan-clang
+  - debug-compile-ubsan
+  - release-compile
+  - debug-compile-nosasl-nossl
+  - debug-compile-no-align
+  - .debug-compile .stdflags
+  - .debug-compile !.sspi .openssl
+  - .debug-compile !.sspi .nossl
+  - .authentication-tests .openssl
+  - .authentication-tests .valgrind
+  - .4.4 .openssl !.nosasl .server
+  - .4.2 .openssl !.nosasl .server
+  - .4.0 .openssl !.nosasl .server
+  - .3.6 .openssl !.nosasl .server
+  - .test-coverage .3.6
 - name: gcc48ubuntu
   display_name: GCC 4.8 (Ubuntu 14.04)
-  expansions: {CC: gcc}
+  expansions:
+    CC: gcc
   run_on: ubuntu1404-build
-  tasks: [release-compile, debug-compile-nosasl-nossl, .debug-compile !.sspi .openssl,
-    .debug-compile !.sspi .nossl, .authentication-tests .openssl, .4.0 .openssl !.nosasl
-      .server, .3.6 .openssl !.nosasl .server]
+  tasks:
+  - release-compile
+  - debug-compile-nosasl-nossl
+  - .debug-compile !.sspi .openssl
+  - .debug-compile !.sspi .nossl
+  - .authentication-tests .openssl
+  - .4.0 .openssl !.nosasl .server
+  - .3.6 .openssl !.nosasl .server
 - name: gcc82rhel
   display_name: GCC 8.2 (RHEL 8.0)
-  expansions: {CC: gcc}
+  expansions:
+    CC: gcc
   run_on: rhel80-test
-  tasks: [.hardened, .compression !.snappy !.zstd, release-compile, debug-compile-nosasl-nossl,
-    .debug-compile !.sspi .openssl, .debug-compile !.sspi .nossl, .authentication-tests
-      .openssl, .latest .openssl !.nosasl .server, .latest .nossl]
+  tasks:
+  - .hardened
+  - .compression !.snappy !.zstd
+  - release-compile
+  - debug-compile-nosasl-nossl
+  - .debug-compile !.sspi .openssl
+  - .debug-compile !.sspi .nossl
+  - .authentication-tests .openssl
+  - .latest .openssl !.nosasl .server
+  - .latest .nossl
 - name: gcc48rhel
   display_name: GCC 4.8 (RHEL 7.0)
-  expansions: {CC: gcc}
+  expansions:
+    CC: gcc
   run_on: rhel70
-  tasks: [.hardened, .compression !.snappy, release-compile, debug-compile-nosasl-nossl,
-    .debug-compile !.sspi .openssl, .debug-compile !.sspi .nossl, .authentication-tests
-      .openssl, .latest .openssl !.nosasl .server, .latest .nossl, .5.0 .openssl !.nosasl
-      .server, .4.4 .openssl !.nosasl .server, .4.2 .openssl !.nosasl .server, .4.0
-      .openssl !.nosasl .server, .3.6 .openssl !.nosasl .server]
+  tasks:
+  - .hardened
+  - .compression !.snappy
+  - release-compile
+  - debug-compile-nosasl-nossl
+  - .debug-compile !.sspi .openssl
+  - .debug-compile !.sspi .nossl
+  - .authentication-tests .openssl
+  - .latest .openssl !.nosasl .server
+  - .latest .nossl
+  - .5.0 .openssl !.nosasl .server
+  - .4.4 .openssl !.nosasl .server
+  - .4.2 .openssl !.nosasl .server
+  - .4.0 .openssl !.nosasl .server
+  - .3.6 .openssl !.nosasl .server
 - name: gcc49
   display_name: GCC 4.9 (Debian 8.1)
-  expansions: {CC: gcc}
+  expansions:
+    CC: gcc
   run_on: debian81-test
-  tasks: [release-compile, debug-compile-nosasl-nossl, .debug-compile !.sspi .openssl,
-    .debug-compile !.sspi .nossl, .authentication-tests .openssl, .4.0 .openssl !.nosasl
-      .server]
+  tasks:
+  - release-compile
+  - debug-compile-nosasl-nossl
+  - .debug-compile !.sspi .openssl
+  - .debug-compile !.sspi .nossl
+  - .authentication-tests .openssl
+  - .4.0 .openssl !.nosasl .server
 - name: gcc63
   display_name: GCC 6.3 (Debian 9.2)
-  expansions: {CC: gcc}
+  expansions:
+    CC: gcc
   run_on: debian92-test
-  tasks: [release-compile, debug-compile-nosasl-nossl, .debug-compile !.sspi .openssl,
-    .debug-compile !.sspi .openssl-static, .debug-compile !.sspi .nossl, .latest .openssl
-      !.nosasl .server, .latest .openssl-static !.nosasl .server, .latest .nossl,
-    .5.0 .openssl !.nosasl .server, .4.4 .openssl !.nosasl .server, .4.2 .openssl
-      !.nosasl .server]
+  tasks:
+  - release-compile
+  - debug-compile-nosasl-nossl
+  - .debug-compile !.sspi .openssl
+  - .debug-compile !.sspi .openssl-static
+  - .debug-compile !.sspi .nossl
+  - .latest .openssl !.nosasl .server
+  - .latest .openssl-static !.nosasl .server
+  - .latest .nossl
+  - .5.0 .openssl !.nosasl .server
+  - .4.4 .openssl !.nosasl .server
+  - .4.2 .openssl !.nosasl .server
 - name: gcc83
   display_name: GCC 8.3 (Debian 10.0)
-  expansions: {CC: gcc}
+  expansions:
+    CC: gcc
   run_on: debian10-test
-  tasks: [release-compile, debug-compile-nosasl-nossl, .debug-compile !.sspi .openssl,
-    .debug-compile !.sspi .openssl-static, .debug-compile !.sspi .nossl, .latest .openssl
-      !.nosasl .server, .latest .openssl-static !.nosasl .server, .latest .nossl]
+  tasks:
+  - release-compile
+  - debug-compile-nosasl-nossl
+  - .debug-compile !.sspi .openssl
+  - .debug-compile !.sspi .openssl-static
+  - .debug-compile !.sspi .nossl
+  - .latest .openssl !.nosasl .server
+  - .latest .openssl-static !.nosasl .server
+  - .latest .nossl
 - name: gcc75-i686
   display_name: GCC 7.5 (i686) (Ubuntu 18.04)
-  expansions: {CC: gcc, MARCH: i686}
+  expansions:
+    CC: gcc
+    MARCH: i686
   run_on: ubuntu1804-test
-  tasks: [debug-compile-coverage, release-compile, debug-compile-nosasl-nossl, debug-compile-no-align,
-    .debug-compile !.sspi .nossl .nosasl, .latest .nossl .nosasl, .5.0 .nossl .nosasl,
-    .4.4 .nossl .nosasl, .4.2 .nossl .nosasl, .4.0 .nossl .nosasl]
+  tasks:
+  - debug-compile-coverage
+  - release-compile
+  - debug-compile-nosasl-nossl
+  - debug-compile-no-align
+  - .debug-compile !.sspi .nossl .nosasl
+  - .latest .nossl .nosasl
+  - .5.0 .nossl .nosasl
+  - .4.4 .nossl .nosasl
+  - .4.2 .nossl .nosasl
+  - .4.0 .nossl .nosasl
 - name: gcc75
   display_name: GCC 7.5 (Ubuntu 18.04)
-  expansions: {CC: gcc}
+  expansions:
+    CC: gcc
   run_on: ubuntu1804-test
-  tasks: [.compression !.zstd, debug-compile-asan-gcc, debug-compile-coverage, debug-compile-nosrv,
-    release-compile, debug-compile-nosasl-nossl, debug-compile-no-align, .debug-compile
-      !.sspi .openssl, .debug-compile !.sspi .nossl, .authentication-tests .openssl,
-    .authentication-tests .valgrind, .latest .openssl !.nosasl .server, .latest .nossl,
-    .latest .openssl .nosasl .replica_set, .latest .openssl !.nosasl .replica_set,
-    retry-true-latest-server, .5.0 .openssl !.nosasl .server, .4.4 .openssl !.nosasl
-      .server, .4.2 .openssl !.nosasl .server, .4.0 .openssl !.nosasl .server, test-dns-openssl,
-    test-dns-auth-openssl, test-dns-loadbalanced-openssl]
+  tasks:
+  - .compression !.zstd
+  - debug-compile-asan-gcc
+  - debug-compile-coverage
+  - debug-compile-nosrv
+  - release-compile
+  - debug-compile-nosasl-nossl
+  - debug-compile-no-align
+  - .debug-compile !.sspi .openssl
+  - .debug-compile !.sspi .nossl
+  - .authentication-tests .openssl
+  - .authentication-tests .valgrind
+  - .latest .openssl !.nosasl .server
+  - .latest .nossl
+  - .latest .openssl .nosasl .replica_set
+  - .latest .openssl !.nosasl .replica_set
+  - retry-true-latest-server
+  - .5.0 .openssl !.nosasl .server
+  - .4.4 .openssl !.nosasl .server
+  - .4.2 .openssl !.nosasl .server
+  - .4.0 .openssl !.nosasl .server
+  - test-dns-openssl
+  - test-dns-auth-openssl
+  - test-dns-loadbalanced-openssl
 - name: gcc54
   display_name: GCC 5.4 (Ubuntu 16.04)
-  expansions: {CC: gcc}
+  expansions:
+    CC: gcc
   run_on: ubuntu1604-test
-  tasks: [.compression !.zstd, debug-compile-asan-gcc, debug-compile-coverage, debug-compile-nosrv,
-    release-compile, debug-compile-nosasl-nossl, debug-compile-no-align, .debug-compile
-      !.sspi .openssl, .debug-compile !.sspi .nossl]
+  tasks:
+  - .compression !.zstd
+  - debug-compile-asan-gcc
+  - debug-compile-coverage
+  - debug-compile-nosrv
+  - release-compile
+  - debug-compile-nosasl-nossl
+  - debug-compile-no-align
+  - .debug-compile !.sspi .openssl
+  - .debug-compile !.sspi .nossl
 - name: darwin
   display_name: '*Darwin, macOS (Apple LLVM)'
-  expansions: {CC: clang}
+  expansions:
+    CC: clang
   run_on: macos-1014
-  tasks: [.compression !.snappy !.zstd, debug-compile-coverage, release-compile, debug-compile-nosasl-nossl,
-    debug-compile-rdtscp, debug-compile-no-align, debug-compile-nosrv, .debug-compile
-      .darwinssl, .debug-compile !.sspi .nossl, .debug-compile .clang, .authentication-tests
-      .darwinssl, .latest .darwinssl !.nosasl .server, .latest .nossl, .5.0 .darwinssl
-      !.nosasl .server, .4.4 .darwinssl !.nosasl .server, .4.2 .darwinssl !.nosasl
-      .server, .4.0 .darwinssl !.nosasl .server, .3.6 .darwinssl !.nosasl .server,
-    test-dns-darwinssl, test-dns-auth-darwinssl, debug-compile-lto, debug-compile-lto-thin,
-    debug-compile-aws, test-aws-openssl-regular-4.4, test-aws-openssl-regular-latest]
+  tasks:
+  - .compression !.snappy !.zstd
+  - debug-compile-coverage
+  - release-compile
+  - debug-compile-nosasl-nossl
+  - debug-compile-rdtscp
+  - debug-compile-no-align
+  - debug-compile-nosrv
+  - .debug-compile .darwinssl
+  - .debug-compile !.sspi .nossl
+  - .debug-compile .clang
+  - .authentication-tests .darwinssl
+  - .latest .darwinssl !.nosasl .server
+  - .latest .nossl
+  - .5.0 .darwinssl !.nosasl .server
+  - .4.4 .darwinssl !.nosasl .server
+  - .4.2 .darwinssl !.nosasl .server
+  - .4.0 .darwinssl !.nosasl .server
+  - .3.6 .darwinssl !.nosasl .server
+  - test-dns-darwinssl
+  - test-dns-auth-darwinssl
+  - debug-compile-lto
+  - debug-compile-lto-thin
+  - debug-compile-aws
+  - test-aws-openssl-regular-4.4
+  - test-aws-openssl-regular-latest
 - name: windows-2017-32
   display_name: Windows (i686) (VS 2017)
-  expansions: {CC: Visual Studio 15 2017}
+  expansions:
+    CC: Visual Studio 15 2017
   run_on: windows-64-vs2017-test
-  tasks: [.debug-compile .winssl .nosasl, .debug-compile !.sspi .nossl .nosasl, .debug-compile
-      .sspi !.openssl !.openssl-static, .server .winssl .latest .nosasl, .latest .nossl
-      .nosasl, .nosasl .latest .nossl, .sspi .latest]
+  tasks:
+  - .debug-compile .winssl .nosasl
+  - .debug-compile !.sspi .nossl .nosasl
+  - .debug-compile .sspi !.openssl !.openssl-static
+  - .server .winssl .latest .nosasl
+  - .latest .nossl .nosasl
+  - .nosasl .latest .nossl
+  - .sspi .latest
 - name: windows-2017
   display_name: Windows (VS 2017)
-  expansions: {CC: Visual Studio 15 2017 Win64}
+  expansions:
+    CC: Visual Studio 15 2017 Win64
   run_on: windows-64-vs2017-test
-  tasks: [.debug-compile .winssl, .debug-compile !.sspi .openssl, .debug-compile !.sspi
-      .nossl, .debug-compile .sspi !.openssl-static, .server .winssl .latest, .server
-      .openssl .latest !.nosasl, .latest .nossl, .nosasl .latest .nossl, .sspi .latest,
-    test-dns-winssl, test-dns-auth-winssl, debug-compile-aws, .5.0 .winssl !.nosasl
-      .server, .4.4 .winssl !.nosasl .server, test-aws-openssl-regular-4.4, test-aws-openssl-regular-latest]
+  tasks:
+  - .debug-compile .winssl
+  - .debug-compile !.sspi .openssl
+  - .debug-compile !.sspi .nossl
+  - .debug-compile .sspi !.openssl-static
+  - .server .winssl .latest
+  - .server .openssl .latest !.nosasl
+  - .latest .nossl
+  - .nosasl .latest .nossl
+  - .sspi .latest
+  - test-dns-winssl
+  - test-dns-auth-winssl
+  - debug-compile-aws
+  - .5.0 .winssl !.nosasl .server
+  - .4.4 .winssl !.nosasl .server
+  - test-aws-openssl-regular-4.4
+  - test-aws-openssl-regular-latest
 - name: windows-2015
   display_name: Windows (VS 2015)
-  expansions: {CC: Visual Studio 14 2015 Win64}
+  expansions:
+    CC: Visual Studio 14 2015 Win64
   run_on: windows-64-vs2015-compile
-  tasks: [.compression !.snappy !.zstd !.latest, release-compile, debug-compile-nosasl-nossl,
-    debug-compile-no-align, debug-compile-nosrv, .debug-compile .winssl, .debug-compile
-      !.sspi .openssl, .debug-compile !.sspi .nossl, .debug-compile .sspi !.openssl-static,
-    .authentication-tests .openssl !.sasl, .authentication-tests .winssl, .4.2 .winssl
-      !.nosasl .server, .4.0 .winssl !.nosasl .server, .3.6 .winssl !.nosasl .server]
+  tasks:
+  - .compression !.snappy !.zstd !.latest
+  - release-compile
+  - debug-compile-nosasl-nossl
+  - debug-compile-no-align
+  - debug-compile-nosrv
+  - .debug-compile .winssl
+  - .debug-compile !.sspi .openssl
+  - .debug-compile !.sspi .nossl
+  - .debug-compile .sspi !.openssl-static
+  - .authentication-tests .openssl !.sasl
+  - .authentication-tests .winssl
+  - .4.2 .winssl !.nosasl .server
+  - .4.0 .winssl !.nosasl .server
+  - .3.6 .winssl !.nosasl .server
 - name: windows-2015-32
   display_name: Windows (i686) (VS 2015)
-  expansions: {CC: Visual Studio 14 2015}
+  expansions:
+    CC: Visual Studio 14 2015
   run_on: windows-64-vs2015-compile
-  tasks: [.compression !.snappy !.zstd !.latest, release-compile, debug-compile-nosasl-nossl,
-    debug-compile-no-align, .debug-compile .sspi !.openssl !.openssl-static, .debug-compile
-      .winssl .nosasl, .debug-compile !.sspi .nossl .nosasl, .authentication-tests
-      .winssl, .4.2 .winssl .nosasl .server, .4.0 .winssl .nosasl .server]
+  tasks:
+  - .compression !.snappy !.zstd !.latest
+  - release-compile
+  - debug-compile-nosasl-nossl
+  - debug-compile-no-align
+  - .debug-compile .sspi !.openssl !.openssl-static
+  - .debug-compile .winssl .nosasl
+  - .debug-compile !.sspi .nossl .nosasl
+  - .authentication-tests .winssl
+  - .4.2 .winssl .nosasl .server
+  - .4.0 .winssl .nosasl .server
 - name: windows-2013
   display_name: Windows (VS 2013)
-  expansions: {CC: Visual Studio 12 2013 Win64}
+  expansions:
+    CC: Visual Studio 12 2013 Win64
   run_on: windows-64-vs2013-compile
-  tasks: [.compression !.snappy !.zstd !.latest, release-compile, debug-compile-nosasl-nossl,
-    .debug-compile .winssl !.client-side-encryption, .debug-compile !.sspi .openssl
-      !.client-side-encryption, .debug-compile !.sspi .nossl, .debug-compile .sspi
-      !.client-side-encryption !.openssl-static, .authentication-tests .openssl !.sasl,
-    .authentication-tests .winssl, .4.2 .winssl !.nosasl .server !.client-side-encryption,
-    .4.0 .winssl !.nosasl .server]
+  tasks:
+  - .compression !.snappy !.zstd !.latest
+  - release-compile
+  - debug-compile-nosasl-nossl
+  - .debug-compile .winssl !.client-side-encryption
+  - .debug-compile !.sspi .openssl !.client-side-encryption
+  - .debug-compile !.sspi .nossl
+  - .debug-compile .sspi !.client-side-encryption !.openssl-static
+  - .authentication-tests .openssl !.sasl
+  - .authentication-tests .winssl
+  - .4.2 .winssl !.nosasl .server !.client-side-encryption
+  - .4.0 .winssl !.nosasl .server
 - name: windows-2013-32
   display_name: Windows (i686) (VS 2013)
-  expansions: {CC: Visual Studio 12 2013}
+  expansions:
+    CC: Visual Studio 12 2013
   run_on: windows-64-vs2013-compile
-  tasks: [release-compile, debug-compile-nosasl-nossl, debug-compile-rdtscp, .debug-compile
-      .sspi !.openssl !.openssl-static, .debug-compile .winssl .nosasl !.client-side-encryption,
-    .debug-compile !.sspi .nossl .nosasl, .authentication-tests .winssl, .4.2 .winssl
-      .nosasl .server !.client-side-encryption, .4.0 .winssl .nosasl .server]
+  tasks:
+  - release-compile
+  - debug-compile-nosasl-nossl
+  - debug-compile-rdtscp
+  - .debug-compile .sspi !.openssl !.openssl-static
+  - .debug-compile .winssl .nosasl !.client-side-encryption
+  - .debug-compile !.sspi .nossl .nosasl
+  - .authentication-tests .winssl
+  - .4.2 .winssl .nosasl .server !.client-side-encryption
+  - .4.0 .winssl .nosasl .server
 - name: mingw-windows2016
   display_name: MinGW-W64 (Windows Server 2016)
-  expansions: {CC: mingw}
+  expansions:
+    CC: mingw
   run_on: windows-64-vs2017-test
-  tasks: [debug-compile-nosasl-nossl, .debug-compile .winssl .sspi, .latest .nossl
-      .nosasl .server, .latest .winssl .sspi .server]
+  tasks:
+  - debug-compile-nosasl-nossl
+  - .debug-compile .winssl .sspi
+  - .latest .nossl .nosasl .server
+  - .latest .winssl .sspi .server
 - name: mingw
   display_name: MinGW-W64
-  expansions: {CC: mingw}
+  expansions:
+    CC: mingw
   run_on: windows-64-vs2013-compile
-  tasks: [debug-compile-nosasl-nossl, debug-compile-no-align, .debug-compile .nossl
-      .nosasl, .debug-compile .winssl .sspi]
+  tasks:
+  - debug-compile-nosasl-nossl
+  - debug-compile-no-align
+  - .debug-compile .nossl .nosasl
+  - .debug-compile .winssl .sspi
 - name: power8-rhel81
   display_name: Power8 (ppc64le) (RHEL 8.1)
-  expansions: {CC: gcc}
+  expansions:
+    CC: gcc
   run_on: rhel81-power8-test
-  tasks: [release-compile, debug-compile-nosasl-nossl, .debug-compile !.sspi .openssl
-      !.client-side-encryption, .debug-compile !.sspi .openssl-static !.client-side-encryption,
-    .debug-compile !.sspi .nossl, .latest .openssl !.nosasl .server !.client-side-encryption,
-    .latest .openssl-static !.nosasl .server !.client-side-encryption, .latest .nossl,
-    .5.0 .openssl !.nosasl .server !.client-side-encryption, .4.4 .openssl !.nosasl
-      .server !.client-side-encryption, .4.2 .openssl !.nosasl .server !.client-side-encryption,
-    test-dns-openssl]
+  tasks:
+  - release-compile
+  - debug-compile-nosasl-nossl
+  - .debug-compile !.sspi .openssl !.client-side-encryption
+  - .debug-compile !.sspi .openssl-static !.client-side-encryption
+  - .debug-compile !.sspi .nossl
+  - .latest .openssl !.nosasl .server !.client-side-encryption
+  - .latest .openssl-static !.nosasl .server !.client-side-encryption
+  - .latest .nossl
+  - .5.0 .openssl !.nosasl .server !.client-side-encryption
+  - .4.4 .openssl !.nosasl .server !.client-side-encryption
+  - .4.2 .openssl !.nosasl .server !.client-side-encryption
+  - test-dns-openssl
   batchtime: 1440
 - name: arm-ubuntu1804
   display_name: '*ARM (aarch64) (Ubuntu 18.04)'
-  expansions: {CC: gcc}
+  expansions:
+    CC: gcc
   run_on: ubuntu1804-arm64-large
-  tasks: [.compression !.snappy !.zstd, debug-compile-scan-build, debug-compile-coverage,
-    debug-compile-no-align, release-compile, debug-compile-nosasl-nossl, .debug-compile
-      !.sspi .openssl, .debug-compile !.sspi .nossl, .authentication-tests .openssl,
-    .latest .openssl !.nosasl .server, .latest .nossl, .5.0 .openssl !.nosasl .server,
-    .4.4 .openssl !.nosasl .server, .4.2 .openssl !.nosasl .server, test-dns-openssl]
+  tasks:
+  - .compression !.snappy !.zstd
+  - debug-compile-scan-build
+  - debug-compile-coverage
+  - debug-compile-no-align
+  - release-compile
+  - debug-compile-nosasl-nossl
+  - .debug-compile !.sspi .openssl
+  - .debug-compile !.sspi .nossl
+  - .authentication-tests .openssl
+  - .latest .openssl !.nosasl .server
+  - .latest .nossl
+  - .5.0 .openssl !.nosasl .server
+  - .4.4 .openssl !.nosasl .server
+  - .4.2 .openssl !.nosasl .server
+  - test-dns-openssl
   batchtime: 1440
 - name: arm-ubuntu1604
   display_name: '*ARM (aarch64) (Ubuntu 16.04)'
-  expansions: {CC: gcc}
+  expansions:
+    CC: gcc
   run_on: ubuntu1604-arm64-large
-  tasks: [.compression !.snappy !.zstd, debug-compile-scan-build, debug-compile-coverage,
-    debug-compile-no-align, release-compile, debug-compile-nosasl-nossl, .debug-compile
-      !.sspi .openssl, .debug-compile !.sspi .nossl, .4.0 .openssl !.nosasl .server]
+  tasks:
+  - .compression !.snappy !.zstd
+  - debug-compile-scan-build
+  - debug-compile-coverage
+  - debug-compile-no-align
+  - release-compile
+  - debug-compile-nosasl-nossl
+  - .debug-compile !.sspi .openssl
+  - .debug-compile !.sspi .nossl
+  - .4.0 .openssl !.nosasl .server
   batchtime: 1440
 - name: zseries-rhel83
   display_name: '*zSeries'
-  expansions: {CC: gcc}
+  expansions:
+    CC: gcc
   run_on: rhel83-zseries-small
-  tasks: [release-compile, debug-compile-nosasl-nossl, debug-compile-no-align, .debug-compile
-      !.sspi .openssl, .debug-compile !.sspi .nossl, .authentication-tests .openssl,
-    .latest .openssl !.nosasl .server, .latest .nossl, .5.0 .openssl !.nosasl .server,
-    .4.4 .openssl !.nosasl .server, .4.2 .openssl !.nosasl .server, .4.0 .openssl
-      !.nosasl .server]
+  tasks:
+  - release-compile
+  - debug-compile-nosasl-nossl
+  - debug-compile-no-align
+  - .debug-compile !.sspi .openssl
+  - .debug-compile !.sspi .nossl
+  - .authentication-tests .openssl
+  - .latest .openssl !.nosasl .server
+  - .latest .nossl
+  - .5.0 .openssl !.nosasl .server
+  - .4.4 .openssl !.nosasl .server
+  - .4.2 .openssl !.nosasl .server
+  - .4.0 .openssl !.nosasl .server
   batchtime: 1440
 - name: valgrind-ubuntu
   display_name: Valgrind Tests (Ubuntu 18.04)
-  expansions: {CC: gcc}
+  expansions:
+    CC: gcc
   run_on: ubuntu1804-build
-  tasks: [.debug-compile !.sspi .openssl !.sasl, .debug-compile !.sspi .nossl !.sasl,
-    .debug-compile .special .valgrind, .test-valgrind !.3.6]
+  tasks:
+  - .debug-compile !.sspi .openssl !.sasl
+  - .debug-compile !.sspi .nossl !.sasl
+  - .debug-compile .special .valgrind
+  - .test-valgrind !.3.6
   batchtime: 1440
 - name: valgrind-ubuntu-1404
   display_name: Valgrind Tests - MongoDB (pre 4.0) (Ubuntu 14.04)
-  expansions: {CC: gcc}
+  expansions:
+    CC: gcc
   run_on: ubuntu1404-build
-  tasks: [.debug-compile !.sspi .openssl !.sasl, .debug-compile !.sspi .nossl !.sasl,
-    .debug-compile .special .valgrind, .test-valgrind .3.6]
+  tasks:
+  - .debug-compile !.sspi .openssl !.sasl
+  - .debug-compile !.sspi .nossl !.sasl
+  - .debug-compile .special .valgrind
+  - .test-valgrind .3.6
   batchtime: 1440
 - name: asan-ubuntu
   display_name: ASAN Tests (Ubuntu 18.04)
-  expansions: {CC: clang}
+  expansions:
+    CC: clang
   run_on: ubuntu1804-test
-  tasks: [.debug-compile .asan-clang, .test-asan !.3.6]
+  tasks:
+  - .debug-compile .asan-clang
+  - .test-asan !.3.6
   batchtime: 1440
 - name: asan-ubuntu-without-csfle
   display_name: ASAN Tests without csfle (Ubuntu 18.04)
-  expansions: {CC: clang, USE_CRYPT_SHARED: 'OFF'}
+  expansions:
+    CC: clang
+    USE_CRYPT_SHARED: 'OFF'
   run_on: ubuntu1804-test
-  tasks: [debug-compile-asan-openssl-cse, .test-asan !.3.6 .client-side-encryption]
+  tasks:
+  - debug-compile-asan-openssl-cse
+  - .test-asan !.3.6 .client-side-encryption
   batchtime: 1440
 - name: asan-ubuntu-ubuntu1604
   display_name: ASAN Tests (Ubuntu 16.04)
-  expansions: {CC: clang}
+  expansions:
+    CC: clang
   run_on: ubuntu1604-test
-  tasks: [.debug-compile .asan-clang, .test-asan .3.6]
+  tasks:
+  - .debug-compile .asan-clang
+  - .test-asan .3.6
   batchtime: 1440
 - name: clang60ubuntu
   display_name: clang 6.0 (Ubuntu 18.04)
-  expansions: {CC: clang}
+  expansions:
+    CC: clang
   run_on: ubuntu1804-test
-  tasks: [debug-compile-aws, debug-compile-nosasl-openssl-static, debug-compile-sasl-openssl-static,
-    debug-compile-sspi-openssl-static, test-aws-openssl-regular-latest, test-aws-openssl-ec2-latest,
-    test-aws-openssl-ecs-latest, test-aws-openssl-assume_role-latest, test-aws-openssl-lambda-latest,
-    test-aws-openssl-regular-4.4, test-aws-openssl-ec2-4.4, test-aws-openssl-ecs-4.4,
-    test-aws-openssl-assume_role-4.4, test-aws-openssl-lambda-4.4]
+  tasks:
+  - debug-compile-aws
+  - debug-compile-nosasl-openssl-static
+  - debug-compile-sasl-openssl-static
+  - debug-compile-sspi-openssl-static
+  - test-aws-openssl-regular-latest
+  - test-aws-openssl-ec2-latest
+  - test-aws-openssl-ecs-latest
+  - test-aws-openssl-assume_role-latest
+  - test-aws-openssl-lambda-latest
+  - test-aws-openssl-regular-4.4
+  - test-aws-openssl-ec2-4.4
+  - test-aws-openssl-ecs-4.4
+  - test-aws-openssl-assume_role-4.4
+  - test-aws-openssl-lambda-4.4
 - name: rhel62
   display_name: RHEL 6.2
-  expansions: {CC: gcc}
+  expansions:
+    CC: gcc
   run_on: rhel62-test
-  tasks: [debug-compile-sasl-openssl, test-4.0-server-auth-sasl-openssl, test-4.0-replica-set-auth-sasl-openssl,
-    test-latest-server-auth-sasl-openssl, test-latest-replica-set-auth-sasl-openssl]
+  tasks:
+  - debug-compile-sasl-openssl
+  - test-4.0-server-auth-sasl-openssl
+  - test-4.0-replica-set-auth-sasl-openssl
+  - test-latest-server-auth-sasl-openssl
+  - test-latest-replica-set-auth-sasl-openssl
   batchtime: 1440
 - name: mongohouse
   display_name: Mongohouse Test
   run_on: ubuntu1804-test
-  tasks: [debug-compile-sasl-openssl, test-mongohouse]
+  tasks:
+  - debug-compile-sasl-openssl
+  - test-mongohouse
 - name: ocsp
   display_name: OCSP tests
   run_on: ubuntu2004-small
   tasks:
   - name: debug-compile-nosasl-openssl
-    distros: [ubuntu2004-small]
+    distros:
+    - ubuntu2004-small
   - name: debug-compile-nosasl-openssl-static
-    distros: [ubuntu2004-small]
+    distros:
+    - ubuntu2004-small
   - name: debug-compile-nosasl-darwinssl
-    distros: [macos-1014]
+    distros:
+    - macos-1014
   - name: debug-compile-nosasl-winssl
-    distros: [windows-64-vs2017-test]
+    distros:
+    - windows-64-vs2017-test
   - name: .ocsp-openssl
-    distros: [ubuntu2004-small]
+    distros:
+    - ubuntu2004-small
   - name: .ocsp-darwinssl
-    distros: [macos-1014]
+    distros:
+    - macos-1014
   - name: .ocsp-winssl
-    distros: [windows-64-vs2017-test]
+    distros:
+    - windows-64-vs2017-test
   - name: debug-compile-nosasl-openssl-1.0.1
-    distros: [ubuntu2004-small]
+    distros:
+    - ubuntu2004-small
   - name: .ocsp-openssl-1.0.1
-    distros: [ubuntu2004-small]
+    distros:
+    - ubuntu2004-small
   batchtime: 10080
 - name: packaging
   display_name: Linux Distro Packaging
@@ -14008,20 +24774,28 @@ buildvariants:
   tasks:
   - debian-package-build
   - name: rpm-package-build
-    distros: [rhel82-arm64-small]
+    distros:
+    - rhel82-arm64-small
   batchtime: 1440
 - name: tsan-ubuntu
   display_name: Thread Sanitizer (TSAN) Tests (Ubuntu 18.04)
-  expansions: {CC: /opt/mongodbtoolchain/v3/bin/clang}
+  expansions:
+    CC: /opt/mongodbtoolchain/v3/bin/clang
   run_on: ubuntu1804-small
-  tasks: [.tsan !.3.6]
+  tasks:
+  - .tsan !.3.6
   batchtime: 1440
 - name: versioned-api
   display_name: Versioned API Tests
   run_on: ubuntu1804-test
-  tasks: [debug-compile-nosasl-openssl, debug-compile-nosasl-nossl, .versioned-api]
+  tasks:
+  - debug-compile-nosasl-openssl
+  - debug-compile-nosasl-nossl
+  - .versioned-api
 - name: macos_m1
   display_name: macOS m1 (Apple LLVM)
-  expansions: {CC: clang}
+  expansions:
+    CC: clang
   run_on: macos-1100-arm64
-  tasks: [debug-compile-sasl-darwinssl]
+  tasks:
+  - debug-compile-sasl-darwinssl

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -13,8 +13,7 @@ exec_timeout_secs: 2400
 functions:
   fetch source:
   - command: git.get_project
-    params:
-      directory: mongoc
+    params: {directory: mongoc}
   - command: shell.exec
     params:
       working_dir: mongoc
@@ -30,8 +29,7 @@ functions:
         fi
         echo "CURRENT_VERSION: $VERSION" > expansion.yml
   - command: expansions.update
-    params:
-      file: mongoc/expansion.yml
+    params: {file: mongoc/expansion.yml}
   - command: shell.exec
     params:
       continue_on_err: true
@@ -42,35 +40,21 @@ functions:
         curl --retry 5 https://s3.amazonaws.com/mciuploads/${project}/${branch_name}/mongo-c-driver-${CURRENT_VERSION}.tar.gz --output mongoc.tar.gz -sS --max-time 120
   upload release:
   - command: shell.exec
-    params:
-      shell: bash
-      script: '[ -f mongoc/cmake_build/mongo*gz ] && mv mongoc/cmake_build/mongo*gz
-        mongoc.tar.gz'
+    params: {shell: bash, script: '[ -f mongoc/cmake_build/mongo*gz ] && mv mongoc/cmake_build/mongo*gz
+        mongoc.tar.gz'}
   - command: s3.put
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      remote_file: ${project}/${branch_name}/mongo-c-driver-${CURRENT_VERSION}.tar.gz
-      bucket: mciuploads
-      permissions: public-read
-      local_file: mongoc.tar.gz
-      content_type: ${content_type|application/x-gzip}
+    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${branch_name}/mongo-c-driver-${CURRENT_VERSION}.tar.gz',
+      bucket: mciuploads, permissions: public-read, local_file: mongoc.tar.gz, content_type: '${content_type|application/x-gzip}'}
   upload build:
   - command: archive.targz_pack
     params:
       target: ${build_id}.tar.gz
       source_dir: mongoc
-      include:
-      - ./**
+      include: [./**]
   - command: s3.put
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      remote_file: ${project}/${build_variant}/${revision}/${task_name}/${build_id}.tar.gz
-      bucket: mciuploads
-      permissions: public-read
-      local_file: ${build_id}.tar.gz
-      content_type: ${content_type|application/x-gzip}
+    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${build_variant}/${revision}/${task_name}/${build_id}.tar.gz',
+      bucket: mciuploads, permissions: public-read, local_file: '${build_id}.tar.gz',
+      content_type: '${content_type|application/x-gzip}'}
   release archive:
   - command: shell.exec
     type: test
@@ -106,12 +90,8 @@ functions:
         set -o errexit
         rm -rf mongoc
   - command: s3.get
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      remote_file: ${project}/${build_variant}/${revision}/${BUILD_NAME}/${build_id}.tar.gz
-      bucket: mciuploads
-      local_file: build.tar.gz
+    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${build_variant}/${revision}/${BUILD_NAME}/${build_id}.tar.gz',
+      bucket: mciuploads, local_file: build.tar.gz}
   - command: shell.exec
     params:
       continue_on_err: true
@@ -137,15 +117,9 @@ functions:
         export AWS_SECRET_ACCESS_KEY=${aws_secret}
         aws s3 cp doc/html s3://mciuploads/${project}/docs/libbson/${CURRENT_VERSION} --recursive --acl public-read --region us-east-1
   - command: s3.put
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      remote_file: ${project}/docs/libbson/${CURRENT_VERSION}/index.html
-      bucket: mciuploads
-      permissions: public-read
-      local_file: mongoc/cmake_build/src/libbson/doc/html/index.html
-      content_type: text/html
-      display_name: libbson docs
+    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/docs/libbson/${CURRENT_VERSION}/index.html',
+      bucket: mciuploads, permissions: public-read, local_file: mongoc/cmake_build/src/libbson/doc/html/index.html,
+      content_type: text/html, display_name: libbson docs}
   - command: shell.exec
     params:
       silent: true
@@ -157,15 +131,9 @@ functions:
         export AWS_SECRET_ACCESS_KEY=${aws_secret}
         aws s3 cp doc/html s3://mciuploads/${project}/docs/libmongoc/${CURRENT_VERSION} --recursive --acl public-read --region us-east-1
   - command: s3.put
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      remote_file: ${project}/docs/libmongoc/${CURRENT_VERSION}/index.html
-      bucket: mciuploads
-      permissions: public-read
-      local_file: mongoc/cmake_build/src/libmongoc/doc/html/index.html
-      content_type: text/html
-      display_name: libmongoc docs
+    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/docs/libmongoc/${CURRENT_VERSION}/index.html',
+      bucket: mciuploads, permissions: public-read, local_file: mongoc/cmake_build/src/libmongoc/doc/html/index.html,
+      content_type: text/html, display_name: libmongoc docs}
   upload man pages:
   - command: shell.exec
     params:
@@ -183,25 +151,13 @@ functions:
         sh .evergreen/man-pages-to-html.sh libbson cmake_build/src/libbson/doc/man > bson-man-pages.html
         sh .evergreen/man-pages-to-html.sh libmongoc cmake_build/src/libmongoc/doc/man > mongoc-man-pages.html
   - command: s3.put
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      remote_file: ${project}/man-pages/libbson/${CURRENT_VERSION}/index.html
-      bucket: mciuploads
-      permissions: public-read
-      local_file: mongoc/bson-man-pages.html
-      content_type: text/html
-      display_name: libbson man pages
+    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/man-pages/libbson/${CURRENT_VERSION}/index.html',
+      bucket: mciuploads, permissions: public-read, local_file: mongoc/bson-man-pages.html,
+      content_type: text/html, display_name: libbson man pages}
   - command: s3.put
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      remote_file: ${project}/man-pages/libmongoc/${CURRENT_VERSION}/index.html
-      bucket: mciuploads
-      permissions: public-read
-      local_file: mongoc/mongoc-man-pages.html
-      content_type: text/html
-      display_name: libmongoc man pages
+    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/man-pages/libmongoc/${CURRENT_VERSION}/index.html',
+      bucket: mciuploads, permissions: public-read, local_file: mongoc/mongoc-man-pages.html,
+      content_type: text/html, display_name: libmongoc man pages}
   upload coverage:
   - command: shell.exec
     params:
@@ -214,15 +170,9 @@ functions:
         export AWS_SECRET_ACCESS_KEY=${aws_secret}
         aws s3 cp coverage s3://mciuploads/${project}/${build_variant}/${revision}/${version_id}/${build_id}/coverage/ --recursive --acl public-read --region us-east-1
   - command: s3.put
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      remote_file: ${project}/${build_variant}/${revision}/${version_id}/${build_id}/coverage/index.html
-      bucket: mciuploads
-      permissions: public-read
-      local_file: mongoc/coverage/index.html
-      content_type: text/html
-      display_name: Coverage Report
+    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${build_variant}/${revision}/${version_id}/${build_id}/coverage/index.html',
+      bucket: mciuploads, permissions: public-read, local_file: mongoc/coverage/index.html,
+      content_type: text/html, display_name: Coverage Report}
   abi report:
   - command: shell.exec
     params:
@@ -247,15 +197,9 @@ functions:
           exit 0
         fi
   - command: s3.put
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      remote_file: ${project}/${build_variant}/${revision}/${version_id}/${build_id}/abi-compliance/compat_report.html
-      bucket: mciuploads
-      permissions: public-read
-      local_files_include_filter: mongoc/abi-compliance/compat_reports/**/*.html
-      content_type: text/html
-      display_name: 'ABI Report:'
+    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${build_variant}/${revision}/${version_id}/${build_id}/abi-compliance/compat_report.html',
+      bucket: mciuploads, permissions: public-read, local_files_include_filter: mongoc/abi-compliance/compat_reports/**/*.html,
+      content_type: text/html, display_name: 'ABI Report:'}
   upload scan artifacts:
   - command: shell.exec
     type: test
@@ -280,15 +224,9 @@ functions:
         export AWS_SECRET_ACCESS_KEY=${aws_secret}
         aws s3 cp scan s3://mciuploads/${project}/${build_variant}/${revision}/${version_id}/${build_id}/scan/ --recursive --acl public-read --region us-east-1
   - command: s3.put
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      remote_file: ${project}/${build_variant}/${revision}/${version_id}/${build_id}/scan/index.html
-      bucket: mciuploads
-      permissions: public-read
-      local_file: mongoc/scan.html
-      content_type: text/html
-      display_name: Scan Build Report
+    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${build_variant}/${revision}/${version_id}/${build_id}/scan/index.html',
+      bucket: mciuploads, permissions: public-read, local_file: mongoc/scan.html,
+      content_type: text/html, display_name: Scan Build Report}
   upload mo artifacts:
   - command: shell.exec
     params:
@@ -300,25 +238,13 @@ functions:
         [ -d "/cygdrive/c/data/mo" ] && DIR="/cygdrive/c/data/mo"
         [ -d $DIR ] && find $DIR -name \*.log | xargs tar czf mongodb-logs.tar.gz
   - command: s3.put
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      remote_file: ${project}/${build_variant}/${revision}/${version_id}/${build_id}/logs/${task_id}-${execution}-mongodb-logs.tar.gz
-      bucket: mciuploads
-      permissions: public-read
-      local_file: mongoc/mongodb-logs.tar.gz
-      content_type: ${content_type|application/x-gzip}
-      display_name: mongodb-logs.tar.gz
+    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${build_variant}/${revision}/${version_id}/${build_id}/logs/${task_id}-${execution}-mongodb-logs.tar.gz',
+      bucket: mciuploads, permissions: public-read, local_file: mongoc/mongodb-logs.tar.gz,
+      content_type: '${content_type|application/x-gzip}', display_name: mongodb-logs.tar.gz}
   - command: s3.put
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      remote_file: ${project}/${build_variant}/${revision}/${version_id}/${build_id}/logs/${task_id}-${execution}-orchestration.log
-      bucket: mciuploads
-      permissions: public-read
-      local_file: mongoc/MO/server.log
-      content_type: ${content_type|text/plain}
-      display_name: orchestration.log
+    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${build_variant}/${revision}/${version_id}/${build_id}/logs/${task_id}-${execution}-orchestration.log',
+      bucket: mciuploads, permissions: public-read, local_file: mongoc/MO/server.log,
+      content_type: '${content_type|text/plain}', display_name: orchestration.log}
   - command: shell.exec
     params:
       working_dir: mongoc
@@ -343,20 +269,12 @@ functions:
     params:
       target: mongo-coredumps.tgz
       source_dir: mongoc
-      include:
-      - ./**.core
-      - ./**.mdmp
+      include: [./**.core, ./**.mdmp]
   - command: s3.put
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      remote_file: ${project}/${build_variant}/${revision}/${version_id}/${build_id}/coredumps/${task_id}-${execution}-coredumps.log
-      bucket: mciuploads
-      permissions: public-read
-      local_file: mongo-coredumps.tgz
-      content_type: ${content_type|application/x-gzip}
-      display_name: Core Dumps - Execution ${execution}
-      optional: 'True'
+    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${build_variant}/${revision}/${version_id}/${build_id}/coredumps/${task_id}-${execution}-coredumps.log',
+      bucket: mciuploads, permissions: public-read, local_file: mongo-coredumps.tgz,
+      content_type: '${content_type|application/x-gzip}', display_name: 'Core Dumps
+        - Execution ${execution}', optional: 'True'}
   backtrace:
   - command: shell.exec
     params:
@@ -370,22 +288,14 @@ functions:
     params:
       target: working-dir.tar.gz
       source_dir: mongoc
-      include:
-      - ./**
+      include: [./**]
   - command: s3.put
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      remote_file: ${project}/${build_variant}/${revision}/${version_id}/${build_id}/artifacts/${task_id}-${execution}-working-dir.tar.gz
-      bucket: mciuploads
-      permissions: public-read
-      local_file: working-dir.tar.gz
-      content_type: ${content_type|application/x-gzip}
-      display_name: working-dir.tar.gz
+    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${build_variant}/${revision}/${version_id}/${build_id}/artifacts/${task_id}-${execution}-working-dir.tar.gz',
+      bucket: mciuploads, permissions: public-read, local_file: working-dir.tar.gz,
+      content_type: '${content_type|application/x-gzip}', display_name: working-dir.tar.gz}
   upload test results:
   - command: attach.results
-    params:
-      file_location: mongoc/test-results.json
+    params: {file_location: mongoc/test-results.json}
   bootstrap mongo-orchestration:
   - command: shell.exec
     params:
@@ -794,8 +704,7 @@ functions:
         export MONGODB_URI="${MONGODB_URI}"
         bash $DRIVERS_TOOLS/.evergreen/run-load-balancer.sh start
   - command: expansions.update
-    params:
-      file: lb-expansion.yml
+    params: {file: lb-expansion.yml}
   stop load balancer:
   - command: shell.exec
     params:
@@ -811,19 +720,19 @@ functions:
         export MONGODB_URI="foo" # TODO: DRIVERS-1833 remove this.
         $DRIVERS_TOOLS/.evergreen/run-load-balancer.sh stop
 pre:
-- func: fetch source
-- func: windows fix
-- func: make files executable
-- func: prepare kerberos
+- {func: fetch source}
+- {func: windows fix}
+- {func: make files executable}
+- {func: prepare kerberos}
 post:
-- func: backtrace
-- func: upload working dir
-- func: upload mo artifacts
-- func: upload test results
-- func: cleanup
-- func: stop load balancer
+- {func: backtrace}
+- {func: upload working dir}
+- {func: upload mo artifacts}
+- {func: upload test results}
+- {func: cleanup}
+- {func: stop load balancer}
 timeout:
-- func: backtrace
+- {func: backtrace}
 tasks:
 - name: check-headers
   commands:
@@ -845,14 +754,13 @@ tasks:
         python ./.evergreen/check-preludes.py .
 - name: make-release-archive
   commands:
-  - func: release archive
-  - func: upload docs
-  - func: upload man pages
-  - func: upload release
-  - func: upload build
+  - {func: release archive}
+  - {func: upload docs}
+  - {func: upload man pages}
+  - {func: upload release}
+  - {func: upload build}
 - name: hardened-compile
-  tags:
-  - hardened
+  tags: [hardened]
   commands:
   - command: shell.exec
     type: test
@@ -869,14 +777,12 @@ tasks:
         export ZLIB="OFF"
         export ZSTD="OFF"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: abi-compliance-check
   commands:
-  - func: abi report
+  - {func: abi report}
 - name: debug-compile-compression-zlib
-  tags:
-  - compression
-  - zlib
+  tags: [compression, zlib]
   commands:
   - command: shell.exec
     type: test
@@ -891,11 +797,9 @@ tasks:
         export ZLIB="BUNDLED"
         export ZSTD="OFF"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-compression-snappy
-  tags:
-  - compression
-  - snappy
+  tags: [compression, snappy]
   commands:
   - command: shell.exec
     type: test
@@ -910,11 +814,9 @@ tasks:
         export ZLIB="OFF"
         export ZSTD="OFF"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-compression-zstd
-  tags:
-  - compression
-  - zstd
+  tags: [compression, zstd]
   commands:
   - command: shell.exec
     type: test
@@ -929,13 +831,9 @@ tasks:
         export ZLIB="OFF"
         export ZSTD="ON"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-compression
-  tags:
-  - compression
-  - snappy
-  - zlib
-  - zstd
+  tags: [compression, snappy, zlib, zstd]
   commands:
   - command: shell.exec
     type: test
@@ -950,10 +848,9 @@ tasks:
         export ZLIB="BUNDLED"
         export ZSTD="ON"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-no-align
-  tags:
-  - debug-compile
+  tags: [debug-compile]
   commands:
   - command: shell.exec
     type: test
@@ -969,12 +866,9 @@ tasks:
         export ZLIB="BUNDLED"
         export ZSTD="OFF"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-nosasl-nossl
-  tags:
-  - debug-compile
-  - nosasl
-  - nossl
+  tags: [debug-compile, nosasl, nossl]
   commands:
   - command: shell.exec
     type: test
@@ -987,7 +881,7 @@ tasks:
         export SANITIZE=""
         export SSL="OFF"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-lto
   commands:
   - command: shell.exec
@@ -1001,7 +895,7 @@ tasks:
         export DEBUG="ON"
         export SANITIZE=""
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-lto-thin
   commands:
   - command: shell.exec
@@ -1015,13 +909,9 @@ tasks:
         export DEBUG="ON"
         export SANITIZE=""
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-c11
-  tags:
-  - c11
-  - debug-compile
-  - special
-  - stdflags
+  tags: [c11, debug-compile, special, stdflags]
   commands:
   - command: shell.exec
     type: test
@@ -1034,13 +924,9 @@ tasks:
         export DEBUG="ON"
         export SANITIZE=""
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-c99
-  tags:
-  - c99
-  - debug-compile
-  - special
-  - stdflags
+  tags: [c99, debug-compile, special, stdflags]
   commands:
   - command: shell.exec
     type: test
@@ -1053,12 +939,9 @@ tasks:
         export DEBUG="ON"
         export SANITIZE=""
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-valgrind
-  tags:
-  - debug-compile
-  - special
-  - valgrind
+  tags: [debug-compile, special, valgrind]
   commands:
   - command: shell.exec
     type: test
@@ -1073,12 +956,9 @@ tasks:
         export SSL="OPENSSL"
         export VALGRIND="ON"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-coverage
-  tags:
-  - coverage
-  - debug-compile
-  - special
+  tags: [coverage, debug-compile, special]
   commands:
   - command: shell.exec
     type: test
@@ -1091,12 +971,10 @@ tasks:
         export DEBUG="ON"
         export SANITIZE=""
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
-  - func: upload coverage
+  - {func: upload build}
+  - {func: upload coverage}
 - name: debug-compile-no-counters
-  tags:
-  - debug-compile
-  - no-counters
+  tags: [debug-compile, no-counters]
   commands:
   - command: shell.exec
     type: test
@@ -1109,12 +987,9 @@ tasks:
         export ENABLE_SHM_COUNTERS="OFF"
         export SANITIZE=""
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-asan-clang
-  tags:
-  - asan-clang
-  - debug-compile
-  - special
+  tags: [asan-clang, debug-compile, special]
   commands:
   - command: shell.exec
     type: test
@@ -1134,10 +1009,9 @@ tasks:
         export ZLIB="BUNDLED"
         export ZSTD="OFF"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-asan-gcc
-  tags:
-  - special
+  tags: [special]
   commands:
   - command: shell.exec
     type: test
@@ -1155,12 +1029,9 @@ tasks:
         export ZLIB="BUNDLED"
         export ZSTD="OFF"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-asan-clang-openssl
-  tags:
-  - asan-clang
-  - debug-compile
-  - special
+  tags: [asan-clang, debug-compile, special]
   commands:
   - command: shell.exec
     type: test
@@ -1181,10 +1052,9 @@ tasks:
         export ZLIB="BUNDLED"
         export ZSTD="OFF"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-ubsan
-  tags:
-  - special
+  tags: [special]
   commands:
   - command: shell.exec
     type: test
@@ -1204,13 +1074,9 @@ tasks:
         export ZLIB="BUNDLED"
         export ZSTD="OFF"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-scan-build
-  tags:
-  - clang
-  - debug-compile
-  - scan-build
-  - special
+  tags: [clang, debug-compile, scan-build, special]
   commands:
   - command: shell.exec
     type: test
@@ -1224,8 +1090,8 @@ tasks:
         export DEBUG="ON"
         export SANITIZE=""
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
-  - func: upload scan artifacts
+  - {func: upload build}
+  - {func: upload scan artifacts}
   - command: shell.exec
     type: test
     params:
@@ -1250,11 +1116,9 @@ tasks:
         export SANITIZE=""
         export TRACING="ON"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: release-compile
-  depends_on:
-    name: make-release-archive
-    variant: releng
+  depends_on: {name: make-release-archive, variant: releng}
   commands:
   - command: shell.exec
     type: test
@@ -1266,12 +1130,9 @@ tasks:
         export RELEASE="ON"
         export SANITIZE=""
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-nosasl-openssl
-  tags:
-  - debug-compile
-  - nosasl
-  - openssl
+  tags: [debug-compile, nosasl, openssl]
   commands:
   - command: shell.exec
     type: test
@@ -1284,12 +1145,9 @@ tasks:
         export SANITIZE=""
         export SSL="OPENSSL"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-nosasl-openssl-static
-  tags:
-  - debug-compile
-  - nosasl
-  - openssl-static
+  tags: [debug-compile, nosasl, openssl-static]
   commands:
   - command: shell.exec
     type: test
@@ -1302,12 +1160,9 @@ tasks:
         export SANITIZE=""
         export SSL="OPENSSL_STATIC"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-nosasl-darwinssl
-  tags:
-  - darwinssl
-  - debug-compile
-  - nosasl
+  tags: [darwinssl, debug-compile, nosasl]
   commands:
   - command: shell.exec
     type: test
@@ -1320,12 +1175,9 @@ tasks:
         export SANITIZE=""
         export SSL="DARWIN"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-nosasl-winssl
-  tags:
-  - debug-compile
-  - nosasl
-  - winssl
+  tags: [debug-compile, nosasl, winssl]
   commands:
   - command: shell.exec
     type: test
@@ -1338,12 +1190,9 @@ tasks:
         export SANITIZE=""
         export SSL="WINDOWS"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-sasl-nossl
-  tags:
-  - debug-compile
-  - nossl
-  - sasl
+  tags: [debug-compile, nossl, sasl]
   commands:
   - command: shell.exec
     type: test
@@ -1357,12 +1206,9 @@ tasks:
         export SASL="AUTO"
         export SSL="OFF"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-sasl-openssl
-  tags:
-  - debug-compile
-  - openssl
-  - sasl
+  tags: [debug-compile, openssl, sasl]
   commands:
   - command: shell.exec
     type: test
@@ -1376,12 +1222,9 @@ tasks:
         export SASL="AUTO"
         export SSL="OPENSSL"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-sasl-openssl-static
-  tags:
-  - debug-compile
-  - openssl-static
-  - sasl
+  tags: [debug-compile, openssl-static, sasl]
   commands:
   - command: shell.exec
     type: test
@@ -1395,12 +1238,9 @@ tasks:
         export SASL="AUTO"
         export SSL="OPENSSL_STATIC"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-sasl-darwinssl
-  tags:
-  - darwinssl
-  - debug-compile
-  - sasl
+  tags: [darwinssl, debug-compile, sasl]
   commands:
   - command: shell.exec
     type: test
@@ -1414,12 +1254,9 @@ tasks:
         export SASL="AUTO"
         export SSL="DARWIN"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-sasl-winssl
-  tags:
-  - debug-compile
-  - sasl
-  - winssl
+  tags: [debug-compile, sasl, winssl]
   commands:
   - command: shell.exec
     type: test
@@ -1433,12 +1270,9 @@ tasks:
         export SASL="CYRUS"
         export SSL="WINDOWS"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-sspi-nossl
-  tags:
-  - debug-compile
-  - nossl
-  - sspi
+  tags: [debug-compile, nossl, sspi]
   commands:
   - command: shell.exec
     type: test
@@ -1452,12 +1286,9 @@ tasks:
         export SASL="SSPI"
         export SSL="OFF"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-sspi-openssl
-  tags:
-  - debug-compile
-  - openssl
-  - sspi
+  tags: [debug-compile, openssl, sspi]
   commands:
   - command: shell.exec
     type: test
@@ -1471,12 +1302,9 @@ tasks:
         export SASL="SSPI"
         export SSL="OPENSSL"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-sspi-openssl-static
-  tags:
-  - debug-compile
-  - openssl-static
-  - sspi
+  tags: [debug-compile, openssl-static, sspi]
   commands:
   - command: shell.exec
     type: test
@@ -1490,7 +1318,7 @@ tasks:
         export SASL="SSPI"
         export SSL="OPENSSL_STATIC"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-rdtscp
   commands:
   - command: shell.exec
@@ -1504,12 +1332,9 @@ tasks:
         export ENABLE_RDTSCP="ON"
         export SANITIZE=""
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-sspi-winssl
-  tags:
-  - debug-compile
-  - sspi
-  - winssl
+  tags: [debug-compile, sspi, winssl]
   commands:
   - command: shell.exec
     type: test
@@ -1523,10 +1348,9 @@ tasks:
         export SASL="SSPI"
         export SSL="WINDOWS"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-nosrv
-  tags:
-  - debug-compile
+  tags: [debug-compile]
   commands:
   - command: shell.exec
     type: test
@@ -1539,197 +1363,124 @@ tasks:
         export SANITIZE=""
         export SRV="OFF"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: link-with-cmake
-  depends_on:
-    name: make-release-archive
-    variant: releng
+  depends_on: {name: make-release-archive, variant: releng}
   commands:
   - func: bootstrap mongo-orchestration
-    vars:
-      VERSION: latest
+    vars: {VERSION: latest}
   - func: link sample program
-    vars:
-      BUILD_SAMPLE_WITH_CMAKE: 1
+    vars: {BUILD_SAMPLE_WITH_CMAKE: 1}
 - name: link-with-cmake-ssl
-  depends_on:
-    name: make-release-archive
-    variant: releng
+  depends_on: {name: make-release-archive, variant: releng}
   commands:
   - func: bootstrap mongo-orchestration
-    vars:
-      VERSION: latest
+    vars: {VERSION: latest}
   - func: link sample program
-    vars:
-      BUILD_SAMPLE_WITH_CMAKE: 1
-      ENABLE_SSL: 1
+    vars: {BUILD_SAMPLE_WITH_CMAKE: 1, ENABLE_SSL: 1}
 - name: link-with-cmake-snappy
-  depends_on:
-    name: make-release-archive
-    variant: releng
+  depends_on: {name: make-release-archive, variant: releng}
   commands:
   - func: bootstrap mongo-orchestration
-    vars:
-      VERSION: latest
+    vars: {VERSION: latest}
   - func: link sample program
-    vars:
-      BUILD_SAMPLE_WITH_CMAKE: 1
-      ENABLE_SNAPPY: 1
+    vars: {BUILD_SAMPLE_WITH_CMAKE: 1, ENABLE_SNAPPY: 1}
 - name: link-with-cmake-mac
-  depends_on:
-    name: make-release-archive
-    variant: releng
+  depends_on: {name: make-release-archive, variant: releng}
   commands:
   - func: bootstrap mongo-orchestration
-    vars:
-      VERSION: latest
+    vars: {VERSION: latest}
   - func: link sample program
-    vars:
-      BUILD_SAMPLE_WITH_CMAKE: 1
+    vars: {BUILD_SAMPLE_WITH_CMAKE: 1}
 - name: link-with-cmake-deprecated
-  depends_on:
-    name: make-release-archive
-    variant: releng
+  depends_on: {name: make-release-archive, variant: releng}
   commands:
   - func: bootstrap mongo-orchestration
-    vars:
-      VERSION: latest
+    vars: {VERSION: latest}
   - func: link sample program
-    vars:
-      BUILD_SAMPLE_WITH_CMAKE: 1
-      BUILD_SAMPLE_WITH_CMAKE_DEPRECATED: 1
+    vars: {BUILD_SAMPLE_WITH_CMAKE: 1, BUILD_SAMPLE_WITH_CMAKE_DEPRECATED: 1}
 - name: link-with-cmake-ssl-deprecated
-  depends_on:
-    name: make-release-archive
-    variant: releng
+  depends_on: {name: make-release-archive, variant: releng}
   commands:
   - func: bootstrap mongo-orchestration
-    vars:
-      VERSION: latest
+    vars: {VERSION: latest}
   - func: link sample program
-    vars:
-      BUILD_SAMPLE_WITH_CMAKE: 1
-      BUILD_SAMPLE_WITH_CMAKE_DEPRECATED: 1
-      ENABLE_SSL: 1
+    vars: {BUILD_SAMPLE_WITH_CMAKE: 1, BUILD_SAMPLE_WITH_CMAKE_DEPRECATED: 1, ENABLE_SSL: 1}
 - name: link-with-cmake-snappy-deprecated
-  depends_on:
-    name: make-release-archive
-    variant: releng
+  depends_on: {name: make-release-archive, variant: releng}
   commands:
   - func: bootstrap mongo-orchestration
-    vars:
-      VERSION: latest
+    vars: {VERSION: latest}
   - func: link sample program
-    vars:
-      BUILD_SAMPLE_WITH_CMAKE: 1
-      BUILD_SAMPLE_WITH_CMAKE_DEPRECATED: 1
-      ENABLE_SNAPPY: 1
+    vars: {BUILD_SAMPLE_WITH_CMAKE: 1, BUILD_SAMPLE_WITH_CMAKE_DEPRECATED: 1, ENABLE_SNAPPY: 1}
 - name: link-with-cmake-mac-deprecated
-  depends_on:
-    name: make-release-archive
-    variant: releng
+  depends_on: {name: make-release-archive, variant: releng}
   commands:
   - func: bootstrap mongo-orchestration
-    vars:
-      VERSION: latest
+    vars: {VERSION: latest}
   - func: link sample program
-    vars:
-      BUILD_SAMPLE_WITH_CMAKE: 1
-      BUILD_SAMPLE_WITH_CMAKE_DEPRECATED: 1
+    vars: {BUILD_SAMPLE_WITH_CMAKE: 1, BUILD_SAMPLE_WITH_CMAKE_DEPRECATED: 1}
 - name: link-with-cmake-windows
-  depends_on:
-    name: make-release-archive
-    variant: releng
+  depends_on: {name: make-release-archive, variant: releng}
   commands:
   - func: bootstrap mongo-orchestration
-    vars:
-      VERSION: latest
-  - func: link sample program MSVC
+    vars: {VERSION: latest}
+  - {func: link sample program MSVC}
 - name: link-with-cmake-windows-ssl
-  depends_on:
-    name: make-release-archive
-    variant: releng
+  depends_on: {name: make-release-archive, variant: releng}
   commands:
   - func: bootstrap mongo-orchestration
-    vars:
-      SSL: 1
-      VERSION: latest
+    vars: {SSL: 1, VERSION: latest}
   - func: link sample program MSVC
-    vars:
-      ENABLE_SSL: 1
+    vars: {ENABLE_SSL: 1}
 - name: link-with-cmake-windows-snappy
-  depends_on:
-    name: make-release-archive
-    variant: releng
+  depends_on: {name: make-release-archive, variant: releng}
   commands:
   - func: bootstrap mongo-orchestration
-    vars:
-      VERSION: latest
+    vars: {VERSION: latest}
   - func: link sample program MSVC
-    vars:
-      ENABLE_SNAPPY: 1
+    vars: {ENABLE_SNAPPY: 1}
 - name: link-with-cmake-mingw
-  depends_on:
-    name: make-release-archive
-    variant: releng
+  depends_on: {name: make-release-archive, variant: releng}
   commands:
   - func: bootstrap mongo-orchestration
-    vars:
-      VERSION: latest
-  - func: link sample program mingw
+    vars: {VERSION: latest}
+  - {func: link sample program mingw}
 - name: link-with-pkg-config
-  depends_on:
-    name: make-release-archive
-    variant: releng
+  depends_on: {name: make-release-archive, variant: releng}
   commands:
   - func: bootstrap mongo-orchestration
-    vars:
-      VERSION: latest
-  - func: link sample program
+    vars: {VERSION: latest}
+  - {func: link sample program}
 - name: link-with-pkg-config-mac
-  depends_on:
-    name: make-release-archive
-    variant: releng
+  depends_on: {name: make-release-archive, variant: releng}
   commands:
   - func: bootstrap mongo-orchestration
-    vars:
-      VERSION: latest
-  - func: link sample program
+    vars: {VERSION: latest}
+  - {func: link sample program}
 - name: link-with-pkg-config-ssl
-  depends_on:
-    name: make-release-archive
-    variant: releng
+  depends_on: {name: make-release-archive, variant: releng}
   commands:
   - func: bootstrap mongo-orchestration
-    vars:
-      VERSION: latest
+    vars: {VERSION: latest}
   - func: link sample program
-    vars:
-      ENABLE_SSL: 1
+    vars: {ENABLE_SSL: 1}
 - name: link-with-bson
-  depends_on:
-    name: make-release-archive
-    variant: releng
+  depends_on: {name: make-release-archive, variant: releng}
   commands:
-  - func: link sample program bson
+  - {func: link sample program bson}
 - name: link-with-bson-mac
-  depends_on:
-    name: make-release-archive
-    variant: releng
+  depends_on: {name: make-release-archive, variant: releng}
   commands:
-  - func: link sample program bson
+  - {func: link sample program bson}
 - name: link-with-bson-windows
-  depends_on:
-    name: make-release-archive
-    variant: releng
+  depends_on: {name: make-release-archive, variant: releng}
   commands:
-  - func: link sample program MSVC bson
+  - {func: link sample program MSVC bson}
 - name: link-with-bson-mingw
-  depends_on:
-    name: make-release-archive
-    variant: releng
+  depends_on: {name: make-release-archive, variant: releng}
   commands:
-  - func: link sample program mingw bson
+  - {func: link sample program mingw bson}
 - name: debian-package-build
   commands:
   - command: shell.exec
@@ -1742,23 +1493,11 @@ tasks:
         export IS_PATCH="${is_patch}"
         sh .evergreen/debian_package_build.sh
   - command: s3.put
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      remote_file: ${project}/${branch_name}/mongo-c-driver-debian-packages-${CURRENT_VERSION}.tar.gz
-      bucket: mciuploads
-      permissions: public-read
-      local_file: deb.tar.gz
-      content_type: ${content_type|application/x-gzip}
+    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${branch_name}/mongo-c-driver-debian-packages-${CURRENT_VERSION}.tar.gz',
+      bucket: mciuploads, permissions: public-read, local_file: deb.tar.gz, content_type: '${content_type|application/x-gzip}'}
   - command: s3.put
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      remote_file: ${project}/${branch_name}/${revision}/${version_id}/${build_id}/${execution}/mongo-c-driver-debian-packages.tar.gz
-      bucket: mciuploads
-      permissions: public-read
-      local_file: deb.tar.gz
-      content_type: ${content_type|application/x-gzip}
+    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${branch_name}/${revision}/${version_id}/${build_id}/${execution}/mongo-c-driver-debian-packages.tar.gz',
+      bucket: mciuploads, permissions: public-read, local_file: deb.tar.gz, content_type: '${content_type|application/x-gzip}'}
 - name: rpm-package-build
   commands:
   - command: shell.exec
@@ -1770,27 +1509,13 @@ tasks:
         set -o errexit
         sh .evergreen/build_snapshot_rpm.sh
   - command: s3.put
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      remote_file: ${project}/${branch_name}/mongo-c-driver-rpm-packages-${CURRENT_VERSION}.tar.gz
-      bucket: mciuploads
-      permissions: public-read
-      local_file: rpm.tar.gz
-      content_type: ${content_type|application/x-gzip}
+    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${branch_name}/mongo-c-driver-rpm-packages-${CURRENT_VERSION}.tar.gz',
+      bucket: mciuploads, permissions: public-read, local_file: rpm.tar.gz, content_type: '${content_type|application/x-gzip}'}
   - command: s3.put
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      remote_file: ${project}/${branch_name}/${revision}/${version_id}/${build_id}/${execution}/mongo-c-driver-rpm-packages.tar.gz
-      bucket: mciuploads
-      permissions: public-read
-      local_file: rpm.tar.gz
-      content_type: ${content_type|application/x-gzip}
+    params: {aws_key: '${aws_key}', aws_secret: '${aws_secret}', remote_file: '${project}/${branch_name}/${revision}/${version_id}/${build_id}/${execution}/mongo-c-driver-rpm-packages.tar.gz',
+      bucket: mciuploads, permissions: public-read, local_file: rpm.tar.gz, content_type: '${content_type|application/x-gzip}'}
 - name: install-uninstall-check-mingw
-  depends_on:
-    name: make-release-archive
-    variant: releng
+  depends_on: {name: make-release-archive, variant: releng}
   commands:
   - command: shell.exec
     type: test
@@ -1803,9 +1528,7 @@ tasks:
         BSON_ONLY=1 cmd.exe /c .\\.evergreen\\install-uninstall-check-windows.cmd
         cmd.exe /c .\\.evergreen\\install-uninstall-check-windows.cmd
 - name: install-uninstall-check-msvc
-  depends_on:
-    name: make-release-archive
-    variant: releng
+  depends_on: {name: make-release-archive, variant: releng}
   commands:
   - command: shell.exec
     type: test
@@ -1818,9 +1541,7 @@ tasks:
         BSON_ONLY=1 cmd.exe /c .\\.evergreen\\install-uninstall-check-windows.cmd
         cmd.exe /c .\\.evergreen\\install-uninstall-check-windows.cmd
 - name: install-uninstall-check
-  depends_on:
-    name: make-release-archive
-    variant: releng
+  depends_on: {name: make-release-archive, variant: releng}
   commands:
   - command: shell.exec
     type: test
@@ -1845,14 +1566,9 @@ tasks:
         export DEBUG="ON"
         export SANITIZE=""
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-sasl-openssl-cse
-  tags:
-  - client-side-encryption
-  - debug-compile
-  - openssl
-  - sasl
-  - special
+  tags: [client-side-encryption, debug-compile, openssl, sasl, special]
   commands:
   - command: shell.exec
     type: test
@@ -1878,14 +1594,9 @@ tasks:
         export SASL="AUTO"
         export SSL="OPENSSL"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-sasl-openssl-static-cse
-  tags:
-  - client-side-encryption
-  - debug-compile
-  - openssl-static
-  - sasl
-  - special
+  tags: [client-side-encryption, debug-compile, openssl-static, sasl, special]
   commands:
   - command: shell.exec
     type: test
@@ -1911,14 +1622,9 @@ tasks:
         export SASL="AUTO"
         export SSL="OPENSSL_STATIC"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-sasl-darwinssl-cse
-  tags:
-  - client-side-encryption
-  - darwinssl
-  - debug-compile
-  - sasl
-  - special
+  tags: [client-side-encryption, darwinssl, debug-compile, sasl, special]
   commands:
   - command: shell.exec
     type: test
@@ -1944,14 +1650,9 @@ tasks:
         export SASL="AUTO"
         export SSL="DARWIN"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-sasl-winssl-cse
-  tags:
-  - client-side-encryption
-  - debug-compile
-  - sasl
-  - special
-  - winssl
+  tags: [client-side-encryption, debug-compile, sasl, special, winssl]
   commands:
   - command: shell.exec
     type: test
@@ -1977,12 +1678,9 @@ tasks:
         export SASL="AUTO"
         export SSL="WINDOWS"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-asan-openssl-cse
-  tags:
-  - asan-clang
-  - client-side-encryption
-  - debug-compile
+  tags: [asan-clang, client-side-encryption, debug-compile]
   commands:
   - command: shell.exec
     type: test
@@ -2012,12 +1710,11 @@ tasks:
         export SANITIZE="address"
         export SSL="OPENSSL"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: install ssl
-    vars:
-      SSL: openssl-1.0.1u
+    vars: {SSL: openssl-1.0.1u}
   - command: shell.exec
     type: test
     params:
@@ -2031,11 +1728,9 @@ tasks:
         export SASL="OFF"
         export SSL="OPENSSL"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: debug-compile-tsan-openssl
-  tags:
-  - special
-  - tsan
+  tags: [special, tsan]
   commands:
   - command: shell.exec
     type: test
@@ -2051,16 +1746,13 @@ tasks:
         export SANITIZE="thread"
         export SSL="OPENSSL"
         CC='${CC}' MARCH='${MARCH}' sh .evergreen/compile.sh
-  - func: upload build
+  - {func: upload build}
 - name: build-and-test-with-toolchain
   commands:
   - command: s3.get
-    params:
-      aws_key: ${toolchain_aws_key}
-      aws_secret: ${toolchain_aws_secret}
-      remote_file: mongo-c-toolchain/${distro_id}/mongo-c-toolchain.tar.gz
-      bucket: mongo-c-toolchain
-      local_file: mongo-c-toolchain.tar.gz
+    params: {aws_key: '${toolchain_aws_key}', aws_secret: '${toolchain_aws_secret}',
+      remote_file: 'mongo-c-toolchain/${distro_id}/mongo-c-toolchain.tar.gz', bucket: mongo-c-toolchain,
+      local_file: mongo-c-toolchain.tar.gz}
   - command: shell.exec
     type: test
     params:
@@ -2070,14843 +1762,6349 @@ tasks:
         set -o errexit
         sh ./.evergreen/build-and-test-with-toolchain.sh
 - name: test-valgrind-latest-server-auth-nosasl-openssl
-  tags:
-  - latest
-  - test-valgrind
+  tags: [latest, test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
 - name: test-valgrind-latest-server-noauth-nosasl-nossl
-  tags:
-  - latest
-  - test-valgrind
+  tags: [latest, test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
 - name: test-valgrind-latest-replica-set-auth-nosasl-openssl
-  tags:
-  - latest
-  - test-valgrind
+  tags: [latest, test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
 - name: test-valgrind-latest-replica-set-noauth-nosasl-nossl
-  tags:
-  - latest
-  - test-valgrind
+  tags: [latest, test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
 - name: test-valgrind-latest-sharded-auth-nosasl-openssl
-  tags:
-  - latest
-  - test-valgrind
+  tags: [latest, test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
 - name: test-valgrind-latest-sharded-noauth-nosasl-nossl
-  tags:
-  - latest
-  - test-valgrind
+  tags: [latest, test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
 - name: test-valgrind-6.0-server-auth-nosasl-openssl
-  tags:
-  - '6.0'
-  - test-valgrind
+  tags: ['6.0', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
 - name: test-valgrind-6.0-server-noauth-nosasl-nossl
-  tags:
-  - '6.0'
-  - test-valgrind
+  tags: ['6.0', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
 - name: test-valgrind-6.0-replica-set-auth-nosasl-openssl
-  tags:
-  - '6.0'
-  - test-valgrind
+  tags: ['6.0', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
 - name: test-valgrind-6.0-replica-set-noauth-nosasl-nossl
-  tags:
-  - '6.0'
-  - test-valgrind
+  tags: ['6.0', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
 - name: test-valgrind-6.0-sharded-auth-nosasl-openssl
-  tags:
-  - '6.0'
-  - test-valgrind
+  tags: ['6.0', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
 - name: test-valgrind-6.0-sharded-noauth-nosasl-nossl
-  tags:
-  - '6.0'
-  - test-valgrind
+  tags: ['6.0', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
 - name: test-valgrind-5.0-server-auth-nosasl-openssl
-  tags:
-  - '5.0'
-  - test-valgrind
+  tags: ['5.0', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
 - name: test-valgrind-5.0-server-noauth-nosasl-nossl
-  tags:
-  - '5.0'
-  - test-valgrind
+  tags: ['5.0', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
 - name: test-valgrind-5.0-replica-set-auth-nosasl-openssl
-  tags:
-  - '5.0'
-  - test-valgrind
+  tags: ['5.0', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
 - name: test-valgrind-5.0-replica-set-noauth-nosasl-nossl
-  tags:
-  - '5.0'
-  - test-valgrind
+  tags: ['5.0', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
 - name: test-valgrind-5.0-sharded-auth-nosasl-openssl
-  tags:
-  - '5.0'
-  - test-valgrind
+  tags: ['5.0', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
 - name: test-valgrind-5.0-sharded-noauth-nosasl-nossl
-  tags:
-  - '5.0'
-  - test-valgrind
+  tags: ['5.0', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
 - name: test-valgrind-4.4-server-auth-nosasl-openssl
-  tags:
-  - '4.4'
-  - test-valgrind
+  tags: ['4.4', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
 - name: test-valgrind-4.4-server-noauth-nosasl-nossl
-  tags:
-  - '4.4'
-  - test-valgrind
+  tags: ['4.4', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
 - name: test-valgrind-4.4-replica-set-auth-nosasl-openssl
-  tags:
-  - '4.4'
-  - test-valgrind
+  tags: ['4.4', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
 - name: test-valgrind-4.4-replica-set-noauth-nosasl-nossl
-  tags:
-  - '4.4'
-  - test-valgrind
+  tags: ['4.4', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
 - name: test-valgrind-4.4-sharded-auth-nosasl-openssl
-  tags:
-  - '4.4'
-  - test-valgrind
+  tags: ['4.4', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
 - name: test-valgrind-4.4-sharded-noauth-nosasl-nossl
-  tags:
-  - '4.4'
-  - test-valgrind
+  tags: ['4.4', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
 - name: test-valgrind-4.2-server-auth-nosasl-openssl
-  tags:
-  - '4.2'
-  - test-valgrind
+  tags: ['4.2', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
 - name: test-valgrind-4.2-server-noauth-nosasl-nossl
-  tags:
-  - '4.2'
-  - test-valgrind
+  tags: ['4.2', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
 - name: test-valgrind-4.2-replica-set-auth-nosasl-openssl
-  tags:
-  - '4.2'
-  - test-valgrind
+  tags: ['4.2', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
 - name: test-valgrind-4.2-replica-set-noauth-nosasl-nossl
-  tags:
-  - '4.2'
-  - test-valgrind
+  tags: ['4.2', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
 - name: test-valgrind-4.2-sharded-auth-nosasl-openssl
-  tags:
-  - '4.2'
-  - test-valgrind
+  tags: ['4.2', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
 - name: test-valgrind-4.2-sharded-noauth-nosasl-nossl
-  tags:
-  - '4.2'
-  - test-valgrind
+  tags: ['4.2', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
 - name: test-valgrind-4.0-server-auth-nosasl-openssl
-  tags:
-  - '4.0'
-  - test-valgrind
+  tags: ['4.0', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
 - name: test-valgrind-4.0-server-noauth-nosasl-nossl
-  tags:
-  - '4.0'
-  - test-valgrind
+  tags: ['4.0', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
 - name: test-valgrind-4.0-replica-set-auth-nosasl-openssl
-  tags:
-  - '4.0'
-  - test-valgrind
+  tags: ['4.0', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
 - name: test-valgrind-4.0-replica-set-noauth-nosasl-nossl
-  tags:
-  - '4.0'
-  - test-valgrind
+  tags: ['4.0', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
 - name: test-valgrind-4.0-sharded-auth-nosasl-openssl
-  tags:
-  - '4.0'
-  - test-valgrind
+  tags: ['4.0', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
 - name: test-valgrind-4.0-sharded-noauth-nosasl-nossl
-  tags:
-  - '4.0'
-  - test-valgrind
+  tags: ['4.0', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
 - name: test-valgrind-3.6-server-auth-nosasl-openssl
-  tags:
-  - '3.6'
-  - test-valgrind
+  tags: ['3.6', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
 - name: test-valgrind-3.6-server-noauth-nosasl-nossl
-  tags:
-  - '3.6'
-  - test-valgrind
+  tags: ['3.6', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
 - name: test-valgrind-3.6-replica-set-auth-nosasl-openssl
-  tags:
-  - '3.6'
-  - test-valgrind
+  tags: ['3.6', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
 - name: test-valgrind-3.6-replica-set-noauth-nosasl-nossl
-  tags:
-  - '3.6'
-  - test-valgrind
+  tags: ['3.6', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
 - name: test-valgrind-3.6-sharded-auth-nosasl-openssl
-  tags:
-  - '3.6'
-  - test-valgrind
+  tags: ['3.6', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'on'}
 - name: test-valgrind-3.6-sharded-noauth-nosasl-nossl
-  tags:
-  - '3.6'
-  - test-valgrind
+  tags: ['3.6', test-valgrind]
   exec_timeout_secs: 14400
-  depends_on:
-    name: debug-compile-valgrind
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'on'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'on'}
 - name: test-asan-latest-server-auth-nosasl-openssl-cse
-  tags:
-  - client-side-encryption
-  - latest
-  - test-asan
+  tags: [client-side-encryption, latest, test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-openssl-cse
+  depends_on: {name: debug-compile-asan-openssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-openssl-cse
+    vars: {BUILD_NAME: debug-compile-asan-openssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: latest
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: latest}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-latest-server-auth-nosasl-openssl
-  tags:
-  - latest
-  - test-asan
+  tags: [latest, test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang-openssl
+  depends_on: {name: debug-compile-asan-clang-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang-openssl
+    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-latest-server-noauth-nosasl-nossl
-  tags:
-  - latest
-  - test-asan
+  tags: [latest, test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang
+  depends_on: {name: debug-compile-asan-clang}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang
+    vars: {BUILD_NAME: debug-compile-asan-clang}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-asan-latest-replica-set-auth-nosasl-openssl-cse
-  tags:
-  - client-side-encryption
-  - latest
-  - test-asan
+  tags: [client-side-encryption, latest, test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-openssl-cse
+  depends_on: {name: debug-compile-asan-openssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-openssl-cse
+    vars: {BUILD_NAME: debug-compile-asan-openssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: latest
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: latest}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-latest-replica-set-auth-nosasl-openssl
-  tags:
-  - latest
-  - test-asan
+  tags: [latest, test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang-openssl
+  depends_on: {name: debug-compile-asan-clang-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang-openssl
+    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-latest-replica-set-noauth-nosasl-nossl
-  tags:
-  - latest
-  - test-asan
+  tags: [latest, test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang
+  depends_on: {name: debug-compile-asan-clang}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang
+    vars: {BUILD_NAME: debug-compile-asan-clang}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-asan-latest-sharded-auth-nosasl-openssl
-  tags:
-  - latest
-  - test-asan
+  tags: [latest, test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang-openssl
+  depends_on: {name: debug-compile-asan-clang-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang-openssl
+    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-latest-sharded-noauth-nosasl-nossl
-  tags:
-  - latest
-  - test-asan
+  tags: [latest, test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang
+  depends_on: {name: debug-compile-asan-clang}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang
+    vars: {BUILD_NAME: debug-compile-asan-clang}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-asan-6.0-server-auth-nosasl-openssl-cse
-  tags:
-  - '6.0'
-  - client-side-encryption
-  - test-asan
+  tags: ['6.0', client-side-encryption, test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-openssl-cse
+  depends_on: {name: debug-compile-asan-openssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-openssl-cse
+    vars: {BUILD_NAME: debug-compile-asan-openssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '6.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '6.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-6.0-server-auth-nosasl-openssl
-  tags:
-  - '6.0'
-  - test-asan
+  tags: ['6.0', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang-openssl
+  depends_on: {name: debug-compile-asan-clang-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang-openssl
+    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-6.0-server-noauth-nosasl-nossl
-  tags:
-  - '6.0'
-  - test-asan
+  tags: ['6.0', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang
+  depends_on: {name: debug-compile-asan-clang}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang
+    vars: {BUILD_NAME: debug-compile-asan-clang}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-asan-6.0-replica-set-auth-nosasl-openssl-cse
-  tags:
-  - '6.0'
-  - client-side-encryption
-  - test-asan
+  tags: ['6.0', client-side-encryption, test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-openssl-cse
+  depends_on: {name: debug-compile-asan-openssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-openssl-cse
+    vars: {BUILD_NAME: debug-compile-asan-openssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '6.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-6.0-replica-set-auth-nosasl-openssl
-  tags:
-  - '6.0'
-  - test-asan
+  tags: ['6.0', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang-openssl
+  depends_on: {name: debug-compile-asan-clang-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang-openssl
+    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-6.0-replica-set-noauth-nosasl-nossl
-  tags:
-  - '6.0'
-  - test-asan
+  tags: ['6.0', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang
+  depends_on: {name: debug-compile-asan-clang}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang
+    vars: {BUILD_NAME: debug-compile-asan-clang}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-asan-6.0-sharded-auth-nosasl-openssl
-  tags:
-  - '6.0'
-  - test-asan
+  tags: ['6.0', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang-openssl
+  depends_on: {name: debug-compile-asan-clang-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang-openssl
+    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-6.0-sharded-noauth-nosasl-nossl
-  tags:
-  - '6.0'
-  - test-asan
+  tags: ['6.0', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang
+  depends_on: {name: debug-compile-asan-clang}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang
+    vars: {BUILD_NAME: debug-compile-asan-clang}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-asan-5.0-server-auth-nosasl-openssl-cse
-  tags:
-  - '5.0'
-  - client-side-encryption
-  - test-asan
+  tags: ['5.0', client-side-encryption, test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-openssl-cse
+  depends_on: {name: debug-compile-asan-openssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-openssl-cse
+    vars: {BUILD_NAME: debug-compile-asan-openssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '5.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '5.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-5.0-server-auth-nosasl-openssl
-  tags:
-  - '5.0'
-  - test-asan
+  tags: ['5.0', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang-openssl
+  depends_on: {name: debug-compile-asan-clang-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang-openssl
+    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-5.0-server-noauth-nosasl-nossl
-  tags:
-  - '5.0'
-  - test-asan
+  tags: ['5.0', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang
+  depends_on: {name: debug-compile-asan-clang}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang
+    vars: {BUILD_NAME: debug-compile-asan-clang}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-asan-5.0-replica-set-auth-nosasl-openssl
-  tags:
-  - '5.0'
-  - test-asan
+  tags: ['5.0', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang-openssl
+  depends_on: {name: debug-compile-asan-clang-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang-openssl
+    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-5.0-replica-set-noauth-nosasl-nossl
-  tags:
-  - '5.0'
-  - test-asan
+  tags: ['5.0', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang
+  depends_on: {name: debug-compile-asan-clang}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang
+    vars: {BUILD_NAME: debug-compile-asan-clang}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-asan-5.0-sharded-auth-nosasl-openssl
-  tags:
-  - '5.0'
-  - test-asan
+  tags: ['5.0', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang-openssl
+  depends_on: {name: debug-compile-asan-clang-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang-openssl
+    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-5.0-sharded-noauth-nosasl-nossl
-  tags:
-  - '5.0'
-  - test-asan
+  tags: ['5.0', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang
+  depends_on: {name: debug-compile-asan-clang}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang
+    vars: {BUILD_NAME: debug-compile-asan-clang}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-asan-4.4-server-auth-nosasl-openssl-cse
-  tags:
-  - '4.4'
-  - client-side-encryption
-  - test-asan
+  tags: ['4.4', client-side-encryption, test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-openssl-cse
+  depends_on: {name: debug-compile-asan-openssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-openssl-cse
+    vars: {BUILD_NAME: debug-compile-asan-openssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.4'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.4'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-4.4-server-auth-nosasl-openssl
-  tags:
-  - '4.4'
-  - test-asan
+  tags: ['4.4', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang-openssl
+  depends_on: {name: debug-compile-asan-clang-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang-openssl
+    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-4.4-server-noauth-nosasl-nossl
-  tags:
-  - '4.4'
-  - test-asan
+  tags: ['4.4', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang
+  depends_on: {name: debug-compile-asan-clang}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang
+    vars: {BUILD_NAME: debug-compile-asan-clang}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-asan-4.4-replica-set-auth-nosasl-openssl
-  tags:
-  - '4.4'
-  - test-asan
+  tags: ['4.4', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang-openssl
+  depends_on: {name: debug-compile-asan-clang-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang-openssl
+    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-4.4-replica-set-noauth-nosasl-nossl
-  tags:
-  - '4.4'
-  - test-asan
+  tags: ['4.4', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang
+  depends_on: {name: debug-compile-asan-clang}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang
+    vars: {BUILD_NAME: debug-compile-asan-clang}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-asan-4.4-sharded-auth-nosasl-openssl
-  tags:
-  - '4.4'
-  - test-asan
+  tags: ['4.4', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang-openssl
+  depends_on: {name: debug-compile-asan-clang-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang-openssl
+    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-4.4-sharded-noauth-nosasl-nossl
-  tags:
-  - '4.4'
-  - test-asan
+  tags: ['4.4', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang
+  depends_on: {name: debug-compile-asan-clang}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang
+    vars: {BUILD_NAME: debug-compile-asan-clang}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-asan-4.2-server-auth-nosasl-openssl-cse
-  tags:
-  - '4.2'
-  - client-side-encryption
-  - test-asan
+  tags: ['4.2', client-side-encryption, test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-openssl-cse
+  depends_on: {name: debug-compile-asan-openssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-openssl-cse
+    vars: {BUILD_NAME: debug-compile-asan-openssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.2'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.2'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-4.2-server-auth-nosasl-openssl
-  tags:
-  - '4.2'
-  - test-asan
+  tags: ['4.2', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang-openssl
+  depends_on: {name: debug-compile-asan-clang-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang-openssl
+    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-4.2-server-noauth-nosasl-nossl
-  tags:
-  - '4.2'
-  - test-asan
+  tags: ['4.2', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang
+  depends_on: {name: debug-compile-asan-clang}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang
+    vars: {BUILD_NAME: debug-compile-asan-clang}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-asan-4.2-replica-set-auth-nosasl-openssl
-  tags:
-  - '4.2'
-  - test-asan
+  tags: ['4.2', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang-openssl
+  depends_on: {name: debug-compile-asan-clang-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang-openssl
+    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-4.2-replica-set-noauth-nosasl-nossl
-  tags:
-  - '4.2'
-  - test-asan
+  tags: ['4.2', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang
+  depends_on: {name: debug-compile-asan-clang}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang
+    vars: {BUILD_NAME: debug-compile-asan-clang}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-asan-4.2-sharded-auth-nosasl-openssl
-  tags:
-  - '4.2'
-  - test-asan
+  tags: ['4.2', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang-openssl
+  depends_on: {name: debug-compile-asan-clang-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang-openssl
+    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-4.2-sharded-noauth-nosasl-nossl
-  tags:
-  - '4.2'
-  - test-asan
+  tags: ['4.2', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang
+  depends_on: {name: debug-compile-asan-clang}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang
+    vars: {BUILD_NAME: debug-compile-asan-clang}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-asan-4.0-server-auth-nosasl-openssl
-  tags:
-  - '4.0'
-  - test-asan
+  tags: ['4.0', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang-openssl
+  depends_on: {name: debug-compile-asan-clang-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang-openssl
+    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-4.0-server-noauth-nosasl-nossl
-  tags:
-  - '4.0'
-  - test-asan
+  tags: ['4.0', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang
+  depends_on: {name: debug-compile-asan-clang}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang
+    vars: {BUILD_NAME: debug-compile-asan-clang}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-asan-4.0-replica-set-auth-nosasl-openssl
-  tags:
-  - '4.0'
-  - test-asan
+  tags: ['4.0', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang-openssl
+  depends_on: {name: debug-compile-asan-clang-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang-openssl
+    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-4.0-replica-set-noauth-nosasl-nossl
-  tags:
-  - '4.0'
-  - test-asan
+  tags: ['4.0', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang
+  depends_on: {name: debug-compile-asan-clang}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang
+    vars: {BUILD_NAME: debug-compile-asan-clang}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-asan-4.0-sharded-auth-nosasl-openssl
-  tags:
-  - '4.0'
-  - test-asan
+  tags: ['4.0', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang-openssl
+  depends_on: {name: debug-compile-asan-clang-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang-openssl
+    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-4.0-sharded-noauth-nosasl-nossl
-  tags:
-  - '4.0'
-  - test-asan
+  tags: ['4.0', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang
+  depends_on: {name: debug-compile-asan-clang}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang
+    vars: {BUILD_NAME: debug-compile-asan-clang}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-asan-3.6-server-auth-nosasl-openssl
-  tags:
-  - '3.6'
-  - test-asan
+  tags: ['3.6', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang-openssl
+  depends_on: {name: debug-compile-asan-clang-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang-openssl
+    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-3.6-server-noauth-nosasl-nossl
-  tags:
-  - '3.6'
-  - test-asan
+  tags: ['3.6', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang
+  depends_on: {name: debug-compile-asan-clang}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang
+    vars: {BUILD_NAME: debug-compile-asan-clang}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-asan-3.6-replica-set-auth-nosasl-openssl
-  tags:
-  - '3.6'
-  - test-asan
+  tags: ['3.6', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang-openssl
+  depends_on: {name: debug-compile-asan-clang-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang-openssl
+    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-3.6-replica-set-noauth-nosasl-nossl
-  tags:
-  - '3.6'
-  - test-asan
+  tags: ['3.6', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang
+  depends_on: {name: debug-compile-asan-clang}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang
+    vars: {BUILD_NAME: debug-compile-asan-clang}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-asan-3.6-sharded-auth-nosasl-openssl
-  tags:
-  - '3.6'
-  - test-asan
+  tags: ['3.6', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang-openssl
+  depends_on: {name: debug-compile-asan-clang-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang-openssl
+    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-asan-3.6-sharded-noauth-nosasl-nossl
-  tags:
-  - '3.6'
-  - test-asan
+  tags: ['3.6', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang
+  depends_on: {name: debug-compile-asan-clang}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang
+    vars: {BUILD_NAME: debug-compile-asan-clang}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'on', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-tsan-latest-server-auth-nosasl-openssl
-  tags:
-  - latest
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: [latest, tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-latest-server-noauth-nosasl-openssl
-  tags:
-  - latest
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: [latest, tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-latest-replica-set-auth-nosasl-openssl
-  tags:
-  - latest
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: [latest, tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-latest-replica-set-noauth-nosasl-openssl
-  tags:
-  - latest
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: [latest, tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-latest-sharded-auth-nosasl-openssl
-  tags:
-  - latest
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: [latest, tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-latest-sharded-noauth-nosasl-openssl
-  tags:
-  - latest
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: [latest, tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-6.0-server-auth-nosasl-openssl
-  tags:
-  - '6.0'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['6.0', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-6.0-server-noauth-nosasl-openssl
-  tags:
-  - '6.0'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['6.0', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-6.0-replica-set-auth-nosasl-openssl
-  tags:
-  - '6.0'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['6.0', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-6.0-replica-set-noauth-nosasl-openssl
-  tags:
-  - '6.0'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['6.0', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-6.0-sharded-auth-nosasl-openssl
-  tags:
-  - '6.0'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['6.0', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-6.0-sharded-noauth-nosasl-openssl
-  tags:
-  - '6.0'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['6.0', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-5.0-server-auth-nosasl-openssl
-  tags:
-  - '5.0'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['5.0', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-5.0-server-noauth-nosasl-openssl
-  tags:
-  - '5.0'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['5.0', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-5.0-replica-set-auth-nosasl-openssl
-  tags:
-  - '5.0'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['5.0', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-5.0-replica-set-noauth-nosasl-openssl
-  tags:
-  - '5.0'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['5.0', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-5.0-sharded-auth-nosasl-openssl
-  tags:
-  - '5.0'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['5.0', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-5.0-sharded-noauth-nosasl-openssl
-  tags:
-  - '5.0'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['5.0', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-4.4-server-auth-nosasl-openssl
-  tags:
-  - '4.4'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['4.4', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-4.4-server-noauth-nosasl-openssl
-  tags:
-  - '4.4'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['4.4', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-4.4-replica-set-auth-nosasl-openssl
-  tags:
-  - '4.4'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['4.4', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-4.4-replica-set-noauth-nosasl-openssl
-  tags:
-  - '4.4'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['4.4', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-4.4-sharded-auth-nosasl-openssl
-  tags:
-  - '4.4'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['4.4', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-4.4-sharded-noauth-nosasl-openssl
-  tags:
-  - '4.4'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['4.4', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-4.2-server-auth-nosasl-openssl
-  tags:
-  - '4.2'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['4.2', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-4.2-server-noauth-nosasl-openssl
-  tags:
-  - '4.2'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['4.2', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-4.2-replica-set-auth-nosasl-openssl
-  tags:
-  - '4.2'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['4.2', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-4.2-replica-set-noauth-nosasl-openssl
-  tags:
-  - '4.2'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['4.2', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-4.2-sharded-auth-nosasl-openssl
-  tags:
-  - '4.2'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['4.2', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-4.2-sharded-noauth-nosasl-openssl
-  tags:
-  - '4.2'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['4.2', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-4.0-server-auth-nosasl-openssl
-  tags:
-  - '4.0'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['4.0', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-4.0-server-noauth-nosasl-openssl
-  tags:
-  - '4.0'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['4.0', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-4.0-replica-set-auth-nosasl-openssl
-  tags:
-  - '4.0'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['4.0', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-4.0-replica-set-noauth-nosasl-openssl
-  tags:
-  - '4.0'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['4.0', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-4.0-sharded-auth-nosasl-openssl
-  tags:
-  - '4.0'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['4.0', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-4.0-sharded-noauth-nosasl-openssl
-  tags:
-  - '4.0'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['4.0', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-3.6-server-auth-nosasl-openssl
-  tags:
-  - '3.6'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['3.6', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-3.6-server-noauth-nosasl-openssl
-  tags:
-  - '3.6'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['3.6', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-3.6-replica-set-auth-nosasl-openssl
-  tags:
-  - '3.6'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['3.6', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-3.6-replica-set-noauth-nosasl-openssl
-  tags:
-  - '3.6'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['3.6', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-3.6-sharded-auth-nosasl-openssl
-  tags:
-  - '3.6'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['3.6', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-tsan-3.6-sharded-noauth-nosasl-openssl
-  tags:
-  - '3.6'
-  - tsan
-  depends_on:
-    name: debug-compile-tsan-openssl
+  tags: ['3.6', tsan]
+  depends_on: {name: debug-compile-tsan-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-tsan-openssl
+    vars: {BUILD_NAME: debug-compile-tsan-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-coverage-latest-server-auth-nosasl-openssl
-  tags:
-  - latest
-  - test-coverage
+  tags: [latest, test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-openssl
+  - {func: debug-compile-coverage-notest-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-latest-server-noauth-nosasl-nossl
-  tags:
-  - latest
-  - test-coverage
+  tags: [latest, test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-nossl
+  - {func: debug-compile-coverage-notest-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-latest-replica-set-auth-nosasl-openssl
-  tags:
-  - latest
-  - test-coverage
+  tags: [latest, test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-openssl
+  - {func: debug-compile-coverage-notest-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-latest-replica-set-noauth-nosasl-nossl
-  tags:
-  - latest
-  - test-coverage
+  tags: [latest, test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-nossl
+  - {func: debug-compile-coverage-notest-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-latest-sharded-auth-nosasl-openssl
-  tags:
-  - latest
-  - test-coverage
+  tags: [latest, test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-openssl
+  - {func: debug-compile-coverage-notest-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-latest-sharded-noauth-nosasl-nossl
-  tags:
-  - latest
-  - test-coverage
+  tags: [latest, test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-nossl
+  - {func: debug-compile-coverage-notest-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-6.0-server-auth-nosasl-openssl
-  tags:
-  - '6.0'
-  - test-coverage
+  tags: ['6.0', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-openssl
+  - {func: debug-compile-coverage-notest-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-6.0-server-noauth-nosasl-nossl
-  tags:
-  - '6.0'
-  - test-coverage
+  tags: ['6.0', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-nossl
+  - {func: debug-compile-coverage-notest-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-6.0-replica-set-auth-nosasl-openssl
-  tags:
-  - '6.0'
-  - test-coverage
+  tags: ['6.0', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-openssl
+  - {func: debug-compile-coverage-notest-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-6.0-replica-set-noauth-nosasl-nossl
-  tags:
-  - '6.0'
-  - test-coverage
+  tags: ['6.0', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-nossl
+  - {func: debug-compile-coverage-notest-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-6.0-sharded-auth-nosasl-openssl
-  tags:
-  - '6.0'
-  - test-coverage
+  tags: ['6.0', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-openssl
+  - {func: debug-compile-coverage-notest-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-6.0-sharded-noauth-nosasl-nossl
-  tags:
-  - '6.0'
-  - test-coverage
+  tags: ['6.0', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-nossl
+  - {func: debug-compile-coverage-notest-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-5.0-server-auth-nosasl-openssl
-  tags:
-  - '5.0'
-  - test-coverage
+  tags: ['5.0', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-openssl
+  - {func: debug-compile-coverage-notest-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-5.0-server-noauth-nosasl-nossl
-  tags:
-  - '5.0'
-  - test-coverage
+  tags: ['5.0', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-nossl
+  - {func: debug-compile-coverage-notest-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-5.0-replica-set-auth-nosasl-openssl
-  tags:
-  - '5.0'
-  - test-coverage
+  tags: ['5.0', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-openssl
+  - {func: debug-compile-coverage-notest-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-5.0-replica-set-noauth-nosasl-nossl
-  tags:
-  - '5.0'
-  - test-coverage
+  tags: ['5.0', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-nossl
+  - {func: debug-compile-coverage-notest-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-5.0-sharded-auth-nosasl-openssl
-  tags:
-  - '5.0'
-  - test-coverage
+  tags: ['5.0', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-openssl
+  - {func: debug-compile-coverage-notest-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-5.0-sharded-noauth-nosasl-nossl
-  tags:
-  - '5.0'
-  - test-coverage
+  tags: ['5.0', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-nossl
+  - {func: debug-compile-coverage-notest-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-4.4-server-auth-nosasl-openssl
-  tags:
-  - '4.4'
-  - test-coverage
+  tags: ['4.4', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-openssl
+  - {func: debug-compile-coverage-notest-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-4.4-server-noauth-nosasl-nossl
-  tags:
-  - '4.4'
-  - test-coverage
+  tags: ['4.4', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-nossl
+  - {func: debug-compile-coverage-notest-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-4.4-replica-set-auth-nosasl-openssl
-  tags:
-  - '4.4'
-  - test-coverage
+  tags: ['4.4', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-openssl
+  - {func: debug-compile-coverage-notest-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-4.4-replica-set-noauth-nosasl-nossl
-  tags:
-  - '4.4'
-  - test-coverage
+  tags: ['4.4', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-nossl
+  - {func: debug-compile-coverage-notest-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-4.4-sharded-auth-nosasl-openssl
-  tags:
-  - '4.4'
-  - test-coverage
+  tags: ['4.4', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-openssl
+  - {func: debug-compile-coverage-notest-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-4.4-sharded-noauth-nosasl-nossl
-  tags:
-  - '4.4'
-  - test-coverage
+  tags: ['4.4', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-nossl
+  - {func: debug-compile-coverage-notest-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-4.2-server-auth-nosasl-openssl
-  tags:
-  - '4.2'
-  - test-coverage
+  tags: ['4.2', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-openssl
+  - {func: debug-compile-coverage-notest-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-4.2-server-noauth-nosasl-nossl
-  tags:
-  - '4.2'
-  - test-coverage
+  tags: ['4.2', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-nossl
+  - {func: debug-compile-coverage-notest-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-4.2-replica-set-auth-nosasl-openssl
-  tags:
-  - '4.2'
-  - test-coverage
+  tags: ['4.2', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-openssl
+  - {func: debug-compile-coverage-notest-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-4.2-replica-set-noauth-nosasl-nossl
-  tags:
-  - '4.2'
-  - test-coverage
+  tags: ['4.2', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-nossl
+  - {func: debug-compile-coverage-notest-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-4.2-sharded-auth-nosasl-openssl
-  tags:
-  - '4.2'
-  - test-coverage
+  tags: ['4.2', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-openssl
+  - {func: debug-compile-coverage-notest-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-4.2-sharded-noauth-nosasl-nossl
-  tags:
-  - '4.2'
-  - test-coverage
+  tags: ['4.2', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-nossl
+  - {func: debug-compile-coverage-notest-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-4.0-server-auth-nosasl-openssl
-  tags:
-  - '4.0'
-  - test-coverage
+  tags: ['4.0', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-openssl
+  - {func: debug-compile-coverage-notest-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-4.0-server-noauth-nosasl-nossl
-  tags:
-  - '4.0'
-  - test-coverage
+  tags: ['4.0', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-nossl
+  - {func: debug-compile-coverage-notest-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-4.0-replica-set-auth-nosasl-openssl
-  tags:
-  - '4.0'
-  - test-coverage
+  tags: ['4.0', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-openssl
+  - {func: debug-compile-coverage-notest-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-4.0-replica-set-noauth-nosasl-nossl
-  tags:
-  - '4.0'
-  - test-coverage
+  tags: ['4.0', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-nossl
+  - {func: debug-compile-coverage-notest-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-4.0-sharded-auth-nosasl-openssl
-  tags:
-  - '4.0'
-  - test-coverage
+  tags: ['4.0', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-openssl
+  - {func: debug-compile-coverage-notest-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-4.0-sharded-noauth-nosasl-nossl
-  tags:
-  - '4.0'
-  - test-coverage
+  tags: ['4.0', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-nossl
+  - {func: debug-compile-coverage-notest-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-3.6-server-auth-nosasl-openssl
-  tags:
-  - '3.6'
-  - test-coverage
+  tags: ['3.6', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-openssl
+  - {func: debug-compile-coverage-notest-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-3.6-server-noauth-nosasl-nossl
-  tags:
-  - '3.6'
-  - test-coverage
+  tags: ['3.6', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-nossl
+  - {func: debug-compile-coverage-notest-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-3.6-replica-set-auth-nosasl-openssl
-  tags:
-  - '3.6'
-  - test-coverage
+  tags: ['3.6', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-openssl
+  - {func: debug-compile-coverage-notest-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-3.6-replica-set-noauth-nosasl-nossl
-  tags:
-  - '3.6'
-  - test-coverage
+  tags: ['3.6', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-nossl
+  - {func: debug-compile-coverage-notest-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-3.6-sharded-auth-nosasl-openssl
-  tags:
-  - '3.6'
-  - test-coverage
+  tags: ['3.6', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-openssl
+  - {func: debug-compile-coverage-notest-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-coverage-3.6-sharded-noauth-nosasl-nossl
-  tags:
-  - '3.6'
-  - test-coverage
+  tags: ['3.6', test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-nossl
+  - {func: debug-compile-coverage-notest-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
-  - func: update codecov.io
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
+  - {func: update codecov.io}
 - name: test-latest-server-auth-sasl-openssl-cse
-  tags:
-  - auth
-  - client-side-encryption
-  - latest
-  - openssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-cse
+  tags: [auth, client-side-encryption, latest, openssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: latest
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: latest}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
 - name: test-latest-server-auth-sasl-openssl
-  tags:
-  - auth
-  - latest
-  - openssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: [auth, latest, openssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-latest-server-auth-sasl-openssl-static-cse
-  tags:
-  - auth
-  - client-side-encryption
-  - latest
-  - openssl-static
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-static-cse
+  tags: [auth, client-side-encryption, latest, openssl-static, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-static-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: latest
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: latest}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
+      VALGRIND: 'off'}
 - name: test-latest-server-auth-sasl-openssl-static
-  tags:
-  - auth
-  - latest
-  - openssl-static
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: [auth, latest, openssl-static, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-latest-server-auth-sasl-darwinssl-cse
-  tags:
-  - auth
-  - client-side-encryption
-  - darwinssl
-  - latest
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-darwinssl-cse
+  tags: [auth, client-side-encryption, darwinssl, latest, sasl, server]
+  depends_on: {name: debug-compile-sasl-darwinssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: latest
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: latest}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
+      VALGRIND: 'off'}
 - name: test-latest-server-auth-sasl-darwinssl
-  tags:
-  - auth
-  - darwinssl
-  - latest
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: [auth, darwinssl, latest, sasl, server]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-latest-server-auth-sasl-winssl-cse
-  tags:
-  - auth
-  - client-side-encryption
-  - latest
-  - sasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl-cse
+  tags: [auth, client-side-encryption, latest, sasl, server, winssl]
+  depends_on: {name: debug-compile-sasl-winssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: latest
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: latest}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
 - name: test-latest-server-auth-sasl-winssl
-  tags:
-  - auth
-  - latest
-  - sasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: [auth, latest, sasl, server, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-latest-server-auth-sspi-winssl
-  tags:
-  - auth
-  - latest
-  - server
-  - sspi
-  - winssl
-  depends_on:
-    name: debug-compile-sspi-winssl
+  tags: [auth, latest, server, sspi, winssl]
+  depends_on: {name: debug-compile-sspi-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sspi-winssl
+    vars: {BUILD_NAME: debug-compile-sspi-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-latest-server-auth-nosasl-openssl
-  tags:
-  - auth
-  - latest
-  - nosasl
-  - openssl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [auth, latest, nosasl, openssl, server]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-latest-server-auth-nosasl-openssl-static
-  tags:
-  - auth
-  - latest
-  - nosasl
-  - openssl-static
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: [auth, latest, nosasl, openssl-static, server]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-latest-server-auth-nosasl-darwinssl
-  tags:
-  - auth
-  - darwinssl
-  - latest
-  - nosasl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [auth, darwinssl, latest, nosasl, server]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-latest-server-auth-nosasl-winssl
-  tags:
-  - auth
-  - latest
-  - nosasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [auth, latest, nosasl, server, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-latest-server-noauth-sasl-openssl-cse
-  tags:
-  - client-side-encryption
-  - latest
-  - noauth
-  - openssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-cse
+  tags: [client-side-encryption, latest, noauth, openssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: latest
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: latest}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl,
+      VALGRIND: 'off'}
 - name: test-latest-server-noauth-sasl-openssl
-  tags:
-  - latest
-  - noauth
-  - openssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: [latest, noauth, openssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-latest-server-noauth-sasl-openssl-static-cse
-  tags:
-  - client-side-encryption
-  - latest
-  - noauth
-  - openssl-static
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-static-cse
+  tags: [client-side-encryption, latest, noauth, openssl-static, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-static-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: latest
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: latest}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
+      VALGRIND: 'off'}
 - name: test-latest-server-noauth-sasl-openssl-static
-  tags:
-  - latest
-  - noauth
-  - openssl-static
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: [latest, noauth, openssl-static, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-latest-server-noauth-sasl-darwinssl-cse
-  tags:
-  - client-side-encryption
-  - darwinssl
-  - latest
-  - noauth
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-darwinssl-cse
+  tags: [client-side-encryption, darwinssl, latest, noauth, sasl, server]
+  depends_on: {name: debug-compile-sasl-darwinssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: latest
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: latest}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
+      VALGRIND: 'off'}
 - name: test-latest-server-noauth-sasl-darwinssl
-  tags:
-  - darwinssl
-  - latest
-  - noauth
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: [darwinssl, latest, noauth, sasl, server]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-latest-server-noauth-sasl-winssl-cse
-  tags:
-  - client-side-encryption
-  - latest
-  - noauth
-  - sasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl-cse
+  tags: [client-side-encryption, latest, noauth, sasl, server, winssl]
+  depends_on: {name: debug-compile-sasl-winssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: latest
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: latest}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
 - name: test-latest-server-noauth-sasl-winssl
-  tags:
-  - latest
-  - noauth
-  - sasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: [latest, noauth, sasl, server, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-latest-server-noauth-nosasl-openssl
-  tags:
-  - latest
-  - noauth
-  - nosasl
-  - openssl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [latest, noauth, nosasl, openssl, server]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-latest-server-noauth-nosasl-openssl-static
-  tags:
-  - latest
-  - noauth
-  - nosasl
-  - openssl-static
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: [latest, noauth, nosasl, openssl-static, server]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-latest-server-noauth-nosasl-darwinssl
-  tags:
-  - darwinssl
-  - latest
-  - noauth
-  - nosasl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [darwinssl, latest, noauth, nosasl, server]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-latest-server-noauth-nosasl-winssl
-  tags:
-  - latest
-  - noauth
-  - nosasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [latest, noauth, nosasl, server, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-latest-server-noauth-nosasl-nossl
-  tags:
-  - latest
-  - noauth
-  - nosasl
-  - nossl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: [latest, noauth, nosasl, nossl, server]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-latest-replica-set-auth-sasl-openssl-cse
-  tags:
-  - auth
-  - client-side-encryption
-  - latest
-  - openssl
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl-cse
+  tags: [auth, client-side-encryption, latest, openssl, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: latest
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: latest}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
 - name: test-latest-replica-set-auth-sasl-openssl
-  tags:
-  - auth
-  - latest
-  - openssl
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: [auth, latest, openssl, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-latest-replica-set-auth-sasl-openssl-static-cse
-  tags:
-  - auth
-  - client-side-encryption
-  - latest
-  - openssl-static
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl-static-cse
+  tags: [auth, client-side-encryption, latest, openssl-static, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl-static-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: latest
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: latest}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
+      VALGRIND: 'off'}
 - name: test-latest-replica-set-auth-sasl-openssl-static
-  tags:
-  - auth
-  - latest
-  - openssl-static
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: [auth, latest, openssl-static, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-latest-replica-set-auth-sasl-darwinssl-cse
-  tags:
-  - auth
-  - client-side-encryption
-  - darwinssl
-  - latest
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-darwinssl-cse
+  tags: [auth, client-side-encryption, darwinssl, latest, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-darwinssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: latest
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: latest}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
+      VALGRIND: 'off'}
 - name: test-latest-replica-set-auth-sasl-darwinssl
-  tags:
-  - auth
-  - darwinssl
-  - latest
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: [auth, darwinssl, latest, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-latest-replica-set-auth-sasl-winssl-cse
-  tags:
-  - auth
-  - client-side-encryption
-  - latest
-  - replica_set
-  - sasl
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl-cse
+  tags: [auth, client-side-encryption, latest, replica_set, sasl, winssl]
+  depends_on: {name: debug-compile-sasl-winssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: latest
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: latest}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
 - name: test-latest-replica-set-auth-sasl-winssl
-  tags:
-  - auth
-  - latest
-  - replica_set
-  - sasl
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: [auth, latest, replica_set, sasl, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-latest-replica-set-auth-nosasl-openssl
-  tags:
-  - auth
-  - latest
-  - nosasl
-  - openssl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [auth, latest, nosasl, openssl, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-latest-replica-set-auth-nosasl-openssl-static
-  tags:
-  - auth
-  - latest
-  - nosasl
-  - openssl-static
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: [auth, latest, nosasl, openssl-static, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-latest-replica-set-auth-nosasl-darwinssl
-  tags:
-  - auth
-  - darwinssl
-  - latest
-  - nosasl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [auth, darwinssl, latest, nosasl, replica_set]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-latest-replica-set-auth-nosasl-winssl
-  tags:
-  - auth
-  - latest
-  - nosasl
-  - replica_set
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [auth, latest, nosasl, replica_set, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-latest-replica-set-noauth-sasl-openssl-cse
-  tags:
-  - client-side-encryption
-  - latest
-  - noauth
-  - openssl
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl-cse
+  tags: [client-side-encryption, latest, noauth, openssl, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: latest
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: latest}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl,
+      VALGRIND: 'off'}
 - name: test-latest-replica-set-noauth-sasl-openssl
-  tags:
-  - latest
-  - noauth
-  - openssl
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: [latest, noauth, openssl, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-latest-replica-set-noauth-sasl-openssl-static-cse
-  tags:
-  - client-side-encryption
-  - latest
-  - noauth
-  - openssl-static
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl-static-cse
+  tags: [client-side-encryption, latest, noauth, openssl-static, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl-static-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: latest
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: latest}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
+      VALGRIND: 'off'}
 - name: test-latest-replica-set-noauth-sasl-openssl-static
-  tags:
-  - latest
-  - noauth
-  - openssl-static
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: [latest, noauth, openssl-static, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-latest-replica-set-noauth-sasl-darwinssl-cse
-  tags:
-  - client-side-encryption
-  - darwinssl
-  - latest
-  - noauth
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-darwinssl-cse
+  tags: [client-side-encryption, darwinssl, latest, noauth, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-darwinssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: latest
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: latest}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
+      VALGRIND: 'off'}
 - name: test-latest-replica-set-noauth-sasl-darwinssl
-  tags:
-  - darwinssl
-  - latest
-  - noauth
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: [darwinssl, latest, noauth, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-latest-replica-set-noauth-sasl-winssl-cse
-  tags:
-  - client-side-encryption
-  - latest
-  - noauth
-  - replica_set
-  - sasl
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl-cse
+  tags: [client-side-encryption, latest, noauth, replica_set, sasl, winssl]
+  depends_on: {name: debug-compile-sasl-winssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: latest
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: latest}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
 - name: test-latest-replica-set-noauth-sasl-winssl
-  tags:
-  - latest
-  - noauth
-  - replica_set
-  - sasl
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: [latest, noauth, replica_set, sasl, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-latest-replica-set-noauth-nosasl-openssl
-  tags:
-  - latest
-  - noauth
-  - nosasl
-  - openssl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [latest, noauth, nosasl, openssl, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-latest-replica-set-noauth-nosasl-openssl-static
-  tags:
-  - latest
-  - noauth
-  - nosasl
-  - openssl-static
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: [latest, noauth, nosasl, openssl-static, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-latest-replica-set-noauth-nosasl-darwinssl
-  tags:
-  - darwinssl
-  - latest
-  - noauth
-  - nosasl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [darwinssl, latest, noauth, nosasl, replica_set]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-latest-replica-set-noauth-nosasl-winssl
-  tags:
-  - latest
-  - noauth
-  - nosasl
-  - replica_set
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [latest, noauth, nosasl, replica_set, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-latest-replica-set-noauth-nosasl-nossl
-  tags:
-  - latest
-  - noauth
-  - nosasl
-  - nossl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: [latest, noauth, nosasl, nossl, replica_set]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-latest-sharded-auth-sasl-openssl
-  tags:
-  - auth
-  - latest
-  - openssl
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: [auth, latest, openssl, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-latest-sharded-auth-sasl-openssl-static
-  tags:
-  - auth
-  - latest
-  - openssl-static
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: [auth, latest, openssl-static, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-latest-sharded-auth-sasl-darwinssl
-  tags:
-  - auth
-  - darwinssl
-  - latest
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: [auth, darwinssl, latest, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-latest-sharded-auth-sasl-winssl
-  tags:
-  - auth
-  - latest
-  - sasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: [auth, latest, sasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-latest-sharded-auth-nosasl-openssl
-  tags:
-  - auth
-  - latest
-  - nosasl
-  - openssl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [auth, latest, nosasl, openssl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-latest-sharded-auth-nosasl-openssl-static
-  tags:
-  - auth
-  - latest
-  - nosasl
-  - openssl-static
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: [auth, latest, nosasl, openssl-static, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-latest-sharded-auth-nosasl-darwinssl
-  tags:
-  - auth
-  - darwinssl
-  - latest
-  - nosasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [auth, darwinssl, latest, nosasl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-latest-sharded-auth-nosasl-winssl
-  tags:
-  - auth
-  - latest
-  - nosasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [auth, latest, nosasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-latest-sharded-noauth-sasl-openssl
-  tags:
-  - latest
-  - noauth
-  - openssl
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: [latest, noauth, openssl, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-latest-sharded-noauth-sasl-openssl-static
-  tags:
-  - latest
-  - noauth
-  - openssl-static
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: [latest, noauth, openssl-static, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-latest-sharded-noauth-sasl-darwinssl
-  tags:
-  - darwinssl
-  - latest
-  - noauth
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: [darwinssl, latest, noauth, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-latest-sharded-noauth-sasl-winssl
-  tags:
-  - latest
-  - noauth
-  - sasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: [latest, noauth, sasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-latest-sharded-noauth-nosasl-openssl
-  tags:
-  - latest
-  - noauth
-  - nosasl
-  - openssl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [latest, noauth, nosasl, openssl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-latest-sharded-noauth-nosasl-openssl-static
-  tags:
-  - latest
-  - noauth
-  - nosasl
-  - openssl-static
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: [latest, noauth, nosasl, openssl-static, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-latest-sharded-noauth-nosasl-darwinssl
-  tags:
-  - darwinssl
-  - latest
-  - noauth
-  - nosasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [darwinssl, latest, noauth, nosasl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-latest-sharded-noauth-nosasl-winssl
-  tags:
-  - latest
-  - noauth
-  - nosasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [latest, noauth, nosasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-latest-sharded-noauth-nosasl-nossl
-  tags:
-  - latest
-  - noauth
-  - nosasl
-  - nossl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: [latest, noauth, nosasl, nossl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: latest}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-6.0-server-auth-sasl-openssl-cse
-  tags:
-  - '6.0'
-  - auth
-  - client-side-encryption
-  - openssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-cse
+  tags: ['6.0', auth, client-side-encryption, openssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '6.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '6.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
 - name: test-6.0-server-auth-sasl-openssl
-  tags:
-  - '6.0'
-  - auth
-  - openssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['6.0', auth, openssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-6.0-server-auth-sasl-openssl-static-cse
-  tags:
-  - '6.0'
-  - auth
-  - client-side-encryption
-  - openssl-static
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-static-cse
+  tags: ['6.0', auth, client-side-encryption, openssl-static, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-static-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '6.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '6.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
+      VALGRIND: 'off'}
 - name: test-6.0-server-auth-sasl-openssl-static
-  tags:
-  - '6.0'
-  - auth
-  - openssl-static
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['6.0', auth, openssl-static, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-6.0-server-auth-sasl-darwinssl-cse
-  tags:
-  - '6.0'
-  - auth
-  - client-side-encryption
-  - darwinssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-darwinssl-cse
+  tags: ['6.0', auth, client-side-encryption, darwinssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-darwinssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '6.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '6.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
+      VALGRIND: 'off'}
 - name: test-6.0-server-auth-sasl-darwinssl
-  tags:
-  - '6.0'
-  - auth
-  - darwinssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['6.0', auth, darwinssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-6.0-server-auth-sasl-winssl-cse
-  tags:
-  - '6.0'
-  - auth
-  - client-side-encryption
-  - sasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl-cse
+  tags: ['6.0', auth, client-side-encryption, sasl, server, winssl]
+  depends_on: {name: debug-compile-sasl-winssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '6.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '6.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
 - name: test-6.0-server-auth-sasl-winssl
-  tags:
-  - '6.0'
-  - auth
-  - sasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['6.0', auth, sasl, server, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-6.0-server-auth-nosasl-openssl
-  tags:
-  - '6.0'
-  - auth
-  - nosasl
-  - openssl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['6.0', auth, nosasl, openssl, server]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-6.0-server-auth-nosasl-openssl-static
-  tags:
-  - '6.0'
-  - auth
-  - nosasl
-  - openssl-static
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['6.0', auth, nosasl, openssl-static, server]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-6.0-server-auth-nosasl-darwinssl
-  tags:
-  - '6.0'
-  - auth
-  - darwinssl
-  - nosasl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['6.0', auth, darwinssl, nosasl, server]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-6.0-server-auth-nosasl-winssl
-  tags:
-  - '6.0'
-  - auth
-  - nosasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['6.0', auth, nosasl, server, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-6.0-server-noauth-sasl-openssl-cse
-  tags:
-  - '6.0'
-  - client-side-encryption
-  - noauth
-  - openssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-cse
+  tags: ['6.0', client-side-encryption, noauth, openssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '6.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '6.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl,
+      VALGRIND: 'off'}
 - name: test-6.0-server-noauth-sasl-openssl
-  tags:
-  - '6.0'
-  - noauth
-  - openssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['6.0', noauth, openssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-6.0-server-noauth-sasl-openssl-static-cse
-  tags:
-  - '6.0'
-  - client-side-encryption
-  - noauth
-  - openssl-static
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-static-cse
+  tags: ['6.0', client-side-encryption, noauth, openssl-static, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-static-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '6.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '6.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
+      VALGRIND: 'off'}
 - name: test-6.0-server-noauth-sasl-openssl-static
-  tags:
-  - '6.0'
-  - noauth
-  - openssl-static
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['6.0', noauth, openssl-static, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-6.0-server-noauth-sasl-darwinssl-cse
-  tags:
-  - '6.0'
-  - client-side-encryption
-  - darwinssl
-  - noauth
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-darwinssl-cse
+  tags: ['6.0', client-side-encryption, darwinssl, noauth, sasl, server]
+  depends_on: {name: debug-compile-sasl-darwinssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '6.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '6.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
+      VALGRIND: 'off'}
 - name: test-6.0-server-noauth-sasl-darwinssl
-  tags:
-  - '6.0'
-  - darwinssl
-  - noauth
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['6.0', darwinssl, noauth, sasl, server]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-6.0-server-noauth-sasl-winssl-cse
-  tags:
-  - '6.0'
-  - client-side-encryption
-  - noauth
-  - sasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl-cse
+  tags: ['6.0', client-side-encryption, noauth, sasl, server, winssl]
+  depends_on: {name: debug-compile-sasl-winssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '6.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '6.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
 - name: test-6.0-server-noauth-sasl-winssl
-  tags:
-  - '6.0'
-  - noauth
-  - sasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['6.0', noauth, sasl, server, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-6.0-server-noauth-nosasl-openssl
-  tags:
-  - '6.0'
-  - noauth
-  - nosasl
-  - openssl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['6.0', noauth, nosasl, openssl, server]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-6.0-server-noauth-nosasl-openssl-static
-  tags:
-  - '6.0'
-  - noauth
-  - nosasl
-  - openssl-static
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['6.0', noauth, nosasl, openssl-static, server]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-6.0-server-noauth-nosasl-darwinssl
-  tags:
-  - '6.0'
-  - darwinssl
-  - noauth
-  - nosasl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['6.0', darwinssl, noauth, nosasl, server]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-6.0-server-noauth-nosasl-winssl
-  tags:
-  - '6.0'
-  - noauth
-  - nosasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['6.0', noauth, nosasl, server, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-6.0-server-noauth-nosasl-nossl
-  tags:
-  - '6.0'
-  - noauth
-  - nosasl
-  - nossl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: ['6.0', noauth, nosasl, nossl, server]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-6.0-replica-set-auth-sasl-openssl-cse
-  tags:
-  - '6.0'
-  - auth
-  - client-side-encryption
-  - openssl
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl-cse
+  tags: ['6.0', auth, client-side-encryption, openssl, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '6.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
 - name: test-6.0-replica-set-auth-sasl-openssl
-  tags:
-  - '6.0'
-  - auth
-  - openssl
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['6.0', auth, openssl, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-6.0-replica-set-auth-sasl-openssl-static-cse
-  tags:
-  - '6.0'
-  - auth
-  - client-side-encryption
-  - openssl-static
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl-static-cse
+  tags: ['6.0', auth, client-side-encryption, openssl-static, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl-static-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '6.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
+      VALGRIND: 'off'}
 - name: test-6.0-replica-set-auth-sasl-openssl-static
-  tags:
-  - '6.0'
-  - auth
-  - openssl-static
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['6.0', auth, openssl-static, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-6.0-replica-set-auth-sasl-darwinssl-cse
-  tags:
-  - '6.0'
-  - auth
-  - client-side-encryption
-  - darwinssl
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-darwinssl-cse
+  tags: ['6.0', auth, client-side-encryption, darwinssl, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-darwinssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '6.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
+      VALGRIND: 'off'}
 - name: test-6.0-replica-set-auth-sasl-darwinssl
-  tags:
-  - '6.0'
-  - auth
-  - darwinssl
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['6.0', auth, darwinssl, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-6.0-replica-set-auth-sasl-winssl-cse
-  tags:
-  - '6.0'
-  - auth
-  - client-side-encryption
-  - replica_set
-  - sasl
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl-cse
+  tags: ['6.0', auth, client-side-encryption, replica_set, sasl, winssl]
+  depends_on: {name: debug-compile-sasl-winssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '6.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
 - name: test-6.0-replica-set-auth-sasl-winssl
-  tags:
-  - '6.0'
-  - auth
-  - replica_set
-  - sasl
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['6.0', auth, replica_set, sasl, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-6.0-replica-set-auth-nosasl-openssl
-  tags:
-  - '6.0'
-  - auth
-  - nosasl
-  - openssl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['6.0', auth, nosasl, openssl, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-6.0-replica-set-auth-nosasl-openssl-static
-  tags:
-  - '6.0'
-  - auth
-  - nosasl
-  - openssl-static
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['6.0', auth, nosasl, openssl-static, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-6.0-replica-set-auth-nosasl-darwinssl
-  tags:
-  - '6.0'
-  - auth
-  - darwinssl
-  - nosasl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['6.0', auth, darwinssl, nosasl, replica_set]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-6.0-replica-set-auth-nosasl-winssl
-  tags:
-  - '6.0'
-  - auth
-  - nosasl
-  - replica_set
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['6.0', auth, nosasl, replica_set, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-6.0-replica-set-noauth-sasl-openssl-cse
-  tags:
-  - '6.0'
-  - client-side-encryption
-  - noauth
-  - openssl
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl-cse
+  tags: ['6.0', client-side-encryption, noauth, openssl, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '6.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl,
+      VALGRIND: 'off'}
 - name: test-6.0-replica-set-noauth-sasl-openssl
-  tags:
-  - '6.0'
-  - noauth
-  - openssl
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['6.0', noauth, openssl, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-6.0-replica-set-noauth-sasl-openssl-static-cse
-  tags:
-  - '6.0'
-  - client-side-encryption
-  - noauth
-  - openssl-static
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl-static-cse
+  tags: ['6.0', client-side-encryption, noauth, openssl-static, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl-static-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '6.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
+      VALGRIND: 'off'}
 - name: test-6.0-replica-set-noauth-sasl-openssl-static
-  tags:
-  - '6.0'
-  - noauth
-  - openssl-static
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['6.0', noauth, openssl-static, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-6.0-replica-set-noauth-sasl-darwinssl-cse
-  tags:
-  - '6.0'
-  - client-side-encryption
-  - darwinssl
-  - noauth
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-darwinssl-cse
+  tags: ['6.0', client-side-encryption, darwinssl, noauth, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-darwinssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '6.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
+      VALGRIND: 'off'}
 - name: test-6.0-replica-set-noauth-sasl-darwinssl
-  tags:
-  - '6.0'
-  - darwinssl
-  - noauth
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['6.0', darwinssl, noauth, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-6.0-replica-set-noauth-sasl-winssl-cse
-  tags:
-  - '6.0'
-  - client-side-encryption
-  - noauth
-  - replica_set
-  - sasl
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl-cse
+  tags: ['6.0', client-side-encryption, noauth, replica_set, sasl, winssl]
+  depends_on: {name: debug-compile-sasl-winssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '6.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
 - name: test-6.0-replica-set-noauth-sasl-winssl
-  tags:
-  - '6.0'
-  - noauth
-  - replica_set
-  - sasl
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['6.0', noauth, replica_set, sasl, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-6.0-replica-set-noauth-nosasl-openssl
-  tags:
-  - '6.0'
-  - noauth
-  - nosasl
-  - openssl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['6.0', noauth, nosasl, openssl, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-6.0-replica-set-noauth-nosasl-openssl-static
-  tags:
-  - '6.0'
-  - noauth
-  - nosasl
-  - openssl-static
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['6.0', noauth, nosasl, openssl-static, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-6.0-replica-set-noauth-nosasl-darwinssl
-  tags:
-  - '6.0'
-  - darwinssl
-  - noauth
-  - nosasl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['6.0', darwinssl, noauth, nosasl, replica_set]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-6.0-replica-set-noauth-nosasl-winssl
-  tags:
-  - '6.0'
-  - noauth
-  - nosasl
-  - replica_set
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['6.0', noauth, nosasl, replica_set, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-6.0-replica-set-noauth-nosasl-nossl
-  tags:
-  - '6.0'
-  - noauth
-  - nosasl
-  - nossl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: ['6.0', noauth, nosasl, nossl, replica_set]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-6.0-sharded-auth-sasl-openssl
-  tags:
-  - '6.0'
-  - auth
-  - openssl
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['6.0', auth, openssl, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-6.0-sharded-auth-sasl-openssl-static
-  tags:
-  - '6.0'
-  - auth
-  - openssl-static
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['6.0', auth, openssl-static, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-6.0-sharded-auth-sasl-darwinssl
-  tags:
-  - '6.0'
-  - auth
-  - darwinssl
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['6.0', auth, darwinssl, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-6.0-sharded-auth-sasl-winssl
-  tags:
-  - '6.0'
-  - auth
-  - sasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['6.0', auth, sasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-6.0-sharded-auth-nosasl-openssl
-  tags:
-  - '6.0'
-  - auth
-  - nosasl
-  - openssl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['6.0', auth, nosasl, openssl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-6.0-sharded-auth-nosasl-openssl-static
-  tags:
-  - '6.0'
-  - auth
-  - nosasl
-  - openssl-static
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['6.0', auth, nosasl, openssl-static, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-6.0-sharded-auth-nosasl-darwinssl
-  tags:
-  - '6.0'
-  - auth
-  - darwinssl
-  - nosasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['6.0', auth, darwinssl, nosasl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-6.0-sharded-auth-nosasl-winssl
-  tags:
-  - '6.0'
-  - auth
-  - nosasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['6.0', auth, nosasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '6.0'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-6.0-sharded-noauth-sasl-openssl
-  tags:
-  - '6.0'
-  - noauth
-  - openssl
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['6.0', noauth, openssl, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-6.0-sharded-noauth-sasl-openssl-static
-  tags:
-  - '6.0'
-  - noauth
-  - openssl-static
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['6.0', noauth, openssl-static, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-6.0-sharded-noauth-sasl-darwinssl
-  tags:
-  - '6.0'
-  - darwinssl
-  - noauth
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['6.0', darwinssl, noauth, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-6.0-sharded-noauth-sasl-winssl
-  tags:
-  - '6.0'
-  - noauth
-  - sasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['6.0', noauth, sasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-6.0-sharded-noauth-nosasl-openssl
-  tags:
-  - '6.0'
-  - noauth
-  - nosasl
-  - openssl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['6.0', noauth, nosasl, openssl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-6.0-sharded-noauth-nosasl-openssl-static
-  tags:
-  - '6.0'
-  - noauth
-  - nosasl
-  - openssl-static
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['6.0', noauth, nosasl, openssl-static, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-6.0-sharded-noauth-nosasl-darwinssl
-  tags:
-  - '6.0'
-  - darwinssl
-  - noauth
-  - nosasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['6.0', darwinssl, noauth, nosasl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-6.0-sharded-noauth-nosasl-winssl
-  tags:
-  - '6.0'
-  - noauth
-  - nosasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['6.0', noauth, nosasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-6.0-sharded-noauth-nosasl-nossl
-  tags:
-  - '6.0'
-  - noauth
-  - nosasl
-  - nossl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: ['6.0', noauth, nosasl, nossl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: '6.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '6.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-5.0-server-auth-sasl-openssl-cse
-  tags:
-  - '5.0'
-  - auth
-  - client-side-encryption
-  - openssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-cse
+  tags: ['5.0', auth, client-side-encryption, openssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '5.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '5.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
 - name: test-5.0-server-auth-sasl-openssl
-  tags:
-  - '5.0'
-  - auth
-  - openssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['5.0', auth, openssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-5.0-server-auth-sasl-openssl-static-cse
-  tags:
-  - '5.0'
-  - auth
-  - client-side-encryption
-  - openssl-static
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-static-cse
+  tags: ['5.0', auth, client-side-encryption, openssl-static, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-static-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '5.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '5.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
+      VALGRIND: 'off'}
 - name: test-5.0-server-auth-sasl-openssl-static
-  tags:
-  - '5.0'
-  - auth
-  - openssl-static
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['5.0', auth, openssl-static, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-5.0-server-auth-sasl-darwinssl-cse
-  tags:
-  - '5.0'
-  - auth
-  - client-side-encryption
-  - darwinssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-darwinssl-cse
+  tags: ['5.0', auth, client-side-encryption, darwinssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-darwinssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '5.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '5.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
+      VALGRIND: 'off'}
 - name: test-5.0-server-auth-sasl-darwinssl
-  tags:
-  - '5.0'
-  - auth
-  - darwinssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['5.0', auth, darwinssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-5.0-server-auth-sasl-winssl-cse
-  tags:
-  - '5.0'
-  - auth
-  - client-side-encryption
-  - sasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl-cse
+  tags: ['5.0', auth, client-side-encryption, sasl, server, winssl]
+  depends_on: {name: debug-compile-sasl-winssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '5.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '5.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
 - name: test-5.0-server-auth-sasl-winssl
-  tags:
-  - '5.0'
-  - auth
-  - sasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['5.0', auth, sasl, server, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-5.0-server-auth-nosasl-openssl
-  tags:
-  - '5.0'
-  - auth
-  - nosasl
-  - openssl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['5.0', auth, nosasl, openssl, server]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-5.0-server-auth-nosasl-openssl-static
-  tags:
-  - '5.0'
-  - auth
-  - nosasl
-  - openssl-static
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['5.0', auth, nosasl, openssl-static, server]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-5.0-server-auth-nosasl-darwinssl
-  tags:
-  - '5.0'
-  - auth
-  - darwinssl
-  - nosasl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['5.0', auth, darwinssl, nosasl, server]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-5.0-server-auth-nosasl-winssl
-  tags:
-  - '5.0'
-  - auth
-  - nosasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['5.0', auth, nosasl, server, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-5.0-server-noauth-sasl-openssl-cse
-  tags:
-  - '5.0'
-  - client-side-encryption
-  - noauth
-  - openssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-cse
+  tags: ['5.0', client-side-encryption, noauth, openssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '5.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '5.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl,
+      VALGRIND: 'off'}
 - name: test-5.0-server-noauth-sasl-openssl
-  tags:
-  - '5.0'
-  - noauth
-  - openssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['5.0', noauth, openssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-5.0-server-noauth-sasl-openssl-static-cse
-  tags:
-  - '5.0'
-  - client-side-encryption
-  - noauth
-  - openssl-static
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-static-cse
+  tags: ['5.0', client-side-encryption, noauth, openssl-static, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-static-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '5.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '5.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
+      VALGRIND: 'off'}
 - name: test-5.0-server-noauth-sasl-openssl-static
-  tags:
-  - '5.0'
-  - noauth
-  - openssl-static
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['5.0', noauth, openssl-static, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-5.0-server-noauth-sasl-darwinssl-cse
-  tags:
-  - '5.0'
-  - client-side-encryption
-  - darwinssl
-  - noauth
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-darwinssl-cse
+  tags: ['5.0', client-side-encryption, darwinssl, noauth, sasl, server]
+  depends_on: {name: debug-compile-sasl-darwinssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '5.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '5.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
+      VALGRIND: 'off'}
 - name: test-5.0-server-noauth-sasl-darwinssl
-  tags:
-  - '5.0'
-  - darwinssl
-  - noauth
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['5.0', darwinssl, noauth, sasl, server]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-5.0-server-noauth-sasl-winssl-cse
-  tags:
-  - '5.0'
-  - client-side-encryption
-  - noauth
-  - sasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl-cse
+  tags: ['5.0', client-side-encryption, noauth, sasl, server, winssl]
+  depends_on: {name: debug-compile-sasl-winssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '5.0'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '5.0'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
 - name: test-5.0-server-noauth-sasl-winssl
-  tags:
-  - '5.0'
-  - noauth
-  - sasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['5.0', noauth, sasl, server, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-5.0-server-noauth-nosasl-openssl
-  tags:
-  - '5.0'
-  - noauth
-  - nosasl
-  - openssl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['5.0', noauth, nosasl, openssl, server]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-5.0-server-noauth-nosasl-openssl-static
-  tags:
-  - '5.0'
-  - noauth
-  - nosasl
-  - openssl-static
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['5.0', noauth, nosasl, openssl-static, server]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-5.0-server-noauth-nosasl-darwinssl
-  tags:
-  - '5.0'
-  - darwinssl
-  - noauth
-  - nosasl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['5.0', darwinssl, noauth, nosasl, server]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-5.0-server-noauth-nosasl-winssl
-  tags:
-  - '5.0'
-  - noauth
-  - nosasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['5.0', noauth, nosasl, server, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-5.0-server-noauth-nosasl-nossl
-  tags:
-  - '5.0'
-  - noauth
-  - nosasl
-  - nossl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: ['5.0', noauth, nosasl, nossl, server]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-5.0-replica-set-auth-sasl-openssl
-  tags:
-  - '5.0'
-  - auth
-  - openssl
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['5.0', auth, openssl, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-5.0-replica-set-auth-sasl-openssl-static
-  tags:
-  - '5.0'
-  - auth
-  - openssl-static
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['5.0', auth, openssl-static, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-5.0-replica-set-auth-sasl-darwinssl
-  tags:
-  - '5.0'
-  - auth
-  - darwinssl
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['5.0', auth, darwinssl, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-5.0-replica-set-auth-sasl-winssl
-  tags:
-  - '5.0'
-  - auth
-  - replica_set
-  - sasl
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['5.0', auth, replica_set, sasl, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-5.0-replica-set-auth-nosasl-openssl
-  tags:
-  - '5.0'
-  - auth
-  - nosasl
-  - openssl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['5.0', auth, nosasl, openssl, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-5.0-replica-set-auth-nosasl-openssl-static
-  tags:
-  - '5.0'
-  - auth
-  - nosasl
-  - openssl-static
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['5.0', auth, nosasl, openssl-static, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-5.0-replica-set-auth-nosasl-darwinssl
-  tags:
-  - '5.0'
-  - auth
-  - darwinssl
-  - nosasl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['5.0', auth, darwinssl, nosasl, replica_set]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-5.0-replica-set-auth-nosasl-winssl
-  tags:
-  - '5.0'
-  - auth
-  - nosasl
-  - replica_set
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['5.0', auth, nosasl, replica_set, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-5.0-replica-set-noauth-sasl-openssl
-  tags:
-  - '5.0'
-  - noauth
-  - openssl
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['5.0', noauth, openssl, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-5.0-replica-set-noauth-sasl-openssl-static
-  tags:
-  - '5.0'
-  - noauth
-  - openssl-static
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['5.0', noauth, openssl-static, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-5.0-replica-set-noauth-sasl-darwinssl
-  tags:
-  - '5.0'
-  - darwinssl
-  - noauth
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['5.0', darwinssl, noauth, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-5.0-replica-set-noauth-sasl-winssl
-  tags:
-  - '5.0'
-  - noauth
-  - replica_set
-  - sasl
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['5.0', noauth, replica_set, sasl, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-5.0-replica-set-noauth-nosasl-openssl
-  tags:
-  - '5.0'
-  - noauth
-  - nosasl
-  - openssl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['5.0', noauth, nosasl, openssl, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-5.0-replica-set-noauth-nosasl-openssl-static
-  tags:
-  - '5.0'
-  - noauth
-  - nosasl
-  - openssl-static
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['5.0', noauth, nosasl, openssl-static, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-5.0-replica-set-noauth-nosasl-darwinssl
-  tags:
-  - '5.0'
-  - darwinssl
-  - noauth
-  - nosasl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['5.0', darwinssl, noauth, nosasl, replica_set]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-5.0-replica-set-noauth-nosasl-winssl
-  tags:
-  - '5.0'
-  - noauth
-  - nosasl
-  - replica_set
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['5.0', noauth, nosasl, replica_set, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-5.0-replica-set-noauth-nosasl-nossl
-  tags:
-  - '5.0'
-  - noauth
-  - nosasl
-  - nossl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: ['5.0', noauth, nosasl, nossl, replica_set]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-5.0-sharded-auth-sasl-openssl
-  tags:
-  - '5.0'
-  - auth
-  - openssl
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['5.0', auth, openssl, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-5.0-sharded-auth-sasl-openssl-static
-  tags:
-  - '5.0'
-  - auth
-  - openssl-static
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['5.0', auth, openssl-static, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-5.0-sharded-auth-sasl-darwinssl
-  tags:
-  - '5.0'
-  - auth
-  - darwinssl
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['5.0', auth, darwinssl, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-5.0-sharded-auth-sasl-winssl
-  tags:
-  - '5.0'
-  - auth
-  - sasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['5.0', auth, sasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-5.0-sharded-auth-nosasl-openssl
-  tags:
-  - '5.0'
-  - auth
-  - nosasl
-  - openssl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['5.0', auth, nosasl, openssl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-5.0-sharded-auth-nosasl-openssl-static
-  tags:
-  - '5.0'
-  - auth
-  - nosasl
-  - openssl-static
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['5.0', auth, nosasl, openssl-static, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-5.0-sharded-auth-nosasl-darwinssl
-  tags:
-  - '5.0'
-  - auth
-  - darwinssl
-  - nosasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['5.0', auth, darwinssl, nosasl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-5.0-sharded-auth-nosasl-winssl
-  tags:
-  - '5.0'
-  - auth
-  - nosasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['5.0', auth, nosasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-5.0-sharded-noauth-sasl-openssl
-  tags:
-  - '5.0'
-  - noauth
-  - openssl
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['5.0', noauth, openssl, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-5.0-sharded-noauth-sasl-openssl-static
-  tags:
-  - '5.0'
-  - noauth
-  - openssl-static
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['5.0', noauth, openssl-static, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-5.0-sharded-noauth-sasl-darwinssl
-  tags:
-  - '5.0'
-  - darwinssl
-  - noauth
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['5.0', darwinssl, noauth, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-5.0-sharded-noauth-sasl-winssl
-  tags:
-  - '5.0'
-  - noauth
-  - sasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['5.0', noauth, sasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-5.0-sharded-noauth-nosasl-openssl
-  tags:
-  - '5.0'
-  - noauth
-  - nosasl
-  - openssl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['5.0', noauth, nosasl, openssl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-5.0-sharded-noauth-nosasl-openssl-static
-  tags:
-  - '5.0'
-  - noauth
-  - nosasl
-  - openssl-static
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['5.0', noauth, nosasl, openssl-static, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-5.0-sharded-noauth-nosasl-darwinssl
-  tags:
-  - '5.0'
-  - darwinssl
-  - noauth
-  - nosasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['5.0', darwinssl, noauth, nosasl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-5.0-sharded-noauth-nosasl-winssl
-  tags:
-  - '5.0'
-  - noauth
-  - nosasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['5.0', noauth, nosasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-5.0-sharded-noauth-nosasl-nossl
-  tags:
-  - '5.0'
-  - noauth
-  - nosasl
-  - nossl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: ['5.0', noauth, nosasl, nossl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-4.4-server-auth-sasl-openssl-cse
-  tags:
-  - '4.4'
-  - auth
-  - client-side-encryption
-  - openssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-cse
+  tags: ['4.4', auth, client-side-encryption, openssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.4'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.4'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
 - name: test-4.4-server-auth-sasl-openssl
-  tags:
-  - '4.4'
-  - auth
-  - openssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['4.4', auth, openssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.4-server-auth-sasl-openssl-static-cse
-  tags:
-  - '4.4'
-  - auth
-  - client-side-encryption
-  - openssl-static
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-static-cse
+  tags: ['4.4', auth, client-side-encryption, openssl-static, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-static-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '4.4'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.4'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
+      VALGRIND: 'off'}
 - name: test-4.4-server-auth-sasl-openssl-static
-  tags:
-  - '4.4'
-  - auth
-  - openssl-static
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['4.4', auth, openssl-static, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.4-server-auth-sasl-darwinssl-cse
-  tags:
-  - '4.4'
-  - auth
-  - client-side-encryption
-  - darwinssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-darwinssl-cse
+  tags: ['4.4', auth, client-side-encryption, darwinssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-darwinssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '4.4'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.4'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
+      VALGRIND: 'off'}
 - name: test-4.4-server-auth-sasl-darwinssl
-  tags:
-  - '4.4'
-  - auth
-  - darwinssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['4.4', auth, darwinssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.4-server-auth-sasl-winssl-cse
-  tags:
-  - '4.4'
-  - auth
-  - client-side-encryption
-  - sasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl-cse
+  tags: ['4.4', auth, client-side-encryption, sasl, server, winssl]
+  depends_on: {name: debug-compile-sasl-winssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '4.4'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '4.4'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
 - name: test-4.4-server-auth-sasl-winssl
-  tags:
-  - '4.4'
-  - auth
-  - sasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['4.4', auth, sasl, server, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.4-server-auth-nosasl-openssl
-  tags:
-  - '4.4'
-  - auth
-  - nosasl
-  - openssl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['4.4', auth, nosasl, openssl, server]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.4-server-auth-nosasl-openssl-static
-  tags:
-  - '4.4'
-  - auth
-  - nosasl
-  - openssl-static
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['4.4', auth, nosasl, openssl-static, server]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.4-server-auth-nosasl-darwinssl
-  tags:
-  - '4.4'
-  - auth
-  - darwinssl
-  - nosasl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['4.4', auth, darwinssl, nosasl, server]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.4-server-auth-nosasl-winssl
-  tags:
-  - '4.4'
-  - auth
-  - nosasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['4.4', auth, nosasl, server, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.4-server-noauth-sasl-openssl-cse
-  tags:
-  - '4.4'
-  - client-side-encryption
-  - noauth
-  - openssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-cse
+  tags: ['4.4', client-side-encryption, noauth, openssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.4'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '4.4'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl,
+      VALGRIND: 'off'}
 - name: test-4.4-server-noauth-sasl-openssl
-  tags:
-  - '4.4'
-  - noauth
-  - openssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['4.4', noauth, openssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.4-server-noauth-sasl-openssl-static-cse
-  tags:
-  - '4.4'
-  - client-side-encryption
-  - noauth
-  - openssl-static
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-static-cse
+  tags: ['4.4', client-side-encryption, noauth, openssl-static, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-static-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '4.4'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.4'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
+      VALGRIND: 'off'}
 - name: test-4.4-server-noauth-sasl-openssl-static
-  tags:
-  - '4.4'
-  - noauth
-  - openssl-static
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['4.4', noauth, openssl-static, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.4-server-noauth-sasl-darwinssl-cse
-  tags:
-  - '4.4'
-  - client-side-encryption
-  - darwinssl
-  - noauth
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-darwinssl-cse
+  tags: ['4.4', client-side-encryption, darwinssl, noauth, sasl, server]
+  depends_on: {name: debug-compile-sasl-darwinssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '4.4'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.4'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
+      VALGRIND: 'off'}
 - name: test-4.4-server-noauth-sasl-darwinssl
-  tags:
-  - '4.4'
-  - darwinssl
-  - noauth
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['4.4', darwinssl, noauth, sasl, server]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.4-server-noauth-sasl-winssl-cse
-  tags:
-  - '4.4'
-  - client-side-encryption
-  - noauth
-  - sasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl-cse
+  tags: ['4.4', client-side-encryption, noauth, sasl, server, winssl]
+  depends_on: {name: debug-compile-sasl-winssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '4.4'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '4.4'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
 - name: test-4.4-server-noauth-sasl-winssl
-  tags:
-  - '4.4'
-  - noauth
-  - sasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['4.4', noauth, sasl, server, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.4-server-noauth-nosasl-openssl
-  tags:
-  - '4.4'
-  - noauth
-  - nosasl
-  - openssl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['4.4', noauth, nosasl, openssl, server]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.4-server-noauth-nosasl-openssl-static
-  tags:
-  - '4.4'
-  - noauth
-  - nosasl
-  - openssl-static
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['4.4', noauth, nosasl, openssl-static, server]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.4-server-noauth-nosasl-darwinssl
-  tags:
-  - '4.4'
-  - darwinssl
-  - noauth
-  - nosasl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['4.4', darwinssl, noauth, nosasl, server]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.4-server-noauth-nosasl-winssl
-  tags:
-  - '4.4'
-  - noauth
-  - nosasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['4.4', noauth, nosasl, server, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.4-server-noauth-nosasl-nossl
-  tags:
-  - '4.4'
-  - noauth
-  - nosasl
-  - nossl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: ['4.4', noauth, nosasl, nossl, server]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-4.4-replica-set-auth-sasl-openssl
-  tags:
-  - '4.4'
-  - auth
-  - openssl
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['4.4', auth, openssl, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.4-replica-set-auth-sasl-openssl-static
-  tags:
-  - '4.4'
-  - auth
-  - openssl-static
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['4.4', auth, openssl-static, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.4-replica-set-auth-sasl-darwinssl
-  tags:
-  - '4.4'
-  - auth
-  - darwinssl
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['4.4', auth, darwinssl, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.4-replica-set-auth-sasl-winssl
-  tags:
-  - '4.4'
-  - auth
-  - replica_set
-  - sasl
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['4.4', auth, replica_set, sasl, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.4-replica-set-auth-nosasl-openssl
-  tags:
-  - '4.4'
-  - auth
-  - nosasl
-  - openssl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['4.4', auth, nosasl, openssl, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.4-replica-set-auth-nosasl-openssl-static
-  tags:
-  - '4.4'
-  - auth
-  - nosasl
-  - openssl-static
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['4.4', auth, nosasl, openssl-static, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.4-replica-set-auth-nosasl-darwinssl
-  tags:
-  - '4.4'
-  - auth
-  - darwinssl
-  - nosasl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['4.4', auth, darwinssl, nosasl, replica_set]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.4-replica-set-auth-nosasl-winssl
-  tags:
-  - '4.4'
-  - auth
-  - nosasl
-  - replica_set
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['4.4', auth, nosasl, replica_set, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.4-replica-set-noauth-sasl-openssl
-  tags:
-  - '4.4'
-  - noauth
-  - openssl
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['4.4', noauth, openssl, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.4-replica-set-noauth-sasl-openssl-static
-  tags:
-  - '4.4'
-  - noauth
-  - openssl-static
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['4.4', noauth, openssl-static, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.4-replica-set-noauth-sasl-darwinssl
-  tags:
-  - '4.4'
-  - darwinssl
-  - noauth
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['4.4', darwinssl, noauth, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.4-replica-set-noauth-sasl-winssl
-  tags:
-  - '4.4'
-  - noauth
-  - replica_set
-  - sasl
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['4.4', noauth, replica_set, sasl, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.4-replica-set-noauth-nosasl-openssl
-  tags:
-  - '4.4'
-  - noauth
-  - nosasl
-  - openssl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['4.4', noauth, nosasl, openssl, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.4-replica-set-noauth-nosasl-openssl-static
-  tags:
-  - '4.4'
-  - noauth
-  - nosasl
-  - openssl-static
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['4.4', noauth, nosasl, openssl-static, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.4-replica-set-noauth-nosasl-darwinssl
-  tags:
-  - '4.4'
-  - darwinssl
-  - noauth
-  - nosasl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['4.4', darwinssl, noauth, nosasl, replica_set]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.4-replica-set-noauth-nosasl-winssl
-  tags:
-  - '4.4'
-  - noauth
-  - nosasl
-  - replica_set
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['4.4', noauth, nosasl, replica_set, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.4-replica-set-noauth-nosasl-nossl
-  tags:
-  - '4.4'
-  - noauth
-  - nosasl
-  - nossl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: ['4.4', noauth, nosasl, nossl, replica_set]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-4.4-sharded-auth-sasl-openssl
-  tags:
-  - '4.4'
-  - auth
-  - openssl
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['4.4', auth, openssl, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.4-sharded-auth-sasl-openssl-static
-  tags:
-  - '4.4'
-  - auth
-  - openssl-static
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['4.4', auth, openssl-static, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.4-sharded-auth-sasl-darwinssl
-  tags:
-  - '4.4'
-  - auth
-  - darwinssl
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['4.4', auth, darwinssl, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.4-sharded-auth-sasl-winssl
-  tags:
-  - '4.4'
-  - auth
-  - sasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['4.4', auth, sasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.4-sharded-auth-nosasl-openssl
-  tags:
-  - '4.4'
-  - auth
-  - nosasl
-  - openssl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['4.4', auth, nosasl, openssl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.4-sharded-auth-nosasl-openssl-static
-  tags:
-  - '4.4'
-  - auth
-  - nosasl
-  - openssl-static
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['4.4', auth, nosasl, openssl-static, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.4-sharded-auth-nosasl-darwinssl
-  tags:
-  - '4.4'
-  - auth
-  - darwinssl
-  - nosasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['4.4', auth, darwinssl, nosasl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.4-sharded-auth-nosasl-winssl
-  tags:
-  - '4.4'
-  - auth
-  - nosasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['4.4', auth, nosasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.4'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.4-sharded-noauth-sasl-openssl
-  tags:
-  - '4.4'
-  - noauth
-  - openssl
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['4.4', noauth, openssl, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.4-sharded-noauth-sasl-openssl-static
-  tags:
-  - '4.4'
-  - noauth
-  - openssl-static
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['4.4', noauth, openssl-static, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.4-sharded-noauth-sasl-darwinssl
-  tags:
-  - '4.4'
-  - darwinssl
-  - noauth
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['4.4', darwinssl, noauth, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.4-sharded-noauth-sasl-winssl
-  tags:
-  - '4.4'
-  - noauth
-  - sasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['4.4', noauth, sasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.4-sharded-noauth-nosasl-openssl
-  tags:
-  - '4.4'
-  - noauth
-  - nosasl
-  - openssl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['4.4', noauth, nosasl, openssl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.4-sharded-noauth-nosasl-openssl-static
-  tags:
-  - '4.4'
-  - noauth
-  - nosasl
-  - openssl-static
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['4.4', noauth, nosasl, openssl-static, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.4-sharded-noauth-nosasl-darwinssl
-  tags:
-  - '4.4'
-  - darwinssl
-  - noauth
-  - nosasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['4.4', darwinssl, noauth, nosasl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.4-sharded-noauth-nosasl-winssl
-  tags:
-  - '4.4'
-  - noauth
-  - nosasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['4.4', noauth, nosasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.4-sharded-noauth-nosasl-nossl
-  tags:
-  - '4.4'
-  - noauth
-  - nosasl
-  - nossl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: ['4.4', noauth, nosasl, nossl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.4'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '4.4'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-4.2-server-auth-sasl-openssl-cse
-  tags:
-  - '4.2'
-  - auth
-  - client-side-encryption
-  - openssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-cse
+  tags: ['4.2', auth, client-side-encryption, openssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.2'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.2'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl, VALGRIND: 'off'}
 - name: test-4.2-server-auth-sasl-openssl
-  tags:
-  - '4.2'
-  - auth
-  - openssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['4.2', auth, openssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.2-server-auth-sasl-openssl-static-cse
-  tags:
-  - '4.2'
-  - auth
-  - client-side-encryption
-  - openssl-static
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-static-cse
+  tags: ['4.2', auth, client-side-encryption, openssl-static, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-static-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '4.2'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.2'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
+      VALGRIND: 'off'}
 - name: test-4.2-server-auth-sasl-openssl-static
-  tags:
-  - '4.2'
-  - auth
-  - openssl-static
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['4.2', auth, openssl-static, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.2-server-auth-sasl-darwinssl-cse
-  tags:
-  - '4.2'
-  - auth
-  - client-side-encryption
-  - darwinssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-darwinssl-cse
+  tags: ['4.2', auth, client-side-encryption, darwinssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-darwinssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '4.2'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.2'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
+      VALGRIND: 'off'}
 - name: test-4.2-server-auth-sasl-darwinssl
-  tags:
-  - '4.2'
-  - auth
-  - darwinssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['4.2', auth, darwinssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.2-server-auth-sasl-winssl-cse
-  tags:
-  - '4.2'
-  - auth
-  - client-side-encryption
-  - sasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl-cse
+  tags: ['4.2', auth, client-side-encryption, sasl, server, winssl]
+  depends_on: {name: debug-compile-sasl-winssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '4.2'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '4.2'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
 - name: test-4.2-server-auth-sasl-winssl
-  tags:
-  - '4.2'
-  - auth
-  - sasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['4.2', auth, sasl, server, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.2-server-auth-nosasl-openssl
-  tags:
-  - '4.2'
-  - auth
-  - nosasl
-  - openssl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['4.2', auth, nosasl, openssl, server]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.2-server-auth-nosasl-openssl-static
-  tags:
-  - '4.2'
-  - auth
-  - nosasl
-  - openssl-static
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['4.2', auth, nosasl, openssl-static, server]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.2-server-auth-nosasl-darwinssl
-  tags:
-  - '4.2'
-  - auth
-  - darwinssl
-  - nosasl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['4.2', auth, darwinssl, nosasl, server]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.2-server-auth-nosasl-winssl
-  tags:
-  - '4.2'
-  - auth
-  - nosasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['4.2', auth, nosasl, server, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.2-server-noauth-sasl-openssl-cse
-  tags:
-  - '4.2'
-  - client-side-encryption
-  - noauth
-  - openssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-cse
+  tags: ['4.2', client-side-encryption, noauth, openssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.2'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '4.2'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl,
+      VALGRIND: 'off'}
 - name: test-4.2-server-noauth-sasl-openssl
-  tags:
-  - '4.2'
-  - noauth
-  - openssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['4.2', noauth, openssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.2-server-noauth-sasl-openssl-static-cse
-  tags:
-  - '4.2'
-  - client-side-encryption
-  - noauth
-  - openssl-static
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-static-cse
+  tags: ['4.2', client-side-encryption, noauth, openssl-static, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-static-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static-cse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '4.2'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.2'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: openssl-static,
+      VALGRIND: 'off'}
 - name: test-4.2-server-noauth-sasl-openssl-static
-  tags:
-  - '4.2'
-  - noauth
-  - openssl-static
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['4.2', noauth, openssl-static, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.2-server-noauth-sasl-darwinssl-cse
-  tags:
-  - '4.2'
-  - client-side-encryption
-  - darwinssl
-  - noauth
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-darwinssl-cse
+  tags: ['4.2', client-side-encryption, darwinssl, noauth, sasl, server]
+  depends_on: {name: debug-compile-sasl-darwinssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '4.2'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.2'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: darwinssl,
+      VALGRIND: 'off'}
 - name: test-4.2-server-noauth-sasl-darwinssl
-  tags:
-  - '4.2'
-  - darwinssl
-  - noauth
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['4.2', darwinssl, noauth, sasl, server]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.2-server-noauth-sasl-winssl-cse
-  tags:
-  - '4.2'
-  - client-side-encryption
-  - noauth
-  - sasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl-cse
+  tags: ['4.2', client-side-encryption, noauth, sasl, server, winssl]
+  depends_on: {name: debug-compile-sasl-winssl-cse}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl-cse
+    vars: {BUILD_NAME: debug-compile-sasl-winssl-cse}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '4.2'
-  - func: clone drivers-evergreen-tools
-  - func: run kms servers
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '4.2'}
+  - {func: clone drivers-evergreen-tools}
+  - {func: run kms servers}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      CLIENT_SIDE_ENCRYPTION: 'on'
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, CLIENT_SIDE_ENCRYPTION: 'on', SSL: winssl, VALGRIND: 'off'}
 - name: test-4.2-server-noauth-sasl-winssl
-  tags:
-  - '4.2'
-  - noauth
-  - sasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['4.2', noauth, sasl, server, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.2-server-noauth-nosasl-openssl
-  tags:
-  - '4.2'
-  - noauth
-  - nosasl
-  - openssl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['4.2', noauth, nosasl, openssl, server]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.2-server-noauth-nosasl-openssl-static
-  tags:
-  - '4.2'
-  - noauth
-  - nosasl
-  - openssl-static
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['4.2', noauth, nosasl, openssl-static, server]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.2-server-noauth-nosasl-darwinssl
-  tags:
-  - '4.2'
-  - darwinssl
-  - noauth
-  - nosasl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['4.2', darwinssl, noauth, nosasl, server]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.2-server-noauth-nosasl-winssl
-  tags:
-  - '4.2'
-  - noauth
-  - nosasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['4.2', noauth, nosasl, server, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.2-server-noauth-nosasl-nossl
-  tags:
-  - '4.2'
-  - noauth
-  - nosasl
-  - nossl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: ['4.2', noauth, nosasl, nossl, server]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-4.2-replica-set-auth-sasl-openssl
-  tags:
-  - '4.2'
-  - auth
-  - openssl
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['4.2', auth, openssl, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.2-replica-set-auth-sasl-openssl-static
-  tags:
-  - '4.2'
-  - auth
-  - openssl-static
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['4.2', auth, openssl-static, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.2-replica-set-auth-sasl-darwinssl
-  tags:
-  - '4.2'
-  - auth
-  - darwinssl
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['4.2', auth, darwinssl, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.2-replica-set-auth-sasl-winssl
-  tags:
-  - '4.2'
-  - auth
-  - replica_set
-  - sasl
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['4.2', auth, replica_set, sasl, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.2-replica-set-auth-nosasl-openssl
-  tags:
-  - '4.2'
-  - auth
-  - nosasl
-  - openssl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['4.2', auth, nosasl, openssl, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.2-replica-set-auth-nosasl-openssl-static
-  tags:
-  - '4.2'
-  - auth
-  - nosasl
-  - openssl-static
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['4.2', auth, nosasl, openssl-static, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.2-replica-set-auth-nosasl-darwinssl
-  tags:
-  - '4.2'
-  - auth
-  - darwinssl
-  - nosasl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['4.2', auth, darwinssl, nosasl, replica_set]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.2-replica-set-auth-nosasl-winssl
-  tags:
-  - '4.2'
-  - auth
-  - nosasl
-  - replica_set
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['4.2', auth, nosasl, replica_set, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.2-replica-set-noauth-sasl-openssl
-  tags:
-  - '4.2'
-  - noauth
-  - openssl
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['4.2', noauth, openssl, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.2-replica-set-noauth-sasl-openssl-static
-  tags:
-  - '4.2'
-  - noauth
-  - openssl-static
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['4.2', noauth, openssl-static, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.2-replica-set-noauth-sasl-darwinssl
-  tags:
-  - '4.2'
-  - darwinssl
-  - noauth
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['4.2', darwinssl, noauth, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.2-replica-set-noauth-sasl-winssl
-  tags:
-  - '4.2'
-  - noauth
-  - replica_set
-  - sasl
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['4.2', noauth, replica_set, sasl, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.2-replica-set-noauth-nosasl-openssl
-  tags:
-  - '4.2'
-  - noauth
-  - nosasl
-  - openssl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['4.2', noauth, nosasl, openssl, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.2-replica-set-noauth-nosasl-openssl-static
-  tags:
-  - '4.2'
-  - noauth
-  - nosasl
-  - openssl-static
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['4.2', noauth, nosasl, openssl-static, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.2-replica-set-noauth-nosasl-darwinssl
-  tags:
-  - '4.2'
-  - darwinssl
-  - noauth
-  - nosasl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['4.2', darwinssl, noauth, nosasl, replica_set]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.2-replica-set-noauth-nosasl-winssl
-  tags:
-  - '4.2'
-  - noauth
-  - nosasl
-  - replica_set
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['4.2', noauth, nosasl, replica_set, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.2-replica-set-noauth-nosasl-nossl
-  tags:
-  - '4.2'
-  - noauth
-  - nosasl
-  - nossl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: ['4.2', noauth, nosasl, nossl, replica_set]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-4.2-sharded-auth-sasl-openssl
-  tags:
-  - '4.2'
-  - auth
-  - openssl
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['4.2', auth, openssl, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.2-sharded-auth-sasl-openssl-static
-  tags:
-  - '4.2'
-  - auth
-  - openssl-static
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['4.2', auth, openssl-static, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.2-sharded-auth-sasl-darwinssl
-  tags:
-  - '4.2'
-  - auth
-  - darwinssl
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['4.2', auth, darwinssl, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.2-sharded-auth-sasl-winssl
-  tags:
-  - '4.2'
-  - auth
-  - sasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['4.2', auth, sasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.2-sharded-auth-nosasl-openssl
-  tags:
-  - '4.2'
-  - auth
-  - nosasl
-  - openssl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['4.2', auth, nosasl, openssl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.2-sharded-auth-nosasl-openssl-static
-  tags:
-  - '4.2'
-  - auth
-  - nosasl
-  - openssl-static
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['4.2', auth, nosasl, openssl-static, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.2-sharded-auth-nosasl-darwinssl
-  tags:
-  - '4.2'
-  - auth
-  - darwinssl
-  - nosasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['4.2', auth, darwinssl, nosasl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.2-sharded-auth-nosasl-winssl
-  tags:
-  - '4.2'
-  - auth
-  - nosasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['4.2', auth, nosasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.2'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.2-sharded-noauth-sasl-openssl
-  tags:
-  - '4.2'
-  - noauth
-  - openssl
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['4.2', noauth, openssl, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.2-sharded-noauth-sasl-openssl-static
-  tags:
-  - '4.2'
-  - noauth
-  - openssl-static
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['4.2', noauth, openssl-static, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.2-sharded-noauth-sasl-darwinssl
-  tags:
-  - '4.2'
-  - darwinssl
-  - noauth
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['4.2', darwinssl, noauth, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.2-sharded-noauth-sasl-winssl
-  tags:
-  - '4.2'
-  - noauth
-  - sasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['4.2', noauth, sasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.2-sharded-noauth-nosasl-openssl
-  tags:
-  - '4.2'
-  - noauth
-  - nosasl
-  - openssl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['4.2', noauth, nosasl, openssl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.2-sharded-noauth-nosasl-openssl-static
-  tags:
-  - '4.2'
-  - noauth
-  - nosasl
-  - openssl-static
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['4.2', noauth, nosasl, openssl-static, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.2-sharded-noauth-nosasl-darwinssl
-  tags:
-  - '4.2'
-  - darwinssl
-  - noauth
-  - nosasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['4.2', darwinssl, noauth, nosasl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.2-sharded-noauth-nosasl-winssl
-  tags:
-  - '4.2'
-  - noauth
-  - nosasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['4.2', noauth, nosasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.2-sharded-noauth-nosasl-nossl
-  tags:
-  - '4.2'
-  - noauth
-  - nosasl
-  - nossl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: ['4.2', noauth, nosasl, nossl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.2'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '4.2'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-4.0-server-auth-sasl-openssl
-  tags:
-  - '4.0'
-  - auth
-  - openssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['4.0', auth, openssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.0-server-auth-sasl-openssl-static
-  tags:
-  - '4.0'
-  - auth
-  - openssl-static
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['4.0', auth, openssl-static, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.0-server-auth-sasl-darwinssl
-  tags:
-  - '4.0'
-  - auth
-  - darwinssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['4.0', auth, darwinssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.0-server-auth-sasl-winssl
-  tags:
-  - '4.0'
-  - auth
-  - sasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['4.0', auth, sasl, server, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.0-server-auth-nosasl-openssl
-  tags:
-  - '4.0'
-  - auth
-  - nosasl
-  - openssl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['4.0', auth, nosasl, openssl, server]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.0-server-auth-nosasl-openssl-static
-  tags:
-  - '4.0'
-  - auth
-  - nosasl
-  - openssl-static
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['4.0', auth, nosasl, openssl-static, server]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.0-server-auth-nosasl-darwinssl
-  tags:
-  - '4.0'
-  - auth
-  - darwinssl
-  - nosasl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['4.0', auth, darwinssl, nosasl, server]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.0-server-auth-nosasl-winssl
-  tags:
-  - '4.0'
-  - auth
-  - nosasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['4.0', auth, nosasl, server, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.0-server-noauth-sasl-openssl
-  tags:
-  - '4.0'
-  - noauth
-  - openssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['4.0', noauth, openssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.0-server-noauth-sasl-openssl-static
-  tags:
-  - '4.0'
-  - noauth
-  - openssl-static
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['4.0', noauth, openssl-static, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.0-server-noauth-sasl-darwinssl
-  tags:
-  - '4.0'
-  - darwinssl
-  - noauth
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['4.0', darwinssl, noauth, sasl, server]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.0-server-noauth-sasl-winssl
-  tags:
-  - '4.0'
-  - noauth
-  - sasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['4.0', noauth, sasl, server, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.0-server-noauth-nosasl-openssl
-  tags:
-  - '4.0'
-  - noauth
-  - nosasl
-  - openssl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['4.0', noauth, nosasl, openssl, server]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.0-server-noauth-nosasl-openssl-static
-  tags:
-  - '4.0'
-  - noauth
-  - nosasl
-  - openssl-static
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['4.0', noauth, nosasl, openssl-static, server]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.0-server-noauth-nosasl-darwinssl
-  tags:
-  - '4.0'
-  - darwinssl
-  - noauth
-  - nosasl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['4.0', darwinssl, noauth, nosasl, server]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.0-server-noauth-nosasl-winssl
-  tags:
-  - '4.0'
-  - noauth
-  - nosasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['4.0', noauth, nosasl, server, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.0-server-noauth-nosasl-nossl
-  tags:
-  - '4.0'
-  - noauth
-  - nosasl
-  - nossl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: ['4.0', noauth, nosasl, nossl, server]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-4.0-replica-set-auth-sasl-openssl
-  tags:
-  - '4.0'
-  - auth
-  - openssl
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['4.0', auth, openssl, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.0-replica-set-auth-sasl-openssl-static
-  tags:
-  - '4.0'
-  - auth
-  - openssl-static
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['4.0', auth, openssl-static, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.0-replica-set-auth-sasl-darwinssl
-  tags:
-  - '4.0'
-  - auth
-  - darwinssl
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['4.0', auth, darwinssl, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.0-replica-set-auth-sasl-winssl
-  tags:
-  - '4.0'
-  - auth
-  - replica_set
-  - sasl
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['4.0', auth, replica_set, sasl, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.0-replica-set-auth-nosasl-openssl
-  tags:
-  - '4.0'
-  - auth
-  - nosasl
-  - openssl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['4.0', auth, nosasl, openssl, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.0-replica-set-auth-nosasl-openssl-static
-  tags:
-  - '4.0'
-  - auth
-  - nosasl
-  - openssl-static
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['4.0', auth, nosasl, openssl-static, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.0-replica-set-auth-nosasl-darwinssl
-  tags:
-  - '4.0'
-  - auth
-  - darwinssl
-  - nosasl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['4.0', auth, darwinssl, nosasl, replica_set]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.0-replica-set-auth-nosasl-winssl
-  tags:
-  - '4.0'
-  - auth
-  - nosasl
-  - replica_set
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['4.0', auth, nosasl, replica_set, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.0-replica-set-noauth-sasl-openssl
-  tags:
-  - '4.0'
-  - noauth
-  - openssl
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['4.0', noauth, openssl, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.0-replica-set-noauth-sasl-openssl-static
-  tags:
-  - '4.0'
-  - noauth
-  - openssl-static
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['4.0', noauth, openssl-static, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.0-replica-set-noauth-sasl-darwinssl
-  tags:
-  - '4.0'
-  - darwinssl
-  - noauth
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['4.0', darwinssl, noauth, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.0-replica-set-noauth-sasl-winssl
-  tags:
-  - '4.0'
-  - noauth
-  - replica_set
-  - sasl
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['4.0', noauth, replica_set, sasl, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.0-replica-set-noauth-nosasl-openssl
-  tags:
-  - '4.0'
-  - noauth
-  - nosasl
-  - openssl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['4.0', noauth, nosasl, openssl, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.0-replica-set-noauth-nosasl-openssl-static
-  tags:
-  - '4.0'
-  - noauth
-  - nosasl
-  - openssl-static
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['4.0', noauth, nosasl, openssl-static, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.0-replica-set-noauth-nosasl-darwinssl
-  tags:
-  - '4.0'
-  - darwinssl
-  - noauth
-  - nosasl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['4.0', darwinssl, noauth, nosasl, replica_set]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.0-replica-set-noauth-nosasl-winssl
-  tags:
-  - '4.0'
-  - noauth
-  - nosasl
-  - replica_set
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['4.0', noauth, nosasl, replica_set, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.0-replica-set-noauth-nosasl-nossl
-  tags:
-  - '4.0'
-  - noauth
-  - nosasl
-  - nossl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: ['4.0', noauth, nosasl, nossl, replica_set]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-4.0-sharded-auth-sasl-openssl
-  tags:
-  - '4.0'
-  - auth
-  - openssl
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['4.0', auth, openssl, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.0-sharded-auth-sasl-openssl-static
-  tags:
-  - '4.0'
-  - auth
-  - openssl-static
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['4.0', auth, openssl-static, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.0-sharded-auth-sasl-darwinssl
-  tags:
-  - '4.0'
-  - auth
-  - darwinssl
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['4.0', auth, darwinssl, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.0-sharded-auth-sasl-winssl
-  tags:
-  - '4.0'
-  - auth
-  - sasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['4.0', auth, sasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.0-sharded-auth-nosasl-openssl
-  tags:
-  - '4.0'
-  - auth
-  - nosasl
-  - openssl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['4.0', auth, nosasl, openssl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.0-sharded-auth-nosasl-openssl-static
-  tags:
-  - '4.0'
-  - auth
-  - nosasl
-  - openssl-static
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['4.0', auth, nosasl, openssl-static, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.0-sharded-auth-nosasl-darwinssl
-  tags:
-  - '4.0'
-  - auth
-  - darwinssl
-  - nosasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['4.0', auth, darwinssl, nosasl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.0-sharded-auth-nosasl-winssl
-  tags:
-  - '4.0'
-  - auth
-  - nosasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['4.0', auth, nosasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.0'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.0-sharded-noauth-sasl-openssl
-  tags:
-  - '4.0'
-  - noauth
-  - openssl
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['4.0', noauth, openssl, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.0-sharded-noauth-sasl-openssl-static
-  tags:
-  - '4.0'
-  - noauth
-  - openssl-static
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['4.0', noauth, openssl-static, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.0-sharded-noauth-sasl-darwinssl
-  tags:
-  - '4.0'
-  - darwinssl
-  - noauth
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['4.0', darwinssl, noauth, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.0-sharded-noauth-sasl-winssl
-  tags:
-  - '4.0'
-  - noauth
-  - sasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['4.0', noauth, sasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.0-sharded-noauth-nosasl-openssl
-  tags:
-  - '4.0'
-  - noauth
-  - nosasl
-  - openssl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['4.0', noauth, nosasl, openssl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-4.0-sharded-noauth-nosasl-openssl-static
-  tags:
-  - '4.0'
-  - noauth
-  - nosasl
-  - openssl-static
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['4.0', noauth, nosasl, openssl-static, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-4.0-sharded-noauth-nosasl-darwinssl
-  tags:
-  - '4.0'
-  - darwinssl
-  - noauth
-  - nosasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['4.0', darwinssl, noauth, nosasl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-4.0-sharded-noauth-nosasl-winssl
-  tags:
-  - '4.0'
-  - noauth
-  - nosasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['4.0', noauth, nosasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-4.0-sharded-noauth-nosasl-nossl
-  tags:
-  - '4.0'
-  - noauth
-  - nosasl
-  - nossl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: ['4.0', noauth, nosasl, nossl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: '4.0'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '4.0'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-3.6-server-auth-sasl-openssl
-  tags:
-  - '3.6'
-  - auth
-  - openssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['3.6', auth, openssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-3.6-server-auth-sasl-openssl-static
-  tags:
-  - '3.6'
-  - auth
-  - openssl-static
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['3.6', auth, openssl-static, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-3.6-server-auth-sasl-darwinssl
-  tags:
-  - '3.6'
-  - auth
-  - darwinssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['3.6', auth, darwinssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-3.6-server-auth-sasl-winssl
-  tags:
-  - '3.6'
-  - auth
-  - sasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['3.6', auth, sasl, server, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-3.6-server-auth-nosasl-openssl
-  tags:
-  - '3.6'
-  - auth
-  - nosasl
-  - openssl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['3.6', auth, nosasl, openssl, server]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: server, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-3.6-server-auth-nosasl-openssl-static
-  tags:
-  - '3.6'
-  - auth
-  - nosasl
-  - openssl-static
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['3.6', auth, nosasl, openssl-static, server]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: server, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-3.6-server-auth-nosasl-darwinssl
-  tags:
-  - '3.6'
-  - auth
-  - darwinssl
-  - nosasl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['3.6', auth, darwinssl, nosasl, server]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: server, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-3.6-server-auth-nosasl-winssl
-  tags:
-  - '3.6'
-  - auth
-  - nosasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['3.6', auth, nosasl, server, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: server, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-3.6-server-noauth-sasl-openssl
-  tags:
-  - '3.6'
-  - noauth
-  - openssl
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['3.6', noauth, openssl, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-3.6-server-noauth-sasl-openssl-static
-  tags:
-  - '3.6'
-  - noauth
-  - openssl-static
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['3.6', noauth, openssl-static, sasl, server]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-3.6-server-noauth-sasl-darwinssl
-  tags:
-  - '3.6'
-  - darwinssl
-  - noauth
-  - sasl
-  - server
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['3.6', darwinssl, noauth, sasl, server]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-3.6-server-noauth-sasl-winssl
-  tags:
-  - '3.6'
-  - noauth
-  - sasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['3.6', noauth, sasl, server, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-3.6-server-noauth-nosasl-openssl
-  tags:
-  - '3.6'
-  - noauth
-  - nosasl
-  - openssl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['3.6', noauth, nosasl, openssl, server]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: server
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: server, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-3.6-server-noauth-nosasl-openssl-static
-  tags:
-  - '3.6'
-  - noauth
-  - nosasl
-  - openssl-static
-  - server
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['3.6', noauth, nosasl, openssl-static, server]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: server
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: server, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-3.6-server-noauth-nosasl-darwinssl
-  tags:
-  - '3.6'
-  - darwinssl
-  - noauth
-  - nosasl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['3.6', darwinssl, noauth, nosasl, server]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: server
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: server, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-3.6-server-noauth-nosasl-winssl
-  tags:
-  - '3.6'
-  - noauth
-  - nosasl
-  - server
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['3.6', noauth, nosasl, server, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: server
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: server, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-3.6-server-noauth-nosasl-nossl
-  tags:
-  - '3.6'
-  - noauth
-  - nosasl
-  - nossl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: ['3.6', noauth, nosasl, nossl, server]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: server, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-3.6-replica-set-auth-sasl-openssl
-  tags:
-  - '3.6'
-  - auth
-  - openssl
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['3.6', auth, openssl, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-3.6-replica-set-auth-sasl-openssl-static
-  tags:
-  - '3.6'
-  - auth
-  - openssl-static
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['3.6', auth, openssl-static, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-3.6-replica-set-auth-sasl-darwinssl
-  tags:
-  - '3.6'
-  - auth
-  - darwinssl
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['3.6', auth, darwinssl, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-3.6-replica-set-auth-sasl-winssl
-  tags:
-  - '3.6'
-  - auth
-  - replica_set
-  - sasl
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['3.6', auth, replica_set, sasl, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-3.6-replica-set-auth-nosasl-openssl
-  tags:
-  - '3.6'
-  - auth
-  - nosasl
-  - openssl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['3.6', auth, nosasl, openssl, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-3.6-replica-set-auth-nosasl-openssl-static
-  tags:
-  - '3.6'
-  - auth
-  - nosasl
-  - openssl-static
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['3.6', auth, nosasl, openssl-static, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-3.6-replica-set-auth-nosasl-darwinssl
-  tags:
-  - '3.6'
-  - auth
-  - darwinssl
-  - nosasl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['3.6', auth, darwinssl, nosasl, replica_set]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-3.6-replica-set-auth-nosasl-winssl
-  tags:
-  - '3.6'
-  - auth
-  - nosasl
-  - replica_set
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['3.6', auth, nosasl, replica_set, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-3.6-replica-set-noauth-sasl-openssl
-  tags:
-  - '3.6'
-  - noauth
-  - openssl
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['3.6', noauth, openssl, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-3.6-replica-set-noauth-sasl-openssl-static
-  tags:
-  - '3.6'
-  - noauth
-  - openssl-static
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['3.6', noauth, openssl-static, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-3.6-replica-set-noauth-sasl-darwinssl
-  tags:
-  - '3.6'
-  - darwinssl
-  - noauth
-  - replica_set
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['3.6', darwinssl, noauth, replica_set, sasl]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-3.6-replica-set-noauth-sasl-winssl
-  tags:
-  - '3.6'
-  - noauth
-  - replica_set
-  - sasl
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['3.6', noauth, replica_set, sasl, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-3.6-replica-set-noauth-nosasl-openssl
-  tags:
-  - '3.6'
-  - noauth
-  - nosasl
-  - openssl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['3.6', noauth, nosasl, openssl, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: replica_set
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: replica_set, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-3.6-replica-set-noauth-nosasl-openssl-static
-  tags:
-  - '3.6'
-  - noauth
-  - nosasl
-  - openssl-static
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['3.6', noauth, nosasl, openssl-static, replica_set]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: replica_set
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: replica_set, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-3.6-replica-set-noauth-nosasl-darwinssl
-  tags:
-  - '3.6'
-  - darwinssl
-  - noauth
-  - nosasl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['3.6', darwinssl, noauth, nosasl, replica_set]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: replica_set
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: replica_set, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-3.6-replica-set-noauth-nosasl-winssl
-  tags:
-  - '3.6'
-  - noauth
-  - nosasl
-  - replica_set
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['3.6', noauth, nosasl, replica_set, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: replica_set
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: replica_set, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-3.6-replica-set-noauth-nosasl-nossl
-  tags:
-  - '3.6'
-  - noauth
-  - nosasl
-  - nossl
-  - replica_set
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: ['3.6', noauth, nosasl, nossl, replica_set]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: replica_set
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: replica_set, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-3.6-sharded-auth-sasl-openssl
-  tags:
-  - '3.6'
-  - auth
-  - openssl
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['3.6', auth, openssl, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-3.6-sharded-auth-sasl-openssl-static
-  tags:
-  - '3.6'
-  - auth
-  - openssl-static
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['3.6', auth, openssl-static, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-3.6-sharded-auth-sasl-darwinssl
-  tags:
-  - '3.6'
-  - auth
-  - darwinssl
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['3.6', auth, darwinssl, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-3.6-sharded-auth-sasl-winssl
-  tags:
-  - '3.6'
-  - auth
-  - sasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['3.6', auth, sasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-3.6-sharded-auth-nosasl-openssl
-  tags:
-  - '3.6'
-  - auth
-  - nosasl
-  - openssl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['3.6', auth, nosasl, openssl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl, VALGRIND: 'off'}
 - name: test-3.6-sharded-auth-nosasl-openssl-static
-  tags:
-  - '3.6'
-  - auth
-  - nosasl
-  - openssl-static
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['3.6', auth, nosasl, openssl-static, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-3.6-sharded-auth-nosasl-darwinssl
-  tags:
-  - '3.6'
-  - auth
-  - darwinssl
-  - nosasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['3.6', auth, darwinssl, nosasl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-3.6-sharded-auth-nosasl-winssl
-  tags:
-  - '3.6'
-  - auth
-  - nosasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['3.6', auth, nosasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '3.6'
+    vars: {AUTH: auth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: auth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: auth, SSL: winssl, VALGRIND: 'off'}
 - name: test-3.6-sharded-noauth-sasl-openssl
-  tags:
-  - '3.6'
-  - noauth
-  - openssl
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: ['3.6', noauth, openssl, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-3.6-sharded-noauth-sasl-openssl-static
-  tags:
-  - '3.6'
-  - noauth
-  - openssl-static
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: ['3.6', noauth, openssl-static, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-3.6-sharded-noauth-sasl-darwinssl
-  tags:
-  - '3.6'
-  - darwinssl
-  - noauth
-  - sasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: ['3.6', darwinssl, noauth, sasl, sharded_cluster]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-3.6-sharded-noauth-sasl-winssl
-  tags:
-  - '3.6'
-  - noauth
-  - sasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-sasl-winssl
+  tags: ['3.6', noauth, sasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-sasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-winssl
+    vars: {BUILD_NAME: debug-compile-sasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-3.6-sharded-noauth-nosasl-openssl
-  tags:
-  - '3.6'
-  - noauth
-  - nosasl
-  - openssl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: ['3.6', noauth, nosasl, openssl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: openssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl, VALGRIND: 'off'}
 - name: test-3.6-sharded-noauth-nosasl-openssl-static
-  tags:
-  - '3.6'
-  - noauth
-  - nosasl
-  - openssl-static
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-openssl-static
+  tags: ['3.6', noauth, nosasl, openssl-static, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-static
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-static}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: openssl-static
-      TOPOLOGY: sharded_cluster
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: openssl-static, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: openssl-static
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: openssl-static, VALGRIND: 'off'}
 - name: test-3.6-sharded-noauth-nosasl-darwinssl
-  tags:
-  - '3.6'
-  - darwinssl
-  - noauth
-  - nosasl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: ['3.6', darwinssl, noauth, nosasl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: darwinssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: darwinssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: darwinssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: darwinssl, VALGRIND: 'off'}
 - name: test-3.6-sharded-noauth-nosasl-winssl
-  tags:
-  - '3.6'
-  - noauth
-  - nosasl
-  - sharded_cluster
-  - winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: ['3.6', noauth, nosasl, sharded_cluster, winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: winssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: winssl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: winssl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: winssl, VALGRIND: 'off'}
 - name: test-3.6-sharded-noauth-nosasl-nossl
-  tags:
-  - '3.6'
-  - noauth
-  - nosasl
-  - nossl
-  - sharded_cluster
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: ['3.6', noauth, nosasl, nossl, sharded_cluster]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: '3.6'
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '3.6'}
   - func: run tests
-    vars:
-      ASAN: 'off'
-      AUTH: noauth
-      SSL: nossl
-      VALGRIND: 'off'
+    vars: {ASAN: 'off', AUTH: noauth, SSL: nossl, VALGRIND: 'off'}
 - name: test-dns-openssl
-  depends_on:
-    name: debug-compile-sasl-openssl
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: ssl
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: ssl, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      AUTH: noauth
-      DNS: 'on'
-      SSL: ssl
+    vars: {AUTH: noauth, DNS: 'on', SSL: ssl}
 - name: test-dns-winssl
-  depends_on:
-    name: debug-compile-sspi-winssl
+  depends_on: {name: debug-compile-sspi-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sspi-winssl
+    vars: {BUILD_NAME: debug-compile-sspi-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: ssl
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: ssl, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      AUTH: noauth
-      DNS: 'on'
-      SSL: ssl
+    vars: {AUTH: noauth, DNS: 'on', SSL: ssl}
 - name: test-dns-darwinssl
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: ssl
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: noauth, SSL: ssl, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      AUTH: noauth
-      DNS: 'on'
-      SSL: ssl
+    vars: {AUTH: noauth, DNS: 'on', SSL: ssl}
 - name: test-dns-loadbalanced-openssl
-  depends_on:
-    name: debug-compile-sasl-openssl
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: ssl
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
-  - func: clone drivers-evergreen-tools
+    vars: {AUTH: noauth, SSL: ssl, TOPOLOGY: sharded_cluster, VERSION: latest}
+  - {func: clone drivers-evergreen-tools}
   - func: start load balancer
-    vars:
-      MONGODB_URI: mongodb://localhost:27017,localhost:27018
+    vars: {MONGODB_URI: 'mongodb://localhost:27017,localhost:27018'}
   - func: run tests
-    vars:
-      AUTH: noauth
-      DNS: loadbalanced
-      SSL: ssl
+    vars: {AUTH: noauth, DNS: loadbalanced, SSL: ssl}
 - name: test-dns-auth-openssl
-  depends_on:
-    name: debug-compile-sasl-openssl
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: ssl
-      TOPOLOGY: replica_set
-      VERSION: latest
-      AUTHSOURCE: thisDB
+    vars: {AUTH: auth, SSL: ssl, TOPOLOGY: replica_set, VERSION: latest, AUTHSOURCE: thisDB}
   - func: run tests
-    vars:
-      AUTH: auth
-      DNS: dns-auth
-      SSL: ssl
+    vars: {AUTH: auth, DNS: dns-auth, SSL: ssl}
 - name: test-dns-auth-winssl
-  depends_on:
-    name: debug-compile-sspi-winssl
+  depends_on: {name: debug-compile-sspi-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sspi-winssl
+    vars: {BUILD_NAME: debug-compile-sspi-winssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: ssl
-      TOPOLOGY: replica_set
-      VERSION: latest
-      AUTHSOURCE: thisDB
+    vars: {AUTH: auth, SSL: ssl, TOPOLOGY: replica_set, VERSION: latest, AUTHSOURCE: thisDB}
   - func: run tests
-    vars:
-      AUTH: auth
-      DNS: dns-auth
-      SSL: ssl
+    vars: {AUTH: auth, DNS: dns-auth, SSL: ssl}
 - name: test-dns-auth-darwinssl
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: ssl
-      TOPOLOGY: replica_set
-      VERSION: latest
-      AUTHSOURCE: thisDB
+    vars: {AUTH: auth, SSL: ssl, TOPOLOGY: replica_set, VERSION: latest, AUTHSOURCE: thisDB}
   - func: run tests
-    vars:
-      AUTH: auth
-      DNS: dns-auth
-      SSL: ssl
+    vars: {AUTH: auth, DNS: dns-auth, SSL: ssl}
 - name: test-latest-server-compression-zlib
-  tags:
-  - compression
-  - latest
-  - zlib
-  depends_on:
-    name: debug-compile-compression-zlib
+  tags: [compression, latest, zlib]
+  depends_on: {name: debug-compile-compression-zlib}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-compression-zlib
+    vars: {BUILD_NAME: debug-compile-compression-zlib}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      ORCHESTRATION_FILE: zlib
-      SSL: nossl
-      VERSION: latest
+    vars: {AUTH: noauth, ORCHESTRATION_FILE: zlib, SSL: nossl, VERSION: latest}
   - func: run tests
-    vars:
-      AUTH: noauth
-      COMPRESSORS: zlib
-      SSL: nossl
+    vars: {AUTH: noauth, COMPRESSORS: zlib, SSL: nossl}
 - name: test-latest-server-compression-snappy
-  tags:
-  - compression
-  - latest
-  - snappy
-  depends_on:
-    name: debug-compile-compression-snappy
+  tags: [compression, latest, snappy]
+  depends_on: {name: debug-compile-compression-snappy}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-compression-snappy
+    vars: {BUILD_NAME: debug-compile-compression-snappy}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      ORCHESTRATION_FILE: snappy
-      SSL: nossl
-      VERSION: latest
+    vars: {AUTH: noauth, ORCHESTRATION_FILE: snappy, SSL: nossl, VERSION: latest}
   - func: run tests
-    vars:
-      AUTH: noauth
-      COMPRESSORS: snappy
-      SSL: nossl
+    vars: {AUTH: noauth, COMPRESSORS: snappy, SSL: nossl}
 - name: test-latest-server-compression-zstd
-  tags:
-  - compression
-  - latest
-  - zstd
-  depends_on:
-    name: debug-compile-compression-zstd
+  tags: [compression, latest, zstd]
+  depends_on: {name: debug-compile-compression-zstd}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-compression-zstd
+    vars: {BUILD_NAME: debug-compile-compression-zstd}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      ORCHESTRATION_FILE: zstd
-      SSL: nossl
-      VERSION: latest
+    vars: {AUTH: noauth, ORCHESTRATION_FILE: zstd, SSL: nossl, VERSION: latest}
   - func: run tests
-    vars:
-      AUTH: noauth
-      COMPRESSORS: zstd
-      SSL: nossl
+    vars: {AUTH: noauth, COMPRESSORS: zstd, SSL: nossl}
 - name: test-latest-server-compression
-  tags:
-  - compression
-  - latest
-  - snappy
-  - zlib
-  - zstd
-  depends_on:
-    name: debug-compile-compression
+  tags: [compression, latest, snappy, zlib, zstd]
+  depends_on: {name: debug-compile-compression}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-compression
+    vars: {BUILD_NAME: debug-compile-compression}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      ORCHESTRATION_FILE: snappy-zlib-zstd
-      SSL: nossl
-      VERSION: latest
+    vars: {AUTH: noauth, ORCHESTRATION_FILE: snappy-zlib-zstd, SSL: nossl, VERSION: latest}
   - func: run tests
-    vars:
-      AUTH: noauth
-      COMPRESSORS: snappy,zlib,zstd
-      SSL: nossl
+    vars: {AUTH: noauth, COMPRESSORS: 'snappy,zlib,zstd', SSL: nossl}
 - name: retry-true-latest-server
-  depends_on:
-    name: debug-compile-sasl-openssl
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {TOPOLOGY: server, VERSION: latest}
   - func: run tests
-    vars:
-      URI: mongodb://localhost/?retryWrites=true
+    vars: {URI: 'mongodb://localhost/?retryWrites=true'}
 - name: test-latest-server-hardened
-  tags:
-  - hardened
-  - latest
-  depends_on:
-    name: hardened-compile
+  tags: [hardened, latest]
+  depends_on: {name: hardened-compile}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: hardened-compile
+    vars: {BUILD_NAME: hardened-compile}
   - func: bootstrap mongo-orchestration
-    vars:
-      TOPOLOGY: server
-      VERSION: latest
-  - func: run tests
+    vars: {TOPOLOGY: server, VERSION: latest}
+  - {func: run tests}
 - name: authentication-tests-openssl
-  tags:
-  - authentication-tests
-  - openssl
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl
+  tags: [authentication-tests, openssl, sasl]
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
-  - func: run auth tests
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+  - {func: run auth tests}
 - name: authentication-tests-openssl-static
-  tags:
-  - authentication-tests
-  - openssl-static
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl-static
+  tags: [authentication-tests, openssl-static, sasl]
+  depends_on: {name: debug-compile-sasl-openssl-static}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
-  - func: run auth tests
+    vars: {BUILD_NAME: debug-compile-sasl-openssl-static}
+  - {func: run auth tests}
 - name: authentication-tests-darwinssl
-  tags:
-  - authentication-tests
-  - darwinssl
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-darwinssl
+  tags: [authentication-tests, darwinssl, sasl]
+  depends_on: {name: debug-compile-sasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-darwinssl
-  - func: run auth tests
+    vars: {BUILD_NAME: debug-compile-sasl-darwinssl}
+  - {func: run auth tests}
 - name: authentication-tests-winssl
-  tags:
-  - authentication-tests
-  - sspi
-  - winssl
-  depends_on:
-    name: debug-compile-sspi-winssl
+  tags: [authentication-tests, sspi, winssl]
+  depends_on: {name: debug-compile-sspi-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sspi-winssl
-  - func: run auth tests
+    vars: {BUILD_NAME: debug-compile-sspi-winssl}
+  - {func: run auth tests}
 - name: authentication-tests-openssl-nosasl
-  tags:
-  - authentication-tests
-  - nosasl
-  - openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [authentication-tests, nosasl, openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
-  - func: run auth tests
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
+  - {func: run auth tests}
 - name: test-valgrind-memcheck-mock-server
-  tags:
-  - test-valgrind
-  depends_on:
-    name: debug-compile-valgrind
+  tags: [test-valgrind]
+  depends_on: {name: debug-compile-valgrind}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-valgrind
+    vars: {BUILD_NAME: debug-compile-valgrind}
   - func: run mock server tests
-    vars:
-      SSL: ssl
-      VALGRIND: 'on'
+    vars: {SSL: ssl, VALGRIND: 'on'}
 - name: test-asan-memcheck-mock-server
-  tags:
-  - test-asan
-  depends_on:
-    name: debug-compile-asan-clang
+  tags: [test-asan]
+  depends_on: {name: debug-compile-asan-clang}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang
+    vars: {BUILD_NAME: debug-compile-asan-clang}
   - func: run mock server tests
-    vars:
-      ASAN: 'on'
-      SSL: ssl
+    vars: {ASAN: 'on', SSL: ssl}
 - name: test-mongohouse
-  depends_on:
-    name: debug-compile-sasl-openssl
+  depends_on: {name: debug-compile-sasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl
-  - func: build mongohouse
-  - func: run mongohouse
-  - func: test mongohouse
+    vars: {BUILD_NAME: debug-compile-sasl-openssl}
+  - {func: build mongohouse}
+  - {func: run mongohouse}
+  - {func: test mongohouse}
 - name: test-coverage-mock-server
-  tags:
-  - test-coverage
+  tags: [test-coverage]
   commands:
-  - func: debug-compile-coverage-notest-nosasl-openssl
+  - {func: debug-compile-coverage-notest-nosasl-openssl}
   - func: run mock server tests
-    vars:
-      SSL: ssl
-  - func: update codecov.io
+    vars: {SSL: ssl}
+  - {func: update codecov.io}
 - name: test-coverage-latest-server-dns
-  tags:
-  - test-coverage
+  tags: [test-coverage]
   exec_timeout_secs: 3600
   commands:
-  - func: debug-compile-coverage-notest-nosasl-openssl
+  - {func: debug-compile-coverage-notest-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: ssl
-      TOPOLOGY: replica_set
-      VERSION: latest
+    vars: {AUTH: auth, SSL: ssl, TOPOLOGY: replica_set, VERSION: latest}
   - func: run tests
-    vars:
-      AUTH: auth
-      DNS: 'on'
-      SSL: ssl
-  - func: update codecov.io
+    vars: {AUTH: auth, DNS: 'on', SSL: ssl}
+  - {func: update codecov.io}
 - name: authentication-tests-memcheck
-  tags:
-  - authentication-tests
-  - valgrind
+  tags: [authentication-tests, valgrind]
   commands:
   - command: shell.exec
     type: test
@@ -16917,53 +8115,32 @@ tasks:
         set -o errexit
         VALGRIND=ON DEBUG=ON CC='${CC}' MARCH='${MARCH}' SASL=AUTO                   SSL=OPENSSL sh .evergreen/compile.sh
   - func: run auth tests
-    vars:
-      valgrind: 'true'
+    vars: {valgrind: 'true'}
 - name: test-versioned-api
-  tags:
-  - versioned-api
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [versioned-api]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      REQUIRE_API_VERSION: 'true'
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: auth, REQUIRE_API_VERSION: 'true', SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
   - func: test versioned api
-    vars:
-      AUTH: auth
-      SSL: ssl
+    vars: {AUTH: auth, SSL: ssl}
 - name: test-versioned-api-accept-version-two
-  tags:
-  - versioned-api
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: [versioned-api]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      ORCHESTRATION_FILE: versioned-api-testing
-      SSL: nossl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: noauth, ORCHESTRATION_FILE: versioned-api-testing, SSL: nossl, TOPOLOGY: server,
+      VERSION: '5.0'}
   - func: test versioned api
-    vars:
-      AUTH: noauth
-      SSL: nossl
+    vars: {AUTH: noauth, SSL: nossl}
 - name: build-and-run-authentication-tests-openssl-0.9.8
   commands:
   - func: install ssl
-    vars:
-      SSL: openssl-0.9.8zh
+    vars: {SSL: openssl-0.9.8zh}
   - command: shell.exec
     type: test
     params:
@@ -16973,14 +8150,12 @@ tasks:
         set -o errexit
         DEBUG=ON CC='${CC}' MARCH='${MARCH}' SASL=OFF SSL=OPENSSL sh .evergreen/compile.sh
   - func: run auth tests
-    vars:
-      obsolete_tls: true
-  - func: upload build
+    vars: {obsolete_tls: true}
+  - {func: upload build}
 - name: build-and-run-authentication-tests-openssl-1.0.0
   commands:
   - func: install ssl
-    vars:
-      SSL: openssl-1.0.0t
+    vars: {SSL: openssl-1.0.0t}
   - command: shell.exec
     type: test
     params:
@@ -16990,14 +8165,12 @@ tasks:
         set -o errexit
         DEBUG=ON CC='${CC}' MARCH='${MARCH}' SASL=OFF SSL=OPENSSL sh .evergreen/compile.sh
   - func: run auth tests
-    vars:
-      obsolete_tls: true
-  - func: upload build
+    vars: {obsolete_tls: true}
+  - {func: upload build}
 - name: build-and-run-authentication-tests-openssl-1.0.1
   commands:
   - func: install ssl
-    vars:
-      SSL: openssl-1.0.1u
+    vars: {SSL: openssl-1.0.1u}
   - command: shell.exec
     type: test
     params:
@@ -17007,13 +8180,12 @@ tasks:
         set -o errexit
         export CFLAGS=-Wno-redundant-decls
         DEBUG=ON CC='${CC}' MARCH='${MARCH}' SASL=OFF SSL=OPENSSL sh .evergreen/compile.sh
-  - func: run auth tests
-  - func: upload build
+  - {func: run auth tests}
+  - {func: upload build}
 - name: build-and-run-authentication-tests-openssl-1.0.1-fips
   commands:
   - func: install ssl
-    vars:
-      SSL: openssl-1.0.1u-fips
+    vars: {SSL: openssl-1.0.1u-fips}
   - command: shell.exec
     type: test
     params:
@@ -17023,13 +8195,12 @@ tasks:
         set -o errexit
         export CFLAGS=-Wno-redundant-decls
         DEBUG=ON CC='${CC}' MARCH='${MARCH}' SASL=OFF SSL=OPENSSL OPENSSL_FIPS=1 sh .evergreen/compile.sh
-  - func: run auth tests
-  - func: upload build
+  - {func: run auth tests}
+  - {func: upload build}
 - name: build-and-run-authentication-tests-openssl-1.0.2
   commands:
   - func: install ssl
-    vars:
-      SSL: openssl-1.0.2l
+    vars: {SSL: openssl-1.0.2l}
   - command: shell.exec
     type: test
     params:
@@ -17038,13 +8209,12 @@ tasks:
       script: |-
         set -o errexit
         DEBUG=ON CC='${CC}' MARCH='${MARCH}' SASL=OFF SSL=OPENSSL sh .evergreen/compile.sh
-  - func: run auth tests
-  - func: upload build
+  - {func: run auth tests}
+  - {func: upload build}
 - name: build-and-run-authentication-tests-openssl-1.1.0
   commands:
   - func: install ssl
-    vars:
-      SSL: openssl-1.1.0f
+    vars: {SSL: openssl-1.1.0f}
   - command: shell.exec
     type: test
     params:
@@ -17053,13 +8223,12 @@ tasks:
       script: |-
         set -o errexit
         DEBUG=ON CC='${CC}' MARCH='${MARCH}' SASL=OFF SSL=OPENSSL sh .evergreen/compile.sh
-  - func: run auth tests
-  - func: upload build
+  - {func: run auth tests}
+  - {func: upload build}
 - name: build-and-run-authentication-tests-libressl-2.5
   commands:
   - func: install ssl
-    vars:
-      SSL: libressl-2.5.2
+    vars: {SSL: libressl-2.5.2}
   - command: shell.exec
     type: test
     params:
@@ -17069,14 +8238,12 @@ tasks:
         set -o errexit
         DEBUG=ON CC='${CC}' MARCH='${MARCH}' SASL=OFF SSL=LIBRESSL sh .evergreen/compile.sh
   - func: run auth tests
-    vars:
-      require_tls12: true
-  - func: upload build
+    vars: {require_tls12: true}
+  - {func: upload build}
 - name: build-and-run-authentication-tests-libressl-3.0-auto
   commands:
   - func: install ssl
-    vars:
-      SSL: libressl-3.0.2
+    vars: {SSL: libressl-3.0.2}
   - command: shell.exec
     type: test
     params:
@@ -17087,14 +8254,12 @@ tasks:
         export CFLAGS=-Wno-redundant-decls
         DEBUG=ON CC='${CC}' MARCH='${MARCH}' SASL=OFF SSL=AUTO sh .evergreen/compile.sh
   - func: run auth tests
-    vars:
-      require_tls12: true
-  - func: upload build
+    vars: {require_tls12: true}
+  - {func: upload build}
 - name: build-and-run-authentication-tests-libressl-3.0
   commands:
   - func: install ssl
-    vars:
-      SSL: libressl-3.0.2
+    vars: {SSL: libressl-3.0.2}
   - command: shell.exec
     type: test
     params:
@@ -17104,93 +8269,48 @@ tasks:
         set -o errexit
         DEBUG=ON CC='${CC}' MARCH='${MARCH}' SASL=OFF SSL=LIBRESSL sh .evergreen/compile.sh
   - func: run auth tests
-    vars:
-      require_tls12: true
-  - func: upload build
+    vars: {require_tls12: true}
+  - {func: upload build}
 - name: test-latest-server-ipv6-client-ipv6-noauth-nosasl-nossl
-  tags:
-  - ipv4-ipv6
-  - latest
-  - nosasl
-  - nossl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: [ipv4-ipv6, latest, nosasl, nossl, server]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      IPV4_ONLY: 'off'
-      VERSION: latest
+    vars: {IPV4_ONLY: 'off', VERSION: latest}
   - func: run tests
-    vars:
-      IPV4_ONLY: 'off'
-      URI: mongodb://[::1]/
+    vars: {IPV4_ONLY: 'off', URI: 'mongodb://[::1]/'}
 - name: test-latest-server-ipv6-client-ipv4-noauth-nosasl-nossl
-  tags:
-  - ipv4-ipv6
-  - latest
-  - nosasl
-  - nossl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: [ipv4-ipv6, latest, nosasl, nossl, server]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      IPV4_ONLY: 'off'
-      VERSION: latest
+    vars: {IPV4_ONLY: 'off', VERSION: latest}
   - func: run tests
-    vars:
-      IPV4_ONLY: 'off'
-      URI: mongodb://127.0.0.1/
+    vars: {IPV4_ONLY: 'off', URI: 'mongodb://127.0.0.1/'}
 - name: test-latest-server-ipv4-client-ipv4-noauth-nosasl-nossl
-  tags:
-  - ipv4-ipv6
-  - latest
-  - nosasl
-  - nossl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: [ipv4-ipv6, latest, nosasl, nossl, server]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      IPV4_ONLY: 'on'
-      VERSION: latest
+    vars: {IPV4_ONLY: 'on', VERSION: latest}
   - func: run tests
-    vars:
-      IPV4_ONLY: 'on'
-      URI: mongodb://127.0.0.1/
+    vars: {IPV4_ONLY: 'on', URI: 'mongodb://127.0.0.1/'}
 - name: test-latest-server-ipv4-client-localhost-noauth-nosasl-nossl
-  tags:
-  - ipv4-ipv6
-  - latest
-  - nosasl
-  - nossl
-  - server
-  depends_on:
-    name: debug-compile-nosasl-nossl
+  tags: [ipv4-ipv6, latest, nosasl, nossl, server]
+  depends_on: {name: debug-compile-nosasl-nossl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-nossl
+    vars: {BUILD_NAME: debug-compile-nosasl-nossl}
   - func: bootstrap mongo-orchestration
-    vars:
-      IPV4_ONLY: 'on'
-      VERSION: latest
+    vars: {IPV4_ONLY: 'on', VERSION: latest}
   - func: run tests
-    vars:
-      IPV4_ONLY: 'on'
-      URI: mongodb://localhost/
+    vars: {IPV4_ONLY: 'on', URI: 'mongodb://localhost/'}
 - name: debug-compile-aws
   commands:
   - command: shell.exec
@@ -17205,256 +8325,148 @@ tasks:
         export CC='${CC}'
         $CMAKE -DENABLE_SASL=OFF -DENABLE_SNAPPY=OFF -DENABLE_ZSTD=OFF -DENABLE_CLIENT_SIDE_ENCRYPTION=OFF .
         $CMAKE --build . --target mongoc-ping
-  - func: upload build
+  - {func: upload build}
 - name: test-aws-openssl-regular-latest
-  depends_on:
-    name: debug-compile-aws
+  depends_on: {name: debug-compile-aws}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-aws
+    vars: {BUILD_NAME: debug-compile-aws}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      ORCHESTRATION_FILE: auth-aws
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: latest}
   - func: run aws tests
-    vars:
-      TESTCASE: REGULAR
+    vars: {TESTCASE: REGULAR}
 - name: test-aws-openssl-regular-5.0
-  depends_on:
-    name: debug-compile-aws
+  depends_on: {name: debug-compile-aws}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-aws
+    vars: {BUILD_NAME: debug-compile-aws}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      ORCHESTRATION_FILE: auth-aws
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: '5.0'}
   - func: run aws tests
-    vars:
-      TESTCASE: REGULAR
+    vars: {TESTCASE: REGULAR}
 - name: test-aws-openssl-regular-4.4
-  depends_on:
-    name: debug-compile-aws
+  depends_on: {name: debug-compile-aws}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-aws
+    vars: {BUILD_NAME: debug-compile-aws}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      ORCHESTRATION_FILE: auth-aws
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: '4.4'}
   - func: run aws tests
-    vars:
-      TESTCASE: REGULAR
+    vars: {TESTCASE: REGULAR}
 - name: test-aws-openssl-ec2-latest
-  depends_on:
-    name: debug-compile-aws
+  depends_on: {name: debug-compile-aws}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-aws
+    vars: {BUILD_NAME: debug-compile-aws}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      ORCHESTRATION_FILE: auth-aws
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: latest}
   - func: run aws tests
-    vars:
-      TESTCASE: EC2
+    vars: {TESTCASE: EC2}
 - name: test-aws-openssl-ec2-5.0
-  depends_on:
-    name: debug-compile-aws
+  depends_on: {name: debug-compile-aws}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-aws
+    vars: {BUILD_NAME: debug-compile-aws}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      ORCHESTRATION_FILE: auth-aws
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: '5.0'}
   - func: run aws tests
-    vars:
-      TESTCASE: EC2
+    vars: {TESTCASE: EC2}
 - name: test-aws-openssl-ec2-4.4
-  depends_on:
-    name: debug-compile-aws
+  depends_on: {name: debug-compile-aws}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-aws
+    vars: {BUILD_NAME: debug-compile-aws}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      ORCHESTRATION_FILE: auth-aws
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: '4.4'}
   - func: run aws tests
-    vars:
-      TESTCASE: EC2
+    vars: {TESTCASE: EC2}
 - name: test-aws-openssl-ecs-latest
-  depends_on:
-    name: debug-compile-aws
+  depends_on: {name: debug-compile-aws}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-aws
+    vars: {BUILD_NAME: debug-compile-aws}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      ORCHESTRATION_FILE: auth-aws
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: latest}
   - func: run aws tests
-    vars:
-      TESTCASE: ECS
+    vars: {TESTCASE: ECS}
 - name: test-aws-openssl-ecs-5.0
-  depends_on:
-    name: debug-compile-aws
+  depends_on: {name: debug-compile-aws}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-aws
+    vars: {BUILD_NAME: debug-compile-aws}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      ORCHESTRATION_FILE: auth-aws
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: '5.0'}
   - func: run aws tests
-    vars:
-      TESTCASE: ECS
+    vars: {TESTCASE: ECS}
 - name: test-aws-openssl-ecs-4.4
-  depends_on:
-    name: debug-compile-aws
+  depends_on: {name: debug-compile-aws}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-aws
+    vars: {BUILD_NAME: debug-compile-aws}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      ORCHESTRATION_FILE: auth-aws
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: '4.4'}
   - func: run aws tests
-    vars:
-      TESTCASE: ECS
+    vars: {TESTCASE: ECS}
 - name: test-aws-openssl-lambda-latest
-  depends_on:
-    name: debug-compile-aws
+  depends_on: {name: debug-compile-aws}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-aws
+    vars: {BUILD_NAME: debug-compile-aws}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      ORCHESTRATION_FILE: auth-aws
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: latest}
   - func: run aws tests
-    vars:
-      TESTCASE: LAMBDA
+    vars: {TESTCASE: LAMBDA}
 - name: test-aws-openssl-lambda-5.0
-  depends_on:
-    name: debug-compile-aws
+  depends_on: {name: debug-compile-aws}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-aws
+    vars: {BUILD_NAME: debug-compile-aws}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      ORCHESTRATION_FILE: auth-aws
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: '5.0'}
   - func: run aws tests
-    vars:
-      TESTCASE: LAMBDA
+    vars: {TESTCASE: LAMBDA}
 - name: test-aws-openssl-lambda-4.4
-  depends_on:
-    name: debug-compile-aws
+  depends_on: {name: debug-compile-aws}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-aws
+    vars: {BUILD_NAME: debug-compile-aws}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      ORCHESTRATION_FILE: auth-aws
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: '4.4'}
   - func: run aws tests
-    vars:
-      TESTCASE: LAMBDA
+    vars: {TESTCASE: LAMBDA}
 - name: test-aws-openssl-assume_role-latest
-  depends_on:
-    name: debug-compile-aws
+  depends_on: {name: debug-compile-aws}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-aws
+    vars: {BUILD_NAME: debug-compile-aws}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      ORCHESTRATION_FILE: auth-aws
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: latest}
   - func: run aws tests
-    vars:
-      TESTCASE: ASSUME_ROLE
+    vars: {TESTCASE: ASSUME_ROLE}
 - name: test-aws-openssl-assume_role-5.0
-  depends_on:
-    name: debug-compile-aws
+  depends_on: {name: debug-compile-aws}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-aws
+    vars: {BUILD_NAME: debug-compile-aws}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      ORCHESTRATION_FILE: auth-aws
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: '5.0'}
   - func: run aws tests
-    vars:
-      TESTCASE: ASSUME_ROLE
+    vars: {TESTCASE: ASSUME_ROLE}
 - name: test-aws-openssl-assume_role-4.4
-  depends_on:
-    name: debug-compile-aws
+  depends_on: {name: debug-compile-aws}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-aws
+    vars: {BUILD_NAME: debug-compile-aws}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      ORCHESTRATION_FILE: auth-aws
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {AUTH: auth, ORCHESTRATION_FILE: auth-aws, TOPOLOGY: server, VERSION: '4.4'}
   - func: run aws tests
-    vars:
-      TESTCASE: ASSUME_ROLE
+    vars: {TESTCASE: ASSUME_ROLE}
 - name: ocsp-openssl-test_1-rsa-delegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -17464,12 +8476,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -17479,14 +8487,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_1-rsa-delegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -17496,12 +8501,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -17511,14 +8512,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_1-rsa-delegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -17528,12 +8526,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -17543,14 +8537,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_1-rsa-delegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -17560,12 +8551,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -17576,14 +8563,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_1-rsa-delegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -17593,12 +8577,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -17609,14 +8589,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_1-rsa-delegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -17626,12 +8603,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -17642,14 +8615,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_1-ecdsa-delegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -17659,12 +8629,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -17674,14 +8640,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_1-ecdsa-delegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -17691,12 +8654,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -17706,14 +8665,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_1-ecdsa-delegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -17723,12 +8679,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -17738,14 +8690,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_1-ecdsa-delegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -17755,12 +8704,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -17771,14 +8716,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_1-ecdsa-delegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -17788,12 +8730,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -17804,14 +8742,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_1-ecdsa-delegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -17821,12 +8756,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -17837,14 +8768,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_1-rsa-nodelegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -17854,12 +8782,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -17869,14 +8793,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_1-rsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -17886,12 +8807,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -17901,14 +8818,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_1-rsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -17918,12 +8832,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -17933,14 +8843,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_1-rsa-nodelegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -17950,12 +8857,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -17966,14 +8869,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_1-rsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -17983,12 +8883,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -17999,14 +8895,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_1-rsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -18016,12 +8909,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -18032,14 +8921,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_1-ecdsa-nodelegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -18049,12 +8935,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -18064,14 +8946,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_1-ecdsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -18081,12 +8960,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -18096,14 +8971,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_1-ecdsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -18113,12 +8985,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -18128,14 +8996,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_1-ecdsa-nodelegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -18145,12 +9010,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -18161,14 +9022,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_1-ecdsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -18178,12 +9036,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -18194,14 +9048,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_1-ecdsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -18211,12 +9062,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -18227,14 +9074,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_2-rsa-delegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -18244,12 +9088,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -18259,14 +9099,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_2-rsa-delegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -18276,12 +9113,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -18291,14 +9124,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_2-rsa-delegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -18308,12 +9138,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -18323,14 +9149,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_2-rsa-delegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -18340,12 +9163,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -18356,14 +9175,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_2-rsa-delegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -18373,12 +9189,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -18389,14 +9201,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_2-rsa-delegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -18406,12 +9215,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -18422,14 +9227,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_2-ecdsa-delegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -18439,12 +9241,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -18454,14 +9252,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_2-ecdsa-delegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -18471,12 +9266,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -18486,14 +9277,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_2-ecdsa-delegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -18503,12 +9291,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -18518,14 +9302,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_2-ecdsa-delegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -18535,12 +9316,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -18551,14 +9328,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_2-ecdsa-delegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -18568,12 +9342,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -18584,14 +9354,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_2-ecdsa-delegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -18601,12 +9368,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -18617,14 +9380,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_2-rsa-nodelegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -18634,12 +9394,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -18649,14 +9405,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_2-rsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -18666,12 +9419,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -18681,14 +9430,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_2-rsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -18698,12 +9444,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -18713,14 +9455,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_2-rsa-nodelegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -18730,12 +9469,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -18746,14 +9481,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_2-rsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -18763,12 +9495,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -18779,14 +9507,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_2-rsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -18796,12 +9521,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -18812,14 +9533,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_2-ecdsa-nodelegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -18829,12 +9547,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -18844,14 +9558,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_2-ecdsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -18861,12 +9572,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -18876,14 +9583,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_2-ecdsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -18893,12 +9597,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -18908,14 +9608,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_2-ecdsa-nodelegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -18925,12 +9622,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -18941,14 +9634,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_2-ecdsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -18958,12 +9648,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -18974,14 +9660,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_2-ecdsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -18991,12 +9674,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -19007,14 +9686,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-rsa-delegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -19024,12 +9700,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -19039,14 +9711,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-rsa-delegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -19056,12 +9725,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -19071,14 +9736,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-rsa-delegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -19088,12 +9750,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -19103,14 +9761,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_3-rsa-delegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -19120,12 +9775,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -19136,14 +9787,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_3-rsa-delegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -19153,12 +9801,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -19169,14 +9813,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_3-rsa-delegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -19186,12 +9827,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -19202,14 +9839,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-test_3-rsa-delegate-latest
-  tags:
-  - ocsp-darwinssl
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [ocsp-darwinssl]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - command: shell.exec
     type: test
     params:
@@ -19219,12 +9853,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -19234,14 +9864,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-test_3-rsa-delegate-5.0
-  tags:
-  - ocsp-darwinssl
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [ocsp-darwinssl]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - command: shell.exec
     type: test
     params:
@@ -19251,12 +9878,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -19266,14 +9889,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-test_3-rsa-delegate-4.4
-  tags:
-  - ocsp-darwinssl
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [ocsp-darwinssl]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - command: shell.exec
     type: test
     params:
@@ -19283,12 +9903,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -19298,14 +9914,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-test_3-rsa-delegate-latest
-  tags:
-  - ocsp-winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [ocsp-winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - command: shell.exec
     type: test
     params:
@@ -19315,12 +9928,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -19330,14 +9939,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-test_3-rsa-delegate-5.0
-  tags:
-  - ocsp-winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [ocsp-winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - command: shell.exec
     type: test
     params:
@@ -19347,12 +9953,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -19362,14 +9964,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-test_3-rsa-delegate-4.4
-  tags:
-  - ocsp-winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [ocsp-winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - command: shell.exec
     type: test
     params:
@@ -19379,12 +9978,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -19394,14 +9989,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-ecdsa-delegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -19411,12 +10003,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -19426,14 +10014,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-ecdsa-delegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -19443,12 +10028,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -19458,14 +10039,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-ecdsa-delegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -19475,12 +10053,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -19490,14 +10064,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_3-ecdsa-delegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -19507,12 +10078,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -19523,14 +10090,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_3-ecdsa-delegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -19540,12 +10104,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -19556,14 +10116,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_3-ecdsa-delegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -19573,12 +10130,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -19589,14 +10142,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-rsa-nodelegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -19606,12 +10156,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -19621,14 +10167,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-rsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -19638,12 +10181,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -19653,14 +10192,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-rsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -19670,12 +10206,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -19685,14 +10217,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_3-rsa-nodelegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -19702,12 +10231,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -19718,14 +10243,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_3-rsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -19735,12 +10257,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -19751,14 +10269,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_3-rsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -19768,12 +10283,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -19784,14 +10295,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-test_3-rsa-nodelegate-latest
-  tags:
-  - ocsp-darwinssl
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [ocsp-darwinssl]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - command: shell.exec
     type: test
     params:
@@ -19801,12 +10309,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -19816,14 +10320,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-test_3-rsa-nodelegate-5.0
-  tags:
-  - ocsp-darwinssl
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [ocsp-darwinssl]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - command: shell.exec
     type: test
     params:
@@ -19833,12 +10334,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -19848,14 +10345,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-test_3-rsa-nodelegate-4.4
-  tags:
-  - ocsp-darwinssl
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [ocsp-darwinssl]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - command: shell.exec
     type: test
     params:
@@ -19865,12 +10359,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -19880,14 +10370,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-test_3-rsa-nodelegate-latest
-  tags:
-  - ocsp-winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [ocsp-winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - command: shell.exec
     type: test
     params:
@@ -19897,12 +10384,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -19912,14 +10395,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-test_3-rsa-nodelegate-5.0
-  tags:
-  - ocsp-winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [ocsp-winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - command: shell.exec
     type: test
     params:
@@ -19929,12 +10409,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -19944,14 +10420,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-test_3-rsa-nodelegate-4.4
-  tags:
-  - ocsp-winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [ocsp-winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - command: shell.exec
     type: test
     params:
@@ -19961,12 +10434,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -19976,14 +10445,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-ecdsa-nodelegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -19993,12 +10459,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -20008,14 +10470,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-ecdsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -20025,12 +10484,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -20040,14 +10495,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_3-ecdsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -20057,12 +10509,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -20072,14 +10520,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_3-ecdsa-nodelegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -20089,12 +10534,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -20105,14 +10546,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_3-ecdsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -20122,12 +10560,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -20138,14 +10572,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_3-ecdsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -20155,12 +10586,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -20171,14 +10598,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_3 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_4-rsa-delegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -20188,12 +10612,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -20203,14 +10623,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_4-rsa-delegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -20220,12 +10637,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -20235,14 +10648,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_4-rsa-delegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -20252,12 +10662,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -20267,14 +10673,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_4-rsa-delegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -20284,12 +10687,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -20300,14 +10699,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_4-rsa-delegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -20317,12 +10713,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -20333,14 +10725,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_4-rsa-delegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -20350,12 +10739,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -20366,14 +10751,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-test_4-rsa-delegate-latest
-  tags:
-  - ocsp-darwinssl
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [ocsp-darwinssl]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - command: shell.exec
     type: test
     params:
@@ -20383,12 +10765,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -20398,14 +10776,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-test_4-rsa-delegate-5.0
-  tags:
-  - ocsp-darwinssl
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [ocsp-darwinssl]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - command: shell.exec
     type: test
     params:
@@ -20415,12 +10790,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -20430,14 +10801,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-test_4-rsa-delegate-4.4
-  tags:
-  - ocsp-darwinssl
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [ocsp-darwinssl]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - command: shell.exec
     type: test
     params:
@@ -20447,12 +10815,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -20462,14 +10826,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-test_4-rsa-delegate-latest
-  tags:
-  - ocsp-winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [ocsp-winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - command: shell.exec
     type: test
     params:
@@ -20479,12 +10840,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -20494,14 +10851,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-test_4-rsa-delegate-5.0
-  tags:
-  - ocsp-winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [ocsp-winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - command: shell.exec
     type: test
     params:
@@ -20511,12 +10865,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -20526,14 +10876,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-test_4-rsa-delegate-4.4
-  tags:
-  - ocsp-winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [ocsp-winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - command: shell.exec
     type: test
     params:
@@ -20543,12 +10890,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -20558,14 +10901,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_4-ecdsa-delegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -20575,12 +10915,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -20590,14 +10926,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_4-ecdsa-delegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -20607,12 +10940,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -20622,14 +10951,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_4-ecdsa-delegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -20639,12 +10965,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -20654,14 +10976,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_4-ecdsa-delegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -20671,12 +10990,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -20687,14 +11002,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_4-ecdsa-delegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -20704,12 +11016,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -20720,14 +11028,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_4-ecdsa-delegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -20737,12 +11042,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -20753,14 +11054,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_4-rsa-nodelegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -20770,12 +11068,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -20785,14 +11079,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_4-rsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -20802,12 +11093,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -20817,14 +11104,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_4-rsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -20834,12 +11118,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -20849,14 +11129,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_4-rsa-nodelegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -20866,12 +11143,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -20882,14 +11155,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_4-rsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -20899,12 +11169,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -20915,14 +11181,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_4-rsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -20932,12 +11195,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -20948,14 +11207,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-test_4-rsa-nodelegate-latest
-  tags:
-  - ocsp-darwinssl
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [ocsp-darwinssl]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - command: shell.exec
     type: test
     params:
@@ -20965,12 +11221,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -20980,14 +11232,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-test_4-rsa-nodelegate-5.0
-  tags:
-  - ocsp-darwinssl
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [ocsp-darwinssl]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - command: shell.exec
     type: test
     params:
@@ -20997,12 +11246,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -21012,14 +11257,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-test_4-rsa-nodelegate-4.4
-  tags:
-  - ocsp-darwinssl
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [ocsp-darwinssl]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - command: shell.exec
     type: test
     params:
@@ -21029,12 +11271,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -21044,14 +11282,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-test_4-rsa-nodelegate-latest
-  tags:
-  - ocsp-winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [ocsp-winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - command: shell.exec
     type: test
     params:
@@ -21061,12 +11296,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -21076,14 +11307,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-test_4-rsa-nodelegate-5.0
-  tags:
-  - ocsp-winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [ocsp-winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - command: shell.exec
     type: test
     params:
@@ -21093,12 +11321,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -21108,14 +11332,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-test_4-rsa-nodelegate-4.4
-  tags:
-  - ocsp-winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [ocsp-winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - command: shell.exec
     type: test
     params:
@@ -21125,12 +11346,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -21140,14 +11357,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_4-ecdsa-nodelegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -21157,12 +11371,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -21172,14 +11382,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_4-ecdsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -21189,12 +11396,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -21204,14 +11407,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-test_4-ecdsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -21221,12 +11421,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -21236,14 +11432,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_4-ecdsa-nodelegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -21253,12 +11446,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -21269,14 +11458,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_4-ecdsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -21286,12 +11472,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -21302,14 +11484,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-test_4-ecdsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -21319,12 +11498,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -21335,14 +11510,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-soft_fail_test-rsa-nodelegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -21352,12 +11524,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -21367,14 +11535,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-soft_fail_test-rsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -21384,12 +11549,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -21399,14 +11560,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-soft_fail_test-rsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -21416,12 +11574,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -21431,14 +11585,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-soft_fail_test-rsa-nodelegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -21448,12 +11599,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -21464,14 +11611,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-soft_fail_test-rsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -21481,12 +11625,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -21497,14 +11637,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-soft_fail_test-rsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -21514,12 +11651,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -21530,14 +11663,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-soft_fail_test-rsa-nodelegate-latest
-  tags:
-  - ocsp-darwinssl
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [ocsp-darwinssl]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - command: shell.exec
     type: test
     params:
@@ -21547,12 +11677,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -21562,14 +11688,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-soft_fail_test-rsa-nodelegate-5.0
-  tags:
-  - ocsp-darwinssl
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [ocsp-darwinssl]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - command: shell.exec
     type: test
     params:
@@ -21579,12 +11702,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -21594,14 +11713,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-soft_fail_test-rsa-nodelegate-4.4
-  tags:
-  - ocsp-darwinssl
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [ocsp-darwinssl]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - command: shell.exec
     type: test
     params:
@@ -21611,12 +11727,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -21626,14 +11738,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-soft_fail_test-rsa-nodelegate-latest
-  tags:
-  - ocsp-winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [ocsp-winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - command: shell.exec
     type: test
     params:
@@ -21643,12 +11752,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -21658,14 +11763,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-soft_fail_test-rsa-nodelegate-5.0
-  tags:
-  - ocsp-winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [ocsp-winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - command: shell.exec
     type: test
     params:
@@ -21675,12 +11777,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -21690,14 +11788,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-soft_fail_test-rsa-nodelegate-4.4
-  tags:
-  - ocsp-winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [ocsp-winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - command: shell.exec
     type: test
     params:
@@ -21707,12 +11802,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -21722,14 +11813,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-soft_fail_test-ecdsa-nodelegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -21739,12 +11827,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -21754,14 +11838,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-soft_fail_test-ecdsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -21771,12 +11852,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -21786,14 +11863,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-soft_fail_test-ecdsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -21803,12 +11877,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -21818,14 +11888,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-soft_fail_test-ecdsa-nodelegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -21835,12 +11902,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -21851,14 +11914,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-soft_fail_test-ecdsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -21868,12 +11928,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -21884,14 +11940,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-soft_fail_test-ecdsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -21901,12 +11954,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -21917,14 +11966,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=SOFT_FAIL_TEST CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_1-rsa-delegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -21934,12 +11980,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -21949,14 +11991,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_1-rsa-delegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -21966,12 +12005,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -21981,14 +12016,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_1-rsa-delegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -21998,12 +12030,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -22013,14 +12041,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_1-rsa-delegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -22030,12 +12055,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -22046,14 +12067,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_1-rsa-delegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -22063,12 +12081,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -22079,14 +12093,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_1-rsa-delegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -22096,12 +12107,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -22112,14 +12119,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-malicious_server_test_1-rsa-delegate-latest
-  tags:
-  - ocsp-darwinssl
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [ocsp-darwinssl]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - command: shell.exec
     type: test
     params:
@@ -22129,12 +12133,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -22144,14 +12144,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-malicious_server_test_1-rsa-delegate-5.0
-  tags:
-  - ocsp-darwinssl
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [ocsp-darwinssl]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - command: shell.exec
     type: test
     params:
@@ -22161,12 +12158,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -22176,14 +12169,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-malicious_server_test_1-rsa-delegate-4.4
-  tags:
-  - ocsp-darwinssl
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [ocsp-darwinssl]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - command: shell.exec
     type: test
     params:
@@ -22193,12 +12183,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -22208,14 +12194,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-malicious_server_test_1-rsa-delegate-latest
-  tags:
-  - ocsp-winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [ocsp-winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - command: shell.exec
     type: test
     params:
@@ -22225,12 +12208,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -22240,14 +12219,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-malicious_server_test_1-rsa-delegate-5.0
-  tags:
-  - ocsp-winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [ocsp-winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - command: shell.exec
     type: test
     params:
@@ -22257,12 +12233,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -22272,14 +12244,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-malicious_server_test_1-rsa-delegate-4.4
-  tags:
-  - ocsp-winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [ocsp-winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - command: shell.exec
     type: test
     params:
@@ -22289,12 +12258,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -22304,14 +12269,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_1-ecdsa-delegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -22321,12 +12283,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -22336,14 +12294,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_1-ecdsa-delegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -22353,12 +12308,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -22368,14 +12319,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_1-ecdsa-delegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -22385,12 +12333,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -22400,14 +12344,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_1-ecdsa-delegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -22417,12 +12358,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -22433,14 +12370,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_1-ecdsa-delegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -22450,12 +12384,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -22466,14 +12396,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_1-ecdsa-delegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -22483,12 +12410,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=on sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -22499,14 +12422,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_1-rsa-nodelegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -22516,12 +12436,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -22531,14 +12447,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_1-rsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -22548,12 +12461,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -22563,14 +12472,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_1-rsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -22580,12 +12486,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -22595,14 +12497,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_1-rsa-nodelegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -22612,12 +12511,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -22628,14 +12523,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_1-rsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -22645,12 +12537,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -22661,14 +12549,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_1-rsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -22678,12 +12563,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -22694,14 +12575,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-malicious_server_test_1-rsa-nodelegate-latest
-  tags:
-  - ocsp-darwinssl
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [ocsp-darwinssl]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - command: shell.exec
     type: test
     params:
@@ -22711,12 +12589,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -22726,14 +12600,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-malicious_server_test_1-rsa-nodelegate-5.0
-  tags:
-  - ocsp-darwinssl
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [ocsp-darwinssl]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - command: shell.exec
     type: test
     params:
@@ -22743,12 +12614,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -22758,14 +12625,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-darwinssl-malicious_server_test_1-rsa-nodelegate-4.4
-  tags:
-  - ocsp-darwinssl
-  depends_on:
-    name: debug-compile-nosasl-darwinssl
+  tags: [ocsp-darwinssl]
+  depends_on: {name: debug-compile-nosasl-darwinssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-darwinssl
+    vars: {BUILD_NAME: debug-compile-nosasl-darwinssl}
   - command: shell.exec
     type: test
     params:
@@ -22775,12 +12639,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -22790,14 +12650,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-malicious_server_test_1-rsa-nodelegate-latest
-  tags:
-  - ocsp-winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [ocsp-winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - command: shell.exec
     type: test
     params:
@@ -22807,12 +12664,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -22822,14 +12675,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-malicious_server_test_1-rsa-nodelegate-5.0
-  tags:
-  - ocsp-winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [ocsp-winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - command: shell.exec
     type: test
     params:
@@ -22839,12 +12689,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -22854,14 +12700,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-malicious_server_test_1-rsa-nodelegate-4.4
-  tags:
-  - ocsp-winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [ocsp-winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - command: shell.exec
     type: test
     params:
@@ -22871,12 +12714,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -22886,14 +12725,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_1-ecdsa-nodelegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -22903,12 +12739,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -22918,14 +12750,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_1-ecdsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -22935,12 +12764,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -22950,14 +12775,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_1-ecdsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -22967,12 +12789,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -22982,14 +12800,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_1-ecdsa-nodelegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -22999,12 +12814,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -23015,14 +12826,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_1-ecdsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -23032,12 +12840,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -23048,14 +12852,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_1-ecdsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -23065,12 +12866,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -23081,14 +12878,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_1 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_2-rsa-nodelegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -23098,12 +12892,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -23113,14 +12903,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_2-rsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -23130,12 +12917,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -23145,14 +12928,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_2-rsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -23162,12 +12942,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -23177,14 +12953,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_2-rsa-nodelegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -23194,12 +12967,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -23210,14 +12979,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_2-rsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -23227,12 +12993,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -23243,14 +13005,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_2-rsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -23260,12 +13019,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -23276,14 +13031,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-malicious_server_test_2-rsa-nodelegate-latest
-  tags:
-  - ocsp-winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [ocsp-winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - command: shell.exec
     type: test
     params:
@@ -23293,12 +13045,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -23308,14 +13056,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-malicious_server_test_2-rsa-nodelegate-5.0
-  tags:
-  - ocsp-winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [ocsp-winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - command: shell.exec
     type: test
     params:
@@ -23325,12 +13070,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -23340,14 +13081,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-winssl-malicious_server_test_2-rsa-nodelegate-4.4
-  tags:
-  - ocsp-winssl
-  depends_on:
-    name: debug-compile-nosasl-winssl
+  tags: [ocsp-winssl]
+  depends_on: {name: debug-compile-nosasl-winssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-winssl
+    vars: {BUILD_NAME: debug-compile-nosasl-winssl}
   - command: shell.exec
     type: test
     params:
@@ -23357,12 +13095,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -23372,14 +13106,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=rsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_2-ecdsa-nodelegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -23389,12 +13120,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -23404,14 +13131,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_2-ecdsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -23421,12 +13145,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -23436,14 +13156,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-malicious_server_test_2-ecdsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -23453,12 +13170,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -23468,14 +13181,11 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_2-ecdsa-nodelegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -23485,12 +13195,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -23501,14 +13207,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_2-ecdsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -23518,12 +13221,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -23534,14 +13233,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-1.0.1-malicious_server_test_2-ecdsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -23551,12 +13247,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling,
+      SSL: ssl, TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -23567,14 +13259,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         TEST_COLUMN=MALICIOUS_SERVER_TEST_2 CERT_TYPE=ecdsa sh .evergreen/run-ocsp-test.sh
 - name: ocsp-openssl-cache-rsa-nodelegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -23584,12 +13273,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -23599,14 +13284,11 @@ tasks:
         set -o errexit
         CERT_TYPE=rsa .evergreen/run-ocsp-cache-test.sh
 - name: ocsp-openssl-cache-rsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -23616,12 +13298,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -23631,14 +13309,11 @@ tasks:
         set -o errexit
         CERT_TYPE=rsa .evergreen/run-ocsp-cache-test.sh
 - name: ocsp-openssl-cache-rsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -23648,12 +13323,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -23663,14 +13334,11 @@ tasks:
         set -o errexit
         CERT_TYPE=rsa .evergreen/run-ocsp-cache-test.sh
 - name: ocsp-openssl-1.0.1-cache-rsa-nodelegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -23680,12 +13348,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -23696,14 +13360,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         CERT_TYPE=rsa .evergreen/run-ocsp-cache-test.sh
 - name: ocsp-openssl-1.0.1-cache-rsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -23713,12 +13374,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -23729,14 +13386,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         CERT_TYPE=rsa .evergreen/run-ocsp-cache-test.sh
 - name: ocsp-openssl-1.0.1-cache-rsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -23746,12 +13400,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=rsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -23762,14 +13412,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         CERT_TYPE=rsa .evergreen/run-ocsp-cache-test.sh
 - name: ocsp-openssl-cache-ecdsa-nodelegate-latest
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -23779,12 +13426,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -23794,14 +13437,11 @@ tasks:
         set -o errexit
         CERT_TYPE=ecdsa .evergreen/run-ocsp-cache-test.sh
 - name: ocsp-openssl-cache-ecdsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -23811,12 +13451,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -23826,14 +13462,11 @@ tasks:
         set -o errexit
         CERT_TYPE=ecdsa .evergreen/run-ocsp-cache-test.sh
 - name: ocsp-openssl-cache-ecdsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl
-  depends_on:
-    name: debug-compile-nosasl-openssl
+  tags: [ocsp-openssl]
+  depends_on: {name: debug-compile-nosasl-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl}
   - command: shell.exec
     type: test
     params:
@@ -23843,12 +13476,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -23858,14 +13487,11 @@ tasks:
         set -o errexit
         CERT_TYPE=ecdsa .evergreen/run-ocsp-cache-test.sh
 - name: ocsp-openssl-1.0.1-cache-ecdsa-nodelegate-latest
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -23875,12 +13501,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: latest
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: latest}
   - command: shell.exec
     type: test
     params:
@@ -23891,14 +13513,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         CERT_TYPE=ecdsa .evergreen/run-ocsp-cache-test.sh
 - name: ocsp-openssl-1.0.1-cache-ecdsa-nodelegate-5.0
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -23908,12 +13527,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '5.0'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '5.0'}
   - command: shell.exec
     type: test
     params:
@@ -23924,14 +13539,11 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         CERT_TYPE=ecdsa .evergreen/run-ocsp-cache-test.sh
 - name: ocsp-openssl-1.0.1-cache-ecdsa-nodelegate-4.4
-  tags:
-  - ocsp-openssl-1.0.1
-  depends_on:
-    name: debug-compile-nosasl-openssl-1.0.1
+  tags: [ocsp-openssl-1.0.1]
+  depends_on: {name: debug-compile-nosasl-openssl-1.0.1}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-nosasl-openssl-1.0.1
+    vars: {BUILD_NAME: debug-compile-nosasl-openssl-1.0.1}
   - command: shell.exec
     type: test
     params:
@@ -23941,12 +13553,8 @@ tasks:
         set -o errexit
         TEST_COLUMN=TEST_4 CERT_TYPE=ecdsa USE_DELEGATE=off sh .evergreen/run-ocsp-responder.sh
   - func: bootstrap mongo-orchestration
-    vars:
-      OCSP: 'on'
-      ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling
-      SSL: ssl
-      TOPOLOGY: server
-      VERSION: '4.4'
+    vars: {OCSP: 'on', ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling, SSL: ssl,
+      TOPOLOGY: server, VERSION: '4.4'}
   - command: shell.exec
     type: test
     params:
@@ -23957,113 +13565,61 @@ tasks:
         export LD_LIBRARY_PATH=$(pwd)/install-dir/lib
         CERT_TYPE=ecdsa .evergreen/run-ocsp-cache-test.sh
 - name: test-loadbalanced-asan-auth-openssl-5.0
-  tags:
-  - '5.0'
-  - test-asan
+  tags: ['5.0', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang-openssl
+  depends_on: {name: debug-compile-asan-clang-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang-openssl
+    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: ssl
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
-  - func: clone drivers-evergreen-tools
+    vars: {AUTH: auth, SSL: ssl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+  - {func: clone drivers-evergreen-tools}
   - func: start load balancer
-    vars:
-      MONGODB_URI: mongodb://localhost:27017,localhost:27018
+    vars: {MONGODB_URI: 'mongodb://localhost:27017,localhost:27018'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      LOADBALANCED: loadbalanced
-      SSL: ssl
+    vars: {ASAN: 'on', AUTH: auth, LOADBALANCED: loadbalanced, SSL: ssl}
 - name: test-loadbalanced-asan-auth-openssl-latest
-  tags:
-  - latest
-  - test-asan
+  tags: [latest, test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang-openssl
+  depends_on: {name: debug-compile-asan-clang-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang-openssl
+    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: auth
-      SSL: ssl
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
-  - func: clone drivers-evergreen-tools
+    vars: {AUTH: auth, SSL: ssl, TOPOLOGY: sharded_cluster, VERSION: latest}
+  - {func: clone drivers-evergreen-tools}
   - func: start load balancer
-    vars:
-      MONGODB_URI: mongodb://localhost:27017,localhost:27018
+    vars: {MONGODB_URI: 'mongodb://localhost:27017,localhost:27018'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: auth
-      LOADBALANCED: loadbalanced
-      SSL: ssl
+    vars: {ASAN: 'on', AUTH: auth, LOADBALANCED: loadbalanced, SSL: ssl}
 - name: test-loadbalanced-asan-noauth-nossl-5.0
-  tags:
-  - '5.0'
-  - test-asan
+  tags: ['5.0', test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang-openssl
+  depends_on: {name: debug-compile-asan-clang-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang-openssl
+    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: '5.0'
-  - func: clone drivers-evergreen-tools
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: '5.0'}
+  - {func: clone drivers-evergreen-tools}
   - func: start load balancer
-    vars:
-      MONGODB_URI: mongodb://localhost:27017,localhost:27018
+    vars: {MONGODB_URI: 'mongodb://localhost:27017,localhost:27018'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: noauth
-      LOADBALANCED: loadbalanced
-      SSL: nossl
+    vars: {ASAN: 'on', AUTH: noauth, LOADBALANCED: loadbalanced, SSL: nossl}
 - name: test-loadbalanced-asan-noauth-nossl-latest
-  tags:
-  - latest
-  - test-asan
+  tags: [latest, test-asan]
   exec_timeout_secs: 3600
-  depends_on:
-    name: debug-compile-asan-clang-openssl
+  depends_on: {name: debug-compile-asan-clang-openssl}
   commands:
   - func: fetch build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang-openssl
+    vars: {BUILD_NAME: debug-compile-asan-clang-openssl}
   - func: bootstrap mongo-orchestration
-    vars:
-      AUTH: noauth
-      SSL: nossl
-      TOPOLOGY: sharded_cluster
-      VERSION: latest
-  - func: clone drivers-evergreen-tools
+    vars: {AUTH: noauth, SSL: nossl, TOPOLOGY: sharded_cluster, VERSION: latest}
+  - {func: clone drivers-evergreen-tools}
   - func: start load balancer
-    vars:
-      MONGODB_URI: mongodb://localhost:27017,localhost:27018
+    vars: {MONGODB_URI: 'mongodb://localhost:27017,localhost:27018'}
   - func: run tests
-    vars:
-      ASAN: 'on'
-      AUTH: noauth
-      LOADBALANCED: loadbalanced
-      SSL: nossl
+    vars: {ASAN: 'on', AUTH: noauth, LOADBALANCED: loadbalanced, SSL: nossl}
 buildvariants:
 - name: releng
   display_name: '**Release Archive Creator'
@@ -24075,11 +13631,9 @@ buildvariants:
   - .debug-compile .stdflags
   - .debug-compile !.sspi .openssl !.asan-clang
   - name: debug-compile-sasl-openssl-static
-    distros:
-    - ubuntu1804-build
+    distros: [ubuntu1804-build]
   - name: debug-compile-nosasl-openssl-static
-    distros:
-    - ubuntu1804-build
+    distros: [ubuntu1804-build]
   - .debug-compile !.sspi .nossl
   - debug-compile-valgrind
   - debug-compile-no-counters
@@ -24092,681 +13646,361 @@ buildvariants:
   - link-with-cmake-snappy
   - link-with-cmake-snappy-deprecated
   - name: link-with-cmake-mac
-    distros:
-    - macos-1014
+    distros: [macos-1014]
   - name: link-with-cmake-mac-deprecated
-    distros:
-    - macos-1014
+    distros: [macos-1014]
   - name: link-with-cmake-windows
-    distros:
-    - windows-64-vs2017-test
+    distros: [windows-64-vs2017-test]
   - name: link-with-cmake-windows-ssl
-    distros:
-    - windows-64-vs2017-test
+    distros: [windows-64-vs2017-test]
   - name: link-with-cmake-windows-snappy
-    distros:
-    - windows-64-vs2017-test
+    distros: [windows-64-vs2017-test]
   - name: link-with-cmake-mingw
-    distros:
-    - windows-64-vs2017-test
+    distros: [windows-64-vs2017-test]
   - name: link-with-pkg-config
-    distros:
-    - ubuntu1804-test
+    distros: [ubuntu1804-test]
   - name: link-with-pkg-config-mac
-    distros:
-    - macos-1014
+    distros: [macos-1014]
   - link-with-pkg-config-ssl
   - link-with-bson
   - name: link-with-bson-windows
-    distros:
-    - windows-64-vs2017-test
+    distros: [windows-64-vs2017-test]
   - name: link-with-bson-mac
-    distros:
-    - macos-1014
+    distros: [macos-1014]
   - name: link-with-bson-mingw
-    distros:
-    - windows-64-vs2013-compile
+    distros: [windows-64-vs2013-compile]
   - check-headers
   - install-uninstall-check
   - name: install-uninstall-check-mingw
-    distros:
-    - windows-64-vs2017-test
+    distros: [windows-64-vs2017-test]
   - name: install-uninstall-check-msvc
-    distros:
-    - windows-64-vs2017-test
+    distros: [windows-64-vs2017-test]
   - debug-compile-with-warnings
   - name: build-and-test-with-toolchain
-    distros:
-    - debian10-small
+    distros: [debian10-small]
 - name: clang34ubuntu
   display_name: clang 3.4 (Ubuntu 14.04)
-  expansions:
-    CC: clang
+  expansions: {CC: clang}
   run_on: ubuntu1404-build
-  tasks:
-  - debug-compile-scan-build
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - debug-compile-rdtscp
-  - .debug-compile !.sspi .openssl
-  - .debug-compile !.sspi .nossl
-  - .authentication-tests .openssl
-  - .4.0 .openssl !.nosasl .server
-  - .3.6 .openssl !.nosasl .server
+  tasks: [debug-compile-scan-build, release-compile, debug-compile-nosasl-nossl, debug-compile-rdtscp,
+    .debug-compile !.sspi .openssl, .debug-compile !.sspi .nossl, .authentication-tests
+      .openssl, .4.0 .openssl !.nosasl .server, .3.6 .openssl !.nosasl .server]
 - name: clang35
   display_name: clang 3.5 (Debian 8.1)
-  expansions:
-    CC: clang
+  expansions: {CC: clang}
   run_on: debian81-test
-  tasks:
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - .debug-compile .stdflags
-  - .debug-compile !.sspi .openssl
-  - .debug-compile !.sspi .nossl
-  - .authentication-tests .openssl
-  - .4.0 .openssl !.nosasl .server
+  tasks: [release-compile, debug-compile-nosasl-nossl, .debug-compile .stdflags, .debug-compile
+      !.sspi .openssl, .debug-compile !.sspi .nossl, .authentication-tests .openssl,
+    .4.0 .openssl !.nosasl .server]
 - name: clang38
   display_name: clang 3.8 (Debian 9.2)
-  expansions:
-    CC: clang
+  expansions: {CC: clang}
   run_on: debian92-test
-  tasks:
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - .debug-compile .stdflags
-  - .debug-compile !.sspi .openssl
-  - .debug-compile !.sspi .openssl-static
-  - .debug-compile !.sspi .nossl
-  - .latest .openssl !.nosasl .server
-  - .latest .openssl-static !.nosasl .server
-  - .latest .nossl
-  - .5.0 .openssl !.nosasl .server
-  - .4.4 .openssl !.nosasl .server
-  - .4.2 .openssl !.nosasl .server
+  tasks: [release-compile, debug-compile-nosasl-nossl, .debug-compile .stdflags, .debug-compile
+      !.sspi .openssl, .debug-compile !.sspi .openssl-static, .debug-compile !.sspi
+      .nossl, .latest .openssl !.nosasl .server, .latest .openssl-static !.nosasl
+      .server, .latest .nossl, .5.0 .openssl !.nosasl .server, .4.4 .openssl !.nosasl
+      .server, .4.2 .openssl !.nosasl .server]
 - name: openssl
   display_name: OpenSSL / LibreSSL
   run_on: archlinux-build
-  tasks:
-  - build-and-run-authentication-tests-openssl-0.9.8
-  - build-and-run-authentication-tests-openssl-1.0.0
-  - build-and-run-authentication-tests-openssl-1.0.1
-  - build-and-run-authentication-tests-openssl-1.0.2
-  - build-and-run-authentication-tests-openssl-1.1.0
-  - build-and-run-authentication-tests-openssl-1.0.1-fips
-  - build-and-run-authentication-tests-libressl-2.5
-  - build-and-run-authentication-tests-libressl-3.0-auto
-  - build-and-run-authentication-tests-libressl-3.0
+  tasks: [build-and-run-authentication-tests-openssl-0.9.8, build-and-run-authentication-tests-openssl-1.0.0,
+    build-and-run-authentication-tests-openssl-1.0.1, build-and-run-authentication-tests-openssl-1.0.2,
+    build-and-run-authentication-tests-openssl-1.1.0, build-and-run-authentication-tests-openssl-1.0.1-fips,
+    build-and-run-authentication-tests-libressl-2.5, build-and-run-authentication-tests-libressl-3.0-auto,
+    build-and-run-authentication-tests-libressl-3.0]
 - name: clang37
   display_name: clang 3.7 (Archlinux)
-  expansions:
-    CC: clang
+  expansions: {CC: clang}
   run_on: archlinux-test
-  tasks:
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - .debug-compile .stdflags
-  - .debug-compile !.sspi .openssl
-  - .debug-compile !.sspi .nossl
-  - .authentication-tests .openssl
-  - .4.0 .nossl
-  - .3.6 .nossl
+  tasks: [release-compile, debug-compile-nosasl-nossl, .debug-compile .stdflags, .debug-compile
+      !.sspi .openssl, .debug-compile !.sspi .nossl, .authentication-tests .openssl,
+    .4.0 .nossl, .3.6 .nossl]
 - name: clang60-i686
   display_name: clang 6.0 (i686) (Ubuntu 18.04)
-  expansions:
-    CC: clang
-    MARCH: i686
+  expansions: {CC: clang, MARCH: i686}
   run_on: ubuntu1804-test
-  tasks:
-  - debug-compile-scan-build
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - debug-compile-no-align
-  - .debug-compile .stdflags
-  - .debug-compile !.sspi .nossl .nosasl
-  - .latest .nossl .nosasl
-  - .5.0 .nossl .nosasl
-  - .4.4 .nossl .nosasl
-  - .4.2 .nossl .nosasl
-  - .4.0 .nossl .nosasl
+  tasks: [debug-compile-scan-build, release-compile, debug-compile-nosasl-nossl, debug-compile-no-align,
+    .debug-compile .stdflags, .debug-compile !.sspi .nossl .nosasl, .latest .nossl
+      .nosasl, .5.0 .nossl .nosasl, .4.4 .nossl .nosasl, .4.2 .nossl .nosasl, .4.0
+      .nossl .nosasl]
 - name: clang38-i686
   display_name: clang 3.8 (i686) (Ubuntu 16.04)
-  expansions:
-    CC: clang
-    MARCH: i686
+  expansions: {CC: clang, MARCH: i686}
   run_on: ubuntu1604-test
-  tasks:
-  - debug-compile-scan-build
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - debug-compile-no-align
-  - .debug-compile .stdflags
-  - .debug-compile !.sspi .nossl .nosasl
-  - .3.6 .nossl .nosasl
+  tasks: [debug-compile-scan-build, release-compile, debug-compile-nosasl-nossl, debug-compile-no-align,
+    .debug-compile .stdflags, .debug-compile !.sspi .nossl .nosasl, .3.6 .nossl .nosasl]
 - name: clang38ubuntu
   display_name: clang 3.8 (Ubuntu 16.04)
-  expansions:
-    CC: clang
+  expansions: {CC: clang}
   run_on: ubuntu1604-test
-  tasks:
-  - .compression !.zstd
-  - debug-compile-scan-build
-  - debug-compile-asan-clang
-  - debug-compile-ubsan
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - debug-compile-no-align
-  - .debug-compile .stdflags
-  - .debug-compile !.sspi .openssl
-  - .debug-compile !.sspi .nossl
-  - .authentication-tests .openssl
-  - .authentication-tests .valgrind
-  - .4.4 .openssl !.nosasl .server
-  - .4.2 .openssl !.nosasl .server
-  - .4.0 .openssl !.nosasl .server
-  - .3.6 .openssl !.nosasl .server
-  - .test-coverage .3.6
+  tasks: [.compression !.zstd, debug-compile-scan-build, debug-compile-asan-clang,
+    debug-compile-ubsan, release-compile, debug-compile-nosasl-nossl, debug-compile-no-align,
+    .debug-compile .stdflags, .debug-compile !.sspi .openssl, .debug-compile !.sspi
+      .nossl, .authentication-tests .openssl, .authentication-tests .valgrind, .4.4
+      .openssl !.nosasl .server, .4.2 .openssl !.nosasl .server, .4.0 .openssl !.nosasl
+      .server, .3.6 .openssl !.nosasl .server, .test-coverage .3.6]
 - name: gcc48ubuntu
   display_name: GCC 4.8 (Ubuntu 14.04)
-  expansions:
-    CC: gcc
+  expansions: {CC: gcc}
   run_on: ubuntu1404-build
-  tasks:
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - .debug-compile !.sspi .openssl
-  - .debug-compile !.sspi .nossl
-  - .authentication-tests .openssl
-  - .4.0 .openssl !.nosasl .server
-  - .3.6 .openssl !.nosasl .server
+  tasks: [release-compile, debug-compile-nosasl-nossl, .debug-compile !.sspi .openssl,
+    .debug-compile !.sspi .nossl, .authentication-tests .openssl, .4.0 .openssl !.nosasl
+      .server, .3.6 .openssl !.nosasl .server]
 - name: gcc82rhel
   display_name: GCC 8.2 (RHEL 8.0)
-  expansions:
-    CC: gcc
+  expansions: {CC: gcc}
   run_on: rhel80-test
-  tasks:
-  - .hardened
-  - .compression !.snappy !.zstd
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - .debug-compile !.sspi .openssl
-  - .debug-compile !.sspi .nossl
-  - .authentication-tests .openssl
-  - .latest .openssl !.nosasl .server
-  - .latest .nossl
+  tasks: [.hardened, .compression !.snappy !.zstd, release-compile, debug-compile-nosasl-nossl,
+    .debug-compile !.sspi .openssl, .debug-compile !.sspi .nossl, .authentication-tests
+      .openssl, .latest .openssl !.nosasl .server, .latest .nossl]
 - name: gcc48rhel
   display_name: GCC 4.8 (RHEL 7.0)
-  expansions:
-    CC: gcc
+  expansions: {CC: gcc}
   run_on: rhel70
-  tasks:
-  - .hardened
-  - .compression !.snappy
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - .debug-compile !.sspi .openssl
-  - .debug-compile !.sspi .nossl
-  - .authentication-tests .openssl
-  - .latest .openssl !.nosasl .server
-  - .latest .nossl
-  - .5.0 .openssl !.nosasl .server
-  - .4.4 .openssl !.nosasl .server
-  - .4.2 .openssl !.nosasl .server
-  - .4.0 .openssl !.nosasl .server
-  - .3.6 .openssl !.nosasl .server
+  tasks: [.hardened, .compression !.snappy, release-compile, debug-compile-nosasl-nossl,
+    .debug-compile !.sspi .openssl, .debug-compile !.sspi .nossl, .authentication-tests
+      .openssl, .latest .openssl !.nosasl .server, .latest .nossl, .5.0 .openssl !.nosasl
+      .server, .4.4 .openssl !.nosasl .server, .4.2 .openssl !.nosasl .server, .4.0
+      .openssl !.nosasl .server, .3.6 .openssl !.nosasl .server]
 - name: gcc49
   display_name: GCC 4.9 (Debian 8.1)
-  expansions:
-    CC: gcc
+  expansions: {CC: gcc}
   run_on: debian81-test
-  tasks:
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - .debug-compile !.sspi .openssl
-  - .debug-compile !.sspi .nossl
-  - .authentication-tests .openssl
-  - .4.0 .openssl !.nosasl .server
+  tasks: [release-compile, debug-compile-nosasl-nossl, .debug-compile !.sspi .openssl,
+    .debug-compile !.sspi .nossl, .authentication-tests .openssl, .4.0 .openssl !.nosasl
+      .server]
 - name: gcc63
   display_name: GCC 6.3 (Debian 9.2)
-  expansions:
-    CC: gcc
+  expansions: {CC: gcc}
   run_on: debian92-test
-  tasks:
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - .debug-compile !.sspi .openssl
-  - .debug-compile !.sspi .openssl-static
-  - .debug-compile !.sspi .nossl
-  - .latest .openssl !.nosasl .server
-  - .latest .openssl-static !.nosasl .server
-  - .latest .nossl
-  - .5.0 .openssl !.nosasl .server
-  - .4.4 .openssl !.nosasl .server
-  - .4.2 .openssl !.nosasl .server
+  tasks: [release-compile, debug-compile-nosasl-nossl, .debug-compile !.sspi .openssl,
+    .debug-compile !.sspi .openssl-static, .debug-compile !.sspi .nossl, .latest .openssl
+      !.nosasl .server, .latest .openssl-static !.nosasl .server, .latest .nossl,
+    .5.0 .openssl !.nosasl .server, .4.4 .openssl !.nosasl .server, .4.2 .openssl
+      !.nosasl .server]
 - name: gcc83
   display_name: GCC 8.3 (Debian 10.0)
-  expansions:
-    CC: gcc
+  expansions: {CC: gcc}
   run_on: debian10-test
-  tasks:
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - .debug-compile !.sspi .openssl
-  - .debug-compile !.sspi .openssl-static
-  - .debug-compile !.sspi .nossl
-  - .latest .openssl !.nosasl .server
-  - .latest .openssl-static !.nosasl .server
-  - .latest .nossl
+  tasks: [release-compile, debug-compile-nosasl-nossl, .debug-compile !.sspi .openssl,
+    .debug-compile !.sspi .openssl-static, .debug-compile !.sspi .nossl, .latest .openssl
+      !.nosasl .server, .latest .openssl-static !.nosasl .server, .latest .nossl]
 - name: gcc75-i686
   display_name: GCC 7.5 (i686) (Ubuntu 18.04)
-  expansions:
-    CC: gcc
-    MARCH: i686
+  expansions: {CC: gcc, MARCH: i686}
   run_on: ubuntu1804-test
-  tasks:
-  - debug-compile-coverage
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - debug-compile-no-align
-  - .debug-compile !.sspi .nossl .nosasl
-  - .latest .nossl .nosasl
-  - .5.0 .nossl .nosasl
-  - .4.4 .nossl .nosasl
-  - .4.2 .nossl .nosasl
-  - .4.0 .nossl .nosasl
+  tasks: [debug-compile-coverage, release-compile, debug-compile-nosasl-nossl, debug-compile-no-align,
+    .debug-compile !.sspi .nossl .nosasl, .latest .nossl .nosasl, .5.0 .nossl .nosasl,
+    .4.4 .nossl .nosasl, .4.2 .nossl .nosasl, .4.0 .nossl .nosasl]
 - name: gcc75
   display_name: GCC 7.5 (Ubuntu 18.04)
-  expansions:
-    CC: gcc
+  expansions: {CC: gcc}
   run_on: ubuntu1804-test
-  tasks:
-  - .compression !.zstd
-  - debug-compile-asan-gcc
-  - debug-compile-coverage
-  - debug-compile-nosrv
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - debug-compile-no-align
-  - .debug-compile !.sspi .openssl
-  - .debug-compile !.sspi .nossl
-  - .authentication-tests .openssl
-  - .authentication-tests .valgrind
-  - .latest .openssl !.nosasl .server
-  - .latest .nossl
-  - .latest .openssl .nosasl .replica_set
-  - .latest .openssl !.nosasl .replica_set
-  - retry-true-latest-server
-  - .5.0 .openssl !.nosasl .server
-  - .4.4 .openssl !.nosasl .server
-  - .4.2 .openssl !.nosasl .server
-  - .4.0 .openssl !.nosasl .server
-  - test-dns-openssl
-  - test-dns-auth-openssl
-  - test-dns-loadbalanced-openssl
+  tasks: [.compression !.zstd, debug-compile-asan-gcc, debug-compile-coverage, debug-compile-nosrv,
+    release-compile, debug-compile-nosasl-nossl, debug-compile-no-align, .debug-compile
+      !.sspi .openssl, .debug-compile !.sspi .nossl, .authentication-tests .openssl,
+    .authentication-tests .valgrind, .latest .openssl !.nosasl .server, .latest .nossl,
+    .latest .openssl .nosasl .replica_set, .latest .openssl !.nosasl .replica_set,
+    retry-true-latest-server, .5.0 .openssl !.nosasl .server, .4.4 .openssl !.nosasl
+      .server, .4.2 .openssl !.nosasl .server, .4.0 .openssl !.nosasl .server, test-dns-openssl,
+    test-dns-auth-openssl, test-dns-loadbalanced-openssl]
 - name: gcc54
   display_name: GCC 5.4 (Ubuntu 16.04)
-  expansions:
-    CC: gcc
+  expansions: {CC: gcc}
   run_on: ubuntu1604-test
-  tasks:
-  - .compression !.zstd
-  - debug-compile-asan-gcc
-  - debug-compile-coverage
-  - debug-compile-nosrv
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - debug-compile-no-align
-  - .debug-compile !.sspi .openssl
-  - .debug-compile !.sspi .nossl
+  tasks: [.compression !.zstd, debug-compile-asan-gcc, debug-compile-coverage, debug-compile-nosrv,
+    release-compile, debug-compile-nosasl-nossl, debug-compile-no-align, .debug-compile
+      !.sspi .openssl, .debug-compile !.sspi .nossl]
 - name: darwin
   display_name: '*Darwin, macOS (Apple LLVM)'
-  expansions:
-    CC: clang
+  expansions: {CC: clang}
   run_on: macos-1014
-  tasks:
-  - .compression !.snappy !.zstd
-  - debug-compile-coverage
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - debug-compile-rdtscp
-  - debug-compile-no-align
-  - debug-compile-nosrv
-  - .debug-compile .darwinssl
-  - .debug-compile !.sspi .nossl
-  - .debug-compile .clang
-  - .authentication-tests .darwinssl
-  - .latest .darwinssl !.nosasl .server
-  - .latest .nossl
-  - .5.0 .darwinssl !.nosasl .server
-  - .4.4 .darwinssl !.nosasl .server
-  - .4.2 .darwinssl !.nosasl .server
-  - .4.0 .darwinssl !.nosasl .server
-  - .3.6 .darwinssl !.nosasl .server
-  - test-dns-darwinssl
-  - test-dns-auth-darwinssl
-  - debug-compile-lto
-  - debug-compile-lto-thin
-  - debug-compile-aws
-  - test-aws-openssl-regular-4.4
-  - test-aws-openssl-regular-latest
+  tasks: [.compression !.snappy !.zstd, debug-compile-coverage, release-compile, debug-compile-nosasl-nossl,
+    debug-compile-rdtscp, debug-compile-no-align, debug-compile-nosrv, .debug-compile
+      .darwinssl, .debug-compile !.sspi .nossl, .debug-compile .clang, .authentication-tests
+      .darwinssl, .latest .darwinssl !.nosasl .server, .latest .nossl, .5.0 .darwinssl
+      !.nosasl .server, .4.4 .darwinssl !.nosasl .server, .4.2 .darwinssl !.nosasl
+      .server, .4.0 .darwinssl !.nosasl .server, .3.6 .darwinssl !.nosasl .server,
+    test-dns-darwinssl, test-dns-auth-darwinssl, debug-compile-lto, debug-compile-lto-thin,
+    debug-compile-aws, test-aws-openssl-regular-4.4, test-aws-openssl-regular-latest]
 - name: windows-2017-32
   display_name: Windows (i686) (VS 2017)
-  expansions:
-    CC: Visual Studio 15 2017
+  expansions: {CC: Visual Studio 15 2017}
   run_on: windows-64-vs2017-test
-  tasks:
-  - .debug-compile .winssl .nosasl
-  - .debug-compile !.sspi .nossl .nosasl
-  - .debug-compile .sspi !.openssl !.openssl-static
-  - .server .winssl .latest .nosasl
-  - .latest .nossl .nosasl
-  - .nosasl .latest .nossl
-  - .sspi .latest
+  tasks: [.debug-compile .winssl .nosasl, .debug-compile !.sspi .nossl .nosasl, .debug-compile
+      .sspi !.openssl !.openssl-static, .server .winssl .latest .nosasl, .latest .nossl
+      .nosasl, .nosasl .latest .nossl, .sspi .latest]
 - name: windows-2017
   display_name: Windows (VS 2017)
-  expansions:
-    CC: Visual Studio 15 2017 Win64
+  expansions: {CC: Visual Studio 15 2017 Win64}
   run_on: windows-64-vs2017-test
-  tasks:
-  - .debug-compile .winssl
-  - .debug-compile !.sspi .openssl
-  - .debug-compile !.sspi .nossl
-  - .debug-compile .sspi !.openssl-static
-  - .server .winssl .latest
-  - .server .openssl .latest !.nosasl
-  - .latest .nossl
-  - .nosasl .latest .nossl
-  - .sspi .latest
-  - test-dns-winssl
-  - test-dns-auth-winssl
-  - debug-compile-aws
-  - .5.0 .winssl !.nosasl .server
-  - .4.4 .winssl !.nosasl .server
-  - test-aws-openssl-regular-4.4
-  - test-aws-openssl-regular-latest
+  tasks: [.debug-compile .winssl, .debug-compile !.sspi .openssl, .debug-compile !.sspi
+      .nossl, .debug-compile .sspi !.openssl-static, .server .winssl .latest, .server
+      .openssl .latest !.nosasl, .latest .nossl, .nosasl .latest .nossl, .sspi .latest,
+    test-dns-winssl, test-dns-auth-winssl, debug-compile-aws, .5.0 .winssl !.nosasl
+      .server, .4.4 .winssl !.nosasl .server, test-aws-openssl-regular-4.4, test-aws-openssl-regular-latest]
 - name: windows-2015
   display_name: Windows (VS 2015)
-  expansions:
-    CC: Visual Studio 14 2015 Win64
+  expansions: {CC: Visual Studio 14 2015 Win64}
   run_on: windows-64-vs2015-compile
-  tasks:
-  - .compression !.snappy !.zstd !.latest
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - debug-compile-no-align
-  - debug-compile-nosrv
-  - .debug-compile .winssl
-  - .debug-compile !.sspi .openssl
-  - .debug-compile !.sspi .nossl
-  - .debug-compile .sspi !.openssl-static
-  - .authentication-tests .openssl !.sasl
-  - .authentication-tests .winssl
-  - .4.2 .winssl !.nosasl .server
-  - .4.0 .winssl !.nosasl .server
-  - .3.6 .winssl !.nosasl .server
+  tasks: [.compression !.snappy !.zstd !.latest, release-compile, debug-compile-nosasl-nossl,
+    debug-compile-no-align, debug-compile-nosrv, .debug-compile .winssl, .debug-compile
+      !.sspi .openssl, .debug-compile !.sspi .nossl, .debug-compile .sspi !.openssl-static,
+    .authentication-tests .openssl !.sasl, .authentication-tests .winssl, .4.2 .winssl
+      !.nosasl .server, .4.0 .winssl !.nosasl .server, .3.6 .winssl !.nosasl .server]
 - name: windows-2015-32
   display_name: Windows (i686) (VS 2015)
-  expansions:
-    CC: Visual Studio 14 2015
+  expansions: {CC: Visual Studio 14 2015}
   run_on: windows-64-vs2015-compile
-  tasks:
-  - .compression !.snappy !.zstd !.latest
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - debug-compile-no-align
-  - .debug-compile .sspi !.openssl !.openssl-static
-  - .debug-compile .winssl .nosasl
-  - .debug-compile !.sspi .nossl .nosasl
-  - .authentication-tests .winssl
-  - .4.2 .winssl .nosasl .server
-  - .4.0 .winssl .nosasl .server
+  tasks: [.compression !.snappy !.zstd !.latest, release-compile, debug-compile-nosasl-nossl,
+    debug-compile-no-align, .debug-compile .sspi !.openssl !.openssl-static, .debug-compile
+      .winssl .nosasl, .debug-compile !.sspi .nossl .nosasl, .authentication-tests
+      .winssl, .4.2 .winssl .nosasl .server, .4.0 .winssl .nosasl .server]
 - name: windows-2013
   display_name: Windows (VS 2013)
-  expansions:
-    CC: Visual Studio 12 2013 Win64
+  expansions: {CC: Visual Studio 12 2013 Win64}
   run_on: windows-64-vs2013-compile
-  tasks:
-  - .compression !.snappy !.zstd !.latest
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - .debug-compile .winssl !.client-side-encryption
-  - .debug-compile !.sspi .openssl !.client-side-encryption
-  - .debug-compile !.sspi .nossl
-  - .debug-compile .sspi !.client-side-encryption !.openssl-static
-  - .authentication-tests .openssl !.sasl
-  - .authentication-tests .winssl
-  - .4.2 .winssl !.nosasl .server !.client-side-encryption
-  - .4.0 .winssl !.nosasl .server
+  tasks: [.compression !.snappy !.zstd !.latest, release-compile, debug-compile-nosasl-nossl,
+    .debug-compile .winssl !.client-side-encryption, .debug-compile !.sspi .openssl
+      !.client-side-encryption, .debug-compile !.sspi .nossl, .debug-compile .sspi
+      !.client-side-encryption !.openssl-static, .authentication-tests .openssl !.sasl,
+    .authentication-tests .winssl, .4.2 .winssl !.nosasl .server !.client-side-encryption,
+    .4.0 .winssl !.nosasl .server]
 - name: windows-2013-32
   display_name: Windows (i686) (VS 2013)
-  expansions:
-    CC: Visual Studio 12 2013
+  expansions: {CC: Visual Studio 12 2013}
   run_on: windows-64-vs2013-compile
-  tasks:
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - debug-compile-rdtscp
-  - .debug-compile .sspi !.openssl !.openssl-static
-  - .debug-compile .winssl .nosasl !.client-side-encryption
-  - .debug-compile !.sspi .nossl .nosasl
-  - .authentication-tests .winssl
-  - .4.2 .winssl .nosasl .server !.client-side-encryption
-  - .4.0 .winssl .nosasl .server
+  tasks: [release-compile, debug-compile-nosasl-nossl, debug-compile-rdtscp, .debug-compile
+      .sspi !.openssl !.openssl-static, .debug-compile .winssl .nosasl !.client-side-encryption,
+    .debug-compile !.sspi .nossl .nosasl, .authentication-tests .winssl, .4.2 .winssl
+      .nosasl .server !.client-side-encryption, .4.0 .winssl .nosasl .server]
 - name: mingw-windows2016
   display_name: MinGW-W64 (Windows Server 2016)
-  expansions:
-    CC: mingw
+  expansions: {CC: mingw}
   run_on: windows-64-vs2017-test
-  tasks:
-  - debug-compile-nosasl-nossl
-  - .debug-compile .winssl .sspi
-  - .latest .nossl .nosasl .server
-  - .latest .winssl .sspi .server
+  tasks: [debug-compile-nosasl-nossl, .debug-compile .winssl .sspi, .latest .nossl
+      .nosasl .server, .latest .winssl .sspi .server]
 - name: mingw
   display_name: MinGW-W64
-  expansions:
-    CC: mingw
+  expansions: {CC: mingw}
   run_on: windows-64-vs2013-compile
-  tasks:
-  - debug-compile-nosasl-nossl
-  - debug-compile-no-align
-  - .debug-compile .nossl .nosasl
-  - .debug-compile .winssl .sspi
+  tasks: [debug-compile-nosasl-nossl, debug-compile-no-align, .debug-compile .nossl
+      .nosasl, .debug-compile .winssl .sspi]
 - name: power8-rhel81
   display_name: Power8 (ppc64le) (RHEL 8.1)
-  expansions:
-    CC: gcc
+  expansions: {CC: gcc}
   run_on: rhel81-power8-test
-  tasks:
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - .debug-compile !.sspi .openssl !.client-side-encryption
-  - .debug-compile !.sspi .openssl-static !.client-side-encryption
-  - .debug-compile !.sspi .nossl
-  - .latest .openssl !.nosasl .server !.client-side-encryption
-  - .latest .openssl-static !.nosasl .server !.client-side-encryption
-  - .latest .nossl
-  - .5.0 .openssl !.nosasl .server !.client-side-encryption
-  - .4.4 .openssl !.nosasl .server !.client-side-encryption
-  - .4.2 .openssl !.nosasl .server !.client-side-encryption
-  - test-dns-openssl
+  tasks: [release-compile, debug-compile-nosasl-nossl, .debug-compile !.sspi .openssl
+      !.client-side-encryption, .debug-compile !.sspi .openssl-static !.client-side-encryption,
+    .debug-compile !.sspi .nossl, .latest .openssl !.nosasl .server !.client-side-encryption,
+    .latest .openssl-static !.nosasl .server !.client-side-encryption, .latest .nossl,
+    .5.0 .openssl !.nosasl .server !.client-side-encryption, .4.4 .openssl !.nosasl
+      .server !.client-side-encryption, .4.2 .openssl !.nosasl .server !.client-side-encryption,
+    test-dns-openssl]
   batchtime: 1440
 - name: arm-ubuntu1804
   display_name: '*ARM (aarch64) (Ubuntu 18.04)'
-  expansions:
-    CC: gcc
+  expansions: {CC: gcc}
   run_on: ubuntu1804-arm64-large
-  tasks:
-  - .compression !.snappy !.zstd
-  - debug-compile-scan-build
-  - debug-compile-coverage
-  - debug-compile-no-align
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - .debug-compile !.sspi .openssl
-  - .debug-compile !.sspi .nossl
-  - .authentication-tests .openssl
-  - .latest .openssl !.nosasl .server
-  - .latest .nossl
-  - .5.0 .openssl !.nosasl .server
-  - .4.4 .openssl !.nosasl .server
-  - .4.2 .openssl !.nosasl .server
-  - test-dns-openssl
+  tasks: [.compression !.snappy !.zstd, debug-compile-scan-build, debug-compile-coverage,
+    debug-compile-no-align, release-compile, debug-compile-nosasl-nossl, .debug-compile
+      !.sspi .openssl, .debug-compile !.sspi .nossl, .authentication-tests .openssl,
+    .latest .openssl !.nosasl .server, .latest .nossl, .5.0 .openssl !.nosasl .server,
+    .4.4 .openssl !.nosasl .server, .4.2 .openssl !.nosasl .server, test-dns-openssl]
   batchtime: 1440
 - name: arm-ubuntu1604
   display_name: '*ARM (aarch64) (Ubuntu 16.04)'
-  expansions:
-    CC: gcc
+  expansions: {CC: gcc}
   run_on: ubuntu1604-arm64-large
-  tasks:
-  - .compression !.snappy !.zstd
-  - debug-compile-scan-build
-  - debug-compile-coverage
-  - debug-compile-no-align
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - .debug-compile !.sspi .openssl
-  - .debug-compile !.sspi .nossl
-  - .4.0 .openssl !.nosasl .server
+  tasks: [.compression !.snappy !.zstd, debug-compile-scan-build, debug-compile-coverage,
+    debug-compile-no-align, release-compile, debug-compile-nosasl-nossl, .debug-compile
+      !.sspi .openssl, .debug-compile !.sspi .nossl, .4.0 .openssl !.nosasl .server]
   batchtime: 1440
 - name: zseries-rhel83
   display_name: '*zSeries'
-  expansions:
-    CC: gcc
+  expansions: {CC: gcc}
   run_on: rhel83-zseries-small
-  tasks:
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - debug-compile-no-align
-  - .debug-compile !.sspi .openssl
-  - .debug-compile !.sspi .nossl
-  - .authentication-tests .openssl
-  - .latest .openssl !.nosasl .server
-  - .latest .nossl
-  - .5.0 .openssl !.nosasl .server
-  - .4.4 .openssl !.nosasl .server
-  - .4.2 .openssl !.nosasl .server
-  - .4.0 .openssl !.nosasl .server
+  tasks: [release-compile, debug-compile-nosasl-nossl, debug-compile-no-align, .debug-compile
+      !.sspi .openssl, .debug-compile !.sspi .nossl, .authentication-tests .openssl,
+    .latest .openssl !.nosasl .server, .latest .nossl, .5.0 .openssl !.nosasl .server,
+    .4.4 .openssl !.nosasl .server, .4.2 .openssl !.nosasl .server, .4.0 .openssl
+      !.nosasl .server]
   batchtime: 1440
 - name: valgrind-ubuntu
   display_name: Valgrind Tests (Ubuntu 18.04)
-  expansions:
-    CC: gcc
+  expansions: {CC: gcc}
   run_on: ubuntu1804-build
-  tasks:
-  - .debug-compile !.sspi .openssl !.sasl
-  - .debug-compile !.sspi .nossl !.sasl
-  - .debug-compile .special .valgrind
-  - .test-valgrind !.3.6
+  tasks: [.debug-compile !.sspi .openssl !.sasl, .debug-compile !.sspi .nossl !.sasl,
+    .debug-compile .special .valgrind, .test-valgrind !.3.6]
   batchtime: 1440
 - name: valgrind-ubuntu-1404
   display_name: Valgrind Tests - MongoDB (pre 4.0) (Ubuntu 14.04)
-  expansions:
-    CC: gcc
+  expansions: {CC: gcc}
   run_on: ubuntu1404-build
-  tasks:
-  - .debug-compile !.sspi .openssl !.sasl
-  - .debug-compile !.sspi .nossl !.sasl
-  - .debug-compile .special .valgrind
-  - .test-valgrind .3.6
+  tasks: [.debug-compile !.sspi .openssl !.sasl, .debug-compile !.sspi .nossl !.sasl,
+    .debug-compile .special .valgrind, .test-valgrind .3.6]
   batchtime: 1440
 - name: asan-ubuntu
   display_name: ASAN Tests (Ubuntu 18.04)
-  expansions:
-    CC: clang
+  expansions: {CC: clang}
   run_on: ubuntu1804-test
-  tasks:
-  - .debug-compile .asan-clang
-  - .test-asan !.3.6
+  tasks: [.debug-compile .asan-clang, .test-asan !.3.6]
   batchtime: 1440
 - name: asan-ubuntu-without-csfle
   display_name: ASAN Tests without csfle (Ubuntu 18.04)
-  expansions:
-    CC: clang
-    USE_CRYPT_SHARED: 'OFF'
+  expansions: {CC: clang, USE_CRYPT_SHARED: 'OFF'}
   run_on: ubuntu1804-test
-  tasks:
-  - debug-compile-asan-openssl-cse
-  - .test-asan !.3.6 .client-side-encryption
+  tasks: [debug-compile-asan-openssl-cse, .test-asan !.3.6 .client-side-encryption]
   batchtime: 1440
 - name: asan-ubuntu-ubuntu1604
   display_name: ASAN Tests (Ubuntu 16.04)
-  expansions:
-    CC: clang
+  expansions: {CC: clang}
   run_on: ubuntu1604-test
-  tasks:
-  - .debug-compile .asan-clang
-  - .test-asan .3.6
+  tasks: [.debug-compile .asan-clang, .test-asan .3.6]
   batchtime: 1440
 - name: clang60ubuntu
   display_name: clang 6.0 (Ubuntu 18.04)
-  expansions:
-    CC: clang
+  expansions: {CC: clang}
   run_on: ubuntu1804-test
-  tasks:
-  - debug-compile-aws
-  - debug-compile-nosasl-openssl-static
-  - debug-compile-sasl-openssl-static
-  - debug-compile-sspi-openssl-static
-  - test-aws-openssl-regular-latest
-  - test-aws-openssl-ec2-latest
-  - test-aws-openssl-ecs-latest
-  - test-aws-openssl-assume_role-latest
-  - test-aws-openssl-lambda-latest
-  - test-aws-openssl-regular-4.4
-  - test-aws-openssl-ec2-4.4
-  - test-aws-openssl-ecs-4.4
-  - test-aws-openssl-assume_role-4.4
-  - test-aws-openssl-lambda-4.4
+  tasks: [debug-compile-aws, debug-compile-nosasl-openssl-static, debug-compile-sasl-openssl-static,
+    debug-compile-sspi-openssl-static, test-aws-openssl-regular-latest, test-aws-openssl-ec2-latest,
+    test-aws-openssl-ecs-latest, test-aws-openssl-assume_role-latest, test-aws-openssl-lambda-latest,
+    test-aws-openssl-regular-4.4, test-aws-openssl-ec2-4.4, test-aws-openssl-ecs-4.4,
+    test-aws-openssl-assume_role-4.4, test-aws-openssl-lambda-4.4]
 - name: rhel62
   display_name: RHEL 6.2
-  expansions:
-    CC: gcc
+  expansions: {CC: gcc}
   run_on: rhel62-test
-  tasks:
-  - debug-compile-sasl-openssl
-  - test-4.0-server-auth-sasl-openssl
-  - test-4.0-replica-set-auth-sasl-openssl
-  - test-latest-server-auth-sasl-openssl
-  - test-latest-replica-set-auth-sasl-openssl
+  tasks: [debug-compile-sasl-openssl, test-4.0-server-auth-sasl-openssl, test-4.0-replica-set-auth-sasl-openssl,
+    test-latest-server-auth-sasl-openssl, test-latest-replica-set-auth-sasl-openssl]
   batchtime: 1440
 - name: mongohouse
   display_name: Mongohouse Test
   run_on: ubuntu1804-test
-  tasks:
-  - debug-compile-sasl-openssl
-  - test-mongohouse
+  tasks: [debug-compile-sasl-openssl, test-mongohouse]
 - name: ocsp
   display_name: OCSP tests
   run_on: ubuntu2004-small
   tasks:
   - name: debug-compile-nosasl-openssl
-    distros:
-    - ubuntu2004-small
+    distros: [ubuntu2004-small]
   - name: debug-compile-nosasl-openssl-static
-    distros:
-    - ubuntu2004-small
+    distros: [ubuntu2004-small]
   - name: debug-compile-nosasl-darwinssl
-    distros:
-    - macos-1014
+    distros: [macos-1014]
   - name: debug-compile-nosasl-winssl
-    distros:
-    - windows-64-vs2017-test
+    distros: [windows-64-vs2017-test]
   - name: .ocsp-openssl
-    distros:
-    - ubuntu2004-small
+    distros: [ubuntu2004-small]
   - name: .ocsp-darwinssl
-    distros:
-    - macos-1014
+    distros: [macos-1014]
   - name: .ocsp-winssl
-    distros:
-    - windows-64-vs2017-test
+    distros: [windows-64-vs2017-test]
   - name: debug-compile-nosasl-openssl-1.0.1
-    distros:
-    - ubuntu2004-small
+    distros: [ubuntu2004-small]
   - name: .ocsp-openssl-1.0.1
-    distros:
-    - ubuntu2004-small
+    distros: [ubuntu2004-small]
   batchtime: 10080
 - name: packaging
   display_name: Linux Distro Packaging
@@ -24774,28 +14008,20 @@ buildvariants:
   tasks:
   - debian-package-build
   - name: rpm-package-build
-    distros:
-    - rhel82-arm64-small
+    distros: [rhel82-arm64-small]
   batchtime: 1440
 - name: tsan-ubuntu
   display_name: Thread Sanitizer (TSAN) Tests (Ubuntu 18.04)
-  expansions:
-    CC: /opt/mongodbtoolchain/v3/bin/clang
+  expansions: {CC: /opt/mongodbtoolchain/v3/bin/clang}
   run_on: ubuntu1804-small
-  tasks:
-  - .tsan !.3.6
+  tasks: [.tsan !.3.6]
   batchtime: 1440
 - name: versioned-api
   display_name: Versioned API Tests
   run_on: ubuntu1804-test
-  tasks:
-  - debug-compile-nosasl-openssl
-  - debug-compile-nosasl-nossl
-  - .versioned-api
+  tasks: [debug-compile-nosasl-openssl, debug-compile-nosasl-nossl, .versioned-api]
 - name: macos_m1
   display_name: macOS m1 (Apple LLVM)
-  expansions:
-    CC: clang
+  expansions: {CC: clang}
   run_on: macos-1100-arm64
-  tasks:
-  - debug-compile-sasl-darwinssl
+  tasks: [debug-compile-sasl-darwinssl]

--- a/build/evergreen_config_generator/__init__.py
+++ b/build/evergreen_config_generator/__init__.py
@@ -72,7 +72,7 @@ class _Dumper(yamlordereddictloader.Dumper):
 
 
 def yaml_dump(obj):
-    return yaml.dump(obj, Dumper=_Dumper)
+    return yaml.dump(obj, Dumper=_Dumper, default_flow_style=False)
 
 
 def generate(config, path):

--- a/build/generate-future-functions.py
+++ b/build/generate-future-functions.py
@@ -32,7 +32,8 @@ Written for Python 2.6+, requires Jinja 2 for templating.
 from collections import namedtuple
 from os.path import basename, dirname, join as joinpath, normpath
 
-from jinja2 import Environment, FileSystemLoader  # Please "pip install jinja2".
+# Please "pip install jinja2".
+from jinja2 import Environment, FileSystemLoader
 
 this_dir = dirname(__file__)
 template_dir = joinpath(this_dir, 'future_function_templates')
@@ -60,6 +61,7 @@ typedef_list = [
 
     # Const fundamental.
     typedef("const_char_ptr", "const char *"),
+    typedef("bool_ptr", "bool *"),
 
     # libbson.
     typedef("bson_error_ptr", "bson_error_t *"),
@@ -98,7 +100,8 @@ typedef_list = [
             "const mongoc_find_and_modify_opts_t *"),
     typedef("const_mongoc_iovec_ptr", "const mongoc_iovec_t *"),
     typedef("const_mongoc_read_prefs_ptr", "const mongoc_read_prefs_t *"),
-    typedef("const_mongoc_write_concern_ptr", "const mongoc_write_concern_t *"),
+    typedef("const_mongoc_write_concern_ptr",
+            "const mongoc_write_concern_t *"),
 ]
 
 type_list = [T.name for T in typedef_list]
@@ -451,6 +454,7 @@ future_functions = [
                     [param("mongoc_topology_ptr", "topology"),
                      param("mongoc_ss_optype_t", "optype"),
                      param("const_mongoc_read_prefs_ptr", "read_prefs"),
+                     param("bool_ptr", "must_use_primary"),
                      param("bson_error_ptr", "error")]),
 
     future_function("mongoc_gridfs_ptr",

--- a/src/libmongoc/tests/mock_server/future-functions.c
+++ b/src/libmongoc/tests/mock_server/future-functions.c
@@ -1034,8 +1034,8 @@ BSON_THREAD_FUN (background_mongoc_topology_select, data)
          future_value_get_mongoc_topology_ptr (future_get_param (future, 0)),
          future_value_get_mongoc_ss_optype_t (future_get_param (future, 1)),
          future_value_get_const_mongoc_read_prefs_ptr (future_get_param (future, 2)),
-         NULL /* chosen read mode, unused here */,
-         future_value_get_bson_error_ptr (future_get_param (future, 3))
+         future_value_get_bool_ptr (future_get_param (future, 3)),
+         future_value_get_bson_error_ptr (future_get_param (future, 4))
       ));
 
    future_resolve (future, return_value);
@@ -2563,10 +2563,11 @@ future_topology_select (
    mongoc_topology_ptr topology,
    mongoc_ss_optype_t optype,
    const_mongoc_read_prefs_ptr read_prefs,
+   bool_ptr must_use_primary,
    bson_error_ptr error)
 {
    future_t *future = future_new (future_value_mongoc_server_description_ptr_type,
-                                  4);
+                                  5);
    
    future_value_set_mongoc_topology_ptr (
       future_get_param (future, 0), topology);
@@ -2577,8 +2578,11 @@ future_topology_select (
    future_value_set_const_mongoc_read_prefs_ptr (
       future_get_param (future, 2), read_prefs);
    
+   future_value_set_bool_ptr (
+      future_get_param (future, 3), must_use_primary);
+   
    future_value_set_bson_error_ptr (
-      future_get_param (future, 3), error);
+      future_get_param (future, 4), error);
    
    future_start (future, background_mongoc_topology_select);
    return future;

--- a/src/libmongoc/tests/mock_server/future-functions.h
+++ b/src/libmongoc/tests/mock_server/future-functions.h
@@ -490,6 +490,7 @@ future_topology_select (
    mongoc_topology_ptr topology,
    mongoc_ss_optype_t optype,
    const_mongoc_read_prefs_ptr read_prefs,
+   bool_ptr must_use_primary,
    bson_error_ptr error
 );
 

--- a/src/libmongoc/tests/mock_server/future-value.c
+++ b/src/libmongoc/tests/mock_server/future-value.c
@@ -169,6 +169,20 @@ future_value_get_const_char_ptr (future_value_t *future_value)
 }
 
 void
+future_value_set_bool_ptr (future_value_t *future_value, bool_ptr value)
+{
+   future_value->type = future_value_bool_ptr_type;
+   future_value->value.bool_ptr_value = value;
+}
+
+bool_ptr
+future_value_get_bool_ptr (future_value_t *future_value)
+{
+   BSON_ASSERT (future_value->type == future_value_bool_ptr_type);
+   return future_value->value.bool_ptr_value;
+}
+
+void
 future_value_set_bson_error_ptr (future_value_t *future_value, bson_error_ptr value)
 {
    future_value->type = future_value_bson_error_ptr_type;

--- a/src/libmongoc/tests/mock_server/future-value.h
+++ b/src/libmongoc/tests/mock_server/future-value.h
@@ -22,6 +22,7 @@ typedef char * char_ptr;
 typedef char ** char_ptr_ptr;
 typedef void * void_ptr;
 typedef const char * const_char_ptr;
+typedef bool * bool_ptr;
 typedef bson_error_t * bson_error_ptr;
 typedef bson_t * bson_ptr;
 typedef const bson_t * const_bson_ptr;
@@ -61,6 +62,7 @@ typedef enum {
    future_value_uint32_t_type,
    future_value_void_ptr_type,
    future_value_const_char_ptr_type,
+   future_value_bool_ptr_type,
    future_value_bson_error_ptr_type,
    future_value_bson_ptr_type,
    future_value_const_bson_ptr_type,
@@ -109,6 +111,7 @@ typedef struct _future_value_t
       uint32_t uint32_t_value;
       void_ptr void_ptr_value;
       const_char_ptr const_char_ptr_value;
+      bool_ptr bool_ptr_value;
       bson_error_ptr bson_error_ptr_value;
       bson_ptr bson_ptr_value;
       const_bson_ptr const_bson_ptr_value;
@@ -243,6 +246,15 @@ future_value_set_const_char_ptr(
 
 const_char_ptr
 future_value_get_const_char_ptr (
+   future_value_t *future_value);
+
+void
+future_value_set_bool_ptr(
+   future_value_t *future_value,
+   bool_ptr value);
+
+bool_ptr
+future_value_get_bool_ptr (
    future_value_t *future_value);
 
 void

--- a/src/libmongoc/tests/mock_server/future.c
+++ b/src/libmongoc/tests/mock_server/future.c
@@ -145,6 +145,18 @@ future_get_const_char_ptr (future_t *future)
    abort ();
 }
 
+bool_ptr
+future_get_bool_ptr (future_t *future)
+{
+   if (future_wait (future)) {
+      return future_value_get_bool_ptr (&future->return_value);
+   }
+
+   fprintf (stderr, "%s timed out\n", BSON_FUNC);
+   fflush (stderr);
+   abort ();
+}
+
 bson_error_ptr
 future_get_bson_error_ptr (future_t *future)
 {

--- a/src/libmongoc/tests/mock_server/future.h
+++ b/src/libmongoc/tests/mock_server/future.h
@@ -72,6 +72,9 @@ future_get_void_ptr (future_t *future);
 const_char_ptr
 future_get_const_char_ptr (future_t *future);
 
+bool_ptr
+future_get_bool_ptr (future_t *future);
+
 bson_error_ptr
 future_get_bson_error_ptr (future_t *future);
 

--- a/src/libmongoc/tests/test-mongoc-topology-reconcile.c
+++ b/src/libmongoc/tests/test-mongoc-topology-reconcile.c
@@ -246,7 +246,7 @@ _test_topology_reconcile_sharded (bool pooled)
 
    primary_read_prefs = mongoc_read_prefs_new (MONGOC_READ_PRIMARY);
    future = future_topology_select (
-      client->topology, MONGOC_SS_READ, primary_read_prefs, &error);
+      client->topology, MONGOC_SS_READ, primary_read_prefs, NULL, &error);
 
    /* mongos */
    request = mock_server_receives_any_hello (mongos);

--- a/src/libmongoc/tests/test-mongoc-topology-scanner.c
+++ b/src/libmongoc/tests/test-mongoc-topology-scanner.c
@@ -185,7 +185,7 @@ test_topology_scanner_discovery (void)
    secondary_pref = mongoc_read_prefs_new (MONGOC_READ_SECONDARY_PREFERRED);
 
    future = future_topology_select (
-      client->topology, MONGOC_SS_READ, secondary_pref, &error);
+      client->topology, MONGOC_SS_READ, secondary_pref, NULL, &error);
 
    /* a single scan discovers *and* checks the secondary */
    request = mock_server_receives_any_hello (primary);
@@ -265,7 +265,7 @@ test_topology_scanner_oscillate (void)
 
    BSON_ASSERT (!scanner->async->ncmds);
    future = future_topology_select (
-      client->topology, MONGOC_SS_READ, primary_pref, &error);
+      client->topology, MONGOC_SS_READ, primary_pref, NULL, &error);
 
    /* a single scan discovers servers 0 and 1 */
    request = mock_server_receives_any_hello (server0);

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -367,7 +367,7 @@ _test_server_selection (bool try_once)
 
    /* no primary, selection fails after one try */
    future = future_topology_select (
-      client->topology, MONGOC_SS_READ, primary_pref, &error);
+      client->topology, MONGOC_SS_READ, primary_pref, NULL, &error);
    request = mock_server_receives_any_hello (server);
    BSON_ASSERT (request);
    mock_server_replies_simple (request, secondary_response);
@@ -398,7 +398,7 @@ _test_server_selection (bool try_once)
 
    /* second selection, now we try hello again */
    future = future_topology_select (
-      client->topology, MONGOC_SS_READ, primary_pref, &error);
+      client->topology, MONGOC_SS_READ, primary_pref, NULL, &error);
    request = mock_server_receives_any_hello (server);
    BSON_ASSERT (request);
 
@@ -721,7 +721,7 @@ test_cooldown_standalone (void)
 
    /* first hello fails, selection fails */
    future = future_topology_select (
-      client->topology, MONGOC_SS_READ, primary_pref, &error);
+      client->topology, MONGOC_SS_READ, primary_pref, NULL, &error);
    request = mock_server_receives_any_hello (server);
    BSON_ASSERT (request);
    mock_server_hangs_up (request);
@@ -746,7 +746,7 @@ test_cooldown_standalone (void)
 
    /* third selection doesn't try to call hello: we're still in cooldown */
    future = future_topology_select (
-      client->topology, MONGOC_SS_READ, primary_pref, &error);
+      client->topology, MONGOC_SS_READ, primary_pref, NULL, &error);
    mock_server_set_request_timeout_msec (server, 100);
    BSON_ASSERT (!mock_server_receives_any_hello (server)); /* no hello call */
    BSON_ASSERT (!future_get_mongoc_server_description_ptr (future));
@@ -762,7 +762,7 @@ test_cooldown_standalone (void)
 
    /* cooldown ends, now we try hello again, this time succeeding */
    future = future_topology_select (
-      client->topology, MONGOC_SS_READ, primary_pref, &error);
+      client->topology, MONGOC_SS_READ, primary_pref, NULL, &error);
    request = mock_server_receives_any_hello (server); /* not in cooldown now */
    BSON_ASSERT (request);
    mock_server_replies_simple (request,
@@ -837,7 +837,7 @@ test_cooldown_rs (void)
 
    /* server 0 is a secondary. */
    future = future_topology_select (
-      client->topology, MONGOC_SS_READ, primary_pref, &error);
+      client->topology, MONGOC_SS_READ, primary_pref, NULL, &error);
 
    request = mock_server_receives_any_hello (servers[0]);
    BSON_ASSERT (request);
@@ -858,7 +858,7 @@ test_cooldown_rs (void)
 
    /* second selection doesn't try hello on server 1: it's in cooldown */
    future = future_topology_select (
-      client->topology, MONGOC_SS_READ, primary_pref, &error);
+      client->topology, MONGOC_SS_READ, primary_pref, NULL, &error);
 
    request = mock_server_receives_any_hello (servers[0]);
    BSON_ASSERT (request);
@@ -877,7 +877,7 @@ test_cooldown_rs (void)
 
    /* cooldown ends, now we try hello on server 1, this time succeeding */
    future = future_topology_select (
-      client->topology, MONGOC_SS_READ, primary_pref, &error);
+      client->topology, MONGOC_SS_READ, primary_pref, NULL, &error);
 
    request = mock_server_receives_any_hello (servers[1]);
    BSON_ASSERT (request);
@@ -924,7 +924,7 @@ test_cooldown_retry (void)
    primary_pref = mongoc_read_prefs_new (MONGOC_READ_PRIMARY);
 
    future = future_topology_select (
-      client->topology, MONGOC_SS_READ, primary_pref, &error);
+      client->topology, MONGOC_SS_READ, primary_pref, NULL, &error);
 
    /* first hello fails */
    request = mock_server_receives_any_hello (server);
@@ -1019,8 +1019,8 @@ _test_select_succeed (bool try_once)
 
    /* start waiting for a primary (NULL read pref) */
    start = bson_get_monotonic_time ();
-   future =
-      future_topology_select (client->topology, MONGOC_SS_READ, NULL, &error);
+   future = future_topology_select (
+      client->topology, MONGOC_SS_READ, NULL, NULL, &error);
 
    /* selection succeeds */
    sd = future_get_mongoc_server_description_ptr (future);


### PR DESCRIPTION
## Description

~It seems like something has changed with how the Evergreen config file is generated (namely the formatting). This PR commits these updates to the `config.yml` file.~ Patch applied, prior "block style" formatting is now preserved.

This PR also updates `generate-future-functions.py` to account for the new (as of https://github.com/mongodb/mongo-c-driver/pull/904) `must_use_primary` parameter for `mongoc_topology_select`. Call sites for `future_topology_select` were updated with an additional `NULL` argument accordingly.