### PR TITLE
Assert bounds of tmp->tm_mon to address scan-build warnings

### DIFF
--- a/src/libbson/src/bson/bson-timegm.c
+++ b/src/libbson/src/bson/bson-timegm.c
@@ -440,9 +440,11 @@ timesub (const int64_t *const timep,
    */
    tmp->tm_sec = (int64_t) (rem % SECSPERMIN) + hit;
    ip = mon_lengths[isleap (y)];
-   for (tmp->tm_mon = 0; tmp->tm_mon < MONSPERYEAR && idays >= ip[tmp->tm_mon];
-        ++(tmp->tm_mon))
-      idays -= ip[tmp->tm_mon];
+   tmp->tm_mon = 0;
+   while (idays >= ip[tmp->tm_mon]) {
+      BSON_ASSERT (tmp->tm_mon < MONSPERYEAR);
+      idays -= ip[tmp->tm_mon++];
+   }
    tmp->tm_mday = (int64_t) (idays + 1);
    tmp->tm_isdst = 0;
 #ifdef TM_GMTOFF

--- a/src/libbson/src/bson/bson-timegm.c
+++ b/src/libbson/src/bson/bson-timegm.c
@@ -34,7 +34,7 @@
 #if !defined _Noreturn && \
    (!defined(__STDC_VERSION__) || __STDC_VERSION__ < 201112)
 #if 2 < __GNUC__ + (8 <= __GNUC_MINOR__)
-#define _Noreturn __attribute__((__noreturn__))
+#define _Noreturn __attribute__ ((__noreturn__))
 #else
 #define _Noreturn
 #endif
@@ -181,7 +181,7 @@ struct ttinfo {            /* time type information */
 };
 
 struct lsinfo {          /* leap second information */
-   int64_t ls_trans;      /* transition time */
+   int64_t ls_trans;     /* transition time */
    int_fast64_t ls_corr; /* correction to apply */
 };
 
@@ -241,16 +241,22 @@ static int64_t
 normalize_overflow (int64_t *tensptr, int64_t *unitsptr, int64_t base);
 static int64_t
 time1 (struct bson_tm *tmp,
-       struct bson_tm *(*funcp) (const int64_t *, int_fast32_t, struct bson_tm *),
+       struct bson_tm *(*funcp) (const int64_t *,
+                                 int_fast32_t,
+                                 struct bson_tm *),
        int_fast32_t offset);
 static int64_t
 time2 (struct bson_tm *tmp,
-       struct bson_tm *(*funcp) (const int64_t *, int_fast32_t, struct bson_tm *),
+       struct bson_tm *(*funcp) (const int64_t *,
+                                 int_fast32_t,
+                                 struct bson_tm *),
        int_fast32_t offset,
        int64_t *okayp);
 static int64_t
 time2sub (struct bson_tm *tmp,
-          struct bson_tm *(*funcp) (const int64_t *, int_fast32_t, struct bson_tm *),
+          struct bson_tm *(*funcp) (const int64_t *,
+                                    int_fast32_t,
+                                    struct bson_tm *),
           int_fast32_t offset,
           int64_t *okayp,
           int64_t do_norm_secs);
@@ -490,7 +496,9 @@ increment_overflow32 (int_fast32_t *const lp, int64_t const m)
 }
 
 static int64_t
-normalize_overflow (int64_t *const tensptr, int64_t *const unitsptr, const int64_t base)
+normalize_overflow (int64_t *const tensptr,
+                    int64_t *const unitsptr,
+                    const int64_t base)
 {
    register int64_t tensdelta;
 
@@ -531,7 +539,9 @@ tmcomp (register const struct bson_tm *const atmp,
 
 static int64_t
 time2sub (struct bson_tm *const tmp,
-          struct bson_tm *(*const funcp) (const int64_t *, int_fast32_t, struct bson_tm *),
+          struct bson_tm *(*const funcp) (const int64_t *,
+                                          int_fast32_t,
+                                          struct bson_tm *),
           const int_fast32_t offset,
           int64_t *const okayp,
           const int64_t do_norm_secs)
@@ -700,7 +710,9 @@ label:
 
 static int64_t
 time2 (struct bson_tm *const tmp,
-       struct bson_tm *(*const funcp) (const int64_t *, int_fast32_t, struct bson_tm *),
+       struct bson_tm *(*const funcp) (const int64_t *,
+                                       int_fast32_t,
+                                       struct bson_tm *),
        const int_fast32_t offset,
        int64_t *const okayp)
 {
@@ -717,7 +729,9 @@ time2 (struct bson_tm *const tmp,
 
 static int64_t
 time1 (struct bson_tm *const tmp,
-       struct bson_tm *(*const funcp) (const int64_t *, int_fast32_t, struct bson_tm *),
+       struct bson_tm *(*const funcp) (const int64_t *,
+                                       int_fast32_t,
+                                       struct bson_tm *),
        const int_fast32_t offset)
 {
    register int64_t t;
@@ -792,4 +806,3 @@ _bson_timegm (struct bson_tm *const tmp)
       tmp->tm_isdst = 0;
    return time1 (tmp, gmtsub, 0L);
 }
-

--- a/src/libbson/src/bson/bson-timegm.c
+++ b/src/libbson/src/bson/bson-timegm.c
@@ -440,7 +440,8 @@ timesub (const int64_t *const timep,
    */
    tmp->tm_sec = (int64_t) (rem % SECSPERMIN) + hit;
    ip = mon_lengths[isleap (y)];
-   for (tmp->tm_mon = 0; idays >= ip[tmp->tm_mon]; ++(tmp->tm_mon))
+   for (tmp->tm_mon = 0; tmp->tm_mon < MONSPERYEAR && idays >= ip[tmp->tm_mon];
+        ++(tmp->tm_mon))
       idays -= ip[tmp->tm_mon];
    tmp->tm_mday = (int64_t) (idays + 1);
    tmp->tm_isdst = 0;

--- a/src/libbson/src/bson/bson-timegm.c
+++ b/src/libbson/src/bson/bson-timegm.c
@@ -442,8 +442,8 @@ timesub (const int64_t *const timep,
    ip = mon_lengths[isleap (y)];
    tmp->tm_mon = 0;
    while (idays >= ip[tmp->tm_mon]) {
-      BSON_ASSERT (tmp->tm_mon < MONSPERYEAR);
       idays -= ip[tmp->tm_mon++];
+      BSON_ASSERT (tmp->tm_mon < MONSPERYEAR);
    }
    tmp->tm_mday = (int64_t) (idays + 1);
    tmp->tm_isdst = 0;


### PR DESCRIPTION
Observed a [surprise task failure](https://parsley.mongodb.com/evergreen/mongo_c_driver_darwin_debug_compile_scan_build_patch_21275453cd46253b9d252fdfc319c1880b3dca3a_63c04dcfd6d80a4b2c695915_23_01_12_18_13_36/0/task?bookmarks=0,994&selectedLine=331) during a patch build. I do not expect `tmp->tm_mon < MONSPERYEAR` to ever be violated given the context, but to satisfy scan-build, I elected to add the condition to the loop anyways. Verified by [this patch](https://spruce.mongodb.com/version/63c051db3066157a49372e66/tasks).