### PR TITLE
CDRIVER-4081 Add support for `AssumeRoleWithWebIdentity` in AWS Auth

### DIFF
--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -267,7 +267,12 @@ functions:
             "iam_auth_assume_role_name" : "${iam_auth_assume_role_name}",
             "iam_auth_ec2_instance_account" : "${iam_auth_ec2_instance_account}",
             "iam_auth_ec2_instance_secret_access_key" : "${iam_auth_ec2_instance_secret_access_key}",
-            "iam_auth_ec2_instance_profile" : "${iam_auth_ec2_instance_profile}"
+            "iam_auth_ec2_instance_profile" : "${iam_auth_ec2_instance_profile}",
+            "iam_auth_assume_web_role_name": "${iam_auth_assume_web_role_name}",
+            "iam_web_identity_issuer": "${iam_web_identity_issuer}",
+            "iam_web_identity_rsa_key": "${iam_web_identity_rsa_key}",
+            "iam_web_identity_jwks_uri": "${iam_web_identity_jwks_uri}",
+            "iam_web_identity_token_file": "${iam_web_identity_token_file}"
         }
         EOF
   - command: shell.exec
@@ -2050,6 +2055,57 @@ tasks:
   - func: run aws tests
     vars:
       TESTCASE: ASSUME_ROLE
+- name: test-aws-openssl-assume_role_with_web_identity-latest
+  depends_on:
+    name: debug-compile-aws
+  commands:
+  - func: fetch-build
+    vars:
+      BUILD_NAME: debug-compile-aws
+  - func: fetch-det
+  - func: bootstrap-mongo-orchestration
+    vars:
+      AUTH: auth
+      MONGODB_VERSION: latest
+      ORCHESTRATION_FILE: auth-aws
+      TOPOLOGY: server
+  - func: run aws tests
+    vars:
+      TESTCASE: ASSUME_ROLE_WITH_WEB_IDENTITY
+- name: test-aws-openssl-assume_role_with_web_identity-5.0
+  depends_on:
+    name: debug-compile-aws
+  commands:
+  - func: fetch-build
+    vars:
+      BUILD_NAME: debug-compile-aws
+  - func: fetch-det
+  - func: bootstrap-mongo-orchestration
+    vars:
+      AUTH: auth
+      MONGODB_VERSION: '5.0'
+      ORCHESTRATION_FILE: auth-aws
+      TOPOLOGY: server
+  - func: run aws tests
+    vars:
+      TESTCASE: ASSUME_ROLE_WITH_WEB_IDENTITY
+- name: test-aws-openssl-assume_role_with_web_identity-4.4
+  depends_on:
+    name: debug-compile-aws
+  commands:
+  - func: fetch-build
+    vars:
+      BUILD_NAME: debug-compile-aws
+  - func: fetch-det
+  - func: bootstrap-mongo-orchestration
+    vars:
+      AUTH: auth
+      MONGODB_VERSION: '4.4'
+      ORCHESTRATION_FILE: auth-aws
+      TOPOLOGY: server
+  - func: run aws tests
+    vars:
+      TESTCASE: ASSUME_ROLE_WITH_WEB_IDENTITY
 - name: ocsp-openssl-test_1-rsa-delegate-latest
   tags:
   - ocsp-openssl
@@ -9639,6 +9695,9 @@ buildvariants:
   - test-aws-openssl-ecs-4.4
   - test-aws-openssl-assume_role-4.4
   - test-aws-openssl-lambda-4.4
