### PR TITLE
Address -Wundef of OPENSSL_VERSION_NUMBER in mongoc-rand-openssl.c

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-rand-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-rand-openssl.c
@@ -23,6 +23,7 @@
 
 #include "mongoc.h"
 
+#include <openssl/opensslv.h>
 #include <openssl/rand.h>
 
 int


### PR DESCRIPTION
Observed in [current patches](https://parsley.mongodb.com/evergreen/mongo_c_driver_openssl_build_and_run_authentication_tests_openssl_1.0.1_fips_ce46f36ae21b21dc349e853109da2e4c36832d1d_23_01_26_15_14_56/0/task?bookmarks=0,1183&shareLine=521) compiling against OpenSSL:

```
src/libmongoc/src/mongoc/mongoc-rand-openssl.c:31:5: warning: "OPENSSL_VERSION_NUMBER" is not defined, evaluates to 0 [-Wundef]
    31 | #if OPENSSL_VERSION_NUMBER < 0x10101000L
       |     ^~~~~~~~~~~~~~~~~~~~~~
```

Ensures `<openssl/opensslv.h>` which defines `OPENSSL_VERSION_NUMBER` is included without depending on transitive inclusion.