### PR TITLE
CDRIVER-4499 Set bson_error when hello response is malformed

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -791,7 +791,9 @@ typefailure:
    bson_set_error (&sd->error,
                    MONGOC_ERROR_STREAM,
                    MONGOC_ERROR_STREAM_INVALID_TYPE,
-                   "invalid type sent to hello");
+                   "unexpected type %s for field %s in hello response",
+                   _mongoc_bson_type_to_str (bson_iter_type (&iter)),
+                   bson_iter_key (&iter));
 authfailure:
    sd->type = MONGOC_SERVER_UNKNOWN;
    sd->round_trip_time_msec = MONGOC_RTT_UNSET;

--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -795,6 +795,7 @@ typefailure:
 authfailure:
    sd->type = MONGOC_SERVER_UNKNOWN;
    sd->round_trip_time_msec = MONGOC_RTT_UNSET;
+
    EXIT;
 }
 

--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -601,7 +601,7 @@ mongoc_server_description_handle_hello (mongoc_server_description_t *sd,
              * MUST treat this an authentication error." */
             sd->error.domain = MONGOC_ERROR_CLIENT;
             sd->error.code = MONGOC_ERROR_CLIENT_AUTHENTICATE;
-            goto failure;
+            goto authfailure;
          }
       } else if (strcmp ("isWritablePrimary", bson_iter_key (&iter)) == 0 ||
                  strcmp (HANDSHAKE_RESPONSE_LEGACY_HELLO,
@@ -794,6 +794,11 @@ failure:
                    MONGOC_ERROR_STREAM,
                    MONGOC_ERROR_STREAM_INVALID_TYPE,
                    "invalid type sent to hello");
+   EXIT;
+
+authfailure:
+   sd->type = MONGOC_SERVER_UNKNOWN;
+   sd->round_trip_time_msec = MONGOC_RTT_UNSET;
    EXIT;
 }
 

