### PR TITLE
Disable retryable handshakes by default for mock server tests

### DIFF
--- a/src/libmongoc/tests/mock_server/mock-rs.c
+++ b/src/libmongoc/tests/mock_server/mock-rs.c
@@ -103,6 +103,11 @@ make_uri (mongoc_array_t *servers)
 
    uri = mongoc_uri_new (uri_str->str);
 
+   // Many mock server tests do not expect retryable handshakes. Disable by
+   // default: tests that expect or require retryable handshakes must opt-in.
+   mongoc_uri_set_option_as_bool (uri, MONGOC_URI_RETRYREADS, false);
+   mongoc_uri_set_option_as_bool (uri, MONGOC_URI_RETRYWRITES, false);
+
    bson_string_free (uri_str, true);
 
    return uri;

--- a/src/libmongoc/tests/mock_server/mock-server.c
+++ b/src/libmongoc/tests/mock_server/mock-server.c
@@ -391,6 +391,11 @@ mock_server_run (mock_server_t *server)
       bound_port);
    server->uri = mongoc_uri_new (server->uri_str);
 
+   // Many mock server tests do not expect retryable handshakes. Disable by
+   // default: tests that expect or require retryable handshakes must opt-in.
+   mongoc_uri_set_option_as_bool (server->uri, MONGOC_URI_RETRYREADS, false);
+   mongoc_uri_set_option_as_bool (server->uri, MONGOC_URI_RETRYWRITES, false);
+
    r = mcommon_thread_create (
       &server->main_thread, main_thread, (void *) server);
    BSON_ASSERT (r == 0);

--- a/src/libmongoc/tests/test-mongoc-bulk.c
+++ b/src/libmongoc/tests/test-mongoc-bulk.c
@@ -2918,9 +2918,6 @@ test_unordered_bulk_writes_with_error (void)
                            mock_server_get_host_and_port (server));
 
    uri = mongoc_uri_copy (mock_server_get_uri (server));
-   /* disable retryable writes, so we move to the next operation on error */
-   mongoc_uri_set_option_as_bool (uri, MONGOC_URI_RETRYWRITES, false);
-
    client = test_framework_client_new_from_uri (uri, NULL);
 
    collection = mongoc_client_get_collection (client, "db", "test");

--- a/src/libmongoc/tests/test-mongoc-cluster.c
+++ b/src/libmongoc/tests/test-mongoc-cluster.c
@@ -174,7 +174,6 @@ _test_cluster_node_disconnect (bool pooled)
    mock_server_run (server);
 
    uri = mongoc_uri_copy (mock_server_get_uri (server));
-   mongoc_uri_set_option_as_bool (uri, MONGOC_URI_RETRYREADS, false);
 
    if (pooled) {
       pool = test_framework_client_pool_new_from_uri (uri, NULL);
@@ -1368,8 +1367,6 @@ _test_cluster_hello_fails (bool hangup)
    uri = mongoc_uri_copy (mock_server_get_uri (mock_server));
    /* increase heartbeatFrequencyMS to prevent background server selection. */
    mongoc_uri_set_option_as_int32 (uri, MONGOC_URI_HEARTBEATFREQUENCYMS, 99999);
-   /* prevent retryable handshakes from interfering with mock server hangups */
-   mongoc_uri_set_option_as_bool (uri, MONGOC_URI_RETRYREADS, false);
    pool = test_framework_client_pool_new_from_uri (uri, NULL);
    mongoc_client_pool_set_error_api (pool, 2);
    mongoc_uri_destroy (uri);

--- a/src/libmongoc/tests/test-mongoc-database.c
+++ b/src/libmongoc/tests/test-mongoc-database.c
@@ -1089,7 +1089,6 @@ test_get_collection_names_error (void)
                            WIRE_VERSION_MAX);
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));
-   mongoc_uri_set_option_as_bool (uri, MONGOC_URI_RETRYREADS, false);
    client = test_framework_client_new_from_uri (uri, NULL);
 
    database = mongoc_client_get_database (client, "test");

--- a/src/libmongoc/tests/test-mongoc-loadbalanced.c
+++ b/src/libmongoc/tests/test-mongoc-loadbalanced.c
@@ -564,7 +564,6 @@ test_pre_handshake_error_does_not_clear_pool (void)
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_bool (uri, MONGOC_URI_LOADBALANCED, true);
-   mongoc_uri_set_option_as_bool (uri, MONGOC_URI_RETRYREADS, false);
    pool = mongoc_client_pool_new (uri);
    client_1 = mongoc_client_pool_pop (pool);
    client_2 = mongoc_client_pool_pop (pool);

--- a/src/libmongoc/tests/test-mongoc-retryable-reads.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-reads.c
@@ -93,7 +93,7 @@ test_cmd_helpers (void *ctx)
    BSON_UNUSED (ctx);
 
    uri = test_framework_get_uri ();
-   mongoc_uri_set_option_as_bool (uri, "retryReads", true);
+   mongoc_uri_set_option_as_bool (uri, MONGOC_URI_RETRYREADS, true);
 
    client = test_framework_client_new_from_uri (uri, NULL);
    mongoc_client_set_error_api (client, MONGOC_ERROR_API_VERSION_2);

--- a/src/libmongoc/tests/test-mongoc-retryable-writes.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-writes.c
@@ -80,7 +80,7 @@ test_rs_failover (void)
 
    mock_rs_run (rs);
    uri = mongoc_uri_copy (mock_rs_get_uri (rs));
