### PR TITLE
Fix incorrect assumption of relative CMAKE_INSTALL_LIBDIR

### DIFF
--- a/src/libbson/CMakeLists.txt
+++ b/src/libbson/CMakeLists.txt
@@ -394,7 +394,7 @@ endforeach ()
 
 set (VERSION "${BSON_VERSION}")
 set (prefix "${CMAKE_INSTALL_PREFIX}")
-set (libdir "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+set (libdir "${CMAKE_INSTALL_FULL_LIBDIR}")
 configure_file (
    ${CMAKE_CURRENT_SOURCE_DIR}/src/libbson-1.0.pc.in
    ${CMAKE_CURRENT_BINARY_DIR}/src/libbson-1.0.pc

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -1173,7 +1173,7 @@ endif ()
 # Define pkg-config files
 set (VERSION "${MONGOC_VERSION}")
 set (prefix "${CMAKE_INSTALL_PREFIX}")
-set (libdir "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+set (libdir "${CMAKE_INSTALL_FULL_LIBDIR}")
 
 foreach (
       FLAG


### PR DESCRIPTION
While working on packaging of libbson and libmongoc in NixOS/nixpkgs, I noticed an incorrect assumption in the pkg-config files.

From the CMake docs at
https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html

    > CMAKE_INSTALL_<dir>
    >
    > Destination for files of a given type. This value may be passed to
    > the DESTINATION options of install() commands for the corresponding
    > file type. It should typically be a path relative to the
    > installation prefix so that it can be converted to an absolute path
    > in a relocatable way (see CMAKE_INSTALL_FULL_<dir>). However, an
    > absolute path is also allowed.

See also:
https://github.com/jtojnar/cmake-snips#assuming-cmake_install_dir-is-relative-path