### PR TITLE
CDRIVER-4437 Improve quality of SRV URI parse error messages

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-uri.c
+++ b/src/libmongoc/src/mongoc/mongoc-uri.c
@@ -442,7 +442,7 @@ mongoc_uri_parse_host (mongoc_uri_t *uri, const char *host_and_port_in)
 }
 
 
-bool
+static bool
 mongoc_uri_parse_srv (mongoc_uri_t *uri, const char *str, bson_error_t *error)
 {
    if (*str == '\0') {

--- a/src/libmongoc/src/mongoc/mongoc-uri.c
+++ b/src/libmongoc/src/mongoc/mongoc-uri.c
@@ -443,31 +443,38 @@ mongoc_uri_parse_host (mongoc_uri_t *uri, const char *host_and_port_in)
 
 
 bool
-mongoc_uri_parse_srv (mongoc_uri_t *uri, const char *str)
+mongoc_uri_parse_srv (mongoc_uri_t *uri, const char *str, bson_error_t *error)
 {
-   char *service;
-
    if (*str == '\0') {
+      MONGOC_URI_ERROR (error, "%s", "Missing service name in SRV URI");
       return false;
    }
 
-   service = bson_strdup (str);
-   mongoc_uri_do_unescape (&service);
-   if (!service) {
-      /* invalid */
-      return false;
-   }
+   {
+      char *service = bson_strdup (str);
 
-   if (!valid_hostname (service) || count_dots (service) < 2) {
+      mongoc_uri_do_unescape (&service);
+
+      if (!service || !valid_hostname (service) || count_dots (service) < 2) {
+         MONGOC_URI_ERROR (error, "%s", "Invalid service name in URI");
+         bson_free (service);
+         return false;
+      }
+
+      bson_strncpy (uri->srv, service, sizeof uri->srv);
+
       bson_free (service);
+   }
+
+   if (strchr (uri->srv, ',')) {
+      MONGOC_URI_ERROR (
+         error, "%s", "Multiple service names are prohibited in an SRV URI");
       return false;
    }
 
-   bson_strncpy (uri->srv, service, sizeof uri->srv);
-   bson_free (service);
-
-   if (strchr (uri->srv, ',') || strchr (uri->srv, ':')) {
-      /* prohibit port number or multiple service names */
+   if (strchr (uri->srv, ':')) {
+      MONGOC_URI_ERROR (
+         error, "%s", "Port numbers are prohibited in an SRV URI");
       return false;
    }
 
@@ -1543,8 +1550,7 @@ mongoc_uri_parse_before_slash (mongoc_uri_t *uri,
    }
 
    if (uri->is_srv) {
-      if (!mongoc_uri_parse_srv (uri, hosts)) {
-         MONGOC_URI_ERROR (error, "%s", "Invalid service name in URI");
+      if (!mongoc_uri_parse_srv (uri, hosts, error)) {
          goto error;
       }
    } else {

--- a/src/libmongoc/tests/test-mongoc-uri.c
+++ b/src/libmongoc/tests/test-mongoc-uri.c
@@ -807,6 +807,60 @@ test_mongoc_uri_new_with_error (void)
       MONGOC_ERROR_COMMAND,
       MONGOC_ERROR_COMMAND_INVALID_ARG,
       "Invalid \"zlibcompressionlevel\" of 10: must be between -1 and 9");
+
+   memset (&error, 0, sizeof (bson_error_t));
+   ASSERT (!mongoc_uri_new_with_error (
+      "mongodb+srv://", &error));
+   ASSERT_ERROR_CONTAINS (
+      error,
+      MONGOC_ERROR_COMMAND,
+      MONGOC_ERROR_COMMAND_INVALID_ARG,
+      "Missing service name in SRV URI");
+
+   memset (&error, 0, sizeof (bson_error_t));
+   ASSERT (!mongoc_uri_new_with_error (
+      "mongodb+srv://%", &error));
+   ASSERT_ERROR_CONTAINS (
+      error,
+      MONGOC_ERROR_COMMAND,
+      MONGOC_ERROR_COMMAND_INVALID_ARG,
+      "Invalid service name in URI");
+
+   memset (&error, 0, sizeof (bson_error_t));
+   ASSERT (!mongoc_uri_new_with_error (
+      "mongodb+srv://x", &error));
+   ASSERT_ERROR_CONTAINS (
+      error,
+      MONGOC_ERROR_COMMAND,
+      MONGOC_ERROR_COMMAND_INVALID_ARG,
+      "Invalid service name in URI");
+
+   memset (&error, 0, sizeof (bson_error_t));
+   ASSERT (!mongoc_uri_new_with_error (
+      "mongodb+srv://x.y", &error));
+   ASSERT_ERROR_CONTAINS (
+      error,
+      MONGOC_ERROR_COMMAND,
+      MONGOC_ERROR_COMMAND_INVALID_ARG,
+      "Invalid service name in URI");
+
+   memset (&error, 0, sizeof (bson_error_t));
+   ASSERT (!mongoc_uri_new_with_error (
+      "mongodb+srv://a.b.c,d.e.f", &error));
+   ASSERT_ERROR_CONTAINS (
+      error,
+      MONGOC_ERROR_COMMAND,
+      MONGOC_ERROR_COMMAND_INVALID_ARG,
+      "Multiple service names are prohibited in an SRV URI");
+
+   memset (&error, 0, sizeof (bson_error_t));
+   ASSERT (!mongoc_uri_new_with_error (
+      "mongodb+srv://a.b.c:8000", &error));
+   ASSERT_ERROR_CONTAINS (
+      error,
+      MONGOC_ERROR_COMMAND,
+      MONGOC_ERROR_COMMAND_INVALID_ARG,
+      "Port numbers are prohibited in an SRV URI");
 }
 
 

--- a/src/libmongoc/tests/test-mongoc-uri.c
+++ b/src/libmongoc/tests/test-mongoc-uri.c
@@ -1576,17 +1576,17 @@ test_mongoc_uri_tls_ssl (const char *tls,
    bson_error_t err;
 
    bson_snprintf (url_buffer,
-             sizeof (url_buffer),
-             "mongodb://CN=client,OU=kerneluser,O=10Gen,L=New York City,"
-             "ST=New York,C=US@ldaptest.10gen.cc/?"
-             "%s=true&authMechanism=MONGODB-X509&"
-             "%s=tests/x509gen/legacy-x509.pem&"
-             "%s=tests/x509gen/legacy-ca.crt&"
-             "%s=true",
-             tls,
-             tlsCertificateKeyFile,
-             tlsCAFile,
-             tlsAllowInvalidHostnames);
+                  sizeof (url_buffer),
+                  "mongodb://CN=client,OU=kerneluser,O=10Gen,L=New York City,"
+                  "ST=New York,C=US@ldaptest.10gen.cc/?"
+                  "%s=true&authMechanism=MONGODB-X509&"
+                  "%s=tests/x509gen/legacy-x509.pem&"
+                  "%s=tests/x509gen/legacy-ca.crt&"
+                  "%s=true",
+                  tls,
+                  tlsCertificateKeyFile,
+                  tlsCAFile,
+                  tlsAllowInvalidHostnames);
    uri = mongoc_uri_new (url_buffer);
 
    ASSERT_CMPSTR (
@@ -1614,11 +1614,11 @@ test_mongoc_uri_tls_ssl (const char *tls,
 
 
    bson_snprintf (url_buffer,
-             sizeof (url_buffer),
-             "mongodb://localhost/?%s=true&%s=key.pem&%s=ca.pem",
-             tls,
-             tlsCertificateKeyFile,
-             tlsCAFile);
+                  sizeof (url_buffer),
+                  "mongodb://localhost/?%s=true&%s=key.pem&%s=ca.pem",
+                  tls,
+                  tlsCertificateKeyFile,
+                  tlsCAFile);
    uri = mongoc_uri_new (url_buffer);
 
    ASSERT_CMPSTR (mongoc_uri_get_option_as_utf8 (
@@ -1667,11 +1667,11 @@ test_mongoc_uri_tls_ssl (const char *tls,
 
 
    bson_snprintf (url_buffer,
-             sizeof (url_buffer),
-             "mongodb://localhost/?%s=true&%s=pa$$word!&%s=encrypted.pem",
-             tls,
-             tlsCertificateKeyPassword,
-             tlsCertificateKeyFile);
+                  sizeof (url_buffer),
+                  "mongodb://localhost/?%s=true&%s=pa$$word!&%s=encrypted.pem",
+                  tls,
+                  tlsCertificateKeyPassword,
+                  tlsCertificateKeyFile);
    uri = mongoc_uri_new (url_buffer);
 
    ASSERT_CMPSTR (mongoc_uri_get_option_as_utf8 (
@@ -1700,10 +1700,10 @@ test_mongoc_uri_tls_ssl (const char *tls,
 
 
    bson_snprintf (url_buffer,
-             sizeof (url_buffer),
-             "mongodb://localhost/?%s=true&%s=true",
-             tls,
-             tlsAllowInvalidCertificates);
+                  sizeof (url_buffer),
+                  "mongodb://localhost/?%s=true&%s=true",
+                  tls,
+                  tlsAllowInvalidCertificates);
    uri = mongoc_uri_new (url_buffer);
 
    ASSERT_CMPSTR (mongoc_uri_get_option_as_utf8 (
@@ -1727,9 +1727,9 @@ test_mongoc_uri_tls_ssl (const char *tls,
 
 
    bson_snprintf (url_buffer,
-             sizeof (url_buffer),
-             "mongodb://localhost/?%s=foo.pem",
-             tlsCertificateKeyFile);
+                  sizeof (url_buffer),
+                  "mongodb://localhost/?%s=foo.pem",
+                  tlsCertificateKeyFile);
    uri = mongoc_uri_new (url_buffer);
    ASSERT (mongoc_uri_get_ssl (uri));
    ASSERT (mongoc_uri_get_tls (uri));
@@ -1737,9 +1737,9 @@ test_mongoc_uri_tls_ssl (const char *tls,
 
 
    bson_snprintf (url_buffer,
-             sizeof (url_buffer),
-             "mongodb://localhost/?%s=foo.pem",
-             tlsCAFile);
+                  sizeof (url_buffer),
+                  "mongodb://localhost/?%s=foo.pem",
+                  tlsCAFile);
    uri = mongoc_uri_new (url_buffer);
    ASSERT (mongoc_uri_get_ssl (uri));
    ASSERT (mongoc_uri_get_tls (uri));
@@ -1747,9 +1747,9 @@ test_mongoc_uri_tls_ssl (const char *tls,
 
 
    bson_snprintf (url_buffer,
-             sizeof (url_buffer),
-             "mongodb://localhost/?%s=true",
-             tlsAllowInvalidCertificates);
+                  sizeof (url_buffer),
+                  "mongodb://localhost/?%s=true",
+                  tlsAllowInvalidCertificates);
    uri = mongoc_uri_new (url_buffer);
    ASSERT (mongoc_uri_get_ssl (uri));
    ASSERT (mongoc_uri_get_tls (uri));
@@ -1761,9 +1761,9 @@ test_mongoc_uri_tls_ssl (const char *tls,
 
 
    bson_snprintf (url_buffer,
-             sizeof (url_buffer),
-             "mongodb://localhost/?%s=true",
-             tlsAllowInvalidHostnames);
+                  sizeof (url_buffer),
+                  "mongodb://localhost/?%s=true",
+                  tlsAllowInvalidHostnames);
    uri = mongoc_uri_new (url_buffer);
    ASSERT (mongoc_uri_get_ssl (uri));
    ASSERT (mongoc_uri_get_tls (uri));
@@ -1775,10 +1775,10 @@ test_mongoc_uri_tls_ssl (const char *tls,
 
 
    bson_snprintf (url_buffer,
-             sizeof (url_buffer),
-             "mongodb://localhost/?%s=false&%s=foo.pem",
-             tls,
-             tlsCertificateKeyFile);
+                  sizeof (url_buffer),
+                  "mongodb://localhost/?%s=false&%s=foo.pem",
+                  tls,
+                  tlsCertificateKeyFile);
    uri = mongoc_uri_new (url_buffer);
    ASSERT (!mongoc_uri_get_ssl (uri));
    ASSERT (!mongoc_uri_get_tls (uri));
@@ -1786,10 +1786,10 @@ test_mongoc_uri_tls_ssl (const char *tls,
 
 
    bson_snprintf (url_buffer,
-             sizeof (url_buffer),
-             "mongodb://localhost/?%s=false&%s=foo.pem",
-             tls,
-             tlsCertificateKeyFile);
+                  sizeof (url_buffer),
+                  "mongodb://localhost/?%s=false&%s=foo.pem",
+                  tls,
+                  tlsCertificateKeyFile);
    uri = mongoc_uri_new (url_buffer);
    ASSERT (!mongoc_uri_get_ssl (uri));
    ASSERT (!mongoc_uri_get_tls (uri));
@@ -1797,10 +1797,10 @@ test_mongoc_uri_tls_ssl (const char *tls,
 
 
    bson_snprintf (url_buffer,
-             sizeof (url_buffer),
-             "mongodb://localhost/?%s=false&%s=true",
-             tls,
-             tlsAllowInvalidCertificates);
+                  sizeof (url_buffer),
+                  "mongodb://localhost/?%s=false&%s=true",
+                  tls,
+                  tlsAllowInvalidCertificates);
    uri = mongoc_uri_new (url_buffer);
    ASSERT (!mongoc_uri_get_ssl (uri));
    ASSERT (!mongoc_uri_get_tls (uri));
@@ -1812,10 +1812,10 @@ test_mongoc_uri_tls_ssl (const char *tls,
 
 
    bson_snprintf (url_buffer,
-             sizeof (url_buffer),
-             "mongodb://localhost/?%s=false&%s=false",
-             tls,
-             tlsAllowInvalidHostnames);
+                  sizeof (url_buffer),
+                  "mongodb://localhost/?%s=false&%s=false",
+                  tls,
+                  tlsAllowInvalidHostnames);
    uri = mongoc_uri_new (url_buffer);
    ASSERT (!mongoc_uri_get_ssl (uri));
    ASSERT (!mongoc_uri_get_tls (uri));
@@ -1834,10 +1834,10 @@ test_mongoc_uri_tls_ssl (const char *tls,
    /* Mixing options okay so long as they match */
    capture_logs (true);
    bson_snprintf (url_buffer,
-             sizeof (url_buffer),
-             "mongodb://localhost/?%s=true&%s=true",
-             tls,
-             tlsalt);
+                  sizeof (url_buffer),
+                  "mongodb://localhost/?%s=true&%s=true",
+                  tls,
+                  tlsalt);
    uri = mongoc_uri_new (url_buffer);
    ASSERT (mongoc_uri_get_option_as_bool (uri, tls, false));
    ASSERT_NO_CAPTURED_LOGS (url_buffer);
@@ -1846,10 +1846,10 @@ test_mongoc_uri_tls_ssl (const char *tls,
    /* Same option with different values okay, latter overrides */
    capture_logs (true);
    bson_snprintf (url_buffer,
-             sizeof (url_buffer),
-             "mongodb://localhost/?%s=true&%s=false",
-             tls,
-             tls);
+                  sizeof (url_buffer),
+                  "mongodb://localhost/?%s=true&%s=false",
+                  tls,
+                  tls);
    uri = mongoc_uri_new (url_buffer);
    ASSERT (!mongoc_uri_get_option_as_bool (uri, tls, true));
    if (strcmp (tls, "tls")) {
@@ -1866,10 +1866,10 @@ test_mongoc_uri_tls_ssl (const char *tls,
    /* Mixing options not okay if values differ */
    capture_logs (false);
    bson_snprintf (url_buffer,
-             sizeof (url_buffer),
-             "mongodb://localhost/?%s=true&%s=false",
-             tls,
-             tlsalt);
+                  sizeof (url_buffer),
+                  "mongodb://localhost/?%s=true&%s=false",
+                  tls,
+                  tlsalt);
    uri = mongoc_uri_new_with_error (url_buffer, &err);
    if (strcmp (tls, "tls")) {
       ASSERT_ERROR_CONTAINS (err,
@@ -1889,9 +1889,9 @@ test_mongoc_uri_tls_ssl (const char *tls,
    /* No conflict appears with implicit tls=true via SRV */
    capture_logs (false);
    bson_snprintf (url_buffer,
-             sizeof (url_buffer),
-             "mongodb+srv://a.b.c/?%s=foo.pem",
-             tlsCAFile);
+                  sizeof (url_buffer),
+                  "mongodb+srv://a.b.c/?%s=foo.pem",
+                  tlsCAFile);
    uri = mongoc_uri_new (url_buffer);
    ASSERT (mongoc_uri_get_option_as_bool (uri, tls, false));
    mongoc_uri_destroy (uri);

--- a/src/libmongoc/tests/test-mongoc-uri.c
+++ b/src/libmongoc/tests/test-mongoc-uri.c
@@ -809,44 +809,35 @@ test_mongoc_uri_new_with_error (void)
       "Invalid \"zlibcompressionlevel\" of 10: must be between -1 and 9");
 
    memset (&error, 0, sizeof (bson_error_t));
-   ASSERT (!mongoc_uri_new_with_error (
-      "mongodb+srv://", &error));
-   ASSERT_ERROR_CONTAINS (
-      error,
-      MONGOC_ERROR_COMMAND,
-      MONGOC_ERROR_COMMAND_INVALID_ARG,
-      "Missing service name in SRV URI");
+   ASSERT (!mongoc_uri_new_with_error ("mongodb+srv://", &error));
+   ASSERT_ERROR_CONTAINS (error,
+                          MONGOC_ERROR_COMMAND,
+                          MONGOC_ERROR_COMMAND_INVALID_ARG,
+                          "Missing service name in SRV URI");
 
    memset (&error, 0, sizeof (bson_error_t));
-   ASSERT (!mongoc_uri_new_with_error (
-      "mongodb+srv://%", &error));
-   ASSERT_ERROR_CONTAINS (
-      error,
-      MONGOC_ERROR_COMMAND,
-      MONGOC_ERROR_COMMAND_INVALID_ARG,
-      "Invalid service name in URI");
+   ASSERT (!mongoc_uri_new_with_error ("mongodb+srv://%", &error));
+   ASSERT_ERROR_CONTAINS (error,
+                          MONGOC_ERROR_COMMAND,
+                          MONGOC_ERROR_COMMAND_INVALID_ARG,
+                          "Invalid service name in URI");
 
    memset (&error, 0, sizeof (bson_error_t));
-   ASSERT (!mongoc_uri_new_with_error (
-      "mongodb+srv://x", &error));
-   ASSERT_ERROR_CONTAINS (
-      error,
-      MONGOC_ERROR_COMMAND,
-      MONGOC_ERROR_COMMAND_INVALID_ARG,
-      "Invalid service name in URI");
+   ASSERT (!mongoc_uri_new_with_error ("mongodb+srv://x", &error));
+   ASSERT_ERROR_CONTAINS (error,
+                          MONGOC_ERROR_COMMAND,
+                          MONGOC_ERROR_COMMAND_INVALID_ARG,
+                          "Invalid service name in URI");
 
    memset (&error, 0, sizeof (bson_error_t));
-   ASSERT (!mongoc_uri_new_with_error (
-      "mongodb+srv://x.y", &error));
-   ASSERT_ERROR_CONTAINS (
-      error,
-      MONGOC_ERROR_COMMAND,
-      MONGOC_ERROR_COMMAND_INVALID_ARG,
-      "Invalid service name in URI");
+   ASSERT (!mongoc_uri_new_with_error ("mongodb+srv://x.y", &error));
+   ASSERT_ERROR_CONTAINS (error,
+                          MONGOC_ERROR_COMMAND,
+                          MONGOC_ERROR_COMMAND_INVALID_ARG,
+                          "Invalid service name in URI");
 
    memset (&error, 0, sizeof (bson_error_t));
-   ASSERT (!mongoc_uri_new_with_error (
-      "mongodb+srv://a.b.c,d.e.f", &error));
+   ASSERT (!mongoc_uri_new_with_error ("mongodb+srv://a.b.c,d.e.f", &error));
    ASSERT_ERROR_CONTAINS (
       error,
       MONGOC_ERROR_COMMAND,
@@ -854,13 +845,11 @@ test_mongoc_uri_new_with_error (void)
       "Multiple service names are prohibited in an SRV URI");
 
    memset (&error, 0, sizeof (bson_error_t));
-   ASSERT (!mongoc_uri_new_with_error (
-      "mongodb+srv://a.b.c:8000", &error));
-   ASSERT_ERROR_CONTAINS (
-      error,
-      MONGOC_ERROR_COMMAND,
-      MONGOC_ERROR_COMMAND_INVALID_ARG,
-      "Port numbers are prohibited in an SRV URI");
+   ASSERT (!mongoc_uri_new_with_error ("mongodb+srv://a.b.c:8000", &error));
+   ASSERT_ERROR_CONTAINS (error,
+                          MONGOC_ERROR_COMMAND,
+                          MONGOC_ERROR_COMMAND_INVALID_ARG,
+                          "Port numbers are prohibited in an SRV URI");
 }
 
 


### PR DESCRIPTION
## Description

This PR resolves CDRIVER-4437.

In addition to the existing SRV URI parse error message "Invalid service name in URI", additional messages were added for each potential parse failure condition in `mongoc_uri_parse_srv`:

- "Missing service name in SRV URI"
- "Multiple service names are prohibited in an SRV URI"
- "Port numbers are prohibited in an SRV URI" (specifically requested by CDRIVER-4437)

