### PR TITLE
CDRIVER-4565 Use clock_gettime_nsec_np instead of mach_absolute_time

### DIFF
--- a/src/libbson/src/bson/bson-clock.c
+++ b/src/libbson/src/bson/bson-clock.c
@@ -126,18 +126,8 @@ bson_get_monotonic_time (void)
    clock_gettime (CLOCK_MONOTONIC, &ts);
    return (((int64_t) ts.tv_sec * 1000000) + (ts.tv_nsec / 1000));
 #elif defined(__APPLE__)
-   static mach_timebase_info_data_t info = {0};
-   static double ratio = 0.0;
-
-   if (!info.denom) {
-      /* the value from mach_absolute_time () * info.numer / info.denom
-       * is in nano seconds. So we have to divid by 1000.0 to get micro
-       * seconds*/
-      mach_timebase_info (&info);
-      ratio = (double) info.numer / (double) info.denom / 1000.0;
-   }
-
-   return mach_absolute_time () * ratio;
+   const uint64_t nsec = clock_gettime_nsec_np (CLOCK_UPTIME_RAW);
+   return (int64_t) (nsec / 1000u);
 #elif defined(_WIN32)
    /* Despite it's name, this is in milliseconds! */
    int64_t ticks = GetTickCount64 ();


### PR DESCRIPTION
Resolves(?) CDRIVER-4565. Verified by [this patch](https://spruce.mongodb.com/version/63d803720ae60614180f6406/tasks).

Per [Apple documentation](https://developer.apple.com/documentation/kernel/1462446-mach_absolute_time) for `mach_absolute_time`:

> Prefer to use the equivalent `clock_gettime_nsec_np(CLOCK_UPTIME_RAW)` in nanoseconds.

Simplifies the implementation of `bson_get_monotonic_time` on MacOS and hopefully addresses the occasional `t2 >= t1` assertion violation observed on MacOS by delegating the required ~intermediate floating-point arithmetic~ unit conversion to the implementation of `clock_gettime_nsec_np(CLOCK_UPTIME_RAW)`.

~To fully avoid the intermediate floating-point arithmetic,~ We may want to consider using `CLOCK_MONOTONIC_RAW` instead of `CLOCK_UPTIME_RAW`. Per [MAN pages](https://www.unix.com/man-page/mojave/3/CLOCK_GETTIME/):

> CLOCK_MONOTONIC_RAW: clock that increments monotonically, tracking the time since an arbitrary point like CLOCK_MONOTONIC.  However, this clock is unaffected by frequency or time adjustments.  It should not be compared to other system time sources.

> CLOCK_UPTIME_RAW: clock that increments monotonically, in the same manner as CLOCK_MONOTONIC_RAW, but that does not increment while the system is asleep.  The returned value is identical to the result of mach_absolute_time() after the appropriate mach_timebase conversion is applied.

Using `CLOCK_MONOTONIC_RAW` would be equivalent to using [mach_continuous_time](https://developer.apple.com/documentation/kernel/1646199-mach_continuous_time) instead of `mach_absolute_time`. It is unclear to me why `mach_absolute_time` is currently being used instead of `mach_continuous_time`.