### PR TITLE
CDRIVER-4439 add AWS credential cache

### DIFF
--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -1817,11 +1817,11 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        # Compile mongoc-ping. Disable unnecessary dependencies since mongoc-ping is copied to a remote Ubuntu 18.04 ECS cluster for testing, which may not have all dependent libraries.
+        # Compile test-awsauth. Disable unnecessary dependencies since test-awsauth is copied to a remote Ubuntu 18.04 ECS cluster for testing, which may not have all dependent libraries.
         . .evergreen/scripts/find-cmake.sh
         export CC='${CC}'
         $CMAKE -DENABLE_SASL=OFF -DENABLE_SNAPPY=OFF -DENABLE_ZSTD=OFF -DENABLE_CLIENT_SIDE_ENCRYPTION=OFF .
-        $CMAKE --build . --target mongoc-ping
+        $CMAKE --build . --target test-awsauth
   - func: upload-build
 - name: test-aws-openssl-regular-latest
   depends_on:

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -826,11 +826,11 @@ class IPTask(MatrixTask):
 all_tasks = chain(all_tasks, IPTask.matrix())
 
 aws_compile_task = NamedTask('debug-compile-aws', commands=[shell_mongoc('''
-        # Compile mongoc-ping. Disable unnecessary dependencies since mongoc-ping is copied to a remote Ubuntu 18.04 ECS cluster for testing, which may not have all dependent libraries.
+        # Compile test-awsauth. Disable unnecessary dependencies since test-awsauth is copied to a remote Ubuntu 18.04 ECS cluster for testing, which may not have all dependent libraries.
         . .evergreen/scripts/find-cmake.sh
         export CC='${CC}'
         $CMAKE -DENABLE_SASL=OFF -DENABLE_SNAPPY=OFF -DENABLE_ZSTD=OFF -DENABLE_CLIENT_SIDE_ENCRYPTION=OFF .
-        $CMAKE --build . --target mongoc-ping
+        $CMAKE --build . --target test-awsauth
 '''), func('upload-build')])
 
 all_tasks = chain(all_tasks, [aws_compile_task])

--- a/.evergreen/scripts/run-aws-tests.sh
+++ b/.evergreen/scripts/run-aws-tests.sh
@@ -9,19 +9,6 @@
 # run-aws-tests.sh EC2
 #
 # Optional environment variables:
-#
-# drivers_tools_dir
-#   The path to clone of https://github.com/mongodb-labs/drivers-evergreen-tools.
-#   Defaults to $(pwd)../drivers-evergreen-tools
-# mongoc_dir
-#   The path to the build of mongo-c-driver (e.g. mongo-c-driver/cmake-build).
-#   Defaults to $(pwd)
-# mongoc_dir
-#   The path to mongo-c-driver source (may be same as mongoc_dir).
-#   Defaults to $(pwd)
-# mongodb_bin_dir
-#   The path to mongodb binaries.
-#   Defaults to $(pwd)/mongodb/bin
 # iam_auth_ecs_account and iam_auth_ecs_secret_access_key
 #   Set to access key id/secret access key. Required for some tests.
 

--- a/.evergreen/scripts/run-aws-tests.sh
+++ b/.evergreen/scripts/run-aws-tests.sh
@@ -3,10 +3,10 @@
 # Test runner for AWS authentication.
 #
 # This script is meant to be run in parts (so to isolate the AWS tests).
-# Pass the desired test first argument (REGULAR, EC2, ECS, ASSUME_ROLE, LAMBDA)
+# Pass the desired test as the environment variable TESTCASE: (REGULAR, EC2, ECS, ASSUME_ROLE, LAMBDA)
 #
 # Example:
-# run-aws-tests.sh EC2
+# TESTCASE=EC2 run-aws-tests.sh
 #
 # Optional environment variables:
 # iam_auth_ecs_account and iam_auth_ecs_secret_access_key

--- a/.evergreen/scripts/run-aws-tests.sh
+++ b/.evergreen/scripts/run-aws-tests.sh
@@ -35,24 +35,8 @@ drivers_tools_dir="$(to_absolute "${mongoc_dir}/../drivers-evergreen-tools")"
 declare mongodb_bin_dir="${mongoc_dir}/mongodb/bin"
 declare test_awsauth="${mongoc_dir}/src/libmongoc/test-awsauth"
 
-# TODO: test-awsauth statically links. Remove env vars set in these blocks:
-# Add libmongoc-1.0 and libbson-1.0 to library path, so mongoc-ping can find them at runtime.
 if [[ "${OSTYPE}" == "cygwin" ]]; then
