### PR TITLE
Disable /speculative_auth tests when SASL is disabled

### DIFF
--- a/src/libmongoc/tests/test-mongoc-speculative-auth.c
+++ b/src/libmongoc/tests/test-mongoc-speculative-auth.c
@@ -434,7 +434,7 @@ test_mongoc_speculative_auth_request_scram_pool (void)
 void
 test_speculative_auth_install (TestSuite *suite)
 {
-#ifdef MONGOC_ENABLE_CRYPTO
+#if defined(MONGOC_ENABLE_CRYPTO) && defined(MONGOC_ENABLE_SASL)
    TestSuite_AddMockServerTest (suite,
                                 "/speculative_auth/request_none",
                                 test_mongoc_speculative_auth_request_none);
@@ -457,5 +457,5 @@ test_speculative_auth_install (TestSuite *suite)
       suite,
       "/speculative_auth_pool/request_scram",
       test_mongoc_speculative_auth_request_scram_pool);
-#endif /* MONGOC_ENABLE_CRYPTO */
+#endif // defined(MONGOC_ENABLE_CRYPTO) && defined(MONGOC_ENABLE_SASL)
 }


### PR DESCRIPTION
My understanding is that the speculative auth tests require SASL for correct behavior, but are not being disabled when SASL is disabled. This PR adds a `MONGOC_ENABLE_SASL` check in addition the existing `MONGOC_ENABLE_CRYPTO` check to avoid running SASL tests when crypto is enabled but SASL is disabled (not a normal/expected configuration, but nevertheless).