### PR TITLE
CDRIVER-4590 don't call ERR_load_BIO_strings for OpenSSL 3.0+

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-openssl.c
@@ -77,6 +77,7 @@ _mongoc_openssl_init (void)
    SSL_library_init ();
    SSL_load_error_strings ();
 #if OPENSSL_VERSION_NUMBER < 0x30000000L
+   // See: https://www.openssl.org/docs/man3.0/man7/migration_guide.html#Deprecated-function-mappings
    ERR_load_BIO_strings ();
 #endif
    OpenSSL_add_all_algorithms ();

--- a/src/libmongoc/src/mongoc/mongoc-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-openssl.c
@@ -76,7 +76,9 @@ _mongoc_openssl_init (void)
 
    SSL_library_init ();
    SSL_load_error_strings ();
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
    ERR_load_BIO_strings ();
+#endif
    OpenSSL_add_all_algorithms ();
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
    _mongoc_openssl_thread_startup ();


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-4590

OpenSSL 3.0 loads error strings automatically and deprecated this function.