-  export PATH
-  PATH+=":${mongoc_dir}/src/libmongoc/Debug"
-  PATH+=":${mongoc_dir}/src/libbson/Debug"
-
-  chmod -f +x src/libmongoc/Debug/* src/libbson/Debug/* || true
-
   test_awsauth="${mongoc_dir}/src/libmongoc/Debug/test-awsauth.exe"
-elif [[ "${OSTYPE}" == darwin* ]]; then
-  export DYLD_LIBRARY_PATH
-  DYLD_LIBRARY_PATH+=":${mongoc_dir}/src/libmongoc"
-  DYLD_LIBRARY_PATH+=":${mongoc_dir}/src/libbson"
-else
-  export LD_LIBRARY_PATH
-  LD_LIBRARY_PATH+=":${mongoc_dir}/src/libmongoc"
-  LD_LIBRARY_PATH+=":$mongoc_dir/src/libbson"
 fi
 
 expect_success() {

--- a/.evergreen/scripts/run-mongodb-aws-ecs-test.sh
+++ b/.evergreen/scripts/run-mongodb-aws-ecs-test.sh
@@ -4,16 +4,10 @@
 
 echo "run-mongodb-aws-ecs-test.sh"
 
-# TODO: remove paths and comment.
-# Set paths so mongoc-ping can find dependencies
-export LD_LIBRARY_PATH
-LD_LIBRARY_PATH+=":/root/mongoc/src/libmongoc"
-LD_LIBRARY_PATH+=":/root/mongoc/src/libbson"
 
 expect_success() {
   echo "Should succeed:"
   if ! /root/mongoc/src/libmongoc/test-awsauth "${1:?}" "EXPECT_SUCCESS"; then
-    echo "Unexpected auth failure" 1>&2
     exit 1
   fi
 }

--- a/.evergreen/scripts/run-mongodb-aws-ecs-test.sh
+++ b/.evergreen/scripts/run-mongodb-aws-ecs-test.sh
@@ -4,6 +4,7 @@
 
 echo "run-mongodb-aws-ecs-test.sh"
 
+# TODO: remove paths and comment.
 # Set paths so mongoc-ping can find dependencies
 export LD_LIBRARY_PATH
 LD_LIBRARY_PATH+=":/root/mongoc/src/libmongoc"
@@ -11,7 +12,7 @@ LD_LIBRARY_PATH+=":/root/mongoc/src/libbson"
 
 expect_success() {
   echo "Should succeed:"
-  if ! /root/mongoc/src/libmongoc/mongoc-ping "${1:?}"; then
+  if ! /root/mongoc/src/libmongoc/test-awsauth "${1:?}" "EXPECT_SUCCESS"; then
     echo "Unexpected auth failure" 1>&2
     exit 1
   fi

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -1063,6 +1063,7 @@ mongoc_add_test (test-mongoc-gssapi FALSE ${PROJECT_SOURCE_DIR}/tests/test-mongo
 mongoc_add_test (test-mongoc-cache FALSE ${PROJECT_SOURCE_DIR}/tests/test-mongoc-cache.c)
 mongoc_add_test (test-azurekms FALSE ${PROJECT_SOURCE_DIR}/tests/test-azurekms.c)
 mongoc_add_test (test-gcpkms FALSE ${PROJECT_SOURCE_DIR}/tests/test-gcpkms.c)
+mongoc_add_test (test-awsauth FALSE ${PROJECT_SOURCE_DIR}/tests/test-awsauth.c)
 
 if (ENABLE_TESTS)
    # "make test" doesn't compile tests, so we create "make check" which compiles

--- a/src/libmongoc/src/mongoc/mongoc-cluster-aws-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-aws-private.h
@@ -29,7 +29,7 @@ _mongoc_cluster_auth_node_aws (mongoc_cluster_t *cluster,
                                bson_error_t *error);
 
 /* The following are declared in the private header for testing. It is only used
- * in test-mongoc-aws.c and mongoc-cluster.aws.c */
+ * in test-mongoc-aws.c, mongoc-cluster-aws.c, and test-awsauth.c */
 typedef struct {
    char *access_key_id;
    char *secret_access_key;

--- a/src/libmongoc/src/mongoc/mongoc-cluster-aws-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-aws-private.h
@@ -21,6 +21,7 @@
 
 #include "bson/bson.h"
 #include "mongoc/mongoc-cluster-private.h"
+#include "common-thread-private.h" // bson_mutex_t
 
 bool
 _mongoc_cluster_auth_node_aws (mongoc_cluster_t *cluster,
@@ -34,12 +35,84 @@ typedef struct {
    char *access_key_id;
    char *secret_access_key;
    char *session_token;
+   // expiration is the time in milliseconds since the Epoch when these
+   // credentials expire. If expiration is 0, the credentials do not have a
+   // known expiration.
+   uint64_t expiration_ms;
 } _mongoc_aws_credentials_t;
+
+#define MONGOC_AWS_CREDENTIALS_EXPIRATION_WINDOW_MS 60 * 5 * 1000
+
+// _mongoc_aws_credentials_cache_t is a thread-safe global cache of AWS
+// credentials.
+typedef struct {
+   struct {
+      _mongoc_aws_credentials_t value;
+      bool set;
+   } cached;
+   bson_mutex_t mutex; // guards cached.
+} _mongoc_aws_credentials_cache_t;
+
+extern _mongoc_aws_credentials_cache_t mongoc_aws_credentials_cache;
+
+// _mongoc_aws_credentials_cache_init initializes the global
+// `mongoc_aws_credentials_cache. It is expected to be called by mongoc_init.
+void
+_mongoc_aws_credentials_cache_init (void);
+
+// _mongoc_aws_credentials_cache_lock exclusively locks the cache.
+void
+_mongoc_aws_credentials_cache_lock (void);
+
+// _mongoc_aws_credentials_cache_unlock unlocks the cache.
+void
+_mongoc_aws_credentials_cache_unlock (void);
+
+// _mongoc_aws_credentials_cache_put_nolock is a non-locking variant of
+// _mongoc_aws_credentials_cache_put.
+void
+_mongoc_aws_credentials_cache_put_nolock (
+   const _mongoc_aws_credentials_t *creds);
+
+// _mongoc_aws_credentials_cache_put adds credentials into the global cache.
+void
+_mongoc_aws_credentials_cache_put (const _mongoc_aws_credentials_t *creds);
+
+// _mongoc_aws_credentials_cache_get_nolock is a non-locking variant of
+// _mongoc_aws_credentials_cache_get.
+bool
+_mongoc_aws_credentials_cache_get_nolock (_mongoc_aws_credentials_t *creds);
+
+// _mongoc_aws_credentials_cache_get returns true if cached credentials were
+// retrieved. Retrieved credentials are copied to `creds`. Returns false if
+// there are no valid cached credentials.
+// Callers are expected to call _mongoc_aws_credentials_cleanup on `creds`.
+bool
+_mongoc_aws_credentials_cache_get (_mongoc_aws_credentials_t *creds);
+
+// _mongoc_aws_credentials_cache_clear_nolock is the non-locking variant of
+// _mongoc_aws_credentials_cache_clear
+void
+_mongoc_aws_credentials_cache_clear_nolock (void);
+
+// _mongoc_aws_credentials_cache_clear clears credentials in the global cache
+void
+_mongoc_aws_credentials_cache_clear (void);
+
+// _mongoc_aws_credentials_cache_cleanup frees data for the global cache.
+// It is expected to be called by mongoc_cleanup.
+void
+_mongoc_aws_credentials_cache_cleanup (void);
+
 
 bool
 _mongoc_aws_credentials_obtain (mongoc_uri_t *uri,
                                 _mongoc_aws_credentials_t *creds,
                                 bson_error_t *error);
+
+void
+_mongoc_aws_credentials_copy_to (const _mongoc_aws_credentials_t *src,
+                                 _mongoc_aws_credentials_t *dst);
 
 void
 _mongoc_aws_credentials_cleanup (_mongoc_aws_credentials_t *creds);

--- a/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
@@ -555,14 +555,6 @@ fail:
    return ret;
 }
 
-void
-_mongoc_aws_credentials_cleanup (_mongoc_aws_credentials_t *creds)
-{
-   bson_free (creds->access_key_id);
-   bson_free (creds->secret_access_key);
-   bson_free (creds->session_token);
-}
-
 /*
  * Validate the STS host returned by the server and derive the region.
  *
@@ -999,12 +991,6 @@ fail:
    return false;
 }
 
-void
-_mongoc_aws_credentials_cleanup (_mongoc_aws_credentials_t *creds)
-{
-   return;
-}
-
 bool
 _mongoc_validate_and_derive_region (char *sts_fqdn,
                                     uint32_t sts_fqdn_len,
@@ -1018,3 +1004,11 @@ fail:
 }
 
 #endif /* MONGOC_ENABLE_MONGODB_AWS_AUTH */
+
+void
+_mongoc_aws_credentials_cleanup (_mongoc_aws_credentials_t *creds)
+{
+   bson_free (creds->access_key_id);
+   bson_free (creds->secret_access_key);
+   bson_free (creds->session_token);
+}

--- a/src/libmongoc/src/mongoc/mongoc-init.c
+++ b/src/libmongoc/src/mongoc/mongoc-init.c
@@ -23,6 +23,8 @@
 
 #include "mongoc-handshake-private.h"
 
+#include "mongoc-cluster-aws-private.h"
+
 #ifdef MONGOC_ENABLE_SSL_OPENSSL
 #include "mongoc-openssl-private.h"
 #elif defined(MONGOC_ENABLE_SSL_LIBRESSL)
@@ -144,8 +146,10 @@ static BSON_ONCE_FUN (_mongoc_do_init)
 #endif
 
 #if defined(MONGOC_ENABLE_OCSP_OPENSSL)
-  _mongoc_ocsp_cache_init ();
+   _mongoc_ocsp_cache_init ();
 #endif
+
+   _mongoc_aws_credentials_cache_init ();
 
    BSON_ONCE_RETURN;
 }
