### PR TITLE
CDRIVER-4519 Replace activate_venv.sh with new hygienic scripts

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -442,11 +442,11 @@ functions:
           export AWS_SECRET_ACCESS_KEY="${client_side_encryption_aws_secret_access_key}"
           export AWS_ACCESS_KEY_ID="${client_side_encryption_aws_access_key_id}"
           export AWS_DEFAULT_REGION="us-east-1"
-          echo "Running activate_venv.sh..."
-          . ./activate_venv.sh
-          echo "Running activate_venv.sh... done."
+          echo "Running activate-kmstlsvenv.sh..."
+          . ./activate-kmstlsvenv.sh
+          echo "Running activate-kmstlsvenv.sh... done."
           echo "Running set-temp-creds.sh..."
-          PYTHON="$(type -P python)" . ./set-temp-creds.sh
+          . ./set-temp-creds.sh
           echo "Running set-temp-creds.sh... done."
           deactivate
           popd
@@ -789,7 +789,9 @@ functions:
         set +o xtrace
         export IAM_AUTH_ECS_ACCOUNT=${iam_auth_ecs_account}
         export IAM_AUTH_ECS_SECRET_ACCESS_KEY=${iam_auth_ecs_secret_access_key}
-        . ../drivers-evergreen-tools/.evergreen/auth_aws/activate_venv.sh
+        pushd ../drivers-evergreen-tools/.evergreen/auth_aws
+        . .activate-authawsvenv.sh
+        popd # ../drivers-evergreen-tools/.evergreen/auth_aws
         sh ./.evergreen/run-aws-tests.sh ${TESTCASE}
   clone drivers-evergreen-tools:
   - command: shell.exec
@@ -808,12 +810,12 @@ functions:
         set -o errexit
         echo "Preparing CSFLE venv environment..."
         cd ./drivers-evergreen-tools/.evergreen/csfle
-        # This function ensures future invocations of activate_venv.sh conducted in
+        # This function ensures future invocations of activate-kmstlsvenv.sh conducted in
         # parallel do not race to setup a venv environment; it has already been prepared.
         # This primarily addresses the situation where the "run tests" and "run kms servers"
-        # functions invoke 'activate_venv.sh' simultaneously.
+        # functions invoke 'activate-kmstlsvenv.sh' simultaneously.
         # TODO: remove this function along with the "run kms servers" function.
-        . ./activate_venv.sh
+        . ./activate-kmstlsvenv.sh
         deactivate
         echo "Preparing CSFLE venv environment... done."
   - command: shell.exec
@@ -824,7 +826,7 @@ functions:
         set -o errexit
         echo "Starting mock KMS servers..."
         cd ./drivers-evergreen-tools/.evergreen/csfle
-        . ./activate_venv.sh
+        . ./activate-kmstlsvenv.sh
         python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/server.pem --port 8999 &
         python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 9000 &
         python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 9001 &

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -819,13 +819,8 @@ functions:
             # Avoid using Python 3.10 on Windows due to incompatible cipher suites.
             # See CDRIVER-4530.
             . ../venv-utils.sh
-            if [[ -f "C:/python/Python39/python.exe" ]]; then
-                # windows-2017
-                venvcreate "C:/python/Python39/python.exe" kmstlsvenv
-            elif [[ -f "C:/python/Python38/python.exe" ]]; then
-                # windows-2015
-                venvcreate "C:/python/Python38/python.exe" kmstlsvenv
-            fi
+            venvcreate "C:/python/Python39/python.exe" kmstlsvenv || # windows-2017
+            venvcreate "C:/python/Python38/python.exe" kmstlsvenv    # windows-2015
             python -m pip install --upgrade boto3~=1.19 pykmip~=0.10.0
             deactivate
         else

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -815,8 +815,23 @@ functions:
         # This primarily addresses the situation where the "run tests" and "run kms servers"
         # functions invoke 'activate-kmstlsvenv.sh' simultaneously.
         # TODO: remove this function along with the "run kms servers" function.
