### PR TITLE
CDRIVER-4539 wait for unacknowledged writes to apply in `test_bulk_reply_w0`

### DIFF
--- a/src/libmongoc/tests/test-mongoc-bulk.c
+++ b/src/libmongoc/tests/test-mongoc-bulk.c
@@ -4955,9 +4955,6 @@ test_bulk_write_multiple_errors (void *unused)
    // the first error.
    bson_append_bool (&opts, "ordered", 7, false);
    bulk = mongoc_collection_create_bulk_operation_with_opts (collection, &opts);
-   // Insert three documents. This is sent as one "insert" command to the
-   // server.
-   // configure fail point
    bool ret = mongoc_client_command_simple (
       client,
       "admin",


### PR DESCRIPTION
# Summary

This PR intends to resolve test failures observed in `/BulkOperation/multiple_errors`.

- wait for unacknowledged writes to apply in `test_bulk_reply_w0`
- set `appName` in failpoint for `test_bulk_write_multiple_errors`.

# Background & Motivation

The `/BulkOperation/multiple_errors` test was recently added. It infrequently fails with an error matching the expected `errorReplies`. See CDRIVER-4539 for a sample test output.

`test_bulk_write_multiple_errors` sets a failpoint and expects the `insert` and `delete` commands to fail.

This [patch build with command monitoring enabled](https://spruce.mongodb.com/task/mongo_c_driver_asan_ubuntu_test_asan_latest_replica_set_noauth_nosasl_nossl_patch_218445d89368f5b6b89476b97900f33b071dfd1c_63a223aa2a60ed4a7b7f4db0_22_12_20_21_05_47/logs?execution=0) reproduced the test failure. It shows that the `delete` unexpectedly succeeds.

```
command configureFailPoint started [...]
command configureFailPoint succeeded [...]
command insert started [...]
command insert failed [...]
command delete started [...]
command delete succeeded [...] <-- UNEXPECTED. EXPECTED failed.
```

Inspecting [the mongod logs](https://spruce.mongodb.com/task/mongo_c_driver_asan_ubuntu_test_asan_latest_replica_set_noauth_nosasl_nossl_patch_218445d89368f5b6b89476b97900f33b071dfd1c_63a223aa2a60ed4a7b7f4db0_22_12_20_21_05_47/files?execution=0) show that the `delete` command from the prior `test_bulk_reply_w0` is triggering the failpoint:

```
{"t":{"$date":"2022-12-20T21:25:44.278+00:00"},"s":"D1", "c":"COMMAND",  "id":21962,   "ctx":"conn394","msg":"Assertion while executing command","attr":{"command":"insert","db":"test","commandArgs":{"insert":"test_bulk_write_multiple_errors_1574510557_25208","ordered":false,"$db":"test","$clusterTime":{"clusterTime":{"$timestamp":{"t":1671571544,"i":6}},"signature":{"hash":{"$binary":{"base64":"AAAAAAAAAAAAAAAAAAAAAAAAAAA=","subType":"0"}},"keyId":0}}},"error":"UnknownError: Failing command via 'failCommand' failpoint"}}
[...]
{"t":{"$date":"2022-12-20T21:25:44.280+00:00"},"s":"D1", "c":"COMMAND",  "id":21962,   "ctx":"conn388","msg":"Assertion while executing command","attr":{"command":"delete","db":"test","commandArgs":{"delete":"test_insert_w0_1574490982_25208","ordered":true,"$db":"test","$clusterTime":{"clusterTime":{"$timestamp":{"t":1671571544,"i":5}},"signature":{"hash":{"$binary":{"base64":"AAAAAAAAAAAAAAAAAAAAAAAAAAA=","subType":"0"}},"keyId":0}},"writeConcern":{"w":0}},"error":"UnknownError: Failing command via 'failCommand' failpoint"}}
```
