### PR TITLE
CDRIVER-4504 Add -Wstrict-prototypes to maintainer flags

### DIFF
--- a/build/maintainer-flags.txt
+++ b/build/maintainer-flags.txt
@@ -1,5 +1,7 @@
+-pedantic
 -Wall
 -Wempty-body
+-Wexpansion-to-defined
 -Wformat
 -Wformat-nonliteral
 -Wformat-security
@@ -9,9 +11,8 @@
 -Wno-uninitialized
 -Wredundant-decls
 -Wshadow
+-Wstrict-prototypes
 -Wswitch-default
 -Wswitch-enum
 -Wundef
 -Wuninitialized
--Wexpansion-to-defined
--pedantic


### PR DESCRIPTION
This PR resolves CDRIVER-4504 as followup to CDRIVER-4484.

Changes were verified by [this patch](https://spruce.mongodb.com/version/63485b21850e6128847b27fe).