### PR TITLE
CDRIVER-4456 (Debian packaging) Explicitly link to libatomic on riscv64 (Closes: #1017345)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mongo-c-driver (1.22.1-2) UNRELEASED; urgency=medium
+
+  * Explicitly link to libatomic on riscv64 (Closes: #1017345)
+
+ -- Roberto C. Sanchez <roberto@connexer.com>  Mon, 15 Aug 2022 17:06:22 -0400
+
 mongo-c-driver (1.22.1-1) unstable; urgency=medium
 
   * New upstream release (Closes: #1013404)

--- a/debian/rules
+++ b/debian/rules
@@ -16,6 +16,10 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 #export DEB_CFLAGS_MAINT_APPEND  = -Wall -pedantic
 # package maintainers to append LDFLAGS
 export DEB_LDFLAGS_MAINT_APPEND := -lpthread
+# Link with libatomic on riscv64 to get access to the __atomic_*_1 functions
+ifeq ($(DEB_HOST_ARCH),riscv64)
+	export DEB_LDFLAGS_MAINT_APPEND += -Wl,--no-as-needed -latomic -Wl,--as-needed
+endif
 
 ifneq (,$(findstring nodoc,$(DEB_BUILD_OPTIONS)))
 	DOCS=OFF


### PR DESCRIPTION
Note that after merging this PR I will also cherry-pick and push on the `r1.22` branch.