### PR TITLE
Fix _mongoc_get_cpu_count on Android

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-counters-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-counters-private.h
@@ -48,8 +48,14 @@ _mongoc_counters_cleanup (void);
 static BSON_INLINE unsigned
 _mongoc_get_cpu_count (void)
 {
-#if defined(__linux__)
+#if defined(__linux__) && !defined(__ANDROID__)
    return get_nprocs ();
+#elif defined(__ANDROID__) && defined(_SC_NPROCESSORS_CONF)
+   long count = sysconf (_SC_NPROCESSORS_CONF);
+   if (count < 1) {
+      return 1;
+   }
+   return count;
 #elif defined(__hpux__)
    struct pst_dynamic psd;
 

--- a/src/libmongoc/src/mongoc/mongoc-counters-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-counters-private.h
@@ -48,9 +48,7 @@ _mongoc_counters_cleanup (void);
 static BSON_INLINE unsigned
 _mongoc_get_cpu_count (void)
 {
-#if defined(__linux__) && !defined(__ANDROID__)
-   return get_nprocs ();
-#elif defined(__ANDROID__) && defined(_SC_NPROCESSORS_CONF)
+#if defined(__linux__) && defined(_SC_NPROCESSORS_CONF)
    long count = sysconf (_SC_NPROCESSORS_CONF);
    if (count < 1) {
       return 1;


### PR DESCRIPTION
get_nprocs is not available on Android below API level 23.