### PR TITLE
CDRIVER-4275 and CDRIVER-4275

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -16645,7 +16645,7 @@ tasks:
   - func: bootstrap mongo-orchestration
     vars:
       AUTH: noauth
-      LOAD_BALANCER: 'true'
+      LOAD_BALANCER: 'on'
       SSL: ssl
       TOPOLOGY: sharded_cluster
       VERSION: latest
@@ -24024,7 +24024,7 @@ tasks:
   - func: bootstrap mongo-orchestration
     vars:
       AUTH: auth
-      LOAD_BALANCER: 'true'
+      LOAD_BALANCER: 'on'
       SSL: ssl
       TOPOLOGY: sharded_cluster
       VERSION: '5.0'
@@ -24052,7 +24052,7 @@ tasks:
   - func: bootstrap mongo-orchestration
     vars:
       AUTH: auth
-      LOAD_BALANCER: 'true'
+      LOAD_BALANCER: 'on'
       SSL: ssl
       TOPOLOGY: sharded_cluster
       VERSION: latest
@@ -24080,7 +24080,7 @@ tasks:
   - func: bootstrap mongo-orchestration
     vars:
       AUTH: noauth
-      LOAD_BALANCER: 'true'
+      LOAD_BALANCER: 'on'
       SSL: nossl
       TOPOLOGY: sharded_cluster
       VERSION: '5.0'
@@ -24108,7 +24108,7 @@ tasks:
   - func: bootstrap mongo-orchestration
     vars:
       AUTH: noauth
-      LOAD_BALANCER: 'true'
+      LOAD_BALANCER: 'on'
       SSL: nossl
       TOPOLOGY: sharded_cluster
       VERSION: latest

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -408,7 +408,7 @@ functions:
         export OCSP=${OCSP}
         export REQUIRE_API_VERSION=${REQUIRE_API_VERSION}
         export LOAD_BALANCER=${LOAD_BALANCER}
-        sh .evergreen/integration-tests.sh
+        bash .evergreen/integration-tests.sh
   - command: expansions.update
     params:
       file: mongoc/mo-expansion.yml

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -407,6 +407,7 @@ functions:
         export ORCHESTRATION_FILE=${ORCHESTRATION_FILE}
         export OCSP=${OCSP}
         export REQUIRE_API_VERSION=${REQUIRE_API_VERSION}
+        export LOAD_BALANCER=${LOAD_BALANCER}
         sh .evergreen/integration-tests.sh
   - command: expansions.update
     params:
@@ -16644,6 +16645,7 @@ tasks:
   - func: bootstrap mongo-orchestration
     vars:
       AUTH: noauth
+      LOAD_BALANCER: 'true'
       SSL: ssl
       TOPOLOGY: sharded_cluster
       VERSION: latest
@@ -24022,6 +24024,7 @@ tasks:
   - func: bootstrap mongo-orchestration
     vars:
       AUTH: auth
+      LOAD_BALANCER: 'true'
       SSL: ssl
       TOPOLOGY: sharded_cluster
       VERSION: '5.0'
@@ -24049,6 +24052,7 @@ tasks:
   - func: bootstrap mongo-orchestration
     vars:
       AUTH: auth
+      LOAD_BALANCER: 'true'
       SSL: ssl
       TOPOLOGY: sharded_cluster
       VERSION: latest
@@ -24076,6 +24080,7 @@ tasks:
   - func: bootstrap mongo-orchestration
     vars:
       AUTH: noauth
+      LOAD_BALANCER: 'true'
       SSL: nossl
       TOPOLOGY: sharded_cluster
       VERSION: '5.0'
@@ -24103,6 +24108,7 @@ tasks:
   - func: bootstrap mongo-orchestration
     vars:
       AUTH: noauth
+      LOAD_BALANCER: 'true'
       SSL: nossl
       TOPOLOGY: sharded_cluster
       VERSION: latest

