### PR TITLE
CDRIVER-4468 revert additional ccache checks

### DIFF
--- a/build/cmake/CCache.cmake
+++ b/build/cmake/CCache.cmake
@@ -8,43 +8,15 @@
     ON or OFF.
 ]]
 
-# Find and enable ccache for compiling if not already found.
-if (NOT DEFINED MONGO_USE_CCACHE)
-    find_program (CCACHE_EXECUTABLE ccache)
-    if (CCACHE_EXECUTABLE)
-        message (STATUS "Found ccache: ${CCACHE_EXECUTABLE}")
-
-        execute_process (
-            COMMAND ${CCACHE_EXECUTABLE} --version | perl -ne "print $1 if /^ccache version (.+)$/"
-            OUTPUT_VARIABLE CCACHE_VERSION
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-        )
-
-        # Assume `ccache --version` mentions a simple version string, e.g. "1.2.3".
-        # Permit patch number to be omitted, e.g. "1.2".
-        set (SIMPLE_SEMVER_REGEX "([0-9]+)\.([0-9]+)(\.([0-9]+))?")
-        string (REGEX MATCH "${SIMPLE_SEMVER_REGEX}" CCACHE_VERSION ${CCACHE_VERSION})
-
-        if (CCACHE_VERSION)
-            message (STATUS "Detected ccache version: ${CCACHE_VERSION}")
-        else ()
-            message (WARNING "Could not obtain ccache version from `ccache --version`. Defaulting to 0.1.0.")
-            set (CCACHE_VERSION 0.1.0)
-        endif ()
-
-        # Avoid spurious "ccache.conf: No such file or directory" errors due to ccache being invoked in parallel, which was patched in ccache version 3.4.3.
-        if (${CCACHE_VERSION} VERSION_LESS 3.4.3)
-            message (STATUS "Detected ccache version ${CCACHE_VERSION} is less than 3.4.3, which may lead to spurious failures when run in parallel. See https://github.com/ccache/ccache/issues/260 for more information.")
-            message (STATUS "Compiling with CCache disabled. Enable by setting MONGO_USE_CCACHE to ON")
-            option (MONGO_USE_CCACHE "Use CCache when compiling" OFF)
-        else ()
-            message (STATUS "Compiling with CCache enabled. Disable by setting MONGO_USE_CCACHE to OFF")
-            option (MONGO_USE_CCACHE "Use CCache when compiling" ON)
-        endif ()
-    endif (CCACHE_EXECUTABLE)
-endif (NOT DEFINED MONGO_USE_CCACHE)
+# Find and enable ccache for compiling
+find_program (CCACHE_EXECUTABLE ccache)
+if (CCACHE_EXECUTABLE)
+    message (STATUS "Found ccache: ${CCACHE_EXECUTABLE}")
+    option (MONGO_USE_CCACHE "Use CCache when compiling" ON)
+endif ()
 
 if (MONGO_USE_CCACHE)
+    message (STATUS "Compiling with CCache enabled. Disable by setting MONGO_USE_CCACHE to OFF")
     set (CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_EXECUTABLE}")
     set (CMAKE_C_COMPILER_LAUNCHER "${CCACHE_EXECUTABLE}")
 endif ()


### PR DESCRIPTION
# Summary
- Revert changes of https://github.com/mongodb/mongo-c-driver/pull/1031 and https://github.com/mongodb/mongo-c-driver/pull/1029.

# Background & Motivation
The changes appear to introduce a regression building on macOS:

```
-- Found ccache: /usr/local/bin/ccache
ccache: invalid option -- n
CMake Error at build/cmake/CCache.cmake:28 (string):
  string sub-command REGEX, mode MATCH needs at least 5 arguments total to
  command.
Call Stack (most recent call first):
  CMakeLists.txt:86 (include)
```

This was noticed during an attempt to prepare a release for 1.23.0. I had not noticed before since I was configuring with `MONGO_USE_CCACHE=ON`.

[This comment](https://jira.mongodb.org/browse/CDRIVER-4468?focusedCommentId=4791607&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-4791607) has additional details.

The fix is not obvious to me. Since these are improvements intended for stability in Evergreen, I want to revert to unblock the 1.23.0 release for today.