### PR TITLE
CDRIVER-4531 sync insertOne-noWritesPerformedError

### DIFF
--- a/src/libmongoc/tests/json/retryable_writes/unified/insertOne-noWritesPerformedError.json
+++ b/src/libmongoc/tests/json/retryable_writes/unified/insertOne-noWritesPerformedError.json
@@ -1,0 +1,90 @@
+{
+  "description": "retryable-writes insertOne noWritesPerformedErrors",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "6.0",
+      "topologies": [
+        "replicaset"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandFailedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "retryable-writes-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "no-writes-performed-collection"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "InsertOne fails after NoWritesPerformed error",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 64,
+                "errorLabels": [
+                  "NoWritesPerformed",
+                  "RetryableWriteError"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          },
+          "expectError": {
+            "errorCode": 64,
+            "errorLabelsContain": [
+              "NoWritesPerformed",
+              "RetryableWriteError"
+            ]
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "no-writes-performed-collection",
+          "databaseName": "retryable-writes-tests",
+          "documents": []
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

- Sync `insertOne-noWritesPerformedError` test from https://github.com/mongodb/specifications/commit/2051f3522390dd342f5bdd4703145eeb38cfd36f

# Background & Motivation

DRIVERS-2501 fixed [a bug](https://github.com/mongodb/specifications/commit/2051f3522390dd342f5bdd4703145eeb38cfd36f#diff-01c94ffec48124f66d321265e57d6c892b1355813cf2bce099d0345ff222eabeR482) in the specification pseudo-code for retryable writes. As written, the pseudo-code resulted in reporting a `null` error if both write attempts failed with an error containing the `NoWritesPerformed` label. The intended behavior is to report the first error if both errors contain the `NoWritesPerformed` label.

The intended behavior was implemented in CDRIVER-4449 and is validated by the `insertOne-noWritesPerformedError` test.
