### PR TITLE
build/mongodl.py: Extract version of RHEL via .*

### DIFF
--- a/build/mongodl.py
+++ b/build/mongodl.py
@@ -101,7 +101,7 @@ def _infer_target_os_rel():
         # the build for RHEL8, which is reasonably compatible with other modern
         # distributions (including Arch).
         return 'rhel80'
-    ver_id_re = re.compile(r'VERSION_ID=("?)(.*?)\1')
+    ver_id_re = re.compile(r'VERSION_ID=("?)(.*)\1')
     mat = ver_id_re.search(content)
     assert mat, 'Unable to detect VERSION_ID from [/etc/os-release] content:\n{}'.format(
         content)


### PR DESCRIPTION
During 'cmake --build .' file linked by /etc/os-release is used to obtain operating system's type and its version number. Version is extracted in _infer_target_os_rel() from VERSION_ID field by regular expression r'VERSION_ID=("?)(.*?)\1'. Version is extracted as a second group of the regular expression. This pattern is correct for Debian-based operating systems, where value for this field is followed and ended with quotation marks, e.g. VERSION_ID="20.02". On RHEL-based distributions there are no quotation marks, e.g. VERSION_ID=36. Without quotation marks, ("?) and \1 are matched to null string; lazy operator is not forced to match anything, thus it is also matched to null string. This results in extraction of version number as a null string. In DISTRO_VERSION_MAP there is no entry for null string in any present dictionary, thus RuntimeError is thrown. Tested on Fedora 32, 34 and 36.

Change from lazy (.*?) to greedy (.*) operator to extract correct version of RHEL- and Debian-based distributions.

Signed-off-by: Michał Grzelak <mig@semihalf.com>