### PR TITLE
CDRIVER-4505 Fix build on MacOS due to undeclared getpagesize

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-counters.c
+++ b/src/libmongoc/src/mongoc/mongoc-counters.c
@@ -20,11 +20,11 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #ifdef BSON_OS_UNIX
 #include <sys/mman.h>
 #include <sys/shm.h>
+#include <unistd.h>
 #endif
 
 #ifdef _MSC_VER

--- a/src/libmongoc/src/mongoc/mongoc-counters.c
+++ b/src/libmongoc/src/mongoc/mongoc-counters.c
@@ -112,7 +112,7 @@ mongoc_counters_calc_size (void)
            (n_cpu * n_groups * sizeof (mongoc_counter_slots_t)));
 
 #ifdef BSON_OS_UNIX
-   return BSON_MAX (sysconf(_SC_PAGESIZE), size);
+   return BSON_MAX (sysconf (_SC_PAGESIZE), size);
 #else
    return size;
 #endif

--- a/src/libmongoc/src/mongoc/mongoc-counters.c
+++ b/src/libmongoc/src/mongoc/mongoc-counters.c
@@ -20,6 +20,7 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #ifdef BSON_OS_UNIX
 #include <sys/mman.h>
@@ -111,7 +112,7 @@ mongoc_counters_calc_size (void)
            (n_cpu * n_groups * sizeof (mongoc_counter_slots_t)));
 
 #ifdef BSON_OS_UNIX
-   return BSON_MAX (getpagesize (), size);
+   return BSON_MAX (sysconf(_SC_PAGESIZE), size);
 #else
    return size;
 #endif


### PR DESCRIPTION
CDRIVER-4505

It appears that getpagesize has been deprecated on newer MacOS versions. We can see that POSIX version 7 (link below) has removed getpagesize altogether from the standard, so even including unistd.h does not solve this problem on newer MacOS versions.

Please see here at section B.3.2 System Interfaces Removed in the Previous Version:
https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xsh_chap03.html

Relevant stackoverflow:
https://stackoverflow.com/a/37193970

Jira:
https://jira.mongodb.org/browse/CDRIVER-4505