-   mongoc_uri_set_option_as_bool (uri, "retryWrites", true);
+   mongoc_uri_set_option_as_bool (uri, MONGOC_URI_RETRYWRITES, true);
    client = test_framework_client_new_from_uri (uri, NULL);
    collection = mongoc_client_get_collection (client, "db", "collection");
    cs = mongoc_client_start_session (client, NULL, &error);
@@ -144,7 +144,7 @@ test_command_with_opts (void *ctx)
    BSON_UNUSED (ctx);
 
    uri = test_framework_get_uri ();
-   mongoc_uri_set_option_as_bool (uri, "retryWrites", true);
+   mongoc_uri_set_option_as_bool (uri, MONGOC_URI_RETRYWRITES, true);
 
    client = test_framework_client_new_from_uri (uri, NULL);
    test_framework_set_ssl_opts (client);
@@ -216,7 +216,7 @@ test_insert_one_unacknowledged (void)
    server = mock_mongos_new (WIRE_VERSION_RETRY_WRITES);
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));
-   mongoc_uri_set_option_as_bool (uri, "retryWrites", true);
+   mongoc_uri_set_option_as_bool (uri, MONGOC_URI_RETRYWRITES, true);
    client = test_framework_client_new_from_uri (uri, NULL);
    collection = mongoc_client_get_collection (client, "db", "collection");
 
@@ -264,7 +264,7 @@ test_update_one_unacknowledged (void)
    server = mock_mongos_new (WIRE_VERSION_RETRY_WRITES);
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));
-   mongoc_uri_set_option_as_bool (uri, "retryWrites", true);
+   mongoc_uri_set_option_as_bool (uri, MONGOC_URI_RETRYWRITES, true);
    client = test_framework_client_new_from_uri (uri, NULL);
    collection = mongoc_client_get_collection (client, "db", "collection");
 
@@ -315,7 +315,7 @@ test_delete_one_unacknowledged (void)
    server = mock_mongos_new (WIRE_VERSION_RETRY_WRITES);
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));
-   mongoc_uri_set_option_as_bool (uri, "retryWrites", true);
+   mongoc_uri_set_option_as_bool (uri, MONGOC_URI_RETRYWRITES, true);
    client = test_framework_client_new_from_uri (uri, NULL);
    collection = mongoc_client_get_collection (client, "db", "collection");
 
@@ -363,7 +363,7 @@ test_bulk_operation_execute_unacknowledged (void)
    server = mock_mongos_new (WIRE_VERSION_RETRY_WRITES);
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));
-   mongoc_uri_set_option_as_bool (uri, "retryWrites", true);
+   mongoc_uri_set_option_as_bool (uri, MONGOC_URI_RETRYWRITES, true);
    client = test_framework_client_new_from_uri (uri, NULL);
    collection = mongoc_client_get_collection (client, "db", "collection");
 
@@ -412,7 +412,7 @@ test_remove_unacknowledged (void)
    server = mock_mongos_new (WIRE_VERSION_RETRY_WRITES);
    mock_server_run (server);
    uri = mongoc_uri_copy (mock_server_get_uri (server));
-   mongoc_uri_set_option_as_bool (uri, "retryWrites", true);
+   mongoc_uri_set_option_as_bool (uri, MONGOC_URI_RETRYWRITES, true);
    client = test_framework_client_new_from_uri (uri, NULL);
    collection = mongoc_client_get_collection (client, "db", "collection");
 
@@ -519,6 +519,7 @@ static void
 test_unsupported_storage_engine_error (void)
 {
    mock_rs_t *rs;
+   mongoc_uri_t *uri;
    mongoc_client_t *client;
    mongoc_collection_t *coll;
    bson_t reply;
@@ -533,7 +534,9 @@ test_unsupported_storage_engine_error (void)
 
    rs = mock_rs_with_auto_hello (WIRE_VERSION_RETRY_WRITES, true, 0, 0);
    mock_rs_run (rs);
-   client = test_framework_client_new_from_uri (mock_rs_get_uri (rs), NULL);
+   uri = mongoc_uri_copy (mock_rs_get_uri (rs));
+   mongoc_uri_set_option_as_bool (uri, MONGOC_URI_RETRYWRITES, true);
+   client = test_framework_client_new_from_uri (uri, NULL);
    session = mongoc_client_start_session (client, NULL, &error);
    ASSERT_OR_PRINT (session, error);
    mongoc_client_set_error_api (client, MONGOC_ERROR_API_VERSION_2);
@@ -566,6 +569,7 @@ test_unsupported_storage_engine_error (void)
    future_destroy (future);
    mongoc_collection_destroy (coll);
    mongoc_client_destroy (client);
+   mongoc_uri_destroy (uri);
    mock_rs_destroy (rs);
 }
 


### PR DESCRIPTION
There have been several mock server tests since https://github.com/mongodb/mongo-c-driver/pull/1141 was merged that required manually disabling retryable handshakes to maintain correct test behavior (i.e. expectations that a single mock server hangup request should trigger progress). This PR removes those workarounds in favor of setting `retryReads=false` and `retryWrites=false` by default in the URI returned by `mock_server_get_uri` and `mock_rs_get_uri`. Mock server tests that actually require retryable handshakes are thus appropriately limited to `test-mongoc-retryable-reads.c` and `test-mongoc-retryable-writes.c` where `retryReads=true` or `retryWrites=true` is explicitly set as needed.