### PR TITLE
IMDS Mock Server Testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,9 @@ include (MakeDistFiles)
 
 # Enable CTest
 include (CTest)
+if (BUILD_TESTING)
+   include (TestFixtures)
+endif ()
 
 # Ensure the default behavior: don't ignore RPATH settings.
 set (CMAKE_SKIP_BUILD_RPATH OFF)

--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -15,6 +15,7 @@ set (build_cmake_MODULES
    Sanitizers.cmake
    CCache.cmake
    LLDLinker.cmake
+   TestFixtures.cmake
 )
 
 set_local_dist (build_cmake_DIST_local

--- a/build/cmake/LoadTests.cmake
+++ b/build/cmake/LoadTests.cmake
@@ -26,7 +26,7 @@ endif ()
 # Split lines on newlines
 string (REPLACE "\n" ";" lines "${tests_out}")
 
-# XXX: Allow individual test cases to specify the fixtures they want.
+# TODO: Allow individual test cases to specify the fixtures they want.
 set (all_fixtures "mongoc/fixtures/fake_imds")
 set (all_env
     MCD_TEST_AZURE_IMDS_HOST=localhost:14987  # Refer: Fixtures.cmake

--- a/build/cmake/LoadTests.cmake
+++ b/build/cmake/LoadTests.cmake
@@ -26,6 +26,12 @@ endif ()
 # Split lines on newlines
 string (REPLACE "\n" ";" lines "${tests_out}")
 
+# XXX: Allow individual test cases to specify the fixtures they want.
+set (all_fixtures "mongoc/fixtures/fake_imds")
+set (all_env
+    MCD_TEST_AZURE_IMDS_HOST=localhost:14987  # Refer: Fixtures.cmake
+    )
+
 # Generate the test definitions
 foreach (line IN LISTS lines)
     if (NOT line MATCHES "^/")
@@ -44,5 +50,7 @@ foreach (line IN LISTS lines)
         SKIP_REGULAR_EXPRESSION "@@ctest-skipped@@"
         # 45 seconds of timeout on each test.
         TIMEOUT 45
+        FIXTURES_REQUIRED "${all_fixtures}"
+        ENVIRONMENT "${all_env}"
         )
 endforeach ()

--- a/build/cmake/TestFixtures.cmake
+++ b/build/cmake/TestFixtures.cmake
@@ -1,0 +1,49 @@
+find_package (Python3 COMPONENTS Interpreter)
+
+if (NOT TARGET Python3::Interpreter)
+    message (STATUS "Python3 was not found, so test fixtures will not be defined")
+    return ()
+endif ()
+
+get_filename_component(_MONGOC_BUILD_SCRIPT_DIR "${CMAKE_CURRENT_LIST_DIR}" DIRECTORY)
+set (_MONGOC_PROC_CTL_COMMAND "$<TARGET_FILE:Python3::Interpreter>" -u -- "${_MONGOC_BUILD_SCRIPT_DIR}/proc-ctl.py")
+
+
+function (mongo_define_subprocess_fixture name)
+    cmake_parse_arguments(PARSE_ARGV 1 ARG "" "SPAWN_WAIT;STOP_WAIT;WORKING_DIRECTORY" "COMMAND")
+    string (MAKE_C_IDENTIFIER ident "${name}")
+    if (NOT ARG_SPAWN_WAIT)
+        set (ARG_SPAWN_WAIT 1)
+    endif ()
+    if (NOT ARG_STOP_WAIT)
+        set (ARG_STOP_WAIT 5)
+    endif ()
+    if (NOT ARG_WORKING_DIRECTORY)
+        set (ARG_WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+    endif ()
+    if (NOT ARG_COMMAND)
+        message (SEND_ERROR "mongo_define_subprocess_fixture(${name}) requires a COMMAND")
+        return ()
+    endif ()
+    get_filename_component (ctl_dir "${CMAKE_CURRENT_BINARY_DIR}/${ident}.ctl" ABSOLUTE)
+    add_test (NAME "${name}/start"
+              COMMAND ${_MONGOC_PROC_CTL_COMMAND} start
+                "--ctl-dir=${ctl_dir}"
+                "--cwd=${ARG_WORKING_DIRECTORY}"
+                "--spawn-wait=${ARG_SPAWN_WAIT}"
+                -- ${ARG_COMMAND})
+    add_test (NAME "${name}/stop"
+              COMMAND ${_MONGOC_PROC_CTL_COMMAND} stop "--ctl-dir=${ctl_dir}" --if-not-running=ignore)
+    set_property (TEST "${name}/start" PROPERTY FIXTURES_SETUP "${name}")
+    set_property (TEST "${name}/stop" PROPERTY FIXTURES_CLEANUP "${name}")
+endfunction ()
+
+# Create a fixture that runs a fake Azure IMDS server
+mongo_define_subprocess_fixture(
+    mongoc/fixtures/fake_imds
+    SPAWN_WAIT 0.2
+    COMMAND
+        "$<TARGET_FILE:Python3::Interpreter>" -u --
+        "${_MONGOC_BUILD_SCRIPT_DIR}/bottle.py" fake_azure:imds
+            --bind localhost:14987  # Port 14987 chosen arbitrarily
+    )

--- a/build/proc-ctl.py
+++ b/build/proc-ctl.py
@@ -1,0 +1,271 @@
+"""
+Extremely basic subprocess control
+"""
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+import traceback
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING, NoReturn, Sequence, Union, cast
+
+if TYPE_CHECKING:
+    from typing import (Literal, NamedTuple, TypedDict)
+
+INTERUPT_SIGNAL = signal.SIGINT if os.name != 'nt' else signal.CTRL_C_SIGNAL
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser('proc-ctl')
+    grp = parser.add_subparsers(title='Commands',
+                                dest='command',
+                                metavar='<subcommand>')
+
+    start = grp.add_parser('start', help='Start a new subprocess')
+    start.add_argument('--ctl-dir',
+                       help='The control directory for the subprocess',
+                       required=True,
+                       type=Path)
+    start.add_argument('--cwd',
+                       help='The new subdirectory of the spawned process',
+                       type=Path)
+    start.add_argument(
+        '--spawn-wait',
+        help='Number of seconds to wait for child to be running',
+        type=float,
+        default=3)
+    start.add_argument('child_command',
+                       nargs=argparse.REMAINDER,
+                       help='The command to execute',
+                       metavar='<command> [args...]')
+
+    stop = grp.add_parser('stop', help='Stop a running subprocess')
+    stop.add_argument('--ctl-dir',
+                      help='The control directory for the subprocess',
+                      required=True,
+                      type=Path)
+    stop.add_argument('--stop-wait',
+                      help='Number of seconds to wait for stopping',
+                      type=float,
+                      default=5)
+    stop.add_argument('--if-not-running',
+                      help='Action to take if the child is not running',
+                      choices=['fail', 'ignore'],
+                      default='fail')
+
+    ll_run = grp.add_parser('__run')
+    ll_run.add_argument('--ctl-dir', type=Path, required=True)
+    ll_run.add_argument('child_command', nargs=argparse.REMAINDER)
+
+    return parser
+
+
+if TYPE_CHECKING:
+    StartCommandArgs = NamedTuple('StartCommandArgs', [
+        ('command', Literal['start']),
+        ('ctl_dir', Path),
+        ('cwd', Path),
+        ('child_command', Sequence[str]),
+        ('spawn_wait', int),
+    ])
+
+    StopCommandArgs = NamedTuple('StopCommandArgs', [
+        ('command', Literal['stop']),
+        ('ctl_dir', Path),
+        ('stop_wait', float),
+        ('if_not_running', Literal['fail', 'ignore']),
+    ])
+
+    _RunCommandArgs = NamedTuple('_RunCommandArgs', [
+        ('command', Literal['__run']),
+        ('child_command', Sequence[str]),
+        ('ctl_dir', Path),
+    ])
+
+    CommandArgs = Union[StartCommandArgs, StopCommandArgs, _RunCommandArgs]
+
+    _ResultType = TypedDict('_ResultType', {
+        'exit': 'str | int | None',
+        'error': 'str | None'
+    })
+
+
+def parse_argv(argv: 'Sequence[str]') -> 'CommandArgs':
+    parser = create_parser()
+    args = parser.parse_args(argv)
+    return cast('CommandArgs', args)
+
+
+class _ChildControl:
+
+    def __init__(self, ctl_dir: Path) -> None:
+        self._ctl_dir = ctl_dir
+
+    @property
+    def pid_file(self):
+        """The file containing the child PID"""
+        return self._ctl_dir / 'pid.txt'
+
+    @property
+    def result_file(self):
+        """The file containing the exit result"""
+        return self._ctl_dir / 'exit.json'
+
+    def set_pid(self, pid: int):
+        self.pid_file.write_text(str(pid))
+
+    def get_pid(self) -> 'int | None':
+        try:
+            txt = self.pid_file.read_text()
+        except FileNotFoundError:
+            return None
+        return int(txt)
+
+    def set_exit(self, exit: 'str | int | None', error: 'str | None') -> None:
+        self.result_file.write_text(json.dumps({'exit': exit, 'error': error}))
+        self._unlink(self.pid_file)
+
+    def get_result(self) -> 'None | _ResultType':
+        try:
+            txt = self.result_file.read_text()
+        except FileNotFoundError:
+            return None
+        try:
+            return json.loads(txt)
+        except json.JSONDecodeError:
+            return self.get_result()
+
+    def clear_result(self) -> None:
+        self._unlink(self.result_file)
+
+    @staticmethod
+    def _unlink(p: Path) -> None:
+        try:
+            p.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _start(args: 'StartCommandArgs') -> int:
+    ll_run_cmd = [
+        sys.executable,
+        '-u',
+        '--',
+        __file__,
+        '__run',
+        '--ctl-dir={}'.format(args.ctl_dir),
+        '--',
+        *args.child_command[1:],
+    ]
+    args.ctl_dir.mkdir(exist_ok=True, parents=True)
+    child = _ChildControl(args.ctl_dir)
+    if child.get_pid() is not None:
+        raise RuntimeError('Child process is already running [PID {}]'.format(
+            child.get_pid()))
+    child.clear_result()
+    # Spawn the child controller
+    subprocess.Popen(
+        ll_run_cmd,
+        cwd=args.cwd,
+        stderr=subprocess.STDOUT,
+        stdout=args.ctl_dir.joinpath('.runner-output.txt').open('wb'),
+        stdin=subprocess.DEVNULL)
+    expire = datetime.now() + timedelta(seconds=args.spawn_wait)
+    # Wait for the PID to appear
+    while child.get_pid() is None and child.get_result() is None:
+        if expire < datetime.now():
+            break
+    # Check that it actually spawned
+    if child.get_pid() is None:
+        result = child.get_result()
+        if result is None:
+            raise RuntimeError('Failed to spawn child runner?')
+        if result['error']:
+            print(result['error'], file=sys.stderr)
+        raise RuntimeError('Child exited immediately [Exited {}]'.format(
+            result['exit']))
+    # Wait to see that it is still running after --spawn-wait seconds
+    while child.get_result() is None:
+        if expire < datetime.now():
+            break
+    # A final check to see if it is running
+    result = child.get_result()
+    if result is not None:
+        if result['error']:
+            print(result['error'], file=sys.stderr)
+        raise RuntimeError('Child exited prematurely [Exited {}]'.format(
+            result['exit']))
+    return 0
+
+
+def _stop(args: 'StopCommandArgs') -> int:
+    child = _ChildControl(args.ctl_dir)
+    pid = child.get_pid()
+    if pid is None:
+        if args.if_not_running == 'fail':
+            raise RuntimeError('Child process is not running')
+        elif args.if_not_running == 'ignore':
+            # Nothing to do
+            return 0
+        else:
+            assert False
+    os.kill(pid, INTERUPT_SIGNAL)
+    expire_at = datetime.now() + timedelta(seconds=args.stop_wait)
+    while expire_at > datetime.now() and child.get_result() is None:
+        pass
+    result = child.get_result()
+    if result is None:
+        raise RuntimeError(
+            'Child process did not exit within the grace period')
+    return 0
+
+
+def __run(args: '_RunCommandArgs') -> int:
+    this = _ChildControl(args.ctl_dir)
+    try:
+        pipe = subprocess.Popen(
+            args.child_command[1:],
+            stdout=args.ctl_dir.joinpath('child-output.txt').open('wb'),
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL)
+    except:
+        this.set_exit('spawn-failed', traceback.format_exc())
+        raise
+    this.set_pid(pipe.pid)
+    retc = None
+    try:
+        while 1:
+            try:
+                retc = pipe.wait(0.5)
+            except subprocess.TimeoutExpired:
+                pass
+            except KeyboardInterrupt:
+                pipe.send_signal(INTERUPT_SIGNAL)
+            if retc is not None:
+                break
+    finally:
+        this.set_exit(retc, None)
+    return 0
+
+
+def main(argv: 'Sequence[str]') -> int:
+    args = parse_argv(argv)
+    if args.command == 'start':
+        return _start(args)
+    if args.command == '__run':
+        return __run(args)
+    if args.command == 'stop':
+        return _stop(args)
+    return 0
+
+
+def start_main() -> NoReturn:
+    sys.exit(main(sys.argv[1:]))
+
+
+if __name__ == '__main__':
+    start_main()

--- a/src/libmongoc/tests/test-mcd-azure-imds.c
+++ b/src/libmongoc/tests/test-mcd-azure-imds.c
@@ -102,15 +102,13 @@ _test_with_mock_server (void *ctx)
    _run_http_test_case ("", 0, 0, ""); // (No error)
    _run_http_test_case ("404", MONGOC_ERROR_AZURE, MONGOC_ERROR_AZURE_HTTP, "");
    _run_http_test_case (
+      "slow", MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Timeout");
+   _run_http_test_case (
       "empty-json", MONGOC_ERROR_AZURE, MONGOC_ERROR_AZURE_BAD_JSON, "");
    _run_http_test_case (
       "bad-json", MONGOC_ERROR_CLIENT, MONGOC_ERROR_STREAM_INVALID_TYPE, "");
-
    _run_http_test_case (
       "giant", MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "too large");
-
-   _run_http_test_case (
-      "slow", MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Timeout");
 }
 
 static int


### PR DESCRIPTION
This is a follow-up to #1104. This changeset introduces automated testing of the IMDS server via CTest test fixtures. CTest will handle spawning and stopping the IMDS server as it is needed for executing tests. The `fake_azure.py` script was cleaned up for older Python compatibility in anticipation of sharing with other driver codebases and other platforms.