### PR TITLE
Remove journal from all configs

### DIFF
--- a/orchestration_configs/replica_sets/auth-ssl.json
+++ b/orchestration_configs/replica_sets/auth-ssl.json
@@ -8,7 +8,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "port": 27017,
         "setParameter" : { "enableTestCommands": 1 }
       },
@@ -23,7 +22,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "port": 27018,
         "setParameter" : { "enableTestCommands": 1 }
       },
@@ -38,7 +36,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "port": 27019,
         "setParameter" : { "enableTestCommands": 1 }
       },

--- a/orchestration_configs/replica_sets/auth-thisDB-ssl.json
+++ b/orchestration_configs/replica_sets/auth-thisDB-ssl.json
@@ -9,7 +9,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "port": 27017,
         "setParameter" : { "enableTestCommands": 1 }
       },
@@ -24,7 +23,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "port": 27018,
         "setParameter" : { "enableTestCommands": 1 }
       },
@@ -39,7 +37,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "port": 27019,
         "setParameter" : { "enableTestCommands": 1 }
       },

--- a/orchestration_configs/replica_sets/auth.json
+++ b/orchestration_configs/replica_sets/auth.json
@@ -7,7 +7,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "port": 27017,
         "setParameter" : { "enableTestCommands": 1 }
       },
@@ -22,7 +21,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "port": 27018,
         "setParameter" : { "enableTestCommands": 1 }
       },
@@ -37,7 +35,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "port": 27019,
         "setParameter" : { "enableTestCommands": 1 }
       },

--- a/orchestration_configs/replica_sets/basic-ssl.json
+++ b/orchestration_configs/replica_sets/basic-ssl.json
@@ -5,7 +5,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "port": 27017,
         "setParameter" : { "enableTestCommands": 1 }
       },
@@ -20,7 +19,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "port": 27018,
         "setParameter" : { "enableTestCommands": 1 }
       },
@@ -35,7 +33,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "port": 27019,
         "setParameter" : { "enableTestCommands": 1 }
       },

--- a/orchestration_configs/replica_sets/basic.json
+++ b/orchestration_configs/replica_sets/basic.json
@@ -5,7 +5,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "port": 27017,
         "setParameter" : { "enableTestCommands": 1 }
       },
@@ -20,7 +19,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "port": 27018,
         "setParameter" : { "enableTestCommands": 1 }
       },
@@ -35,7 +33,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "port": 27019,
         "setParameter" : { "enableTestCommands": 1 }
       },

--- a/orchestration_configs/servers/auth-aws.json
+++ b/orchestration_configs/servers/auth-aws.json
@@ -8,7 +8,6 @@
     "ipv6": true,
     "bind_ip": "127.0.0.1,::1",
     "logappend": true,
-    "journal": true,
     "port": 27017,
     "setParameter": {"enableTestCommands": 1, "authenticationMechanisms": "MONGODB-AWS,SCRAM-SHA-256,SCRAM-SHA-1"}
   }

--- a/orchestration_configs/servers/auth-ssl.json
+++ b/orchestration_configs/servers/auth-ssl.json
@@ -7,7 +7,6 @@
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
         "logappend": true,
-        "journal": true,
         "port": 27017
     },
     "sslParams": {

--- a/orchestration_configs/servers/auth.json
+++ b/orchestration_configs/servers/auth.json
@@ -8,7 +8,6 @@
     "ipv6": true,
     "bind_ip": "127.0.0.1,::1",
     "logappend": true,
-    "journal": true,
     "port": 27017
   }
 }

--- a/orchestration_configs/servers/basic-ipv4-only.json
+++ b/orchestration_configs/servers/basic-ipv4-only.json
@@ -3,7 +3,6 @@
   "procParams": {
     "ipv6": false,
     "logappend": true,
-    "journal": true,
     "port": 27017
   }
 }

--- a/orchestration_configs/servers/basic-ssl.json
+++ b/orchestration_configs/servers/basic-ssl.json
@@ -5,7 +5,6 @@
       "ipv6": true,
       "bind_ip": "127.0.0.1,::1",
       "logappend": true,
-      "journal": true,
       "port": 27017
    },
    "sslParams": {

--- a/orchestration_configs/servers/basic.json
+++ b/orchestration_configs/servers/basic.json
@@ -4,7 +4,6 @@
     "ipv6": true,
     "bind_ip": "127.0.0.1,::1",
     "logappend": true,
-    "journal": true,
     "port": 27017
   }
 }

--- a/orchestration_configs/servers/ecdsa-basic-tls-ocsp-disableStapling.json
+++ b/orchestration_configs/servers/ecdsa-basic-tls-ocsp-disableStapling.json
@@ -5,7 +5,6 @@
       "ipv6": true,
       "bind_ip": "127.0.0.1,::1",
       "logappend": true,
-      "journal": true,
       "port": 27017,
       "setParameter": {"failpoint.disableStapling":"{\"mode\":\"alwaysOn\"}}"}
    },

--- a/orchestration_configs/servers/ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json
+++ b/orchestration_configs/servers/ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json
@@ -5,7 +5,6 @@
       "ipv6": true,
       "bind_ip": "127.0.0.1,::1",
       "logappend": true,