--- a/.evergreen/integration-tests.sh
+++ b/.evergreen/integration-tests.sh
@@ -61,6 +61,10 @@ if [ -z "$ORCHESTRATION_FILE" ]; then
    if [ "$SSL" != "nossl" ]; then
       ORCHESTRATION_FILE="${ORCHESTRATION_FILE}-ssl"
    fi
+
+   if [ -n "$LOAD_BALANCER" ]; then
+      ORCHESTRATION_FILE="${ORCHESTRATION_FILE}-load-balancer"
+   fi
 fi
 
 # Set up mongo orchestration home.

--- a/.evergreen/integration-tests.sh
+++ b/.evergreen/integration-tests.sh
@@ -62,7 +62,7 @@ if [ -z "$ORCHESTRATION_FILE" ]; then
       ORCHESTRATION_FILE="${ORCHESTRATION_FILE}-ssl"
    fi
 
-   if [ -n "$LOAD_BALANCER" ]; then
+   if [ "$LOAD_BALANCER" = "on" ]; then
       ORCHESTRATION_FILE="${ORCHESTRATION_FILE}-load-balancer"
    fi
 fi

--- a/.evergreen/integration-tests.sh
+++ b/.evergreen/integration-tests.sh
@@ -14,11 +14,14 @@
 # OCSP: off, on
 # REQUIRE_API_VERSION: set to a non-empty string to set the requireApiVersion parameter
 #   This is currently only supported for standalone servers
+# LOAD_BALANCER: off, on
 #
 # This script may be run locally.
 #
 
 set -o errexit  # Exit the script with error if any of the commands fail
+
+: "${LOAD_BALANCER:=off}"
 
 DIR=$(dirname $0)
 # Functions to fetch MongoDB binaries

--- a/.evergreen/integration-tests.sh
+++ b/.evergreen/integration-tests.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 # Start up mongo-orchestration (a server to spawn mongodb clusters) and set up a cluster.
 #
 # Specify the following environment variables:

--- a/build/evergreen_config_lib/functions.py
+++ b/build/evergreen_config_lib/functions.py
@@ -281,7 +281,7 @@ all_functions = OD([
         export OCSP=${OCSP}
         export REQUIRE_API_VERSION=${REQUIRE_API_VERSION}
         export LOAD_BALANCER=${LOAD_BALANCER}
-        sh .evergreen/integration-tests.sh
+        bash .evergreen/integration-tests.sh
         ''', test=False),
         OD([
             ("command", "expansions.update"),

--- a/build/evergreen_config_lib/functions.py
+++ b/build/evergreen_config_lib/functions.py
@@ -280,6 +280,7 @@ all_functions = OD([
         export ORCHESTRATION_FILE=${ORCHESTRATION_FILE}
         export OCSP=${OCSP}
         export REQUIRE_API_VERSION=${REQUIRE_API_VERSION}
+        export LOAD_BALANCER=${LOAD_BALANCER}
         sh .evergreen/integration-tests.sh
         ''', test=False),
         OD([

--- a/build/evergreen_config_lib/tasks.py
+++ b/build/evergreen_config_lib/tasks.py
@@ -669,15 +669,15 @@ class DNSTask(MatrixTask):
         commands.append(
             func('fetch build', BUILD_NAME=self.depends_on['name']))
 
-        if not self.loadbalanced:
-            orchestration = bootstrap(TOPOLOGY='replica_set',
-                                      AUTH='auth' if self.auth else 'noauth',
-                                      SSL='ssl')
-        else:
+        if self.loadbalanced:
             orchestration = bootstrap(TOPOLOGY='sharded_cluster',
                                       AUTH='auth' if self.auth else 'noauth',
                                       SSL='ssl',
                                       LOAD_BALANCER='true')
+        else:
+            orchestration = bootstrap(TOPOLOGY='replica_set',
+                                      AUTH='auth' if self.auth else 'noauth',
+                                      SSL='ssl')
 
         if self.auth:
             orchestration['vars']['AUTHSOURCE'] = 'thisDB'

--- a/build/evergreen_config_lib/tasks.py
+++ b/build/evergreen_config_lib/tasks.py
@@ -669,9 +669,15 @@ class DNSTask(MatrixTask):
         commands.append(
             func('fetch build', BUILD_NAME=self.depends_on['name']))
 
-        orchestration = bootstrap(TOPOLOGY='sharded_cluster' if self.loadbalanced else 'replica_set',
-                                  AUTH='auth' if self.auth else 'noauth',
-                                  SSL='ssl')
+        if not self.loadbalanced:
+            orchestration = bootstrap(TOPOLOGY='replica_set',
+                                      AUTH='auth' if self.auth else 'noauth',
+                                      SSL='ssl')
+        else:
+            orchestration = bootstrap(TOPOLOGY='sharded_cluster',
+                                      AUTH='auth' if self.auth else 'noauth',
+                                      SSL='ssl',
+                                      LOAD_BALANCER='true')
 
         if self.auth:
             orchestration['vars']['AUTHSOURCE'] = 'thisDB'
@@ -1150,7 +1156,8 @@ class LoadBalancedTask(MatrixTask):
         orchestration = bootstrap(TOPOLOGY='sharded_cluster',
                                   AUTH='auth' if self.test_auth else 'noauth',
                                   SSL='ssl' if self.test_ssl else 'nossl',
-                                  VERSION=self.version)
+                                  VERSION=self.version,
+                                  LOAD_BALANCER='true')
         commands.append(orchestration)
         commands.append(func("clone drivers-evergreen-tools"))
         commands.append(func("start load balancer",

--- a/build/evergreen_config_lib/tasks.py
+++ b/build/evergreen_config_lib/tasks.py
@@ -673,7 +673,7 @@ class DNSTask(MatrixTask):
             orchestration = bootstrap(TOPOLOGY='sharded_cluster',
                                       AUTH='auth' if self.auth else 'noauth',
                                       SSL='ssl',
-                                      LOAD_BALANCER='true')
+                                      LOAD_BALANCER='on')
         else:
             orchestration = bootstrap(TOPOLOGY='replica_set',
                                       AUTH='auth' if self.auth else 'noauth',
@@ -1157,7 +1157,7 @@ class LoadBalancedTask(MatrixTask):
                                   AUTH='auth' if self.test_auth else 'noauth',
                                   SSL='ssl' if self.test_ssl else 'nossl',
                                   VERSION=self.version,
-                                  LOAD_BALANCER='true')
+                                  LOAD_BALANCER='on')
         commands.append(orchestration)
         commands.append(func("clone drivers-evergreen-tools"))
         commands.append(func("start load balancer",

--- a/orchestration_configs/sharded_clusters/auth-load-balancer.json
+++ b/orchestration_configs/sharded_clusters/auth-load-balancer.json
@@ -1,0 +1,57 @@
+{
+  "id": "shard_cluster_1",
+  "login": "bob",
+  "password": "pwd123",
+  "auth_key": "secret",
+  "shards": [
+    {
+      "id": "sh01",
+      "shardParams": {
+        "members": [
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27217
+            }
+          },
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27218
+            }
+          },
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27219
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "routers": [
+    {
+      "ipv6": true,
+      "bind_ip": "127.0.0.1,::1",
+      "port": 27017,
+      "setParameter": {
+        "loadBalancerPort": 27050
+      }
+    },
+    {
+      "ipv6": true,
+      "bind_ip": "127.0.0.1,::1",
+      "port": 27018,
+      "setParameter": {
+        "loadBalancerPort": 27051
+      }
+    }
+  ]
+}

--- a/orchestration_configs/sharded_clusters/auth-ssl-load-balancer.json
+++ b/orchestration_configs/sharded_clusters/auth-ssl-load-balancer.json
@@ -56,8 +56,8 @@
   ],
   "sslParams": {
       "sslOnNormalPorts": true,
-      "sslPEMKeyFile": "ABSOLUTE_PATH_REPLACEMENT_TOKEN/.evergreen/x509gen/server.pem",
-      "sslCAFile": "ABSOLUTE_PATH_REPLACEMENT_TOKEN/.evergreen/x509gen/ca.pem",
+      "sslPEMKeyFile": "/tmp/orchestration-home/server.pem",
+      "sslCAFile": "/tmp/orchestration-home/ca.pem",
       "sslWeakCertificateValidation" : true
   }
 }

--- a/orchestration_configs/sharded_clusters/auth-ssl-load-balancer.json
+++ b/orchestration_configs/sharded_clusters/auth-ssl-load-balancer.json
@@ -1,0 +1,63 @@
+{
+  "id": "shard_cluster_1",
+  "login": "bob",
+  "password": "pwd123",
+  "auth_key": "secret",
+  "shards": [
+    {
+      "id": "sh01",
+      "shardParams": {
+        "members": [
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27217
+            }
+          },
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27218
+            }
+          },
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27219
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "routers": [
+    {
+      "ipv6": true,
+      "bind_ip": "127.0.0.1,::1",
+      "port": 27017,
+      "setParameter": {
+        "loadBalancerPort": 27050
+      }
+    },
+    {
+      "ipv6": true,
+      "bind_ip": "127.0.0.1,::1",
+      "port": 27018,
+      "setParameter": {
+        "loadBalancerPort": 27051
+      }
+    }
+  ],
+  "sslParams": {
+      "sslOnNormalPorts": true,
+      "sslPEMKeyFile": "ABSOLUTE_PATH_REPLACEMENT_TOKEN/.evergreen/x509gen/server.pem",
+      "sslCAFile": "ABSOLUTE_PATH_REPLACEMENT_TOKEN/.evergreen/x509gen/ca.pem",
+      "sslWeakCertificateValidation" : true
+  }
+}

--- a/orchestration_configs/sharded_clusters/basic-load-balancer.json
+++ b/orchestration_configs/sharded_clusters/basic-load-balancer.json
@@ -1,0 +1,54 @@
+{
+  "id": "shard_cluster_1",
+  "shards": [
+    {
+      "id": "sh01",
+      "shardParams": {
+        "members": [
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27217
+            }
+          },
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27218
+            }
+          },
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27219
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "routers": [
+    {
+      "ipv6": true,
+      "bind_ip": "127.0.0.1,::1",
+      "port": 27017,
+      "setParameter": {
+        "loadBalancerPort": 27050
+      }
+    },
+    {
+      "ipv6": true,
+      "bind_ip": "127.0.0.1,::1",
+      "port": 27018,
+      "setParameter": {
+        "loadBalancerPort": 27051
+      }
+    }
+  ]
+}

--- a/orchestration_configs/sharded_clusters/basic-ssl-load-balancer.json
+++ b/orchestration_configs/sharded_clusters/basic-ssl-load-balancer.json
@@ -53,8 +53,8 @@
   ],
   "sslParams": {
       "sslOnNormalPorts": true,
-      "sslPEMKeyFile": "ABSOLUTE_PATH_REPLACEMENT_TOKEN/.evergreen/x509gen/server.pem",
-      "sslCAFile": "ABSOLUTE_PATH_REPLACEMENT_TOKEN/.evergreen/x509gen/ca.pem",
+      "sslPEMKeyFile": "/tmp/orchestration-home/server.pem",
+      "sslCAFile": "/tmp/orchestration-home/ca.pem",
       "sslWeakCertificateValidation" : true
   }
 }

