### PR TITLE
CDRIVER-4484 Address -Wformat and -Wstrict-prototypes warnings

### DIFF
--- a/src/kms-message/src/kms_crypto.h
+++ b/src/kms-message/src/kms_crypto.h
@@ -35,10 +35,10 @@ typedef struct {
 } _kms_crypto_t;
 
 int
-kms_crypto_init ();
+kms_crypto_init (void);
 
 void
-kms_crypto_cleanup ();
+kms_crypto_cleanup (void);
 
 bool
 kms_sha256 (void *ctx, const char *input, size_t len, unsigned char *hash_out);

--- a/src/kms-message/src/kms_crypto_libcrypto.c
+++ b/src/kms-message/src/kms_crypto_libcrypto.c
@@ -39,13 +39,13 @@ EVP_MD_CTX_free (EVP_MD_CTX *ctx)
 #endif
 
 int
-kms_crypto_init ()
+kms_crypto_init (void)
 {
    return 0;
 }
 
 void
-kms_crypto_cleanup ()
+kms_crypto_cleanup (void)
 {
 }
 

--- a/src/kms-message/src/kms_request_str.c
+++ b/src/kms-message/src/kms_request_str.c
@@ -30,7 +30,7 @@ bool rfc_3986_tab[256] = {0};
 bool kms_initialized = false;
 
 static void
