### PR TITLE
CDRIVER-4429 sync change-streams-resume-errorLabels test

### DIFF
--- a/src/libmongoc/tests/json/change_streams/unified/change-streams-resume-errorLabels.json
+++ b/src/libmongoc/tests/json/change_streams/unified/change-streams-resume-errorLabels.json
@@ -1478,6 +1478,11 @@
     },
     {
       "description": "change stream resumes after StaleShardVersion",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "6.0.99"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",


### PR DESCRIPTION
# Summary
- Sync change-streams-resume-errorLabels test https://github.com/mongodb/specifications/commit/8d897ad01f8c600ddaef139740d5b68fd2950c0e

# Background & Motivation
This resolves test failures on the `*-latest-*` tasks due to the issue described in DRIVERS-2387. Here is a [patch build](https://spruce.mongodb.com/version/62debbe43e8e864fca2721d5/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) with the previously failing task.