### PR TITLE
CDRIVER-4150 fix the AWS ECS test tasks

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -757,9 +757,7 @@ functions:
         set +o xtrace
         export IAM_AUTH_ECS_ACCOUNT=${iam_auth_ecs_account}
         export IAM_AUTH_ECS_SECRET_ACCESS_KEY=${iam_auth_ecs_secret_access_key}
-        cd ../drivers-evergreen-tools/.evergreen/auth_aws/
-        . ./activate_venv.sh
-        cd -
+        . ../drivers-evergreen-tools/.evergreen/auth_aws/activate_venv.sh
         sh ./.evergreen/run-aws-tests.sh ${TESTCASE}
   clone drivers-evergreen-tools:
   - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -758,6 +758,9 @@ functions:
         set +o xtrace
         export IAM_AUTH_ECS_ACCOUNT=${iam_auth_ecs_account}
         export IAM_AUTH_ECS_SECRET_ACCESS_KEY=${iam_auth_ecs_secret_access_key}
+        cd ../drivers-evergreen-tools/.evergreen/auth_aws/
+        . ./activate_venv.sh
+        cd -
         sh ./.evergreen/run-aws-tests.sh ${TESTCASE}
   clone drivers-evergreen-tools:
   - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -753,7 +753,6 @@ functions:
       shell: bash
       script: |-
         set -o errexit
-        set -o errexit
         # Export the variables we need to construct URIs
         set +o xtrace
         export IAM_AUTH_ECS_ACCOUNT=${iam_auth_ecs_account}

--- a/.evergreen/ecs_hosted_test.js
+++ b/.evergreen/ecs_hosted_test.js
@@ -33,8 +33,12 @@ TestData = {};
     const smoke = runMongoProgram(program, uri);
     assert.eq(smoke, 0, "Could not auth");
 
-    // Try the auth function
-    assert(external.auth({mechanism: 'MONGODB-AWS'}));
+    // Try the auth function on a new client.
+    (function () {
+        const conn = Mongo("mongodb://127.0.0.1:20000");
+        const external = conn.getDB("$external");
+        assert(external.auth({mechanism: 'MONGODB-AWS'}));
+    }());
 
     MongoRunner.stopMongod(conn);
 }());

--- a/build/evergreen_config_lib/functions.py
+++ b/build/evergreen_config_lib/functions.py
@@ -542,11 +542,11 @@ all_functions = OD([
         EOF
         ''', silent=True),
         shell_mongoc(r'''
-        set -o errexit
         # Export the variables we need to construct URIs
         set +o xtrace
         export IAM_AUTH_ECS_ACCOUNT=${iam_auth_ecs_account}
         export IAM_AUTH_ECS_SECRET_ACCESS_KEY=${iam_auth_ecs_secret_access_key}
+        . ../drivers-evergreen-tools/.evergreen/auth_aws/activate_venv.sh
         sh ./.evergreen/run-aws-tests.sh ${TESTCASE}
         ''')
     )),


### PR DESCRIPTION
# Summary
This PR fixes the [AWS ECS test tasks](https://spruce.mongodb.com/version/62d9e3f83627e0054179d630/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&taskName=ecs).

- Use a Python virtual environment with upgraded boto3.
- Use separate client in shell auth.

# Background & Motivation

Upgrading boto3 resolves [the error](https://spruce.mongodb.com/task/mongo_c_driver_clang60ubuntu_test_aws_openssl_ecs_4.4_99b55d7f4b3e3ea96152d689e81f6563ec99d664_22_07_20_21_42_37/logs?execution=0) `botocore.exceptions.ParamValidationError: Parameter validation failed`. It is suggested in DRIVERS-1462. A script for creating the virtual environment was added in https://github.com/mongodb-labs/drivers-evergreen-tools/pull/138.

Using a separate client in the shell auth resolves [the error](https://evergreen.mongodb.com/lobster/evergreen/task/mongo_c_driver_clang60ubuntu_test_aws_openssl_ecs_latest_patch_99b55d7f4b3e3ea96152d689e81f6563ec99d664_62d9cf8ea4cf475623ab3a60_22_07_21_22_13_35/0/task#bookmarks=0%2C1418&l=1&shareLine=921): `Error: Each client connection may only be authenticated once. Previously authenticated as: admin@admin`.