### PR TITLE
Avoid compiling libmongoc when compiling libmongocrypt

### DIFF
--- a/.evergreen/scripts/compile-test-azurekms.sh
+++ b/.evergreen/scripts/compile-test-azurekms.sh
@@ -9,8 +9,15 @@ INSTALL_DIR=$ROOT/install
 . .evergreen/scripts/find-cmake.sh
 echo "Installing libmongocrypt ... begin"
 git clone --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.7.0
+# TODO: remove once latest libmongocrypt release contains commit 4c4aa8bf.
+{
+    echo "1.7.0+4c4aa8bf" >|libmongocrypt/VERSION_CURRENT
+    git -C libmongocrypt fetch -q origin master
+    git -C libmongocrypt checkout -q 4c4aa8bf # Allows -DENABLE_MONGOC=OFF.
+}
 MONGOCRYPT_INSTALL_PREFIX=${INSTALL_DIR} \
-DEFAULT_BUILD_ONLY=true \
+    DEFAULT_BUILD_ONLY=true \
+    LIBMONGOCRYPT_EXTRA_CMAKE_FLAGS="-DMONGOCRYPT_MONGOC_DIR=$ROOT -DBUILD_TESTING=OFF -DENABLE_ONLINE_TESTS=OFF -DENABLE_MONGOC=OFF" \
     ./libmongocrypt/.evergreen/compile.sh
 echo "Installing libmongocrypt ... end"
 

--- a/.evergreen/scripts/compile-test-azurekms.sh
+++ b/.evergreen/scripts/compile-test-azurekms.sh
@@ -11,9 +11,11 @@ echo "Installing libmongocrypt ... begin"
 git clone --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.7.0
 # TODO: remove once latest libmongocrypt release contains commit 4c4aa8bf.
 {
+    pushd libmongocrypt
     echo "1.7.0+4c4aa8bf" >|libmongocrypt/VERSION_CURRENT
-    git -C libmongocrypt fetch -q origin master
-    git -C libmongocrypt checkout -q 4c4aa8bf # Allows -DENABLE_MONGOC=OFF.
+    git fetch -q origin master
+    git checkout -q 4c4aa8bf # Allows -DENABLE_MONGOC=OFF.
+    popd # libmongocrypt
 }
 MONGOCRYPT_INSTALL_PREFIX=${INSTALL_DIR} \
     DEFAULT_BUILD_ONLY=true \

