### PR TITLE
CDRIVER-4146 Add live server version 3.6 condition to /retryable_writes/legacy tests

### DIFF
--- a/src/libmongoc/tests/test-mongoc-retryable-writes.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-writes.c
@@ -809,12 +809,14 @@ retryable_writes_original_error_general_command (void *ctx)
 static void
 test_all_spec_tests (TestSuite *suite)
 {
-   install_json_test_suite_with_check (suite,
-                                       JSON_DIR,
-                                       "retryable_writes/legacy",
-                                       test_retryable_writes_cb,
-                                       test_framework_skip_if_no_crypto,
-                                       test_framework_skip_if_slow);
+   install_json_test_suite_with_check (
+      suite,
+      JSON_DIR,
+      "retryable_writes/legacy",
+      test_retryable_writes_cb,
+      test_framework_skip_if_max_wire_version_less_than_6,
+      test_framework_skip_if_no_crypto,
+      test_framework_skip_if_slow);
 }
 
 


### PR DESCRIPTION
Resolves CDRIVER-4146. Verified by [this patch](https://spruce.mongodb.com/version/6398a0785623437037b6d485/tasks).

`test_framework_skip_if_max_wire_version_less_than_6` was chosen to comply with the [Retryable Writes Tests spec](https://github.com/mongodb/specifications/blob/3634d568587a776f18885502cde4f26f1c0ac051/source/retryable-writes/tests/README.rst#introduction):

> Tests will require a MongoClient created with options defined in the tests. Integration tests will require a running MongoDB cluster with server versions 3.6.0 or later.