### PR TITLE
Silence xtrace and debug output when compiling libmongocrypt

### DIFF
--- a/.evergreen/scripts/compile-test-azurekms.sh
+++ b/.evergreen/scripts/compile-test-azurekms.sh
@@ -17,7 +17,10 @@ git clone --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.7.0
     git checkout -q 4c4aa8bf # Allows -DENABLE_MONGOC=OFF.
     popd # libmongocrypt
 }
-MONGOCRYPT_INSTALL_PREFIX=${INSTALL_DIR} \
+exec 3>/dev/null
+BASH_XTRACEFD="3" \
+    DEBUG="0" \
+    MONGOCRYPT_INSTALL_PREFIX=${INSTALL_DIR} \
     DEFAULT_BUILD_ONLY=true \
     LIBMONGOCRYPT_EXTRA_CMAKE_FLAGS="-DMONGOCRYPT_MONGOC_DIR=$ROOT -DBUILD_TESTING=OFF -DENABLE_ONLINE_TESTS=OFF -DENABLE_MONGOC=OFF" \
     ./libmongocrypt/.evergreen/compile.sh

--- a/.evergreen/scripts/compile-test-azurekms.sh
+++ b/.evergreen/scripts/compile-test-azurekms.sh
@@ -9,17 +9,15 @@ INSTALL_DIR=$ROOT/install
 . .evergreen/scripts/find-cmake.sh
 echo "Installing libmongocrypt ... begin"
 git clone --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.7.0
-# TODO: remove once latest libmongocrypt release contains commit 4c4aa8bf.
+# TODO: remove once latest libmongocrypt release contains commit c6f65fe6.
 {
     pushd libmongocrypt
-    echo "1.7.0+4c4aa8bf" >|VERSION_CURRENT
+    echo "1.7.0+c6f65fe6" >|VERSION_CURRENT
     git fetch -q origin master
-    git checkout -q 4c4aa8bf # Allows -DENABLE_MONGOC=OFF.
+    git checkout -q c6f65fe6 # Allows -DENABLE_MONGOC=OFF.
     popd # libmongocrypt
 }
-exec 3>/dev/null
-BASH_XTRACEFD="3" \
-    DEBUG="0" \
+DEBUG="0" \
     MONGOCRYPT_INSTALL_PREFIX=${INSTALL_DIR} \
     DEFAULT_BUILD_ONLY=true \
     LIBMONGOCRYPT_EXTRA_CMAKE_FLAGS="-DMONGOCRYPT_MONGOC_DIR=$ROOT -DBUILD_TESTING=OFF -DENABLE_ONLINE_TESTS=OFF -DENABLE_MONGOC=OFF" \

--- a/.evergreen/scripts/compile-test-gcpkms.sh
+++ b/.evergreen/scripts/compile-test-gcpkms.sh
@@ -17,7 +17,10 @@ git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.7.0
     git checkout -q 4c4aa8bf # Allows -DENABLE_MONGOC=OFF.
     popd # libmongocrypt
 }
-MONGOCRYPT_INSTALL_PREFIX=${INSTALL_DIR} \
+exec 3>/dev/null
+BASH_XTRACEFD="3" \
+    DEBUG="0" \
+    MONGOCRYPT_INSTALL_PREFIX=${INSTALL_DIR} \
     DEFAULT_BUILD_ONLY=true \
     LIBMONGOCRYPT_EXTRA_CMAKE_FLAGS="-DMONGOCRYPT_MONGOC_DIR=$ROOT -DBUILD_TESTING=OFF -DENABLE_ONLINE_TESTS=OFF -DENABLE_MONGOC=OFF" \
     ./libmongocrypt/.evergreen/compile.sh

--- a/.evergreen/scripts/compile-test-gcpkms.sh
+++ b/.evergreen/scripts/compile-test-gcpkms.sh
@@ -9,17 +9,15 @@ INSTALL_DIR=$ROOT/install
 . .evergreen/scripts/find-cmake.sh
 echo "Installing libmongocrypt ... begin"
 git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.7.0
