### PR TITLE
CDRIVER-4503 Address aligned_alloc failures due to violating minimum alignment

### DIFF
--- a/src/libmongoc/tests/unified/entity-map.c
+++ b/src/libmongoc/tests/unified/entity-map.c
@@ -370,7 +370,7 @@ entity_client_new (entity_map_t *em, bson_t *bson, bson_error_t *error)
                 then (error ("'observeSensitiveCommands' must be a bool"))),
             do({
                bool *p = entity->observe_sensitive_commands =
-                  BSON_ALIGNED_ALLOC0 (bool);
+                  bson_malloc (sizeof (bool));
                *p = bsonAs (bool);
             })),
       // Which events should be available as entities:


### PR DESCRIPTION
## Description

This PR is a followup to https://github.com/mongodb/mongo-c-driver/pull/1094 to address [current task failures on Evergreen](https://spruce.mongodb.com/version/mongo_c_driver_40a64c2ffd6634021741e5435be15089d1f466f3/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).

I [overlooked](https://github.com/mongodb/mongo-c-driver/pull/1094#discussion_r1004734154) during code review that on top of `aligned_alloc`/`posix_memalign` requirements that the requested alignment to be both a multiple of 2 and a multiple of `sizeof(void*)`, several implementations ([one](https://www.freebsd.org/cgi/man.cgi?query=aligned_alloc), [two](https://man.netbsd.org/aligned_alloc.3)) additionally require that the alignment is _at least as large as_ `sizeof(void*)` , which `bool` does not satisfy.

This is what motivated [alignment promotion in mongoc_ts_pool_new](https://github.com/mongodb/mongo-c-driver/blob/40a64c2ffd6634021741e5435be15089d1f466f3/src/libmongoc/src/mongoc/mongoc-ts-pool.c#L223) and was also [loosely documented](https://github.com/mongodb/mongo-c-driver/blob/40a64c2ffd6634021741e5435be15089d1f466f3/src/libbson/doc/bson_aligned_alloc.rst#description) in libbson as:

> In general, this function will return an allocation at least `sizeof(void*)` bytes or bigger with an alignment of at least `alignment`.

This PR simply replaces the `BSON_ALIGNED_ALLOC0 (bool)` with a `bson_malloc (sizeof (bool))`. The 0-init is omitted as the value is immediately assigned-to after allocation.