### PR TITLE
Fix sasl_client_done detection

### DIFF
--- a/build/cmake/FindSASL2.cmake
+++ b/build/cmake/FindSASL2.cmake
@@ -1,4 +1,5 @@
 include (CheckSymbolExists)
+include (CMakePushCheckState)
 
 message (STATUS "Searching for sasl/sasl.h")
 find_path (
@@ -27,12 +28,16 @@ endif ()
 if (SASL_INCLUDE_DIRS AND SASL_LIBRARIES)
     set (SASL_FOUND 1)
 
+    cmake_push_check_state ()
+    list (APPEND CMAKE_REQUIRED_INCLUDES ${SASL_INCLUDE_DIRS})
+    list (APPEND CMAKE_REQUIRED_LIBRARIES ${SASL_LIBRARIES})
     check_symbol_exists (
         sasl_client_done
-        ${SASL_INCLUDE_DIRS}/sasl/sasl.h
-        MONGOC_HAVE_SASL_CLIENT_DONE)
+        sasl/sasl.h
+        HAVE_SASL_CLIENT_DONE)
+    cmake_pop_check_state()
 
-    if (MONGOC_HAVE_SASL_CLIENT_DONE)
+    if (HAVE_SASL_CLIENT_DONE)
         set (MONGOC_HAVE_SASL_CLIENT_DONE 1)
     else ()
         set (MONGOC_HAVE_SASL_CLIENT_DONE 0)


### PR DESCRIPTION
## Description

The normal variable `MONGOC_HAVE_SASL_CLIENT_DONE` being set to `0` by default in [src/libmongoc/CMakeLists.txt](https://github.com/eramongodb/mongo-c-driver/blob/9c4f49f2e9e69d6ae61070095457fb742a375919/src/libmongoc/CMakeLists.txt#L254) interferes with `check_symbol_exists` which tries to set the result variable [as an internal cache variable](https://cmake.org/cmake/help/latest/module/CheckSymbolExists.html), as noted under [Set Cache Entry](https://cmake.org/cmake/help/latest/command/set.html#set-cache-entry):

> The content of the cache variable will not be directly accessible if a normal variable of the same name already exists (see [rules of variable evaluation](https://cmake.org/cmake/help/latest/manual/cmake-language.7.html#cmake-language-variables)).

This is demonstrated by this minimal example:
```
# CMakeLists.txt
cmake_minimum_required (VERSION 3.0)
project (example LANGUAGES C)
include (CheckSymbolExists)
set (MONGOC_HAVE_MALLOC 0)
check_symbol_exists (malloc "stdlib.h" MONGOC_HAVE_MALLOC)
message (STATUS "MONGOC_HAVE_MALLOC: ${MONGOC_HAVE_MALLOC}")
```
```
$ cmake -S . -B build
-- The C compiler identification is GNU 9.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- MONGOC_HAVE_MALLOC: 0
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/cmake/build
```
Note the lack of a `Looking for malloc` message and the unexpected output `HAVE_MALLOC: 0`.

This PR resolves this bug by removing the normal variable conflict:
```
# CMakeLists.txt
cmake_minimum_required (VERSION 3.0)
project (example LANGUAGES C)
include (CheckSymbolExists)
set (MONGOC_HAVE_MALLOC 0)
check_symbol_exists (malloc "stdlib.h" HAVE_MALLOC)
set (MONGOC_HAVE_MALLOC ${HAVE_MALLOC})
message (STATUS "MONGOC_HAVE_MALLOC: ${MONGOC_HAVE_MALLOC}")
```
```
$ cmake -S . -B build
-- The C compiler identification is GNU 9.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Looking for malloc
-- Looking for malloc - found
-- MONGOC_HAVE_MALLOC: 1
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/cmake/build
```

Other instances of `check_*_exists` do not appear to have this issue.