### PR TITLE
CDRIVER-4136 Update cmd scripts to use strict C99 via CMake config vars

### DIFF
--- a/.evergreen/compile-windows-mingw.bat
+++ b/.evergreen/compile-windows-mingw.bat
@@ -6,7 +6,7 @@ set CMAKE=C:\cmake\bin\cmake
 set CMAKE_MAKE_PROGRAM=C:\mingw-w64\x86_64-4.9.1-posix-seh-rt_v3-rev1\mingw64\bin\mingw32-make.exe
 set CC=C:\mingw-w64\x86_64-4.9.1-posix-seh-rt_v3-rev1\mingw64\bin\gcc.exe
 
-%CMAKE% -G "MinGW Makefiles" -DCMAKE_MAKE_PROGRAM=%CMAKE_MAKE_PROGRAM% -DCMAKE_PREFIX_PATH=%INSTALL_DIR%\lib\cmake -DCMAKE_C_FLAGS="-std=c99 -pedantic" %CONFIGURE_FLAGS%
+%CMAKE% -G "MinGW Makefiles" -DCMAKE_MAKE_PROGRAM=%CMAKE_MAKE_PROGRAM% -DCMAKE_PREFIX_PATH=%INSTALL_DIR%\lib\cmake -DCMAKE_C_STANDARD=99 -DCMAKE_C_STANDARD_REQUIRED=ON -DCMAKE_C_EXTENSIONS=OFF  %CONFIGURE_FLAGS%
 
 %CMAKE_MAKE_PROGRAM%
 

--- a/.evergreen/install-uninstall-check-windows.cmd
+++ b/.evergreen/install-uninstall-check-windows.cmd
@@ -43,7 +43,7 @@ if "%BSON_ONLY%"=="1" (
 
 echo.%CC%| findstr /I "gcc">Nul && (
   rem Build libmongoc, with flags that the downstream R driver mongolite uses
-  %CMAKE% -G "MinGW Makefiles" -DCMAKE_MAKE_PROGRAM=%CMAKE_MAKE_PROGRAM% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DCMAKE_CFLAGS="-std=c99 -pedantic" -DCMAKE_PREFIX_PATH=%INSTALL_DIR%\lib\cmake %BSON_ONLY_OPTION% .
+  %CMAKE% -G "MinGW Makefiles" -DCMAKE_MAKE_PROGRAM=%CMAKE_MAKE_PROGRAM% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DCMAKE_C_STANDARD=99 -DCMAKE_C_STANDARD_REQUIRED=ON -DCMAKE_C_EXTENSIONS=OFF  -DCMAKE_PREFIX_PATH=%INSTALL_DIR%\lib\cmake %BSON_ONLY_OPTION% .
   %CMAKE% --build .
   if errorlevel 1 (
      exit /B 1

--- a/.evergreen/link-sample-program-mingw-bson.cmd
+++ b/.evergreen/link-sample-program-mingw-bson.cmd
@@ -27,7 +27,7 @@ cd %BUILD_DIR%
 %TAR% xf ..\..\mongoc.tar.gz -C . --strip-components=1
 
 rem Build libmongoc, with flags that the downstream R driver mongolite uses
-%CMAKE% -G "MinGW Makefiles" -DCMAKE_MAKE_PROGRAM=%CMAKE_MAKE_PROGRAM% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DCMAKE_CFLAGS="-std=c99 -pedantic" -DCMAKE_PREFIX_PATH=%INSTALL_DIR%\lib\cmake -DENABLE_BSON=ON -DENABLE_STATIC=ON .
+%CMAKE% -G "MinGW Makefiles" -DCMAKE_MAKE_PROGRAM=%CMAKE_MAKE_PROGRAM% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DCMAKE_C_STANDARD=99 -DCMAKE_C_STANDARD_REQUIRED=ON -DCMAKE_C_EXTENSIONS=OFF -DCMAKE_PREFIX_PATH=%INSTALL_DIR%\lib\cmake -DENABLE_BSON=ON -DENABLE_STATIC=ON .
 %CMAKE% --build .
 if errorlevel 1 (
    exit /B 1

--- a/.evergreen/link-sample-program-mingw.cmd
+++ b/.evergreen/link-sample-program-mingw.cmd
@@ -27,7 +27,7 @@ cd %BUILD_DIR%
 %TAR% xf ..\..\mongoc.tar.gz -C . --strip-components=1
 
 rem Build libmongoc, with flags that the downstream R driver mongolite uses
-%CMAKE% -G "MinGW Makefiles" -DCMAKE_MAKE_PROGRAM=%CMAKE_MAKE_PROGRAM% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DCMAKE_CFLAGS="-std=c99 -pedantic" -DCMAKE_PREFIX_PATH=%INSTALL_DIR%\lib\cmake %CMAKE_FLAGS% -DENABLE_BSON=ON .
+%CMAKE% -G "MinGW Makefiles" -DCMAKE_MAKE_PROGRAM=%CMAKE_MAKE_PROGRAM% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DCMAKE_C_STANDARD=99 -DCMAKE_C_STANDARD_REQUIRED=ON -DCMAKE_C_EXTENSIONS=OFF -DCMAKE_PREFIX_PATH=%INSTALL_DIR%\lib\cmake %CMAKE_FLAGS% -DENABLE_BSON=ON .
 %CMAKE% --build .
 if errorlevel 1 (
    exit /B 1


### PR DESCRIPTION
## Description

Related to CDRIVER-4136. Followup to https://github.com/mongodb/mongo-c-driver/pull/1067. A recent [patch build](https://evergreen.mongodb.com/lobster/evergreen/task/mongo_c_driver_releng_link_with_bson_mingw_patch_2966c67d69bc22c3f68fc4f2b2d2164b7cf5b665_62e8462430661553e63af154_22_08_01_21_31_17/0/task#bookmarks=0%2C743&l=1&shareLine=683) exposed some scripts that were missed in https://github.com/mongodb/mongo-c-driver/pull/1067. This PR applies the appropriate CMake config vars to consistently opt into strict C99 conformance.