### PR TITLE
CDRIVER-4454 fix error return and HTTP version check

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-crypt.c
+++ b/src/libmongoc/src/mongoc/mongoc-crypt.c
@@ -760,7 +760,7 @@ _try_add_azure_from_env (_mongoc_crypt_t *crypt,
       // abstract monotonic "now"
       crypt->azure_token_issued_at = mcd_now ();
       // Get the token:
-      if (_request_new_azure_token (&crypt->azure_token, error)) {
+      if (!_request_new_azure_token (&crypt->azure_token, error)) {
          return false;
       }
    }

--- a/src/libmongoc/src/mongoc/mongoc-http.c
+++ b/src/libmongoc/src/mongoc/mongoc-http.c
@@ -246,17 +246,27 @@ _mongoc_http_send (const mongoc_http_request_t *req,
    const char *const resp_end_ptr =
       http_response_str + http_response_buf.datalen;
 
-   const char *proto_leader = "HTTP/1.0 ";
-   ptr = strstr (http_response_str, proto_leader);
+
+   const char *proto_leader_10 = "HTTP/1.0 ";
+   const char *proto_leader_11 = "HTTP/1.1 ";
+   ptr = strstr (http_response_str, proto_leader_10);
    if (!ptr) {
-      bson_set_error (error,
-                      MONGOC_ERROR_STREAM,
-                      MONGOC_ERROR_STREAM_SOCKET,
-                      "No HTTP version leader in HTTP response");
+      ptr = strstr (http_response_str, proto_leader_11);
+   }
+
+   if (!ptr) {
+      bson_set_error (
+         error,
+         MONGOC_ERROR_STREAM,
+         MONGOC_ERROR_STREAM_SOCKET,
+         "No HTTP version leader in HTTP response. Expected '%s' or '%s'",
+         proto_leader_10,
+         proto_leader_11);
       goto fail;
    }
 
-   ptr += strlen (proto_leader);
+   /* Both protocol leaders have the same length. */
+   ptr += strlen (proto_leader_10);
    ssize_t remain = resp_end_ptr - ptr;
    if (remain < 4) {
       bson_set_error (error,


### PR DESCRIPTION
# Summary

- Allow HTTP/1.1 protocol in response
- Fix error return check in `_try_add_azure_from_env`

# Background & Motivation

Discovered during integration testing for DRIVERS-2411. WIP integration tests pass with these fixes.

HTTP requests from libmongoc use [HTTP/1.0](https://github.com/mongodb/mongo-c-driver/blob/master/src/libmongoc/src/mongoc/mongoc-http.c#L68). The Azure IMDS server responds with HTTP/1.1. https://www.rfc-editor.org/rfc/rfc2145#section-2.3 does not prohibit a server response with a minor version greater than the one received.

> An HTTP server SHOULD send a response version equal to the highest
   version for which the server is at least conditionally compliant, and
   whose major version is less than or equal to the one received in the
   request.  An HTTP server MUST NOT send a version for which it is not
   at least conditionally compliant.  A server MAY send a 505 (HTTP
   Version Not Supported) response if cannot send a response using the
   major version used in the client's request.