-        . ./activate-kmstlsvenv.sh
-        deactivate
+        if [[ "$OSTYPE" =~ cygwin && ! -d kmstlsvenv ]]; then
+            # Avoid using Python 3.10 on Windows due to incompatible cipher suites.
+            # See CDRIVER-4530.
+            . ../venv-utils.sh
+            if [[ -f "C:/python/Python39/python.exe" ]]; then
+                # windows-2017
+                venvcreate "C:/python/Python39/python.exe" kmstlsvenv
+            elif [[ -f "C:/python/Python38/python.exe" ]]; then
+                # windows-2015
+                venvcreate "C:/python/Python38/python.exe" kmstlsvenv
+            fi
+            python -m pip install --upgrade boto3~=1.19 pykmip~=0.10.0
+            deactivate
+        else
+            . ./activate-kmstlsvenv.sh
+            deactivate
+        fi
         echo "Preparing CSFLE venv environment... done."
   - command: shell.exec
     params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -790,7 +790,7 @@ functions:
         export IAM_AUTH_ECS_ACCOUNT=${iam_auth_ecs_account}
         export IAM_AUTH_ECS_SECRET_ACCESS_KEY=${iam_auth_ecs_secret_access_key}
         pushd ../drivers-evergreen-tools/.evergreen/auth_aws
-        . .activate-authawsvenv.sh
+        . ./activate-authawsvenv.sh
         popd # ../drivers-evergreen-tools/.evergreen/auth_aws
         sh ./.evergreen/run-aws-tests.sh ${TESTCASE}
   clone drivers-evergreen-tools:

