### PR TITLE
CDRIVER-4502: Handle int64 connectionId values in hello responses

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-apm-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-apm-private.h
@@ -56,7 +56,7 @@ struct _mongoc_apm_command_started_t {
    const mongoc_host_list_t *host;
    uint32_t server_id;
    bson_oid_t service_id;
-   int32_t server_connection_id;
+   int64_t server_connection_id;
    void *context;
 };
 
@@ -70,7 +70,7 @@ struct _mongoc_apm_command_succeeded_t {
    const mongoc_host_list_t *host;
    uint32_t server_id;
    bson_oid_t service_id;
-   int32_t server_connection_id;
+   int64_t server_connection_id;
    void *context;
 };
 
@@ -85,7 +85,7 @@ struct _mongoc_apm_command_failed_t {
    const mongoc_host_list_t *host;
    uint32_t server_id;
    bson_oid_t service_id;
-   int32_t server_connection_id;
+   int64_t server_connection_id;
    void *context;
 };
 
@@ -162,7 +162,7 @@ mongoc_apm_command_started_init (mongoc_apm_command_started_t *event,
                                  const mongoc_host_list_t *host,
                                  uint32_t server_id,
                                  const bson_oid_t *service_id,
-                                 int32_t server_connection_id,
+                                 int64_t server_connection_id,
                                  bool *is_redacted, /* out */
                                  void *context);
 
@@ -186,7 +186,7 @@ mongoc_apm_command_succeeded_init (mongoc_apm_command_succeeded_t *event,
                                    const mongoc_host_list_t *host,
                                    uint32_t server_id,
                                    const bson_oid_t *service_id,
-                                   int32_t server_connection_id,
+                                   int64_t server_connection_id,
                                    bool force_redaction,
                                    void *context);
 
@@ -204,7 +204,7 @@ mongoc_apm_command_failed_init (mongoc_apm_command_failed_t *event,
                                 const mongoc_host_list_t *host,
                                 uint32_t server_id,
                                 const bson_oid_t *service_id,
-                                int32_t server_connection_id,
+                                int64_t server_connection_id,
                                 bool force_redaction,
                                 void *context);
 

--- a/src/libmongoc/src/mongoc/mongoc-apm.c
+++ b/src/libmongoc/src/mongoc/mongoc-apm.c
@@ -77,7 +77,7 @@ mongoc_apm_command_started_init (mongoc_apm_command_started_t *event,
                                  const mongoc_host_list_t *host,
                                  uint32_t server_id,
                                  const bson_oid_t *service_id,
-                                 int32_t server_connection_id,
+                                 int64_t server_connection_id,
                                  bool *is_redacted, /* out */
                                  void *context)
 {
@@ -208,7 +208,7 @@ mongoc_apm_command_succeeded_init (mongoc_apm_command_succeeded_t *event,
                                    const mongoc_host_list_t *host,
                                    uint32_t server_id,
                                    const bson_oid_t *service_id,
-                                   int32_t server_connection_id,
+                                   int64_t server_connection_id,
                                    bool force_redaction,
                                    void *context)
 {
@@ -271,7 +271,7 @@ mongoc_apm_command_failed_init (mongoc_apm_command_failed_t *event,
                                 const mongoc_host_list_t *host,
                                 uint32_t server_id,
                                 const bson_oid_t *service_id,
-                                int32_t server_connection_id,
+                                int64_t server_connection_id,
                                 bool force_redaction,
                                 void *context)
 {
@@ -390,7 +390,12 @@ int32_t
 mongoc_apm_command_started_get_server_connection_id (
    const mongoc_apm_command_started_t *event)
 {
-   return event->server_connection_id;
+   if (event->server_connection_id > INT32_MAX ||
+       event->server_connection_id < INT32_MIN) {
+      return MONGOC_NO_SERVER_CONNECTION_ID;
+   }
+
+   return (int32_t) event->server_connection_id;
 }
 
 
@@ -477,7 +482,12 @@ int32_t
 mongoc_apm_command_succeeded_get_server_connection_id (
    const mongoc_apm_command_succeeded_t *event)
 {
-   return event->server_connection_id;
+   if (event->server_connection_id > INT32_MAX ||
+       event->server_connection_id < INT32_MIN) {
+      return MONGOC_NO_SERVER_CONNECTION_ID;
+   }
+
+   return (int32_t) event->server_connection_id;
 }
 
 
@@ -568,7 +578,12 @@ int32_t
 mongoc_apm_command_failed_get_server_connection_id (
    const mongoc_apm_command_failed_t *event)
 {
-   return event->server_connection_id;
+   if (event->server_connection_id > INT32_MAX ||
+       event->server_connection_id < INT32_MIN) {
+      return MONGOC_NO_SERVER_CONNECTION_ID;
+   }
+
+   return (int32_t) event->server_connection_id;
 }
 
 

--- a/src/libmongoc/src/mongoc/mongoc-server-description-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-server-description-private.h
@@ -125,7 +125,7 @@ struct _mongoc_server_description_t {
     * service IDs. The only server generation is mapped from kZeroServiceID */
    mongoc_generation_map_t *_generation_map_;
    bson_oid_t service_id;
-   int32_t server_connection_id;
+   int64_t server_connection_id;
 };
 
 /** Get a mutable pointer to the server's generation map */

--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -740,9 +740,9 @@ mongoc_server_description_handle_hello (mongoc_server_description_t *sd,
             goto failure;
          bson_oid_copy_unsafe (bson_iter_oid (&iter), &sd->service_id);
       } else if (strcmp ("connectionId", bson_iter_key (&iter)) == 0) {
-         if (!BSON_ITER_HOLDS_INT32 (&iter))
+         if (!BSON_ITER_HOLDS_INT (&iter))
             goto failure;
-         sd->server_connection_id = bson_iter_int32 (&iter);
+         sd->server_connection_id = bson_iter_as_int64 (&iter);
       }
    }
 

--- a/src/libmongoc/tests/unified/entity-map.h
+++ b/src/libmongoc/tests/unified/entity-map.h
@@ -30,7 +30,7 @@ typedef struct _event_t {
    bson_t *command;
    bson_t *reply;
    bson_oid_t service_id;
-   int32_t server_connection_id;
+   int64_t server_connection_id;
    struct _event_t *next;
 } event_t;
 

--- a/src/libmongoc/tests/unified/runner.c
+++ b/src/libmongoc/tests/unified/runner.c
@@ -1145,7 +1145,7 @@ test_check_event (test_t *test,
       }
 
       if (!*expected_has_server_connection_id && has_server_connection_id) {
-         test_error ("expected no server connectionId, but got %d",
+         test_error ("expected no server connectionId, but got %" PRId64,
                      actual->server_connection_id);
       }
    }


### PR DESCRIPTION
CDRIVER-4502

This updates the server description and command monitoring struct to store the connection ID as `int64_t` to reflect the type returned by the server. `mongoc_server_description_handle_hello` was updated to accept any integer for the `connectionId` field in the response and will read the field as int64.

To preserve backward compatibility, `mongoc_apm_command_started_get_server_connection_id` (and the equivalent methods for other command monitoring events) still return the value as `int32_t`. If the connection ID returned from the server exceeds the 32-bit range, `-1` is returned.