-tables_init ()
+tables_init (void)
 {
    int i;
 

--- a/src/libbson/src/bson/bson-atomic.c
+++ b/src/libbson/src/bson/bson-atomic.c
@@ -54,7 +54,7 @@ bson_memory_barrier (void)
 static int8_t gEmulAtomicLock = 0;
 
 static void
-_lock_emul_atomic ()
+_lock_emul_atomic (void)
 {
    int i;
    if (bson_atomic_int8_compare_exchange_weak (
@@ -78,7 +78,7 @@ _lock_emul_atomic ()
 }
 
 static void
-_unlock_emul_atomic ()
+_unlock_emul_atomic (void)
 {
    int64_t rv = bson_atomic_int8_exchange (
       &gEmulAtomicLock, 0, bson_memory_order_release);

--- a/src/libmongoc/examples/example-collection-watch.c
+++ b/src/libmongoc/examples/example-collection-watch.c
@@ -1,7 +1,7 @@
 #include <mongoc/mongoc.h>
 
 int
-main ()
+main (void)
 {
    bson_t empty = BSON_INITIALIZER;
    const bson_t *doc;

--- a/src/libmongoc/examples/example-resume.c
+++ b/src/libmongoc/examples/example-resume.c
@@ -97,7 +97,7 @@ _load_resume_token (bson_t *opts)
 }
 
 int
-main ()
+main (void)
 {
    int exit_code = EXIT_FAILURE;
    const char *uri_string;

--- a/src/libmongoc/examples/example-start-at-optime.c
+++ b/src/libmongoc/examples/example-start-at-optime.c
@@ -2,7 +2,7 @@
 #include <mongoc/mongoc.h>
 
 int
-main ()
+main (void)
 {
    int exit_code = EXIT_FAILURE;
    const char *uri_string;

--- a/src/libmongoc/src/mongoc/mongoc-async-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-async-private.h
@@ -56,7 +56,7 @@ typedef int (*mongoc_async_cmd_setup_t) (mongoc_stream_t *stream,
 
 
 mongoc_async_t *
-mongoc_async_new ();
+mongoc_async_new (void);
 
 void
 mongoc_async_destroy (mongoc_async_t *async);

--- a/src/libmongoc/src/mongoc/mongoc-async.c
+++ b/src/libmongoc/src/mongoc/mongoc-async.c
@@ -29,7 +29,7 @@
 
 
 mongoc_async_t *
-mongoc_async_new ()
+mongoc_async_new (void)
 {
    mongoc_async_t *async = (mongoc_async_t *) bson_malloc0 (sizeof (*async));
 

--- a/src/libmongoc/src/mongoc/mongoc-generation-map-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-generation-map-private.h
@@ -26,7 +26,7 @@
 typedef struct _mongoc_generation_map mongoc_generation_map_t;
 
 mongoc_generation_map_t *
-mongoc_generation_map_new ();
+mongoc_generation_map_new (void);
 
 mongoc_generation_map_t *
 mongoc_generation_map_copy (const mongoc_generation_map_t *gm);

--- a/src/libmongoc/src/mongoc/mongoc-generation-map.c
+++ b/src/libmongoc/src/mongoc/mongoc-generation-map.c
@@ -25,7 +25,7 @@ typedef struct _gm_node_t {
 } gm_node_t;
 
 static gm_node_t *
-gm_node_new ()
+gm_node_new (void)
 {
    return bson_malloc0 (sizeof (gm_node_t));
 }
@@ -54,7 +54,7 @@ struct _mongoc_generation_map {
 };
 
 mongoc_generation_map_t *
-mongoc_generation_map_new ()
+mongoc_generation_map_new (void)
 {
    mongoc_generation_map_t *gm;
 

--- a/src/libmongoc/src/mongoc/mongoc-ocsp-cache.c
+++ b/src/libmongoc/src/mongoc/mongoc-ocsp-cache.c
@@ -34,7 +34,7 @@ static cache_entry_list_t *cache;
 static bson_mutex_t ocsp_cache_mutex;
 
 void
-_mongoc_ocsp_cache_init ()
+_mongoc_ocsp_cache_init (void)
 {
    bson_mutex_init (&ocsp_cache_mutex);
 }
@@ -125,7 +125,7 @@ _mongoc_ocsp_cache_set_resp (OCSP_CERTID *id,
 }
 
 int
-_mongoc_ocsp_cache_length ()
+_mongoc_ocsp_cache_length (void)
 {
    cache_entry_list_t *iter;
    int counter;
@@ -184,7 +184,7 @@ done:
 }
 
 void
-_mongoc_ocsp_cache_cleanup ()
+_mongoc_ocsp_cache_cleanup (void)
 {
    cache_entry_list_t *iter = NULL;
    cache_entry_list_t *next = NULL;

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -475,7 +475,9 @@ mongoc_secure_channel_read (mongoc_stream_tls_t *tls,
    ssize_t length;
 
    errno = 0;
-   TRACE ("Wanting to read: %d, timeout is %d", data_length, tls->timeout_msec);
+   TRACE ("Wanting to read: %zu, timeout is %" PRId32,
+          data_length,
+          tls->timeout_msec);
    /* 4th argument is minimum bytes, while the data_length is the
     * size of the buffer. We are totally fine with just one TLS record (few
     *bytes)
@@ -483,7 +485,7 @@ mongoc_secure_channel_read (mongoc_stream_tls_t *tls,
    length = mongoc_stream_read (
       tls->base_stream, data, data_length, 0, tls->timeout_msec);
 
-   TRACE ("Got %d", length);
+   TRACE ("Got %zd", length);
 
    if (length > 0) {
       return length;
@@ -500,10 +502,10 @@ mongoc_secure_channel_write (mongoc_stream_tls_t *tls,
    ssize_t length;
 
    errno = 0;
-   TRACE ("Wanting to write: %d", data_length);
+   TRACE ("Wanting to write: %zd", data_length);
    length = mongoc_stream_write (
       tls->base_stream, (void *) data, data_length, tls->timeout_msec);
-   TRACE ("Wrote: %d", length);
+   TRACE ("Wrote: %zd", length);
 
 
    return length;

--- a/src/libmongoc/src/mongoc/mongoc-socket.c
+++ b/src/libmongoc/src/mongoc/mongoc-socket.c
@@ -432,8 +432,8 @@ _mongoc_socket_setkeepalive_windows (SOCKET sd)
       TRACE ("%s", "Could not set keepalive values");
    } else {
       TRACE ("%s", "KeepAlive values updated");
-      TRACE ("KeepAliveTime: %d", keepalive.keepalivetime);
-      TRACE ("KeepAliveInterval: %d", keepalive.keepaliveinterval);
+      TRACE ("KeepAliveTime: %lu", keepalive.keepalivetime);
+      TRACE ("KeepAliveInterval: %lu", keepalive.keepaliveinterval);
    }
 }
 #else
@@ -1293,7 +1293,7 @@ _mongoc_socket_try_sendv (mongoc_socket_t *sock, /* IN */
 #ifdef _WIN32
    ret = WSASend (
       sock->sd, (LPWSABUF) iov, iovcnt, &dwNumberofBytesSent, 0, NULL, NULL);
-   TRACE ("WSASend sent: %ld (out of: %ld), ret: %d",
+   TRACE ("WSASend sent: %ld (out of: %zu), ret: %d",
           dwNumberofBytesSent,
           iov->iov_len,
           ret);
@@ -1389,7 +1389,7 @@ mongoc_socket_sendv (mongoc_socket_t *sock,  /* IN */
    for (;;) {
       sent = _mongoc_socket_try_sendv (sock, &iov[cur], iovcnt - cur);
       TRACE (
-         "Sent %ld (of %ld) out of iovcnt=%ld", sent, iov[cur].iov_len, iovcnt);
+         "Sent %zd (of %zu) out of iovcnt=%zu", sent, iov[cur].iov_len, iovcnt);
 
       /*
        * If we failed with anything other than EAGAIN or EWOULDBLOCK,
@@ -1414,7 +1414,7 @@ mongoc_socket_sendv (mongoc_socket_t *sock,  /* IN */
           * Subtract the sent amount from what we still need to send.
           */
          while ((cur < iovcnt) && (sent >= (ssize_t) iov[cur].iov_len)) {
-            TRACE ("still got bytes left: sent -= iov_len: %ld -= %ld",
+            TRACE ("still got bytes left: sent -= iov_len: %zd -= %zu",
                    sent,
                    iov[cur].iov_len);
             sent -= iov[cur++].iov_len;
@@ -1433,12 +1433,12 @@ mongoc_socket_sendv (mongoc_socket_t *sock,  /* IN */
           * Increment the current iovec buffer to its proper offset and adjust
           * the number of bytes to write.
           */
-         TRACE ("Seeked io_base+%ld", sent);
+         TRACE ("Seeked io_base+%zd", sent);
          TRACE (
-            "Subtracting iov_len -= sent; %ld -= %ld", iov[cur].iov_len, sent);
+            "Subtracting iov_len -= sent; %zu -= %zd", iov[cur].iov_len, sent);
          iov[cur].iov_base = ((char *) iov[cur].iov_base) + sent;
          iov[cur].iov_len -= sent;
-         TRACE ("iov_len remaining %ld", iov[cur].iov_len);
+         TRACE ("iov_len remaining %zu", iov[cur].iov_len);
 
          BSON_ASSERT (iovcnt - cur);
          BSON_ASSERT (iov[cur].iov_len);

--- a/src/libmongoc/src/mongoc/mongoc-socket.c
+++ b/src/libmongoc/src/mongoc/mongoc-socket.c
@@ -557,7 +557,7 @@ static bool
 #ifdef _WIN32
 _mongoc_socket_setnodelay (SOCKET sd) /* IN */
 #else
-_mongoc_socket_setnodelay (int sd) /* IN */
+_mongoc_socket_setnodelay (int sd)   /* IN */
 #endif
 {
 #ifdef _WIN32
@@ -1023,7 +1023,7 @@ mongoc_socket_new (int domain,   /* IN */
    /* Set SO_NOSIGPIPE, to ignore SIGPIPE on writes for platforms where
       setting MSG_NOSIGNAL on writes is not supported (primarily OSX). */
 #ifdef SO_NOSIGPIPE
-   setsockopt(sd, SOL_SOCKET, SO_NOSIGPIPE, &on, sizeof(on));
+   setsockopt (sd, SOL_SOCKET, SO_NOSIGPIPE, &on, sizeof (on));
 #endif
 
    sock = (mongoc_socket_t *) bson_malloc0 (sizeof *sock);

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl-bio-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl-bio-private.h
@@ -29,7 +29,7 @@
 BSON_BEGIN_DECLS
 
 BIO_METHOD *
-mongoc_stream_tls_openssl_bio_meth_new ();
+mongoc_stream_tls_openssl_bio_meth_new (void);
 
 void
 mongoc_stream_tls_openssl_bio_set_data (BIO *b, void *ptr);

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl-bio.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl-bio.c
@@ -85,7 +85,7 @@ mongoc_stream_tls_openssl_bio_meth_new ()
 #else
 
 BIO_METHOD *
-mongoc_stream_tls_openssl_bio_meth_new ()
+mongoc_stream_tls_openssl_bio_meth_new (void)
 {
    BIO_METHOD *meth = NULL;
 

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
@@ -155,7 +155,7 @@ _mongoc_stream_tls_secure_channel_destroy (mongoc_stream_t *stream)
          FreeContextBuffer (outbuf.pvBuffer);
 
          if (outbuf.cbBuffer != (size_t) written) {
-            TRACE ("failed to send close msg (wrote %zd out of %zd)",
+            TRACE ("failed to send close msg (wrote %zd out of %lu)",
                    written,
                    outbuf.cbBuffer);
          }
@@ -255,7 +255,7 @@ _mongoc_stream_tls_secure_channel_write (mongoc_stream_t *stream,
    ENTRY;
 
    BSON_ASSERT (secure_channel);
-   TRACE ("The entire buffer is: %d", buf_len);
+   TRACE ("The entire buffer is: %zu", buf_len);
 
    /* check if the maximum stream sizes were queried */
    if (secure_channel->stream_sizes.cbMaximumMessage == 0) {
@@ -271,7 +271,7 @@ _mongoc_stream_tls_secure_channel_write (mongoc_stream_t *stream,
 
    /* check if the buffer is longer than the maximum message length */
    if (buf_len > secure_channel->stream_sizes.cbMaximumMessage) {
-      TRACE ("SHRINKING buf_len from %lu to %lu",
+      TRACE ("SHRINKING buf_len from %zu to %lu",
              buf_len,
              secure_channel->stream_sizes.cbMaximumMessage);
       buf_len = secure_channel->stream_sizes.cbMaximumMessage;
@@ -374,12 +374,12 @@ _mongoc_stream_tls_secure_channel_writev (mongoc_stream_t *stream,
    TRACE ("%s", "Trying to write to the server");
    tls->timeout_msec = timeout_msec;
 
-   TRACE ("count: %d, 0th: %lu", iovcnt, iov[0].iov_len);
+   TRACE ("count: %zu, 0th: %zu", iovcnt, iov[0].iov_len);
 
    for (i = 0; i < iovcnt; i++) {
       iov_pos = 0;
 
-      TRACE ("iov %d size: %lu", i, iov[i].iov_len);
+      TRACE ("iov %zu size: %zu", i, iov[i].iov_len);
       while (iov_pos < iov[i].iov_len) {
          if (buf_head != buf_tail ||
              ((i + 1 < iovcnt) &&
@@ -420,7 +420,7 @@ _mongoc_stream_tls_secure_channel_writev (mongoc_stream_t *stream,
 
             child_ret = _mongoc_stream_tls_secure_channel_write (
                stream, to_write, to_write_len);
-            TRACE ("Child0wrote: %d, was supposed to write: %d",
+            TRACE ("Child0wrote: %zd, was supposed to write: %zu",
                    child_ret,
                    to_write_len);
 
@@ -442,7 +442,7 @@ _mongoc_stream_tls_secure_channel_writev (mongoc_stream_t *stream,
 
       child_ret = _mongoc_stream_tls_secure_channel_write (
          stream, buf_head, buf_tail - buf_head);
-      TRACE ("Child1wrote: %d, was supposed to write: %d",
+      TRACE ("Child1wrote: %zd, was supposed to write: %td",
              child_ret,
              buf_tail - buf_head);
 
@@ -603,7 +603,7 @@ _mongoc_stream_tls_secure_channel_decrypt (
       } else if (sspi_status == SEC_E_INCOMPLETE_MESSAGE) {
          TRACE ("%s", "failed to decrypt data, need more data");
       } else {
-         TRACE ("failed to read data from server: %d", sspi_status);
+         TRACE ("failed to read data from server: %ld", sspi_status);
          secure_channel->recv_unrecoverable_err = true;
       }
    }

--- a/src/libmongoc/src/mongoc/mongoc-stream.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream.c
@@ -439,7 +439,7 @@ _mongoc_stream_writev_full (mongoc_stream_t *stream,
    }
 
    r = mongoc_stream_writev (stream, iov, iovcnt, timeout_msec);
-   TRACE ("writev returned: %ld", r);
+   TRACE ("writev returned: %zd", r);
 
    if (r < 0) {
       if (error) {

--- a/src/libmongoc/src/mongoc/mongoc-timeout-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-timeout-private.h
@@ -25,7 +25,7 @@
 typedef struct _mongoc_timeout_t mongoc_timeout_t;
 
 mongoc_timeout_t *
-mongoc_timeout_new ();
+mongoc_timeout_new (void);
 
 mongoc_timeout_t *
 mongoc_timeout_new_timeout_int64 (int64_t timeout_ms);

--- a/src/libmongoc/src/mongoc/mongoc-timeout.c
+++ b/src/libmongoc/src/mongoc/mongoc-timeout.c
@@ -53,7 +53,7 @@ mongoc_timeout_set_timeout_ms (mongoc_timeout_t *timeout, int64_t timeout_ms)
 }
 
 mongoc_timeout_t *
-mongoc_timeout_new ()
+mongoc_timeout_new (void)
 {
    return (mongoc_timeout_t *) bson_malloc0 (sizeof (mongoc_timeout_t));
 }

--- a/src/libmongoc/tests/bsonutil/bson-match.h
+++ b/src/libmongoc/tests/bsonutil/bson-match.h
@@ -31,7 +31,7 @@ bson_match (const bson_val_t *expected,
 typedef struct _bson_matcher_t bson_matcher_t;
 
 bson_matcher_t *
-bson_matcher_new ();
+bson_matcher_new (void);
 
 typedef bool (*special_fn) (bson_matcher_t *matcher,
                             const bson_t *assertion,

--- a/src/libmongoc/tests/mock_server/future-value.h
+++ b/src/libmongoc/tests/mock_server/future-value.h
@@ -146,7 +146,7 @@ typedef struct _future_value_t
    } value;
 } future_value_t;
 
-future_value_t *future_value_new ();
+future_value_t *future_value_new (void);
 
 #ifdef __clang__
 #pragma clang diagnostic push

--- a/src/libmongoc/tests/mock_server/mock-server.h
+++ b/src/libmongoc/tests/mock_server/mock-server.h
@@ -48,7 +48,7 @@ typedef bool (*hello_callback_func_t) (request_t *request,
 typedef void (*destructor_t) (void *data);
 
 mock_server_t *
-mock_server_new ();
+mock_server_new (void);
 
 mock_server_t *
 mock_server_with_auto_hello (int32_t max_wire_version);

--- a/src/libmongoc/tests/mock_server/sync-queue.h
+++ b/src/libmongoc/tests/mock_server/sync-queue.h
@@ -23,7 +23,7 @@
 typedef struct _sync_queue_t sync_queue_t;
 
 sync_queue_t *
-q_new ();
+q_new (void);
 
 void
 q_put (sync_queue_t *q, void *item);

--- a/src/libmongoc/tests/test-conveniences.c
+++ b/src/libmongoc/tests/test-conveniences.c
@@ -1651,7 +1651,7 @@ huge_string_length (mongoc_client_t *client)
 
 
 static void
-init_four_mb_string ()
+init_four_mb_string (void)
 {
    test_conveniences_init ();
 

--- a/src/libmongoc/tests/test-conveniences.h
+++ b/src/libmongoc/tests/test-conveniences.h
@@ -32,7 +32,7 @@
  * Safe to call repeatedly, or after calling test_conveniences_cleanup().
  */
 void
-test_conveniences_init ();
+test_conveniences_init (void);
 
 /* Tear down global test conveniences.
  * Safe to call repeatedly.
@@ -65,12 +65,12 @@ bson_iter_bson (const bson_iter_t *iter, bson_t *bson);
  * returned bson_t does not need to be freed. This corresponds to the same
  * document in json_with_all_types. */
 bson_t *
-bson_with_all_types ();
+bson_with_all_types (void);
 
 /* returns a json string with all types of values, and an empty key. This
  * corresponds to the same document in bson_with_all_types. */
 const char *
-json_with_all_types ();
+json_with_all_types (void);
 
 
 #ifndef PATH_MAX
@@ -222,7 +222,7 @@ size_t
 huge_string_length (mongoc_client_t *client);
 
 const char *
-four_mb_string ();
+four_mb_string (void);
 
 void
 assert_no_duplicate_keys (const bson_t *doc);

--- a/src/libmongoc/tests/test-happy-eyeballs.c
+++ b/src/libmongoc/tests/test-happy-eyeballs.c
@@ -438,7 +438,7 @@ test_happy_eyeballs_dns_cache (void)
 }
 
 void
-test_happy_eyeballs_retirement ()
+test_happy_eyeballs_retirement (void)
 {
    /* test connecting to a retired node that fails to initiate a connection. */
 }

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -776,7 +776,7 @@ test_framework_get_compressors ()
  *--------------------------------------------------------------------------
  */
 bool
-test_framework_has_compressors ()
+test_framework_has_compressors (void)
 {
    bool retval;
    char *compressors = test_framework_get_compressors ();

--- a/src/libmongoc/tests/test-mongoc-cache.c
+++ b/src/libmongoc/tests/test-mongoc-cache.c
@@ -29,7 +29,7 @@
 static char *ca_file;
 
 static int
-ping ()
+ping (void)
 {
    mongoc_client_t *client;
    mongoc_database_t *database;

--- a/src/libmongoc/tests/test-mongoc-counters.c
+++ b/src/libmongoc/tests/test-mongoc-counters.c
@@ -58,7 +58,7 @@
    } while (0)
 
 static void
-reset_all_counters ()
+reset_all_counters (void)
 {
 #define COUNTER(id, category, name, description) RESET (id);
 #include "mongoc/mongoc-counters.defs"
@@ -447,7 +447,7 @@ test_counters_dns (void)
 
 
 static void
-test_counters_streams_timeout ()
+test_counters_streams_timeout (void)
 {
    mock_server_t *server;
    bson_error_t err = {0};

--- a/src/libmongoc/tests/test-mongoc-database.c
+++ b/src/libmongoc/tests/test-mongoc-database.c
@@ -848,7 +848,7 @@ test_get_collection_info_with_opts_regex (void)
 }
 
 static void
-_test_get_collection_info_getmore ()
+_test_get_collection_info_getmore (void)
 {
    mock_server_t *server;
    mongoc_client_t *client;

--- a/src/libmongoc/tests/test-mongoc-interrupt.c
+++ b/src/libmongoc/tests/test-mongoc-interrupt.c
@@ -24,7 +24,7 @@
 #include "common-thread-private.h"
 
 static int64_t
-_time_ms ()
+_time_ms (void)
 {
    return bson_get_monotonic_time () / 1000;
 }

--- a/src/libmongoc/tests/test-mongoc-scram.c
+++ b/src/libmongoc/tests/test-mongoc-scram.c
@@ -425,7 +425,7 @@ test_mongoc_scram_auth (void *ctx)
 }
 
 static int
-_skip_if_no_sha256 ()
+_skip_if_no_sha256 (void)
 {
    mongoc_client_t *client;
    bool res;
@@ -476,7 +476,7 @@ skip_if_icu (void)
 }
 
 static void
-_create_saslprep_users ()
+_create_saslprep_users (void)
 {
    mongoc_client_t *client;
    bool res;
@@ -505,7 +505,7 @@ _create_saslprep_users ()
 }
 
 static void
-_drop_saslprep_users ()
+_drop_saslprep_users (void)
 {
    mongoc_client_t *client;
    mongoc_database_t *db;

--- a/src/libmongoc/tests/test-mongoc-shared.c
+++ b/src/libmongoc/tests/test-mongoc-shared.c
@@ -8,7 +8,7 @@ typedef struct {
 } my_value;
 
 my_value *
-my_value_new ()
+my_value_new (void)
 {
    my_value *p = bson_malloc0 (sizeof (my_value));
    p->value = 42;

--- a/src/libmongoc/tests/unified/entity-map.c
+++ b/src/libmongoc/tests/unified/entity-map.c
@@ -955,7 +955,7 @@ typedef struct {
 } coll_or_db_opts_t;
 
 static coll_or_db_opts_t *
-coll_or_db_opts_new ()
+coll_or_db_opts_new (void)
 {
    return bson_malloc0 (sizeof (coll_or_db_opts_t));
 }

--- a/src/libmongoc/tests/unified/entity-map.h
+++ b/src/libmongoc/tests/unified/entity-map.h
@@ -59,7 +59,7 @@ typedef struct {
 } entity_map_t;
 
 entity_map_t *
-entity_map_new ();
+entity_map_new (void);
 
 void
 entity_map_destroy (entity_map_t *em);


### PR DESCRIPTION
## Description

This PR resolves CDRIVER-4484 by addressing `-Wformat=2` and `-Wstrict-prototypes` warnings.

Warnings were detected using GCC 12.1.0 and Clang 10.0.0 on Ubuntu 20.04 and GCC 12.1.0 (mingw-w64) on Windows with `ENABLE_CLIENT_SIDE_ENCRYPTION=(OFF|ON)` and `ENABLE_TRACING=(OFF|ON)`.