### PR TITLE
CDRIVER-4413, CDRIVER-4399

### DIFF
--- a/.evergreen/build_snapshot_rpm.sh
+++ b/.evergreen/build_snapshot_rpm.sh
@@ -39,7 +39,7 @@ done
 
 package=mongo-c-driver
 spec_file=../mongo-c-driver.spec
-config=${MOCK_TARGET_CONFIG:=fedora-35-aarch64}
+config=${MOCK_TARGET_CONFIG:=fedora-37-aarch64}
 
 if [ ! -x /usr/bin/rpmbuild -o ! -x /usr/bin/rpmspec ]; then
   echo "Missing the rpmbuild or rpmspec utility from the rpm-build package"

--- a/.evergreen/mongo-c-driver.spec
+++ b/.evergreen/mongo-c-driver.spec
@@ -10,7 +10,7 @@
 %global gh_project   mongo-c-driver
 %global libname      libmongoc
 %global libver       1.0
-%global up_version   1.21.2
+%global up_version   1.22.0
 #global up_prever    rc0
 # disabled as require a MongoDB server
 %bcond_with          tests
@@ -44,7 +44,7 @@ BuildRequires: mongodb-server
 BuildRequires: openssl
 %endif
 %if %{with libmongocrypt}
-BuildRequires: cmake(mongocrypt) >= 1.3.0
+BuildRequires: cmake(mongocrypt) >= 1.5.0
 %endif
 BuildRequires: perl-interpreter
 # From man pages
@@ -236,6 +236,10 @@ exit $ret
 
 
 %changelog
+* Mon Jul 18 2022 Remi Collet <remi@remirepo.net> - 1.22.0-1
+- update to 1.22.0
+- raise dependency to libmongocrypt 1.5.0
+
 * Wed Jun  8 2022 Remi Collet <remi@remirepo.net> - 1.21.2-1
 - update to 1.21.2 (no change)
 

--- a/.evergreen/spec.patch
+++ b/.evergreen/spec.patch
@@ -4,7 +4,7 @@
  %global gh_project   mongo-c-driver
  %global libname      libmongoc
  %global libver       1.0
--%global up_version   1.21.2
+-%global up_version   1.22.0
 +%global up_version   1.23.0
  #global up_prever    rc0
  # disabled as require a MongoDB server

--- a/src/libmongoc/doc/conf.py
+++ b/src/libmongoc/doc/conf.py
@@ -29,6 +29,8 @@ language = 'en'
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 master_doc = 'index'
 
+intersphinx_disabled_reftypes = []
+
 # don't fetch libbson's inventory from mongoc.org during build - Debian and
 # Fedora package builds must work offline - maintain a recent copy here
 intersphinx_mapping = {

--- a/src/libmongoc/doc/conf.py
+++ b/src/libmongoc/doc/conf.py
@@ -29,6 +29,9 @@ language = 'en'
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 master_doc = 'index'
 
+# Set an empty list of disabled reftypes.
+# Sphinx 5.0 disables "std:doc" by default.
+# Many documentation references use :doc:
 intersphinx_disabled_reftypes = []
 
 # don't fetch libbson's inventory from mongoc.org during build - Debian and


### PR DESCRIPTION
Included changes:

* CDRIVER-4399 update to Fedora 37 environment for RPM build
* sync RPM spec file for 1.22.0 release
* CDRIVER-4413 adjust configuration for building docs with Sphinx 5.0+

Evergreen patch build: https://spruce.mongodb.com/version/62e438853627e033781fccc3/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC