### PR TITLE
CDRIVER-4543 Use find-python3.sh in integration-tests.sh

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -692,7 +692,7 @@ functions:
       script: |-
         set -o errexit
         if [ ! -d "drivers-evergreen-tools" ]; then
-           git clone git@github.com:mongodb-labs/drivers-evergreen-tools.git
+           git clone --depth 1 git@github.com:mongodb-labs/drivers-evergreen-tools.git
         fi
         cd drivers-evergreen-tools
         export DRIVERS_TOOLS=$(pwd)
@@ -760,7 +760,9 @@ functions:
         set -o errexit
         # Add AWS variables to a file.
         # Clone in one directory above so it does not get uploaded in working directory.
-        git clone --depth=1 https://github.com/mongodb-labs/drivers-evergreen-tools.git ../drivers-evergreen-tools
+        if [ ! -d ../drivers-evergreen-tools ]; then
+            git clone --depth 1 git@github.com:mongodb-labs/drivers-evergreen-tools.git ../drivers-evergreen-tools
+        fi
         cat <<EOF > ../drivers-evergreen-tools/.evergreen/auth_aws/aws_e2e_setup.json
         {
             "iam_auth_ecs_account" : "${iam_auth_ecs_account}",
@@ -801,7 +803,7 @@ functions:
       script: |-
         set -o errexit
         if [ ! -d "drivers-evergreen-tools" ]; then
-            git clone git@github.com:mongodb-labs/drivers-evergreen-tools.git --depth=1
+            git clone --depth 1 git@github.com:mongodb-labs/drivers-evergreen-tools.git
         fi
   run kms servers:
   - command: shell.exec
@@ -24171,7 +24173,9 @@ task_groups:
       shell: bash
       script: |-
         set -o errexit
-        git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git --depth=1 drivers-evergreen-tools
+        if [ ! -d drivers-evergreen-tools ]; then
+            git clone --depth 1 git@github.com:mongodb-labs/drivers-evergreen-tools.git
+        fi
         DRIVERS_TOOLS=$(pwd)/drivers-evergreen-tools
         echo '${testazurekms_publickey}' > /tmp/testazurekms_publickey
         echo '${testazurekms_privatekey}' > /tmp/testazurekms_privatekey
@@ -24211,7 +24215,9 @@ task_groups:
       shell: bash
       script: |-
         set -o errexit
-        git clone --depth=1 https://github.com/mongodb-labs/drivers-evergreen-tools.git
+        if [ ! -d drivers-evergreen-tools ]; then
+            git clone --depth 1 git@github.com:mongodb-labs/drivers-evergreen-tools.git
+        fi
         DRIVERS_TOOLS=$(pwd)/drivers-evergreen-tools
         echo '${testgcpkms_key_file}' > /tmp/testgcpkms_key_file.json
         export GCPKMS_KEYFILE=/tmp/testgcpkms_key_file.json

--- a/.evergreen/integration-tests.sh
+++ b/.evergreen/integration-tests.sh
@@ -162,7 +162,6 @@ wait_for_mongo_orchestration() {
 wait_for_mongo_orchestration 8889
 echo "Waiting for mongo-orchestration to start... done."
 
-curl http://localhost:8889/ -sS --fail
 sleep 5
 pwd
 curl -sS --data @"$ORCHESTRATION_FILE" "$ORCHESTRATION_URL" --fail

--- a/.evergreen/integration-tests.sh
+++ b/.evergreen/integration-tests.sh
@@ -150,7 +150,7 @@ echo "Waiting for mongo-orchestration to start..."
 wait_for_mongo_orchestration() {
    for i in $(seq 300); do
       # Exit code 7: "Failed to connect to host".
-      if curl -s "localhost:$1"; test $? -ne 7; then
+      if curl -s "localhost:$1" 1>|curl_mo.txt; test $? -ne 7; then
          return 0
       else
          sleep 1
@@ -162,9 +162,11 @@ wait_for_mongo_orchestration() {
 wait_for_mongo_orchestration 8889
 echo "Waiting for mongo-orchestration to start... done."
 
+python -m json.tool curl_mo.txt
 sleep 5
 pwd
-curl -sS --data @"$ORCHESTRATION_FILE" "$ORCHESTRATION_URL" --fail
+curl -s --data @"$ORCHESTRATION_FILE" "$ORCHESTRATION_URL" 1>|curl_mo.txt
+python -m json.tool curl_mo.txt
 sleep 15
 
 if [ "$AUTH" = "auth" ]; then

--- a/.evergreen/run-aws-tests.sh
+++ b/.evergreen/run-aws-tests.sh
@@ -9,7 +9,7 @@
 # Optional environment variables:
 #
 # DRIVERS_TOOLS
-#   The path to clone of https://github.com/mongodb-labs/drivers-evergreen-tools.git.
+#   The path to clone of https://github.com/mongodb-labs/drivers-evergreen-tools.
 #   Defaults to $(pwd)../drivers-evergreen-tools
 # CDRIVER_BUILD
 #   The path to the build of mongo-c-driver (e.g. mongo-c-driver/cmake-build).

--- a/.evergreen/run-ocsp-responder.sh
+++ b/.evergreen/run-ocsp-responder.sh
@@ -73,7 +73,7 @@ fi
 if [ -n "$RESPONDER_REQUIRED" ]; then
     echo "Starting mock responder"
     if [ ! -d "../drivers-evergreen-tools" ]; then
-        git clone --depth=1 git@github.com:mongodb-labs/drivers-evergreen-tools.git ../drivers-evergreen-tools
+        git clone --depth 1 git@github.com:mongodb-labs/drivers-evergreen-tools.git ../drivers-evergreen-tools
     fi
 
     pushd ../drivers-evergreen-tools/.evergreen/ocsp

--- a/build/evergreen_config_lib/functions.py
+++ b/build/evergreen_config_lib/functions.py
@@ -500,7 +500,7 @@ all_functions = OD([
     ('build mongohouse', Function(
         shell_mongoc(r'''
         if [ ! -d "drivers-evergreen-tools" ]; then
-           git clone git@github.com:mongodb-labs/drivers-evergreen-tools.git
+           git clone --depth 1 git@github.com:mongodb-labs/drivers-evergreen-tools.git
         fi
         cd drivers-evergreen-tools
         export DRIVERS_TOOLS=$(pwd)
@@ -557,7 +557,9 @@ all_functions = OD([
         shell_mongoc(r'''
         # Add AWS variables to a file.
         # Clone in one directory above so it does not get uploaded in working directory.
-        git clone --depth=1 https://github.com/mongodb-labs/drivers-evergreen-tools.git ../drivers-evergreen-tools
+        if [ ! -d ../drivers-evergreen-tools ]; then
+            git clone --depth 1 git@github.com:mongodb-labs/drivers-evergreen-tools.git ../drivers-evergreen-tools
+        fi
         cat <<EOF > ../drivers-evergreen-tools/.evergreen/auth_aws/aws_e2e_setup.json
         {
             "iam_auth_ecs_account" : "${iam_auth_ecs_account}",
@@ -591,7 +593,7 @@ all_functions = OD([
     ('clone drivers-evergreen-tools', Function(
         shell_exec(r'''
         if [ ! -d "drivers-evergreen-tools" ]; then
-            git clone git@github.com:mongodb-labs/drivers-evergreen-tools.git --depth=1
+            git clone --depth 1 git@github.com:mongodb-labs/drivers-evergreen-tools.git
         fi
         ''', test=False)
     )),

--- a/build/evergreen_config_lib/testazurekms.py
+++ b/build/evergreen_config_lib/testazurekms.py
@@ -99,7 +99,9 @@ def _create_task_group():
     task_group.setup_group_timeout_secs = 1800  # 30 minutes
     task_group.setup_group = [
         shell_exec(r'''
-            git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git --depth=1 drivers-evergreen-tools
+            if [ ! -d drivers-evergreen-tools ]; then
+                git clone --depth 1 git@github.com:mongodb-labs/drivers-evergreen-tools.git
+            fi
             DRIVERS_TOOLS=$(pwd)/drivers-evergreen-tools
             echo '${testazurekms_publickey}' > /tmp/testazurekms_publickey
             echo '${testazurekms_privatekey}' > /tmp/testazurekms_privatekey

--- a/build/evergreen_config_lib/testgcpkms.py
+++ b/build/evergreen_config_lib/testgcpkms.py
@@ -89,7 +89,9 @@ def _create_task_group():
     task_group.setup_group = [
         # Create and set up a GCE instance using driver tools script
         shell_exec(r'''
-            git clone --depth=1 https://github.com/mongodb-labs/drivers-evergreen-tools.git
+            if [ ! -d drivers-evergreen-tools ]; then
+                git clone --depth 1 git@github.com:mongodb-labs/drivers-evergreen-tools.git
+            fi
             DRIVERS_TOOLS=$(pwd)/drivers-evergreen-tools
             echo '${testgcpkms_key_file}' > /tmp/testgcpkms_key_file.json
             export GCPKMS_KEYFILE=/tmp/testgcpkms_key_file.json


### PR DESCRIPTION
This PR resolves CDRIVER-4543. Verified by [this patch](https://spruce.mongodb.com/version/639cded4d6d80a5cc50b8d8e/tasks).

As drive-by fix/improvement, ensures all cloning of the DET repository is consistent in their "already exists" check, use of `--depth 1`, and use of `git@github.com:<owner>/<repo>.git`.