### PR TITLE
CDRIVER-4428 do not check encryptedFieldsMap in CreateEncryptedCollection

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
@@ -2965,6 +2965,7 @@ mongoc_client_encryption_create_encrypted_collection (
           mongoc_database_get_name (database),
           name,
           in_options,
+          false /* checkEncryptedFieldsMap */,
           &in_encryptedFields,
           error)) {
       // Error finding the encryptedFields

--- a/src/libmongoc/src/mongoc/mongoc-collection.c
+++ b/src/libmongoc/src/mongoc/mongoc-collection.c
@@ -1158,6 +1158,7 @@ mongoc_collection_drop_with_opts (mongoc_collection_t *collection,
           collection->db,
           mongoc_collection_get_name (collection),
           opts,
+          true /* checkEncryptedFieldsMap */,
           &encryptedFields,
           error)) {
       goto done;

--- a/src/libmongoc/src/mongoc/mongoc-database-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-database-private.h
@@ -80,6 +80,8 @@ _mongoc_get_encryptedFields_from_server (mongoc_client_t *client,
  * @param collName The name of the collection
  * @param opts (Optional) The collection options, which may contain the
  * fields
+ * @param checkEncryptedFieldsMap If false, the encryptedFieldsMap will not be
+ * checked.
  * @param[out] encryptedFields An output where a view of the encryptedFields
  * will be written
  * @param[out] error An error output
@@ -94,6 +96,7 @@ _mongoc_get_collection_encryptedFields (mongoc_client_t *client,
                                         const char *dbName,
                                         const char *collName,
                                         const bson_t *opts,
+                                        bool checkEncryptedFieldsMap,
                                         bson_t *encryptedFields,
                                         bson_error_t *error);
 

--- a/src/libmongoc/src/mongoc/mongoc-database.c
+++ b/src/libmongoc/src/mongoc/mongoc-database.c
@@ -1253,6 +1253,7 @@ _mongoc_get_collection_encryptedFields (mongoc_client_t *client,
                                         const char *dbName,
                                         const char *collName,
                                         const bson_t *opts,
+                                        bool checkEncryptedFieldsMap,
                                         bson_t *encryptedFields,
                                         bson_error_t *error)
 {
@@ -1275,7 +1276,7 @@ _mongoc_get_collection_encryptedFields (mongoc_client_t *client,
                    then (error ("'encryptedFields' should be a document"))),
                // Update encryptedFields to be a reference to the subdocument:
                storeDocRef (*encryptedFields),
-               do(found = true)));
+               do (found = true)));
       if (bsonParseError) {
          // Error while parsing
          bson_set_error (error,
@@ -1293,7 +1294,8 @@ _mongoc_get_collection_encryptedFields (mongoc_client_t *client,
    }
 
    // Look in the encryptedFieldsMap based on this collection name
-   if (!_mongoc_get_encryptedFields_from_map (
+   if (checkEncryptedFieldsMap &&
+       !_mongoc_get_encryptedFields_from_map (
           client, dbName, collName, encryptedFields, error)) {
       // Error during lookup.
       return false;
@@ -1321,6 +1323,7 @@ mongoc_database_create_collection (mongoc_database_t *database,
           mongoc_database_get_name (database),
           name,
           opts,
+          true /* checkEncryptedFieldsMap */,
           &encryptedFields,
           error)) {
       // Error during fields lookup

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -6393,11 +6393,6 @@ test_create_encrypted_collection_no_encryptedFields (void *unused)
       mongoc_auto_encryption_opts_destroy (aeOpts);
       mongoc_client_destroy (client);
    }
-
-
-   // This is not a required specification test. But also check that
-   // encryptedFieldsMap is not checked. Create a client with
-   // encryptedFieldsMap.
 }
 
 static void
@@ -6536,7 +6531,7 @@ test_create_encrypted_collection_insert (void *unused)
             visitEach (require (type (doc)),
                        parse (require (key ("keyId"),
                                        require (type (binary)),
-                                       do({
+                                       do ({
                                           bson_value_copy (
                                              bson_iter_value (
                                                 (bson_iter_t *) &bsonVisitIter),
@@ -6628,7 +6623,8 @@ static BSON_THREAD_FUN (listen_socket, arg)
    r = mongoc_socket_listen (socket, 100);
    BSON_ASSERT (r == 0);
    _mongoc_usleep (1000); // wait to see if received connection
-   mongoc_socket_t *ret = mongoc_socket_accept (socket, bson_get_monotonic_time() + 100);
+   mongoc_socket_t *ret =
+      mongoc_socket_accept (socket, bson_get_monotonic_time () + 100);
    if (ret) {
       // not null received a connection and test should fail
       args->failed = true;


### PR DESCRIPTION
# Summary

- do not check encryptedFieldsMap in CreateEncryptedCollection

# Background & Motivation

Implements https://github.com/mongodb/specifications/pull/1376