### PR TITLE
add "or equal to" to version compare macro

### DIFF
--- a/src/libbson/src/bson/bson-version.h.in
+++ b/src/libbson/src/bson/bson-version.h.in
@@ -90,7 +90,7 @@
  * @micro: required micro version
  *
  * Compile-time version checking. Evaluates to %TRUE if the version
- * of BSON is greater than the required one.
+ * of BSON is greater than or equal to the required one.
  */
 #define BSON_CHECK_VERSION(major,minor,micro)   \
         (BSON_MAJOR_VERSION > (major) || \

--- a/src/libmongoc/src/mongoc/mongoc-version.h.in
+++ b/src/libmongoc/src/mongoc/mongoc-version.h.in
@@ -91,7 +91,7 @@
  * @micro: required micro version
  *
  * Compile-time version checking. Evaluates to %TRUE if the version
- * of MONGOC is greater than the required one.
+ * of MONGOC is greater than or equal to the required one.
  */
 #define MONGOC_CHECK_VERSION(major,minor,micro)   \
         (MONGOC_MAJOR_VERSION > (major) || \


### PR DESCRIPTION
# Summary

- add "or equal to" to `MONGOC_CHECK_VERSION` and `BSON_CHECK_VERSION`

# Background & Motivation

This is a documentation fix to correctly describe the behavior.
`MONGOC_CHECK_VERSION` and `BSON_CHECK_VERSION` are also documented in RST with "greater than or equal to" behavior:
- http://mongoc.org/libmongoc/current/mongoc_version.html
- http://mongoc.org/libbson/current/version.html