### PR TITLE
Remove windows-64-2016 from Evergreen config

### DIFF
--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -160,7 +160,6 @@ WINDOWS_DISTROS = [
     Distro(name='windows-2022-large', os='windows', os_type='windows', os_ver='2022'),
     Distro(name='windows-2022-small', os='windows', os_type='windows', os_ver='2022'),
 
-    Distro(name='windows-64-2016', os='windows', os_type='windows', os_ver='2016'),
     Distro(name='windows-64-2019', os='windows', os_type='windows', os_ver='2019'),
 
     Distro(name='windows-64-vsMulti-small', os='windows', os_type='windows', vs_ver='vsMulti', size='small'),

--- a/.evergreen/scripts/find-cmake-version.sh
+++ b/.evergreen/scripts/find-cmake-version.sh
@@ -35,12 +35,7 @@ local_cache_dir() {
   declare res
   case "${OSTYPE:?}" in
   cygwin)
-    if [[ "${distro_id:?}" == windows-64-2016 ]]; then
-      # Remove once BUILD-16821 is resolved.
-      res="${HOME:?}/.cache" || return
-    else
-      res="$(cygpath -au "${LOCALAPPDATA:?}")" || return
-    fi
+    res="$(cygpath -au "${LOCALAPPDATA:?}")" || return
     ;;
   darwin*)
     res="${HOME:?}/Library/Caches"


### PR DESCRIPTION
We currently do not use the windows-64-2016 distro. Discussion in BUILD-16821 suggests we shouldn't/won't be using it in the foreseeable future either.