### PR TITLE
CDRIVER-4517 Sync unified retryable read and write test files with 35b17b70

### DIFF
--- a/src/libmongoc/tests/json/retryable_reads/unified/handshakeError.json
+++ b/src/libmongoc/tests/json/retryable_reads/unified/handshakeError.json
@@ -1,6 +1,6 @@
 {
   "description": "retryable reads handshake failures",
-  "schemaVersion": "1.3",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "4.2",
@@ -62,7 +62,7 @@
   ],
   "tests": [
     {
-      "description": "listDatabases succeeds after retryable handshake network error",
+      "description": "client.listDatabases succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -155,7 +155,7 @@
       ]
     },
     {
-      "description": "listDatabases succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "client.listDatabases succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -248,7 +248,7 @@
       ]
     },
     {
-      "description": "listDatabaseNames succeeds after retryable handshake network error",
+      "description": "client.listDatabaseNames succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -338,7 +338,7 @@
       ]
     },
     {
-      "description": "listDatabaseNames succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "client.listDatabaseNames succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -428,7 +428,12 @@
       ]
     },
     {
-      "description": "createChangeStream succeeds after retryable handshake network error",
+      "description": "client.createChangeStream succeeds after retryable handshake network error",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -522,7 +527,12 @@
       ]
     },
     {
-      "description": "createChangeStream succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "client.createChangeStream succeeds after retryable handshake server error (ShutdownInProgress)",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -616,7 +626,12 @@
       ]
     },
     {
-      "description": "aggregate succeeds after retryable handshake network error",
+      "description": "database.aggregate succeeds after retryable handshake network error",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -716,7 +731,12 @@
       ]
     },
     {
-      "description": "aggregate succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "database.aggregate succeeds after retryable handshake server error (ShutdownInProgress)",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -816,7 +836,7 @@
       ]
     },
     {
-      "description": "listCollections succeeds after retryable handshake network error",
+      "description": "database.listCollections succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -909,7 +929,7 @@
       ]
     },
     {
-      "description": "listCollections succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "database.listCollections succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -1002,7 +1022,7 @@
       ]
     },
     {
-      "description": "listCollectionNames succeeds after retryable handshake network error",
+      "description": "database.listCollectionNames succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -1095,7 +1115,7 @@
       ]
     },
     {
-      "description": "listCollectionNames succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "database.listCollectionNames succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -1188,7 +1208,12 @@
       ]
     },
     {
-      "description": "createChangeStream succeeds after retryable handshake network error",
+      "description": "database.createChangeStream succeeds after retryable handshake network error",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -1282,7 +1307,12 @@
       ]
     },
     {
-      "description": "createChangeStream succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "database.createChangeStream succeeds after retryable handshake server error (ShutdownInProgress)",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -1376,7 +1406,7 @@
       ]
     },
     {
-      "description": "aggregate succeeds after retryable handshake network error",
+      "description": "collection.aggregate succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -1469,7 +1499,7 @@
       ]
     },
     {
-      "description": "aggregate succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.aggregate succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -1562,7 +1592,7 @@
       ]
     },
     {
-      "description": "countDocuments succeeds after retryable handshake network error",
+      "description": "collection.countDocuments succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -1655,7 +1685,7 @@
       ]
     },
     {
-      "description": "countDocuments succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.countDocuments succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -1748,7 +1778,7 @@
       ]
     },
     {
-      "description": "estimatedDocumentCount succeeds after retryable handshake network error",
+      "description": "collection.estimatedDocumentCount succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -1838,7 +1868,7 @@
       ]
     },
     {
-      "description": "estimatedDocumentCount succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.estimatedDocumentCount succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -1928,7 +1958,7 @@
       ]
     },
     {
-      "description": "distinct succeeds after retryable handshake network error",
+      "description": "collection.distinct succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -2022,7 +2052,7 @@
       ]
     },
     {
-      "description": "distinct succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.distinct succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -2116,7 +2146,7 @@
       ]
     },
     {
-      "description": "find succeeds after retryable handshake network error",
+      "description": "collection.find succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -2209,7 +2239,7 @@
       ]
     },
     {
-      "description": "find succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.find succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -2302,7 +2332,7 @@
       ]
     },
     {
-      "description": "findOne succeeds after retryable handshake network error",
+      "description": "collection.findOne succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -2395,7 +2425,7 @@
       ]
     },
     {
-      "description": "findOne succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.findOne succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -2488,7 +2518,7 @@
       ]
     },
     {
-      "description": "listIndexes succeeds after retryable handshake network error",
+      "description": "collection.listIndexes succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -2578,7 +2608,7 @@
       ]
     },
     {
-      "description": "listIndexes succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.listIndexes succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -2668,7 +2698,7 @@
       ]
     },
     {
-      "description": "listIndexNames succeeds after retryable handshake network error",
+      "description": "collection.listIndexNames succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -2758,7 +2788,7 @@
       ]
     },
     {
-      "description": "listIndexNames succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.listIndexNames succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -2848,7 +2878,12 @@
       ]
     },
     {
-      "description": "createChangeStream succeeds after retryable handshake network error",
+      "description": "collection.createChangeStream succeeds after retryable handshake network error",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -2942,7 +2977,12 @@
       ]
     },
     {
-      "description": "createChangeStream succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.createChangeStream succeeds after retryable handshake server error (ShutdownInProgress)",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",

--- a/src/libmongoc/tests/json/retryable_writes/unified/handshakeError.json
+++ b/src/libmongoc/tests/json/retryable_writes/unified/handshakeError.json
@@ -54,7 +54,7 @@
   ],
   "tests": [
     {
-      "description": "insertOne succeeds after retryable handshake network error",
+      "description": "collection.insertOne succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -150,7 +150,7 @@
       ]
     },
     {
-      "description": "insertOne succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.insertOne succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -246,7 +246,7 @@
       ]
     },
     {
-      "description": "insertMany succeeds after retryable handshake network error",
+      "description": "collection.insertMany succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -344,7 +344,7 @@
       ]
     },
     {
-      "description": "insertMany succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.insertMany succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -442,7 +442,7 @@
       ]
     },
     {
-      "description": "deleteOne succeeds after retryable handshake network error",
+      "description": "collection.deleteOne succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -535,7 +535,7 @@
       ]
     },
     {
-      "description": "deleteOne succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.deleteOne succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -628,7 +628,7 @@
       ]
     },
     {
-      "description": "replaceOne succeeds after retryable handshake network error",
+      "description": "collection.replaceOne succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -724,7 +724,7 @@
       ]
     },
     {
-      "description": "replaceOne succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.replaceOne succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -820,7 +820,7 @@
       ]
     },
     {
-      "description": "updateOne succeeds after retryable handshake network error",
+      "description": "collection.updateOne succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -918,7 +918,7 @@
       ]
     },
     {
-      "description": "updateOne succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.updateOne succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -1016,7 +1016,7 @@
       ]
     },
     {
-      "description": "findOneAndDelete succeeds after retryable handshake network error",
+      "description": "collection.findOneAndDelete succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -1109,7 +1109,7 @@
       ]
     },
     {
-      "description": "findOneAndDelete succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.findOneAndDelete succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -1202,7 +1202,7 @@
       ]
     },
     {
-      "description": "findOneAndReplace succeeds after retryable handshake network error",
+      "description": "collection.findOneAndReplace succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -1298,7 +1298,7 @@
       ]
     },
     {
-      "description": "findOneAndReplace succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.findOneAndReplace succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -1394,7 +1394,7 @@
       ]
     },
     {
-      "description": "findOneAndUpdate succeeds after retryable handshake network error",
+      "description": "collection.findOneAndUpdate succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -1492,7 +1492,7 @@
       ]
     },
     {
-      "description": "findOneAndUpdate succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.findOneAndUpdate succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -1590,7 +1590,7 @@
       ]
     },
     {
-      "description": "bulkWrite succeeds after retryable handshake network error",
+      "description": "collection.bulkWrite succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -1692,7 +1692,7 @@
       ]
     },
     {
-      "description": "bulkWrite succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.bulkWrite succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",

--- a/src/libmongoc/tests/unified/runner.c
+++ b/src/libmongoc/tests/unified/runner.c
@@ -57,14 +57,11 @@ skipped_unified_test_t SKIPPED_TESTS[] = {
    // libmongoc does not pin connections to cursors. It cannot force an error from waitQueueTimeoutMS by creating cursors in load balanced mode.
    {"wait queue timeout errors include details about checked out connections", SKIP_ALL_TESTS},
    // libmongoc does not support the optional findOne helper.
-   {"retryable reads handshake failures", "findOne succeeds after retryable handshake network error"},
-   {"retryable reads handshake failures", "findOne succeeds after retryable handshake server error (ShutdownInProgress)"},
-   // libmongoc does not support the optional count helper.
-   {"retryable reads handshake failures", "count succeeds after retryable handshake network error"},
-   {"retryable reads handshake failures", "count succeeds after retryable handshake server error (ShutdownInProgress)"},
+   {"retryable reads handshake failures", "collection.findOne succeeds after retryable handshake network error"},
+   {"retryable reads handshake failures", "collection.findOne succeeds after retryable handshake server error (ShutdownInProgress)"},
    // libmongoc does not support the optional listIndexNames helper.
-   {"retryable reads handshake failures", "listIndexNames succeeds after retryable handshake network error"},
-   {"retryable reads handshake failures", "listIndexNames succeeds after retryable handshake server error (ShutdownInProgress)"},
+   {"retryable reads handshake failures", "collection.listIndexNames succeeds after retryable handshake network error"},
+   {"retryable reads handshake failures", "collection.listIndexNames succeeds after retryable handshake server error (ShutdownInProgress)"},
    {0},
 };
 // clang-format on


### PR DESCRIPTION
## Description

This PR amends CDRIVER-4517 and is a followup to https://github.com/mongodb/mongo-c-driver/pull/1141 that applies a bugfix that skips createChangeStream and listLocalSessions operations on serverless where they are not supported.