### PR TITLE
Address scan-build warning: value stored to ok is never read

### DIFF
--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -2792,7 +2792,6 @@ test_example_60 (mongoc_database_t *db)
 
    if (mongoc_cursor_error (cursor, &error)) {
       MONGOC_ERROR ("could not get totalDailySales: %s", error.message);
-      ok = false;
       goto cleanup;
    }
 


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1156, observed in [this patch](https://parsley.mongodb.com/evergreen/mongo_c_driver_arm_ubuntu1604_debug_compile_scan_build_patch_766a8a3c8c6afe2fa3031520c0fb6fef135d2d8a_6398bf553066157ccb88b3e0_22_12_13_18_07_20/0/task?bookmarks=0,867&selectedLine=667).