+  - test-aws-openssl-assume_role_with_web_identity-latest
+  - test-aws-openssl-assume_role_with_web_identity-5.0
+  - test-aws-openssl-assume_role_with_web_identity-4.4
 - name: mongohouse
   display_name: Mongohouse Test
   run_on: ubuntu1804-test

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/functions.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/functions.py
@@ -193,7 +193,12 @@ all_functions = OD([
             "iam_auth_assume_role_name" : "${iam_auth_assume_role_name}",
             "iam_auth_ec2_instance_account" : "${iam_auth_ec2_instance_account}",
             "iam_auth_ec2_instance_secret_access_key" : "${iam_auth_ec2_instance_secret_access_key}",
-            "iam_auth_ec2_instance_profile" : "${iam_auth_ec2_instance_profile}"
+            "iam_auth_ec2_instance_profile" : "${iam_auth_ec2_instance_profile}",
+            "iam_auth_assume_web_role_name": "${iam_auth_assume_web_role_name}",
+            "iam_web_identity_issuer": "${iam_web_identity_issuer}",
+            "iam_web_identity_rsa_key": "${iam_web_identity_rsa_key}",
+            "iam_web_identity_jwks_uri": "${iam_web_identity_jwks_uri}",
+            "iam_web_identity_token_file": "${iam_web_identity_token_file}"
         }
         EOF
         ''', silent=True),

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -826,7 +826,7 @@ all_tasks = chain(all_tasks, [aws_compile_task])
 
 
 class AWSTestTask(MatrixTask):
-    axes = OD([('testcase', ['regular', 'ec2', 'ecs', 'lambda', 'assume_role']),
+    axes = OD([('testcase', ['regular', 'ec2', 'ecs', 'lambda', 'assume_role', 'assume_role_with_web_identity']),
                ('version', ['latest', '5.0', '4.4'])])
 
     name_prefix = 'test-aws-openssl'

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -397,7 +397,10 @@ all_variants = [
         'test-aws-openssl-ec2-4.4',
         'test-aws-openssl-ecs-4.4',
         'test-aws-openssl-assume_role-4.4',
-        'test-aws-openssl-lambda-4.4'
+        'test-aws-openssl-lambda-4.4',
+        'test-aws-openssl-assume_role_with_web_identity-latest',
+        'test-aws-openssl-assume_role_with_web_identity-5.0',
+        'test-aws-openssl-assume_role_with_web_identity-4.4',
     ], {'CC': 'clang'}),
     Variant('mongohouse',
             'Mongohouse Test',

--- a/.evergreen/scripts/run-aws-tests.sh
+++ b/.evergreen/scripts/run-aws-tests.sh
@@ -174,19 +174,23 @@ if [[ "${TESTCASE}" == "ASSUME_ROLE_WITH_WEB_IDENTITY" ]]; then
   AWS_ROLE_ARN="${iam_auth_assume_web_role_name}" \
   AWS_WEB_IDENTITY_TOKEN_FILE="${iam_web_identity_token_file}" \
     expect_success "mongodb://localhost/?authMechanism=MONGODB-AWS"
+
   echo "Valid credentials via Web Identity with session name - should succeed"
   AWS_ROLE_ARN="${iam_auth_assume_web_role_name}" \
   AWS_WEB_IDENTITY_TOKEN_FILE="${iam_web_identity_token_file}" \
   AWS_ROLE_SESSION_NAME=test \
     expect_success "mongodb://localhost/?authMechanism=MONGODB-AWS"
+
   echo "Invalid AWS_ROLE_ARN via Web Identity with session name - should fail"
   AWS_ROLE_ARN="invalid_role_arn" \
   AWS_WEB_IDENTITY_TOKEN_FILE="${iam_web_identity_token_file}" \
     expect_failure "mongodb://localhost/?authMechanism=MONGODB-AWS"
+
   echo "Invalid AWS_WEB_IDENTITY_TOKEN_FILE via Web Identity with session name - should fail"
   AWS_ROLE_ARN="${iam_auth_assume_web_role_name}" \
   AWS_WEB_IDENTITY_TOKEN_FILE="/invalid/path" \
     expect_failure "mongodb://localhost/?authMechanism=MONGODB-AWS"
+
   echo "Invalid AWS_ROLE_SESSION_NAME via Web Identity with session name - should fail"
   AWS_ROLE_ARN="${iam_auth_assume_web_role_name}" \
   AWS_WEB_IDENTITY_TOKEN_FILE="${iam_web_identity_token_file}" \

--- a/src/libbson/src/bson/bson-string.c
+++ b/src/libbson/src/bson/bson-string.c
@@ -90,7 +90,9 @@ bson_string_free (bson_string_t *string, /* IN */
 {
    char *ret = NULL;
 
-   BSON_ASSERT (string);
+   if (!string) {
+      return NULL;
+   }
 
    if (!free_segment) {
       ret = string->str;

--- a/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
@@ -495,9 +495,9 @@ _obtain_creds_from_assumerolewithwebidentity (_mongoc_aws_credentials_t *creds,
    bool ret = false;
    char *http_response_headers = NULL;
    char *http_response_body = NULL;
-   char *AWS_WEB_IDENTITY_TOKEN_FILE = NULL;
-   char *AWS_ROLE_ARN = NULL;
-   char *AWS_ROLE_SESSION_NAME = NULL;
+   char *aws_web_identity_token_file = NULL;
+   char *aws_role_arn = NULL;
+   char *aws_role_session_name = NULL;
    bson_t *response_bson = NULL;
    bson_iter_t iter;
    const char *access_key_id = NULL;
@@ -508,21 +508,21 @@ _obtain_creds_from_assumerolewithwebidentity (_mongoc_aws_credentials_t *creds,
    bson_string_t *token_file_contents = NULL;
    char *path_and_query = NULL;
 
-   AWS_WEB_IDENTITY_TOKEN_FILE = _mongoc_getenv ("AWS_WEB_IDENTITY_TOKEN_FILE");
-   AWS_ROLE_ARN = _mongoc_getenv ("AWS_ROLE_ARN");
-   if (!AWS_WEB_IDENTITY_TOKEN_FILE ||
-       strlen (AWS_WEB_IDENTITY_TOKEN_FILE) == 0 || !AWS_ROLE_ARN ||
-       strlen (AWS_ROLE_ARN) == 0) {
-      bson_free (AWS_ROLE_ARN);
-      bson_free (AWS_WEB_IDENTITY_TOKEN_FILE);
+   aws_web_identity_token_file = _mongoc_getenv ("AWS_WEB_IDENTITY_TOKEN_FILE");
+   aws_role_arn = _mongoc_getenv ("AWS_ROLE_ARN");
+   if (!aws_web_identity_token_file ||
+       strlen (aws_web_identity_token_file) == 0 || !aws_role_arn ||
+       strlen (aws_role_arn) == 0) {
+      bson_free (aws_role_arn);
+      bson_free (aws_web_identity_token_file);
       // Not an error. May need to obtain credentials another way.
       return true;
    }
 
-   AWS_ROLE_SESSION_NAME = _mongoc_getenv ("AWS_ROLE_SESSION_NAME");
-   if (!AWS_ROLE_SESSION_NAME) {
-      AWS_ROLE_SESSION_NAME = generate_AWS_ROLE_SESSION_NAME (error);
-      if (!AWS_ROLE_SESSION_NAME) {
+   aws_role_session_name = _mongoc_getenv ("AWS_ROLE_SESSION_NAME");
+   if (!aws_role_session_name) {
+      aws_role_session_name = generate_AWS_ROLE_SESSION_NAME (error);
+      if (!aws_role_session_name) {
          goto fail;
       }
    }
@@ -530,11 +530,11 @@ _obtain_creds_from_assumerolewithwebidentity (_mongoc_aws_credentials_t *creds,
    // Read the contents of the file given by ``AWS_WEB_IDENTITY_TOKEN_FILE``.
    {
       fstream = mongoc_stream_file_new_for_path (
-         AWS_WEB_IDENTITY_TOKEN_FILE, O_RDONLY, 0);
+         aws_web_identity_token_file, O_RDONLY, 0);
       if (!fstream) {
          AUTH_ERROR_AND_FAIL (
             "failed to open AWS_WEB_IDENTITY_TOKEN_FILE: %s. Reason: %s",
-            AWS_WEB_IDENTITY_TOKEN_FILE,
+            aws_web_identity_token_file,
             strerror (errno));
       }
 
@@ -559,7 +559,7 @@ _obtain_creds_from_assumerolewithwebidentity (_mongoc_aws_credentials_t *creds,
          } else {
             AUTH_ERROR_AND_FAIL (
                "failed to read AWS_WEB_IDENTITY_TOKEN_FILE: %s. Reason: %s",
-               AWS_WEB_IDENTITY_TOKEN_FILE,
+               aws_web_identity_token_file,
                strerror (errno));
          }
       }
@@ -568,8 +568,8 @@ _obtain_creds_from_assumerolewithwebidentity (_mongoc_aws_credentials_t *creds,
    path_and_query =
       bson_strdup_printf ("/?Action=AssumeRoleWithWebIdentity&RoleSessionName=%"
                           "s&RoleArn=%s&WebIdentityToken=%s&Version=2011-06-15",
-                          AWS_ROLE_SESSION_NAME,
-                          AWS_ROLE_ARN,
+                          aws_role_session_name,
+                          aws_role_arn,
                           token_file_contents->str);
 
    // send an HTTP request to sts.amazonaws.com.
@@ -690,9 +690,9 @@ fail:
    bson_free (http_response_body);
    bson_string_free (token_file_contents, true /* free segment */);
    mongoc_stream_destroy (fstream);
-   bson_free (AWS_ROLE_SESSION_NAME);
-   bson_free (AWS_ROLE_ARN);
-   bson_free (AWS_WEB_IDENTITY_TOKEN_FILE);
+   bson_free (aws_role_session_name);
+   bson_free (aws_role_arn);
+   bson_free (aws_web_identity_token_file);
    return ret;
 }
 

--- a/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
@@ -668,7 +668,7 @@ _obtain_creds_from_assumerolewithwebidentity (_mongoc_aws_credentials_t *creds,
       // "Expiration" is returned as a double representing the number of seconds
       // since Unix Epoch. This differs from the ISO-8601 string returned in EC2
       // and ECS responses.
-      int64_t expiration_ms = ((int64_t) bson_iter_double (&iter)) * 1000;
+      int64_t expiration_ms = (int64_t) (1000.0 * bson_iter_double (&iter));
       if (!expiration_ms_to_timer (
              expiration_ms, &creds->expiration.value, error)) {
          goto fail;

--- a/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
@@ -545,7 +545,7 @@ _obtain_creds_from_assumerolewithwebidentity (_mongoc_aws_credentials_t *creds,
          ssize_t got = mongoc_stream_read (
             fstream,
             buf,
-            sizeof (buf) - 1 /* subtract 1 to for null terminator */,
+            sizeof (buf) - 1 /* leave space for null terminator */,
             0 /* min_bytes */,
             0 /* timeout_msec. Unused for file stream. */);
 

--- a/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
@@ -566,8 +566,10 @@ _obtain_creds_from_assumerolewithwebidentity (_mongoc_aws_credentials_t *creds,
    }
 
    path_and_query =
-      bson_strdup_printf ("/?Action=AssumeRoleWithWebIdentity&RoleSessionName=%"
-                          "s&RoleArn=%s&WebIdentityToken=%s&Version=2011-06-15",
+      bson_strdup_printf ("/?Action=AssumeRoleWithWebIdentity"
+                          "&RoleSessionName=%s"
+                          "&RoleArn=%s"
+                          "&WebIdentityToken=%s&Version=2011-06-15",
                           aws_role_session_name,
                           aws_role_arn,
                           token_file_contents->str);

--- a/src/libmongoc/src/mongoc/mongoc-http.c
+++ b/src/libmongoc/src/mongoc/mongoc-http.c
@@ -217,7 +217,7 @@ _mongoc_http_send (const mongoc_http_request_t *req,
       if (bytes_read <= 0) {
          break;
       }
-      if (http_response_buf.datalen > 1024 * 1024 * 8) {
+      if (http_response_buf.len > 1024 * 1024 * 8) {
          bson_set_error (error,
                          MONGOC_ERROR_STREAM,
                          MONGOC_ERROR_STREAM_SOCKET,
@@ -243,8 +243,7 @@ _mongoc_http_send (const mongoc_http_request_t *req,
    }
 
    http_response_str = (char *) http_response_buf.data;
-   const char *const resp_end_ptr =
-      http_response_str + http_response_buf.datalen;
+   const char *const resp_end_ptr = http_response_str + http_response_buf.len;
 
 
    const char *proto_leader_10 = "HTTP/1.0 ";

--- a/src/libmongoc/src/mongoc/mongoc-util-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-util-private.h
@@ -241,6 +241,12 @@ _mongoc_iter_document_as_bson (const bson_iter_t *iter,
                                bson_t *bson,
                                bson_error_t *error);
 
+uint8_t *
+hex_to_bin (const char *hex, uint32_t *len);
+
+char *
+bin_to_hex (const uint8_t *bin, uint32_t len);
+
 BSON_END_DECLS
 
 #endif /* MONGOC_UTIL_PRIVATE_H */

--- a/src/libmongoc/src/mongoc/mongoc-util.c
+++ b/src/libmongoc/src/mongoc/mongoc-util.c
@@ -903,3 +903,42 @@ _mongoc_iter_document_as_bson (const bson_iter_t *iter,
 
    return true;
 }
+
+uint8_t *
+hex_to_bin (const char *hex, uint32_t *len)
+{
+   int i;
+   int hex_len;
+   uint8_t *out;
+
+   hex_len = strlen (hex);
+   if (hex_len % 2 != 0) {
+      return NULL;
+   }
+
+   *len = hex_len / 2;
+   out = bson_malloc0 (*len);
+
+   for (i = 0; i < hex_len; i += 2) {
+      uint32_t hex_char;
+
+      if (1 != sscanf (hex + i, "%2x", &hex_char)) {
+         bson_free (out);
+         return NULL;
+      }
+      out[i / 2] = (uint8_t) hex_char;
+   }
+   return out;
+}
+
+char *
+bin_to_hex (const uint8_t *bin, uint32_t len)
+{
+   char *out = bson_malloc0 (2 * len + 1);
+   uint32_t i;
+
+   for (i = 0; i < len; i++) {
+      bson_snprintf (out + (2 * i), 3, "%02x", bin[i]);
+   }
+   return out;
+}

--- a/src/libmongoc/tests/bsonutil/bson-match.c
+++ b/src/libmongoc/tests/bsonutil/bson-match.c
@@ -15,6 +15,7 @@
  */
 
 #include "bsonutil/bson-match.h"
+#include "mongoc-util-private.h" // hex_to_bin
 #include "test-conveniences.h"
 #include "TestSuite.h"
 #include "unified/util.h"

--- a/src/libmongoc/tests/test-mongoc-util.c
+++ b/src/libmongoc/tests/test-mongoc-util.c
@@ -92,6 +92,29 @@ test_wire_server_versions (void)
       "_mongoc_wire_version_to_server_version");
 }
 
+static void
+test_bin_to_hex (void)
+{
+   const char *bin = "foobar";
+   const char *expect = "666f6f626172";
+
+   char *got = bin_to_hex ((const uint8_t *) bin, strlen (bin));
+   ASSERT_CMPSTR (got, expect);
+   bson_free (got);
+}
+
+static void
+test_hex_to_bin (void)
+{
+   const char *hexstr = "666f6f62617200";
+   const char *expect = "foobar";
+
+   uint32_t len;
+   uint8_t *got = hex_to_bin (hexstr, &len);
+   ASSERT_CMPSTR ((const char *) got, expect);
+   ASSERT_CMPUINT32 (len, ==, 7);
+   bson_free (got);
+}
 
 void
 test_util_install (TestSuite *suite)
@@ -101,4 +124,6 @@ test_util_install (TestSuite *suite)
    TestSuite_Add (suite, "/Util/lowercase_utf8", test_lowercase_utf8);
    TestSuite_Add (
       suite, "/Util/wire_server_versions", test_wire_server_versions);
+   TestSuite_Add (suite, "/Util/bin_to_hex", test_bin_to_hex);
+   TestSuite_Add (suite, "/Util/hex_to_bin", test_hex_to_bin);
 }

--- a/src/libmongoc/tests/unified/operation.c
+++ b/src/libmongoc/tests/unified/operation.c
@@ -17,6 +17,7 @@
 #include "operation.h"
 
 #include "mongoc-array-private.h"
+#include "mongoc-util-private.h" // hex_to_bin
 #include "result.h"
 #include "test-diagnostics.h"
 #include "util.h"

--- a/src/libmongoc/tests/unified/util.c
+++ b/src/libmongoc/tests/unified/util.c
@@ -53,7 +53,7 @@ bin_to_hex (const uint8_t *bin, uint32_t len)
    uint32_t i;
 
    for (i = 0; i < len; i++) {
-      bson_snprintf (out + (2 * i), 2, "%02x", bin[i]);
+      bson_snprintf (out + (2 * i), 3, "%02x", bin[i]);
    }
    return out;
 }

--- a/src/libmongoc/tests/unified/util.c
+++ b/src/libmongoc/tests/unified/util.c
@@ -19,45 +19,6 @@
 #include "test-conveniences.h"
 #include "TestSuite.h"
 
-uint8_t *
-hex_to_bin (const char *hex, uint32_t *len)
-{
-   int i;
-   int hex_len;
-   uint8_t *out;
-
-   hex_len = strlen (hex);
-   if (hex_len % 2 != 0) {
-      return NULL;
-   }
-
-   *len = hex_len / 2;
-   out = bson_malloc0 (*len);
-
-   for (i = 0; i < hex_len; i += 2) {
-      uint32_t hex_char;
-
-      if (1 != sscanf (hex + i, "%2x", &hex_char)) {
-         bson_free (out);
-         return NULL;
-      }
-      out[i / 2] = (uint8_t) hex_char;
-   }
-   return out;
-}
-
-char *
-bin_to_hex (const uint8_t *bin, uint32_t len)
-{
-   char *out = bson_malloc0 (2 * len + 1);
-   uint32_t i;
-
-   for (i = 0; i < len; i++) {
-      bson_snprintf (out + (2 * i), 3, "%02x", bin[i]);
-   }
-   return out;
-}
-
 static int
 cmp_key (const void *a, const void *b)
 {

--- a/src/libmongoc/tests/unified/util.h
+++ b/src/libmongoc/tests/unified/util.h
@@ -19,12 +19,6 @@
 
 #include "mongoc/mongoc.h"
 
-uint8_t *
-hex_to_bin (const char *hex, uint32_t *len);
-
-char *
-bin_to_hex (const uint8_t *bin, uint32_t len);
-
 bson_t *
 bson_copy_and_sort (const bson_t *in);
 

--- a/src/libmongoc/tests/unified/util.h
+++ b/src/libmongoc/tests/unified/util.h
@@ -34,7 +34,9 @@ bson_type_from_string (const char *in);
 const char *
 bson_type_to_string (bson_type_t btype);
 
-/* Returns true if this is an event type (part of observeEvents or expectedEvents) that is unsupported and not emitted by the C driver. */
-bool is_unsupported_event_type (const char* event_type);
+/* Returns true if this is an event type (part of observeEvents or
+ * expectedEvents) that is unsupported and not emitted by the C driver. */
+bool
+is_unsupported_event_type (const char *event_type);
 
 #endif /* UNIFIED_UTIL_H */


### PR DESCRIPTION
# Summary
- Add support for `AssumeRoleWithWebIdentity` in AWS Auth

## Other improvements
- Fix length in `_mongoc_http_send`.
- Fix size arg in `bin_to_hex` utility.
- Ignore NULL for `bson_string_free`. 

AWS tasks were verified in this [Evergreen patch build](https://spruce.mongodb.com/version/63ff8372850e612de432d042).

# Background & Motivation

The specification change is described in DRIVERS-1746.

`generate_AWS_ROLE_SESSION_NAME` generates a random 32 character hex string to generate `AWS_ROLE_SESSION_NAME` if needed:

> If ``AWS_ROLE_SESSION_NAME`` is set, it MUST be used for the ``RoleSessionName`` parameter, otherwise a suitable random name can be chosen.

https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html lists the constraints for RoleSessionName:

> Length Constraints: Minimum length of 2. Maximum length of 64.
> Pattern: [\w+=,.@-]*