### PR TITLE
CDRIVER-3882 Support AWS temporary credentials

### DIFF
--- a/.evergreen/add-build-dirs-to-paths.sh
+++ b/.evergreen/add-build-dirs-to-paths.sh
@@ -5,12 +5,12 @@ set_path ()
 {
    case "$OS" in
       cygwin*)
-         export PATH=$PATH:`pwd`/src/libbson/Debug
-         export PATH=$PATH:`pwd`/src/libbson/Release
-         export PATH=$PATH:`pwd`/install-dir/bin
+         export PATH="$PATH:$(pwd)/src/libbson/Debug"
+         export PATH="$PATH:$(pwd)/src/libbson/Release"
+         export PATH="$PATH:$(pwd)/install-dir/bin"
          chmod +x src/libmongoc/Debug/* src/libbson/Debug/* || true
          chmod +x src/libmongoc/Release/* src/libbson/Release/* || true
-         chmod +x `pwd`/install-dir/bin/* || true
+         chmod +x $(pwd)/install-dir/bin/* || true
          ;;
 
       darwin)

--- a/.evergreen/add-build-dirs-to-paths.sh
+++ b/.evergreen/add-build-dirs-to-paths.sh
@@ -8,9 +8,11 @@ set_path ()
          export PATH="$PATH:$(pwd)/src/libbson/Debug"
          export PATH="$PATH:$(pwd)/src/libbson/Release"
          export PATH="$PATH:$(pwd)/install-dir/bin"
-         chmod +x src/libmongoc/Debug/* src/libbson/Debug/* || true
-         chmod +x src/libmongoc/Release/* src/libbson/Release/* || true
-         chmod +x $(pwd)/install-dir/bin/* || true
+         chmod -f +x src/libmongoc/Debug/* || true
+         chmod -f +x src/libbson/Debug/* || true
+         chmod -f +x src/libmongoc/Release/* || true
+         chmod -f +x src/libbson/Release/* || true
+         chmod -f +x $(pwd)/install-dir/bin/* || true
          ;;
 
       darwin)

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -796,7 +796,7 @@ functions:
         if [ ! -d "drivers-evergreen-tools" ]; then
             git clone git@github.com:mongodb-labs/drivers-evergreen-tools.git --depth=1
         fi
-  prepare csfle venv:
+  run kms servers:
   - command: shell.exec
     params:
       shell: bash
@@ -812,7 +812,6 @@ functions:
         . ./activate_venv.sh
         deactivate
         echo "Preparing CSFLE venv environment... done."
-  run kms servers:
   - command: shell.exec
     params:
       background: true
@@ -3103,7 +3102,6 @@ tasks:
       TOPOLOGY: server
       VERSION: latest
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -3177,7 +3175,6 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: latest
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -3297,7 +3294,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -3371,7 +3367,6 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -3491,7 +3486,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '5.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -3657,7 +3651,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.4'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -3823,7 +3816,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.2'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -6031,7 +6023,6 @@ tasks:
       TOPOLOGY: server
       VERSION: latest
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -6086,7 +6077,6 @@ tasks:
       TOPOLOGY: server
       VERSION: latest
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -6141,7 +6131,6 @@ tasks:
       TOPOLOGY: server
       VERSION: latest
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -6196,7 +6185,6 @@ tasks:
       TOPOLOGY: server
       VERSION: latest
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -6376,7 +6364,6 @@ tasks:
       TOPOLOGY: server
       VERSION: latest
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -6431,7 +6418,6 @@ tasks:
       TOPOLOGY: server
       VERSION: latest
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -6486,7 +6472,6 @@ tasks:
       TOPOLOGY: server
       VERSION: latest
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -6541,7 +6526,6 @@ tasks:
       TOPOLOGY: server
       VERSION: latest
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -6721,7 +6705,6 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: latest
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -6776,7 +6759,6 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: latest
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -6831,7 +6813,6 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: latest
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -6886,7 +6867,6 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: latest
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -7041,7 +7021,6 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: latest
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -7096,7 +7075,6 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: latest
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -7151,7 +7129,6 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: latest
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -7206,7 +7183,6 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: latest
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -7811,7 +7787,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -7866,7 +7841,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -7921,7 +7895,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -7976,7 +7949,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -8131,7 +8103,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -8186,7 +8157,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -8241,7 +8211,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -8296,7 +8265,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -8476,7 +8444,6 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -8531,7 +8498,6 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -8586,7 +8552,6 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -8641,7 +8606,6 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -8796,7 +8760,6 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -8851,7 +8814,6 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -8906,7 +8868,6 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -8961,7 +8922,6 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -9566,7 +9526,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '5.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -9621,7 +9580,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '5.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -9676,7 +9634,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '5.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -9731,7 +9688,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '5.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -9886,7 +9842,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '5.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -9941,7 +9896,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '5.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -9996,7 +9950,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '5.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -10051,7 +10004,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '5.0'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -11081,7 +11033,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.4'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -11136,7 +11087,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.4'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -11191,7 +11141,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.4'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -11246,7 +11195,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.4'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -11401,7 +11349,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.4'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -11456,7 +11403,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.4'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -11511,7 +11457,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.4'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -11566,7 +11511,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.4'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -12596,7 +12540,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.2'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -12651,7 +12594,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.2'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -12706,7 +12648,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.2'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -12761,7 +12702,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.2'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -12916,7 +12856,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.2'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -12971,7 +12910,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.2'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -13026,7 +12964,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.2'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -13081,7 +13018,6 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.2'
   - func: clone drivers-evergreen-tools
-  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -443,7 +443,7 @@ functions:
           . ./activate_venv.sh
           echo "Running activate_venv.sh... done."
           echo "Running set-temp-creds.sh..."
-          . ./set-temp-creds.sh
+          PYTHON="$(type -P python)" . ./set-temp-creds.sh
           echo "Running set-temp-creds.sh... done."
           popd
           echo "Setting temporary credentials... done."

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -796,6 +796,22 @@ functions:
         if [ ! -d "drivers-evergreen-tools" ]; then
             git clone git@github.com:mongodb-labs/drivers-evergreen-tools.git --depth=1
         fi
+  prepare csfle venv:
+  - command: shell.exec
+    params:
+      shell: bash
+      script: |-
+        set -o errexit
+        echo "Preparing CSFLE venv environment..."
+        cd ./drivers-evergreen-tools/.evergreen/csfle
+        # This function ensures future invocations of activate_venv.sh conducted in
+        # parallel do not race to setup a venv environment; it has already been prepared.
+        # This primarily addresses the situation where the "run tests" and "run kms servers"
+        # functions invoke 'activate_venv.sh' simultaneously.
+        # TODO: remove this function along with the "run kms servers" function.
+        . ./activate_venv.sh
+        deactivate
+        echo "Preparing CSFLE venv environment... done."
   run kms servers:
   - command: shell.exec
     params:
@@ -3087,6 +3103,7 @@ tasks:
       TOPOLOGY: server
       VERSION: latest
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -3160,6 +3177,7 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: latest
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -3279,6 +3297,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -3352,6 +3371,7 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -3471,6 +3491,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '5.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -3636,6 +3657,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.4'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -3801,6 +3823,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.2'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -6008,6 +6031,7 @@ tasks:
       TOPOLOGY: server
       VERSION: latest
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -6062,6 +6086,7 @@ tasks:
       TOPOLOGY: server
       VERSION: latest
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -6116,6 +6141,7 @@ tasks:
       TOPOLOGY: server
       VERSION: latest
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -6170,6 +6196,7 @@ tasks:
       TOPOLOGY: server
       VERSION: latest
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -6349,6 +6376,7 @@ tasks:
       TOPOLOGY: server
       VERSION: latest
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -6403,6 +6431,7 @@ tasks:
       TOPOLOGY: server
       VERSION: latest
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -6457,6 +6486,7 @@ tasks:
       TOPOLOGY: server
       VERSION: latest
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -6511,6 +6541,7 @@ tasks:
       TOPOLOGY: server
       VERSION: latest
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -6690,6 +6721,7 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: latest
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -6744,6 +6776,7 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: latest
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -6798,6 +6831,7 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: latest
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -6852,6 +6886,7 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: latest
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -7006,6 +7041,7 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: latest
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -7060,6 +7096,7 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: latest
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -7114,6 +7151,7 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: latest
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -7168,6 +7206,7 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: latest
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -7772,6 +7811,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -7826,6 +7866,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -7880,6 +7921,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -7934,6 +7976,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -8088,6 +8131,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -8142,6 +8186,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -8196,6 +8241,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -8250,6 +8296,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -8429,6 +8476,7 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -8483,6 +8531,7 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -8537,6 +8586,7 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -8591,6 +8641,7 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -8745,6 +8796,7 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -8799,6 +8851,7 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -8853,6 +8906,7 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -8907,6 +8961,7 @@ tasks:
       TOPOLOGY: replica_set
       VERSION: '6.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -9511,6 +9566,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '5.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -9565,6 +9621,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '5.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -9619,6 +9676,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '5.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -9673,6 +9731,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '5.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -9827,6 +9886,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '5.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -9881,6 +9941,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '5.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -9935,6 +9996,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '5.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -9989,6 +10051,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '5.0'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -11018,6 +11081,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.4'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -11072,6 +11136,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.4'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -11126,6 +11191,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.4'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -11180,6 +11246,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.4'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -11334,6 +11401,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.4'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -11388,6 +11456,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.4'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -11442,6 +11511,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.4'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -11496,6 +11566,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.4'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -12525,6 +12596,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.2'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -12579,6 +12651,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.2'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -12633,6 +12706,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.2'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -12687,6 +12761,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.2'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -12841,6 +12916,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.2'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -12895,6 +12971,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.2'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -12949,6 +13026,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.2'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:
@@ -13003,6 +13081,7 @@ tasks:
       TOPOLOGY: server
       VERSION: '4.2'
   - func: clone drivers-evergreen-tools
+  - func: prepare csfle venv
   - func: run kms servers
   - func: run tests
     vars:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -439,8 +439,12 @@ functions:
           export AWS_SECRET_ACCESS_KEY="${client_side_encryption_aws_secret_access_key}"
           export AWS_ACCESS_KEY_ID="${client_side_encryption_aws_access_key_id}"
           export AWS_DEFAULT_REGION="us-east-1"
-          . ./activate_venv.sh || true # May have already been activated.
+          echo "Running activate_venv.sh..."
+          . ./activate_venv.sh
+          echo "Running activate_venv.sh... done."
+          echo "Running set-temp-creds.sh..."
           . ./set-temp-creds.sh
+          echo "Running set-temp-creds.sh... done."
           popd
           echo "Setting temporary credentials... done."
           # Ensure temporary credentials were properly set.

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -445,6 +445,7 @@ functions:
           echo "Running set-temp-creds.sh..."
           PYTHON="$(type -P python)" . ./set-temp-creds.sh
           echo "Running set-temp-creds.sh... done."
+          deactivate
           popd
           echo "Setting temporary credentials... done."
           # Ensure temporary credentials were properly set.
@@ -810,6 +811,7 @@ functions:
         python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 9001 &
         python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/server.pem --require_client_cert --port 9002 &
         python -u kms_kmip_server.py &
+        deactivate
         echo "Starting mock KMS servers... done."
   start load balancer:
   - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -427,16 +427,33 @@ functions:
         export DNS=${DNS}
         export ASAN=${ASAN}
         export CLIENT_SIDE_ENCRYPTION=${CLIENT_SIDE_ENCRYPTION}
-        # Hide credentials.
-        set +o xtrace
-        set +o errexit
         # Only set creds if testing with Client Side Encryption.
         # libmongoc may build with CSE enabled (if the host has libmongocrypt installed)
         # and will try to run those tests (which fail on ASAN unless spawning is bypassed).
         if [ -n "$CLIENT_SIDE_ENCRYPTION" ]; then
-          echo "testing with CSE"
-          export MONGOC_TEST_AWS_SECRET_ACCESS_KEY="${client_side_encryption_aws_secret_access_key}"
-          export MONGOC_TEST_AWS_ACCESS_KEY_ID="${client_side_encryption_aws_access_key_id}"
+          # Avoid printing credentials in logs.
+          set +o xtrace
+          echo "Testing with Client Side Encryption enabled."
+          echo "Setting temporary credentials..."
+          pushd ../drivers-evergreen-tools/.evergreen/csfle
+          export AWS_SECRET_ACCESS_KEY="${client_side_encryption_aws_secret_access_key}"
+          export AWS_ACCESS_KEY_ID="${client_side_encryption_aws_access_key_id}"
+          export AWS_DEFAULT_REGION="us-east-1"
+          . ./activate_venv.sh || true # May have already been activated.
+          . ./set-temp-creds.sh
+          popd
+          echo "Setting temporary credentials... done."
+          # Ensure temporary credentials were properly set.
+          if [ -z "$CSFLE_AWS_TEMP_ACCESS_KEY_ID" ]; then
+            echo "Failed to set temporary credentials!"
+            exit 1
+          fi
+          echo "Setting KMS credentials from the environment..."
+          export MONGOC_TEST_AWS_TEMP_ACCESS_KEY_ID="$CSFLE_AWS_TEMP_ACCESS_KEY_ID"
+          export MONGOC_TEST_AWS_TEMP_SECRET_ACCESS_KEY="$CSFLE_AWS_TEMP_SECRET_ACCESS_KEY"
+          export MONGOC_TEST_AWS_TEMP_SESSION_TOKEN="$CSFLE_AWS_TEMP_SESSION_TOKEN"
+          export MONGOC_TEST_AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"
+          export MONGOC_TEST_AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"
           export MONGOC_TEST_AZURE_TENANT_ID="${client_side_encryption_azure_tenant_id}"
           export MONGOC_TEST_AZURE_CLIENT_ID="${client_side_encryption_azure_client_id}"
           export MONGOC_TEST_AZURE_CLIENT_SECRET="${client_side_encryption_azure_client_secret}"
@@ -444,6 +461,7 @@ functions:
           export MONGOC_TEST_GCP_PRIVATEKEY="${client_side_encryption_gcp_privatekey}"
           export MONGOC_TEST_CSFLE_TLS_CA_FILE=../drivers-evergreen-tools/.evergreen/x509gen/ca.pem
           export MONGOC_TEST_CSFLE_TLS_CERTIFICATE_KEY_FILE=../drivers-evergreen-tools/.evergreen/x509gen/client.pem
+          echo "Setting KMS credentials from the environment... done."
         fi
         export LOADBALANCED=${LOADBALANCED}
         export SINGLE_MONGOS_LB_URI="${SINGLE_MONGOS_LB_URI}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,6 +248,14 @@ For GCP:
 * `MONGOC_TEST_GCP_EMAIL=<string>`
 * `MONGOC_TEST_GCP_PRIVATEKEY=<string>`
 
+Tests of Client-Side Field Level Encryption also require temporary credentials to external KMS providers.
+
+For AWS:
+
+* `MONGOC_TEST_AWS_TEMP_SECRET_ACCESS_KEY=<string>`
+* `MONGOC_TEST_AWS_TEMP_ACCESS_KEY_ID=<string>`
+* `MONGOC_TEST_AWS_TEMP_SESSION_TOKEN=<string>`
+
 Tests of Client-Side Field Level Encryption spawn an extra process, "mongocryptd", by default. To bypass this spawning,
 start mongocryptd on port 27020 and set the following:
 

--- a/build/evergreen_config_lib/functions.py
+++ b/build/evergreen_config_lib/functions.py
@@ -587,7 +587,7 @@ all_functions = OD([
         fi
         ''', test=False)
     )),
-    ('prepare csfle venv', Function(
+    ('run kms servers', Function(
         shell_exec(r'''
         echo "Preparing CSFLE venv environment..."
         cd ./drivers-evergreen-tools/.evergreen/csfle
@@ -599,9 +599,7 @@ all_functions = OD([
         . ./activate_venv.sh
         deactivate
         echo "Preparing CSFLE venv environment... done."
-        ''', test=False)
-    )),
-    ('run kms servers', Function(
+        ''', test=False),
         shell_exec(r'''
         echo "Starting mock KMS servers..."
         cd ./drivers-evergreen-tools/.evergreen/csfle

--- a/build/evergreen_config_lib/functions.py
+++ b/build/evergreen_config_lib/functions.py
@@ -587,6 +587,20 @@ all_functions = OD([
         fi
         ''', test=False)
     )),
+    ('prepare csfle venv', Function(
+        shell_exec(r'''
+        echo "Preparing CSFLE venv environment..."
+        cd ./drivers-evergreen-tools/.evergreen/csfle
+        # This function ensures future invocations of activate_venv.sh conducted in
+        # parallel do not race to setup a venv environment; it has already been prepared.
+        # This primarily addresses the situation where the "run tests" and "run kms servers"
+        # functions invoke 'activate_venv.sh' simultaneously.
+        # TODO: remove this function along with the "run kms servers" function.
+        . ./activate_venv.sh
+        deactivate
+        echo "Preparing CSFLE venv environment... done."
+        ''', test=False)
+    )),
     ('run kms servers', Function(
         shell_exec(r'''
         echo "Starting mock KMS servers..."

--- a/build/evergreen_config_lib/functions.py
+++ b/build/evergreen_config_lib/functions.py
@@ -315,7 +315,7 @@ all_functions = OD([
           . ./activate_venv.sh
           echo "Running activate_venv.sh... done."
           echo "Running set-temp-creds.sh..."
-          . ./set-temp-creds.sh
+          PYTHON="$(type -P python)" . ./set-temp-creds.sh
           echo "Running set-temp-creds.sh... done."
           popd
           echo "Setting temporary credentials... done."

--- a/build/evergreen_config_lib/functions.py
+++ b/build/evergreen_config_lib/functions.py
@@ -317,6 +317,7 @@ all_functions = OD([
           echo "Running set-temp-creds.sh..."
           PYTHON="$(type -P python)" . ./set-temp-creds.sh
           echo "Running set-temp-creds.sh... done."
+          deactivate
           popd
           echo "Setting temporary credentials... done."
 
@@ -596,6 +597,7 @@ all_functions = OD([
         python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 9001 &
         python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/server.pem --require_client_cert --port 9002 &
         python -u kms_kmip_server.py &
+        deactivate
         echo "Starting mock KMS servers... done."
         ''', test=False, background=True),
     )),

--- a/build/evergreen_config_lib/functions.py
+++ b/build/evergreen_config_lib/functions.py
@@ -311,8 +311,12 @@ all_functions = OD([
           export AWS_SECRET_ACCESS_KEY="${client_side_encryption_aws_secret_access_key}"
           export AWS_ACCESS_KEY_ID="${client_side_encryption_aws_access_key_id}"
           export AWS_DEFAULT_REGION="us-east-1"
+          echo "Running activate_venv.sh..."
           . ./activate_venv.sh
+          echo "Running activate_venv.sh... done."
+          echo "Running set-temp-creds.sh..."
           . ./set-temp-creds.sh
+          echo "Running set-temp-creds.sh... done."
           popd
           echo "Setting temporary credentials... done."
 

--- a/build/evergreen_config_lib/functions.py
+++ b/build/evergreen_config_lib/functions.py
@@ -296,26 +296,46 @@ all_functions = OD([
         export DNS=${DNS}
         export ASAN=${ASAN}
         export CLIENT_SIDE_ENCRYPTION=${CLIENT_SIDE_ENCRYPTION}
-        # Hide credentials.
-        set +o xtrace
-        set +o errexit
+
         # Only set creds if testing with Client Side Encryption.
         # libmongoc may build with CSE enabled (if the host has libmongocrypt installed)
         # and will try to run those tests (which fail on ASAN unless spawning is bypassed).
         if [ -n "$CLIENT_SIDE_ENCRYPTION" ]; then
-          echo "testing with CSE"
-          export MONGOC_TEST_AWS_SECRET_ACCESS_KEY="${client_side_encryption_aws_secret_access_key}"
-          export MONGOC_TEST_AWS_ACCESS_KEY_ID="${client_side_encryption_aws_access_key_id}"
+          # Avoid printing credentials in logs.
+          set +o xtrace
 
+          echo "Testing with Client Side Encryption enabled."
+
+          echo "Setting temporary credentials..."
+          pushd ../drivers-evergreen-tools/.evergreen/csfle
+          export AWS_SECRET_ACCESS_KEY="${client_side_encryption_aws_secret_access_key}"
+          export AWS_ACCESS_KEY_ID="${client_side_encryption_aws_access_key_id}"
+          export AWS_DEFAULT_REGION="us-east-1"
+          . ./activate_venv.sh
+          . ./set-temp-creds.sh
+          popd
+          echo "Setting temporary credentials... done."
+
+          # Ensure temporary credentials were properly set.
+          if [ -z "$CSFLE_AWS_TEMP_ACCESS_KEY_ID" ]; then
+            echo "Failed to set temporary credentials!"
+            exit 1
+          fi
+
+          echo "Setting KMS credentials from the environment..."
+          export MONGOC_TEST_AWS_TEMP_ACCESS_KEY_ID="$CSFLE_AWS_TEMP_ACCESS_KEY_ID"
+          export MONGOC_TEST_AWS_TEMP_SECRET_ACCESS_KEY="$CSFLE_AWS_TEMP_SECRET_ACCESS_KEY"
+          export MONGOC_TEST_AWS_TEMP_SESSION_TOKEN="$CSFLE_AWS_TEMP_SESSION_TOKEN"
+          export MONGOC_TEST_AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"
+          export MONGOC_TEST_AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"
           export MONGOC_TEST_AZURE_TENANT_ID="${client_side_encryption_azure_tenant_id}"
           export MONGOC_TEST_AZURE_CLIENT_ID="${client_side_encryption_azure_client_id}"
           export MONGOC_TEST_AZURE_CLIENT_SECRET="${client_side_encryption_azure_client_secret}"
-
           export MONGOC_TEST_GCP_EMAIL="${client_side_encryption_gcp_email}"
           export MONGOC_TEST_GCP_PRIVATEKEY="${client_side_encryption_gcp_privatekey}"
-
           export MONGOC_TEST_CSFLE_TLS_CA_FILE=../drivers-evergreen-tools/.evergreen/x509gen/ca.pem
           export MONGOC_TEST_CSFLE_TLS_CERTIFICATE_KEY_FILE=../drivers-evergreen-tools/.evergreen/x509gen/client.pem
+          echo "Setting KMS credentials from the environment... done."
         fi
         export LOADBALANCED=${LOADBALANCED}
         export SINGLE_MONGOS_LB_URI="${SINGLE_MONGOS_LB_URI}"
@@ -581,7 +601,7 @@ all_functions = OD([
         export MONGODB_URI="${MONGODB_URI}"
         bash $DRIVERS_TOOLS/.evergreen/run-load-balancer.sh start
         ''', test=False),
-        OD ([
+        OD([
             ("command", "expansions.update"),
             ("params", OD([("file", "lb-expansion.yml")]))
         ]),

--- a/build/evergreen_config_lib/tasks.py
+++ b/build/evergreen_config_lib/tasks.py
@@ -561,6 +561,7 @@ class IntegrationTask(MatrixTask):
         if self.cse:
             extra["CLIENT_SIDE_ENCRYPTION"] = "on"
             commands.append(func('clone drivers-evergreen-tools'))
+            commands.append(func('prepare csfle venv'))
             commands.append(func('run kms servers'))
         commands.append(run_tests(VALGRIND=self.on_off('valgrind'),
                                   ASAN='on' if self.sanitizer == 'asan' else 'off',

--- a/build/evergreen_config_lib/tasks.py
+++ b/build/evergreen_config_lib/tasks.py
@@ -561,7 +561,6 @@ class IntegrationTask(MatrixTask):
         if self.cse:
             extra["CLIENT_SIDE_ENCRYPTION"] = "on"
             commands.append(func('clone drivers-evergreen-tools'))
-            commands.append(func('prepare csfle venv'))
             commands.append(func('run kms servers'))
         commands.append(run_tests(VALGRIND=self.on_off('valgrind'),
                                   ASAN='on' if self.sanitizer == 'asan' else 'off',

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/awsTemporary.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/awsTemporary.json
@@ -1,0 +1,225 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.1.10"
+    }
+  ],
+  "database_name": "default",
+  "collection_name": "default",
+  "data": [],
+  "json_schema": {
+    "properties": {
+      "encrypted_w_altname": {
+        "encrypt": {
+          "keyId": "/altname",
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+        }
+      },
+      "encrypted_string": {
+        "encrypt": {
+          "keyId": [
+            {
+              "$binary": {
+                "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                "subType": "04"
+              }
+            }
+          ],
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+        }
+      },
+      "random": {
+        "encrypt": {
+          "keyId": [
+            {
+              "$binary": {
+                "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                "subType": "04"
+              }
+            }
+          ],
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+        }
+      },
+      "encrypted_string_equivalent": {
+        "encrypt": {
+          "keyId": [
+            {
+              "$binary": {
+                "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                "subType": "04"
+              }
+            }
+          ],
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+        }
+      }
+    },
+    "bsonType": "object"
+  },
+  "key_vault_data": [
+    {
+      "status": 1,
+      "_id": {
+        "$binary": {
+          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+          "subType": "04"
+        }
+      },
+      "masterKey": {
+        "provider": "aws",
+        "key": "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
+        "region": "us-east-1"
+      },
+      "updateDate": {
+        "$date": {
+          "$numberLong": "1552949630483"
+        }
+      },
+      "keyMaterial": {
+        "$binary": {
+          "base64": "AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gEqnsxXlR51T5EbEVezUqqKAAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDHa4jo6yp0Z18KgbUgIBEIB74sKxWtV8/YHje5lv5THTl0HIbhSwM6EqRlmBiFFatmEWaeMk4tO4xBX65eq670I5TWPSLMzpp8ncGHMmvHqRajNBnmFtbYxN3E3/WjxmdbOOe+OXpnGJPcGsftc7cB2shRfA4lICPnE26+oVNXT6p0Lo20nY5XC7jyCO",
+          "subType": "00"
+        }
+      },
+      "creationDate": {
+        "$date": {
+          "$numberLong": "1552949630483"
+        }
+      },
+      "keyAltNames": [
+        "altname",
+        "another_altname"
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Insert a document with auto encryption using the AWS provider with temporary credentials",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "awsTemporary": {}
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "encrypted_string": "string0"
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "listCollections": 1,
+              "filter": {
+                "name": "default"
+              }
+            },
+            "command_name": "listCollections"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "datakeys",
+              "filter": {
+                "$or": [
+                  {
+                    "_id": {
+                      "$in": [
+                        {
+                          "$binary": {
+                            "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                            "subType": "04"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "keyAltNames": {
+                      "$in": []
+                    }
+                  }
+                ]
+              },
+              "$db": "keyvault"
+            },
+            "command_name": "find"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "default",
+              "documents": [
+                {
+                  "_id": 1,
+                  "encrypted_string": {
+                    "$binary": {
+                      "base64": "AQAAAAAAAAAAAAAAAAAAAAACwj+3zkv2VM+aTfk60RqhXq6a/77WlLwu/BxXFkL7EppGsju/m8f0x5kBDD3EZTtGALGXlym5jnpZAoSIkswHoA==",
+                      "subType": "06"
+                    }
+                  }
+                }
+              ],
+              "ordered": true
+            },
+            "command_name": "insert"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "encrypted_string": {
+                "$binary": {
+                  "base64": "AQAAAAAAAAAAAAAAAAAAAAACwj+3zkv2VM+aTfk60RqhXq6a/77WlLwu/BxXFkL7EppGsju/m8f0x5kBDD3EZTtGALGXlym5jnpZAoSIkswHoA==",
+                  "subType": "06"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Insert with invalid temporary credentials",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "awsTemporaryNoSessionToken": {}
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "encrypted_string": "string0"
+            }
+          },
+          "result": {
+            "errorContains": "security token"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description

This PR address CDRIVER-3882.

No changes were necessary to the C Driver interfaces to support AWS temp creds, as they are specified via BSON fields. Support for the `aws.sessionToken` field already added by https://github.com/mongodb/mongo-c-driver/pull/1043. This PR only required updating the legacy test runner to support the new corresponding spec tests.

Documentation was updated to describe the new `MONGOC_TEST_AWS_TEMP_*` environment variables by which AWS temp creds are communicated to the legacy test runner. The Evergreen config file and test scripts were updated to set these new environment variables accordingly via the [Drivers Evergreen Tools set-temp-creds.sh script](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/fd450866cbff621b3753ba6101b41454df612781/.evergreen/csfle/set-temp-creds.sh).

As a drive-by fix, some noisy error messages generated by `add-build-dirs-to-paths.sh` were addressed.

## Implementation Difficulties

During implementation of these changes, various unexpected issues were discovered or encountered when attempting to verify changes using Evergreen. The effort invested in dealing with these issues far outweighed the time it took to actually implement the required features relevant to CDRIVER-3882 itself. Some of these issues include:

- the need to explicitly set the `$PYTHON` env var when invoking the `set-temp-creds.sh` script to avoid the script from defaulting to an incorrect python binary.
- deactivation of the virtual environment to avoid potential double-activation issues.
- avoiding racing on the creation of the virtual environment in parallel tasks.
- avoid racing on the activation of the virtual environment in parallel tasks (see https://github.com/mongodb-labs/drivers-evergreen-tools/pull/234).

Additional issues encountered during patch builds that are deliberately not addressed in this PR due to being seemingly unrelated or demanding more investigation effort than is relevant to CDRIVER-3882 (to be/should be addressed separately):

- `AssertionError: Filename ... does not start with any of these prefixes: [...]` failure on zSeries (see BUILD-15997).
- Miscellaneous failures of `debug-*` tasks on some variants (not caused by changes in this PR).
- Miscellaneous failures of `test-*` tasks on some variants due to `/http` test (not caused by changes in this PR).

An attempt to avoid parallel invocation of `activate_venv.sh` by moving mock KMS server management into `run-tests.sh` was obstructed by task timeout issues on Windows variants. This issue may be related to [EVG-7818](https://jira.mongodb.org/browse/EVG-7818), but the attempt was aborted due to consuming too much time spent on debugging the problem; may revisit in a separate PR.

Changes verified by [this patch](https://spruce.mongodb.com/version/63335ee756234317acad9e25/tasks). Unrelated nature of failures verified by [this patch](https://spruce.mongodb.com/version/633366be9ccd4e283c62c1cd/tasks) (no changes relative to target branch).