-# TODO: remove once latest libmongocrypt release contains commit 4c4aa8bf.
+# TODO: remove once latest libmongocrypt release contains commit c6f65fe6.
 {
     pushd libmongocrypt
-    echo "1.7.0+4c4aa8bf" >|VERSION_CURRENT
+    echo "1.7.0+c6f65fe6" >|VERSION_CURRENT
     git fetch -q origin master
-    git checkout -q 4c4aa8bf # Allows -DENABLE_MONGOC=OFF.
+    git checkout -q c6f65fe6 # Allows -DENABLE_MONGOC=OFF.
     popd # libmongocrypt
 }
-exec 3>/dev/null
-BASH_XTRACEFD="3" \
-    DEBUG="0" \
+DEBUG="0" \
     MONGOCRYPT_INSTALL_PREFIX=${INSTALL_DIR} \
     DEFAULT_BUILD_ONLY=true \
     LIBMONGOCRYPT_EXTRA_CMAKE_FLAGS="-DMONGOCRYPT_MONGOC_DIR=$ROOT -DBUILD_TESTING=OFF -DENABLE_ONLINE_TESTS=OFF -DENABLE_MONGOC=OFF" \

--- a/.evergreen/scripts/compile-unix.sh
+++ b/.evergreen/scripts/compile-unix.sh
@@ -205,7 +205,7 @@ if [[ "${COMPILE_LIBMONGOCRYPT}" == "ON" ]]; then
     echo "1.7.0+4c4aa8bf" >|VERSION_CURRENT
     git fetch -q origin master
     git checkout -q 4c4aa8bf # Allows -DENABLE_MONGOC=OFF.
-    popd # libmongocrypt
+    popd                     # libmongocrypt
   }
   declare -a crypt_cmake_flags
   crypt_cmake_flags=(
@@ -214,7 +214,10 @@ if [[ "${COMPILE_LIBMONGOCRYPT}" == "ON" ]]; then
     "-DENABLE_ONLINE_TESTS=OFF"
     "-DENABLE_MONGOC=OFF"
   )
-  MONGOCRYPT_INSTALL_PREFIX=${install_dir} \
+  exec 3>/dev/null
+  BASH_XTRACEFD="3" \
+    DEBUG="0" \
+    MONGOCRYPT_INSTALL_PREFIX=${install_dir} \
     DEFAULT_BUILD_ONLY=true \
     LIBMONGOCRYPT_EXTRA_CMAKE_FLAGS="${crypt_cmake_flags[*]}" \
     ./libmongocrypt/.evergreen/compile.sh

--- a/.evergreen/scripts/compile-unix.sh
+++ b/.evergreen/scripts/compile-unix.sh
@@ -199,12 +199,12 @@ IFS=' ' read -ra extra_configure_flags <<<"${EXTRA_CONFIGURE_FLAGS:-}"
 
 if [[ "${COMPILE_LIBMONGOCRYPT}" == "ON" ]]; then
   git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.7.0
-  # TODO: remove once latest libmongocrypt release contains commit 4c4aa8bf.
+  # TODO: remove once latest libmongocrypt release contains commit c6f65fe6.
   {
     pushd libmongocrypt
-    echo "1.7.0+4c4aa8bf" >|VERSION_CURRENT
+    echo "1.7.0+c6f65fe6" >|VERSION_CURRENT
     git fetch -q origin master
-    git checkout -q 4c4aa8bf # Allows -DENABLE_MONGOC=OFF.
+    git checkout -q c6f65fe6 # Allows -DENABLE_MONGOC=OFF.
     popd                     # libmongocrypt
   }
   declare -a crypt_cmake_flags
@@ -214,9 +214,7 @@ if [[ "${COMPILE_LIBMONGOCRYPT}" == "ON" ]]; then
     "-DENABLE_ONLINE_TESTS=OFF"
     "-DENABLE_MONGOC=OFF"
   )
-  exec 3>/dev/null
-  BASH_XTRACEFD="3" \
-    DEBUG="0" \
+  DEBUG="0" \
     MONGOCRYPT_INSTALL_PREFIX=${install_dir} \
     DEFAULT_BUILD_ONLY=true \
     LIBMONGOCRYPT_EXTRA_CMAKE_FLAGS="${crypt_cmake_flags[*]}" \

