### PR TITLE
CDRIVER-4361 Update zSeries RHEL 8.3 tasks and server versions

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -24681,10 +24681,8 @@ buildvariants:
   - .authentication-tests .openssl
   - .latest .openssl !.nosasl .server
   - .latest .nossl
+  - .6.0 .openssl !.nosasl .server
   - .5.0 .openssl !.nosasl .server
-  - .4.4 .openssl !.nosasl .server
-  - .4.2 .openssl !.nosasl .server
-  - .4.0 .openssl !.nosasl .server
   batchtime: 1440
 - name: valgrind-ubuntu
   display_name: Valgrind Tests (Ubuntu 18.04)

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -46,6 +46,7 @@ get_distro ()
 # get_mongodb_download_url_for "linux-distro-version-architecture" "latest|44|42|40|36|34|32|30|28|26|24"
 # Sets EXTRACT to appropriate extract command
 # Sets MONGODB_DOWNLOAD_URL to the appropriate download url
+# Sets MONGO_CRYPT_SHARED_DOWNLOAD_URL to the corresponding URL to a crypt_shared library archive
 get_mongodb_download_url_for ()
 {
    _DISTRO=$1
@@ -54,10 +55,10 @@ get_mongodb_download_url_for ()
    # Set VERSION_RAPID to the latest rapid release each quarter.
    VERSION_RAPID="5.3.1"
    VERSION_60_LATEST="v6.0-latest"
-   VERSION_60="6.0.0-rc8"
-   VERSION_50="5.0.8"
-   VERSION_44="4.4.13"
-   VERSION_42="4.2.19"
+   VERSION_60="6.0.0"
+   VERSION_50="5.0.9"
+   VERSION_44="4.4.15"
+   VERSION_42="4.2.21"
    VERSION_40="4.0.28"
    VERSION_36="3.6.23"
    VERSION_34="3.4.24"
@@ -317,6 +318,8 @@ get_mongodb_download_url_for ()
       linux-ubuntu-18.04-aarch64)
          MONGODB_LATEST="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-ubuntu1804-latest.tgz"
              MONGODB_RAPID="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-ubuntu1804-${VERSION_RAPID}.tgz"
+             MONGODB_60_LATEST="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-ubuntu1804-${VERSION_60_LATEST}.tgz"
+             MONGODB_60="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-ubuntu1804-${VERSION_60}.tgz"
              MONGODB_50="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-ubuntu1804-${VERSION_50}.tgz"
              MONGODB_44="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-ubuntu1804-${VERSION_44}.tgz"
              MONGODB_42="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-ubuntu1804-${VERSION_42}.tgz"
@@ -399,8 +402,8 @@ get_mongodb_download_url_for ()
          EXTRACT="/cygdrive/c/Progra~2/7-Zip/7z.exe x"
          MONGODB_LATEST="http://downloads.10gen.com/windows/mongodb-windows-x86_64-enterprise-latest.zip"
              MONGODB_RAPID="http://downloads.10gen.com/windows/mongodb-windows-x86_64-enterprise-${VERSION_RAPID}.zip"
-             MONGODB_60_LATEST="http://downloads.10gen.com/windows/mongodb-windows-x86_64-enterprise-${VERSION_60_LATEST}.tgz"
-             MONGODB_60="http://downloads.10gen.com/windows/mongodb-windows-x86_64-enterprise-${VERSION_60}.tgz"
+             MONGODB_60_LATEST="http://downloads.10gen.com/windows/mongodb-windows-x86_64-enterprise-${VERSION_60_LATEST}.zip"
+             MONGODB_60="http://downloads.10gen.com/windows/mongodb-windows-x86_64-enterprise-${VERSION_60}.zip"
              MONGODB_50="http://downloads.10gen.com/windows/mongodb-windows-x86_64-enterprise-${VERSION_50}.zip"
              MONGODB_44="http://downloads.10gen.com/windows/mongodb-windows-x86_64-enterprise-${VERSION_44}.zip"
              MONGODB_42="http://downloads.10gen.com/win32/mongodb-win32-x86_64-enterprise-windows-64-${VERSION_42}.zip"
