### PR TITLE
Remove debug-compile-coverage from Apple LLVM variant

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -24629,7 +24629,6 @@ buildvariants:
   run_on: macos-1014
   tasks:
   - .compression !.snappy !.zstd
-  - debug-compile-coverage
   - release-compile
   - debug-compile-nosasl-nossl
   - debug-compile-rdtscp

--- a/build/evergreen_config_lib/variants.py
+++ b/build/evergreen_config_lib/variants.py
@@ -362,7 +362,6 @@ all_variants = [
             'macos-1014',
             ['.compression !.snappy !.zstd',
              # Remove !.zstd in CDRIVER-3483.
-             'debug-compile-coverage',
              'release-compile',
              'debug-compile-nosasl-nossl',
              'debug-compile-rdtscp',


### PR DESCRIPTION
GCOV is sometimes [unusually slow](https://spruce.mongodb.com/task/mongo_c_driver_darwin_debug_compile_coverage_fa7d499b8ca53269b008cf7c19747164f98bede2_23_01_04_01_58_39/logs?execution=0) on macos-1014, regularly timing out on Evergreen due to taking over 1 hour to parse `.gcda` files when it should take [under 4 minutes](https://spruce.mongodb.com/task/mongo_c_driver_darwin_debug_compile_coverage_9e37e3e846395eaa3fa814f59bcf813f15692a4d_22_12_20_17_44_54/logs?execution=0). Some `.gcda` files such as `entity-map.c.gcda` [seem to be culprit](https://parsley.mongodb.com/evergreen/mongo_c_driver_darwin_debug_compile_coverage_fa7d499b8ca53269b008cf7c19747164f98bede2_23_01_04_01_58_39/0/task?bookmarks=0,11899&selectedLine=11759), but it is unclear why this behavior seems to only occur on `macos-1014` when [other coverage tasks](https://spruce.mongodb.com/version/mongo_c_driver_fa7d499b8ca53269b008cf7c19747164f98bede2/task-duration?duration=DESC&page=0&taskName=coverage) take no longer than 10 minutes.

Suggest removing the task rather than diagnosing the issue, as actual difference in code coverage of interest does not seem to be significant across Linux and MacOS (code coverage of different SSL library compatibility backends seems far more significant).