--- a/orchestration_configs/sharded_clusters/basic-ssl-load-balancer.json
+++ b/orchestration_configs/sharded_clusters/basic-ssl-load-balancer.json
@@ -1,0 +1,60 @@
+{
+  "id": "shard_cluster_1",
+  "shards": [
+    {
+      "id": "sh01",
+      "shardParams": {
+        "members": [
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27217
+            }
+          },
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27218
+            }
+          },
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27219
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "routers": [
+    {
+      "ipv6": true,
+      "bind_ip": "127.0.0.1,::1",
+      "port": 27017,
+      "setParameter": {
+        "loadBalancerPort": 27050
+      }
+    },
+    {
+      "ipv6": true,
+      "bind_ip": "127.0.0.1,::1",
+      "port": 27018,
+      "setParameter": {
+        "loadBalancerPort": 27051
+      }
+    }
+  ],
+  "sslParams": {
+      "sslOnNormalPorts": true,
+      "sslPEMKeyFile": "ABSOLUTE_PATH_REPLACEMENT_TOKEN/.evergreen/x509gen/server.pem",
+      "sslCAFile": "ABSOLUTE_PATH_REPLACEMENT_TOKEN/.evergreen/x509gen/ca.pem",
+      "sslWeakCertificateValidation" : true
+  }
+}