@@ -466,25 +469,47 @@ get_mongodb_download_url_for ()
       ;;
    esac
 
+   # The crypt_shared package is available on server 6.0 and newer.
+   VERSION_INCLUDES_CRYPT_SHARED=YES
    case "$_VERSION" in
-      latest) MONGODB_DOWNLOAD_URL=$MONGODB_LATEST ;;
-      rapid) MONGODB_DOWNLOAD_URL=$MONGODB_RAPID ;;
+      latest) MONGODB_DOWNLOAD_URL=$MONGODB_LATEST
+         # If latest is not at least 6.0 on this OS, the crypt_shared package will not be available.
+         if [ -z $MONGODB_60 ]; then
+           VERSION_INCLUDES_CRYPT_SHARED=NO
+         fi ;;
+      rapid) MONGODB_DOWNLOAD_URL=$MONGODB_RAPID
+         VERSION_INCLUDES_CRYPT_SHARED=NO ;;
       v6.0-latest) MONGODB_DOWNLOAD_URL=$MONGODB_60_LATEST ;;
       6.0) MONGODB_DOWNLOAD_URL=$MONGODB_60 ;;
-      5.0) MONGODB_DOWNLOAD_URL=$MONGODB_50 ;;
-      4.4) MONGODB_DOWNLOAD_URL=$MONGODB_44 ;;
-      4.2) MONGODB_DOWNLOAD_URL=$MONGODB_42 ;;
-      4.0) MONGODB_DOWNLOAD_URL=$MONGODB_40 ;;
-      3.6) MONGODB_DOWNLOAD_URL=$MONGODB_36 ;;
-      3.4) MONGODB_DOWNLOAD_URL=$MONGODB_34 ;;
-      3.2) MONGODB_DOWNLOAD_URL=$MONGODB_32 ;;
-      3.0) MONGODB_DOWNLOAD_URL=$MONGODB_30 ;;
-      2.6) MONGODB_DOWNLOAD_URL=$MONGODB_26 ;;
-      2.4) MONGODB_DOWNLOAD_URL=$MONGODB_24 ;;
+      5.0) MONGODB_DOWNLOAD_URL=$MONGODB_50
+         VERSION_INCLUDES_CRYPT_SHARED=NO ;;
+      4.4) MONGODB_DOWNLOAD_URL=$MONGODB_44
+         VERSION_INCLUDES_CRYPT_SHARED=NO ;;
+      4.2) MONGODB_DOWNLOAD_URL=$MONGODB_42
+         VERSION_INCLUDES_CRYPT_SHARED=NO ;;
+      4.0) MONGODB_DOWNLOAD_URL=$MONGODB_40
+         VERSION_INCLUDES_CRYPT_SHARED=NO ;;
+      3.6) MONGODB_DOWNLOAD_URL=$MONGODB_36
+         VERSION_INCLUDES_CRYPT_SHARED=NO ;;
+      3.4) MONGODB_DOWNLOAD_URL=$MONGODB_34
+         VERSION_INCLUDES_CRYPT_SHARED=NO ;;
+      3.2) MONGODB_DOWNLOAD_URL=$MONGODB_32
+         VERSION_INCLUDES_CRYPT_SHARED=NO ;;
+      3.0) MONGODB_DOWNLOAD_URL=$MONGODB_30
+         VERSION_INCLUDES_CRYPT_SHARED=NO ;;
+      2.6) MONGODB_DOWNLOAD_URL=$MONGODB_26
+         VERSION_INCLUDES_CRYPT_SHARED=NO ;;
+      2.4) MONGODB_DOWNLOAD_URL=$MONGODB_24
+         VERSION_INCLUDES_CRYPT_SHARED=NO ;;
    esac
 
    [ -z "$MONGODB_DOWNLOAD_URL" ] && MONGODB_DOWNLOAD_URL="Unknown version: $_VERSION for $_DISTRO"
 
