### PR TITLE
Update getpagesize with POSIX standard sysconf(_SC_PAGESIZE)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ VERSION_CURRENT
 VERSION_RELEASED
 *.pyc
 
+# VSCode and those with clangd indexing
+.vscode
+.cache
+
 # Windows things
 *.sdf
 *.sln

--- a/src/libmongoc/src/mongoc/mongoc-counters.c
+++ b/src/libmongoc/src/mongoc/mongoc-counters.c
@@ -111,7 +111,7 @@ mongoc_counters_calc_size (void)
            (n_cpu * n_groups * sizeof (mongoc_counter_slots_t)));
 
 #ifdef BSON_OS_UNIX
-   return BSON_MAX (getpagesize (), size);
+   return BSON_MAX (sysconf(_SC_PAGESIZE), size);
 #else
    return size;
 #endif


### PR DESCRIPTION
Without this update the library does not build on macOS (Monterey 12.6)
Also add vscode project files and clangd indexing to git ignore