### PR TITLE
Update /scram/auth_tests to handle SCRAM-SHA-256 error messages

### DIFF
--- a/src/libmongoc/tests/test-mongoc-scram.c
+++ b/src/libmongoc/tests/test-mongoc-scram.c
@@ -267,16 +267,24 @@ typedef enum {
 void
 _check_error (const bson_error_t *error, test_error_t expected_error)
 {
-   int32_t domain = 0;
-   int32_t code = 0;
+   uint32_t domain = 0;
+   uint32_t code = 0;
    const char *message = "";
 
    switch (expected_error) {
-   case MONGOC_TEST_AUTH_ERROR:
+   case MONGOC_TEST_AUTH_ERROR: {
       domain = MONGOC_ERROR_CLIENT;
       code = MONGOC_ERROR_CLIENT_AUTHENTICATE;
-      message = "Authentication failed";
+      ASSERT_CMPUINT32 (error->domain, ==, domain);
+      ASSERT_CMPUINT32 (error->code, ==, code);
+      const char *const a = "Authentication failed";
+      const char *const b = "Unable to use";
+      const bool found =
+         strstr (error->message, a) || strstr (error->message, b);
+      ASSERT_WITH_MSG (
+         found, "[%s] does not contain [%s] or [%s]", error->message, a, b);
       break;
+   }
    case MONGOC_TEST_USER_NOT_FOUND_ERROR:
       domain = MONGOC_ERROR_CLIENT;
       code = MONGOC_ERROR_CLIENT_AUTHENTICATE;


### PR DESCRIPTION
Verified by [this patch](https://spruce.mongodb.com/version/63f8e55657e85a26ee8a71ed/tasks).

Several tasks on Evergreen are [currently failing](https://spruce.mongodb.com/version/mongo_c_driver_8eaac64c6893c717ac6af3bfdb4aac870848ee43/tasks) due to an unexpected error message in `/scram/auth_tests` that does not satisfy the expected substring search:

> src/libmongoc/tests/test-mongoc-scram.c:295 _check_error(): [Unable to use SCRAM-SHA-256 based authentication for user without any SCRAM-SHA-256 credentials registered] does not contain [Authentication failed]

It is unclear why the error message has changed. This PR simply proposes modifying the test to account for new error message in its expected output.