### PR TITLE
build/mongodl.py: Add quirk for Ubuntu 22.04

### DIFF
--- a/build/mongodl.py
+++ b/build/mongodl.py
@@ -50,7 +50,8 @@ DISTRO_VERSION_MAP = {
 
 DISTRO_ID_TO_TARGET = {
     'ubuntu': {
-        '22.*': 'ubuntu2204',
+        #quirk
+        '22.*': 'ubuntu2004',
         '20.*': 'ubuntu2004',
         '18.*': 'ubuntu1804',
         '16.*': 'ubuntu1604',


### PR DESCRIPTION
Currently there is no downloadable tarballs for mongo_shared for Ubuntu 22.04. Compilation terminates when this phase is reached. Define a mapping in DISTRO_ID_TO_TARGET from '22.*' to 'ubuntu2004' in order to finish build on latest Ubuntu version.

Signed-off-by: Michał Grzelak <mig@semihalf.com>