### PR TITLE
CDRIVER-3998 move Windows OpenSSL auth to 2017

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -24686,6 +24686,8 @@ buildvariants:
   - .4.4 .winssl !.nosasl .server
   - test-aws-openssl-regular-4.4
   - test-aws-openssl-regular-latest
+  - .authentication-tests .openssl !.sasl
+  - .authentication-tests .winssl
 - name: windows-2015
   display_name: Windows (VS 2015)
   expansions:
@@ -24701,7 +24703,6 @@ buildvariants:
   - .debug-compile !.sspi .openssl
   - .debug-compile !.sspi .nossl
   - .debug-compile .sspi !.openssl-static
-  - .authentication-tests .openssl !.sasl
   - .authentication-tests .winssl
   - .4.2 .winssl !.nosasl .server
   - .4.0 .winssl !.nosasl .server
@@ -24735,7 +24736,6 @@ buildvariants:
   - .debug-compile !.sspi .openssl !.client-side-encryption
   - .debug-compile !.sspi .nossl
   - .debug-compile .sspi !.client-side-encryption !.openssl-static
-  - .authentication-tests .openssl !.sasl
   - .authentication-tests .winssl
   - .4.2 .winssl !.nosasl .server !.client-side-encryption
   - .4.0 .winssl !.nosasl .server

--- a/build/evergreen_config_lib/variants.py
+++ b/build/evergreen_config_lib/variants.py
@@ -418,7 +418,11 @@ all_variants = [
              '.5.0 .winssl !.nosasl .server',
              '.4.4 .winssl !.nosasl .server',
              'test-aws-openssl-regular-4.4',
-             'test-aws-openssl-regular-latest'
+             'test-aws-openssl-regular-latest',
+             # Authentication tests with OpenSSL on Windows are only run on the vs2017 variant.
+             # Older vs variants fail to verify certificates against Atlas tests.
+             '.authentication-tests .openssl !.sasl',
+             '.authentication-tests .winssl'
              ],
             {'CC': 'Visual Studio 15 2017 Win64'}),
     Variant('windows-2015',
@@ -433,7 +437,6 @@ all_variants = [
              '.debug-compile !.sspi .openssl',
              '.debug-compile !.sspi .nossl',
              '.debug-compile .sspi !.openssl-static',
-             '.authentication-tests .openssl !.sasl',
              '.authentication-tests .winssl',
              '.4.2 .winssl !.nosasl .server',
              '.4.0 .winssl !.nosasl .server',
@@ -464,7 +467,6 @@ all_variants = [
              '.debug-compile !.sspi .openssl !.client-side-encryption',
              '.debug-compile !.sspi .nossl',
              '.debug-compile .sspi !.client-side-encryption !.openssl-static',
-             '.authentication-tests .openssl !.sasl',
              '.authentication-tests .winssl',
              '.4.2 .winssl !.nosasl .server !.client-side-encryption',
              '.4.0 .winssl !.nosasl .server'],


### PR DESCRIPTION
The versions of OpenSSL tested on 2013, 2015, and 2017 are all 1.0.2s. The cause of failure is likely a host configuration issue. It is possibly related to BUILD-10841.

# Summary
- Move the `authentication-tests-openssl-nosasl` to the `windows-2017` variant.

# Background & Motivation

The `authentication-tests-openssl-nosasl` task on the `windows-2015` variant is failing.
Enabling verbose logs shows the failure occurs on [Connecting to Atlas Replica Set](https://parsley.mongodb.com/evergreen/mongo_c_driver_windows_2015_authentication_tests_openssl_nosasl_patch_d1134294420514f4308507ff5b2a5f4764d93c73_639dd762850e61492e0eff6d_22_12_17_14_51_16/0/task?bookmarks=0,212&selectedLine=164):

> Ping failure: No suitable servers found: `serverselectiontimeoutms` timed out: [TLS handshake failed: certificate verify failed (20): unable to get local issuer certificate calling hello on [...]

I think this is the same issue described in https://jira.mongodb.org/browse/BUILD-10841. The resolution was applied to the Windows VS 2017 AMI.

On this [patch build](https://spruce.mongodb.com/version/639de23fd6d80a5cc50c5df1/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) the authentication tests pass on Windows 2017. Windows 2017 and Windows 2013, 2015 and 2017 all use OpenSSL 1.0.2s (see [2013 cmake logs](https://parsley.mongodb.com/evergreen/mongo_c_driver_windows_2013_debug_compile_nosasl_openssl_d1134294420514f4308507ff5b2a5f4764d93c73_22_12_16_16_39_44/0/task?bookmarks=0,16195&selectedLine=113), [2015 cmake logs](https://evergreen.mongodb.com/lobster/evergreen/task/mongo_c_driver_windows_2015_debug_compile_nosasl_openssl_patch_d1134294420514f4308507ff5b2a5f4764d93c73_639dd762850e61492e0eff6d_22_12_17_14_51_16/0/task#bookmarks=0%2C4234&l=1&shareLine=118) and [2017 cmake logs](https://parsley.mongodb.com/evergreen/mongo_c_driver_windows_2017_debug_compile_nosasl_openssl_patch_d1134294420514f4308507ff5b2a5f4764d93c73_639de23fd6d80a5cc50c5df1_22_12_17_15_37_36/0/task?bookmarks=0,4130&selectedLine=119)).

Here is a patch build with the [new tasks run on the Windows 2017 host](https://spruce.mongodb.com/version/639de23fd6d80a5cc50c5df1/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).
