### PR TITLE
CDRIVER-4424: Additional error handling tests for CEC

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
@@ -2764,6 +2764,16 @@ mongoc_client_encryption_create_encrypted_collection (
       goto done;
    }
 
+   if (bson_empty (&in_encryptedFields)) {
+      bson_set_error (error,
+                      MONGOC_ERROR_COMMAND,
+                      MONGOC_ERROR_COMMAND_INVALID_ARG,
+                      "No 'encryptedFields' are defined for the creation of "
+                      "the '%s' collection",
+                      name);
+      goto done;
+   }
+
    // Add the keyIds to the encryptedFields.
    // Context for the creation of new datakeys:
    struct cec_context ctx = {

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -5477,7 +5477,7 @@ test_auto_datakeys (void *unused)
 }
 
 static void
-test_create_encrypted_collection (void *unused)
+test_create_encrypted_collection_simple (void *unused)
 {
    BSON_UNUSED (unused);
    bson_error_t error = {0};
@@ -5508,7 +5508,7 @@ test_create_encrypted_collection (void *unused)
       mongoc_client_encryption_opts_new ();
    mongoc_client_encryption_opts_set_kms_providers (ceOpts, kmsProviders);
    mongoc_client_encryption_opts_set_keyvault_namespace (
-      ceOpts, "keyvaule", "datakeys");
+      ceOpts, "keyvault", "datakeys");
    mongoc_client_encryption_opts_set_keyvault_client (ceOpts, client);
    mongoc_client_encryption_t *const ce =
       mongoc_client_encryption_new (ceOpts, &error);
@@ -5540,6 +5540,135 @@ test_create_encrypted_collection (void *unused)
    ASSERT_ERROR_CONTAINS (
       error, MONGOC_ERROR_COLLECTION, 121, "failed validation");
    bson_destroy (&doc);
