### PR TITLE
build/mongodl.py: Port the build system to Mint

### DIFF
--- a/build/mongodl.py
+++ b/build/mongodl.py
@@ -29,6 +29,7 @@ DISTRO_ID_MAP = {
     'fedora': 'rhel',
     'centos': 'rhel',
     'mint': 'ubuntu',
+    'linuxmint': 'ubuntu',
     'opensuse-leap': 'sles',
     'opensuse': 'sles',
     'redhat': 'rhel',
@@ -45,6 +46,17 @@ DISTRO_VERSION_MAP = {
         '34': '8',
         '35': '8',
         '36': '8'
+    },
+    'linuxmint': {
+        '19': '18.04',
+        '19.1': '18.04',
+        '19.2': '18.04',
+        '19.3': '18.04',
+        '20': '20.04',
+        '20.1': '20.04',
+        '20.2': '20.04',
+        '20.3': '20.04',
+        '21': '22.04'
     },
 }
 


### PR DESCRIPTION
In Linux Mint in /etc/os-release there is ID=linuxmint instead of 'mint' present in DISTRO_ID_MAP. Add a mapping to handle it.

Add 'linuxmint' mapping in DISTRO_VERSION_MAP corresponding to official Mint docs: https://linuxmint.com/download_all.php

Signed-off-by: Michał Grzelak <mig@semihalf.com>