### PR TITLE
CDRIVER-3620 Unskip `-cse` tests on Windows

### DIFF
--- a/.evergreen/scripts/compile-unix.sh
+++ b/.evergreen/scripts/compile-unix.sh
@@ -211,6 +211,8 @@ if [[ "${COMPILE_LIBMONGOCRYPT}" == "ON" ]]; then
     ..
   make -j "$(nproc)" install
   popd # libmongocrypt/cmake-build
+  # Fail if the C driver is unable to find the installed libmongocrypt.
+  configure_flags_append "-DENABLE_CLIENT_SIDE_ENCRYPTION=ON"
 else
   # Avoid symbol collisions with libmongocrypt installed via apt/yum.
   # Note: may be overwritten by ${EXTRA_CONFIGURE_FLAGS}.

--- a/.evergreen/scripts/compile-windows.sh
+++ b/.evergreen/scripts/compile-windows.sh
@@ -104,7 +104,7 @@ if [ "${COMPILE_LIBMONGOCRYPT}" = "ON" ]; then
   git clone --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.7.0-alpha1
   mkdir libmongocrypt/cmake-build
   pushd libmongocrypt/cmake-build
-  "${cmake_binary}" -G "${CC}" "-DCMAKE_PREFIX_PATH=$(to_windows_path "${install_dir}")/lib/cmake" -DENABLE_SHARED_BSON=ON -DCMAKE_INSTALL_PREFIX="$(to_windows_path "${install_dir}")" ../
+  "${cmake_binary}" -G "${CC}" "-DCMAKE_PREFIX_PATH=$(to_windows_path "${install_dir}/lib/cmake")" -DENABLE_SHARED_BSON=ON -DCMAKE_INSTALL_PREFIX="$(to_windows_path "${install_dir}")" ../
   "${cmake_binary}" --build . --target INSTALL --config "${build_config}" -- "${compile_flags[@]}"
   popd # libmongocrypt/cmake-build
   # Fail if the C driver is unable to find the installed libmongocrypt.

--- a/.evergreen/scripts/compile-windows.sh
+++ b/.evergreen/scripts/compile-windows.sh
@@ -109,6 +109,6 @@ if [ "${COMPILE_LIBMONGOCRYPT}" = "ON" ]; then
   popd # libmongocrypt/cmake-build
 fi
 
-"${cmake_binary}" -G "$CC" "-DCMAKE_PREFIX_PATH=${install_dir}/lib/cmake" "${configure_flags[@]}"
+"${cmake_binary}" -G "$CC" "${configure_flags[@]}"
 "${cmake_binary}" --build . --target ALL_BUILD --config "${build_config}" -- "${compile_flags[@]}"
 "${cmake_binary}" --build . --target INSTALL --config "${build_config}" -- "${compile_flags[@]}"

--- a/.evergreen/scripts/compile-windows.sh
+++ b/.evergreen/scripts/compile-windows.sh
@@ -104,7 +104,7 @@ if [ "${COMPILE_LIBMONGOCRYPT}" = "ON" ]; then
   git clone --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.7.0-alpha1
   mkdir libmongocrypt/cmake-build
   pushd libmongocrypt/cmake-build
-  "${cmake_binary}" -G "${CC}" "-DCMAKE_PREFIX_PATH=${install_dir}/lib/cmake" -DENABLE_SHARED_BSON=ON -DCMAKE_INSTALL_PREFIX="${install_dir}" ../
+  "${cmake_binary}" -G "${CC}" "-DCMAKE_PREFIX_PATH=$(to_windows_path "${install_dir}")/lib/cmake" -DENABLE_SHARED_BSON=ON -DCMAKE_INSTALL_PREFIX="$(to_windows_path "${install_dir}")" ../
   "${cmake_binary}" --build . --target INSTALL --config "${build_config}" -- "${compile_flags[@]}"
   popd # libmongocrypt/cmake-build
 fi

--- a/.evergreen/scripts/compile-windows.sh
+++ b/.evergreen/scripts/compile-windows.sh
@@ -107,6 +107,8 @@ if [ "${COMPILE_LIBMONGOCRYPT}" = "ON" ]; then
   "${cmake_binary}" -G "${CC}" "-DCMAKE_PREFIX_PATH=$(to_windows_path "${install_dir}")/lib/cmake" -DENABLE_SHARED_BSON=ON -DCMAKE_INSTALL_PREFIX="$(to_windows_path "${install_dir}")" ../
   "${cmake_binary}" --build . --target INSTALL --config "${build_config}" -- "${compile_flags[@]}"
   popd # libmongocrypt/cmake-build
+  # Fail if the C driver is unable to find the installed libmongocrypt.
+  configure_flags_append "-DENABLE_CLIENT_SIDE_ENCRYPTION=ON"
 fi
 
 "${cmake_binary}" -G "$CC" "${configure_flags[@]}"

