### PR TITLE
CDRIVER-4538 Automatically retry on 502 Bad Gateway in /http tests

### DIFF
--- a/src/libmongoc/tests/test-mongoc-http.c
+++ b/src/libmongoc/tests/test-mongoc-http.c
@@ -39,6 +39,16 @@ test_mongoc_http_get (void *unused)
    req.port = 80;
    r = _mongoc_http_send (&req, 10000, false, NULL, &res, &error);
    ASSERT_OR_PRINT (r, error);
+
+   if (res.status == 502) {
+      // This test occasionally fails due to 502 Bad Gateway.
+      // Automatically attempt a retry and hope the issue resolved itself.
+      // ¯\_(ツ)_/¯
+      _mongoc_http_response_cleanup (&res);
+      r = _mongoc_http_send (&req, 10000, false, NULL, &res, &error);
+      ASSERT_OR_PRINT (r, error);
+   }
+
    ASSERT_WITH_MSG (res.status == 200,
                     "unexpected status code %d\n"
                     "RESPONSE BODY BEGIN\n"
@@ -70,6 +80,16 @@ test_mongoc_http_post (void *unused)
    req.port = 80;
    r = _mongoc_http_send (&req, 10000, false, NULL, &res, &error);
    ASSERT_OR_PRINT (r, error);
+
+   if (res.status == 502) {
+      // This test occasionally fails due to 502 Bad Gateway.
+      // Automatically attempt a retry and hope the issue resolved itself.
+      // ¯\_(ツ)_/¯
+      _mongoc_http_response_cleanup (&res);
+      r = _mongoc_http_send (&req, 10000, false, NULL, &res, &error);
+      ASSERT_OR_PRINT (r, error);
+   }
+
    ASSERT_WITH_MSG (res.status == 200,
                     "unexpected status code %d\n"
                     "RESPONSE BODY BEGIN\n"


### PR DESCRIPTION
This PR resolves(?) CDRIVER-4538 and is a followup to https://github.com/mongodb/mongo-c-driver/pull/1161. Verified by [this patch](https://spruce.mongodb.com/version/63c04ebe1e2d175671d92967/tasks).

Spurious test failure due to `502 Bad Gateway` when running `/http` tests is [still occurring](https://parsley.mongodb.com/evergreen/mongo_c_driver_darwin_test_3.6_server_auth_sasl_darwinssl_21275453cd46253b9d252fdfc319c1880b3dca3a_23_01_10_21_07_05/0/task?bookmarks=0,7176&selectedLine=7122). Manually restarting the failed task often resolves the issue, so this PR adds an automatic retry attempt to the test instead.