### PR TITLE
fix unused function warning

### DIFF
--- a/src/libmongoc/tests/test-mongoc-stream-tls.c
+++ b/src/libmongoc/tests/test-mongoc-stream-tls.c
@@ -276,7 +276,7 @@ test_mongoc_tls_expired (void)
    ASSERT_CMPINT (sr.result, ==, SSL_TEST_SUCCESS);
 }
 
-
+#if !defined(MONGOC_ENABLE_SSL_SECURE_TRANSPORT)
 static void
 test_mongoc_tls_common_name (void)
 {
@@ -297,6 +297,7 @@ test_mongoc_tls_common_name (void)
    ASSERT_CMPINT (cr.result, ==, SSL_TEST_SUCCESS);
    ASSERT_CMPINT (sr.result, ==, SSL_TEST_SUCCESS);
 }
+#endif // MONGOC_ENABLE_SSL_SECURE_TRANSPORT
 
 
 static void


### PR DESCRIPTION
# Summary

- Fix an unused function warning when building on macOS

# Background & Motivation

Resolves the following warning when building on macOS with secure transport:

```
/Users/kevin.albertson/review/mongo-c-driver-1152/src/libmongoc/tests/test-mongoc-stream-tls.c:281:1: warning: unused function 'test_mongoc_tls_common_name' [-Wunused-function]
    test_mongoc_tls_common_name (void)
    ^
    1 warning generated.
```

The caller of `test_mongoc_tls_common_name` function [is not defined](https://github.com/mongodb/mongo-c-driver/blob/9e18dd1b08591242a4da33be1f55f3a33c629d07/src/libmongoc/tests/test-mongoc-stream-tls.c#L422-L425) with secure transport.