### PR TITLE
CDRIVER-4457 fix NULL deref on QE collection drop

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-collection.c
+++ b/src/libmongoc/src/mongoc/mongoc-collection.c
@@ -1070,6 +1070,13 @@ drop_with_opts_with_encryptedFields (mongoc_collection_t *collection,
    mongoc_collection_t *ecocCollection = NULL;
    bool ok = false;
    const char *name = mongoc_collection_get_name (collection);
+   bson_error_t local_error = {0};
+
+   if (!error) {
+      /* If no error is passed, use a local error. Error codes are checked
+       * when collections are dropped. */
+      error = &local_error;
+   }
 
    /* Drop ESC collection. */
    escName = _mongoc_get_encryptedField_state_collection (


### PR DESCRIPTION
Fixes a NULL dereference when `mongoc_collection_drop` is called with a NULL `bson_error_t` for a Queryable Encryption collection.