--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -601,33 +601,33 @@ mongoc_server_description_handle_hello (mongoc_server_description_t *sd,
              * MUST treat this an authentication error." */
             sd->error.domain = MONGOC_ERROR_CLIENT;
             sd->error.code = MONGOC_ERROR_CLIENT_AUTHENTICATE;
-            goto authfailure;
+            GOTO (authfailure);
          }
       } else if (strcmp ("isWritablePrimary", bson_iter_key (&iter)) == 0 ||
                  strcmp (HANDSHAKE_RESPONSE_LEGACY_HELLO,
                          bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_BOOL (&iter))
-            goto typefailure;
+            GOTO (typefailure);
          is_primary = bson_iter_bool (&iter);
       } else if (strcmp ("helloOk", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_BOOL (&iter))
-            goto typefailure;
+            GOTO (typefailure);
          sd->hello_ok = bson_iter_bool (&iter);
       } else if (strcmp ("me", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_UTF8 (&iter))
-            goto typefailure;
+            GOTO (typefailure);
          sd->me = bson_iter_utf8 (&iter, NULL);
       } else if (strcmp ("maxMessageSizeBytes", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_INT32 (&iter))
-            goto typefailure;
+            GOTO (typefailure);
          sd->max_msg_size = bson_iter_int32 (&iter);
       } else if (strcmp ("maxBsonObjectSize", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_INT32 (&iter))
-            goto typefailure;
+            GOTO (typefailure);
          sd->max_bson_obj_size = bson_iter_int32 (&iter);
       } else if (strcmp ("maxWriteBatchSize", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_INT32 (&iter))
-            goto typefailure;
+            GOTO (typefailure);
          sd->max_write_batch_size = bson_iter_int32 (&iter);
       } else if (strcmp ("logicalSessionTimeoutMinutes",
                          bson_iter_key (&iter)) == 0) {
@@ -637,72 +637,72 @@ mongoc_server_description_handle_hello (mongoc_server_description_t *sd,
             /* this arises executing standard JSON tests */
             sd->session_timeout_minutes = MONGOC_NO_SESSIONS;
          } else {
-            goto typefailure;
+            GOTO (typefailure);
          }
       } else if (strcmp ("minWireVersion", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_INT32 (&iter))
-            goto typefailure;
+            GOTO (typefailure);
          sd->min_wire_version = bson_iter_int32 (&iter);
       } else if (strcmp ("maxWireVersion", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_INT32 (&iter))
-            goto typefailure;
+            GOTO (typefailure);
          sd->max_wire_version = bson_iter_int32 (&iter);
       } else if (strcmp ("msg", bson_iter_key (&iter)) == 0) {
          const char *msg;
          if (!BSON_ITER_HOLDS_UTF8 (&iter))
-            goto typefailure;
+            GOTO (typefailure);
          msg = bson_iter_utf8 (&iter, NULL);
          if (msg && 0 == strcmp (msg, "isdbgrid")) {
             is_shard = true;
          }
       } else if (strcmp ("setName", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_UTF8 (&iter))
-            goto typefailure;
+            GOTO (typefailure);
          sd->set_name = bson_iter_utf8 (&iter, NULL);
       } else if (strcmp ("setVersion", bson_iter_key (&iter)) == 0) {
          mongoc_server_description_set_set_version (sd,
                                                     bson_iter_as_int64 (&iter));
       } else if (strcmp ("electionId", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_OID (&iter))
-            goto typefailure;
+            GOTO (typefailure);
          mongoc_server_description_set_election_id (sd, bson_iter_oid (&iter));
       } else if (strcmp ("secondary", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_BOOL (&iter))
-            goto typefailure;
+            GOTO (typefailure);
          is_secondary = bson_iter_bool (&iter);
       } else if (strcmp ("hosts", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_ARRAY (&iter))
-            goto typefailure;
+            GOTO (typefailure);
          bson_iter_array (&iter, &len, &bytes);
          bson_destroy (&sd->hosts);
          BSON_ASSERT (bson_init_static (&sd->hosts, bytes, len));
       } else if (strcmp ("passives", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_ARRAY (&iter))
-            goto typefailure;
+            GOTO (typefailure);
          bson_iter_array (&iter, &len, &bytes);
          bson_destroy (&sd->passives);
          BSON_ASSERT (bson_init_static (&sd->passives, bytes, len));
       } else if (strcmp ("arbiters", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_ARRAY (&iter))
-            goto typefailure;
+            GOTO (typefailure);
          bson_iter_array (&iter, &len, &bytes);
          bson_destroy (&sd->arbiters);
          BSON_ASSERT (bson_init_static (&sd->arbiters, bytes, len));
       } else if (strcmp ("primary", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_UTF8 (&iter))
-            goto typefailure;
+            GOTO (typefailure);
          sd->current_primary = bson_iter_utf8 (&iter, NULL);
       } else if (strcmp ("arbiterOnly", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_BOOL (&iter))
-            goto typefailure;
+            GOTO (typefailure);
          is_arbiter = bson_iter_bool (&iter);
       } else if (strcmp ("isreplicaset", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_BOOL (&iter))
-            goto typefailure;
+            GOTO (typefailure);
          is_replicaset = bson_iter_bool (&iter);
       } else if (strcmp ("tags", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_DOCUMENT (&iter))
-            goto typefailure;
+            GOTO (typefailure);
          bson_iter_document (&iter, &len, &bytes);
          bson_destroy (&sd->tags);
          BSON_ASSERT (bson_init_static (&sd->tags, bytes, len));
@@ -713,13 +713,13 @@ mongoc_server_description_handle_hello (mongoc_server_description_t *sd,
              !bson_iter_recurse (&iter, &child) ||
              !bson_iter_find (&child, "lastWriteDate") ||
              !BSON_ITER_HOLDS_DATE_TIME (&child)) {
-            goto typefailure;
+            GOTO (typefailure);
          }
 
          sd->last_write_date_ms = bson_iter_date_time (&child);
       } else if (strcmp ("compression", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_ARRAY (&iter))
-            goto typefailure;
+            GOTO (typefailure);
          bson_iter_array (&iter, &len, &bytes);
          bson_destroy (&sd->compressors);
          BSON_ASSERT (bson_init_static (&sd->compressors, bytes, len));
@@ -727,7 +727,7 @@ mongoc_server_description_handle_hello (mongoc_server_description_t *sd,
          bson_t incoming_topology_version;
 
          if (!BSON_ITER_HOLDS_DOCUMENT (&iter)) {
-            goto typefailure;
+            GOTO (typefailure);
          }
 
          bson_iter_document (&iter, &len, &bytes);
@@ -737,11 +737,11 @@ mongoc_server_description_handle_hello (mongoc_server_description_t *sd,
          bson_destroy (&incoming_topology_version);
       } else if (strcmp ("serviceId", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_OID (&iter))
-            goto typefailure;
+            GOTO (typefailure);
          bson_oid_copy_unsafe (bson_iter_oid (&iter), &sd->service_id);
       } else if (strcmp ("connectionId", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_INT (&iter))
-            goto typefailure;
+            GOTO (typefailure);
          sd->server_connection_id = bson_iter_as_int64 (&iter);
       }
    }
@@ -788,14 +788,10 @@ mongoc_server_description_handle_hello (mongoc_server_description_t *sd,
    EXIT;
 
 typefailure:
-   sd->type = MONGOC_SERVER_UNKNOWN;
-   sd->round_trip_time_msec = MONGOC_RTT_UNSET;
    bson_set_error (&sd->error,
                    MONGOC_ERROR_STREAM,
                    MONGOC_ERROR_STREAM_INVALID_TYPE,
                    "invalid type sent to hello");
-   EXIT;
-
 authfailure:
    sd->type = MONGOC_SERVER_UNKNOWN;
    sd->round_trip_time_msec = MONGOC_RTT_UNSET;

--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -607,27 +607,27 @@ mongoc_server_description_handle_hello (mongoc_server_description_t *sd,
                  strcmp (HANDSHAKE_RESPONSE_LEGACY_HELLO,
                          bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_BOOL (&iter))
-            goto failure;
+            goto typefailure;
          is_primary = bson_iter_bool (&iter);
       } else if (strcmp ("helloOk", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_BOOL (&iter))
-            goto failure;
+            goto typefailure;
          sd->hello_ok = bson_iter_bool (&iter);
       } else if (strcmp ("me", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_UTF8 (&iter))
-            goto failure;
+            goto typefailure;
          sd->me = bson_iter_utf8 (&iter, NULL);
       } else if (strcmp ("maxMessageSizeBytes", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_INT32 (&iter))
-            goto failure;
+            goto typefailure;
          sd->max_msg_size = bson_iter_int32 (&iter);
       } else if (strcmp ("maxBsonObjectSize", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_INT32 (&iter))
-            goto failure;
+            goto typefailure;
          sd->max_bson_obj_size = bson_iter_int32 (&iter);
       } else if (strcmp ("maxWriteBatchSize", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_INT32 (&iter))
-            goto failure;
+            goto typefailure;
          sd->max_write_batch_size = bson_iter_int32 (&iter);
       } else if (strcmp ("logicalSessionTimeoutMinutes",
                          bson_iter_key (&iter)) == 0) {
@@ -637,72 +637,72 @@ mongoc_server_description_handle_hello (mongoc_server_description_t *sd,
             /* this arises executing standard JSON tests */
             sd->session_timeout_minutes = MONGOC_NO_SESSIONS;
          } else {
-            goto failure;
+            goto typefailure;
          }
       } else if (strcmp ("minWireVersion", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_INT32 (&iter))
-            goto failure;
+            goto typefailure;
          sd->min_wire_version = bson_iter_int32 (&iter);
       } else if (strcmp ("maxWireVersion", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_INT32 (&iter))
-            goto failure;
+            goto typefailure;
          sd->max_wire_version = bson_iter_int32 (&iter);
       } else if (strcmp ("msg", bson_iter_key (&iter)) == 0) {
          const char *msg;
          if (!BSON_ITER_HOLDS_UTF8 (&iter))
-            goto failure;
+            goto typefailure;
          msg = bson_iter_utf8 (&iter, NULL);
          if (msg && 0 == strcmp (msg, "isdbgrid")) {
             is_shard = true;
          }
       } else if (strcmp ("setName", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_UTF8 (&iter))
-            goto failure;
+            goto typefailure;
          sd->set_name = bson_iter_utf8 (&iter, NULL);
       } else if (strcmp ("setVersion", bson_iter_key (&iter)) == 0) {
          mongoc_server_description_set_set_version (sd,
                                                     bson_iter_as_int64 (&iter));
       } else if (strcmp ("electionId", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_OID (&iter))
-            goto failure;
+            goto typefailure;
          mongoc_server_description_set_election_id (sd, bson_iter_oid (&iter));
       } else if (strcmp ("secondary", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_BOOL (&iter))
-            goto failure;
+            goto typefailure;
          is_secondary = bson_iter_bool (&iter);
       } else if (strcmp ("hosts", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_ARRAY (&iter))
-            goto failure;
+            goto typefailure;
          bson_iter_array (&iter, &len, &bytes);
          bson_destroy (&sd->hosts);
          BSON_ASSERT (bson_init_static (&sd->hosts, bytes, len));
       } else if (strcmp ("passives", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_ARRAY (&iter))
-            goto failure;
+            goto typefailure;
          bson_iter_array (&iter, &len, &bytes);
          bson_destroy (&sd->passives);
          BSON_ASSERT (bson_init_static (&sd->passives, bytes, len));
       } else if (strcmp ("arbiters", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_ARRAY (&iter))
-            goto failure;
+            goto typefailure;
          bson_iter_array (&iter, &len, &bytes);
          bson_destroy (&sd->arbiters);
          BSON_ASSERT (bson_init_static (&sd->arbiters, bytes, len));
       } else if (strcmp ("primary", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_UTF8 (&iter))
-            goto failure;
+            goto typefailure;
          sd->current_primary = bson_iter_utf8 (&iter, NULL);
       } else if (strcmp ("arbiterOnly", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_BOOL (&iter))
-            goto failure;
+            goto typefailure;
          is_arbiter = bson_iter_bool (&iter);
       } else if (strcmp ("isreplicaset", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_BOOL (&iter))
-            goto failure;
+            goto typefailure;
          is_replicaset = bson_iter_bool (&iter);
       } else if (strcmp ("tags", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_DOCUMENT (&iter))
-            goto failure;
+            goto typefailure;
          bson_iter_document (&iter, &len, &bytes);
          bson_destroy (&sd->tags);
          BSON_ASSERT (bson_init_static (&sd->tags, bytes, len));
@@ -713,13 +713,13 @@ mongoc_server_description_handle_hello (mongoc_server_description_t *sd,
              !bson_iter_recurse (&iter, &child) ||
              !bson_iter_find (&child, "lastWriteDate") ||
              !BSON_ITER_HOLDS_DATE_TIME (&child)) {
-            goto failure;
+            goto typefailure;
          }
 
          sd->last_write_date_ms = bson_iter_date_time (&child);
       } else if (strcmp ("compression", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_ARRAY (&iter))
-            goto failure;
+            goto typefailure;
          bson_iter_array (&iter, &len, &bytes);
          bson_destroy (&sd->compressors);
          BSON_ASSERT (bson_init_static (&sd->compressors, bytes, len));
@@ -727,7 +727,7 @@ mongoc_server_description_handle_hello (mongoc_server_description_t *sd,
          bson_t incoming_topology_version;
 
          if (!BSON_ITER_HOLDS_DOCUMENT (&iter)) {
-            goto failure;
+            goto typefailure;
          }
 
          bson_iter_document (&iter, &len, &bytes);
@@ -737,11 +737,11 @@ mongoc_server_description_handle_hello (mongoc_server_description_t *sd,
          bson_destroy (&incoming_topology_version);
       } else if (strcmp ("serviceId", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_OID (&iter))
-            goto failure;
+            goto typefailure;
          bson_oid_copy_unsafe (bson_iter_oid (&iter), &sd->service_id);
       } else if (strcmp ("connectionId", bson_iter_key (&iter)) == 0) {
          if (!BSON_ITER_HOLDS_INT (&iter))
-            goto failure;
+            goto typefailure;
          sd->server_connection_id = bson_iter_as_int64 (&iter);
       }
    }
@@ -787,7 +787,7 @@ mongoc_server_description_handle_hello (mongoc_server_description_t *sd,
 
    EXIT;
 
-failure:
+typefailure:
    sd->type = MONGOC_SERVER_UNKNOWN;
    sd->round_trip_time_msec = MONGOC_RTT_UNSET;
    bson_set_error (&sd->error,

--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -790,11 +790,10 @@ mongoc_server_description_handle_hello (mongoc_server_description_t *sd,
 failure:
    sd->type = MONGOC_SERVER_UNKNOWN;
    sd->round_trip_time_msec = MONGOC_RTT_UNSET;
-   bson_set_error (error,
+   bson_set_error (&sd->error,
                    MONGOC_ERROR_STREAM,
                    MONGOC_ERROR_STREAM_INVALID_TYPE,
                    "invalid type sent to hello");
-   // gillog: need to set the bson_error_t here!
    EXIT;
 }
 

--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -790,7 +790,11 @@ mongoc_server_description_handle_hello (mongoc_server_description_t *sd,
 failure:
    sd->type = MONGOC_SERVER_UNKNOWN;
    sd->round_trip_time_msec = MONGOC_RTT_UNSET;
-
+   bson_set_error (error,
+                   MONGOC_ERROR_STREAM,
+                   MONGOC_ERROR_STREAM_INVALID_TYPE,
+                   "invalid type sent to hello");
+   // gillog: need to set the bson_error_t here!
    EXIT;
 }
 

--- a/src/libmongoc/tests/test-mongoc-server-description.c
+++ b/src/libmongoc/tests/test-mongoc-server-description.c
@@ -440,7 +440,10 @@ test_server_description_hello_type_error (void)
    mongoc_server_description_handle_hello (&sd, tmp_bson (hello), 0, &error);
    BSON_ASSERT (sd.type == MONGOC_SERVER_UNKNOWN);
    BSON_ASSERT (sd.error.code == MONGOC_ERROR_STREAM_INVALID_TYPE);
-   ASSERT_CMPSTR (sd.error.message, "invalid type sent to hello");
+   ASSERT_ERROR_CONTAINS (sd.error,
+                          MONGOC_ERROR_STREAM,
+                          MONGOC_ERROR_STREAM_INVALID_TYPE,
+                          "unexpected type");
 
    mongoc_server_description_cleanup (&sd);
 }

--- a/src/libmongoc/tests/test-mongoc-server-description.c
+++ b/src/libmongoc/tests/test-mongoc-server-description.c
@@ -440,6 +440,7 @@ test_server_description_hello_type_error (void)
    mongoc_server_description_handle_hello (&sd, tmp_bson (hello), 0, &error);
    BSON_ASSERT (sd.type == MONGOC_SERVER_UNKNOWN);
    BSON_ASSERT (sd.error.code == MONGOC_ERROR_STREAM_INVALID_TYPE);
+   ASSERT_CMPSTR (sd.error.message, "invalid type sent to hello");
 
    mongoc_server_description_cleanup (&sd);
 }

--- a/src/libmongoc/tests/test-mongoc-server-description.c
+++ b/src/libmongoc/tests/test-mongoc-server-description.c
@@ -417,6 +417,34 @@ test_server_description_connection_id (void)
    mongoc_server_description_cleanup (&sd);
 }
 
+// GILLOG
+static void
+test_server_description_error_mongohouse (void)
+{
+   mongoc_server_description_t sd;
+   bson_error_t error;
+   const char *hello =
+      "{"
+      "  'ok' : { '$numberInt' : '1' },"
+      " 'ismaster' : true,"
+      " 'maxBsonObjectSize' : { '$numberInt' : '16777216' },"
+      " 'maxMessageSizeBytes' : { '$numberInt' : '48000000'},"
+      " 'maxWriteBatchSize' : { '$numberLong' : '565160423'},"
+      " 'logicalSessionTimeoutMinutes' : { '$numberInt' : '30'},"
+      " 'connectionId' : { '$numberLong' : '565160423'},"
+      " 'minWireVersion' : { '$numberInt' : '0'},"
+      " 'maxWireVersion' : { '$numberInt' : '15'},"
+      " 'readOnly' : true"
+      "}";
+   mongoc_server_description_init (&sd, "host:1234", 1);
+   memset (&error, 0, sizeof (bson_error_t));
+   mongoc_server_description_handle_hello (&sd, tmp_bson (hello), 0, &error);
+   BSON_ASSERT (sd.type == MONGOC_SERVER_UNKNOWN);
+   printf ("%s%d", "GILLOG:", error.code);
+
+   mongoc_server_description_cleanup (&sd);
+}
+
 void
 test_server_description_install (TestSuite *suite)
 {
@@ -442,4 +470,7 @@ test_server_description_install (TestSuite *suite)
    TestSuite_Add (suite,
                   "/server_description/connection_id",
                   test_server_description_connection_id);
+   TestSuite_Add (suite,
+                  "/server_description/monghouse_hello_error_response",
+                  test_server_description_error_mongohouse);
 }

--- a/src/libmongoc/tests/test-mongoc-server-description.c
+++ b/src/libmongoc/tests/test-mongoc-server-description.c
@@ -417,9 +417,8 @@ test_server_description_connection_id (void)
    mongoc_server_description_cleanup (&sd);
 }
 
-// GILLOG
 static void
-test_server_description_error_mongohouse (void)
+test_server_description_hello_type_error (void)
 {
    mongoc_server_description_t sd;
    bson_error_t error;
@@ -440,7 +439,7 @@ test_server_description_error_mongohouse (void)
    memset (&error, 0, sizeof (bson_error_t));
    mongoc_server_description_handle_hello (&sd, tmp_bson (hello), 0, &error);
    BSON_ASSERT (sd.type == MONGOC_SERVER_UNKNOWN);
-   printf ("%s%d", "GILLOG:", error.code);
+   BSON_ASSERT (sd.error.code == MONGOC_ERROR_STREAM_INVALID_TYPE);
 
    mongoc_server_description_cleanup (&sd);
 }
@@ -471,6 +470,6 @@ test_server_description_install (TestSuite *suite)
                   "/server_description/connection_id",
                   test_server_description_connection_id);
    TestSuite_Add (suite,
-                  "/server_description/monghouse_hello_error_response",
-                  test_server_description_error_mongohouse);
+                  "/server_description/hello_type_error",
+                  test_server_description_hello_type_error);
 }


### PR DESCRIPTION
Before when a type error occurred in `mongoc_server_description_handle_hello` the program jumped to the `failure` label and exited without setting an error. Now the `failure` label sets the error message and code as a type error. There are two different types of failures in `mongoc_server_description_handle_hello` with different error codes, so the `failure` label was split into two labels to make it clearer which type of error is occuring.