--- a/build/evergreen_config_lib/functions.py
+++ b/build/evergreen_config_lib/functions.py
@@ -315,11 +315,11 @@ all_functions = OD([
           export AWS_SECRET_ACCESS_KEY="${client_side_encryption_aws_secret_access_key}"
           export AWS_ACCESS_KEY_ID="${client_side_encryption_aws_access_key_id}"
           export AWS_DEFAULT_REGION="us-east-1"
-          echo "Running activate_venv.sh..."
-          . ./activate_venv.sh
-          echo "Running activate_venv.sh... done."
+          echo "Running activate-kmstlsvenv.sh..."
+          . ./activate-kmstlsvenv.sh
+          echo "Running activate-kmstlsvenv.sh... done."
           echo "Running set-temp-creds.sh..."
-          PYTHON="$(type -P python)" . ./set-temp-creds.sh
+          . ./set-temp-creds.sh
           echo "Running set-temp-creds.sh... done."
           deactivate
           popd
@@ -581,7 +581,9 @@ all_functions = OD([
         set +o xtrace
         export IAM_AUTH_ECS_ACCOUNT=${iam_auth_ecs_account}
         export IAM_AUTH_ECS_SECRET_ACCESS_KEY=${iam_auth_ecs_secret_access_key}
-        . ../drivers-evergreen-tools/.evergreen/auth_aws/activate_venv.sh
+        pushd ../drivers-evergreen-tools/.evergreen/auth_aws
+        . .activate-authawsvenv.sh
+        popd # ../drivers-evergreen-tools/.evergreen/auth_aws
         sh ./.evergreen/run-aws-tests.sh ${TESTCASE}
         ''')
     )),
@@ -596,19 +598,19 @@ all_functions = OD([
         shell_exec(r'''
         echo "Preparing CSFLE venv environment..."
         cd ./drivers-evergreen-tools/.evergreen/csfle
-        # This function ensures future invocations of activate_venv.sh conducted in
+        # This function ensures future invocations of activate-kmstlsvenv.sh conducted in
         # parallel do not race to setup a venv environment; it has already been prepared.
         # This primarily addresses the situation where the "run tests" and "run kms servers"
-        # functions invoke 'activate_venv.sh' simultaneously.
+        # functions invoke 'activate-kmstlsvenv.sh' simultaneously.
         # TODO: remove this function along with the "run kms servers" function.
-        . ./activate_venv.sh
+        . ./activate-kmstlsvenv.sh
         deactivate
         echo "Preparing CSFLE venv environment... done."
         ''', test=False),
         shell_exec(r'''
         echo "Starting mock KMS servers..."
         cd ./drivers-evergreen-tools/.evergreen/csfle
-        . ./activate_venv.sh
+        . ./activate-kmstlsvenv.sh
         python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/server.pem --port 8999 &
         python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 9000 &
         python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 9001 &

--- a/build/evergreen_config_lib/functions.py
+++ b/build/evergreen_config_lib/functions.py
@@ -582,7 +582,7 @@ all_functions = OD([
         export IAM_AUTH_ECS_ACCOUNT=${iam_auth_ecs_account}
         export IAM_AUTH_ECS_SECRET_ACCESS_KEY=${iam_auth_ecs_secret_access_key}
         pushd ../drivers-evergreen-tools/.evergreen/auth_aws
-        . .activate-authawsvenv.sh
+        . ./activate-authawsvenv.sh
         popd # ../drivers-evergreen-tools/.evergreen/auth_aws
         sh ./.evergreen/run-aws-tests.sh ${TESTCASE}
         ''')

--- a/build/evergreen_config_lib/functions.py
+++ b/build/evergreen_config_lib/functions.py
@@ -603,8 +603,23 @@ all_functions = OD([
         # This primarily addresses the situation where the "run tests" and "run kms servers"
         # functions invoke 'activate-kmstlsvenv.sh' simultaneously.
         # TODO: remove this function along with the "run kms servers" function.
-        . ./activate-kmstlsvenv.sh
-        deactivate
+        if [[ "$OSTYPE" =~ cygwin && ! -d kmstlsvenv ]]; then
+            # Avoid using Python 3.10 on Windows due to incompatible cipher suites.
+            # See CDRIVER-4530.
+            . ../venv-utils.sh
+            if [[ -f "C:/python/Python39/python.exe" ]]; then
+                # windows-2017
+                venvcreate "C:/python/Python39/python.exe" kmstlsvenv
+            elif [[ -f "C:/python/Python38/python.exe" ]]; then
+                # windows-2015
+                venvcreate "C:/python/Python38/python.exe" kmstlsvenv
+            fi
+            python -m pip install --upgrade boto3~=1.19 pykmip~=0.10.0
+            deactivate
+        else
+            . ./activate-kmstlsvenv.sh
+            deactivate
+        fi
         echo "Preparing CSFLE venv environment... done."
         ''', test=False),
         shell_exec(r'''

--- a/build/evergreen_config_lib/functions.py
+++ b/build/evergreen_config_lib/functions.py
@@ -607,13 +607,8 @@ all_functions = OD([
             # Avoid using Python 3.10 on Windows due to incompatible cipher suites.
             # See CDRIVER-4530.
             . ../venv-utils.sh
-            if [[ -f "C:/python/Python39/python.exe" ]]; then
-                # windows-2017
-                venvcreate "C:/python/Python39/python.exe" kmstlsvenv
-            elif [[ -f "C:/python/Python38/python.exe" ]]; then
-                # windows-2015
-                venvcreate "C:/python/Python38/python.exe" kmstlsvenv
-            fi
+            venvcreate "C:/python/Python39/python.exe" kmstlsvenv || # windows-2017
+            venvcreate "C:/python/Python38/python.exe" kmstlsvenv    # windows-2015
             python -m pip install --upgrade boto3~=1.19 pykmip~=0.10.0
             deactivate
         else


### PR DESCRIPTION
## Description

This PR resolves CDRIVER-4519. Verified by [this patch](https://spruce.mongodb.com/version/63892c6e3e8e862a7830fa52/tasks).

The proposed changes are a straightforward substitution of the old `activate_venv.sh` scripts for kmstslvenv and authawsvenv with the exception of Python selection behavior on Windows.

CDRIVER-4530 was created in response to issues with default cipher suite incompatibilities on Windows due to use of Python 3.10. A crude but simple workaround was applied that explicitly uses Python 3.9 (windows-2017) or Python 3.8 (windows-2015) instead, as addressing the root problem (upgrading certificates to use a better signature algorithm) required an unexpectedly significant amount of effort. See CDRIVER-4530 for more info.