### PR TITLE
CDRIVER-4454: Use consistent include path for mcd-time.h

### DIFF
--- a/src/libmongoc/src/mongoc/mcd-azure.h
+++ b/src/libmongoc/src/mongoc/mcd-azure.h
@@ -23,7 +23,7 @@
 
 #include <mongoc/mongoc-http-private.h>
 
-#include <mcd-time.h>
+#include <mongoc/mcd-time.h>
 
 /**
  * @brief An Azure OAuth2 access token obtained from the Azure API


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-4454

This include was inconsistent with all others in libmongoc. The path is necessary for compilation in Visual Studio when "src/libmongoc/src/libmongoc/src" is used as an include path.

This was originally introduced in mongodb/mongo-c-driver@686bff81f565f93db83d99902ce1c3a6f89922c7

----

This was responsible for a Windows build failure in PHPC: https://github.com/mongodb/mongo-php-driver/actions/runs/3581633513/jobs/6024994327#step:7:299

```
d:\a\mongo-php-driver\mongo-php-driver\src\libmongoc\src\libmongoc\src\mongoc\./mcd-azure.h(26): fatal error C1083: Cannot open include file: 'mcd-time.h': No such file or directory (compiling source file D:\a\mongo-php-driver\mongo-php-driver\src\libmongoc\src\libmongoc\src\mongoc\mcd-azure.c)
```

See also: https://learn.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2012/36k2cdd4(v=vs.110)