### PR TITLE
[CDRIVER-4478] Fix code snippet in find collection documentation

### DIFF
--- a/src/libmongoc/doc/mongoc_database_find_collections_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_database_find_collections_with_opts.rst
@@ -68,8 +68,8 @@ Examples
         printf ("found collection: %s\n", bson_iter_utf8 (&iter, NULL));
      }
 
-     if (mongoc_cursor_error (cursor, &error))
-        fprintf (stderr, "%s\n", error.msg);
+     if (mongoc_cursor_error (cursor, &error)) {
+        fprintf (stderr, "%s\n", error.message);
      }
 
      mongoc_cursor_destroy (cursor);

--- a/src/libmongoc/doc/mongoc_database_find_collections_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_database_find_collections_with_opts.rst
@@ -56,6 +56,7 @@ Examples
      const bson_t *doc;
      bson_iter_t iter;
      bson_error_t error;
+     mongoc_cursor_t *cursor;
 
      BSON_APPEND_DOCUMENT_BEGIN (&opts, "filter", &name_filter);
      /* find collections with names like "abbbbc" */


### PR DESCRIPTION
The code snippet in the documentation below errored when built using the c driver. The field`.msg` did not exist, there was a missing curly brace, and `cursor` was undefined. 