### PR TITLE
CDRIVER-4537 Ensure all aborts in test suite are preceeded by flushes

### DIFF
--- a/build/future_function_templates/future-value.h.template
+++ b/build/future_function_templates/future-value.h.template
@@ -28,7 +28,7 @@ typedef struct _future_value_t
    } value;
 } future_value_t;
 
-future_value_t *future_value_new ();
+future_value_t *future_value_new (void);
 
 #ifdef __clang__
 #pragma clang diagnostic push

--- a/build/future_function_templates/future.c.template
+++ b/build/future_function_templates/future.c.template
@@ -7,14 +7,23 @@
 
 {{ header_comment }}
 
+#define FUTURE_TIMEOUT_ABORT                         \
+   if (1) {                                          \
+      fflush (stdout);                               \
+      fprintf (stderr, "%s timed out\n", BSON_FUNC); \
+      fflush (stderr);                               \
+      abort ();                                      \
+   } else                                            \
+      ((void) 0)
+
 void
 future_get_void (future_t *future)
 {
-   if (!future_wait (future)) {
-      fprintf (stderr, "%s timed out\n", BSON_FUNC);
-      fflush (stderr);
-      abort ();
+   if (future_wait (future)) {
+      return;
    }
+
+   FUTURE_TIMEOUT_ABORT;
 }
 
 {% for T in type_list %}
@@ -25,9 +34,7 @@ future_get_{{ T }} (future_t *future)
       return future_value_get_{{ T }} (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 {% endfor %}
 
@@ -120,4 +127,3 @@ future_destroy (future_t *future)
    bson_mutex_destroy (&future->mutex);
    bson_free (future);
 }
-

--- a/src/libmongoc/tests/TestSuite.h
+++ b/src/libmongoc/tests/TestSuite.h
@@ -129,12 +129,13 @@ bson_open (const char *filename, int flags, ...)
 void
 _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
 
-#define test_error(...)                                                 \
-   if (1) {                                                             \
-      MONGOC_STDERR_PRINTF (                                            \
-         "test error in: %s %d:%s()\n", __FILE__, __LINE__, BSON_FUNC); \
-      _test_error (__VA_ARGS__);                                        \
-   } else                                                               \
+#define test_error(...)                                                    \
+   if (1) {                                                                \
+      MONGOC_STDERR_PRINTF (                                               \
+         "test error in: %s %d:%s()\n", __FILE__, __LINE__, BSON_FUNC);    \
+      _test_error (__VA_ARGS__);                                           \
+      abort (); /* suppress missing return errors in non-void functions */ \
+   } else                                                                  \
       ((void) 0)
 
 #define bson_eq_bson(bson, expected)                                          \

--- a/src/libmongoc/tests/json-test-monitoring.c
+++ b/src/libmongoc/tests/json-test-monitoring.c
@@ -72,12 +72,9 @@ assert_host_in_uri (const mongoc_host_list_t *host, const mongoc_uri_t *uri)
       hosts = hosts->next;
    }
 
-   fprintf (stderr,
-            "Host \"%s\" not in \"%s\"",
-            host->host_and_port,
-            mongoc_uri_get_string (uri));
-   fflush (stderr);
-   abort ();
+   test_error ("Host \"%s\" not in \"%s\"",
+               host->host_and_port,
+               mongoc_uri_get_string (uri));
 }
 
 

--- a/src/libmongoc/tests/json-test-operations.c
+++ b/src/libmongoc/tests/json-test-operations.c
@@ -45,8 +45,7 @@ session_from_name (json_test_ctx_t *ctx, const char *session_name)
    } else if (!strcmp (session_name, "session1")) {
       return ctx->sessions[1];
    } else {
-      MONGOC_ERROR ("Unrecognized session name: %s", session_name);
-      abort ();
+      test_error ("Unrecognized session name: %s", session_name);
    }
 }
 
@@ -794,7 +793,6 @@ add_request_to_bulk (mongoc_bulk_operation_t *bulk,
          bulk, &filter, &update, &opts, error);
    } else {
       test_error ("unrecognized request name %s", name);
-      abort ();
    }
 
    bson_destroy (&opts);
@@ -957,7 +955,6 @@ single_write (mongoc_collection_t *collection,
          collection, &filter, &update, &opts, reply, &error);
    } else {
       test_error ("unrecognized request name %s", name);
-      abort ();
    }
 
    value_init_from_doc (&value, reply);

--- a/src/libmongoc/tests/mock_server/future.c
+++ b/src/libmongoc/tests/mock_server/future.c
@@ -14,14 +14,23 @@
  *************************************************/
 /* clang-format off */
 