@@ -191,6 +195,8 @@ static BSON_ONCE_FUN (_mongoc_do_cleanup)
 #if defined(MONGOC_ENABLE_OCSP_OPENSSL)
    _mongoc_ocsp_cache_cleanup ();
 #endif
+
+   _mongoc_aws_credentials_cache_cleanup ();
 
    BSON_ONCE_RETURN;
 }

--- a/src/libmongoc/tests/test-awsauth.c
+++ b/src/libmongoc/tests/test-awsauth.c
@@ -1,0 +1,510 @@
+/**
+ * Copyright 2022 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// test-awsauth.c tests authentication with the MONGODB-AWS authMechanism.
+// It may be run in an AWS ECS task or EC2 instance.
+
+#include "common-thread-private.h"
+#include <mongoc/mongoc.h>
+#include "mongoc-cluster-aws-private.h"
+#include "mongoc-client-private.h"
+#include "mongoc-util-private.h" // _mongoc_getenv
+
+// Ensure stdout and stderr are flushed prior to possible following abort().
+#define MONGOC_STDERR_PRINTF(format, ...)    \
+   if (1) {                                  \
+      fflush (stdout);                       \
+      fprintf (stderr, format, __VA_ARGS__); \
+      fflush (stderr);                       \
+   } else                                    \
+      ((void) 0)
+
+#define ASSERT(Cond)                                                           \
+   if (1) {                                                                    \
+      if (!(Cond)) {                                                           \
+         MONGOC_STDERR_PRINTF ("FAIL:%s:%d  %s()\n  Condition '%s' failed.\n", \
+                               __FILE__,                                       \
+                               __LINE__,                                       \
+                               BSON_FUNC,                                      \
+                               BSON_STR (Cond));                               \
+         abort ();                                                             \
+      }                                                                        \
+   } else                                                                      \
+      ((void) 0)
+
+#define ASSERTF(Cond, Fmt, ...)                                                \
+   if (1) {                                                                    \
+      if (!(Cond)) {                                                           \
+         MONGOC_STDERR_PRINTF ("FAIL:%s:%d  %s()\n  Condition '%s' failed.\n", \
+                               __FILE__,                                       \
+                               __LINE__,                                       \
+                               BSON_FUNC,                                      \
+                               BSON_STR (Cond));                               \
+         MONGOC_STDERR_PRINTF ("MESSAGE: " Fmt "\n", __VA_ARGS__);             \
+         abort ();                                                             \
+      }                                                                        \
+   } else                                                                      \
+      ((void) 0)
+
+#define FAILF(Fmt, ...)                                                     \
+   if (1) {                                                                 \
+      MONGOC_STDERR_PRINTF ("FAIL:%s:%d  %s()\n  Condition '%s' failed.\n", \
+                            __FILE__,                                       \
+                            __LINE__,                                       \
+                            BSON_FUNC,                                      \
+                            BSON_STR (Cond));                               \
+      MONGOC_STDERR_PRINTF ("MESSAGE: " Fmt "\n", __VA_ARGS__);             \
+      abort ();                                                             \
+   } else                                                                   \
+      ((void) 0)
+
+static void
+test_auth (mongoc_database_t *db, bool expect_failure)
+{
+   bson_error_t error;
+   bson_t *ping = BCON_NEW ("ping", BCON_INT32 (1));
+   bool ok = mongoc_database_command_with_opts (db,
+                                                ping,
+                                                NULL /* read_prefs */,
+                                                NULL /* opts */,
+                                                NULL /* reply */,
+                                                &error);
+   if (expect_failure) {
+      ASSERTF (!ok, "%s", "Expected auth failure, but got success");
+   } else {
+      ASSERTF (ok, "Expected auth success, but got error: %s", error.message);
+   }
+   bson_destroy (ping);
+}
+
+// creds_eq returns true if `a` and `b` contain the same credentials.
+static bool
+creds_eq (_mongoc_aws_credentials_t *a, _mongoc_aws_credentials_t *b)
+{
+   BSON_ASSERT_PARAM (a);
+   BSON_ASSERT_PARAM (b);
+
+   if (0 != strcmp (a->access_key_id, b->access_key_id)) {
+      return false;
+   }
+   if (0 != strcmp (a->secret_access_key, b->secret_access_key)) {
+      return false;
+   }
+   if (0 != strcmp (a->session_token, b->session_token)) {
+      return false;
+   }
+   if (a->expiration_ms != b->expiration_ms) {
+      return false;
+   }
+   return true;
+}
+
+// _mongoc_setenv sets an environment variable. Returns false on failure.
+static bool
+_mongoc_setenv (const char *name, const char *value)
+{
+#ifdef _WIN32
+   char *envstring;
+
+   envstring = bson_strdup_printf ("%s=%s", name, value);
+   if (0 != _putenv (envstring)) {
+      return false;
+   }
+
+   return true;
+#else
+
+   if (0 != setenv (name, value, 1)) {
+      return false;
+   }
+
+   return true;
+#endif
+}
+
+// clear_env sets all AWS environment variables to empty strings.
+static void
+clear_env (void)
+{
+   ASSERT (_mongoc_setenv ("AWS_ACCESS_KEY_ID", ""));
+   ASSERT (_mongoc_setenv ("AWS_SECRET_ACCESS_KEY", ""));
+   ASSERT (_mongoc_setenv ("AWS_SESSION_TOKEN", ""));
+}
+
+// can_setenv returns true if process is able to set environment variables and
+// get them back.
+static bool
+can_setenv (void)
+{
+   if (!_mongoc_setenv ("MONGOC_TEST_CANARY", "VALUE")) {
+      return false;
+   }
+   char *got = _mongoc_getenv ("MONGOC_TEST_CANARY");
+   if (NULL == got) {
+      return false;
+   }
+   bson_free (got);
+   return true;
+}
+
+// caching_expected returns true if MONGODB-AWS authentication is expected to
+// cache credentials. Caching is expected when credentials are not passed
+// through the URI or environment variables.
+static bool
+caching_expected (const mongoc_uri_t *uri)
+{
+   if (mongoc_uri_get_username (uri)) {
+      // AWS credentials in the URI like:
+      // "mongodb://<access_key>:<secret_key>@mongodb.example.com/?authMechanism=MONGODB-AWS"
+      // are not cached.
+      return false;
+   }
+   char *got = _mongoc_getenv ("AWS_ACCESS_KEY_ID");
+   if (NULL != got) {
+      bson_free (got);
+      // AWS credentials passed in environment are not cached.
+      return false;
+   }
+   return true;
+}
+
+// do_find runs a find command. Returns false and sets `error` on error.
+static bool
+do_find (mongoc_client_t *client, bson_error_t *error)
+{
+   bson_t *filter = bson_new ();
+   mongoc_collection_t *coll =
+      mongoc_client_get_collection (client, "aws", "coll");
+   mongoc_cursor_t *cursor = mongoc_collection_find_with_opts (
+      coll, filter, NULL /* opts */, NULL /* read prefs */);
+   const bson_t *doc;
+   while (mongoc_cursor_next (cursor, &doc))
+      ;
+   bool ok = !mongoc_cursor_error (cursor, error);
+   mongoc_cursor_destroy (cursor);
+   mongoc_collection_destroy (coll);
+   bson_destroy (filter);
+   return ok;
+}
+
+static void
+test_cache (const mongoc_uri_t *uri)
+{
+   bson_error_t error;
+   _mongoc_aws_credentials_t creds;
+
+   if (!caching_expected (uri)) {
+      printf ("Caching credentials is not expected. Skipping tests expecting "
+              "credential caching.\n");
+      return;
+   }
+
+   // Clear the cache.
+   _mongoc_aws_credentials_cache_clear ();
+
+   // Create a new client.
+   {
+      mongoc_client_t *client = mongoc_client_new_from_uri (uri);
+      ASSERT (client);
+
+      // Ensure that a ``find`` operation adds credentials to the cache.
+      ASSERTF (
+         do_find (client, &error), "expected success, got: %s", error.message);
+      bool found = _mongoc_aws_credentials_cache_get (&creds);
+      ASSERT (found);
+      _mongoc_aws_credentials_cleanup (&creds);
+      mongoc_client_destroy (client);
+   }
+   // Override the cached credentials with an "Expiration" that is within one
+   // minute of the current UTC time.
+   _mongoc_aws_credentials_t first_cached;
+   {
+      ASSERT (mongoc_aws_credentials_cache.cached.set);
+      struct timeval now;
+      ASSERT (0 == bson_gettimeofday (&now));
+      uint64_t now_ms = (1000 * now.tv_sec) + (now.tv_usec / 1000);
+      mongoc_aws_credentials_cache.cached.value.expiration_ms =
+         now_ms + (60 * 1000);
+      _mongoc_aws_credentials_copy_to (
+         &mongoc_aws_credentials_cache.cached.value, &first_cached);
+   }
+
+   // Create a new client.
+   {
+      mongoc_client_t *client = mongoc_client_new_from_uri (uri);
+      ASSERT (client);
+      // Ensure that a ``find`` operation updates the credentials in the cache.
+      ASSERTF (
+         do_find (client, &error), "expected success, got: %s", error.message);
+      bool found = _mongoc_aws_credentials_cache_get (&creds);
+      ASSERT (found);
+      ASSERTF (
+         !creds_eq (&first_cached, &mongoc_aws_credentials_cache.cached.value),
+         "%s",
+         "expected unequal credentials, got equal");
+      _mongoc_aws_credentials_cleanup (&creds);
+      mongoc_client_destroy (client);
+   }
+   _mongoc_aws_credentials_cleanup (&first_cached);
+
+   // Poison the cache with an invalid access key id.
+   {
+      ASSERT (mongoc_aws_credentials_cache.cached.set);
+      bson_free (mongoc_aws_credentials_cache.cached.value.access_key_id);
+      mongoc_aws_credentials_cache.cached.value.access_key_id =
+         bson_strdup ("invalid");
+   }
+
+   // Create a new client.
+   {
+      mongoc_client_t *client = mongoc_client_new_from_uri (uri);
+      ASSERT (client);
+
+      // Ensure that a ``find`` operation results in an error.
+      ASSERT (!do_find (client, &error));
+      ASSERTF (NULL != strstr (error.message, "Authentication failed"),
+               "Expected error to contain '%s', but got '%s'",
+               "Authentication failed",
+               error.message);
+
+      // Ensure that the cache has been cleared.
+      bool found = _mongoc_aws_credentials_cache_get (&creds);
+      ASSERT (!found);
+      _mongoc_aws_credentials_cleanup (&creds);
+
+      // Ensure that a subsequent ``find`` operation succeeds.
+      ASSERTF (
+         do_find (client, &error), "expected success, got: %s", error.message);
+
+      // Ensure that the cache has been set.
+      found = _mongoc_aws_credentials_cache_get (&creds);
+      ASSERT (found);
+      _mongoc_aws_credentials_cleanup (&creds);
+
+      mongoc_client_destroy (client);
+   }
+}
+
+static void
+test_cache_with_env (const mongoc_uri_t *uri)
+{
+   bson_error_t error;
+   _mongoc_aws_credentials_t creds;
+
+   if (!caching_expected (uri)) {
+      printf ("Caching credentials is not expected. Skipping tests expecting "
+              "credential caching.\n");
+      return;
+   }
+
+   if (!can_setenv ()) {
+      printf ("Process is unable to setenv. Skipping tests that require "
+              "setting environment variables\n");
+      return;
+   }
+
+   // Clear the cache.
+   _mongoc_aws_credentials_cache_clear ();
+
+   // Create a new client.
+   {
+      mongoc_client_t *client = mongoc_client_new_from_uri (uri);
+      ASSERT (client);
+
+      // Ensure that a ``find`` operation adds credentials to the cache.
+      ASSERTF (
+         do_find (client, &error), "expected success, got: %s", error.message);
+      bool found = _mongoc_aws_credentials_cache_get (&creds);
+      ASSERT (found);
+      _mongoc_aws_credentials_cleanup (&creds);
+
+      // Set the AWS environment variables based on the cached credentials.
+      ASSERT (_mongoc_setenv (
+         "AWS_ACCESS_KEY_ID",
+         mongoc_aws_credentials_cache.cached.value.access_key_id));
+      ASSERT (_mongoc_setenv (
+         "AWS_SECRET_ACCESS_KEY",
+         mongoc_aws_credentials_cache.cached.value.secret_access_key));
+      ASSERT (_mongoc_setenv (
+         "AWS_SESSION_TOKEN",
+         mongoc_aws_credentials_cache.cached.value.session_token));
+
+      // Clear the cache.
+      _mongoc_aws_credentials_cache_clear ();
+      mongoc_client_destroy (client);
+   }
+
+   // Create a new client.
+   {
+      mongoc_client_t *client = mongoc_client_new_from_uri (uri);
+      ASSERT (client);
+      // Ensure that a ``find`` operation succeeds and does not add credentials
+      // to the cache.
+      ASSERTF (
+         do_find (client, &error), "expected success, got: %s", error.message);
+      bool found = _mongoc_aws_credentials_cache_get (&creds);
+      ASSERT (!found);
+      _mongoc_aws_credentials_cleanup (&creds);
+      mongoc_client_destroy (client);
+   }
+
+   // Set the AWS environment variables to invalid values.
+   ASSERT (_mongoc_setenv ("AWS_ACCESS_KEY_ID", "invalid"));
+
+   // Create a new client.
+   {
+      mongoc_client_t *client = mongoc_client_new_from_uri (uri);
+      ASSERT (client);
+      // Ensure that a ``find`` operation results in an error.
+      ASSERT (!do_find (client, &error));
+      ASSERTF (NULL != strstr (error.message, "Authentication failed"),
+               "Expected error to contain '%s', but got '%s'",
+               "Authentication failed",
+               error.message);
+      mongoc_client_destroy (client);
+   }
+
+   // Clear the AWS environment variables.
+   clear_env ();
+
+   // Clear the cache.
+   _mongoc_aws_credentials_cache_clear ();
+
+   // Create a new client.
+   {
+      mongoc_client_t *client = mongoc_client_new_from_uri (uri);
+      ASSERT (client);
+
+      // Ensure that a ``find`` operation adds credentials to the cache.
+      ASSERTF (
+         do_find (client, &error), "expected success, got: %s", error.message);
+      bool found = _mongoc_aws_credentials_cache_get (&creds);
+      ASSERT (found);
+      _mongoc_aws_credentials_cleanup (&creds);
+      mongoc_client_destroy (client);
+   }
+
+   // Set the AWS environment variables to invalid values.
+   ASSERT (_mongoc_setenv ("AWS_ACCESS_KEY_ID", "invalid"));
+
+   // Create a new client.
+   {
+      mongoc_client_t *client = mongoc_client_new_from_uri (uri);
+      ASSERT (client);
+
+      // Ensure that a ``find`` operation succeeds.
+      ASSERTF (
+         do_find (client, &error), "expected success, got: %s", error.message);
+      bool found = _mongoc_aws_credentials_cache_get (&creds);
+      ASSERT (found);
+      _mongoc_aws_credentials_cleanup (&creds);
+      mongoc_client_destroy (client);
+   }
+
+   // Clear the AWS environment variables.
+   clear_env ();
+}
+
+BSON_THREAD_FUN (auth_fn, uri_void)
+{
+   bson_error_t error;
+   const mongoc_uri_t *uri = uri_void;
+
+   mongoc_client_t *client = mongoc_client_new_from_uri (uri);
+   ASSERT (client);
+
+   // Ensure that a ``find`` operation succeeds.
+   ASSERTF (
+      do_find (client, &error), "expected success, got: %s", error.message);
+   mongoc_client_destroy (client);
+
+   BSON_THREAD_RETURN;
+}
+
+static void
+test_multithreaded (const mongoc_uri_t *uri)
+{
+   // Test authenticating in many threads concurrently.
+   bson_thread_t threads[64];
+   for (size_t i = 0; i < sizeof threads / sizeof threads[0]; i++) {
+      ASSERT (0 == mcommon_thread_create (&threads[i], auth_fn, (void *) uri));
+   }
+
+   for (size_t i = 0; i < sizeof threads / sizeof threads[0]; i++) {
+      ASSERT (0 == mcommon_thread_join (threads[i]));
+   }
+
+   // Verify that credentials are cached.
+   if (caching_expected (uri)) {
+      // Assert credentials are cached.
+      _mongoc_aws_credentials_t creds;
+      bool found = _mongoc_aws_credentials_cache_get (&creds);
+      ASSERT (found);
+      _mongoc_aws_credentials_cleanup (&creds);
+   }
+}
+
+int
+main (int argc, char *argv[])
+{
+   mongoc_database_t *db;
+   mongoc_client_t *client;
+   bson_error_t error;
+   mongoc_uri_t *uri;
+   bool expect_failure;
+
+   if (argc != 3) {
+      FAILF ("usage: %s URI [EXPECT_SUCCESS|EXPECT_FAILURE]\n", argv[0]);
+   }
+
+   mongoc_init ();
+
+   uri = mongoc_uri_new_with_error (argv[1], &error);
+   ASSERTF (uri, "Failed to create URI: %s", error.message);
+
+   if (0 == strcmp (argv[2], "EXPECT_FAILURE")) {
+      expect_failure = true;
+   } else if (0 == strcmp (argv[2], "EXPECT_SUCCESS")) {
+      expect_failure = false;
+   } else {
+      FAILF (
+         "Expected 'EXPECT_FAILURE' or 'EXPECT_SUCCESS' for argument. Got: %s",
+         argv[2]);
+   }
+
+   client = mongoc_client_new_from_uri (uri);
+   ASSERT (client);
+
+   mongoc_client_set_error_api (client, MONGOC_ERROR_API_VERSION_2);
+   db = mongoc_client_get_database (client, "test");
+   test_auth (db, expect_failure);
+   if (!expect_failure) {
+      // The test_cache_* functions implement the "Cached Credentials" tests
+      // from the specification.
+      test_cache (uri);
+      test_cache_with_env (uri);
+      test_multithreaded (uri);
+   }
+
+   mongoc_database_destroy (db);
+   mongoc_uri_destroy (uri);
+   mongoc_client_destroy (client);
+
+   printf ("%s tests passed\n", argv[0]);
+
+   mongoc_cleanup ();
+   return EXIT_SUCCESS;
+}

