### PR TITLE
build/mongodl.py: Port mongo-c-driver to Fedora

### DIFF
--- a/build/mongodl.py
+++ b/build/mongodl.py
@@ -39,6 +39,13 @@ DISTRO_VERSION_MAP = {
     'elementary': {
         '6': '20.04'
     },
+    'fedora': {
+        '32': '8',
+        '33': '8',
+        '34': '8',
+        '35': '8',
+        '36': '8'
+    },
 }
 
 DISTRO_ID_TO_TARGET = {


### PR DESCRIPTION
Port the build system to Fedora by extending DISTRO_VERSION_MAP by a mapping from Fedora version 32-36 to RHEL version 8 according to official Fedora documentation:
https://docs.fedoraproject.org/en-US/quick-docs/fedora-and-red-hat-enterprise-linux

Signed-off-by: Michał Grzelak <mig@semihalf.com>