### PR TITLE
CDRIVER-4515 fix `test_bypass_mongocryptd_shared_library`

### DIFF
--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -6627,12 +6627,13 @@ test_bypass_mongocryptd_shared_library (void *unused)
 
    // wait for port and ip to be set on the other thread
    bson_mutex_lock (&args->mutex);
-   while (!args->port || 0 == strlen (args->ip)) {
+   while (!args->port) {
       int cond_ret = mongoc_cond_timedwait (&args->cond, &args->mutex, 5000);
       /* ret non-zero indicates an error (a timeout) */
       BSON_ASSERT (!cond_ret);
    }
    bson_mutex_unlock (&args->mutex);
+   BSON_ASSERT (strlen (args->ip) > 0);
 
    // configure extra options
    bson_t *extra = tmp_bson ("{'mongocryptdURI': 'mongodb://%s:%d', "

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -6578,7 +6578,7 @@ static BSON_THREAD_FUN (listen_socket, arg)
    r = mongoc_socket_listen (socket, 100);
    BSON_ASSERT (r == 0);
    _mongoc_usleep (1000); // wait to see if received connection
-   mongoc_socket_t *ret = mongoc_socket_accept (socket, 100);
+   mongoc_socket_t *ret = mongoc_socket_accept (socket, bson_get_monotonic_time() + 100);
    if (ret) {
       // not null received a connection and test should fail
       args->failed = true;

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -6628,9 +6628,9 @@ test_bypass_mongocryptd_shared_library (void *unused)
    // wait for port and ip to be set on the other thread
    bson_mutex_lock (&args->mutex);
    while (!args->port || 0 == strlen (args->ip)) {
-      int ret = mongoc_cond_timedwait (&args->cond, &args->mutex, 5000);
+      int cond_ret = mongoc_cond_timedwait (&args->cond, &args->mutex, 5000);
       /* ret non-zero indicates an error (a timeout) */
-      BSON_ASSERT (!ret);
+      BSON_ASSERT (!cond_ret);
    }
    bson_mutex_unlock (&args->mutex);
 
@@ -6661,9 +6661,9 @@ test_bypass_mongocryptd_shared_library (void *unused)
    // Wait for listener thread to complete.
    bson_mutex_lock (&args->mutex);
    while (!args->complete) {
-      ret = mongoc_cond_timedwait (&args->cond, &args->mutex, 5000);
+      int cond_ret = mongoc_cond_timedwait (&args->cond, &args->mutex, 5000);
       /* ret non-zero indicates an error (a timeout) */
-      BSON_ASSERT (!ret);
+      BSON_ASSERT (!cond_ret);
    }
    bson_mutex_unlock (&args->mutex);
    // failed should be false if the signal did not receive a connection


### PR DESCRIPTION
# Summary

- Fix condition variable handling in `test_bypass_mongocryptd_shared_library`.
- Fix expire_at time in `mongoc_socket_accept`.

# Background & Motivation

Fixes a possible race. If the listener thread calls `mongoc_cond_signal` before the test thread calls `mongoc_cond_timedwait`, the call to `mongoc_cond_timedwait` may time out.

The `expire_at` argument in `mongoc_socket_accept` is [documented as an absolute time from `bson_get_monotonic_time`](https://github.com/mongodb/mongo-c-driver/blob/9e18dd1b08591242a4da33be1f55f3a33c629d07/src/libmongoc/src/mongoc/mongoc-socket.c#L129-L132).

zseries fix was verified with this [patch build](https://spruce.mongodb.com/version/63c862c72fbabe4a31f1c4a5/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).