+#define FUTURE_TIMEOUT_ABORT                         \
+   if (1) {                                          \
+      fflush (stdout);                               \
+      fprintf (stderr, "%s timed out\n", BSON_FUNC); \
+      fflush (stderr);                               \
+      abort ();                                      \
+   } else                                            \
+      ((void) 0)
+
 void
 future_get_void (future_t *future)
 {
-   if (!future_wait (future)) {
-      fprintf (stderr, "%s timed out\n", BSON_FUNC);
-      fflush (stderr);
-      abort ();
+   if (future_wait (future)) {
+      return;
    }
+
+   FUTURE_TIMEOUT_ABORT;
 }
 
 
@@ -32,9 +41,7 @@ future_get_bool (future_t *future)
       return future_value_get_bool (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 char_ptr
@@ -44,9 +51,7 @@ future_get_char_ptr (future_t *future)
       return future_value_get_char_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 char_ptr_ptr
@@ -56,9 +61,7 @@ future_get_char_ptr_ptr (future_t *future)
       return future_value_get_char_ptr_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 int
@@ -68,9 +71,7 @@ future_get_int (future_t *future)
       return future_value_get_int (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 int64_t
@@ -80,9 +81,7 @@ future_get_int64_t (future_t *future)
       return future_value_get_int64_t (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 size_t
@@ -92,9 +91,7 @@ future_get_size_t (future_t *future)
       return future_value_get_size_t (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 ssize_t
@@ -104,9 +101,7 @@ future_get_ssize_t (future_t *future)
       return future_value_get_ssize_t (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 uint32_t
@@ -116,9 +111,7 @@ future_get_uint32_t (future_t *future)
       return future_value_get_uint32_t (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 void_ptr
@@ -128,9 +121,7 @@ future_get_void_ptr (future_t *future)
       return future_value_get_void_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 const_char_ptr
@@ -140,9 +131,7 @@ future_get_const_char_ptr (future_t *future)
       return future_value_get_const_char_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 bool_ptr
@@ -152,9 +141,7 @@ future_get_bool_ptr (future_t *future)
       return future_value_get_bool_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 bson_error_ptr
@@ -164,9 +151,7 @@ future_get_bson_error_ptr (future_t *future)
       return future_value_get_bson_error_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 bson_ptr
@@ -176,9 +161,7 @@ future_get_bson_ptr (future_t *future)
       return future_value_get_bson_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 const_bson_ptr
@@ -188,9 +171,7 @@ future_get_const_bson_ptr (future_t *future)
       return future_value_get_const_bson_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 const_bson_ptr_ptr
@@ -200,9 +181,7 @@ future_get_const_bson_ptr_ptr (future_t *future)
       return future_value_get_const_bson_ptr_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 mongoc_async_ptr
@@ -212,9 +191,7 @@ future_get_mongoc_async_ptr (future_t *future)
       return future_value_get_mongoc_async_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 mongoc_bulk_operation_ptr
@@ -224,9 +201,7 @@ future_get_mongoc_bulk_operation_ptr (future_t *future)
       return future_value_get_mongoc_bulk_operation_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 mongoc_client_ptr
@@ -236,9 +211,7 @@ future_get_mongoc_client_ptr (future_t *future)
       return future_value_get_mongoc_client_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 mongoc_client_pool_ptr
@@ -248,9 +221,7 @@ future_get_mongoc_client_pool_ptr (future_t *future)
       return future_value_get_mongoc_client_pool_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 mongoc_collection_ptr
@@ -260,9 +231,7 @@ future_get_mongoc_collection_ptr (future_t *future)
       return future_value_get_mongoc_collection_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 mongoc_cluster_ptr
@@ -272,9 +241,7 @@ future_get_mongoc_cluster_ptr (future_t *future)
       return future_value_get_mongoc_cluster_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 mongoc_cmd_parts_ptr
@@ -284,9 +251,7 @@ future_get_mongoc_cmd_parts_ptr (future_t *future)
       return future_value_get_mongoc_cmd_parts_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 mongoc_cursor_ptr
@@ -296,9 +261,7 @@ future_get_mongoc_cursor_ptr (future_t *future)
       return future_value_get_mongoc_cursor_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 mongoc_database_ptr
@@ -308,9 +271,7 @@ future_get_mongoc_database_ptr (future_t *future)
       return future_value_get_mongoc_database_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 mongoc_gridfs_file_ptr
@@ -320,9 +281,7 @@ future_get_mongoc_gridfs_file_ptr (future_t *future)
       return future_value_get_mongoc_gridfs_file_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 mongoc_gridfs_ptr
@@ -332,9 +291,7 @@ future_get_mongoc_gridfs_ptr (future_t *future)
       return future_value_get_mongoc_gridfs_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 mongoc_insert_flags_t
@@ -344,9 +301,7 @@ future_get_mongoc_insert_flags_t (future_t *future)
       return future_value_get_mongoc_insert_flags_t (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 mongoc_iovec_ptr
@@ -356,9 +311,7 @@ future_get_mongoc_iovec_ptr (future_t *future)
       return future_value_get_mongoc_iovec_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 mongoc_server_stream_ptr
@@ -368,9 +321,7 @@ future_get_mongoc_server_stream_ptr (future_t *future)
       return future_value_get_mongoc_server_stream_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 mongoc_query_flags_t
@@ -380,9 +331,7 @@ future_get_mongoc_query_flags_t (future_t *future)
       return future_value_get_mongoc_query_flags_t (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 const_mongoc_index_opt_t
@@ -392,9 +341,7 @@ future_get_const_mongoc_index_opt_t (future_t *future)
       return future_value_get_const_mongoc_index_opt_t (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 mongoc_server_description_ptr
@@ -404,9 +351,7 @@ future_get_mongoc_server_description_ptr (future_t *future)
       return future_value_get_mongoc_server_description_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 mongoc_ss_optype_t
@@ -416,9 +361,7 @@ future_get_mongoc_ss_optype_t (future_t *future)
       return future_value_get_mongoc_ss_optype_t (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 mongoc_topology_ptr
@@ -428,9 +371,7 @@ future_get_mongoc_topology_ptr (future_t *future)
       return future_value_get_mongoc_topology_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 mongoc_write_concern_ptr
@@ -440,9 +381,7 @@ future_get_mongoc_write_concern_ptr (future_t *future)
       return future_value_get_mongoc_write_concern_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 mongoc_change_stream_ptr
@@ -452,9 +391,7 @@ future_get_mongoc_change_stream_ptr (future_t *future)
       return future_value_get_mongoc_change_stream_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 mongoc_remove_flags_t
@@ -464,9 +401,7 @@ future_get_mongoc_remove_flags_t (future_t *future)
       return future_value_get_mongoc_remove_flags_t (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 const_mongoc_find_and_modify_opts_ptr
@@ -476,9 +411,7 @@ future_get_const_mongoc_find_and_modify_opts_ptr (future_t *future)
       return future_value_get_const_mongoc_find_and_modify_opts_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 const_mongoc_iovec_ptr
@@ -488,9 +421,7 @@ future_get_const_mongoc_iovec_ptr (future_t *future)
       return future_value_get_const_mongoc_iovec_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 const_mongoc_read_prefs_ptr
@@ -500,9 +431,7 @@ future_get_const_mongoc_read_prefs_ptr (future_t *future)
       return future_value_get_const_mongoc_read_prefs_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 const_mongoc_write_concern_ptr
@@ -512,9 +441,7 @@ future_get_const_mongoc_write_concern_ptr (future_t *future)
       return future_value_get_const_mongoc_write_concern_ptr (&future->return_value);
    }
 
-   fprintf (stderr, "%s timed out\n", BSON_FUNC);
-   fflush (stderr);
-   abort ();
+   FUTURE_TIMEOUT_ABORT;
 }
 
 
@@ -607,4 +534,3 @@ future_destroy (future_t *future)
    bson_mutex_destroy (&future->mutex);
    bson_free (future);
 }
-

--- a/src/libmongoc/tests/mock_server/mock-server.c
+++ b/src/libmongoc/tests/mock_server/mock-server.c
@@ -505,9 +505,7 @@ auto_hello_generate_response (request_t *request,
    quotes_replaced = single_quotes_to_double (response_json);
 
    if (!bson_init_from_json (hello_response, quotes_replaced, -1, &error)) {
-      fprintf (stderr, "%s\n", error.message);
-      fflush (stderr);
-      abort ();
+      test_error ("%s", error.message);
    }
 
    bson_free (quotes_replaced);
@@ -1785,17 +1783,13 @@ mock_server_replies_to_find (request_t *request,
    /* minimal validation, we're not testing query / find cmd here */
    if (request->is_command && !is_command) {
       test_error ("expected query, got command");
-      abort ();
    }
 
    if (!request->is_command && is_command) {
       test_error ("expected command, got query");
-      abort ();
    }
 
-   if (!request_matches_flags (request, flags)) {
-      abort ();
-   }
+   assert_request_matches_flags (request, flags);
 
    if (is_command) {
       find_reply =
@@ -1866,9 +1860,7 @@ mock_server_destroy (mock_server_t *server)
 
    bson_mutex_lock (&server->mutex);
    if (server->running) {
-      fprintf (stderr, "server still running after timeout\n");
-      fflush (stderr);
-      abort ();
+      test_error ("server still running after timeout");
    }
 
    bson_mutex_unlock (&server->mutex);

--- a/src/libmongoc/tests/mock_server/request.c
+++ b/src/libmongoc/tests/mock_server/request.c
@@ -120,8 +120,7 @@ request_new (const mongoc_buffer_t *buffer,
 
    case MONGOC_OPCODE_REPLY:
    default:
-      fprintf (stderr, "Unimplemented opcode %d\n", request->opcode);
-      abort ();
+      test_error ("Unimplemented opcode %d", request->opcode);
    }
 
    return request;
@@ -134,8 +133,9 @@ request_get_doc (const request_t *request, int n)
    return _mongoc_array_index (&request->docs, const bson_t *, n);
 }
 
-bool
-request_matches_flags (const request_t *request, mongoc_query_flags_t flags)
+void
+assert_request_matches_flags (const request_t *request,
+                              mongoc_query_flags_t flags)
 {
    const mongoc_rpc_t *rpc;
 
@@ -146,10 +146,7 @@ request_matches_flags (const request_t *request, mongoc_query_flags_t flags)
       test_error ("request's query flags are %s, expected %s",
                   query_flags_str (rpc->query.flags),
                   query_flags_str (flags));
-      return false;
    }
-
-   return true;
 }
 
 /* TODO: take file, line, function params from caller, wrap in macro */
@@ -223,10 +220,7 @@ request_matches_query (const request_t *request,
       goto done;
    }
 
-   if (!request_matches_flags (request, flags)) {
-      test_error ("%s", doc_as_json);
-      goto done;
-   }
+   assert_request_matches_flags (request, flags);
 
    if (rpc->query.skip != skip) {
       test_error ("requests's skip = %d, expected %d: %s",
@@ -1133,9 +1127,7 @@ request_from_op_msg (request_t *request, const mongoc_rpc_t *rpc)
          bson_string_append (msg_as_str, "]");
          break;
       default:
-         fprintf (
-            stderr, "Unimplemented payload type %d\n", section->payload_type);
-         abort ();
+         test_error ("Unimplemented payload type %d\n", section->payload_type);
       }
    }
 

--- a/src/libmongoc/tests/mock_server/request.h
+++ b/src/libmongoc/tests/mock_server/request.h
@@ -54,8 +54,9 @@ request_new (const mongoc_buffer_t *buffer,
 const bson_t *
 request_get_doc (const request_t *request, int n);
 
-bool
-request_matches_flags (const request_t *request, mongoc_query_flags_t flags);
+void
+assert_request_matches_flags (const request_t *request,
+                              mongoc_query_flags_t flags);
 
 bool
 request_matches_query (const request_t *request,

--- a/src/libmongoc/tests/ssl-test.c
+++ b/src/libmongoc/tests/ssl-test.c
@@ -199,11 +199,8 @@ static BSON_THREAD_FUN (ssl_test_client, ptr)
    r = mongoc_socket_connect (
       conn_sock, (struct sockaddr *) &server_addr, sizeof (server_addr), -1);
    if (r != 0) {
-      fprintf (stderr,
-               "mongoc_socket_connect returned %zd: \"%s\"",
-               r,
-               strerror (errno));
-      abort ();
+      test_error (
+         "mongoc_socket_connect returned %zd: \"%s\"", r, strerror (errno));
    }
 
    sock_stream = mongoc_stream_socket_new (conn_sock);

--- a/src/libmongoc/tests/test-conveniences.c
+++ b/src/libmongoc/tests/test-conveniences.c
@@ -121,9 +121,7 @@ tmp_bson (const char *json, ...)
       doc = bson_new_from_json ((const uint8_t *) double_quoted, -1, &error);
 
       if (!doc) {
-         fprintf (
-            stderr, "tmp_bson error %s: parsing: %s\n", error.message, json);
-         abort ();
+         test_error ("tmp_bson error %s: parsing: %s", error.message, json);
       }
 
       bson_free (formatted);
@@ -178,9 +176,7 @@ bson_lookup (const bson_t *bson, const char *path, bson_iter_t *out)
 
    bson_iter_init (&iter, bson);
    if (!bson_iter_find_descendant (&iter, path, out)) {
-      fprintf (
-         stderr, "'%s' field not found in BSON: %s", path, tmp_json (bson));
-      abort ();
+      test_error ("'%s' field not found in BSON: %s", path, tmp_json (bson));
    }
 }
 /*--------------------------------------------------------------------------
@@ -470,7 +466,6 @@ bson_lookup_read_prefs (const bson_t *b, const char *key)
       mode = MONGOC_READ_NEAREST;
    } else {
       test_error ("Bad readPreference: {\"mode\": \"%s\"}.", str);
-      abort ();
    }
 
    return mongoc_read_prefs_new (mode);
@@ -757,8 +752,7 @@ match_json (const bson_t *doc,
    pattern = bson_new_from_json ((const uint8_t *) double_quoted, -1, &error);
 
    if (!pattern) {
-      fprintf (stderr, "couldn't parse JSON: %s\n", error.message);
-      abort ();
+      test_error ("couldn't parse JSON: %s", error.message);
    }
 
    ctx.is_command = is_command;
@@ -1243,8 +1237,7 @@ get_type_operator (const bson_value_t *value, bson_type_t *out)
       } else if (0 == strcasecmp ("maxKey", value_string)) {
          *out = BSON_TYPE_MAXKEY;
       } else {
-         fprintf (stderr, "unrecognized $$type value: %s\n", value_string);
-         abort ();
+         test_error ("unrecognized $$type value: %s", value_string);
       }
       return true;
    }
@@ -1342,7 +1335,6 @@ bson_value_as_int64 (const bson_value_t *value)
    } else {
       test_error ("bson_value_as_int64 called on value of type %d",
                   value->value_type);
-      abort ();
    }
 }
 
@@ -1583,7 +1575,6 @@ match_bson_value (const bson_value_t *doc,
       test_error ("unexpected value type %d: %s",
                   doc->value_type,
                   _mongoc_bson_type_to_str (doc->value_type));
-      abort ();
    }
 
    if (!ret) {
@@ -1701,11 +1692,9 @@ assert_no_duplicate_keys (const bson_t *doc)
    while (bson_iter_next (&iter)) {
       if (mongoc_set_find_item (
              keys, find_key, (void *) bson_iter_key (&iter))) {
-         fprintf (stderr,
-                  "Duplicate key \"%s\" in document:\n%s",
-                  bson_iter_key (&iter),
-                  bson_as_json (doc, NULL));
-         abort ();
+         test_error ("Duplicate key \"%s\" in document:\n%s",
+                     bson_iter_key (&iter),
+                     bson_as_json (doc, NULL));
       }
 
       mongoc_set_add (keys, 0 /* index */, (void *) bson_iter_key (&iter));

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -320,11 +320,10 @@ test_framework_getenv_bool (const char *name)
       } else if (!strcasecmp (value, "") || !strcasecmp (value, "on")) {
          ret = true;
       } else {
-         fprintf (stderr,
-                  "Unrecognized value for %s: \"%s\". Use \"on\" or \"off\".\n",
-                  name,
-                  value);
-         abort ();
+         test_error (
+            "Unrecognized value for %s: \"%s\". Use \"on\" or \"off\".",
+            name,
+            value);
       }
    }
 
@@ -360,7 +359,7 @@ test_framework_getenv_int64 (const char *name, int64_t default_value)
       ret = bson_ascii_strtoll (value, &endptr, 10);
       if (errno) {
          perror (bson_strdup_printf ("Parsing %s from environment", name));
-         abort ();
+         test_error ("Failed to parse %s as int64", name);
       }
 
       bson_free (value);
@@ -660,18 +659,14 @@ test_framework_get_user_password (char **user, char **password)
    *password = test_framework_get_admin_password ();
 
    if ((*user && !*password) || (!*user && *password)) {
-      fprintf (stderr,
-               "Specify both MONGOC_TEST_USER and"
-               " MONGOC_TEST_PASSWORD, or neither\n");
-      abort ();
+      test_error ("Specify both MONGOC_TEST_USER and"
+                  " MONGOC_TEST_PASSWORD, or neither");
    }
 
 #ifndef MONGOC_ENABLE_CRYPTO
    if (*user && *password) {
-      fprintf (stderr,
-               "You need to configure with ENABLE_SSL"
-               " when providing user+password (for SCRAM-SHA-1)\n");
-      abort ();
+      test_error ("You need to configure with ENABLE_SSL"
+                  " when providing user+password (for SCRAM-SHA-1)");
    }
 #endif
 
@@ -937,9 +932,10 @@ call_hello_with_host_and_port (const char *host_and_port, bson_t *reply)
              NULL,
              reply,
              &error)) {
-         fprintf (stderr, "error calling legacy hello: '%s'\n", error.message);
-         fprintf (stderr, "URI = %s\n", uri_str);
-         abort ();
+         test_error ("error calling legacy hello: '%s'\n"
+                     "URI = %s",
+                     error.message,
+                     uri_str);
       }
    }
 
@@ -1436,10 +1432,9 @@ test_framework_set_ssl_opts (mongoc_client_t *client)
 
    if (test_framework_get_ssl ()) {
 #ifndef MONGOC_ENABLE_SSL
-      fprintf (stderr,
-               "SSL test config variables are specified in the environment, but"
-               " SSL isn't enabled\n");
-      abort ();
+      test_error (
+         "SSL test config variables are specified in the environment, but"
+         " SSL isn't enabled");
 #else
       mongoc_client_set_ssl_opts (client, &gSSLOptions);
 #endif
@@ -1669,10 +1664,9 @@ test_framework_set_pool_ssl_opts (mongoc_client_pool_t *pool)
 
    if (test_framework_get_ssl ()) {
 #ifndef MONGOC_ENABLE_SSL
-      fprintf (stderr,
-               "SSL test config variables are specified in the environment, but"
-               " SSL isn't enabled\n");
-      abort ();
+      test_error (
+         "SSL test config variables are specified in the environment, but"
+         " SSL isn't enabled");
 #else
       mongoc_client_pool_set_ssl_opts (pool, &gSSLOptions);
 #endif

--- a/src/libmongoc/tests/test-mongoc-async.c
+++ b/src/libmongoc/tests/test-mongoc-async.c
@@ -39,13 +39,8 @@ get_localhost_stream (uint16_t port)
 
    errcode = mongoc_socket_errno (conn_sock);
    if (!(r == 0 || MONGOC_ERRNO_IS_AGAIN (errcode))) {
-      fprintf (stderr,
-               "mongoc_socket_connect unexpected return: "
-               "%d (errno: %d)\n",
-               r,
-               errcode);
-      fflush (stderr);
-      abort ();
+      test_error (
+         "mongoc_socket_connect unexpected return: %d (errno: %d)", r, errcode);
    }
 
    return mongoc_stream_socket_new (conn_sock);
@@ -190,8 +185,7 @@ test_hello_impl (bool with_ssl)
 
    for (i = 0; i < NSERVERS; i++) {
       if (!results[i].finished) {
-         fprintf (stderr, "command %d not finished\n", i);
-         abort ();
+         test_error ("command %d not finished", i);
       }
 
       ASSERT_CMPINT (i, ==, results[i].server_id);

--- a/src/libmongoc/tests/test-mongoc-bulk.c
+++ b/src/libmongoc/tests/test-mongoc-bulk.c
@@ -716,8 +716,7 @@ test_upserted_index (bool ordered)
 
    r = (bool) mongoc_bulk_operation_execute (bulk, &reply, &error);
    if (!r) {
-      fprintf (stderr, "bulk failed: %s\n", error.message);
-      abort ();
+      test_error ("bulk failed: %s", error.message);
    }
 
    ASSERT_MATCH (&reply,
@@ -4072,7 +4071,6 @@ test_bulk_write_concern_split (void *unused)
    if (bson_iter_init_find (&iter, &reply, "err") &&
        BSON_ITER_HOLDS_UTF8 (&iter)) {
       test_error ("%s", bson_iter_utf8 (&iter, NULL));
-      abort ();
    }
 
    bson_destroy (&reply);

--- a/src/libmongoc/tests/test-mongoc-client-session.c
+++ b/src/libmongoc/tests/test-mongoc-client-session.c
@@ -971,14 +971,12 @@ _test_advance_operation_time (mongoc_client_session_t *cs,
       ASSERT_CMPUINT32 (new_t, ==, t);
       ASSERT_CMPUINT32 (new_i, ==, i);
    } else if (new_t == t && new_i == i) {
-      fprintf (stderr,
-               "Shouldn't have advanced from operationTime %" PRIu32
-               ", %" PRIu32 " to %" PRIu32 ", %" PRIu32 "\n",
-               old_t,
-               old_i,
-               t,
-               i);
-      abort ();
+      test_error ("Shouldn't have advanced from operationTime %" PRIu32
+                  ", %" PRIu32 " to %" PRIu32 ", %" PRIu32,
+                  old_t,
+                  old_i,
+                  t,
+                  i);
    }
 }
 
@@ -1076,8 +1074,7 @@ started (const mongoc_apm_command_started_t *event)
 
    if (test->acknowledged) {
       if (!bson_iter_init_find (&iter, cmd, "lsid")) {
-         fprintf (stderr, "no lsid sent with command %s\n", cmd_name);
-         abort ();
+         test_error ("no lsid sent with command %s", cmd_name);
       }
 
       bson_iter_bson (&iter, &lsid);
@@ -1085,17 +1082,13 @@ started (const mongoc_apm_command_started_t *event)
 
       if (test->expect_explicit_lsid) {
          if (!match_bson_with_ctx (&lsid, client_session_lsid, &ctx)) {
-            fprintf (stderr,
-                     "command %s should have used client session's lsid\n",
-                     cmd_name);
-            abort ();
+            test_error ("command %s should have used client session's lsid",
+                        cmd_name);
          }
       } else {
          if (match_bson_with_ctx (&lsid, client_session_lsid, &ctx)) {
-            fprintf (stderr,
-                     "command %s should not have used client session's lsid\n",
-                     cmd_name);
-            abort ();
+            test_error ("command %s should not have used client session's lsid",
+                        cmd_name);
          }
       }
 
@@ -1104,10 +1097,8 @@ started (const mongoc_apm_command_started_t *event)
          bson_copy_to (&lsid, &test->sent_lsid);
       } else {
          if (!match_bson_with_ctx (&lsid, &test->sent_lsid, &ctx)) {
-            fprintf (stderr,
-                     "command %s used different lsid than previous command\n",
-                     cmd_name);
-            abort ();
+            test_error ("command %s used different lsid than previous command",
+                        cmd_name);
          }
       }
    } else {
@@ -1117,8 +1108,7 @@ started (const mongoc_apm_command_started_t *event)
 
    has_cluster_time = bson_iter_init_find (&iter, cmd, "$clusterTime");
    if (test->acknowledged && !has_cluster_time) {
-      fprintf (stderr, "no $clusterTime sent with command %s\n", cmd_name);
-      abort ();
+      test_error ("no $clusterTime sent with command %s", cmd_name);
    }
 
    if (has_cluster_time) {
@@ -1153,8 +1143,7 @@ succeeded (const mongoc_apm_command_succeeded_t *event)
 
    has_cluster_time = bson_iter_init_find (&iter, reply, "$clusterTime");
    if (test->acknowledged && !has_cluster_time) {
-      fprintf (stderr, "no $clusterTime in reply to command %s\n", cmd_name);
-      abort ();
+      test_error ("no $clusterTime in reply to command %s", cmd_name);
    }
 
    if (strcmp (cmd_name, "endSessions") == 0) {
@@ -1311,10 +1300,8 @@ check_session_returned (session_test_t *test, const bson_t *lsid)
     * been used. It is expected behavior for found to be false if
     * ss->last_used_usec == SESSION_NEVER_USED */
    if (!check_state.found) {
-      fprintf (stderr,
-               "server session %s not returned to pool\n",
-               bson_as_json (lsid, NULL));
-      abort ();
+      test_error ("server session %s not returned to pool",
+                  bson_as_json (lsid, NULL));
    }
 }
 
@@ -1342,8 +1329,7 @@ last_non_getmore_cmd (session_test_t *test)
       }
    }
 
-   fprintf (stderr, "No commands besides getMore were recorded\n");
-   abort ();
+   test_error ("No commands besides getMore were recorded");
 }
 
 
@@ -1483,8 +1469,7 @@ check_cluster_time (session_test_t *test)
    capture_logs (true);
    if (_mongoc_cluster_time_greater (&test->received_cluster_time,
                                      session_time)) {
-      fprintf (stderr, "client session's cluster time is outdated\n");
-      abort ();
+      test_error ("client session's cluster time is outdated");
    }
 
    ASSERT_NO_CAPTURED_LOGS ("_mongoc_cluster_time_greater");
@@ -1597,15 +1582,13 @@ parse_reply_time (const bson_t *reply, op_time_t *op_time)
 }
 
 
-#define ASSERT_OP_TIMES_EQUAL(_a, _b)                             \
-   if ((_a).t != (_b).t || (_a).i != (_b).i) {                    \
-      fprintf (stderr,                                            \
-               #_a " (%d, %d) does not match " #_b " (%d, %d)\n", \
-               (_a).t,                                            \
-               (_a).i,                                            \
-               (_b).t,                                            \
-               (_b).i);                                           \
-      abort ();                                                   \
+#define ASSERT_OP_TIMES_EQUAL(_a, _b)                              \
+   if ((_a).t != (_b).t || (_a).i != (_b).i) {                     \
+      test_error (#_a " (%d, %d) does not match " #_b " (%d, %d)", \
+                  (_a).t,                                          \
+                  (_a).i,                                          \
+                  (_b).t,                                          \
+                  (_b).i);                                         \
    }
 
 
@@ -1658,10 +1641,8 @@ _test_causal_consistency (session_test_fn_t test_fn, bool allow_read_concern)
       for (i = 0; i < test->cmds.len; i++) {
          cmd = _mongoc_array_index (&test->cmds, bson_t *, i);
          if (bson_has_field (cmd, "readConcern")) {
-            fprintf (stderr,
-                     "Command should not have included readConcern: %s\n",
-                     bson_as_json (cmd, NULL));
-            abort ();
+            test_error ("Command should not have included readConcern: %s",
+                        bson_as_json (cmd, NULL));
          }
       }
    }

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -220,10 +220,8 @@ _make_gcp_kms_provider (bson_t *kms_providers)
       test_framework_getenv_required ("MONGOC_TEST_GCP_PRIVATEKEY");
 
    if (!gcp_email || !gcp_privatekey) {
-      fprintf (stderr,
-               "Set MONGOC_TEST_GCP_EMAIL and MONGOC_TEST_GCP_PRIVATEKEY to "
-               "enable CSFLE tests.");
-      abort ();
+      test_error ("Set MONGOC_TEST_GCP_EMAIL and MONGOC_TEST_GCP_PRIVATEKEY to "
+                  "enable CSFLE tests.");
    }
 
    if (!kms_providers) {
@@ -5482,9 +5480,10 @@ test_auto_datakeys (void *unused)
       require (
          keyWithType ("0", doc), //
          parse (require (allOf (key ("keyId"), strEqual ("keepme")), nop))),
-      require (keyWithType ("1", doc),
-               parse (require (allOf (keyWithType ("keyId", int32)),
-                               do(ASSERT_CMPINT32 (bsonAs (int32), ==, 42))))));
+      require (
+         keyWithType ("1", doc),
+         parse (require (allOf (keyWithType ("keyId", int32)),
+                         do (ASSERT_CMPINT32 (bsonAs (int32), ==, 42))))));
    ASSERT (bsonParseError == NULL);
    bson_destroy (&out_fields);
 

--- a/src/libmongoc/tests/test-mongoc-client.c
+++ b/src/libmongoc/tests/test-mongoc-client.c
@@ -2594,7 +2594,6 @@ test_mongoc_client_descriptions_pooled (void *unused)
          test_error ("still have %d descriptions, not expected %d, after 1 sec",
                      (int) n,
                      (int) expected_n);
-         abort ();
       }
 
       sds = mongoc_client_get_server_descriptions (client, &n);

--- a/src/libmongoc/tests/test-mongoc-cluster.c
+++ b/src/libmongoc/tests/test-mongoc-cluster.c
@@ -459,12 +459,9 @@ test_cluster_time_cmd_started_cb (const mongoc_apm_command_started_t *event)
          BSON_ASSERT (!bson_empty0 (test->cluster_time));
          bson_iter_bson (&iter, &client_cluster_time);
          if (!bson_equal (test->cluster_time, &client_cluster_time)) {
-            fprintf (stderr,
-                     "Unequal clusterTimes.\nServer sent %s\nClient sent %s\n",
-                     bson_as_json (test->cluster_time, NULL),
-                     bson_as_json (&client_cluster_time, NULL));
-
-            abort ();
+            test_error ("Unequal clusterTimes.\nServer sent %s\nClient sent %s",
+                        bson_as_json (test->cluster_time, NULL),
+                        bson_as_json (&client_cluster_time, NULL));
          }
 
          bson_destroy (&client_cluster_time);
@@ -813,13 +810,11 @@ receives_with_cluster_time (mock_server_t *server,
    BSON_ASSERT (BSON_ITER_HOLDS_TIMESTAMP (&cluster_time));
    bson_iter_timestamp (&cluster_time, &t, &i);
    if (t != timestamp || i != increment) {
-      fprintf (stderr,
-               "Expected Timestamp(%d, %d), got Timestamp(%d, %d)\n",
-               timestamp,
-               increment,
-               t,
-               i);
-      abort ();
+      test_error ("Expected Timestamp(%d, %d), got Timestamp(%d, %d)",
+                  timestamp,
+                  increment,
+                  t,
+                  i);
    }
 
    return request;

--- a/src/libmongoc/tests/test-mongoc-collection-find.c
+++ b/src/libmongoc/tests/test-mongoc-collection-find.c
@@ -82,8 +82,7 @@ _check_cursor (mongoc_cursor_t *cursor, test_collection_find_t *test_data)
    ASSERT_OR_PRINT (!mongoc_cursor_error (cursor, &error), error);
 
    if (i != test_data->n_results) {
-      fprintf (stderr, "expect %d results, got %d\n", test_data->n_results, i);
-      abort ();
+      test_error ("expect %d results, got %d", test_data->n_results, i);
    }
 
    ASSERT (match_json (&actual_result,
@@ -250,9 +249,7 @@ _test_collection_find_command (test_collection_find_t *test_data)
    }
 
    if (i != test_data->n_results) {
-      fprintf (
-         stderr, "Expected %d results, got %d\n", test_data->n_results, i);
-      abort ();
+      test_error ("Expected %d results, got %d\n", test_data->n_results, i);
    }
 
    ASSERT (match_json (&actual_result,

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -2846,10 +2846,7 @@ again:
       for (j = 0; j < 2; j++) {
          r = mongoc_cursor_next (cursor, &doc);
          if (mongoc_cursor_error (cursor, &error)) {
-            fprintf (
-               stderr, "[%d.%d] %s", error.domain, error.code, error.message);
-
-            abort ();
+            test_error ("[%d.%d] %s", error.domain, error.code, error.message);
          }
 
          ASSERT (r);
@@ -2861,8 +2858,7 @@ again:
 
       r = mongoc_cursor_next (cursor, &doc);
       if (mongoc_cursor_error (cursor, &error)) {
-         fprintf (stderr, "%s", error.message);
-         abort ();
+         test_error ("%s", error.message);
       }
 
       ASSERT (!r);
@@ -4084,8 +4080,7 @@ test_command_fq (void *context)
    if (bson_iter_init_find (&iter, doc, "db") && BSON_ITER_HOLDS_UTF8 (&iter)) {
       ASSERT_CMPSTR (bson_iter_utf8 (&iter, NULL), "sometest");
    } else {
-      fprintf (stderr, "dbstats didn't return 'db' key?");
-      abort ();
+      test_error ("dbstats didn't return 'db' key?");
    }
 
 

--- a/src/libmongoc/tests/test-mongoc-command-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-command-monitoring.c
@@ -44,10 +44,9 @@ check_operation_ids (const bson_t *events)
          if (first_operation_id == -1) {
             first_operation_id = operation_id;
          } else if (operation_id != first_operation_id) {
-            MONGOC_ERROR (
+            test_error (
                "%s sent wrong operation_id",
                bson_lookup_utf8 (&event, "command_started_event.command_name"));
-            abort ();
          }
       }
    }

--- a/src/libmongoc/tests/test-mongoc-cursor.c
+++ b/src/libmongoc/tests/test-mongoc-cursor.c
@@ -61,7 +61,6 @@ _test_common_get_host (void *ctx)
    ret = mongoc_cursor_next (cursor, &doc);
    if (!ret && mongoc_cursor_error (cursor, &err)) {
       test_error ("%s", err.message);
-      abort ();
    }
    mongoc_cursor_get_host (cursor, &cursor_host);
    /* In a production deployment the driver can discover servers not in the seed
@@ -780,8 +779,7 @@ _test_kill_cursors (bool pooled)
 
    if (!future_get_bool (future)) {
       mongoc_cursor_error (cursor, &error);
-      fprintf (stderr, "%s\n", error.message);
-      abort ();
+      test_error ("%s", error.message);
    };
 
    ASSERT_MATCH (doc, "{'b': 1}");

--- a/src/libmongoc/tests/test-mongoc-dns.c
+++ b/src/libmongoc/tests/test-mongoc-dns.c
@@ -46,29 +46,25 @@ _assert_options_match (const bson_t *test, mongoc_uri_t *uri)
                                                                 : opts_from_uri;
       if (!bson_iter_init_find_case (
              &uri_opts_iter, opts_or_creds, opt_name_canon)) {
-         fprintf (stderr,
-                  "URI options incorrectly set from TXT record: "
-                  "no option named \"%s\"\n"
-                  "expected: %s\n"
-                  "actual: %s\n",
-                  opt_name,
-                  bson_as_json (&opts_from_test, NULL),
-                  bson_as_json (opts_or_creds, NULL));
-         abort ();
+         test_error ("URI options incorrectly set from TXT record: "
+                     "no option named \"%s\"\n"
+                     "expected: %s\n"
+                     "actual: %s",
+                     opt_name,
+                     bson_as_json (&opts_from_test, NULL),
+                     bson_as_json (opts_or_creds, NULL));
       }
 
       test_value = bson_iter_value (&test_opts_iter);
       uri_value = bson_iter_value (&uri_opts_iter);
       if (!match_bson_value (uri_value, test_value, &ctx)) {
-         fprintf (stderr,
-                  "URI option \"%s\" incorrectly set from TXT record: %s\n"
-                  "expected: %s\n"
-                  "actual: %s\n",
-                  opt_name,
-                  ctx.errmsg,
-                  bson_as_json (&opts_from_test, NULL),
-                  bson_as_json (opts_from_uri, NULL));
-         abort ();
+         test_error ("URI option \"%s\" incorrectly set from TXT record: %s\n"
+                     "expected: %s\n"
+                     "actual: %s",
+                     opt_name,
+                     ctx.errmsg,
+                     bson_as_json (&opts_from_test, NULL),
+                     bson_as_json (opts_from_uri, NULL));
       }
    }
 }
@@ -231,10 +227,9 @@ _test_dns_maybe_pooled (bson_t *test, bool pooled)
    const char *uri_str;
 
    if (!test_framework_get_ssl ()) {
-      fprintf (stderr,
-               "Must configure an SSL replica set and set MONGOC_TEST_SSL=on "
-               "and other ssl options to test DNS\n");
-      abort ();
+      test_error (
+         "Must configure an SSL replica set and set MONGOC_TEST_SSL=on "
+         "and other ssl options to test DNS");
    }
 
    uri_str = bson_lookup_utf8 (test, "uri");

--- a/src/libmongoc/tests/test-mongoc-gssapi.c
+++ b/src/libmongoc/tests/test-mongoc-gssapi.c
@@ -72,7 +72,9 @@ static BSON_THREAD_FUN (gssapi_kerberos_worker, data)
       client = mongoc_client_pool_pop (pool);
       if (!mongoc_client_command_with_opts (
              client, "test", cmd, NULL, NULL, NULL, &error)) {
+         fflush (stdout);
          fprintf (stderr, "ping command failed: %s\n", error.message);
+         fflush (stderr);
          abort ();
       }
       bson_destroy (cmd);
@@ -82,7 +84,9 @@ static BSON_THREAD_FUN (gssapi_kerberos_worker, data)
 
       if (!mongoc_cursor_next (cursor, &doc) &&
           mongoc_cursor_error (cursor, &error)) {
+         fflush (stdout);
          fprintf (stderr, "Cursor Failure: %s\n", error.message);
+         fflush (stderr);
          abort ();
       }
 

--- a/src/libmongoc/tests/test-mongoc-matcher.c
+++ b/src/libmongoc/tests/test-mongoc-matcher.c
@@ -262,11 +262,8 @@ test_mongoc_matcher_logic_ops (void)
       test = tests[i];
       spec = bson_new_from_json ((uint8_t *) test.spec, -1, &error);
       if (!spec) {
-         fprintf (stderr,
-                  "couldn't parse JSON query:\n\n%s\n\n%s\n",
-                  test.spec,
-                  error.message);
-         abort ();
+         test_error (
+            "couldn't parse JSON query:\n\n%s\n\n%s", test.spec, error.message);
       }
 
       matcher = mongoc_matcher_new (spec, &error);
@@ -274,21 +271,17 @@ test_mongoc_matcher_logic_ops (void)
 
       doc = bson_new_from_json ((uint8_t *) test.doc, -1, &error);
       if (!doc) {
-         fprintf (stderr,
-                  "couldn't parse JSON document:\n\n%s\n\n%s\n",
-                  test.doc,
-                  error.message);
-         abort ();
+         test_error ("couldn't parse JSON document:\n\n%s\n\n%s",
+                     test.doc,
+                     error.message);
       }
 
       r = mongoc_matcher_match (matcher, doc);
       if (test.match != r) {
-         fprintf (stderr,
-                  "query:\n\n%s\n\nshould %shave matched:\n\n%s\n",
-                  test.match ? "" : "not ",
-                  test.spec,
-                  test.doc);
-         abort ();
+         test_error ("query:\n\n%s\n\nshould %shave matched:\n\n%s",
+                     test.match ? "" : "not ",
+                     test.spec,
+                     test.doc);
       }
 
       mongoc_matcher_destroy (matcher);

--- a/src/libmongoc/tests/test-mongoc-opts.c
+++ b/src/libmongoc/tests/test-mongoc-opts.c
@@ -135,27 +135,27 @@ func_ctx_cleanup (func_ctx_t *ctx)
    mongoc_write_concern_destroy (wc); \
    mongoc_read_prefs_destroy (prefs);
 
-#define SET_OPT(_type)                                     \
-   static void set_##_type##_opt (mongoc_##_type##_t *obj, \
-                                  opt_type_t opt_type)     \
-   {                                                       \
-      SET_OPT_PREAMBLE (_type);                            \
-                                                           \
-      switch (opt_type) {                                  \
-      case OPT_READ_CONCERN:                               \
-         mongoc_##_type##_set_read_concern (obj, rc);      \
-         break;                                            \
-      case OPT_WRITE_CONCERN:                              \
-         mongoc_##_type##_set_write_concern (obj, wc);     \
-         break;                                            \
-      case OPT_READ_PREFS:                                 \
-         mongoc_##_type##_set_read_prefs (obj, prefs);     \
-         break;                                            \
-      default:                                             \
-         abort ();                                         \
-      }                                                    \
-                                                           \
-      SET_OPT_CLEANUP;                                     \
+#define SET_OPT(_type)                                        \
+   static void set_##_type##_opt (mongoc_##_type##_t *obj,    \
+                                  opt_type_t opt_type)        \
+   {                                                          \
+      SET_OPT_PREAMBLE (_type);                               \
+                                                              \
+      switch (opt_type) {                                     \
+      case OPT_READ_CONCERN:                                  \
+         mongoc_##_type##_set_read_concern (obj, rc);         \
+         break;                                               \
+      case OPT_WRITE_CONCERN:                                 \
+         mongoc_##_type##_set_write_concern (obj, wc);        \
+         break;                                               \
+      case OPT_READ_PREFS:                                    \
+         mongoc_##_type##_set_read_prefs (obj, prefs);        \
+         break;                                               \
+      default:                                                \
+         test_error ("invalid opt_type: %d", (int) opt_type); \
+      }                                                       \
+                                                              \
+      SET_OPT_CLEANUP;                                        \
    }
 
 SET_OPT (client)
@@ -181,7 +181,7 @@ set_func_opt (bson_t *opts,
       *prefs_ptr = mongoc_read_prefs_copy (prefs);
       break;
    default:
-      abort ();
+      test_error ("invalid opt_type: %d", (int) opt_type);
    }
 
    SET_OPT_CLEANUP;
@@ -206,8 +206,7 @@ add_expected_opt (opt_source_t opt_source, opt_type_t opt_type, bson_t *cmd)
    } else if (opt_source & OPT_SOURCE_CLIENT) {
       source_name = "client";
    } else {
-      MONGOC_ERROR ("opt_json called with OPT_SOURCE_NONE");
-      abort ();
+      test_error ("opt_json called with OPT_SOURCE_NONE");
    }
 
    switch (opt_type) {
@@ -223,7 +222,7 @@ add_expected_opt (opt_source_t opt_source, opt_type_t opt_type, bson_t *cmd)
          source_name);
       break;
    default:
-      abort ();
+      test_error ("invalid opt_type: %d", (int) opt_type);
    }
 
    bson_concat (cmd, opt);
@@ -241,7 +240,7 @@ opt_type_name (opt_type_t opt_type)
    case OPT_READ_PREFS:
       return "readPrefs";
    default:
-      abort ();
+      test_error ("invalid opt_type: %d", (int) opt_type);
    }
 }
 

--- a/src/libmongoc/tests/test-mongoc-read-prefs.c
+++ b/src/libmongoc/tests/test-mongoc-read-prefs.c
@@ -216,8 +216,7 @@ _run_server (read_pref_test_type_t test_type)
                               mock_server_get_host_and_port (server));
       break;
    default:
-      fprintf (stderr, "Invalid test_type: : %d\n", test_type);
-      abort ();
+      test_error ("Invalid test_type: %d", (int) test_type);
    }
 
    return server;

--- a/src/libmongoc/tests/test-mongoc-read-write-concern.c
+++ b/src/libmongoc/tests/test-mongoc-read-write-concern.c
@@ -136,9 +136,8 @@ test_rw_concern_uri (bson_t *scenario)
       valid = _mongoc_lookup_bool (&test, "valid", true);
 
       if (_mongoc_lookup_bool (&test, "warning", false)) {
-         MONGOC_ERROR ("update the \"%s\" test to handle warning: true",
-                       description);
-         abort ();
+         test_error ("update the \"%s\" test to handle warning: true",
+                     description);
       }
 
       uri = mongoc_uri_new_with_error (uri_str, NULL);

--- a/src/libmongoc/tests/test-mongoc-rpc.c
+++ b/src/libmongoc/tests/test-mongoc-rpc.c
@@ -28,8 +28,7 @@ get_test_file (const char *filename, size_t *length)
 #endif
 
    if (fd == -1) {
-      fprintf (stderr, "Failed to open: %s\n", real_filename);
-      abort ();
+      test_error ("Failed to open: %s", real_filename);
    }
 
    len = 40960;

--- a/src/libmongoc/tests/test-mongoc-sdam.c
+++ b/src/libmongoc/tests/test-mongoc-sdam.c
@@ -47,11 +47,9 @@ _topology_has_description (const mongoc_topology_description_t *topology,
       } else if (strcmp ("type", bson_iter_key (&server_iter)) == 0) {
          server_type = bson_iter_utf8 (&server_iter, NULL);
          if (sd->type != server_type_from_test (server_type)) {
-            fprintf (stderr,
-                     "expected server type %s not %s\n",
-                     server_type,
-                     mongoc_server_description_type (sd));
-            abort ();
+            test_error ("expected server type %s not %s",
+                        server_type,
+                        mongoc_server_description_type (sd));
          }
       } else if (strcmp ("setVersion", bson_iter_key (&server_iter)) == 0) {
          int64_t expected_set_version;

--- a/src/libmongoc/tests/test-mongoc-stream-tls-error.c
+++ b/src/libmongoc/tests/test-mongoc-stream-tls-error.c
@@ -93,8 +93,7 @@ static BSON_THREAD_FUN (ssl_error_server, ptr)
       break;
    case SSL_TEST_BEHAVIOR_NORMAL:
    default:
-      fprintf (stderr, "unimplemented ssl_test_behavior_t\n");
-      abort ();
+      test_error ("unimplemented ssl_test_behavior_t");
    }
 
    data->server_result->result = SSL_TEST_SUCCESS;
@@ -281,10 +280,8 @@ static BSON_THREAD_FUN (handshake_stall_client, ptr)
    duration_ms = (bson_get_monotonic_time () - start_time) / 1000;
 
    if (llabs (duration_ms - connect_timeout_ms) > 100) {
-      fprintf (stderr,
-               "expected timeout after about 200ms, not %" PRId64 "\n",
-               duration_ms);
-      abort ();
+      test_error ("expected timeout after about 200ms, not %" PRId64,
+                  duration_ms);
    }
 
    data->client_result->result = SSL_TEST_SUCCESS;

--- a/src/libmongoc/tests/test-mongoc-topology-scanner.c
+++ b/src/libmongoc/tests/test-mongoc-topology-scanner.c
@@ -35,8 +35,7 @@ test_topology_scanner_helper (uint32_t id,
    BSON_UNUSED (rtt_msec);
 
    if (error->code) {
-      fprintf (stderr, "scanner error: %s\n", error->message);
-      abort ();
+      test_error ("scanner error: %s", error->message);
    }
 
    /* mock servers are configured to return distinct wire versions */


### PR DESCRIPTION
This PR extends the work done for CDRIVER-4537 by https://github.com/mongodb/mongo-c-driver/pull/1161. Verified by [this patch](https://spruce.mongodb.com/version/639b3a2dd6d80a5d02bfdbb7/tasks).

This PR ensures (almost) all instances of a call to `abort()` within `src/libmongoc/tests` is replaced by an invocation of `test_error ()` instead. The only remaining exceptions are:

* `TestSuite.h` and `TestSuite.c`: defines assertion macros used by test suite.
* `future.c`: avoid including `TestSuite.h` (unnecessary concern?)
* `test-mongoc-gssapi.h`: its own executable; avoid introducing linkage with `TestSuite.c`.

All `abort ()` are replaced by a call to `test_error`, which handles flushing of `stdout` and `stderr`. Any immediately preceeding messages emited via `fprintf()` or `MONGOC_ERROR` are moved into the call to `test_error`. Final `'\n'` characters were removed from error messages as `test_error` ensures the emitted message is followed by a newline character.

This PR is motivated by confusing errors messages in failing tasks such as in [this patch](https://parsley.mongodb.com/evergreen/mongo_c_driver_sasl_matrix_darwinssl_sasl_auto_darwinssl_test_macos_1014_noauth_latest_server_patch_b91eea44f2fa1eb54fa6eb385214210cc46663d2_639b32341e2d17654a06f26d_22_12_15_14_41_57/1/task?bookmarks=0,11055&selectedLine=10989):

```
test error in: /data/mci/4128de49870bba0675944a05b9a9b9bb/mongoc/src/libmongoc/tests/unified/test-diagnostics.c 162:test_diagnostics_abort()
****************************** BEGIN_MONGOC_ERROR ******************************
test info:
[/data/mci/4128de49870bba0675944a05b9a9b9bb/mongoc/src/libmongoc/tests/unified/runner.c:1695 run_one_test_file()]
test file: observeSensitiveCommands
[/data/mci/4128de49870bba0675944a05b9a9b9bb/mongoc/src/libmongoc/tests/unified/runner.c:1699 run_one_test_file()]
running test: getnonce is observed with observeSensitiveCommands=true
error context:
[/data/mci/4128de49870bba0675944a05b9a9b9bb/mongoc/src/libmongoc/tests/unified/runner.c:1622 test_run()]
running operations
2022/12/15 10:04:17.0445: [32793]:    DEBUG:       mongoc: topology changed, adding server id: 1
[/data/mci/4128de49870bba0675944a05b9a9b9bb/mongoc/src/libmongoc/tests/unified/runner.c:1010 test_run_operations()]
2022/12/15 10:04:17.0566: [32793]:    DEBUG:       mongoc: [/data/mci/4128de49870bba0675944a05b9a9b9bb/mongoc/src/libmongoc/tests/unified/runner.c:1666 run_one_test_file()]
running operation: { "name" : "runCommand", "object" : "database0", "arguments" : { "commandName" : "getnonce", "command" : { "getnonce" : { "$numberInt" : "1" } } } }
test file: observeSensitiveCommands
2022/12/15 10:04:17.0566: [32793]:    DEBUG:       mongoc: [/data/mci/4128de49870bba0675944a05b9a9b9bb/mongoc/src/libmongoc/tests/unified/runner.c:1695 run_one_test_file()]
[/data/mci/4128de49870bba0675944a05b9a9b9bb/mongoc/src/libmongoc/tests/unified/operation.c:3431 operation_run()]
test file: observeSensitiveCommands
checking for result ((NULL)) / error ((NULL))
2022/12/15 10:04:17.0566: [32793]:    DEBUG:       mongoc: [/data/mci/4128de49870bba0675944a05b9a9b9bb/mongoc/src/libmongoc/tests/unified/runner.c:1699 run_one_test_file()]
error: expected success, but got error: no such command: 'getnonce'
running test: getnonce is observed with observeSensitiveCommands=true
******************************* END_MONGOC_ERROR *******************************
2022/12/15 10:04:17.0637: [32793]:    DEBUG:       mongoc: running operation: { "name" : "runCommand", "object" : "database0", "arguments" : { "commandName" : "getnonce", "command" : { "getnonce" : { "$numberInt" : "1" } } } }
2022/12/15 10:04:17.0661: [32793]:    DEBUG:       mongoc: [/data/mci/4128de49870bba0675944a05b9a9b9bb/mongoc/src/libmongoc/tests/unified/operation.c:3431 operation_run()]
checking for result ((NULL)) / error ((NULL))
2022/12/15 10:04:17.0661: [32793]:    DEBUG:       mongoc: [/data/mci/4128de49870bba0675944a05b9a9b9bb/mongoc/src/libmongoc/tests/unified/runner.c:1010 test_run_operations()]
running operation: { "name" : "runCommand", "object" : "database0", "arguments" : { "commandName" : "getnonce", "command" : { "getnonce" : { "$numberInt" : "1" } } } }
2022/12/15 10:04:17.0661: [32793]:    DEBUG:       mongoc: [/data/mci/4128de49870bba0675944a05b9a9b9bb/mongoc/src/libmongoc/tests/unified/runner.c:1622 test_run()]
running operations
.evergreen/scripts/run-tests.sh: line 190:  2157 Abort trap: 6           (core dumped) ./src/libmongoc/test-libmongoc --no-fork $TEST_ARGS -d
```

Synchronization of `stdout` and `stderr` ensures the output is not interspersed with `stdout` messages, as observed in [this patch](https://parsley.mongodb.com/evergreen/mongo_c_driver_gcc82rhel_test_latest_server_noauth_sasl_openssl_patch_b91eea44f2fa1eb54fa6eb385214210cc46663d2_639b3a2dd6d80a5d02bfdbb7_22_12_15_15_15_58/0/task?bookmarks=0,10967&selectedLine=10764):

```
test error in: /data/mci/3d1ca01040c2e1c449ccfee0ddfb7500/mongoc/src/libmongoc/tests/unified/test-diagnostics.c 162:test_diagnostics_abort()
****************************** BEGIN_MONGOC_ERROR ******************************
test info:
[/data/mci/3d1ca01040c2e1c449ccfee0ddfb7500/mongoc/src/libmongoc/tests/unified/runner.c:1695 run_one_test_file()]
test file: observeSensitiveCommands
[/data/mci/3d1ca01040c2e1c449ccfee0ddfb7500/mongoc/src/libmongoc/tests/unified/runner.c:1699 run_one_test_file()]
running test: getnonce is observed with observeSensitiveCommands=true
error context:
[/data/mci/3d1ca01040c2e1c449ccfee0ddfb7500/mongoc/src/libmongoc/tests/unified/runner.c:1622 test_run()]
running operations
[/data/mci/3d1ca01040c2e1c449ccfee0ddfb7500/mongoc/src/libmongoc/tests/unified/runner.c:1010 test_run_operations()]
running operation: { "name" : "runCommand", "object" : "database0", "arguments" : { "commandName" : "getnonce", "command" : { "getnonce" : { "$numberInt" : "1" } } } }
[/data/mci/3d1ca01040c2e1c449ccfee0ddfb7500/mongoc/src/libmongoc/tests/unified/operation.c:3431 operation_run()]
checking for result ((NULL)) / error ((NULL))
error: expected success, but got error: no such command: 'getnonce'
******************************* END_MONGOC_ERROR *******************************
.evergreen/run-tests.sh: line 143:  6430 Aborted                 (core dumped) ./src/libmongoc/test-libmongoc --no-fork $TEST_ARGS -d
```