--- a/src/libmongoc/tests/test-mongoc-aws.c
+++ b/src/libmongoc/tests/test-mongoc-aws.c
@@ -272,6 +272,89 @@ test_derive_region (void *unused)
 #undef WITH_LEN
 }
 
+// test_aws_cache unit tests the _mongoc_aws_credentials_cache_t. It does not
+// require libmongoc to be built with MONGOC_ENABLE_MONGODB_AWS_AUTH.
+static void
+test_aws_cache (void)
+{
+   struct timeval now;
+   ASSERT_CMPINT (0, ==, bson_gettimeofday (&now));
+   uint64_t now_ms = (1000 * now.tv_sec) + (now.tv_usec / 1000);
+
+   _mongoc_aws_credentials_t valid_creds = {0};
+   valid_creds.access_key_id = bson_strdup ("access_key_id");
+   valid_creds.secret_access_key = bson_strdup ("secret_access_key");
+   valid_creds.session_token = bson_strdup ("session_token");
+   // Set expiration to one minute after window.
+   valid_creds.expiration_ms =
+      now_ms + MONGOC_AWS_CREDENTIALS_EXPIRATION_WINDOW_MS + (60 * 1000);
+
+   _mongoc_aws_credentials_t expired_creds = {0};
+   expired_creds.access_key_id = bson_strdup ("access_key_id");
+   expired_creds.secret_access_key = bson_strdup ("secret_access_key");
+   expired_creds.session_token = bson_strdup ("session_token");
+   // Set expiration to one minute before window.
+   expired_creds.expiration_ms =
+      now_ms + MONGOC_AWS_CREDENTIALS_EXPIRATION_WINDOW_MS - (60 * 1000);
+
+   _mongoc_aws_credentials_cache_t *cache = &mongoc_aws_credentials_cache;
+   _mongoc_aws_credentials_cache_clear ();
+
+   // Expect `get` to return nothing initially.
+   {
+      _mongoc_aws_credentials_t got = {0};
+      bool found = _mongoc_aws_credentials_cache_get (&got);
+      ASSERT (!found);
+   }
+
+   // Expect `get` to return after valid credentials are added with `put`.
+   {
+      _mongoc_aws_credentials_t got = {0};
+      _mongoc_aws_credentials_cache_put (&valid_creds);
+      bool found = _mongoc_aws_credentials_cache_get (&got);
+      ASSERT (found);
+      ASSERT_CMPSTR (got.access_key_id, valid_creds.access_key_id);
+      ASSERT_CMPSTR (got.secret_access_key, valid_creds.secret_access_key);
+      ASSERT_CMPSTR (got.session_token, valid_creds.session_token);
+      _mongoc_aws_credentials_cleanup (&got);
+   }
+
+   // Expect `clear` to clear cached credentials.
+   {
+      _mongoc_aws_credentials_t got = {0};
+      _mongoc_aws_credentials_cache_put (&valid_creds);
+      _mongoc_aws_credentials_cache_clear ();
+      bool found = _mongoc_aws_credentials_cache_get (&got);
+      ASSERT (!found);
+   }
+
+   // Expect expired credentials are not added to cache.
+   {
+      _mongoc_aws_credentials_t got = {0};
+      _mongoc_aws_credentials_cache_put (&expired_creds);
+      bool found = _mongoc_aws_credentials_cache_get (&got);
+      ASSERT (!found);
+   }
+
+   // Expect credentials that expire are not returned from cache.
+   {
+      _mongoc_aws_credentials_t got = {0};
+      _mongoc_aws_credentials_cache_put (&valid_creds);
+      bool found = _mongoc_aws_credentials_cache_get (&got);
+      ASSERT (found);
+
+      // Manually expire the credentials.
+      cache->cached.value.expiration_ms = expired_creds.expiration_ms;
+      found = _mongoc_aws_credentials_cache_get (&got);
+      ASSERT (!found);
+      _mongoc_aws_credentials_cleanup (&got);
+   }
+
+   _mongoc_aws_credentials_cache_clear ();
+   _mongoc_aws_credentials_cleanup (&expired_creds);
+   _mongoc_aws_credentials_cleanup (&valid_creds);
+}
+
 void
 test_aws_install (TestSuite *suite)
 {
@@ -294,4 +377,5 @@ test_aws_install (TestSuite *suite)
                       NULL /* dtor */,
                       NULL /* ctx */,
                       test_framework_skip_if_no_aws);
+   TestSuite_Add (suite, "/aws/cache", test_aws_cache);
 }


### PR DESCRIPTION
# Summary
- Add global cache for AWS credentials.
- Add a new target, `test-awsauth`, to test new auth in AWS environments.

Verified with [this patch build](https://spruce.mongodb.com/version/63ed00e2a4cf4704208111ef) of AWS tasks.

# Background & Motivation

DRIVERS-2333 describes the required behavior.

The `test-awsauth` target replaces `mongoc-ping` in AWS tests. `test-awsauth` includes caching tests specific to AWS authentication. `test-awsauth` requires access to API in private headers to modify the cache.

## Cache locking
The cache is locked when making requests for credentials that may be cached.
This is consistent with the AWS SDK behavior [locking around fetching](https://github.com/aws/aws-sdk-cpp/blob/91eb614069aab1b3da3bf724c95a0500aac26705/src/aws-cpp-sdk-core/source/auth/AWSCredentialsProvider.cpp#L432-L447).
I assume this is intended to prevent duplicate requests.