+
+   bson_destroy (kmsProviders);
+   mongoc_client_encryption_datakey_opts_destroy (dkOpts);
+   mongoc_collection_destroy (coll);
+   mongoc_database_drop (db, &error);
+   mongoc_database_destroy (db);
+   mongoc_client_encryption_destroy (ce);
+   mongoc_client_destroy (client);
+}
+
+static void
+test_create_encrypted_collection_no_encryptedFields (void *unused)
+{
+   BSON_UNUSED (unused);
+   bson_error_t error = {0};
+   mongoc_client_t *const client = test_framework_new_default_client ();
+   bson_t *const kmsProviders = _make_kms_providers (false, true);
+
+   const char *const dbName = "cec-test-db";
+
+   // Drop prior data
+   {
+      mongoc_collection_t *const coll =
+         mongoc_client_get_collection (client, "keyvault", "datakeys");
+      if (coll) {
+         mongoc_collection_drop (coll, &error);
+         bool okay =
+            error.code == 0 || strstr (error.message, "ns not found") != NULL;
+         ASSERT_OR_PRINT (okay, error);
+      }
+      mongoc_collection_destroy (coll);
+
+      mongoc_database_t *const db = mongoc_client_get_database (client, dbName);
+      ASSERT_OR_PRINT (mongoc_database_drop (db, &error), error);
+      mongoc_database_destroy (db);
+   }
+
+   // Create a CE
+   mongoc_client_encryption_opts_t *const ceOpts =
+      mongoc_client_encryption_opts_new ();
+   mongoc_client_encryption_opts_set_kms_providers (ceOpts, kmsProviders);
+   mongoc_client_encryption_opts_set_keyvault_namespace (
+      ceOpts, "keyvault", "datakeys");
+   mongoc_client_encryption_opts_set_keyvault_client (ceOpts, client);
+   mongoc_client_encryption_t *const ce =
+      mongoc_client_encryption_new (ceOpts, &error);
+   mongoc_client_encryption_opts_destroy (ceOpts);
+   ASSERT_OR_PRINT (ce, error);
+
+   // Create the encrypted collection
+   bsonBuildDecl (ccOpts);
+   mongoc_database_t *const db = mongoc_client_get_database (client, dbName);
+   mongoc_client_encryption_datakey_opts_t *const dkOpts =
+      mongoc_client_encryption_datakey_opts_new ();
+   mongoc_collection_t *const coll =
+      mongoc_client_encryption_create_encrypted_collection (
+         ce, db, "test-coll", &ccOpts, NULL, "local", dkOpts, &error);
+   ASSERT_ERROR_CONTAINS (error,
+                          MONGOC_ERROR_COMMAND,
+                          MONGOC_ERROR_COMMAND_INVALID_ARG,
+                          "No 'encryptedFields' are defined");
+   bson_destroy (&ccOpts);
+
+   bson_destroy (kmsProviders);
+   mongoc_client_encryption_datakey_opts_destroy (dkOpts);
+   mongoc_collection_destroy (coll);
+   mongoc_database_drop (db, &error);
+   mongoc_database_destroy (db);
+   mongoc_client_encryption_destroy (ce);
+   mongoc_client_destroy (client);
+}
+
+static void
+test_create_encrypted_collection_bad_keyId (void *unused)
+{
+   BSON_UNUSED (unused);
+   bson_error_t error = {0};
+   mongoc_client_t *const client = test_framework_new_default_client ();
+   bson_t *const kmsProviders = _make_kms_providers (false, true);
+
+   const char *const dbName = "cec-test-db";
+
+   // Drop prior data
+   {
+      mongoc_collection_t *const coll =
+         mongoc_client_get_collection (client, "keyvault", "datakeys");
+      if (coll) {
+         mongoc_collection_drop (coll, &error);
+         bool okay =
+            error.code == 0 || strstr (error.message, "ns not found") != NULL;
+         ASSERT_OR_PRINT (okay, error);
+      }
+      mongoc_collection_destroy (coll);
+
+      mongoc_database_t *const db = mongoc_client_get_database (client, dbName);
+      ASSERT_OR_PRINT (mongoc_database_drop (db, &error), error);
+      mongoc_database_destroy (db);
+   }
+
+   // Create a CE
+   mongoc_client_encryption_opts_t *const ceOpts =
+      mongoc_client_encryption_opts_new ();
+   mongoc_client_encryption_opts_set_kms_providers (ceOpts, kmsProviders);
+   mongoc_client_encryption_opts_set_keyvault_namespace (
+      ceOpts, "keyvault", "datakeys");
+   mongoc_client_encryption_opts_set_keyvault_client (ceOpts, client);
+   mongoc_client_encryption_t *const ce =
+      mongoc_client_encryption_new (ceOpts, &error);
+   mongoc_client_encryption_opts_destroy (ceOpts);
+   ASSERT_OR_PRINT (ce, error);
+
+   // Create the encrypted collection
+   bsonBuildDecl (ccOpts,
+                  kv ("encryptedFields",
+                      doc (kv ("fields",
+                               array (doc (kv ("path", cstr ("ssn")),
+                                           kv ("bsonType", cstr ("string")),
+                                           kv ("keyId", bool (true))))))));
+   mongoc_database_t *const db = mongoc_client_get_database (client, dbName);
+   mongoc_client_encryption_datakey_opts_t *const dkOpts =
+      mongoc_client_encryption_datakey_opts_new ();
+   mongoc_collection_t *const coll =
+      mongoc_client_encryption_create_encrypted_collection (
+         ce, db, "test-coll", &ccOpts, NULL, "local", dkOpts, &error);
+   ASSERT_ERROR_CONTAINS (error,
+                          MONGOC_ERROR_QUERY,
+                          MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
+                          "create.encryptedFields.fields.keyId");
+   bson_destroy (&ccOpts);
 
    bson_destroy (kmsProviders);
    mongoc_client_encryption_datakey_opts_destroy (dkOpts);
@@ -5858,9 +5987,29 @@ test_client_side_encryption_install (TestSuite *suite)
                       NULL,
                       NULL);
 
+   TestSuite_AddFull (
+      suite,
+      "/client_side_encryption/createEncryptedCollection/simple",
+      test_create_encrypted_collection_simple,
+      NULL,
+      NULL,
+      test_framework_skip_if_no_client_side_encryption,
+      test_framework_skip_if_max_wire_version_less_than_17,
+      test_framework_skip_if_single);
+
    TestSuite_AddFull (suite,
-                      "/client_side_encryption/createEncryptedCollection",
-                      test_create_encrypted_collection,
+                      "/client_side_encryption/createEncryptedCollection/"
+                      "missing-encryptedFields",
+                      test_create_encrypted_collection_no_encryptedFields,
+                      NULL,
+                      NULL,
+                      test_framework_skip_if_no_client_side_encryption,
+                      test_framework_skip_if_max_wire_version_less_than_17,
+                      test_framework_skip_if_single);
+   TestSuite_AddFull (suite,
+                      "/client_side_encryption/createEncryptedCollection/"
+                      "bad-keyId",
+                      test_create_encrypted_collection_bad_keyId,
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,


### PR DESCRIPTION
This adds more to the work for CDRIVER-4424, and adds two very basic error-handling tests. This already caught one minor issue in the implementation (a missing check for encryptedFields resulted in a regular collection being created without issue).