### PR TITLE
Enable tests which were previously skipped

### DIFF
--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -54,6 +54,7 @@ if [ "$DNS" != "nodns" ]; then
       export MONGOC_TEST_DNS_LOADBALANCED=on
    else
       export MONGOC_TEST_DNS=on
+      export MONGOC_TEST_DNS_SRV_POLLING=on
    fi
 fi
 


### PR DESCRIPTION
CDRIVER-4561

Setting MONGOC_TEST_DNS_SRV_POLLING=on enables SRV polling tests to run which were previously skipped.