-      "journal": true,
       "port": 27017,
       "setParameter": {"failpoint.disableStapling":"{\"mode\":\"alwaysOn\"}}"}
    },

--- a/orchestration_configs/servers/ecdsa-basic-tls-ocsp-mustStaple.json
+++ b/orchestration_configs/servers/ecdsa-basic-tls-ocsp-mustStaple.json
@@ -5,7 +5,6 @@
       "ipv6": true,
       "bind_ip": "127.0.0.1,::1",
       "logappend": true,
-      "journal": true,
       "port": 27017,
       "setParameter": {"ocspEnabled": true}
    },

--- a/orchestration_configs/servers/mmapv1.json
+++ b/orchestration_configs/servers/mmapv1.json
@@ -4,7 +4,6 @@
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
         "logappend": true,
-        "journal": true,
         "storageEngine": "mmapv1",
         "port": 27017
     }

--- a/orchestration_configs/servers/rsa-basic-tls-ocsp-disableStapling.json
+++ b/orchestration_configs/servers/rsa-basic-tls-ocsp-disableStapling.json
@@ -5,7 +5,6 @@
       "ipv6": true,
       "bind_ip": "127.0.0.1,::1",
       "logappend": true,
-      "journal": true,
       "port": 27017,
       "setParameter": {"failpoint.disableStapling":"{\"mode\":\"alwaysOn\"}}"}
    },

--- a/orchestration_configs/servers/rsa-basic-tls-ocsp-mustStaple-disableStapling.json
+++ b/orchestration_configs/servers/rsa-basic-tls-ocsp-mustStaple-disableStapling.json
@@ -5,7 +5,6 @@
       "ipv6": true,
       "bind_ip": "127.0.0.1,::1",
       "logappend": true,
-      "journal": true,
       "port": 27017,
       "setParameter": {"failpoint.disableStapling":"{\"mode\":\"alwaysOn\"}}"}
    },

--- a/orchestration_configs/servers/rsa-basic-tls-ocsp-mustStaple.json
+++ b/orchestration_configs/servers/rsa-basic-tls-ocsp-mustStaple.json
@@ -5,7 +5,6 @@
       "ipv6": true,
       "bind_ip": "127.0.0.1,::1",
       "logappend": true,
-      "journal": true,
       "port": 27017,
       "setParameter": {"ocspEnabled": true}
    },

--- a/orchestration_configs/servers/snappy-zlib-zstd.json
+++ b/orchestration_configs/servers/snappy-zlib-zstd.json
@@ -5,7 +5,6 @@
     "ipv6": true,
     "bind_ip": "127.0.0.1,::1",
     "logappend": true,
-    "journal": true,
     "port": 27017
   }
 }

--- a/orchestration_configs/servers/snappy.json
+++ b/orchestration_configs/servers/snappy.json
@@ -5,7 +5,6 @@
     "ipv6": true,
     "bind_ip": "127.0.0.1,::1",
     "logappend": true,
-    "journal": true,
     "port": 27017
   }
 }

--- a/orchestration_configs/servers/versioned-api-testing.json
+++ b/orchestration_configs/servers/versioned-api-testing.json
@@ -5,7 +5,6 @@
     "ipv6": true,
     "bind_ip": "127.0.0.1,::1",
     "logappend": true,
-    "journal": true,
     "port": 27017,
     "setParameter": {
       "enableTestCommands": 1,

--- a/orchestration_configs/servers/wiredtiger.json
+++ b/orchestration_configs/servers/wiredtiger.json
@@ -4,7 +4,6 @@
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
         "logappend": true,
-        "journal": true,
         "storageEngine": "wiredTiger",
         "port": 27017
     }

--- a/orchestration_configs/servers/zlib.json
+++ b/orchestration_configs/servers/zlib.json
@@ -5,7 +5,6 @@
     "ipv6": true,
     "bind_ip": "127.0.0.1,::1",
     "logappend": true,
-    "journal": true,
     "port": 27017
   }
 }

--- a/orchestration_configs/servers/zstd.json
+++ b/orchestration_configs/servers/zstd.json
@@ -5,7 +5,6 @@
       "ipv6": true,
       "bind_ip": "127.0.0.1,::1",
       "logappend": true,
-      "journal": true,
       "port": 27017
     }
   }


### PR DESCRIPTION
# Summary
- Remove `journal: "true"` from all mongo-orchestration configs

# Background & Motivation
See DRIVERS-2388 for a motivation of the removal.

The C driver has copies of the orchestration config files. The first attempted solution was to copy the contents of `.evergreen/orchestration/configs/` from https://github.com/mongodb-labs/drivers-evergreen-tools/commit/fd8d93e30bfea852245da727851078cfb297dc92 into `mongo-c-driver/orchestration_configs`. The diff included changes additional to the removal of `"journal": true`. Attempting to run a patch build resulted in a [test failure](https://spruce.mongodb.com/version/62d1cd59c9ec4462ba444eae/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).

Because this is causing test failures, I prefer proceeding with a simpler fix. This PR proposes a simple fix of applying the same change to remove the `"journal" : true` option. 

CDRIVER-4029 proposes the eventual use of drivers-evergreen-tools. 