### PR TITLE
CDRIVER-4394 Fix libmongocrypt branch in compile-test-gcpkms.sh

### DIFF
--- a/.evergreen/compile-test-azurekms.sh
+++ b/.evergreen/compile-test-azurekms.sh
@@ -9,7 +9,7 @@ INSTALL_DIR=$ROOT/install
 . .evergreen/find-cmake.sh
 echo "Installing libmongocrypt ... begin"
 # TODO(CDRIVER-4394) update to use libmongocrypt 1.7.0 once there is a stable 1.7.0 release.
-git clone https://github.com/mongodb/libmongocrypt --branch 1.7.0-alpha1
+git clone --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.7.0-alpha1
 $CMAKE -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
     -DBUILD_TESTING=OFF \
     "-H$ROOT/libmongocrypt" \

--- a/.evergreen/compile-test-gcpkms.sh
+++ b/.evergreen/compile-test-gcpkms.sh
@@ -8,7 +8,8 @@ ROOT=$(pwd)
 INSTALL_DIR=$ROOT/install
 . .evergreen/find-cmake.sh
 echo "Installing libmongocrypt ... begin"
-git clone --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.6.0
+# TODO(CDRIVER-4394) update to use libmongocrypt 1.7.0 once there is a stable 1.7.0 release.
+git clone --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.7.0-alpha1
 $CMAKE -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
     -DBUILD_TESTING=OFF \
     "-H$ROOT/libmongocrypt" \

--- a/.evergreen/compile-unix.sh
+++ b/.evergreen/compile-unix.sh
@@ -230,7 +230,7 @@ pkg-config --modversion libssl || true
 if [ "$COMPILE_LIBMONGOCRYPT" = "ON" ]; then
    # Build libmongocrypt, using the previously fetched installed source.
    # TODO(CDRIVER-4394) update to use libmongocrypt 1.7.0 once there is a stable 1.7.0 release.
-   git clone https://github.com/mongodb/libmongocrypt --branch 1.7.0-alpha1
+   git clone --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.7.0-alpha1
 
    mkdir libmongocrypt/cmake-build
    cd libmongocrypt/cmake-build

--- a/.evergreen/compile-windows.sh
+++ b/.evergreen/compile-windows.sh
@@ -121,7 +121,7 @@ fi
 if [ "$COMPILE_LIBMONGOCRYPT" = "ON" ]; then
    # Build libmongocrypt, using the previously fetched installed source.
    # TODO(CDRIVER-4394) update to use libmongocrypt 1.7.0 once there is a stable 1.7.0 release.
-   git clone https://github.com/mongodb/libmongocrypt --branch 1.7.0-alpha1
+   git clone --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.7.0-alpha1
    mkdir libmongocrypt/cmake-build
    cd libmongocrypt/cmake-build
    "$CMAKE" -G "$CC" "-DCMAKE_PREFIX_PATH=${INSTALL_DIR}/lib/cmake" -DENABLE_SHARED_BSON=ON -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" ../


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1152. The git clone command for libmongocrypt in `compile-test-gcpkms.sh` appears to have been missed.

As a drive-by improvement, ensured all libmongocrypt git clone commands use `--depth 1` for consistency.