### PR TITLE
CDRIVER-4427 use stable mongo_crypt shared for tests

### DIFF
--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -878,7 +878,7 @@ if (MONGOC_TEST_USE_CRYPT_SHARED)
       COMMAND
          "${_PYTHON3_EXE}" -u "${mongo-c-driver_SOURCE_DIR}/build/mongodl.py"
             --component crypt_shared
-            --version 6.0.0-rc8
+            --version 6.0.0
             --edition enterprise
             --out "${CMAKE_CURRENT_BINARY_DIR}"
             --only "**/mongo_crypt_v1.*"


### PR DESCRIPTION
# Scope
- Use a stable version of the `crypt_shared` library for downloads.

# Background & Motivation
A user reported an error downloading `crypt_shared` attempting to build all targets: https://www.mongodb.com/community/forums/t/problem-downloading-crypt-shared-when-installing-the-mongodb-c-driver/189370

Until CDRIVER-4427 is fully resolved, it may be a small improvement to use a stable version of the `crypt_shared` library for downloads.