### PR TITLE
Use httpbin.org instead of example.com for /http tests

### DIFF
--- a/src/libmongoc/tests/TestSuite.c
+++ b/src/libmongoc/tests/TestSuite.c
@@ -66,8 +66,8 @@ test_msg (const char *format, ...)
    va_start (ap, format);
    vprintf (format, ap);
    printf ("\n");
-   fflush (stdout);
    va_end (ap);
+   fflush (stdout);
 }
 
 
@@ -76,11 +76,12 @@ _test_error (const char *format, ...)
 {
    va_list ap;
 
+   fflush (stdout);
    va_start (ap, format);
    vfprintf (stderr, format, ap);
    fprintf (stderr, "\n");
-   fflush (stderr);
    va_end (ap);
+   fflush (stderr);
    abort ();
 }
 
@@ -222,7 +223,6 @@ TestSuite_Init (TestSuite *suite, const char *name, int argc, char **argv)
       } else {
          test_error ("Unrecognized option: MONGOC_TEST_SERVER_LOG=%s",
                      mock_server_log);
-         abort ();
       }
 
       bson_free (mock_server_log);
@@ -231,7 +231,6 @@ TestSuite_Init (TestSuite *suite, const char *name, int argc, char **argv)
    if (suite->silent) {
       if (suite->outfile) {
          test_error ("Cannot combine -F with --silent");
-         abort ();
       }
 
       suite->flags &= ~(TEST_DEBUGOUTPUT);
@@ -298,11 +297,11 @@ _TestSuite_AddCheck (Test *test, CheckFunc check, const char *name)
 {
    test->checks[test->num_checks] = check;
    if (++test->num_checks > MAX_TEST_CHECK_FUNCS) {
-      fprintf (stderr,
-               "Too many check funcs for %s, increase MAX_TEST_CHECK_FUNCS "
-               "to more than %d\n",
-               name,
-               MAX_TEST_CHECK_FUNCS);
+      MONGOC_STDERR_PRINTF (
+         "Too many check funcs for %s, increase MAX_TEST_CHECK_FUNCS "
+         "to more than %d\n",
+         name,
+         MAX_TEST_CHECK_FUNCS);
       abort ();
    }
 }

--- a/src/libmongoc/tests/TestSuite.h
+++ b/src/libmongoc/tests/TestSuite.h
@@ -103,27 +103,39 @@ bson_open (const char *filename, int flags, ...)
 #ifdef ASSERT
 #undef ASSERT
 #endif
-#define ASSERT(Cond)                                              \
-   do {                                                           \
-      if (!(Cond)) {                                              \
-         fprintf (stderr,                                         \
-                  "FAIL:%s:%d  %s()\n  Condition '%s' failed.\n", \
-                  __FILE__,                                       \
-                  __LINE__,                                       \
-                  BSON_FUNC,                                      \
-                  BSON_STR (Cond));                               \
-         abort ();                                                \
-      }                                                           \
+
+// Ensure stdout and stderr are flushed prior to possible following abort().
+#define MONGOC_STDERR_PRINTF(format, ...)    \
+   if (1) {                                  \
+      fflush (stdout);                       \
+      fprintf (stderr, format, __VA_ARGS__); \
+      fflush (stderr);                       \
+   } else                                    \
+      ((void) 0)
+
+#define ASSERT(Cond)                                                           \
+   do {                                                                        \
+      if (!(Cond)) {                                                           \
+         MONGOC_STDERR_PRINTF ("FAIL:%s:%d  %s()\n  Condition '%s' failed.\n", \
+                               __FILE__,                                       \
+                               __LINE__,                                       \
+                               BSON_FUNC,                                      \
+                               BSON_STR (Cond));                               \
+         abort ();                                                             \
+      }                                                                        \
    } while (0)
 
 
 void
 _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
 
-#define test_error(...)                                                      \
-   fprintf (                                                                 \
-      stderr, "test error in: %s %d:%s()\n", __FILE__, __LINE__, BSON_FUNC); \
-   _test_error (__VA_ARGS__);
+#define test_error(...)                                                 \
+   if (1) {                                                             \
+      MONGOC_STDERR_PRINTF (                                            \
+         "test error in: %s %d:%s()\n", __FILE__, __LINE__, BSON_FUNC); \
+      _test_error (__VA_ARGS__);                                        \
+   } else                                                               \
+      ((void) 0)
 
 #define bson_eq_bson(bson, expected)                                          \
    do {                                                                       \
@@ -149,11 +161,11 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
          if (off == -1) {                                                     \
             off = BSON_MAX ((expected)->len, (bson)->len) - 1;                \
          }                                                                    \
-         fprintf (stderr,                                                     \
-                  "bson objects unequal (byte %u):\n(%s)\n(%s)\n",            \
-                  off,                                                        \
-                  bson_json,                                                  \
-                  expected_json);                                             \
+         MONGOC_STDERR_PRINTF (                                               \
+            "bson objects unequal (byte %u):\n(%s)\n(%s)\n",                  \
+            off,                                                              \
+            bson_json,                                                        \
+            expected_json);                                                   \
          {                                                                    \
             int fd1 = bson_open ("failure.bad.bson", O_RDWR | O_CREAT, 0640); \
             int fd2 =                                                         \
@@ -175,86 +187,81 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
 #undef ASSERT_OR_PRINT
 #endif
 
-#define ASSERT_OR_PRINT(_statement, _err)             \
-   do {                                               \
-      if (!(_statement)) {                            \
-         fprintf (stderr,                             \
-                  "FAIL:%s:%d  %s()\n  %s\n  %s\n\n", \
-                  __FILE__,                           \
-                  __LINE__,                           \
-                  BSON_FUNC,                          \
-                  BSON_STR (_statement),              \
-                  _err.message);                      \
-         abort ();                                    \
-      }                                               \
-   } while (0)
-
-#define ASSERT_CURSOR_NEXT(_cursor, _doc)              \
-   do {                                                \
-      bson_error_t _err;                               \
-      if (!mongoc_cursor_next ((_cursor), (_doc))) {   \
-         if (mongoc_cursor_error ((_cursor), &_err)) { \
-            fprintf (stderr,                           \
-                     "FAIL:%s:%d  %s()\n  %s\n\n",     \
-                     __FILE__,                         \
-                     __LINE__,                         \
-                     BSON_FUNC,                        \
-                     _err.message);                    \
-         } else {                                      \
-            fprintf (stderr,                           \
-                     "FAIL:%s:%d  %s()\n  %s\n\n",     \
-                     __FILE__,                         \
-                     __LINE__,                         \
-                     BSON_FUNC,                        \
-                     "empty cursor");                  \
-         }                                             \
-         abort ();                                     \
-      }                                                \
-   } while (0)
-
-
-#define ASSERT_CURSOR_DONE(_cursor)                 \
-   do {                                             \
-      bson_error_t _err;                            \
-      const bson_t *_doc;                           \
-      if (mongoc_cursor_next ((_cursor), &_doc)) {  \
-         fprintf (stderr,                           \
-                  "FAIL:%s:%d  %s()\n  %s\n\n",     \
-                  __FILE__,                         \
-                  __LINE__,                         \
-                  BSON_FUNC,                        \
-                  "non-empty cursor");              \
-         abort ();                                  \
-      }                                             \
-      if (mongoc_cursor_error ((_cursor), &_err)) { \
-         fprintf (stderr,                           \
-                  "FAIL:%s:%d  %s()\n  %s\n\n",     \
-                  __FILE__,                         \
-                  __LINE__,                         \
-                  BSON_FUNC,                        \
-                  _err.message);                    \
-         abort ();                                  \
-      }                                             \
-   } while (0)
-
-
-#define ASSERT_CMPINT_HELPER(a, eq, b, fmt, type)                  \
+#define ASSERT_OR_PRINT(_statement, _err)                          \
    do {                                                            \
-      /* evaluate once */                                          \
-      type _a = a;                                                 \
-      type _b = b;                                                 \
-      if (!((_a) eq (_b))) {                                       \
-         fprintf (stderr,                                          \
-                  "FAIL\n\nAssert Failure: %" fmt " %s %" fmt "\n" \
-                  "%s:%d  %s()\n",                                 \
-                  _a,                                              \
-                  BSON_STR (eq),                                   \
-                  _b,                                              \
-                  __FILE__,                                        \
-                  __LINE__,                                        \
-                  BSON_FUNC);                                      \
+      if (!(_statement)) {                                         \
+         MONGOC_STDERR_PRINTF ("FAIL:%s:%d  %s()\n  %s\n  %s\n\n", \
+                               __FILE__,                           \
+                               __LINE__,                           \
+                               BSON_FUNC,                          \
+                               BSON_STR (_statement),              \
+                               _err.message);                      \
          abort ();                                                 \
       }                                                            \
+   } while (0)
+
+#define ASSERT_CURSOR_NEXT(_cursor, _doc)                       \
+   do {                                                         \
+      bson_error_t _err;                                        \
+      if (!mongoc_cursor_next ((_cursor), (_doc))) {            \
+         if (mongoc_cursor_error ((_cursor), &_err)) {          \
+            MONGOC_STDERR_PRINTF ("FAIL:%s:%d  %s()\n  %s\n\n", \
+                                  __FILE__,                     \
+                                  __LINE__,                     \
+                                  BSON_FUNC,                    \
+                                  _err.message);                \
+         } else {                                               \
+            MONGOC_STDERR_PRINTF ("FAIL:%s:%d  %s()\n  %s\n\n", \
+                                  __FILE__,                     \
+                                  __LINE__,                     \
+                                  BSON_FUNC,                    \
+                                  "empty cursor");              \
+         }                                                      \
+         abort ();                                              \
+      }                                                         \
+   } while (0)
+
+
+#define ASSERT_CURSOR_DONE(_cursor)                          \
+   do {                                                      \
+      bson_error_t _err;                                     \
+      const bson_t *_doc;                                    \
+      if (mongoc_cursor_next ((_cursor), &_doc)) {           \
+         MONGOC_STDERR_PRINTF ("FAIL:%s:%d  %s()\n  %s\n\n", \
+                               __FILE__,                     \
+                               __LINE__,                     \
+                               BSON_FUNC,                    \
+                               "non-empty cursor");          \
+         abort ();                                           \
+      }                                                      \
+      if (mongoc_cursor_error ((_cursor), &_err)) {          \
+         MONGOC_STDERR_PRINTF ("FAIL:%s:%d  %s()\n  %s\n\n", \
+                               __FILE__,                     \
+                               __LINE__,                     \
+                               BSON_FUNC,                    \
+                               _err.message);                \
+         abort ();                                           \
+      }                                                      \
+   } while (0)
+
+
+#define ASSERT_CMPINT_HELPER(a, eq, b, fmt, type)                          \
+   do {                                                                    \
+      /* evaluate once */                                                  \
+      type _a = a;                                                         \
+      type _b = b;                                                         \
+      if (!((_a) eq (_b))) {                                               \
+         MONGOC_STDERR_PRINTF ("FAIL\n\nAssert Failure: %" fmt " %s %" fmt \
+                               "\n"                                        \
+                               "%s:%d  %s()\n",                            \
+                               _a,                                         \
+                               BSON_STR (eq),                              \
+                               _b,                                         \
+                               __FILE__,                                   \
+                               __LINE__,                                   \
+                               BSON_FUNC);                                 \
+         abort ();                                                         \
+      }                                                                    \
    } while (0)
 
 
@@ -280,245 +287,239 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
 #define ASSERT_CMPDOUBLE(a, eq, b) ASSERT_CMPINT_HELPER (a, eq, b, "f", double)
 #define ASSERT_CMPVOID(a, eq, b) ASSERT_CMPINT_HELPER (a, eq, b, "p", void *)
 
-#define ASSERT_MEMCMP(a, b, n)                                       \
-   do {                                                              \
-      if (0 != memcmp (a, b, n)) {                                   \
-         fprintf (stderr,                                            \
-                  "Failed comparing %d bytes: \"%.*s\" != \"%.*s\"", \
-                  n,                                                 \
-                  n,                                                 \
-                  (char *) a,                                        \
-                  n,                                                 \
-                  (char *) b);                                       \
-         abort ();                                                   \
-      }                                                              \
+#define ASSERT_MEMCMP(a, b, n)                                 \
+   do {                                                        \
+      if (0 != memcmp (a, b, n)) {                             \
+         MONGOC_STDERR_PRINTF (                                \
+            "Failed comparing %d bytes: \"%.*s\" != \"%.*s\"", \
+            n,                                                 \
+            n,                                                 \
+            (char *) a,                                        \
+            n,                                                 \
+            (char *) b);                                       \
+         abort ();                                             \
+      }                                                        \
    } while (0)
 
 
 #ifdef ASSERT_ALMOST_EQUAL
 #undef ASSERT_ALMOST_EQUAL
 #endif
-#define ASSERT_ALMOST_EQUAL(a, b)                        \
-   do {                                                  \
-      /* evaluate once */                                \
-      int64_t _a = (a);                                  \
-      int64_t _b = (b);                                  \
-      if (!(_a > (_b * 2) / 3 && (_a < (_b * 3) / 2))) { \
-         fprintf (stderr,                                \
-                  "FAIL\n\nAssert Failure: %" PRId64     \
-                  " not within 50%% of %" PRId64 "\n"    \
-                  "%s:%d  %s()\n",                       \
-                  _a,                                    \
-                  _b,                                    \
-                  __FILE__,                              \
-                  __LINE__,                              \
-                  BSON_FUNC);                            \
-         abort ();                                       \
-      }                                                  \
+#define ASSERT_ALMOST_EQUAL(a, b)                                  \
+   do {                                                            \
+      /* evaluate once */                                          \
+      int64_t _a = (a);                                            \
+      int64_t _b = (b);                                            \
+      if (!(_a > (_b * 2) / 3 && (_a < (_b * 3) / 2))) {           \
+         MONGOC_STDERR_PRINTF ("FAIL\n\nAssert Failure: %" PRId64  \
+                               " not within 50%% of %" PRId64 "\n" \
+                               "%s:%d  %s()\n",                    \
+                               _a,                                 \
+                               _b,                                 \
+                               __FILE__,                           \
+                               __LINE__,                           \
+                               BSON_FUNC);                         \
+         abort ();                                                 \
+      }                                                            \
    } while (0)
 
 #ifdef ASSERT_EQUAL_DOUBLE
 #undef ASSERT_EQUAL_DOUBLE
 #endif
-#define ASSERT_EQUAL_DOUBLE(a, b)                                      \
-   do {                                                                \
-      double _a = fabs ((double) a);                                   \
-      double _b = fabs ((double) b);                                   \
-      if (!(_a > (_b * 4) / 5 && (_a < (_b * 6) / 5))) {               \
-         fprintf (stderr,                                              \
-                  "FAIL\n\nAssert Failure: %f not within 20%% of %f\n" \
-                  "%s:%d  %s()\n",                                     \
-                  (double) a,                                          \
-                  (double) b,                                          \
-                  __FILE__,                                            \
-                  __LINE__,                                            \
-                  BSON_FUNC);                                          \
-         abort ();                                                     \
-      }                                                                \
+#define ASSERT_EQUAL_DOUBLE(a, b)                                \
+   do {                                                          \
+      double _a = fabs ((double) a);                             \
+      double _b = fabs ((double) b);                             \
+      if (!(_a > (_b * 4) / 5 && (_a < (_b * 6) / 5))) {         \
+         MONGOC_STDERR_PRINTF (                                  \
+            "FAIL\n\nAssert Failure: %f not within 20%% of %f\n" \
+            "%s:%d  %s()\n",                                     \
+            (double) a,                                          \
+            (double) b,                                          \
+            __FILE__,                                            \
+            __LINE__,                                            \
+            BSON_FUNC);                                          \
+         abort ();                                               \
+      }                                                          \
    } while (0)
 
 
-#define ASSERT_CMPSTR(a, b)                                                    \
-   do {                                                                        \
-      /* evaluate once */                                                      \
-      const char *_a = a;                                                      \
-      const char *_b = b;                                                      \
-      if ((_a != _b) && (!_a || !_b || (strcmp (_a, _b) != 0))) {              \
-         fprintf (stderr,                                                      \
-                  "FAIL\n\nAssert Failure:\n  \"%s\"\n  !=\n  \"%s\"\n %s:%d " \
-                  " %s()\n",                                                   \
-                  _a ? _a : "(null)",                                          \
-                  _b ? _b : "(null)",                                          \
-                  __FILE__,                                                    \
-                  __LINE__,                                                    \
-                  BSON_FUNC);                                                  \
-         abort ();                                                             \
-      }                                                                        \
-   } while (0)
-
-#define ASSERT_CMPJSON(_a, _b)                                 \
-   do {                                                        \
-      size_t i = 0;                                            \
-      char *__a = (char *) (_a);                               \
-      char *__b = (char *) (_b);                               \
-      char *__aa = bson_malloc0 (strlen (__a) + 1);            \
-      char *__bb = bson_malloc0 (strlen (__b) + 1);            \
-      char *f = __a;                                           \
-      do {                                                     \
-         while (bson_isspace (*__a))                           \
-            __a++;                                             \
-         __aa[i++] = *__a++;                                   \
-      } while (*__a);                                          \
-      i = 0;                                                   \
-      do {                                                     \
-         while (bson_isspace (*__b))                           \
-            __b++;                                             \
-         __bb[i++] = *__b++;                                   \
-      } while (*__b);                                          \
-      if (!!strcmp ((__aa), (__bb))) {                         \
-         fprintf (stderr,                                      \
-                  "FAIL\n\nAssert Failure: \"%s\" != \"%s\"\n" \
-                  "%s:%d  %s()\n",                             \
-                  __aa,                                        \
-                  __bb,                                        \
-                  __FILE__,                                    \
-                  __LINE__,                                    \
-                  BSON_FUNC);                                  \
-         abort ();                                             \
-      }                                                        \
-      bson_free (__aa);                                        \
-      bson_free (__bb);                                        \
-      bson_free (f);                                           \
-   } while (0)
-
-#define ASSERT_CMPOID(a, b)                                 \
-   do {                                                     \
-      if (bson_oid_compare ((a), (b))) {                    \
-         char oid_a[25];                                    \
-         char oid_b[25];                                    \
-         bson_oid_to_string ((a), oid_a);                   \
-         bson_oid_to_string ((b), oid_b);                   \
-         fprintf (stderr,                                   \
-                  "FAIL\n\nAssert Failure: "                \
-                  "ObjectId(\"%s\") != ObjectId(\"%s\")\n", \
-                  oid_a,                                    \
-                  oid_b);                                   \
-         abort ();                                          \
-      }                                                     \
-   } while (0)
-
-
-#define ASSERT_CONTAINS(a, b)                                 \
-   do {                                                       \
-      char *_a_lower = bson_strdup (a);                       \
-      char *_b_lower = bson_strdup (b);                       \
-      mongoc_lowercase (_a_lower, _a_lower);                  \
-      mongoc_lowercase (_b_lower, _b_lower);                  \
-      if (NULL == strstr ((_a_lower), (_b_lower))) {          \
-         fprintf (stderr,                                     \
-                  "%s:%d %s(): [%s] does not contain [%s]\n", \
-                  __FILE__,                                   \
-                  __LINE__,                                   \
-                  BSON_FUNC,                                  \
-                  a,                                          \
-                  b);                                         \
-         abort ();                                            \
-      }                                                       \
-      bson_free (_a_lower);                                   \
-      bson_free (_b_lower);                                   \
-   } while (0)
-
-#define ASSERT_STARTSWITH(a, b)                                    \
-   do {                                                            \
-      /* evaluate once */                                          \
-      const char *_a = a;                                          \
-      const char *_b = b;                                          \
-      if ((_a) != strstr ((_a), (_b))) {                           \
-         fprintf (stderr,                                          \
-                  "%s:%d %s(): : [%s] does not start with [%s]\n", \
-                  __FILE__,                                        \
-                  __LINE__,                                        \
-                  BSON_FUNC,                                       \
-                  _a,                                              \
-                  _b);                                             \
-         abort ();                                                 \
-      }                                                            \
-   } while (0)
-
-#define ASSERT_ERROR_CONTAINS(error, _domain, _code, _message)              \
-   do {                                                                     \
-      if (error.domain != _domain) {                                        \
-         fprintf (stderr,                                                   \
-                  "%s:%d %s(): error domain %d doesn't match expected %d\n" \
-                  "error: \"%s\"",                                          \
-                  __FILE__,                                                 \
-                  __LINE__,                                                 \
-                  BSON_FUNC,                                                \
-                  error.domain,                                             \
-                  _domain,                                                  \
-                  error.message);                                           \
-         abort ();                                                          \
-      };                                                                    \
-      if (error.code != _code) {                                            \
-         fprintf (stderr,                                                   \
-                  "%s:%d %s(): error code %d doesn't match expected %d\n"   \
-                  "error: \"%s\"",                                          \
-                  __FILE__,                                                 \
-                  __LINE__,                                                 \
-                  BSON_FUNC,                                                \
-                  error.code,                                               \
-                  _code,                                                    \
-                  error.message);                                           \
-         abort ();                                                          \
-      };                                                                    \
-      ASSERT_CONTAINS (error.message, _message);                            \
-   } while (0);
-
-#define ASSERT_CAPTURED_LOG(_info, _level, _msg)                \
-   do {                                                         \
-      if (!has_captured_log (_level, _msg)) {                   \
-         fprintf (stderr,                                       \
-                  "%s:%d %s(): testing %s didn't log \"%s\"\n", \
-                  __FILE__,                                     \
-                  __LINE__,                                     \
-                  BSON_FUNC,                                    \
-                  _info,                                        \
-                  _msg);                                        \
-         print_captured_logs ("\t");                            \
-         abort ();                                              \
-      }                                                         \
-   } while (0);
-
-#define ASSERT_NO_CAPTURED_LOGS(_info)                               \
-   do {                                                              \
-      if (has_captured_logs ()) {                                    \
-         fprintf (stderr,                                            \
-                  "%s:%d %s(): testing %s shouldn't have logged:\n", \
-                  __FILE__,                                          \
-                  __LINE__,                                          \
-                  BSON_FUNC,                                         \
-                  _info);                                            \
-         print_captured_logs ("\t");                                 \
-         abort ();                                                   \
-      }                                                              \
-   } while (0);
-
-#define ASSERT_HAS_FIELD(_bson, _field)                                  \
+#define ASSERT_CMPSTR(a, b)                                              \
    do {                                                                  \
-      if (!bson_has_field ((_bson), (_field))) {                         \
-         fprintf (stderr,                                                \
-                  "FAIL\n\nAssert Failure: No field \"%s\" in \"%s\"\n", \
-                  (_field),                                              \
-                  bson_as_canonical_extended_json (_bson, NULL));        \
+      /* evaluate once */                                                \
+      const char *_a = a;                                                \
+      const char *_b = b;                                                \
+      if ((_a != _b) && (!_a || !_b || (strcmp (_a, _b) != 0))) {        \
+         MONGOC_STDERR_PRINTF (                                          \
+            "FAIL\n\nAssert Failure:\n  \"%s\"\n  !=\n  \"%s\"\n %s:%d " \
+            " %s()\n",                                                   \
+            _a ? _a : "(null)",                                          \
+            _b ? _b : "(null)",                                          \
+            __FILE__,                                                    \
+            __LINE__,                                                    \
+            BSON_FUNC);                                                  \
          abort ();                                                       \
       }                                                                  \
+   } while (0)
+
+#define ASSERT_CMPJSON(_a, _b)                                              \
+   do {                                                                     \
+      size_t i = 0;                                                         \
+      char *__a = (char *) (_a);                                            \
+      char *__b = (char *) (_b);                                            \
+      char *__aa = bson_malloc0 (strlen (__a) + 1);                         \
+      char *__bb = bson_malloc0 (strlen (__b) + 1);                         \
+      char *f = __a;                                                        \
+      do {                                                                  \
+         while (bson_isspace (*__a))                                        \
+            __a++;                                                          \
+         __aa[i++] = *__a++;                                                \
+      } while (*__a);                                                       \
+      i = 0;                                                                \
+      do {                                                                  \
+         while (bson_isspace (*__b))                                        \
+            __b++;                                                          \
+         __bb[i++] = *__b++;                                                \
+      } while (*__b);                                                       \
+      if (!!strcmp ((__aa), (__bb))) {                                      \
+         MONGOC_STDERR_PRINTF ("FAIL\n\nAssert Failure: \"%s\" != \"%s\"\n" \
+                               "%s:%d  %s()\n",                             \
+                               __aa,                                        \
+                               __bb,                                        \
+                               __FILE__,                                    \
+                               __LINE__,                                    \
+                               BSON_FUNC);                                  \
+         abort ();                                                          \
+      }                                                                     \
+      bson_free (__aa);                                                     \
+      bson_free (__bb);                                                     \
+      bson_free (f);                                                        \
+   } while (0)
+
+#define ASSERT_CMPOID(a, b)                                              \
+   do {                                                                  \
+      if (bson_oid_compare ((a), (b))) {                                 \
+         char oid_a[25];                                                 \
+         char oid_b[25];                                                 \
+         bson_oid_to_string ((a), oid_a);                                \
+         bson_oid_to_string ((b), oid_b);                                \
+         MONGOC_STDERR_PRINTF ("FAIL\n\nAssert Failure: "                \
+                               "ObjectId(\"%s\") != ObjectId(\"%s\")\n", \
+                               oid_a,                                    \
+                               oid_b);                                   \
+         abort ();                                                       \
+      }                                                                  \
+   } while (0)
+
+
+#define ASSERT_CONTAINS(a, b)                                              \
+   do {                                                                    \
+      char *_a_lower = bson_strdup (a);                                    \
+      char *_b_lower = bson_strdup (b);                                    \
+      mongoc_lowercase (_a_lower, _a_lower);                               \
+      mongoc_lowercase (_b_lower, _b_lower);                               \
+      if (NULL == strstr ((_a_lower), (_b_lower))) {                       \
+         MONGOC_STDERR_PRINTF ("%s:%d %s(): [%s] does not contain [%s]\n", \
+                               __FILE__,                                   \
+                               __LINE__,                                   \
+                               BSON_FUNC,                                  \
+                               a,                                          \
+                               b);                                         \
+         abort ();                                                         \
+      }                                                                    \
+      bson_free (_a_lower);                                                \
+      bson_free (_b_lower);                                                \
+   } while (0)
+
+#define ASSERT_STARTSWITH(a, b)                              \
+   do {                                                      \
+      /* evaluate once */                                    \
+      const char *_a = a;                                    \
+      const char *_b = b;                                    \
+      if ((_a) != strstr ((_a), (_b))) {                     \
+         MONGOC_STDERR_PRINTF (                              \
+            "%s:%d %s(): : [%s] does not start with [%s]\n", \
+            __FILE__,                                        \
+            __LINE__,                                        \
+            BSON_FUNC,                                       \
+            _a,                                              \
+            _b);                                             \
+         abort ();                                           \
+      }                                                      \
+   } while (0)
+
+#define ASSERT_ERROR_CONTAINS(error, _domain, _code, _message)        \
+   do {                                                               \
+      if (error.domain != _domain) {                                  \
+         MONGOC_STDERR_PRINTF (                                       \
+            "%s:%d %s(): error domain %d doesn't match expected %d\n" \
+            "error: \"%s\"",                                          \
+            __FILE__,                                                 \
+            __LINE__,                                                 \
+            BSON_FUNC,                                                \
+            error.domain,                                             \
+            _domain,                                                  \
+            error.message);                                           \
+         abort ();                                                    \
+      };                                                              \
+      if (error.code != _code) {                                      \
+         MONGOC_STDERR_PRINTF (                                       \
+            "%s:%d %s(): error code %d doesn't match expected %d\n"   \
+            "error: \"%s\"",                                          \
+            __FILE__,                                                 \
+            __LINE__,                                                 \
+            BSON_FUNC,                                                \
+            error.code,                                               \
+            _code,                                                    \
+            error.message);                                           \
+         abort ();                                                    \
+      };                                                              \
+      ASSERT_CONTAINS (error.message, _message);                      \
+   } while (0);
+
+#define ASSERT_CAPTURED_LOG(_info, _level, _msg)                             \
+   do {                                                                      \
+      if (!has_captured_log (_level, _msg)) {                                \
+         MONGOC_STDERR_PRINTF ("%s:%d %s(): testing %s didn't log \"%s\"\n", \
+                               __FILE__,                                     \
+                               __LINE__,                                     \
+                               BSON_FUNC,                                    \
+                               _info,                                        \
+                               _msg);                                        \
+         print_captured_logs ("\t");                                         \
+         abort ();                                                           \
+      }                                                                      \
+   } while (0);
+
+#define ASSERT_NO_CAPTURED_LOGS(_info)                         \
+   do {                                                        \
+      if (has_captured_logs ()) {                              \
+         MONGOC_STDERR_PRINTF (                                \
+            "%s:%d %s(): testing %s shouldn't have logged:\n", \
+            __FILE__,                                          \
+            __LINE__,                                          \
+            BSON_FUNC,                                         \
+            _info);                                            \
+         print_captured_logs ("\t");                           \
+         abort ();                                             \
+      }                                                        \
+   } while (0);
+
+#define ASSERT_HAS_FIELD(_bson, _field)                            \
+   do {                                                            \
+      if (!bson_has_field ((_bson), (_field))) {                   \
+         MONGOC_STDERR_PRINTF (                                    \
+            "FAIL\n\nAssert Failure: No field \"%s\" in \"%s\"\n", \
+            (_field),                                              \
+            bson_as_canonical_extended_json (_bson, NULL));        \
+         abort ();                                                 \
+      }                                                            \
    } while (0)
 
 #define ASSERT_HAS_NOT_FIELD(_bson, _field)                                \
    do {                                                                    \
       if (bson_has_field ((_bson), (_field))) {                            \
-         fprintf (                                                         \
-            stderr,                                                        \
+         MONGOC_STDERR_PRINTF (                                            \
             "FAIL\n\nAssert Failure: Unexpected field \"%s\" in \"%s\"\n", \
             (_field),                                                      \
             bson_as_canonical_extended_json (_bson, NULL));                \
@@ -555,8 +556,7 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
 #define ASSERT_OR_PRINT_ERRNO(_statement, _errcode)                          \
    do {                                                                      \
       if (!(_statement)) {                                                   \
-         fprintf (                                                           \
-            stderr,                                                          \
+         MONGOC_STDERR_PRINTF (                                              \
             "FAIL:%s:%d  %s()\n  %s\n  Failed with error code: %d (%s)\n\n", \
             __FILE__,                                                        \
             __LINE__,                                                        \
@@ -568,42 +568,42 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
       }                                                                      \
    } while (0)
 
-#define ASSERT_COUNT(n, collection)                                     \
-   do {                                                                 \
-      int count = (int) mongoc_collection_count_documents (             \
-         collection, tmp_bson ("{}"), NULL, NULL, NULL, NULL);          \
-      if ((n) != count) {                                               \
-         fprintf (stderr,                                               \
-                  "FAIL\n\nAssert Failure: count of %s is %d, not %d\n" \
-                  "%s:%d  %s()\n",                                      \
-                  mongoc_collection_get_name (collection),              \
-                  count,                                                \
-                  n,                                                    \
-                  __FILE__,                                             \
-                  __LINE__,                                             \
-                  BSON_FUNC);                                           \
-         abort ();                                                      \
-      }                                                                 \
+#define ASSERT_COUNT(n, collection)                               \
+   do {                                                           \
+      int count = (int) mongoc_collection_count_documents (       \
+         collection, tmp_bson ("{}"), NULL, NULL, NULL, NULL);    \
+      if ((n) != count) {                                         \
+         MONGOC_STDERR_PRINTF (                                   \
+            "FAIL\n\nAssert Failure: count of %s is %d, not %d\n" \
+            "%s:%d  %s()\n",                                      \
+            mongoc_collection_get_name (collection),              \
+            count,                                                \
+            n,                                                    \
+            __FILE__,                                             \
+            __LINE__,                                             \
+            BSON_FUNC);                                           \
+         abort ();                                                \
+      }                                                           \
    } while (0)
 
-#define ASSERT_CURSOR_COUNT(_n, _cursor)                                 \
-   do {                                                                  \
-      int _count = 0;                                                    \
-      const bson_t *_doc;                                                \
-      while (mongoc_cursor_next (_cursor, &_doc)) {                      \
-         _count++;                                                       \
-      }                                                                  \
-      if ((_n) != _count) {                                              \
-         fprintf (stderr,                                                \
-                  "FAIL\n\nAssert Failure: cursor count is %d, not %d\n" \
-                  "%s:%d  %s()\n",                                       \
-                  _count,                                                \
-                  _n,                                                    \
-                  __FILE__,                                              \
-                  __LINE__,                                              \
-                  BSON_FUNC);                                            \
-         abort ();                                                       \
-      }                                                                  \
+#define ASSERT_CURSOR_COUNT(_n, _cursor)                           \
+   do {                                                            \
+      int _count = 0;                                              \
+      const bson_t *_doc;                                          \
+      while (mongoc_cursor_next (_cursor, &_doc)) {                \
+         _count++;                                                 \
+      }                                                            \
+      if ((_n) != _count) {                                        \
+         MONGOC_STDERR_PRINTF (                                    \
+            "FAIL\n\nAssert Failure: cursor count is %d, not %d\n" \
+            "%s:%d  %s()\n",                                       \
+            _count,                                                \
+            _n,                                                    \
+            __FILE__,                                              \
+            __LINE__,                                              \
+            BSON_FUNC);                                            \
+         abort ();                                                 \
+      }                                                            \
    } while (0)
 
 #define WAIT_UNTIL(_pred)                                              \
@@ -611,31 +611,31 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
       int64_t _start = bson_get_monotonic_time ();                     \
       while (!(_pred)) {                                               \
          if (bson_get_monotonic_time () - _start > 10 * 1000 * 1000) { \
-            fprintf (stderr,                                           \
-                     "Predicate \"%s\" timed out\n"                    \
-                     "   %s:%d  %s()\n",                               \
-                     BSON_STR (_pred),                                 \
-                     __FILE__,                                         \
-                     __LINE__,                                         \
-                     BSON_FUNC);                                       \
+            MONGOC_STDERR_PRINTF ("Predicate \"%s\" timed out\n"       \
+                                  "   %s:%d  %s()\n",                  \
+                                  BSON_STR (_pred),                    \
+                                  __FILE__,                            \
+                                  __LINE__,                            \
+                                  BSON_FUNC);                          \
             abort ();                                                  \
          }                                                             \
          _mongoc_usleep (10 * 1000);                                   \
       }                                                                \
    } while (0)
 
-#define ASSERT_WITH_MSG(_statement, ...)        \
-   do {                                         \
-      if (!(_statement)) {                      \
-         fprintf (stderr,                       \
-                  "FAIL:%s:%d  %s()\n  %s\n\n", \
-                  __FILE__,                     \
-                  __LINE__,                     \
-                  BSON_FUNC,                    \
-                  BSON_STR (_statement));       \
-         fprintf (stderr, __VA_ARGS__);         \
-         abort ();                              \
-      }                                         \
+#define ASSERT_WITH_MSG(_statement, ...)                     \
+   do {                                                      \
+      if (!(_statement)) {                                   \
+         MONGOC_STDERR_PRINTF ("FAIL:%s:%d  %s()\n  %s\n\n", \
+                               __FILE__,                     \
+                               __LINE__,                     \
+                               BSON_FUNC,                    \
+                               BSON_STR (_statement));       \
+         fprintf (stderr, __VA_ARGS__);                      \
+         fprintf (stderr, "\n");                             \
+         fflush (stderr);                                    \
+         abort ();                                           \
+      }                                                      \
    } while (0)
 
 #define MAX_TEST_NAME_LENGTH 500

--- a/src/libmongoc/tests/test-mongoc-http.c
+++ b/src/libmongoc/tests/test-mongoc-http.c
@@ -38,6 +38,7 @@ test_mongoc_http_get (void *unused)
    req.path = "get";
    req.port = 80;
    r = _mongoc_http_send (&req, 10000, false, NULL, &res, &error);
+   ASSERT_OR_PRINT (r, error);
    ASSERT_WITH_MSG (res.status == 200,
                     "unexpected status code %d\n"
                     "RESPONSE BODY BEGIN\n"
@@ -45,7 +46,6 @@ test_mongoc_http_get (void *unused)
                     "RESPONSE BODY END\n",
                     res.status,
                     res.body_len > 0 ? res.body : "");
-   ASSERT_OR_PRINT (r, error);
    ASSERT_CMPINT (res.body_len, >, 0);
    _mongoc_http_response_cleanup (&res);
 }
@@ -69,6 +69,7 @@ test_mongoc_http_post (void *unused)
    req.path = "post";
    req.port = 80;
    r = _mongoc_http_send (&req, 10000, false, NULL, &res, &error);
+   ASSERT_OR_PRINT (r, error);
    ASSERT_WITH_MSG (res.status == 200,
                     "unexpected status code %d\n"
                     "RESPONSE BODY BEGIN\n"
@@ -76,7 +77,6 @@ test_mongoc_http_post (void *unused)
                     "RESPONSE BODY END\n",
                     res.status,
                     res.body_len > 0 ? res.body : "");
-   ASSERT_OR_PRINT (r, error);
    ASSERT_CMPINT (res.body_len, >, 0);
    _mongoc_http_response_cleanup (&res);
 }


### PR DESCRIPTION
Resolves CDRIVER-4538. Verified by [this patch](https://spruce.mongodb.com/version/6398bf553066157ccb88b3e0/tasks).

The `/http` test has been split into `/http/get` and `/http/post` and uses `httpbin.org` instead of `example.org`.

As a drive-by fix, this PR also resolves CDRIVER-4537 by ensure calls to `abort()` in the test suite are preceeded by both `fflush (stdout)` and `fflush (stderr)` to improve the quality of test output on failures.