--- a/.evergreen/scripts/compile-windows.sh
+++ b/.evergreen/scripts/compile-windows.sh
@@ -104,12 +104,12 @@ declare compile_flags=(
 
 if [ "${COMPILE_LIBMONGOCRYPT}" = "ON" ]; then
   git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.7.0
-  # TODO: remove once latest libmongocrypt release contains commit 4c4aa8bf.
+  # TODO: remove once latest libmongocrypt release contains commit c6f65fe6.
   {
     pushd libmongocrypt
-    echo "1.7.0+4c4aa8bf" >|VERSION_CURRENT
+    echo "1.7.0+c6f65fe6" >|VERSION_CURRENT
     git fetch -q origin master
-    git checkout -q 4c4aa8bf # Allows -DENABLE_MONGOC=OFF.
+    git checkout -q c6f65fe6 # Allows -DENABLE_MONGOC=OFF.
     popd                     # libmongocrypt
   }
   declare -a crypt_cmake_flags
@@ -119,9 +119,7 @@ if [ "${COMPILE_LIBMONGOCRYPT}" = "ON" ]; then
     "-DENABLE_ONLINE_TESTS=OFF"
     "-DENABLE_MONGOC=OFF"
   )
-  exec 3>/dev/null
-  BASH_XTRACEFD="3" \
-    DEBUG="0" \
+  DEBUG="0" \
     MONGOCRYPT_INSTALL_PREFIX="${install_dir}" \
     DEFAULT_BUILD_ONLY=true \
     LIBMONGOCRYPT_BUILD_TYPE="${build_config}" \

--- a/.evergreen/scripts/compile-windows.sh
+++ b/.evergreen/scripts/compile-windows.sh
@@ -110,7 +110,7 @@ if [ "${COMPILE_LIBMONGOCRYPT}" = "ON" ]; then
     echo "1.7.0+4c4aa8bf" >|VERSION_CURRENT
     git fetch -q origin master
     git checkout -q 4c4aa8bf # Allows -DENABLE_MONGOC=OFF.
-    popd # libmongocrypt
+    popd                     # libmongocrypt
   }
   declare -a crypt_cmake_flags
   crypt_cmake_flags=(
@@ -119,7 +119,10 @@ if [ "${COMPILE_LIBMONGOCRYPT}" = "ON" ]; then
     "-DENABLE_ONLINE_TESTS=OFF"
     "-DENABLE_MONGOC=OFF"
   )
-  MONGOCRYPT_INSTALL_PREFIX="${install_dir}" \
+  exec 3>/dev/null
+  BASH_XTRACEFD="3" \
+    DEBUG="0" \
+    MONGOCRYPT_INSTALL_PREFIX="${install_dir}" \
     DEFAULT_BUILD_ONLY=true \
     LIBMONGOCRYPT_BUILD_TYPE="${build_config}" \
     LIBMONGOCRYPT_EXTRA_CMAKE_FLAGS="${crypt_cmake_flags[*]}" \


### PR DESCRIPTION
A small followup to https://github.com/mongodb/mongo-c-driver/pull/1198 and https://github.com/mongodb/mongo-c-driver/pull/1202 that reduces the verbosity of output generated by compiling libmongocrypt. Verified by [this patch](https://spruce.mongodb.com/version/63ea5dc232f4174313be458d/tasks).

Invoking `exec 3>/dev/null` and setting `BASH_XTRACEFD="3"` [redirects xtrace output to /dev/null](https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html#index-BASH_005fXTRACEFD). This workaround can be removed once the libmongocrypt commit being built contains https://github.com/mongodb/libmongocrypt/pull/571. Note, [macos-1014 still emits xtrace output](https://parsley.mongodb.com/evergreen/mongo_c_driver_darwin_debug_compile_sasl_darwinssl_cse_patch_04d975b2e140e9a40859f4a44e533959bdaffa37_63ea5dc232f4174313be458d_23_02_13_15_56_53/0/task?bookmarks=0,2400&shareLine=73) due to running Bash version 3.2; `BASH_XTRACEFD` [requires 4.1 or newer](https://mywiki.wooledge.org/BashFAQ/061).

Setting `DEBUG="0"` silences debug output generated by [calls to debug](https://github.com/mongodb/libmongocrypt/blob/361b208d1e9b90071feb8b842481338189330e0d/.evergreen/init.sh#L55). This variable needs to be set explicitly since `DEBUG` is also being used by [compile-unix.sh](https://github.com/mongodb/mongo-c-driver/blob/04d975b2e140e9a40859f4a44e533959bdaffa37/.evergreen/scripts/compile-unix.sh#L79) to toggle the CMake build configuration.