### PR TITLE
build/mongodl.py: Fall back to /usr/lib/os-release

### DIFF
--- a/build/mongodl.py
+++ b/build/mongodl.py
@@ -89,16 +89,15 @@ def infer_target():
     if sys.platform == 'darwin':
         return 'macos'
     # Now the tricky bit
-    if Path('/etc/os-release').is_file():
-        return _infer_target_os_rel()
-    elif Path('/usr/lib/os-release').is_file():
-        os_rel_path = 'usr/lib/os-release'
-        return _infer_target_os_rel(os_rel_path)
+    cands = map(Path, ['/etc/os-release', '/usr/lib/os-release'])
+    for c in cands:
+        if c.is_file():
+            return _infer_target_os_rel(c)
     raise RuntimeError("We don't know how to find the default '--target'"
                        " option for this system. Please contribute!")
 
 
-def _infer_target_os_rel(os_rel_path='/etc/os-release'):
+def _infer_target_os_rel(os_rel_path: Path):
     with Path(os_rel_path).open('r', encoding='utf-8') as f:
         content = f.read()
     id_re = re.compile(r'\bID=("?)(.*)\1')

--- a/build/mongodl.py
+++ b/build/mongodl.py
@@ -91,17 +91,20 @@ def infer_target():
     # Now the tricky bit
     if Path('/etc/os-release').is_file():
         return _infer_target_os_rel()
+    elif Path('/usr/lib/os-release').is_file():
+        os_rel_path = 'usr/lib/os-release'
+        return _infer_target_os_rel(os_rel_path)
     raise RuntimeError("We don't know how to find the default '--target'"
                        " option for this system. Please contribute!")
 
 
-def _infer_target_os_rel():
-    with Path('/etc/os-release').open('r', encoding='utf-8') as f:
+def _infer_target_os_rel(os_rel_path='/etc/os-release'):
+    with Path(os_rel_path).open('r', encoding='utf-8') as f:
         content = f.read()
     id_re = re.compile(r'\bID=("?)(.*)\1')
     mat = id_re.search(content)
-    assert mat, 'Unable to detect ID from [/etc/os-release] content:\n{}'.format(
-        content)
+    assert mat, 'Unable to detect ID from [{}] content:\n{}'.format(
+        os_rel_path, content)
     os_id = mat.group(2)
     if os_id == 'arch':
         # There are no Archlinux-specific MongoDB downloads, so we'll just use
@@ -110,8 +113,8 @@ def _infer_target_os_rel():
         return 'rhel80'
     ver_id_re = re.compile(r'VERSION_ID=("?)(.*)\1')
     mat = ver_id_re.search(content)
-    assert mat, 'Unable to detect VERSION_ID from [/etc/os-release] content:\n{}'.format(
-        content)
+    assert mat, 'Unable to detect VERSION_ID from [{}] content:\n{}'.format(
+        os_rel_path, content)
     ver_id = mat.group(2)
     mapped_id = DISTRO_ID_MAP.get(os_id)
     if mapped_id:


### PR DESCRIPTION
According to `man os-release', file /etc/os-release isn't mandatory to be present in the system. Fallback to /usr/lib/os-release in absence of /etc/os-release.

Signed-off-by: Michał Grzelak <mig@semihalf.com>