### PR TITLE
AIX platform build fix

### DIFF
--- a/src/libbson/src/bson/bson-atomic.h
+++ b/src/libbson/src/bson/bson-atomic.h
@@ -47,7 +47,7 @@ enum bson_memory_order {
 #define MSVC_MEMORDER_SUFFIX(X)
 #endif
 
-#if defined(USE_LEGACY_GCC_ATOMICS) || (!defined(__clang__) && __GNUC__ == 4) || defined(_AIX)
+#if defined(USE_LEGACY_GCC_ATOMICS) || (!defined(__clang__) && __GNUC__ == 4) || defined(__xlC__)
 #define BSON_USE_LEGACY_GCC_ATOMICS
 #else
 #undef BSON_USE_LEGACY_GCC_ATOMICS
@@ -61,6 +61,7 @@ enum bson_memory_order {
 #ifdef BSON_USE_LEGACY_GCC_ATOMICS
 #undef BSON_IF_GNU_LIKE
 #define BSON_IF_GNU_LIKE(...)
+#define BSON_IF_MSVC(...)
 #define BSON_IF_GNU_LEGACY_ATOMICS(...) __VA_ARGS__
 #else
 #define BSON_IF_GNU_LEGACY_ATOMICS(...)

--- a/src/libbson/src/bson/bson-atomic.h
+++ b/src/libbson/src/bson/bson-atomic.h
@@ -47,7 +47,7 @@ enum bson_memory_order {
 #define MSVC_MEMORDER_SUFFIX(X)
 #endif
 
-#if defined(USE_LEGACY_GCC_ATOMICS) || (!defined(__clang__) && __GNUC__ == 4)
+#if defined(USE_LEGACY_GCC_ATOMICS) || (!defined(__clang__) && __GNUC__ == 4) || defined(_AIX)
 #define BSON_USE_LEGACY_GCC_ATOMICS
 #else
 #undef BSON_USE_LEGACY_GCC_ATOMICS

--- a/src/libbson/src/bson/bson-compat.h
+++ b/src/libbson/src/bson/bson-compat.h
@@ -332,6 +332,7 @@ typedef signed char bool;
 #define BSON_IF_MSVC(...)
 /** Expands the arguments if compiling with GCC or Clang, otherwise empty */
 #define BSON_IF_GNU_LIKE(...) __VA_ARGS__
+#endif
 
 #ifdef BSON_OS_WIN32
 /** Expands the arguments if compiling for Windows, otherwise empty */

--- a/src/libbson/src/bson/bson-compat.h
+++ b/src/libbson/src/bson/bson-compat.h
@@ -332,6 +332,13 @@ typedef signed char bool;
 #define BSON_IF_MSVC(...)
 /** Expands the arguments if compiling with GCC or Clang, otherwise empty */
 #define BSON_IF_GNU_LIKE(...) __VA_ARGS__
+#elif defined(_AIX)
+/** Expands the arguments if compiling with MSVC, otherwise empty */
+#define BSON_IF_MSVC(...)
+/** Expands the arguments if compiling with GCC or Clang, otherwise empty */
+#define BSON_IF_GNU_LIKE(...) 
+/** Expands the arguments if compiling with AIX, otherwise empty */
+#define BSON_IF_GNU_LEGACY_ATOMICS(...) __VA_ARGS__
 #endif
 
 #ifdef BSON_OS_WIN32

--- a/src/libbson/src/bson/bson-compat.h
+++ b/src/libbson/src/bson/bson-compat.h
@@ -332,14 +332,6 @@ typedef signed char bool;
 #define BSON_IF_MSVC(...)
 /** Expands the arguments if compiling with GCC or Clang, otherwise empty */
 #define BSON_IF_GNU_LIKE(...) __VA_ARGS__
-#elif defined(_AIX)
-/** Expands the arguments if compiling with MSVC, otherwise empty */
-#define BSON_IF_MSVC(...)
-/** Expands the arguments if compiling with GCC or Clang, otherwise empty */
-#define BSON_IF_GNU_LIKE(...) 
-/** Expands the arguments if compiling with AIX, otherwise empty */
-#define BSON_IF_GNU_LEGACY_ATOMICS(...) __VA_ARGS__
-#endif
 
 #ifdef BSON_OS_WIN32
 /** Expands the arguments if compiling for Windows, otherwise empty */


### PR DESCRIPTION
These file changes fix the build issues on the IBM AIX platform. 
Since AIX is not taken care of in the existing library, "BSON_USE_LEGACY_GCC_ATOMICS" is not getting defined, and "DEF_ATOMIC_OP" macro which dynamically creates code for atomic functions based on the Operating system, generates incorrect code with multiple return statements (Code expanded using xlC -E ). 
```
static __inline__ signed char bson_atomic_int8_fetch_add(signed char volatile * a, signed char addend, enum bson_memory_order ord) {
   do {
      switch (ord) {
      case bson_memory_order_acq_rel:
         BSON_IF_MSVC(
            return _InterlockedExchangeAdd8(a, addend);) return __tg_builtin("__sync_fetch_and_add", a, addend);
      case bson_memory_order_seq_cst:
         BSON_IF_MSVC(
            return _InterlockedExchangeAdd8(a, addend);) return __tg_builtin("__sync_fetch_and_add", a, addend);
      case bson_memory_order_acquire:
         BSON_IF_MSVC(
            return _InterlockedExchangeAdd8(a, addend);) return __tg_builtin("__sync_fetch_and_add", a, addend);
      case bson_memory_order_consume:
         BSON_IF_MSVC(
            return _InterlockedExchangeAdd8(a, addend);) return __tg_builtin("__sync_fetch_and_add", a, addend);
      case bson_memory_order_release:
         BSON_IF_MSVC(
            return _InterlockedExchangeAdd8(a, addend);) return __tg_builtin("__sync_fetch_and_add", a, addend);
      case bson_memory_order_relaxed:
         BSON_IF_MSVC(
            return _InterlockedExchangeAdd8(a, addend);) return __tg_builtin("__sync_fetch_and_add", a, addend);
      default:
         do {
            fprintf(( & _iob[2]), "%s:%d %s(): Unreachable code reached: %s\n", "bson-atomic.h", 361, __func__, "Invalid bson_memory_order value");
            abort();
         } while (0);
      }
   } while (0);
}
``` 
After the fix, "DEF_ATOMIC_OP" macro is generating legacy atomic functions on the AIX platform, which solves the build issues. 
```
static __inline__ signed char bson_atomic_int8_fetch_add(signed char volatile * a, signed char addend, enum bson_memory_order ord) {
   do {
      switch (ord) {
      case bson_memory_order_acq_rel:
         return __tg_builtin("__sync_fetch_and_add", a, addend);
      case bson_memory_order_seq_cst:
         return __tg_builtin("__sync_fetch_and_add", a, addend);
      case bson_memory_order_acquire:
         return __tg_builtin("__sync_fetch_and_add", a, addend);
      case bson_memory_order_consume:
         return __tg_builtin("__sync_fetch_and_add", a, addend);
      case bson_memory_order_release:
         return __tg_builtin("__sync_fetch_and_add", a, addend);
      case bson_memory_order_relaxed:
         return __tg_builtin("__sync_fetch_and_add", a, addend);
      default:
         do {
            fprintf(( & _iob[2]), "%s:%d %s(): Unreachable code reached: %s\n", "bson-atomic.h", 363, __func__, "Invalid bson_memory_order value");
            abort();
         } while (0);
      }
   } while (0);
}
```