--- a/src/libmongoc/src/mongoc/mongoc-server-description-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-server-description-private.h
@@ -241,10 +241,4 @@ bool
 mongoc_server_description_has_service_id (
    const mongoc_server_description_t *description);
 
-/* mongoc_global_mock_service_id is only used for testing. The test runner sets
- * this to true when testing against a load balanced deployment to mock the
- * presence of a serviceId field in the "hello" response. The purpose of this is
- * further described in the Load Balancer test README. */
-extern bool mongoc_global_mock_service_id;
-
 #endif

--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -33,8 +33,6 @@ static bson_oid_t kObjectIdZero = {{0}};
 
 const bson_oid_t kZeroServiceId = {{0}};
 
-bool mongoc_global_mock_service_id = false;
-
 static bool
 _match_tag_set (const mongoc_server_description_t *sd,
                 bson_iter_t *tag_set_iter);
@@ -743,16 +741,6 @@ mongoc_server_description_handle_hello (mongoc_server_description_t *sd,
          if (!BSON_ITER_HOLDS_INT (&iter))
             GOTO (typefailure);
          sd->server_connection_id = bson_iter_as_int64 (&iter);
-      }
-   }
-
-
-   if (mongoc_global_mock_service_id) {
-      bson_iter_t pid_iter;
-
-      if (bson_iter_init_find (&pid_iter, &sd->topology_version, "processId") &&
-          BSON_ITER_HOLDS_OID (&pid_iter)) {
-         bson_oid_copy (bson_iter_oid (&pid_iter), &sd->service_id);
       }
    }
 

