### PR TITLE
CDRIVER-4550 Do not use aligned_alloc() on Windows

### DIFF
--- a/src/libbson/src/bson/bson-memory.c
+++ b/src/libbson/src/bson/bson-memory.c
@@ -33,7 +33,7 @@ BSON_STATIC_ASSERT2 (bson_mem_vtable_t,
 // For compatibility with C standards prior to C11.
 static void *
 _aligned_alloc_impl (size_t alignment, size_t num_bytes)
-#if __STDC_VERSION__ >= 201112L
+#if __STDC_VERSION__ >= 201112L && !defined(_WIN32)
 {
    return aligned_alloc (alignment, num_bytes);
 }


### PR DESCRIPTION
@kalibera found that `aligned_alloc` is not in stdlib.h and it is not supported in Windows, despite that it is in C11. See the footnote in: https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance:

> The Universal CRT doesn't implement C11 aligned_alloc, but does provide _aligned_malloc and _aligned_free. Because the Windows operating system doesn't support aligned allocations, this function is unlikely to be implemented."

Actually `aligned_alloc()` is also missing on MacOS 10.13 (which we also need) but I will patch that on my end because you are no longer offically supporting MacOS < 10.14.

Downstream issues here: https://github.com/jeroen/mongolite/issues/247 and https://github.com/jeroen/mongolite/issues/244