--- a/.evergreen/scripts/compile-test-azurekms.sh
+++ b/.evergreen/scripts/compile-test-azurekms.sh
@@ -12,7 +12,7 @@ git clone --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.7.0
 # TODO: remove once latest libmongocrypt release contains commit 4c4aa8bf.
 {
     pushd libmongocrypt
-    echo "1.7.0+4c4aa8bf" >|libmongocrypt/VERSION_CURRENT
+    echo "1.7.0+4c4aa8bf" >|VERSION_CURRENT
     git fetch -q origin master
     git checkout -q 4c4aa8bf # Allows -DENABLE_MONGOC=OFF.
     popd # libmongocrypt

--- a/.evergreen/scripts/compile-test-gcpkms.sh
+++ b/.evergreen/scripts/compile-test-gcpkms.sh
@@ -11,9 +11,11 @@ echo "Installing libmongocrypt ... begin"
 git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.7.0
 # TODO: remove once latest libmongocrypt release contains commit 4c4aa8bf.
 {
+    pushd libmongocrypt
     echo "1.7.0+4c4aa8bf" >|libmongocrypt/VERSION_CURRENT
-    git -C libmongocrypt fetch -q origin master
-    git -C libmongocrypt checkout -q 4c4aa8bf # Allows -DENABLE_MONGOC=OFF.
+    git fetch -q origin master
+    git checkout -q 4c4aa8bf # Allows -DENABLE_MONGOC=OFF.
+    popd # libmongocrypt
 }
 MONGOCRYPT_INSTALL_PREFIX=${INSTALL_DIR} \
     DEFAULT_BUILD_ONLY=true \

--- a/.evergreen/scripts/compile-test-gcpkms.sh
+++ b/.evergreen/scripts/compile-test-gcpkms.sh
@@ -12,7 +12,7 @@ git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.7.0
 # TODO: remove once latest libmongocrypt release contains commit 4c4aa8bf.
 {
     pushd libmongocrypt
-    echo "1.7.0+4c4aa8bf" >|libmongocrypt/VERSION_CURRENT
+    echo "1.7.0+4c4aa8bf" >|VERSION_CURRENT
     git fetch -q origin master
     git checkout -q 4c4aa8bf # Allows -DENABLE_MONGOC=OFF.
     popd # libmongocrypt

--- a/.evergreen/scripts/compile-test-gcpkms.sh
+++ b/.evergreen/scripts/compile-test-gcpkms.sh
@@ -8,9 +8,16 @@ ROOT=$(pwd)
 INSTALL_DIR=$ROOT/install
 . .evergreen/scripts/find-cmake.sh
 echo "Installing libmongocrypt ... begin"
-git clone --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.7.0
+git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.7.0
+# TODO: remove once latest libmongocrypt release contains commit 4c4aa8bf.
+{
+    echo "1.7.0+4c4aa8bf" >|libmongocrypt/VERSION_CURRENT
+    git -C libmongocrypt fetch -q origin master
+    git -C libmongocrypt checkout -q 4c4aa8bf # Allows -DENABLE_MONGOC=OFF.
+}
 MONGOCRYPT_INSTALL_PREFIX=${INSTALL_DIR} \
-DEFAULT_BUILD_ONLY=true \
+    DEFAULT_BUILD_ONLY=true \
+    LIBMONGOCRYPT_EXTRA_CMAKE_FLAGS="-DMONGOCRYPT_MONGOC_DIR=$ROOT -DBUILD_TESTING=OFF -DENABLE_ONLINE_TESTS=OFF -DENABLE_MONGOC=OFF" \
     ./libmongocrypt/.evergreen/compile.sh
 echo "Installing libmongocrypt ... end"
 

--- a/.evergreen/scripts/compile-unix.sh
+++ b/.evergreen/scripts/compile-unix.sh
@@ -202,7 +202,7 @@ if [[ "${COMPILE_LIBMONGOCRYPT}" == "ON" ]]; then
   # TODO: remove once latest libmongocrypt release contains commit 4c4aa8bf.
   {
     pushd libmongocrypt
-    echo "1.7.0+4c4aa8bf" >|libmongocrypt/VERSION_CURRENT
+    echo "1.7.0+4c4aa8bf" >|VERSION_CURRENT
     git fetch -q origin master
     git checkout -q 4c4aa8bf # Allows -DENABLE_MONGOC=OFF.
     popd # libmongocrypt

--- a/.evergreen/scripts/compile-unix.sh
+++ b/.evergreen/scripts/compile-unix.sh
@@ -201,9 +201,11 @@ if [[ "${COMPILE_LIBMONGOCRYPT}" == "ON" ]]; then
   git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.7.0
   # TODO: remove once latest libmongocrypt release contains commit 4c4aa8bf.
   {
+    pushd libmongocrypt
     echo "1.7.0+4c4aa8bf" >|libmongocrypt/VERSION_CURRENT
-    git -C libmongocrypt fetch -q origin master
-    git -C libmongocrypt checkout -q 4c4aa8bf # Allows -DENABLE_MONGOC=OFF.
+    git fetch -q origin master
+    git checkout -q 4c4aa8bf # Allows -DENABLE_MONGOC=OFF.
+    popd # libmongocrypt
   }
   declare -a crypt_cmake_flags
   crypt_cmake_flags=(

--- a/.evergreen/scripts/compile-unix.sh
+++ b/.evergreen/scripts/compile-unix.sh
@@ -194,10 +194,27 @@ if [[ "${OSTYPE}" == darwin* ]]; then
   }
 fi
 
+declare -a extra_configure_flags
+IFS=' ' read -ra extra_configure_flags <<<"${EXTRA_CONFIGURE_FLAGS:-}"
+
 if [[ "${COMPILE_LIBMONGOCRYPT}" == "ON" ]]; then
-  git clone --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.7.0
+  git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.7.0
+  # TODO: remove once latest libmongocrypt release contains commit 4c4aa8bf.
+  {
+    echo "1.7.0+4c4aa8bf" >|libmongocrypt/VERSION_CURRENT
+    git -C libmongocrypt fetch -q origin master
+    git -C libmongocrypt checkout -q 4c4aa8bf # Allows -DENABLE_MONGOC=OFF.
+  }
+  declare -a crypt_cmake_flags
+  crypt_cmake_flags=(
+    "-DMONGOCRYPT_MONGOC_DIR=${mongoc_dir}"
+    "-DBUILD_TESTING=OFF"
+    "-DENABLE_ONLINE_TESTS=OFF"
+    "-DENABLE_MONGOC=OFF"
+  )
   MONGOCRYPT_INSTALL_PREFIX=${install_dir} \
     DEFAULT_BUILD_ONLY=true \
+    LIBMONGOCRYPT_EXTRA_CMAKE_FLAGS="${crypt_cmake_flags[*]}" \
     ./libmongocrypt/.evergreen/compile.sh
   # Fail if the C driver is unable to find the installed libmongocrypt.
   configure_flags_append "-DENABLE_CLIENT_SIDE_ENCRYPTION=ON"
@@ -224,14 +241,12 @@ if [[ "${ANALYZE}" == "ON" ]]; then
   # scan-build `--exclude`` flag is not available on all Evergreen variants.
   configure_flags_append "-DENABLE_ZLIB=OFF"
 
-  # shellcheck disable=SC2086
-  "${scan_build_binary}" "${CMAKE}" "${configure_flags[@]}" ${EXTRA_CONFIGURE_FLAGS} .
+  "${scan_build_binary}" "${CMAKE}" "${configure_flags[@]}" "${extra_configure_flags[@]}" .
 
   # Put clang static analyzer results in scan/ and fail build if warnings found.
   "${scan_build_binary}" -o scan --status-bugs make -j "$(nproc)" all
 else
-  # shellcheck disable=SC2086
-  "${CMAKE}" "${configure_flags[@]}" ${EXTRA_CONFIGURE_FLAGS} .
+  "${CMAKE}" "${configure_flags[@]}" "${extra_configure_flags[@]}" .
   make -j "$(nproc)" all
   make install
 fi

--- a/.evergreen/scripts/compile-windows.sh
+++ b/.evergreen/scripts/compile-windows.sh
@@ -107,7 +107,7 @@ if [ "${COMPILE_LIBMONGOCRYPT}" = "ON" ]; then
   # TODO: remove once latest libmongocrypt release contains commit 4c4aa8bf.
   {
     pushd libmongocrypt
-    echo "1.7.0+4c4aa8bf" >|libmongocrypt/VERSION_CURRENT
+    echo "1.7.0+4c4aa8bf" >|VERSION_CURRENT
     git fetch -q origin master
     git checkout -q 4c4aa8bf # Allows -DENABLE_MONGOC=OFF.
     popd # libmongocrypt

--- a/.evergreen/scripts/compile-windows.sh
+++ b/.evergreen/scripts/compile-windows.sh
@@ -106,9 +106,11 @@ if [ "${COMPILE_LIBMONGOCRYPT}" = "ON" ]; then
   git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.7.0
   # TODO: remove once latest libmongocrypt release contains commit 4c4aa8bf.
   {
+    pushd libmongocrypt
     echo "1.7.0+4c4aa8bf" >|libmongocrypt/VERSION_CURRENT
-    git -C libmongocrypt fetch -q origin master
-    git -C libmongocrypt checkout -q 4c4aa8bf # Allows -DENABLE_MONGOC=OFF.
+    git fetch -q origin master
+    git checkout -q 4c4aa8bf # Allows -DENABLE_MONGOC=OFF.
+    popd # libmongocrypt
   }
   declare -a crypt_cmake_flags
   crypt_cmake_flags=(

--- a/.evergreen/scripts/compile-windows.sh
+++ b/.evergreen/scripts/compile-windows.sh
@@ -73,12 +73,15 @@ else
   configure_flags_append "-DENABLE_SSL=${SSL}"
 fi
 
+declare -a extra_configure_flags
+IFS=' ' read -ra extra_configure_flags <<<"${EXTRA_CONFIGURE_FLAGS:-}"
+
 if [[ "${CC}" =~ mingw ]]; then
   # MinGW has trouble compiling src/cpp-check.cpp without some assistance.
   configure_flags_append "-DCMAKE_CXX_STANDARD=11"
 
   env \
-    CONFIGURE_FLAGS="${configure_flags[*]}" \
+    CONFIGURE_FLAGS="${configure_flags[*]} ${extra_configure_flags[*]}" \
     INSTALL_DIR="${install_dir}" \
     NJOBS="$(nproc)" \
     cmd.exe /c "$(to_windows_path "${script_dir}/compile-windows-mingw.bat")"

--- a/.evergreen/scripts/compile-windows.sh
+++ b/.evergreen/scripts/compile-windows.sh
@@ -102,9 +102,6 @@ declare compile_flags=(
   "/m" # Number of concurrent processes. No value=# of cpus
 )
 
-declare -a extra_configure_flags
-IFS=' ' read -ra extra_configure_flags <<<"${EXTRA_CONFIGURE_FLAGS:-}"
-
 if [ "${COMPILE_LIBMONGOCRYPT}" = "ON" ]; then
   git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.7.0
   # TODO: remove once latest libmongocrypt release contains commit 4c4aa8bf.


### PR DESCRIPTION
Followup to https://github.com/mongodb/libmongocrypt/pull/563 (CC @vector-of-bool), motivated by https://github.com/mongodb/mongo-c-driver/pull/1201#discussion_r1098078765 (CC @rcsanchez97).

Verified by ~[this patch](https://spruce.mongodb.com/version/63e3f33e2a60ed5eebfd75b2/tasks)~ [this patch](https://spruce.mongodb.com/version/63e3fa801e2d170a35e7cc82/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) (includes MinGW fixes).

Avoids redundant compilation of libmongoc by libmongocrypt by setting `ENABLE_ONLINE_TESTS=OFF`, `BUILD_TESTING=OFF`, and `ENABLE_MONGOC=OFF`. Also sets `MONGOCRYPT_MONGOC_DIR` to point to the current C Driver repository to avoid a redundant download of the C Driver repo. I considered also forwarding `configure_flags` and `extra_configure_flags` but decided against it given libmongocrypt statically links its own copy of libbson, thus establishing consistency between its libbson and the C Driver's libbson is not necessary.

An extra fetch+checkout of libmongocrypt is currently required to obtain https://github.com/mongodb/libmongocrypt/commit/4c4aa8bf70cbe243c4c04631b50b58ec7de1cce9 which permits `ENABLE_MONGOC=OFF`. This code can be removed once the commit is available in a libmongocrypt release. The `checkout` of the required commit currently includes all changes leading up to that commit. If we want to minimize the changes such that libmongocrypt remains as close to 1.7.0 as possible, we could limit the checkout only to `cmake/ImportBSON.cmake` via `git -C libmongocrypt checkout 4c4aa8bf cmake/ImportBSON.cmake`.

As a drive-by fix, also ensures `EXTRA_CONFIGURE_FLAGS` is actually used when compiling on Windows.