--- a/src/libmongoc/tests/json/initial_dns_seedlist_discovery/load-balanced/loadBalanced-directConnection.json
+++ b/src/libmongoc/tests/json/initial_dns_seedlist_discovery/load-balanced/loadBalanced-directConnection.json
@@ -1,10 +1,10 @@
 {
-  "uri": "mongodb+srv://test20.test.build.10gen.cc/?directConnection=false",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/?directConnection=false",
   "seeds": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "hosts": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "options": {
     "loadBalanced": true,

--- a/src/libmongoc/tests/json/initial_dns_seedlist_discovery/load-balanced/loadBalanced-replicaSet-errors.json
+++ b/src/libmongoc/tests/json/initial_dns_seedlist_discovery/load-balanced/loadBalanced-replicaSet-errors.json
@@ -1,5 +1,5 @@
 {
-  "uri": "mongodb+srv://test20.test.build.10gen.cc/?replicaSet=replset",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/?replicaSet=replset",
   "seeds": [],
   "hosts": [],
   "error": true,

--- a/src/libmongoc/tests/json/initial_dns_seedlist_discovery/load-balanced/loadBalanced-true-txt.json
+++ b/src/libmongoc/tests/json/initial_dns_seedlist_discovery/load-balanced/loadBalanced-true-txt.json
@@ -1,10 +1,10 @@
 {
-  "uri": "mongodb+srv://test20.test.build.10gen.cc/",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/",
   "seeds": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "hosts": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "options": {
     "loadBalanced": true,

--- a/src/libmongoc/tests/json/initial_dns_seedlist_discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.json
+++ b/src/libmongoc/tests/json/initial_dns_seedlist_discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.json
@@ -1,5 +1,5 @@
 {
-  "uri": "mongodb+srv://test20.test.build.10gen.cc/?srvMaxHosts=1",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/?srvMaxHosts=1",
   "seeds": [],
   "hosts": [],
   "error": true,

--- a/src/libmongoc/tests/json/initial_dns_seedlist_discovery/load-balanced/srvMaxHosts-zero-txt.json
+++ b/src/libmongoc/tests/json/initial_dns_seedlist_discovery/load-balanced/srvMaxHosts-zero-txt.json
@@ -1,10 +1,10 @@
 {
-  "uri": "mongodb+srv://test20.test.build.10gen.cc/?srvMaxHosts=0",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/?srvMaxHosts=0",
   "seeds": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "hosts": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "options": {
     "loadBalanced": true,

--- a/src/libmongoc/tests/json/initial_dns_seedlist_discovery/load-balanced/srvMaxHosts-zero.json
+++ b/src/libmongoc/tests/json/initial_dns_seedlist_discovery/load-balanced/srvMaxHosts-zero.json
@@ -1,10 +1,10 @@
 {
-  "uri": "mongodb+srv://test3.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=0",
+  "uri": "mongodb+srv://test23.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=0",
   "seeds": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "hosts": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "options": {
     "loadBalanced": true,

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -916,6 +916,10 @@ call_hello_with_host_and_port (const char *host_and_port, bson_t *reply)
       bson_free (compressors);
    }
 
+   if (test_framework_is_loadbalanced ()) {
+      mongoc_uri_set_option_as_bool (uri, MONGOC_URI_LOADBALANCED, true);
+   }
+
    client = test_framework_client_new_from_uri (uri, NULL);
 
 #ifdef MONGOC_ENABLE_SSL

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -2819,10 +2819,6 @@ main (int argc, char *argv[])
    TEST_INSTALL (test_mcd_azure_imds_install);
    TEST_INSTALL (test_mcd_integer_install);
 
-   if (test_framework_is_loadbalanced ()) {
-      mongoc_global_mock_service_id = true;
-   }
-
    ret = TestSuite_Run (&suite);
 
    TestSuite_Destroy (&suite);


### PR DESCRIPTION
# Summary
- Fix load balancer tasks.
- Remove `mongoc_global_mock_service_id`.
- Update load balancer DNS tests to https://github.com/mongodb/specifications/commit/5d1b42a05017ba27ffdbe6fd068a45e93e5b68c5

Resolves CDRIVER-4275 and CDRIVER-4387.

# Background & Motivation

`integration-tests.sh` and orchestration configs have been updated for load balancer support. The orchestration configs were added in https://github.com/mongodb-labs/drivers-evergreen-tools/pull/183 and later updated in https://github.com/mongodb-labs/drivers-evergreen-tools/pull/186.

The C driver maintains a modified copy of the drivers-evergreen-tools script [`run-orchestration.sh`](https://github.com/mongodb-labs/drivers-evergreen-tools) as `integration-tests.sh`. `integration-tests.sh` may be removed in CDRIVER-4029.

The JSON tests in `src/libmongoc/tests/json/initial_seedlist_dns_discovery/load-balanced` were updated to account for https://github.com/mongodb/specifications/pull/1148.

Here is a full patch build: https://spruce.mongodb.com/version/6390ffd0850e613823e658de
