### PR TITLE
Apply sqlalchemy<2.0.0 patch to Windows Python workaround

### DIFF
--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -716,7 +716,7 @@ functions:
             . ../venv-utils.sh
             venvcreate "C:/python/Python39/python.exe" kmstlsvenv || # windows-2017
             venvcreate "C:/python/Python38/python.exe" kmstlsvenv    # windows-2015
-            python -m pip install --upgrade boto3~=1.19 pykmip~=0.10.0
+            python -m pip install --upgrade boto3~=1.19 pykmip~=0.10.0 "sqlalchemy<2.0.0"
             deactivate
         else
             . ./activate-kmstlsvenv.sh

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/functions.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/functions.py
@@ -505,7 +505,7 @@ all_functions = OD([
             . ../venv-utils.sh
             venvcreate "C:/python/Python39/python.exe" kmstlsvenv || # windows-2017
             venvcreate "C:/python/Python38/python.exe" kmstlsvenv    # windows-2015
-            python -m pip install --upgrade boto3~=1.19 pykmip~=0.10.0
+            python -m pip install --upgrade boto3~=1.19 pykmip~=0.10.0 "sqlalchemy<2.0.0"
             deactivate
         else
             . ./activate-kmstlsvenv.sh

--- a/.evergreen/scripts/run-tests.sh
+++ b/.evergreen/scripts/run-tests.sh
@@ -168,7 +168,7 @@ if [[ "${CLIENT_SIDE_ENCRYPTION}" == "on" ]]; then
     for _ in $(seq 300); do
       # Exit code 7: "Failed to connect to host".
       if
-        curl -s "localhost:${1:?}"
+        curl -s --max-time 1 "localhost:${1:?}"
         test ${?} -ne 7
       then
         return 0


### PR DESCRIPTION
Mirrors the workaround applied in https://github.com/mongodb-labs/drivers-evergreen-tools/commit/df2c1e91f34efa9c05d47c93ae3a410e36c6faae to the package install command used in the C Driver's Python version workaround for Windows to address current failures on Windows distros on Evergreen.

As a drive-by fix, applies `--max-time` to the `curl` command waiting for mock KMS servers to startup as this issue exposed [unexpected timeout on failure](https://spruce.mongodb.com/task/mongo_c_driver_windows_2015_test_4.2_server_auth_sasl_winssl_cse_79400d98d4eb8ca2ea94cc90ea8cc366bdea9199_23_01_27_20_57_36/logs?execution=0) for certain Windows distros.