### PR TITLE
DEB and RPM Packaging for 1.23.1

### DIFF
--- a/.evergreen/mongo-c-driver.spec
+++ b/.evergreen/mongo-c-driver.spec
@@ -10,7 +10,7 @@
 %global gh_project   mongo-c-driver
 %global libname      libmongoc
 %global libver       1.0
-%global up_version   1.22.1
+%global up_version   1.23.1
 #global up_prever    rc0
 # disabled as require a MongoDB server
 %bcond_with          tests
@@ -21,7 +21,7 @@
 Name:      mongo-c-driver
 Summary:   Client library written in C for MongoDB
 Version:   %{up_version}%{?up_prever:~%{up_prever}}
-Release:   1%{?dist}
+Release:   2%{?dist}
 # See THIRD_PARTY_NOTICES
 License:   ASL 2.0 and ISC and MIT and zlib
 URL:       https://github.com/%{gh_owner}/%{gh_project}
@@ -236,6 +236,12 @@ exit $ret
 
 
 %changelog
+* Thu Oct 20 2022 Remi Collet <remi@remirepo.net> - 1.23.1-2
+- update to 1.23.1
+
+* Thu Sep  8 2022 Remi Collet <remi@remirepo.net> - 1.23.0-1
+- update to 1.23.0
+
 * Wed Aug  3 2022 Remi Collet <remi@remirepo.net> - 1.22.1-1
 - update to 1.22.1
 - raise dependency to libmongocrypt 1.5.2

--- a/.evergreen/spec.patch
+++ b/.evergreen/spec.patch
@@ -4,7 +4,7 @@
  %global gh_project   mongo-c-driver
  %global libname      libmongoc
  %global libver       1.0
--%global up_version   1.22.1
+-%global up_version   1.23.1
 +%global up_version   1.24.0
  #global up_prever    rc0
  # disabled as require a MongoDB server
@@ -17,6 +17,6 @@
  Summary:   Client library written in C for MongoDB
 -Version:   %{up_version}%{?up_prever:~%{up_prever}}
 +Version:   %{up_version}%{up_prever}
- Release:   1%{?dist}
+ Release:   2%{?dist}
  # See THIRD_PARTY_NOTICES
  License:   ASL 2.0 and ISC and MIT and zlib

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mongo-c-driver (1.23.1-1) UNRELEASED; urgency=medium
+
+  * New upstream release
+
+ -- Roberto C. Sanchez <roberto@connexer.com>  Thu, 20 Oct 2022 12:58:40 -0400
+
 mongo-c-driver (1.23.0-1) unstable; urgency=medium
 
   * New upstream release

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-mongo-c-driver (1.23.1-1) UNRELEASED; urgency=medium
+mongo-c-driver (1.23.1-1) unstable; urgency=medium
 
   * New upstream release
 


### PR DESCRIPTION
Evergreen patch build: https://spruce.mongodb.com/version/63519bbae3c3315fe0191dae/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

The `debian-package-build` task omitted from the patch build because the task is currently broken as a result of the ongoing Perl transition in Debian unstable.