+   if [ "$VERSION_INCLUDES_CRYPT_SHARED" = "YES" ]; then
+      # The crypt_shared package is simply the same file URL with the "mongodb-"
+      # prefix replaced with "mongo_crypt_shared_v1-"
+      MONGO_CRYPT_SHARED_DOWNLOAD_URL="$(printf '%s' "$MONGODB_DOWNLOAD_URL" | sed 's|/mongodb-|/mongo_crypt_shared_v1-|')"
+   fi
    echo $MONGODB_DOWNLOAD_URL
 }
 
@@ -536,4 +561,35 @@ download_and_extract ()
       rm -rf $DRIVERS_TOOLS/legacy-shell-download
       echo "Download legacy shell from 5.0 ... end"
    fi
+}
+
+# download_and_extract_crypt_shared downloads and extracts a crypt_shared package into the current directory.
+# Use get_mongodb_download_url_for to get a MONGO_CRYPT_SHARED_DOWNLOAD_URL.
+download_and_extract_crypt_shared ()
+{
+   MONGO_CRYPT_SHARED_DOWNLOAD_URL=$1
+   EXTRACT=$2
+   __CRYPT_SHARED_LIB_PATH=${3:-CRYPT_SHARED_LIB_PATH}
+   mkdir crypt_shared_download
+   cd crypt_shared_download
+   curl --retry 8 -sS $MONGO_CRYPT_SHARED_DOWNLOAD_URL --max-time 300 --output crypt_shared-binaries.tgz
+   $EXTRACT crypt_shared-binaries.tgz
+
+   LIBRARY_NAME="mongo_crypt_v1"
+   # Windows package includes .dll in 'bin' directory.
+   if [ -d ./bin ]; then
+      cp bin/$LIBRARY_NAME.* ..
+   else
+      cp lib/$LIBRARY_NAME.* ..
+   fi
+   cd ..
+   rm -rf crypt_shared_download
+
+   RELATIVE_CRYPT_SHARED_LIB_PATH="$(find . -maxdepth 1 -type f \( -name "$LIBRARY_NAME.dll" -o -name "$LIBRARY_NAME.so" -o -name "$LIBRARY_NAME.dylib" \))"
+   ABSOLUTE_CRYPT_SHARED_LIB_PATH=$(pwd)/$(basename $RELATIVE_CRYPT_SHARED_LIB_PATH)
+   if [ "Windows_NT" = "$OS" ]; then
+      # If we're on Windows, convert the "cygdrive" path to Windows-style paths.
+      ABSOLUTE_CRYPT_SHARED_LIB_PATH=$(cygpath -m $ABSOLUTE_CRYPT_SHARED_LIB_PATH)
+   fi
+   eval $__CRYPT_SHARED_LIB_PATH=$ABSOLUTE_CRYPT_SHARED_LIB_PATH
 }

--- a/build/evergreen_config_lib/variants.py
+++ b/build/evergreen_config_lib/variants.py
@@ -561,10 +561,8 @@ all_variants = [
              '.authentication-tests .openssl',
              '.latest .openssl !.nosasl .server',
              '.latest .nossl',
-             '.5.0 .openssl !.nosasl .server',
-             '.4.4 .openssl !.nosasl .server',
-             '.4.2 .openssl !.nosasl .server',
-             '.4.0 .openssl !.nosasl .server'],
+             '.6.0 .openssl !.nosasl .server',
+             '.5.0 .openssl !.nosasl .server'],
             {'CC': 'gcc'},
             batchtime=days(1)),
     # Note, do not use Ubuntu 16.04 for valgrind, as the system valgrind


### PR DESCRIPTION
## Description

This PR resolves CDRIVER-4361.

Server versions 4.0, 4.2, and 4.4 are not available for zSeries RHEL 8.3, so they have been removed. Server version 6.0 has been added instead.

The `download-mongodb.sh` file was synced with [it's latest state](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/8159c42f559900ca28381b284590756ce3a672c6/.evergreen/download-mongodb.sh) to resolve System Failures on Evergreen due to 5.0.8 no longer being available.

Changes verified by [this patch](https://spruce.mongodb.com/version/6308f5b4850e615766de8ca9).