--- a/.evergreen/scripts/run-tests.sh
+++ b/.evergreen/scripts/run-tests.sh
@@ -104,8 +104,8 @@ if [[ -n "${CLIENT_SIDE_ENCRYPTION}" ]]; then
   } &>/dev/null
   echo "Setting KMS credentials from the environment... done."
 
-  export MONGOC_TEST_CSFLE_TLS_CA_FILE="${mongoc_dir}/src/libmongoc/tests/x509gen/ca.pem"
-  export MONGOC_TEST_CSFLE_TLS_CERTIFICATE_KEY_FILE="${mongoc_dir}/src/libmongoc/tests/x509gen/client.pem"
+  export MONGOC_TEST_CSFLE_TLS_CA_FILE="src/libmongoc/tests/x509gen/ca.pem"
+  export MONGOC_TEST_CSFLE_TLS_CERTIFICATE_KEY_FILE="src/libmongoc/tests/x509gen/client.pem"
   export SKIP_CRYPT_SHARED_LIB="${SKIP_CRYPT_SHARED_LIB}"
 fi
 

--- a/.evergreen/scripts/run-tests.sh
+++ b/.evergreen/scripts/run-tests.sh
@@ -43,8 +43,6 @@ if [[ "${SSL}" != "nossl" ]]; then
   export MONGOC_TEST_SSL_WEAK_CERT_VALIDATION="off"
   export MONGOC_TEST_SSL_PEM_FILE="src/libmongoc/tests/x509gen/client.pem"
   export MONGOC_TEST_SSL_CA_FILE="src/libmongoc/tests/x509gen/ca.pem"
-  export MONGOC_TEST_CSFLE_TLS_CERTIFICATE_KEY_FILE="src/libmongoc/tests/x509gen/client.pem"
-  export MONGOC_TEST_CSFLE_TLS_CA_FILE="src/libmongoc/tests/x509gen/ca.pem"
 fi
 
 export MONGOC_ENABLE_MAJORITY_READ_CONCERN=on

--- a/src/libmongoc/src/mongoc/mongoc-crypt.c
+++ b/src/libmongoc/src/mongoc/mongoc-crypt.c
@@ -453,6 +453,15 @@ _get_stream (const char *endpoint,
    tls_stream = mongoc_stream_tls_new_with_hostname (
       base_stream, host.host, &ssl_opt_copy, 1 /* client */);
 
+   if (!tls_stream) {
+      bson_set_error (error,
+                      MONGOC_ERROR_STREAM,
+                      MONGOC_ERROR_STREAM_SOCKET,
+                      "Failed to create TLS stream to: %s",
+                      endpoint);
+      goto fail;
+   }
+
    if (!mongoc_stream_tls_handshake_block (
           tls_stream, host.host, connecttimeoutms, error)) {
       goto fail;


### PR DESCRIPTION
# Summary

- Update `CMAKE_PREFIX_PATH` and `CMAKE_INSTALL_PATH` to use Windows paths to unskip `-cse` tests on Windows.
- Use a relative path for `MONGOC_TEST_CSFLE_TLS_CERTIFICATE_KEY_FILE` and `MONGOC_TEST_CSFLE_TLS_CA_FILE` to fix `-cse` KMIP tests on Windows.
- Return an error on failure to construct a TLS stream for KMS.

# Background & Motivation

Using a relative path for `MONGOC_TEST_CSFLE_TLS_CERTIFICATE_KEY_FILE` and `MONGOC_TEST_CSFLE_TLS_CA_FILE`

Changes in f4a83c084088e3878097b17881458548bc621ea2 result in `-cse` tests being skipped on Windows. Fixing the `CMAKE_PREFIX_PATH` and `CMAKE_INSTALL_PATH` resulted in test failures with with KMIP. [This patch](https://spruce.mongodb.com/version/63da96100ae6068e52b089ec/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) includes additional logs:

```
[2023/02/01 16:59:25.870] 2023/02/01 16:59:25.0869: [ 1040]:    ERROR:       mongoc: Cannot find certificate in '/cygdrive/c/data/mci/e148ff60430bca9ce46a884ba22cc7eb/mongoc/src/libmongoc/tests/x509gen/client.pem'
[2023/02/01 16:59:25.870] c:\data\mci\444b58cc15a1b589829a2430f6fc6e31\mongoc\src\libmongoc\src\mongoc\mongoc-crypt.c:458 _get_stream(): precondition failed: tls_stream != NULL
```

Using a relative path for `MONGOC_TEST_CSFLE_TLS_CERTIFICATE_KEY_FILE` and `MONGOC_TEST_CSFLE_TLS_CA_FILE` resolves the error. The `precondition failed` is unexpected. The failure to load the file now results in an error returned instead of an abort.

Verified with this [patch build](https://spruce.mongodb.com/version/63dab4eb7742ae5872f62095).