### PR TITLE
CDRIVER-2964 Add test-atlas-executor for Atlas Planned Maintenance Tests

### DIFF
--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -952,7 +952,6 @@ target_sources (test-libmongoc-lib PRIVATE
    ${PROJECT_SOURCE_DIR}/tests/mock_server/sync-queue.c
    ${PROJECT_SOURCE_DIR}/tests/test-conveniences.c
    ${PROJECT_SOURCE_DIR}/tests/test-happy-eyeballs.c
-   ${PROJECT_SOURCE_DIR}/tests/test-libmongoc.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-aggregate.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-array.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-async.c
@@ -1073,7 +1072,7 @@ function (mongoc_add_test test)
 endfunction ()
 
 mongoc_add_test (test-libmongoc ${PROJECT_SOURCE_DIR}/tests/test-libmongoc-main.c)
-mongoc_add_test (test-atlas-executor ${PROJECT_SOURCE_DIR}/tests/test-atlas-executor)
+mongoc_add_test (test-atlas-executor ${PROJECT_SOURCE_DIR}/tests/test-atlas-executor.c)
 mongoc_add_test (test-mongoc-gssapi ${PROJECT_SOURCE_DIR}/tests/test-mongoc-gssapi.c)
 mongoc_add_test (test-mongoc-cache ${PROJECT_SOURCE_DIR}/tests/test-mongoc-cache.c)
 mongoc_add_test (test-azurekms ${PROJECT_SOURCE_DIR}/tests/test-azurekms.c)

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -1046,6 +1046,7 @@ function (mongoc_add_test test use_shared)
 endfunction ()
 
 mongoc_add_test (test-libmongoc FALSE ${PROJECT_SOURCE_DIR}/tests/test-libmongoc-main.c)
+mongoc_add_test (test-atlas-executor FALSE ${PROJECT_SOURCE_DIR}/tests/test-atlas-executor)
 mongoc_add_test (test-mongoc-gssapi FALSE ${PROJECT_SOURCE_DIR}/tests/test-mongoc-gssapi.c)
 mongoc_add_test (test-mongoc-cache FALSE ${PROJECT_SOURCE_DIR}/tests/test-mongoc-cache.c)
 mongoc_add_test (test-azurekms FALSE ${PROJECT_SOURCE_DIR}/tests/test-azurekms.c)

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -1035,6 +1035,10 @@ if (ENABLE_TESTS)
             $<$<C_COMPILER_ID:MSVC>:DbgHelp.dll>
             mongoc_static
       )
+      # We have tests that test our deprecated api.
+      target_compile_options (test-libmongoc-lib
+         PRIVATE $<$<NOT:$<C_COMPILER_ID:MSVC>>:-Wno-deprecated-declarations>
+      )
       target_include_directories (${test}
          PRIVATE
             ${PROJECT_SOURCE_DIR}/tests

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -1036,7 +1036,7 @@ if (ENABLE_TESTS)
             mongoc_static
       )
       # We have tests that test our deprecated api.
-      target_compile_options (test-libmongoc-lib
+      target_compile_options (${test}
          PRIVATE $<$<NOT:$<C_COMPILER_ID:MSVC>>:-Wno-deprecated-declarations>
       )
       target_include_directories (${test}

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -759,20 +759,9 @@ if (MONGOC_ENABLE_MONGODB_AWS_AUTH)
    endif()
 endif ()
 
-set (MONGOC_INTERNAL_INCLUDE_DIRS
-   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src>
-   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src/mongoc>
-   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
-   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/mongoc>
-   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/../../src/common>
-   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/../../src>
-   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/../../src/common>
-)
-
 add_library (mongoc_shared SHARED ${SOURCES} ${HEADERS} ${HEADERS_FORWARDING})
 set_target_properties (mongoc_shared PROPERTIES CMAKE_CXX_VISIBILITY_PRESET hidden)
 target_link_libraries (mongoc_shared PRIVATE ${LIBRARIES} PUBLIC ${BSON_LIBRARIES})
-target_include_directories (mongoc_shared BEFORE PRIVATE ${MONGOC_INTERNAL_INCLUDE_DIRS})
 target_include_directories (mongoc_shared PRIVATE ${ZLIB_INCLUDE_DIRS})
 target_include_directories (mongoc_shared PRIVATE ${LIBMONGOCRYPT_INCLUDE_DIRECTORIES})
 if (MONGOC_ENABLE_MONGODB_AWS_AUTH)
@@ -814,7 +803,6 @@ if (MONGOC_ENABLE_STATIC_BUILD)
       target_compile_options (mongoc_static PUBLIC -fPIC)
       message ("Adding -fPIC to compilation of mongoc_static components")
    endif ()
-   target_include_directories (mongoc_static BEFORE PRIVATE ${MONGOC_INTERNAL_INCLUDE_DIRS})
    target_include_directories (mongoc_static PRIVATE ${ZLIB_INCLUDE_DIRS})
    target_include_directories (mongoc_static PRIVATE ${LIBMONGOCRYPT_INCLUDE_DIRECTORIES})
    if (MONGOC_ENABLE_MONGODB_AWS_AUTH)
@@ -867,51 +855,7 @@ if (ENABLE_SHM_COUNTERS STREQUAL "ON")
    )
 endif ()
 
-add_library (test-libmongoc-lib STATIC
-   # At least once source file is required prior to CMake 3.11.
-   # Add the rest of the files with target_sources later below.
-   ${PROJECT_SOURCE_DIR}/tests/test-libmongoc.c
-)
-
-target_link_libraries (test-libmongoc-lib
-   PUBLIC
-      $<$<C_COMPILER_ID:MSVC>:DbgHelp.dll>
-      $<$<PLATFORM_ID:Windows>:shlwapi>
-      $<$<BOOL:${use_shared}>:mongoc_shared>
-      $<$<NOT:$<BOOL:${use_shared}>>:mongoc_static>
-      ${LIBRARIES}
-      ${RESOLV_LIBRARIES}
-)
-# We have tests that test our deprecated api.
-target_compile_options (test-libmongoc-lib
-   PUBLIC $<$<NOT:$<C_COMPILER_ID:MSVC>>:-Wno-deprecated-declarations>
-)
-target_include_directories (test-libmongoc-lib BEFORE PUBLIC ${MONGOC_INTERNAL_INCLUDE_DIRS})
-target_include_directories (test-libmongoc-lib
-   PUBLIC
-      ${PROJECT_SOURCE_DIR}/tests
-      $<$<BOOL:${use_shared}>:${BSON_INCLUDE_DIRS}>
-      $<$<NOT:$<BOOL:${use_shared}>>:${BSON_STATIC_INCLUDE_DIRS}>
-)
-target_compile_definitions (test-libmongoc-lib
-   PUBLIC
-      "MONGOC_COMPILATION"
-      "BSON_COMPILATION"
-      "MCOMMON_NAME_PREFIX=_mongoc_mcommon"
-)
-
-function (mongoc_add_example example)
-   if (ENABLE_EXAMPLES)
-      add_executable (${example} ${ARGN})
-      target_link_libraries (${example} PRIVATE mongoc_shared ${LIBRARIES})
-      if (WIN32)
-         target_link_libraries (${example} PRIVATE shlwapi)
-      endif ()
-      set (EXAMPLES ${EXAMPLES} ${example})
-   endif ()
-endfunction ()
-
-target_sources (test-libmongoc-lib PRIVATE
+set (test-libmongoc-sources
    ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/corpus-test.c
    ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/corpus-test.h
    ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/test-atomic.c
@@ -952,6 +896,7 @@ target_sources (test-libmongoc-lib PRIVATE
    ${PROJECT_SOURCE_DIR}/tests/mock_server/sync-queue.c
    ${PROJECT_SOURCE_DIR}/tests/test-conveniences.c
    ${PROJECT_SOURCE_DIR}/tests/test-happy-eyeballs.c
+   ${PROJECT_SOURCE_DIR}/tests/test-libmongoc.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-aggregate.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-array.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-async.c
@@ -1048,7 +993,7 @@ target_sources (test-libmongoc-lib PRIVATE
 )
 
 if (MONGOC_ENABLE_SSL)
-   target_sources (test-libmongoc-lib PRIVATE
+   set (test-libmongoc-sources ${test-libmongoc-sources}
       ${PROJECT_SOURCE_DIR}/tests/ssl-test.c
       ${PROJECT_SOURCE_DIR}/tests/test-mongoc-client-side-encryption.c
       ${PROJECT_SOURCE_DIR}/tests/test-mongoc-stream-tls-error.c
@@ -1059,27 +1004,62 @@ if (MONGOC_ENABLE_SSL)
 endif ()
 
 if (MONGOC_ENABLE_SASL_CYRUS)
-   target_sources (test-libmongoc-lib PRIVATE
+   set (test-libmongoc-sources ${test-libmongoc-sources}
       ${PROJECT_SOURCE_DIR}/tests/test-mongoc-cyrus.c
    )
 endif ()
 
-function (mongoc_add_test test)
-   if (ENABLE_TESTS)
-      add_executable (${test} ${ARGN})
-      target_link_libraries (${test} PUBLIC test-libmongoc-lib)
-   endif ()
-endfunction ()
-
-mongoc_add_test (test-libmongoc ${PROJECT_SOURCE_DIR}/tests/test-libmongoc-main.c)
-mongoc_add_test (test-atlas-executor ${PROJECT_SOURCE_DIR}/tests/test-atlas-executor.c)
-mongoc_add_test (test-mongoc-gssapi ${PROJECT_SOURCE_DIR}/tests/test-mongoc-gssapi.c)
-mongoc_add_test (test-mongoc-cache ${PROJECT_SOURCE_DIR}/tests/test-mongoc-cache.c)
-mongoc_add_test (test-azurekms ${PROJECT_SOURCE_DIR}/tests/test-azurekms.c)
-mongoc_add_test (test-gcpkms ${PROJECT_SOURCE_DIR}/tests/test-gcpkms.c)
-mongoc_add_test (test-awsauth ${PROJECT_SOURCE_DIR}/tests/test-awsauth.c)
-
 if (ENABLE_TESTS)
+   add_library (test-libmongoc-lib STATIC ${test-libmongoc-sources})
+   target_link_libraries (test-libmongoc-lib PUBLIC mongoc_static)
+   # We have tests that test our deprecated api.
+   target_compile_options (test-libmongoc-lib
+      PRIVATE $<$<NOT:$<C_COMPILER_ID:MSVC>>:-Wno-deprecated-declarations>
+   )
+   target_include_directories (test-libmongoc-lib
+      PRIVATE
+         ${PROJECT_SOURCE_DIR}/tests
+         ${BSON_STATIC_INCLUDE_DIRS}
+   )
+   target_compile_definitions (test-libmongoc-lib
+      PUBLIC
+         "MONGOC_COMPILATION"
+         "BSON_COMPILATION"
+         "MCOMMON_NAME_PREFIX=_mongoc_mcommon"
+   )
+
+   function (mongoc_add_test test)
+      add_executable (${test} ${ARGN})
+      target_link_libraries (${test}
+         PUBLIC
+            $<$<C_COMPILER_ID:MSVC>:DbgHelp.dll>
+            mongoc_static
+      )
+      target_include_directories (${test}
+         PRIVATE
+            ${PROJECT_SOURCE_DIR}/tests
+            ${BSON_STATIC_INCLUDE_DIRS}
+      )
+      target_compile_definitions (${test}
+         PUBLIC
+            "MONGOC_COMPILATION"
+            "BSON_COMPILATION"
+            "MCOMMON_NAME_PREFIX=_mongoc_mcommon"
+      )
+   endfunction ()
+
+   mongoc_add_test (test-libmongoc ${PROJECT_SOURCE_DIR}/tests/test-libmongoc-main.c)
+   target_link_libraries (test-libmongoc PUBLIC test-libmongoc-lib)
+
+   mongoc_add_test (test-atlas-executor ${PROJECT_SOURCE_DIR}/tests/test-atlas-executor.c)
+   target_link_libraries (test-atlas-executor PUBLIC test-libmongoc-lib)
+
+   mongoc_add_test (test-mongoc-gssapi ${PROJECT_SOURCE_DIR}/tests/test-mongoc-gssapi.c)
+   mongoc_add_test (test-mongoc-cache ${PROJECT_SOURCE_DIR}/tests/test-mongoc-cache.c)
+   mongoc_add_test (test-azurekms ${PROJECT_SOURCE_DIR}/tests/test-azurekms.c)
+   mongoc_add_test (test-gcpkms ${PROJECT_SOURCE_DIR}/tests/test-gcpkms.c)
+   mongoc_add_test (test-awsauth ${PROJECT_SOURCE_DIR}/tests/test-awsauth.c)
+
    # "make test" doesn't compile tests, so we create "make check" which compiles
    # and runs tests: https://gitlab.kitware.com/cmake/cmake/issues/8774
    add_custom_target (check COMMAND ${CMAKE_CTEST_COMMAND} -V
@@ -1087,60 +1067,71 @@ if (ENABLE_TESTS)
    )
 endif ()
 
-# examples/
-mongoc_add_example (example-client ${PROJECT_SOURCE_DIR}/examples/example-client.c)
-mongoc_add_example (example-collection-watch ${PROJECT_SOURCE_DIR}/examples/example-collection-watch.c)
-if (NOT WIN32)
-   mongoc_add_example (example-resume ${PROJECT_SOURCE_DIR}/examples/example-resume.c)
-endif()
-mongoc_add_example (example-start-at-optime ${PROJECT_SOURCE_DIR}/examples/example-start-at-optime.c)
-mongoc_add_example (example-command-monitoring ${PROJECT_SOURCE_DIR}/examples/example-command-monitoring.c)
-mongoc_add_example (example-command-with-opts ${PROJECT_SOURCE_DIR}/examples/example-command-with-opts.c)
-mongoc_add_example (example-create-indexes ${PROJECT_SOURCE_DIR}/examples/example-create-indexes.c)
-mongoc_add_example (example-gridfs ${PROJECT_SOURCE_DIR}/examples/example-gridfs.c)
-mongoc_add_example (example-gridfs-bucket ${PROJECT_SOURCE_DIR}/examples/example-gridfs-bucket.c)
-if (NOT WIN32 AND ENABLE_EXAMPLES)
-   mongoc_add_example (example-pool ${PROJECT_SOURCE_DIR}/examples/example-pool.c)
-   target_link_libraries (example-pool PRIVATE Threads::Threads)
-endif ()
-mongoc_add_example (example-scram ${PROJECT_SOURCE_DIR}/examples/example-scram.c)
-mongoc_add_example (example-sdam-monitoring ${PROJECT_SOURCE_DIR}/examples/example-sdam-monitoring.c)
-mongoc_add_example (example-session ${PROJECT_SOURCE_DIR}/examples/example-session.c)
-mongoc_add_example (example-transaction ${PROJECT_SOURCE_DIR}/examples/example-transaction.c)
-mongoc_add_example (example-update ${PROJECT_SOURCE_DIR}/examples/example-update.c)
-mongoc_add_example (find-and-modify ${PROJECT_SOURCE_DIR}/examples/find-and-modify.c)
-mongoc_add_example (hello_mongoc ${PROJECT_SOURCE_DIR}/examples/hello_mongoc.c)
-mongoc_add_example (mongoc-dump ${PROJECT_SOURCE_DIR}/examples/mongoc-dump.c)
-mongoc_add_example (mongoc-ping ${PROJECT_SOURCE_DIR}/examples/mongoc-ping.c)
-mongoc_add_example (mongoc-tail ${PROJECT_SOURCE_DIR}/examples/mongoc-tail.c)
+if (ENABLE_EXAMPLES)
+   function (mongoc_add_example example)
+      add_executable (${example} ${ARGN})
+      target_link_libraries (${example} mongoc_shared ${LIBRARIES})
+      if (WIN32)
+         target_link_libraries (${example} shlwapi)
+      endif ()
+      set (EXAMPLES ${EXAMPLES} ${example})
+   endfunction ()
 
-# examples/aggregation/
-mongoc_add_example (aggregation1 ${PROJECT_SOURCE_DIR}/examples/aggregation/aggregation1.c)
+   # examples/
+   mongoc_add_example (example-client ${PROJECT_SOURCE_DIR}/examples/example-client.c)
+   mongoc_add_example (example-collection-watch ${PROJECT_SOURCE_DIR}/examples/example-collection-watch.c)
+   if (NOT WIN32)
+      mongoc_add_example (example-resume ${PROJECT_SOURCE_DIR}/examples/example-resume.c)
+   endif()
+   mongoc_add_example (example-start-at-optime ${PROJECT_SOURCE_DIR}/examples/example-start-at-optime.c)
+   mongoc_add_example (example-command-monitoring ${PROJECT_SOURCE_DIR}/examples/example-command-monitoring.c)
+   mongoc_add_example (example-command-with-opts ${PROJECT_SOURCE_DIR}/examples/example-command-with-opts.c)
+   mongoc_add_example (example-create-indexes ${PROJECT_SOURCE_DIR}/examples/example-create-indexes.c)
+   mongoc_add_example (example-gridfs ${PROJECT_SOURCE_DIR}/examples/example-gridfs.c)
+   mongoc_add_example (example-gridfs-bucket ${PROJECT_SOURCE_DIR}/examples/example-gridfs-bucket.c)
+   if (NOT WIN32 AND ENABLE_EXAMPLES)
+      mongoc_add_example (example-pool ${PROJECT_SOURCE_DIR}/examples/example-pool.c)
+      target_link_libraries (example-pool Threads::Threads)
+   endif ()
+   mongoc_add_example (example-scram ${PROJECT_SOURCE_DIR}/examples/example-scram.c)
+   mongoc_add_example (example-sdam-monitoring ${PROJECT_SOURCE_DIR}/examples/example-sdam-monitoring.c)
+   mongoc_add_example (example-session ${PROJECT_SOURCE_DIR}/examples/example-session.c)
+   mongoc_add_example (example-transaction ${PROJECT_SOURCE_DIR}/examples/example-transaction.c)
+   mongoc_add_example (example-update ${PROJECT_SOURCE_DIR}/examples/example-update.c)
+   mongoc_add_example (find-and-modify ${PROJECT_SOURCE_DIR}/examples/find-and-modify.c)
+   mongoc_add_example (hello_mongoc ${PROJECT_SOURCE_DIR}/examples/hello_mongoc.c)
+   mongoc_add_example (mongoc-dump ${PROJECT_SOURCE_DIR}/examples/mongoc-dump.c)
+   mongoc_add_example (mongoc-ping ${PROJECT_SOURCE_DIR}/examples/mongoc-ping.c)
+   mongoc_add_example (mongoc-tail ${PROJECT_SOURCE_DIR}/examples/mongoc-tail.c)
 
-# examples/basic_aggregation/
-mongoc_add_example (basic-aggregation ${PROJECT_SOURCE_DIR}/examples/basic_aggregation/basic-aggregation.c)
+   # examples/aggregation/
+   mongoc_add_example (aggregation1 ${PROJECT_SOURCE_DIR}/examples/aggregation/aggregation1.c)
 
-# examples/bulk/
-mongoc_add_example (bulk-collation ${PROJECT_SOURCE_DIR}/examples/bulk/bulk-collation.c)
-mongoc_add_example (bulk1 ${PROJECT_SOURCE_DIR}/examples/bulk/bulk1.c)
-mongoc_add_example (bulk2 ${PROJECT_SOURCE_DIR}/examples/bulk/bulk2.c)
-mongoc_add_example (bulk3 ${PROJECT_SOURCE_DIR}/examples/bulk/bulk3.c)
-mongoc_add_example (bulk4 ${PROJECT_SOURCE_DIR}/examples/bulk/bulk4.c)
-mongoc_add_example (bulk5 ${PROJECT_SOURCE_DIR}/examples/bulk/bulk5.c)
-mongoc_add_example (bulk6 ${PROJECT_SOURCE_DIR}/examples/bulk/bulk6.c)
+   # examples/basic_aggregation/
+   mongoc_add_example (basic-aggregation ${PROJECT_SOURCE_DIR}/examples/basic_aggregation/basic-aggregation.c)
 
-# examples/common_operations/
-mongoc_add_example (common-operations ${PROJECT_SOURCE_DIR}/examples/common_operations/common-operations.c)
+   # examples/bulk/
+   mongoc_add_example (bulk-collation ${PROJECT_SOURCE_DIR}/examples/bulk/bulk-collation.c)
+   mongoc_add_example (bulk1 ${PROJECT_SOURCE_DIR}/examples/bulk/bulk1.c)
+   mongoc_add_example (bulk2 ${PROJECT_SOURCE_DIR}/examples/bulk/bulk2.c)
+   mongoc_add_example (bulk3 ${PROJECT_SOURCE_DIR}/examples/bulk/bulk3.c)
+   mongoc_add_example (bulk4 ${PROJECT_SOURCE_DIR}/examples/bulk/bulk4.c)
+   mongoc_add_example (bulk5 ${PROJECT_SOURCE_DIR}/examples/bulk/bulk5.c)
+   mongoc_add_example (bulk6 ${PROJECT_SOURCE_DIR}/examples/bulk/bulk6.c)
 
-# examples/find_and_modify_with_opts/
-mongoc_add_example (fam ${PROJECT_SOURCE_DIR}/examples/find_and_modify_with_opts/fam.c)
+   # examples/common_operations/
+   mongoc_add_example (common-operations ${PROJECT_SOURCE_DIR}/examples/common_operations/common-operations.c)
 
-if (MONGOC_ENABLE_CLIENT_SIDE_ENCRYPTION)
-   mongoc_add_example (client-side-encryption-schema-map ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-schema-map.c ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-helpers.c)
-   mongoc_add_example (client-side-encryption-server-schema ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-server-schema.c ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-helpers.c)
-   mongoc_add_example (client-side-encryption-explicit ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-explicit.c ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-helpers.c)
-   mongoc_add_example (client-side-encryption-auto-decryption ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-auto-decryption.c ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-helpers.c)
-   mongoc_add_example (client-side-encryption-doc-snippets ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-doc-snippets.c)
+   # examples/find_and_modify_with_opts/
+   mongoc_add_example (fam ${PROJECT_SOURCE_DIR}/examples/find_and_modify_with_opts/fam.c)
+
+   if (MONGOC_ENABLE_CLIENT_SIDE_ENCRYPTION)
+      mongoc_add_example (client-side-encryption-schema-map ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-schema-map.c ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-helpers.c)
+      mongoc_add_example (client-side-encryption-server-schema ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-server-schema.c ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-helpers.c)
+      mongoc_add_example (client-side-encryption-explicit ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-explicit.c ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-helpers.c)
+      mongoc_add_example (client-side-encryption-auto-decryption ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-auto-decryption.c ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-helpers.c)
+      mongoc_add_example (client-side-encryption-doc-snippets ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-doc-snippets.c)
+   endif ()
 endif ()
 
 file (COPY ${PROJECT_SOURCE_DIR}/tests/binary DESTINATION ${PROJECT_BINARY_DIR}/tests)

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -759,10 +759,20 @@ if (MONGOC_ENABLE_MONGODB_AWS_AUTH)
    endif()
 endif ()
 
+set (MONGOC_INTERNAL_INCLUDE_DIRS
+   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src>
+   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src/mongoc>
+   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/mongoc>
+   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/../../src/common>
+   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/../../src>
+   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/../../src/common>
+)
+
 add_library (mongoc_shared SHARED ${SOURCES} ${HEADERS} ${HEADERS_FORWARDING})
 set_target_properties (mongoc_shared PROPERTIES CMAKE_CXX_VISIBILITY_PRESET hidden)
 target_link_libraries (mongoc_shared PRIVATE ${LIBRARIES} PUBLIC ${BSON_LIBRARIES})
-target_include_directories (mongoc_shared BEFORE PUBLIC ${MONGOC_INTERNAL_INCLUDE_DIRS})
+target_include_directories (mongoc_shared BEFORE PRIVATE ${MONGOC_INTERNAL_INCLUDE_DIRS})
 target_include_directories (mongoc_shared PRIVATE ${ZLIB_INCLUDE_DIRS})
 target_include_directories (mongoc_shared PRIVATE ${LIBMONGOCRYPT_INCLUDE_DIRECTORIES})
 if (MONGOC_ENABLE_MONGODB_AWS_AUTH)
@@ -804,7 +814,7 @@ if (MONGOC_ENABLE_STATIC_BUILD)
       target_compile_options (mongoc_static PUBLIC -fPIC)
       message ("Adding -fPIC to compilation of mongoc_static components")
    endif ()
-   target_include_directories (mongoc_static BEFORE PUBLIC ${MONGOC_INTERNAL_INCLUDE_DIRS})
+   target_include_directories (mongoc_static BEFORE PRIVATE ${MONGOC_INTERNAL_INCLUDE_DIRS})
    target_include_directories (mongoc_static PRIVATE ${ZLIB_INCLUDE_DIRS})
    target_include_directories (mongoc_static PRIVATE ${LIBMONGOCRYPT_INCLUDE_DIRECTORIES})
    if (MONGOC_ENABLE_MONGODB_AWS_AUTH)
@@ -858,6 +868,50 @@ if (ENABLE_SHM_COUNTERS STREQUAL "ON")
 endif ()
 
 add_library (test-libmongoc-lib STATIC
+   # At least once source file is required prior to CMake 3.11.
+   # Add the rest of the files with target_sources later below.
+   ${PROJECT_SOURCE_DIR}/tests/test-libmongoc.c
+)
+
+target_link_libraries (test-libmongoc-lib
+   PUBLIC
+      $<$<C_COMPILER_ID:MSVC>:DbgHelp.dll>
+      $<$<PLATFORM_ID:Windows>:shlwapi>
+      $<$<BOOL:${use_shared}>:mongoc_shared>
+      $<$<NOT:$<BOOL:${use_shared}>>:mongoc_static>
+      ${LIBRARIES}
+      ${RESOLV_LIBRARIES}
+)
+# We have tests that test our deprecated api.
+target_compile_options (test-libmongoc-lib
+   PUBLIC $<$<NOT:$<C_COMPILER_ID:MSVC>>:-Wno-deprecated-declarations>
+)
+target_include_directories (test-libmongoc-lib BEFORE PUBLIC ${MONGOC_INTERNAL_INCLUDE_DIRS})
+target_include_directories (test-libmongoc-lib
+   PUBLIC
+      ${PROJECT_SOURCE_DIR}/tests
+      $<$<BOOL:${use_shared}>:${BSON_INCLUDE_DIRS}>
+      $<$<NOT:$<BOOL:${use_shared}>>:${BSON_STATIC_INCLUDE_DIRS}>
+)
+target_compile_definitions (test-libmongoc-lib
+   PUBLIC
+      "MONGOC_COMPILATION"
+      "BSON_COMPILATION"
+      "MCOMMON_NAME_PREFIX=_mongoc_mcommon"
+)
+
+function (mongoc_add_example example)
+   if (ENABLE_EXAMPLES)
+      add_executable (${example} ${ARGN})
+      target_link_libraries (${example} PRIVATE mongoc_shared ${LIBRARIES})
+      if (WIN32)
+         target_link_libraries (${example} PRIVATE shlwapi)
+      endif ()
+      set (EXAMPLES ${EXAMPLES} ${example})
+   endif ()
+endfunction ()
+
+target_sources (test-libmongoc-lib PRIVATE
    ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/corpus-test.c
    ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/corpus-test.h
    ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/test-atomic.c
@@ -1011,47 +1065,20 @@ if (MONGOC_ENABLE_SASL_CYRUS)
    )
 endif ()
 
-target_link_libraries (test-libmongoc-lib
-   PUBLIC
-      $<$<C_COMPILER_ID:MSVC>:DbgHelp.dll>
-      $<$<PLATFORM_ID:Windows>:shlwapi>
-      $<$<BOOL:${use_shared}>:mongoc_shared>
-      $<$<NOT:$<BOOL:${use_shared}>>:mongoc_static>
-      ${LIBRARIES}
-      ${RESOLV_LIBRARIES}
-)
-# We have tests that test our deprecated api.
-target_compile_options (test-libmongoc-lib
-   PUBLIC $<$<NOT:$<C_COMPILER_ID:MSVC>>:-Wno-deprecated-declarations>
-)
-target_include_directories (test-libmongoc-lib
-   PUBLIC
-      ${PROJECT_SOURCE_DIR}/tests
-      ${MONGOC_INTERNAL_INCLUDE_DIRS}
-      $<$<BOOL:${use_shared}>:${BSON_INCLUDE_DIRS}>
-      $<$<NOT:$<BOOL:${use_shared}>>:${BSON_STATIC_INCLUDE_DIRS}>
-)
-target_compile_definitions (test-libmongoc-lib
-   PUBLIC
-      "MONGOC_COMPILATION"
-      "BSON_COMPILATION"
-      "MCOMMON_NAME_PREFIX=_mongoc_mcommon"
-)
-
-function (mongoc_add_test test use_shared)
+function (mongoc_add_test test)
    if (ENABLE_TESTS)
       add_executable (${test} ${ARGN})
-      target_link_libraries (${test} PRIVATE test-libmongoc-lib)
+      target_link_libraries (${test} PUBLIC test-libmongoc-lib)
    endif ()
 endfunction ()
 
-mongoc_add_test (test-libmongoc FALSE ${PROJECT_SOURCE_DIR}/tests/test-libmongoc-main.c)
-mongoc_add_test (test-atlas-executor FALSE ${PROJECT_SOURCE_DIR}/tests/test-atlas-executor)
-mongoc_add_test (test-mongoc-gssapi FALSE ${PROJECT_SOURCE_DIR}/tests/test-mongoc-gssapi.c)
-mongoc_add_test (test-mongoc-cache FALSE ${PROJECT_SOURCE_DIR}/tests/test-mongoc-cache.c)
-mongoc_add_test (test-azurekms FALSE ${PROJECT_SOURCE_DIR}/tests/test-azurekms.c)
-mongoc_add_test (test-gcpkms FALSE ${PROJECT_SOURCE_DIR}/tests/test-gcpkms.c)
-mongoc_add_test (test-awsauth FALSE ${PROJECT_SOURCE_DIR}/tests/test-awsauth.c)
+mongoc_add_test (test-libmongoc ${PROJECT_SOURCE_DIR}/tests/test-libmongoc-main.c)
+mongoc_add_test (test-atlas-executor ${PROJECT_SOURCE_DIR}/tests/test-atlas-executor)
+mongoc_add_test (test-mongoc-gssapi ${PROJECT_SOURCE_DIR}/tests/test-mongoc-gssapi.c)
+mongoc_add_test (test-mongoc-cache ${PROJECT_SOURCE_DIR}/tests/test-mongoc-cache.c)
+mongoc_add_test (test-azurekms ${PROJECT_SOURCE_DIR}/tests/test-azurekms.c)
+mongoc_add_test (test-gcpkms ${PROJECT_SOURCE_DIR}/tests/test-gcpkms.c)
+mongoc_add_test (test-awsauth ${PROJECT_SOURCE_DIR}/tests/test-awsauth.c)
 
 if (ENABLE_TESTS)
    # "make test" doesn't compile tests, so we create "make check" which compiles
@@ -1061,75 +1088,60 @@ if (ENABLE_TESTS)
    )
 endif ()
 
-function (mongoc_add_example example use_shared)
-   if (ENABLE_EXAMPLES)
-      add_executable (${example} ${ARGN})
-      if (${use_shared})
-         target_link_libraries (${example} mongoc_shared ${LIBRARIES})
-      else ()
-         target_link_libraries (${example} mongoc_static ${LIBRARIES})
-      endif ()
-      if (WIN32)
-         target_link_libraries (${example} shlwapi)
-      endif ()
-      set (EXAMPLES ${EXAMPLES} ${example})
-   endif ()
-endfunction ()
-
 # examples/
-mongoc_add_example (example-client TRUE ${PROJECT_SOURCE_DIR}/examples/example-client.c)
-mongoc_add_example (example-collection-watch TRUE ${PROJECT_SOURCE_DIR}/examples/example-collection-watch.c)
+mongoc_add_example (example-client ${PROJECT_SOURCE_DIR}/examples/example-client.c)
+mongoc_add_example (example-collection-watch ${PROJECT_SOURCE_DIR}/examples/example-collection-watch.c)
 if (NOT WIN32)
-   mongoc_add_example (example-resume TRUE ${PROJECT_SOURCE_DIR}/examples/example-resume.c)
+   mongoc_add_example (example-resume ${PROJECT_SOURCE_DIR}/examples/example-resume.c)
 endif()
-mongoc_add_example (example-start-at-optime TRUE ${PROJECT_SOURCE_DIR}/examples/example-start-at-optime.c)
-mongoc_add_example (example-command-monitoring TRUE ${PROJECT_SOURCE_DIR}/examples/example-command-monitoring.c)
-mongoc_add_example (example-command-with-opts TRUE ${PROJECT_SOURCE_DIR}/examples/example-command-with-opts.c)
-mongoc_add_example (example-create-indexes TRUE ${PROJECT_SOURCE_DIR}/examples/example-create-indexes.c)
-mongoc_add_example (example-gridfs TRUE ${PROJECT_SOURCE_DIR}/examples/example-gridfs.c)
-mongoc_add_example (example-gridfs-bucket TRUE ${PROJECT_SOURCE_DIR}/examples/example-gridfs-bucket.c)
+mongoc_add_example (example-start-at-optime ${PROJECT_SOURCE_DIR}/examples/example-start-at-optime.c)
+mongoc_add_example (example-command-monitoring ${PROJECT_SOURCE_DIR}/examples/example-command-monitoring.c)
+mongoc_add_example (example-command-with-opts ${PROJECT_SOURCE_DIR}/examples/example-command-with-opts.c)
+mongoc_add_example (example-create-indexes ${PROJECT_SOURCE_DIR}/examples/example-create-indexes.c)
+mongoc_add_example (example-gridfs ${PROJECT_SOURCE_DIR}/examples/example-gridfs.c)
+mongoc_add_example (example-gridfs-bucket ${PROJECT_SOURCE_DIR}/examples/example-gridfs-bucket.c)
 if (NOT WIN32 AND ENABLE_EXAMPLES)
-   mongoc_add_example (example-pool TRUE ${PROJECT_SOURCE_DIR}/examples/example-pool.c)
-   target_link_libraries (example-pool Threads::Threads)
+   mongoc_add_example (example-pool ${PROJECT_SOURCE_DIR}/examples/example-pool.c)
+   target_link_libraries (example-pool PRIVATE Threads::Threads)
 endif ()
-mongoc_add_example (example-scram TRUE ${PROJECT_SOURCE_DIR}/examples/example-scram.c)
-mongoc_add_example (example-sdam-monitoring TRUE ${PROJECT_SOURCE_DIR}/examples/example-sdam-monitoring.c)
-mongoc_add_example (example-session TRUE ${PROJECT_SOURCE_DIR}/examples/example-session.c)
-mongoc_add_example (example-transaction TRUE ${PROJECT_SOURCE_DIR}/examples/example-transaction.c)
-mongoc_add_example (example-update TRUE ${PROJECT_SOURCE_DIR}/examples/example-update.c)
-mongoc_add_example (find-and-modify TRUE ${PROJECT_SOURCE_DIR}/examples/find-and-modify.c)
-mongoc_add_example (hello_mongoc TRUE ${PROJECT_SOURCE_DIR}/examples/hello_mongoc.c)
-mongoc_add_example (mongoc-dump TRUE ${PROJECT_SOURCE_DIR}/examples/mongoc-dump.c)
-mongoc_add_example (mongoc-ping TRUE ${PROJECT_SOURCE_DIR}/examples/mongoc-ping.c)
-mongoc_add_example (mongoc-tail TRUE ${PROJECT_SOURCE_DIR}/examples/mongoc-tail.c)
+mongoc_add_example (example-scram ${PROJECT_SOURCE_DIR}/examples/example-scram.c)
+mongoc_add_example (example-sdam-monitoring ${PROJECT_SOURCE_DIR}/examples/example-sdam-monitoring.c)
+mongoc_add_example (example-session ${PROJECT_SOURCE_DIR}/examples/example-session.c)
+mongoc_add_example (example-transaction ${PROJECT_SOURCE_DIR}/examples/example-transaction.c)
+mongoc_add_example (example-update ${PROJECT_SOURCE_DIR}/examples/example-update.c)
+mongoc_add_example (find-and-modify ${PROJECT_SOURCE_DIR}/examples/find-and-modify.c)
+mongoc_add_example (hello_mongoc ${PROJECT_SOURCE_DIR}/examples/hello_mongoc.c)
+mongoc_add_example (mongoc-dump ${PROJECT_SOURCE_DIR}/examples/mongoc-dump.c)
+mongoc_add_example (mongoc-ping ${PROJECT_SOURCE_DIR}/examples/mongoc-ping.c)
+mongoc_add_example (mongoc-tail ${PROJECT_SOURCE_DIR}/examples/mongoc-tail.c)
 
 # examples/aggregation/
-mongoc_add_example (aggregation1 TRUE ${PROJECT_SOURCE_DIR}/examples/aggregation/aggregation1.c)
+mongoc_add_example (aggregation1 ${PROJECT_SOURCE_DIR}/examples/aggregation/aggregation1.c)
 
 # examples/basic_aggregation/
-mongoc_add_example (basic-aggregation TRUE ${PROJECT_SOURCE_DIR}/examples/basic_aggregation/basic-aggregation.c)
+mongoc_add_example (basic-aggregation ${PROJECT_SOURCE_DIR}/examples/basic_aggregation/basic-aggregation.c)
 
 # examples/bulk/
-mongoc_add_example (bulk-collation TRUE ${PROJECT_SOURCE_DIR}/examples/bulk/bulk-collation.c)
-mongoc_add_example (bulk1 TRUE ${PROJECT_SOURCE_DIR}/examples/bulk/bulk1.c)
-mongoc_add_example (bulk2 TRUE ${PROJECT_SOURCE_DIR}/examples/bulk/bulk2.c)
-mongoc_add_example (bulk3 TRUE ${PROJECT_SOURCE_DIR}/examples/bulk/bulk3.c)
-mongoc_add_example (bulk4 TRUE ${PROJECT_SOURCE_DIR}/examples/bulk/bulk4.c)
-mongoc_add_example (bulk5 TRUE ${PROJECT_SOURCE_DIR}/examples/bulk/bulk5.c)
-mongoc_add_example (bulk6 TRUE ${PROJECT_SOURCE_DIR}/examples/bulk/bulk6.c)
+mongoc_add_example (bulk-collation ${PROJECT_SOURCE_DIR}/examples/bulk/bulk-collation.c)
+mongoc_add_example (bulk1 ${PROJECT_SOURCE_DIR}/examples/bulk/bulk1.c)
+mongoc_add_example (bulk2 ${PROJECT_SOURCE_DIR}/examples/bulk/bulk2.c)
+mongoc_add_example (bulk3 ${PROJECT_SOURCE_DIR}/examples/bulk/bulk3.c)
+mongoc_add_example (bulk4 ${PROJECT_SOURCE_DIR}/examples/bulk/bulk4.c)
+mongoc_add_example (bulk5 ${PROJECT_SOURCE_DIR}/examples/bulk/bulk5.c)
+mongoc_add_example (bulk6 ${PROJECT_SOURCE_DIR}/examples/bulk/bulk6.c)
 
 # examples/common_operations/
-mongoc_add_example (common-operations TRUE ${PROJECT_SOURCE_DIR}/examples/common_operations/common-operations.c)
+mongoc_add_example (common-operations ${PROJECT_SOURCE_DIR}/examples/common_operations/common-operations.c)
 
 # examples/find_and_modify_with_opts/
-mongoc_add_example (fam TRUE ${PROJECT_SOURCE_DIR}/examples/find_and_modify_with_opts/fam.c)
+mongoc_add_example (fam ${PROJECT_SOURCE_DIR}/examples/find_and_modify_with_opts/fam.c)
 
 if (MONGOC_ENABLE_CLIENT_SIDE_ENCRYPTION)
-   mongoc_add_example (client-side-encryption-schema-map TRUE ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-schema-map.c ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-helpers.c)
-   mongoc_add_example (client-side-encryption-server-schema TRUE ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-server-schema.c ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-helpers.c)
-   mongoc_add_example (client-side-encryption-explicit TRUE ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-explicit.c ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-helpers.c)
-   mongoc_add_example (client-side-encryption-auto-decryption TRUE ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-auto-decryption.c ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-helpers.c)
-   mongoc_add_example (client-side-encryption-doc-snippets TRUE ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-doc-snippets.c)
+   mongoc_add_example (client-side-encryption-schema-map ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-schema-map.c ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-helpers.c)
+   mongoc_add_example (client-side-encryption-server-schema ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-server-schema.c ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-helpers.c)
+   mongoc_add_example (client-side-encryption-explicit ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-explicit.c ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-helpers.c)
+   mongoc_add_example (client-side-encryption-auto-decryption ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-auto-decryption.c ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-helpers.c)
+   mongoc_add_example (client-side-encryption-doc-snippets ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-doc-snippets.c)
 endif ()
 
 file (COPY ${PROJECT_SOURCE_DIR}/tests/binary DESTINATION ${PROJECT_BINARY_DIR}/tests)

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -857,54 +857,7 @@ if (ENABLE_SHM_COUNTERS STREQUAL "ON")
    )
 endif ()
 
-function (mongoc_add_test test use_shared)
-   if (ENABLE_TESTS)
-      add_executable (${test} ${ARGN})
-      target_link_libraries (${test}
-         PRIVATE
-            $<$<C_COMPILER_ID:MSVC>:DbgHelp.dll>
-            $<$<PLATFORM_ID:Windows>:shlwapi>
-            $<$<BOOL:${use_shared}>:mongoc_shared>
-            $<$<NOT:$<BOOL:${use_shared}>>:mongoc_static>
-            ${LIBRARIES}
-            ${RESOLV_LIBRARIES}
-      )
-      # We have tests that test our deprecated api.
-      target_compile_options (${test}
-         PRIVATE $<$<NOT:$<C_COMPILER_ID:MSVC>>:-Wno-deprecated-declarations>
-      )
-      target_include_directories (${test}
-         PRIVATE
-            ${PROJECT_SOURCE_DIR}/tests
-            ${MONGOC_INTERNAL_INCLUDE_DIRS}
-            $<$<BOOL:${use_shared}>:${BSON_INCLUDE_DIRS}>
-            $<$<NOT:$<BOOL:${use_shared}>>:${BSON_STATIC_INCLUDE_DIRS}>
-      )
-      target_compile_definitions (${test}
-         PUBLIC
-            "MONGOC_COMPILATION"
-            "BSON_COMPILATION"
-            "MCOMMON_NAME_PREFIX=_mongoc_mcommon"
-      )
-   endif ()
-endfunction ()
-
-function (mongoc_add_example example use_shared)
-   if (ENABLE_EXAMPLES)
-      add_executable (${example} ${ARGN})
-      if (${use_shared})
-         target_link_libraries (${example} mongoc_shared ${LIBRARIES})
-      else ()
-         target_link_libraries (${example} mongoc_static ${LIBRARIES})
-      endif ()
-      if (WIN32)
-         target_link_libraries (${example} shlwapi)
-      endif ()
-      set (EXAMPLES ${EXAMPLES} ${example})
-   endif ()
-endfunction ()
-
-set (test-libmongoc-sources
+add_library (test-libmongoc-lib STATIC
    ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/corpus-test.c
    ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/corpus-test.h
    ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/test-atomic.c
@@ -1042,7 +995,7 @@ set (test-libmongoc-sources
 )
 
 if (MONGOC_ENABLE_SSL)
-   set (test-libmongoc-sources ${test-libmongoc-sources}
+   target_sources (test-libmongoc-lib PRIVATE
       ${PROJECT_SOURCE_DIR}/tests/ssl-test.c
       ${PROJECT_SOURCE_DIR}/tests/test-mongoc-client-side-encryption.c
       ${PROJECT_SOURCE_DIR}/tests/test-mongoc-stream-tls-error.c
@@ -1053,12 +1006,46 @@ if (MONGOC_ENABLE_SSL)
 endif ()
 
 if (MONGOC_ENABLE_SASL_CYRUS)
-   set (test-libmongoc-sources ${test-libmongoc-sources}
+   target_sources (test-libmongoc-lib PRIVATE
       ${PROJECT_SOURCE_DIR}/tests/test-mongoc-cyrus.c
    )
 endif ()
 
-mongoc_add_test (test-libmongoc FALSE ${test-libmongoc-sources})
+target_link_libraries (test-libmongoc-lib
+   PUBLIC
+      $<$<C_COMPILER_ID:MSVC>:DbgHelp.dll>
+      $<$<PLATFORM_ID:Windows>:shlwapi>
+      $<$<BOOL:${use_shared}>:mongoc_shared>
+      $<$<NOT:$<BOOL:${use_shared}>>:mongoc_static>
+      ${LIBRARIES}
+      ${RESOLV_LIBRARIES}
+)
+# We have tests that test our deprecated api.
+target_compile_options (test-libmongoc-lib
+   PUBLIC $<$<NOT:$<C_COMPILER_ID:MSVC>>:-Wno-deprecated-declarations>
+)
+target_include_directories (test-libmongoc-lib
+   PUBLIC
+      ${PROJECT_SOURCE_DIR}/tests
+      ${MONGOC_INTERNAL_INCLUDE_DIRS}
+      $<$<BOOL:${use_shared}>:${BSON_INCLUDE_DIRS}>
+      $<$<NOT:$<BOOL:${use_shared}>>:${BSON_STATIC_INCLUDE_DIRS}>
+)
+target_compile_definitions (test-libmongoc-lib
+   PUBLIC
+      "MONGOC_COMPILATION"
+      "BSON_COMPILATION"
+      "MCOMMON_NAME_PREFIX=_mongoc_mcommon"
+)
+
+function (mongoc_add_test test use_shared)
+   if (ENABLE_TESTS)
+      add_executable (${test} ${ARGN})
+      target_link_libraries (${test} PRIVATE test-libmongoc-lib)
+   endif ()
+endfunction ()
+
+mongoc_add_test (test-libmongoc FALSE ${PROJECT_SOURCE_DIR}/tests/test-libmongoc-main.c)
 mongoc_add_test (test-mongoc-gssapi FALSE ${PROJECT_SOURCE_DIR}/tests/test-mongoc-gssapi.c)
 mongoc_add_test (test-mongoc-cache FALSE ${PROJECT_SOURCE_DIR}/tests/test-mongoc-cache.c)
 mongoc_add_test (test-azurekms FALSE ${PROJECT_SOURCE_DIR}/tests/test-azurekms.c)
@@ -1072,6 +1059,21 @@ if (ENABLE_TESTS)
       DEPENDS test-libmongoc
    )
 endif ()
+
+function (mongoc_add_example example use_shared)
+   if (ENABLE_EXAMPLES)
+      add_executable (${example} ${ARGN})
+      if (${use_shared})
+         target_link_libraries (${example} mongoc_shared ${LIBRARIES})
+      else ()
+         target_link_libraries (${example} mongoc_static ${LIBRARIES})
+      endif ()
+      if (WIN32)
+         target_link_libraries (${example} shlwapi)
+      endif ()
+      set (EXAMPLES ${EXAMPLES} ${example})
+   endif ()
+endfunction ()
 
 # examples/
 mongoc_add_example (example-client TRUE ${PROJECT_SOURCE_DIR}/examples/example-client.c)

--- a/src/libmongoc/tests/TestSuite.c
+++ b/src/libmongoc/tests/TestSuite.c
@@ -50,12 +50,6 @@ static bson_mutex_t gTestMutex;
 static TestSuite *gTestSuite;
 
 
-#define TEST_NOFORK (1 << 1)
-#define TEST_HELPTEXT (1 << 2)
-#define TEST_DEBUGOUTPUT (1 << 3)
-#define TEST_TRACE (1 << 4)
-#define TEST_LISTTESTS (1 << 5)
-
 MONGOC_PRINTF_FORMAT (1, 2)
 static void
 test_msg (const char *format, ...)

--- a/src/libmongoc/tests/TestSuite.h
+++ b/src/libmongoc/tests/TestSuite.h
@@ -85,6 +85,13 @@ bson_open (const char *filename, int flags, ...)
 #endif
 
 
+#define TEST_NOFORK (1 << 1)
+#define TEST_HELPTEXT (1 << 2)
+#define TEST_DEBUGOUTPUT (1 << 3)
+#define TEST_TRACE (1 << 4)
+#define TEST_LISTTESTS (1 << 5)
+
+
 #define CERT_CA CERT_TEST_DIR "/ca.pem"
 #define CERT_CRL CERT_TEST_DIR "/crl.pem"
 #define CERT_SERVER CERT_TEST_DIR "/server.pem" /* 127.0.0.1 & localhost */

--- a/src/libmongoc/tests/test-atlas-executor.c
+++ b/src/libmongoc/tests/test-atlas-executor.c
@@ -8,6 +8,7 @@
 
 #include <bson/bson.h>
 
+#include <assert.h>
 #include <signal.h>
 #include <stdio.h>
 
@@ -60,8 +61,7 @@ void (*original_sigint_handler) (int) = NULL;
 static void
 sigint_handler (int sigint)
 {
-   BSON_ASSERT (sigint == SIGINT);
-   MONGOC_DEBUG ("detected request to terminate loop operation");
+   assert (sigint == SIGINT);
    operation_loop_terminated = true;
    signal (SIGINT, original_sigint_handler);
 }

--- a/src/libmongoc/tests/test-atlas-executor.c
+++ b/src/libmongoc/tests/test-atlas-executor.c
@@ -1,0 +1,115 @@
+#include "TestSuite.h"
+
+#include "unified/operation.h"
+#include "unified/runner.h"
+
+#include "json-test.h"
+#include "test-libmongoc.h"
+
+#include <bson/bson.h>
+
+#include <signal.h>
+#include <stdio.h>
+
+static void
+TestSuite_Init_Atlas (TestSuite *suite, int argc, char **argv)
+{
+   ASSERT_WITH_MSG (argc > 1, "test-atlas-executor requires a workload spec!");
+
+   *suite = (TestSuite){
+      .ctest_run = NULL,
+      .failing_flaky_skips = {0},
+      .flags = TEST_NOFORK,
+      .match_patterns = {0},
+      .mock_server_log = NULL,
+      .mock_server_log_buf = NULL,
+      .name = bson_strdup ("/atlas"),
+      .outfile = NULL,
+      .prgname = bson_strdup (argv[0]),
+      .silent = false,
+      .tests = NULL,
+   };
+}
+
+bson_t *
+workload_spec_to_bson (const char *workload_spec)
+{
+   BSON_ASSERT_PARAM (workload_spec);
+
+   bson_t *const res = bson_new ();
+
+   const size_t workload_spec_len = strlen (workload_spec);
+   const size_t bson_json_default_buf_size = 1u << 14; // From bson-json.c.
+
+   bson_json_reader_t *const reader =
+      bson_json_data_reader_new (false, bson_json_default_buf_size);
+   bson_json_data_reader_ingest (
+      reader, (const uint8_t *) workload_spec, workload_spec_len);
+
+
+   bson_error_t error;
+   ASSERT_OR_PRINT (bson_json_reader_read (reader, res, &error) == 1, error);
+   bson_json_reader_destroy (reader);
+
+   return res;
+}
+
+// Used to ensure that repeated SIGINT are not ignored.
+void (*original_sigint_handler) (int) = NULL;
+
+static void
+sigint_handler (int sigint)
+{
+   BSON_ASSERT (sigint == SIGINT);
+   MONGOC_DEBUG ("detected request to terminate loop operation");
+   operation_loop_terminated = true;
+   signal (SIGINT, original_sigint_handler);
+}
+
+static void
+TestSuite_Run_Atlas (TestSuite *suite)
+{
+   BSON_ASSERT_PARAM (suite);
+
+   Test *const test = suite->tests;
+
+   ASSERT_WITH_MSG (test, "missing expected test in test suite");
+   ASSERT_WITH_MSG (!test->next, "expected exactly one test in test suite");
+
+   original_sigint_handler = signal (SIGINT, sigint_handler);
+
+   srand (test->seed);
+
+   test_conveniences_init ();
+   test->func (test->ctx);
+   test_conveniences_cleanup ();
+
+   capture_logs (false);
+}
+
+int
+main (int argc, char **argv)
+{
+   ASSERT_WITH_MSG (argc > 1, "test-atlas-executor requires a workload spec!");
+
+   TestSuite suite = {0};
+   TestSuite_Init_Atlas (&suite, argc, argv);
+
+   bson_t *const bson = workload_spec_to_bson (argv[1]);
+
+   TestSuite_AddFull (&suite,
+                      "test",
+                      (TestFuncWC) &run_one_test_file,
+                      (TestFuncDtor) &bson_destroy,
+                      bson,
+                      TestSuite_CheckLive,
+                      NULL);
+
+   mongoc_init ();
+   TestSuite_Run_Atlas (&suite);
+   mongoc_cleanup ();
+
+   TestSuite_Destroy (&suite);
+
+   return 0;
+}

--- a/src/libmongoc/tests/test-libmongoc-main.c
+++ b/src/libmongoc/tests/test-libmongoc-main.c
@@ -1,0 +1,162 @@
+#include <bson/bson.h>
+#include <mongoc/mongoc.h>
+
+#include <common-thread-private.h>
+
+#include "test-libmongoc.h"
+#include "TestSuite.h"
+#include "test-conveniences.h"
+
+int
+main (int argc, char *argv[])
+{
+   TestSuite suite;
+   int ret;
+
+   test_libmongoc_init (&suite, "libmongoc", argc, argv);
+
+   /* libbson */
+
+#define TEST_INSTALL(FuncName)                 \
+   if (1) {                                    \
+      extern void FuncName (TestSuite *suite); \
+      FuncName (&suite);                       \
+   } else                                      \
+      ((void) 0)
+
+   TEST_INSTALL (test_atomic_install);
+   TEST_INSTALL (test_bcon_basic_install);
+   TEST_INSTALL (test_bcon_extract_install);
+   TEST_INSTALL (test_bson_corpus_install);
+   TEST_INSTALL (test_bson_error_install);
+   TEST_INSTALL (test_bson_install);
+   TEST_INSTALL (test_bson_version_install);
+   TEST_INSTALL (test_clock_install);
+   TEST_INSTALL (test_decimal128_install);
+   TEST_INSTALL (test_endian_install);
+   TEST_INSTALL (test_iso8601_install);
+   TEST_INSTALL (test_iter_install);
+   TEST_INSTALL (test_json_install);
+   TEST_INSTALL (test_oid_install);
+   TEST_INSTALL (test_reader_install);
+   TEST_INSTALL (test_string_install);
+   TEST_INSTALL (test_utf8_install);
+   TEST_INSTALL (test_value_install);
+   TEST_INSTALL (test_writer_install);
+   TEST_INSTALL (test_b64_install);
+   TEST_INSTALL (test_bson_cmp_install);
+
+   /* libmongoc */
+
+   TEST_INSTALL (test_aggregate_install);
+   TEST_INSTALL (test_array_install);
+   TEST_INSTALL (test_async_install);
+   TEST_INSTALL (test_buffer_install);
+   TEST_INSTALL (test_change_stream_install);
+   TEST_INSTALL (test_client_install);
+   TEST_INSTALL (test_client_max_staleness_install);
+   TEST_INSTALL (test_client_hedged_reads_install);
+   TEST_INSTALL (test_client_pool_install);
+   TEST_INSTALL (test_client_cmd_install);
+   TEST_INSTALL (test_client_versioned_api_install);
+   TEST_INSTALL (test_write_command_install);
+   TEST_INSTALL (test_bulk_install);
+   TEST_INSTALL (test_cluster_install);
+   TEST_INSTALL (test_collection_install);
+   TEST_INSTALL (test_collection_find_install);
+   TEST_INSTALL (test_collection_find_with_opts_install);
+   TEST_INSTALL (test_connection_uri_install);
+   TEST_INSTALL (test_command_monitoring_install);
+   TEST_INSTALL (test_cursor_install);
+   TEST_INSTALL (test_database_install);
+   TEST_INSTALL (test_error_install);
+   TEST_INSTALL (test_exhaust_install);
+   TEST_INSTALL (test_find_and_modify_install);
+   TEST_INSTALL (test_gridfs_install);
+   TEST_INSTALL (test_gridfs_bucket_install);
+   TEST_INSTALL (test_gridfs_file_page_install);
+   TEST_INSTALL (test_handshake_install);
+   TEST_INSTALL (test_linux_distro_scanner_install);
+   TEST_INSTALL (test_list_install);
+   TEST_INSTALL (test_log_install);
+   TEST_INSTALL (test_long_namespace_install);
+   TEST_INSTALL (test_matcher_install);
+   TEST_INSTALL (test_mongos_pinning_install);
+   TEST_INSTALL (test_queue_install);
+   TEST_INSTALL (test_primary_stepdown_install);
+   TEST_INSTALL (test_read_concern_install);
+   TEST_INSTALL (test_read_write_concern_install);
+   TEST_INSTALL (test_read_prefs_install);
+   TEST_INSTALL (test_retryable_writes_install);
+   TEST_INSTALL (test_retryable_reads_install);
+   TEST_INSTALL (test_rpc_install);
+   TEST_INSTALL (test_socket_install);
+   TEST_INSTALL (test_opts_install);
+   TEST_INSTALL (test_topology_scanner_install);
+   TEST_INSTALL (test_topology_reconcile_install);
+   TEST_INSTALL (test_transactions_install);
+   TEST_INSTALL (test_samples_install);
+   TEST_INSTALL (test_scram_install);
+   TEST_INSTALL (test_sdam_install);
+   TEST_INSTALL (test_sdam_monitoring_install);
+   TEST_INSTALL (test_server_selection_install);
+   TEST_INSTALL (test_dns_install);
+   TEST_INSTALL (test_server_selection_errors_install);
+   TEST_INSTALL (test_session_install);
+   TEST_INSTALL (test_set_install);
+   TEST_INSTALL (test_speculative_auth_install);
+   TEST_INSTALL (test_stream_install);
+   TEST_INSTALL (test_thread_install);
+   TEST_INSTALL (test_topology_install);
+   TEST_INSTALL (test_topology_description_install);
+   TEST_INSTALL (test_ts_pool_install);
+   TEST_INSTALL (test_uri_install);
+   TEST_INSTALL (test_usleep_install);
+   TEST_INSTALL (test_util_install);
+   TEST_INSTALL (test_version_install);
+   TEST_INSTALL (test_with_transaction_install);
+   TEST_INSTALL (test_write_concern_install);
+#ifdef MONGOC_ENABLE_SSL
+   TEST_INSTALL (test_stream_tls_install);
+   TEST_INSTALL (test_x509_install);
+   TEST_INSTALL (test_stream_tls_error_install);
+   TEST_INSTALL (test_client_side_encryption_install);
+#endif
+#ifdef MONGOC_ENABLE_SASL_CYRUS
+   TEST_INSTALL (test_cyrus_install);
+#endif
+   TEST_INSTALL (test_happy_eyeballs_install);
+   TEST_INSTALL (test_counters_install);
+   TEST_INSTALL (test_crud_install);
+   TEST_INSTALL (test_mongohouse_install);
+   TEST_INSTALL (test_apm_install);
+   TEST_INSTALL (test_server_description_install);
+   TEST_INSTALL (test_aws_install);
+   TEST_INSTALL (test_streamable_hello_install);
+#if defined(MONGOC_ENABLE_OCSP_OPENSSL) && OPENSSL_VERSION_NUMBER >= 0x10101000L
+   TEST_INSTALL (test_ocsp_cache_install);
+#endif
+   TEST_INSTALL (test_interrupt_install);
+   TEST_INSTALL (test_monitoring_install);
+   TEST_INSTALL (test_http_install);
+   TEST_INSTALL (test_install_unified);
+   TEST_INSTALL (test_timeout_install);
+   TEST_INSTALL (test_bson_match_install);
+   TEST_INSTALL (test_bson_util_install);
+   TEST_INSTALL (test_result_install);
+   TEST_INSTALL (test_loadbalanced_install);
+   TEST_INSTALL (test_server_stream_install);
+   TEST_INSTALL (test_generation_map_install);
+   TEST_INSTALL (test_shared_install);
+   TEST_INSTALL (test_ssl_install);
+
+   TEST_INSTALL (test_mcd_azure_imds_install);
+   TEST_INSTALL (test_mcd_integer_install);
+   TEST_INSTALL (test_service_gcp_install);
+
+   ret = TestSuite_Run (&suite);
+
+   test_libmongoc_destroy (&suite);
+
+   return ret;
+}

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -2637,12 +2637,10 @@ windows_exception_handler (EXCEPTION_POINTERS *pExceptionInfo)
 }
 #endif
 
-int
-main (int argc, char *argv[])
-{
-   TestSuite suite;
-   int ret;
 
+void
+test_libmongoc_init (TestSuite *suite, const char *name, int argc, char **argv)
+{
 #if defined(_MSC_VER) && defined(_WIN64)
    SetUnhandledExceptionFilter (windows_exception_handler);
 #endif
@@ -2663,157 +2661,18 @@ main (int argc, char *argv[])
    atexit (test_framework_global_ssl_opts_cleanup);
 #endif
 
-   TestSuite_Init (&suite, "", argc, argv);
-   TestSuite_Add (&suite, "/TestSuite/version_cmp", test_version_cmp);
+   TestSuite_Init (suite, "", argc, argv);
+   TestSuite_Add (suite, "/TestSuite/version_cmp", test_version_cmp);
+}
 
-   /* libbson */
 
-#define TEST_INSTALL(FuncName)                 \
-   if (1) {                                    \
-      extern void FuncName (TestSuite *suite); \
-      FuncName (&suite);                       \
-   } else                                      \
-      ((void) 0)
-
-   TEST_INSTALL (test_atomic_install);
-   TEST_INSTALL (test_bcon_basic_install);
-   TEST_INSTALL (test_bcon_extract_install);
-   TEST_INSTALL (test_bson_corpus_install);
-   TEST_INSTALL (test_bson_error_install);
-   TEST_INSTALL (test_bson_install);
-   TEST_INSTALL (test_bson_version_install);
-   TEST_INSTALL (test_clock_install);
-   TEST_INSTALL (test_decimal128_install);
-   TEST_INSTALL (test_endian_install);
-   TEST_INSTALL (test_iso8601_install);
-   TEST_INSTALL (test_iter_install);
-   TEST_INSTALL (test_json_install);
-   TEST_INSTALL (test_oid_install);
-   TEST_INSTALL (test_reader_install);
-   TEST_INSTALL (test_string_install);
-   TEST_INSTALL (test_utf8_install);
-   TEST_INSTALL (test_value_install);
-   TEST_INSTALL (test_writer_install);
-   TEST_INSTALL (test_b64_install);
-   TEST_INSTALL (test_bson_cmp_install);
-
-   /* libmongoc */
-
-   TEST_INSTALL (test_aggregate_install);
-   TEST_INSTALL (test_array_install);
-   TEST_INSTALL (test_async_install);
-   TEST_INSTALL (test_buffer_install);
-   TEST_INSTALL (test_change_stream_install);
-   TEST_INSTALL (test_client_install);
-   TEST_INSTALL (test_client_max_staleness_install);
-   TEST_INSTALL (test_client_hedged_reads_install);
-   TEST_INSTALL (test_client_pool_install);
-   TEST_INSTALL (test_client_cmd_install);
-   TEST_INSTALL (test_client_versioned_api_install);
-   TEST_INSTALL (test_write_command_install);
-   TEST_INSTALL (test_bulk_install);
-   TEST_INSTALL (test_cluster_install);
-   TEST_INSTALL (test_collection_install);
-   TEST_INSTALL (test_collection_find_install);
-   TEST_INSTALL (test_collection_find_with_opts_install);
-   TEST_INSTALL (test_connection_uri_install);
-   TEST_INSTALL (test_command_monitoring_install);
-   TEST_INSTALL (test_cursor_install);
-   TEST_INSTALL (test_database_install);
-   TEST_INSTALL (test_error_install);
-   TEST_INSTALL (test_exhaust_install);
-   TEST_INSTALL (test_find_and_modify_install);
-   TEST_INSTALL (test_gridfs_install);
-   TEST_INSTALL (test_gridfs_bucket_install);
-   TEST_INSTALL (test_gridfs_file_page_install);
-   TEST_INSTALL (test_handshake_install);
-   TEST_INSTALL (test_linux_distro_scanner_install);
-   TEST_INSTALL (test_list_install);
-   TEST_INSTALL (test_log_install);
-   TEST_INSTALL (test_long_namespace_install);
-   TEST_INSTALL (test_matcher_install);
-   TEST_INSTALL (test_mongos_pinning_install);
-   TEST_INSTALL (test_queue_install);
-   TEST_INSTALL (test_primary_stepdown_install);
-   TEST_INSTALL (test_read_concern_install);
-   TEST_INSTALL (test_read_write_concern_install);
-   TEST_INSTALL (test_read_prefs_install);
-   TEST_INSTALL (test_retryable_writes_install);
-   TEST_INSTALL (test_retryable_reads_install);
-   TEST_INSTALL (test_rpc_install);
-   TEST_INSTALL (test_socket_install);
-   TEST_INSTALL (test_opts_install);
-   TEST_INSTALL (test_topology_scanner_install);
-   TEST_INSTALL (test_topology_reconcile_install);
-   TEST_INSTALL (test_transactions_install);
-   TEST_INSTALL (test_samples_install);
-   TEST_INSTALL (test_scram_install);
-   TEST_INSTALL (test_sdam_install);
-   TEST_INSTALL (test_sdam_monitoring_install);
-   TEST_INSTALL (test_server_selection_install);
-   TEST_INSTALL (test_dns_install);
-   TEST_INSTALL (test_server_selection_errors_install);
-   TEST_INSTALL (test_session_install);
-   TEST_INSTALL (test_set_install);
-   TEST_INSTALL (test_speculative_auth_install);
-   TEST_INSTALL (test_stream_install);
-   TEST_INSTALL (test_thread_install);
-   TEST_INSTALL (test_topology_install);
-   TEST_INSTALL (test_topology_description_install);
-   TEST_INSTALL (test_ts_pool_install);
-   TEST_INSTALL (test_uri_install);
-   TEST_INSTALL (test_usleep_install);
-   TEST_INSTALL (test_util_install);
-   TEST_INSTALL (test_version_install);
-   TEST_INSTALL (test_with_transaction_install);
-   TEST_INSTALL (test_write_concern_install);
-#ifdef MONGOC_ENABLE_SSL
-   TEST_INSTALL (test_stream_tls_install);
-   TEST_INSTALL (test_x509_install);
-   TEST_INSTALL (test_stream_tls_error_install);
-   TEST_INSTALL (test_client_side_encryption_install);
-#endif
-#ifdef MONGOC_ENABLE_SASL_CYRUS
-   TEST_INSTALL (test_cyrus_install);
-#endif
-   TEST_INSTALL (test_happy_eyeballs_install);
-   TEST_INSTALL (test_counters_install);
-   TEST_INSTALL (test_crud_install);
-   TEST_INSTALL (test_mongohouse_install);
-   TEST_INSTALL (test_apm_install);
-   TEST_INSTALL (test_server_description_install);
-   TEST_INSTALL (test_aws_install);
-   TEST_INSTALL (test_streamable_hello_install);
-#if defined(MONGOC_ENABLE_OCSP_OPENSSL) && OPENSSL_VERSION_NUMBER >= 0x10101000L
-   TEST_INSTALL (test_ocsp_cache_install);
-#endif
-   TEST_INSTALL (test_interrupt_install);
-   TEST_INSTALL (test_monitoring_install);
-   TEST_INSTALL (test_http_install);
-   TEST_INSTALL (test_install_unified);
-   TEST_INSTALL (test_timeout_install);
-   TEST_INSTALL (test_bson_match_install);
-   TEST_INSTALL (test_bson_util_install);
-   TEST_INSTALL (test_result_install);
-   TEST_INSTALL (test_loadbalanced_install);
-   TEST_INSTALL (test_server_stream_install);
-   TEST_INSTALL (test_generation_map_install);
-   TEST_INSTALL (test_shared_install);
-   TEST_INSTALL (test_ssl_install);
-
-   TEST_INSTALL (test_mcd_azure_imds_install);
-   TEST_INSTALL (test_mcd_integer_install);
-   TEST_INSTALL (test_service_gcp_install);
-
-   ret = TestSuite_Run (&suite);
-
-   TestSuite_Destroy (&suite);
-
+void
+test_libmongoc_destroy (TestSuite *suite)
+{
+   TestSuite_Destroy (suite);
    capture_logs (false); /* clear entries */
    _mongoc_array_destroy (&captured_logs);
    mongoc_cleanup ();
-
-   return ret;
 }
 
 /*

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -987,11 +987,26 @@ set_name (bson_t *hello_response)
 static bool
 uri_str_has_db (bson_string_t *uri_string)
 {
-   const char *after_scheme;
+   BSON_ASSERT_PARAM (uri_string);
 
-   ASSERT_STARTSWITH (uri_string->str, "mongodb://");
-   after_scheme = uri_string->str + strlen ("mongodb://");
-   return strchr (after_scheme, '/') != NULL;
+   const char *const str = uri_string->str;
+   const char *const standard = "mongodb://";
+   const char *const srv = "mongodb+srv://";
+
+   const bool is_standard = strstr (str, standard) == str;
+   const bool is_srv = strstr (str, srv) == str;
+
+   ASSERT_WITH_MSG (is_standard || is_srv,
+                    "[%s] does not start with [%s] or [%s]",
+                    uri_string->str,
+                    standard,
+                    srv);
+
+   if (is_standard) {
+      return strchr (str + strlen (standard), '/') != NULL;
+   } else {
+      return strchr (str + strlen (srv), '/') != NULL;
+   }
 }
 
 

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -1161,10 +1161,14 @@ test_framework_get_uri_str ()
    char *uri_str_no_auth;
    char *uri_str;
 
-   /* no_auth also contains compressors. */
-
-   uri_str_no_auth = test_framework_get_uri_str_no_auth (NULL);
-   uri_str = test_framework_add_user_password_from_env (uri_str_no_auth);
+   if (test_framework_getenv_bool ("MONGOC_TEST_ATLAS")) {
+      // User and password is already embedded in URI.
+      return test_framework_get_uri_str_no_auth (NULL);
+   } else {
+      /* no_auth also contains compressors. */
+      uri_str_no_auth = test_framework_get_uri_str_no_auth (NULL);
+      uri_str = test_framework_add_user_password_from_env (uri_str_no_auth);
+   }
 
    bson_free (uri_str_no_auth);
 

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -1176,10 +1176,12 @@ test_framework_get_uri_str ()
 mongoc_uri_t *
 test_framework_get_uri ()
 {
-   char *test_uri_str = test_framework_get_uri_str ();
-   mongoc_uri_t *uri = mongoc_uri_new (test_uri_str);
+   bson_error_t error = {0};
 
-   BSON_ASSERT (uri);
+   char *test_uri_str = test_framework_get_uri_str ();
+   mongoc_uri_t *uri = mongoc_uri_new_with_error (test_uri_str, &error);
+
+   ASSERT_OR_PRINT (uri, error);
    bson_free (test_uri_str);
 
    return uri;

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -1111,7 +1111,9 @@ test_framework_get_uri_str_no_auth (const char *database_name)
       add_option_to_uri_str (uri_string, MONGOC_URI_COMPRESSORS, compressors);
       bson_free (compressors);
    }
-   /* make tests a little more resilient to transient errors */
+
+   // Required by test-atlas-executor. Not required by normal unified test
+   // runner, but make tests a little more resilient to transient errors.
    add_option_to_uri_str (
       uri_string, MONGOC_URI_SERVERSELECTIONTRYONCE, "false");
 

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -485,6 +485,9 @@ test_framework_get_host (void)
    if (env_uri) {
       /* choose first host */
       hosts = mongoc_uri_get_hosts (env_uri);
+      ASSERT_WITH_MSG (hosts,
+                       "could not obtain hosts from URI [%s]",
+                       mongoc_uri_get_string (env_uri));
       host = bson_strdup (hosts->host);
       mongoc_uri_destroy (env_uri);
       return host;

--- a/src/libmongoc/tests/test-libmongoc.h
+++ b/src/libmongoc/tests/test-libmongoc.h
@@ -19,6 +19,20 @@
 #define TEST_LIBMONGOC_H
 
 
+struct _TestSuite;
+struct _bson_t;
+struct _server_version_t;
+
+
+void
+test_libmongoc_init (struct _TestSuite *suite,
+                     const char *name,
+                     int argc,
+                     char **argv);
+void
+test_libmongoc_destroy (struct _TestSuite *suite);
+
+
 mongoc_database_t *
 get_test_database (mongoc_client_t *client);
 char *

--- a/src/libmongoc/tests/unified/entity-map.c
+++ b/src/libmongoc/tests/unified/entity-map.c
@@ -291,7 +291,7 @@ entity_client_new (entity_map_t *em, bson_t *bson, bson_error_t *error)
       *bson,
       // All clients require an ID string
       find (keyWithType ("id", utf8), storeStrDup (entity->id)),
-      else(error ("A client 'id' string is required")),
+      else (error ("A client 'id' string is required")),
       // Optional 'uriOptions' for the client
       find (key ("uriOptions"),
             if (not(type (doc)),
@@ -301,34 +301,34 @@ entity_client_new (entity_map_t *em, bson_t *bson, bson_error_t *error)
       find (key ("useMultipleMongoses"),
             if (not(type (bool)),
                 then (error ("'useMultipleMongoses' must be a bool value"))),
-            do(use_multiple_mongoses_set = true),
+            do (use_multiple_mongoses_set = true),
             storeBool (use_multiple_mongoses)),
       // Events to observe:
-      find (
-         key ("observeEvents"),
-         if (not(type (array)),
-             then (error ("'observeEvents' must be an array"))),
-         visitEach (case (
-            // Ensure all elements are strings:
-            when (not(type (utf8)),
-                  error ("Every 'observeEvents' element must be a string")),
-            // Dispatch based on the event name:
-            when (strEqual ("commandStartedEvent"),
-                  do(mongoc_apm_set_command_started_cb (callbacks,
-                                                        command_started))),
-            when (strEqual ("commandFailedEvent"),
-                  do(mongoc_apm_set_command_failed_cb (callbacks,
-                                                       command_failed))),
-            when (strEqual ("commandSucceededEvent"),
-                  do(mongoc_apm_set_command_succeeded_cb (callbacks,
-                                                          command_succeeded))),
-            // Unsupported (but known) event names:
-            when (eval (is_unsupported_event_type (
-                     bson_iter_utf8 (&bsonVisitIter, NULL))),
-                  do(MONGOC_DEBUG ("Skipping unsupported event type '%s'",
-                                   bsonAs (cstr)))),
-            // An unknown event name is a hard-error:
-            else(do(test_error ("Unknown event type '%s'", bsonAs (cstr))))))),
+      find (key ("observeEvents"),
+            if (not(type (array)),
+                then (error ("'observeEvents' must be an array"))),
+            visitEach (case (
+               // Ensure all elements are strings:
+               when (not(type (utf8)),
+                     error ("Every 'observeEvents' element must be a string")),
+               // Dispatch based on the event name:
+               when (strEqual ("commandStartedEvent"),
+                     do (mongoc_apm_set_command_started_cb (callbacks,
+                                                            command_started))),
+               when (strEqual ("commandFailedEvent"),
+                     do (mongoc_apm_set_command_failed_cb (callbacks,
+                                                           command_failed))),
+               when (strEqual ("commandSucceededEvent"),
+                     do (mongoc_apm_set_command_succeeded_cb (
+                        callbacks, command_succeeded))),
+               // Unsupported (but known) event names:
+               when (eval (is_unsupported_event_type (
+                        bson_iter_utf8 (&bsonVisitIter, NULL))),
+                     do (MONGOC_DEBUG ("Skipping unsupported event type '%s'",
+                                       bsonAs (cstr)))),
+               // An unknown event name is a hard-error:
+               else (do (
+                  test_error ("Unknown event type '%s'", bsonAs (cstr))))))),
       // Command events to ignore
       find (
          key ("ignoreCommandMonitoringEvents"),
@@ -343,7 +343,7 @@ entity_client_new (entity_map_t *em, bson_t *bson, bson_error_t *error)
          key ("serverApi"),
          if (not(type (doc)), then (error ("'serverApi' must be a document"))),
          parse ( // The "version" string is required first:
-            find (keyWithType ("version", utf8), do({
+            find (keyWithType ("version", utf8), do ({
                      mongoc_server_api_version_t ver;
                      if (!mongoc_server_api_version_from_string (bsonAs (cstr),
                                                                  &ver)) {
@@ -352,23 +352,24 @@ entity_client_new (entity_map_t *em, bson_t *bson, bson_error_t *error)
                         api = mongoc_server_api_new (ver);
                      }
                   })),
-            else(error ("Missing 'version' property in 'serverApi' object")),
+            else (error ("Missing 'version' property in 'serverApi' object")),
             // Toggle strictness:
             find (key ("strict"),
                   if (not(type (bool)),
                       then (error ("'serverApi.strict' must be a bool"))),
-                  do(mongoc_server_api_strict (api, bsonAs (bool)))),
+                  do (mongoc_server_api_strict (api, bsonAs (bool)))),
             // Toggle deprecation errors:
             find (
                key ("deprecationErrors"),
                if (not(type (bool)),
                    then (error ("serverApi.deprecationErrors must be a bool"))),
-               do(mongoc_server_api_deprecation_errors (api, bsonAs (bool)))))),
+               do (
+                  mongoc_server_api_deprecation_errors (api, bsonAs (bool)))))),
       // Toggle observation of sensitive commands
       find (key ("observeSensitiveCommands"),
             if (not(type (bool)),
                 then (error ("'observeSensitiveCommands' must be a bool"))),
-            do({
+            do ({
                bool *p = entity->observe_sensitive_commands =
                   bson_malloc (sizeof (bool));
                *p = bsonAs (bool);

--- a/src/libmongoc/tests/unified/entity-map.c
+++ b/src/libmongoc/tests/unified/entity-map.c
@@ -2011,7 +2011,7 @@ entity_map_add_bson_array (entity_map_t *em,
    // Note: the specification states we should be storing a BSON object of array
    // type, but we use an array of BSON objects instead to make append and
    // iteration easier.
-   mongoc_array_t *array = BSON_ALIGNED_ALLOC (mongoc_array_t);
+   mongoc_array_t *array = bson_malloc (sizeof (mongoc_array_t));
    mongoc_array_aligned_init (array, bson_t *);
    return _entity_map_add (em, id, "bson_array", (void *) array, error);
 }

--- a/src/libmongoc/tests/unified/entity-map.c
+++ b/src/libmongoc/tests/unified/entity-map.c
@@ -282,8 +282,10 @@ static void
 store_event_serialize_started (bson_t *doc,
                                const mongoc_apm_command_started_t *apm_command)
 {
-   BSON_APPEND_DOCUMENT (
-      doc, "command", mongoc_apm_command_started_get_command (apm_command));
+   // Spec: The test runner MAY omit the command field for CommandStartedEvent
+   // and reply field for CommandSucceededEvent.
+   // BSON_APPEND_DOCUMENT (
+   //    doc, "command", mongoc_apm_command_started_get_command (apm_command));
 
    BSON_APPEND_UTF8 (
       doc,
@@ -376,8 +378,10 @@ store_event_serialize_succeeded (
    BSON_APPEND_INT64 (
       doc, "duration", mongoc_apm_command_succeeded_get_duration (apm_command));
 
-   BSON_APPEND_DOCUMENT (
-      doc, "reply", mongoc_apm_command_succeeded_get_reply (apm_command));
+   // Spec: The test runner MAY omit the command field for CommandStartedEvent
+   // and reply field for CommandSucceededEvent.
+   // BSON_APPEND_DOCUMENT (
+   //    doc, "reply", mongoc_apm_command_succeeded_get_reply (apm_command));
 
    BSON_APPEND_UTF8 (
       doc,

--- a/src/libmongoc/tests/unified/entity-map.c
+++ b/src/libmongoc/tests/unified/entity-map.c
@@ -1481,6 +1481,10 @@ entity_destroy (entity_t *entity)
 
       _mongoc_array_destroy (array);
       bson_free (array);
+   } else if (0 == strcmp ("size_t", entity->type)) {
+      size_t *v = entity->value;
+
+      bson_free (v);
    } else {
       test_error ("Attempting to destroy unrecognized entity type: %s, id: %s",
                   entity->type,
@@ -1655,6 +1659,18 @@ entity_map_get_bson_array (entity_map_t *entity_map,
    return (mongoc_array_t *) entity->value;
 }
 
+size_t *
+entity_map_get_size_t (entity_map_t *entity_map,
+                       const char *id,
+                       bson_error_t *error)
+{
+   entity_t *entity = _entity_map_get_by_type (entity_map, id, "size_t", error);
+   if (!entity) {
+      return NULL;
+   }
+   return (size_t *) entity->value;
+}
+
 mongoc_client_session_t *
 entity_map_get_session (entity_map_t *entity_map,
                         const char *id,
@@ -1797,6 +1813,15 @@ entity_map_add_bson_array (entity_map_t *em,
    mongoc_array_t *array = BSON_ALIGNED_ALLOC (mongoc_array_t);
    mongoc_array_aligned_init (array, bson_t *);
    return _entity_map_add (em, id, "bson_array", (void *) array, error);
+}
+
+bool
+entity_map_add_size_t (entity_map_t *em,
+                       const char *id,
+                       size_t *value,
+                       bson_error_t *error)
+{
+   return _entity_map_add (em, id, "size_t", value, error);
 }
 
 /* implement $$sessionLsid */

--- a/src/libmongoc/tests/unified/entity-map.c
+++ b/src/libmongoc/tests/unified/entity-map.c
@@ -213,7 +213,7 @@ typedef const bson_t *(*get_reply_func_t) (const void *);
 typedef const char *(*get_command_name_func_t) (const void *);
 typedef const char *(*get_database_name_func_t) (const void *);
 typedef const bson_oid_t *(*get_service_id_func_t) (const void *);
-typedef int64_t (*get_server_connection_id_func_t) (const void *);
+typedef int32_t (*get_server_connection_id_func_t) (const void *);
 
 
 typedef struct command_callback_funcs_t {

--- a/src/libmongoc/tests/unified/entity-map.c
+++ b/src/libmongoc/tests/unified/entity-map.c
@@ -116,7 +116,7 @@ done:
 }
 
 event_t *
-event_new (char *type)
+event_new (const char *type)
 {
    event_t *event = NULL;
 
@@ -141,11 +141,14 @@ event_destroy (event_t *event)
 }
 
 static entity_t *
-entity_new (const char *type)
+entity_new (entity_map_t *em, const char *type)
 {
    entity_t *entity = NULL;
    entity = bson_malloc0 (sizeof (entity_t));
    entity->type = bson_strdup (type);
+   entity->entity_map = em;
+   _mongoc_array_init (&entity->observe_events, sizeof (observe_event_t));
+   _mongoc_array_init (&entity->store_events, sizeof (store_event_t));
    return entity;
 }
 
@@ -175,6 +178,25 @@ should_ignore_event (entity_t *client_entity, event_t *event)
       }
    }
 
+   {
+      observe_event_t *const begin =
+         (observe_event_t *) client_entity->observe_events.data;
+      observe_event_t *const end = begin + client_entity->observe_events.len;
+
+      bool is_observed = false;
+
+      for (observe_event_t *iter = begin; iter != end; ++iter) {
+         if (strcmp (iter->type, event->type) == 0) {
+            is_observed = true;
+            break;
+         }
+      }
+
+      if (!is_observed) {
+         return true;
+      }
+   }
+
    if (client_entity->observe_sensitive_commands &&
        *client_entity->observe_sensitive_commands) {
       return false;
@@ -184,28 +206,61 @@ should_ignore_event (entity_t *client_entity, event_t *event)
    return is_sensitive_command (event);
 }
 
+
+typedef void *(*get_context_func_t) (const void *);
+typedef const bson_t *(*get_command_func_t) (const void *);
+typedef const bson_t *(*get_reply_func_t) (const void *);
+typedef const char *(*get_command_name_func_t) (const void *);
+typedef const char *(*get_database_name_func_t) (const void *);
+typedef const bson_oid_t *(*get_service_id_func_t) (const void *);
+typedef int64_t (*get_server_connection_id_func_t) (const void *);
+
+
+typedef struct command_callback_funcs_t {
+   get_context_func_t get_context;
+   get_command_func_t get_command;
+   get_reply_func_t get_reply;
+   get_command_name_func_t get_command_name;
+   get_database_name_func_t get_database_name;
+   get_service_id_func_t get_service_id;
+   get_server_connection_id_func_t get_server_connection_id;
+} command_callback_funcs_t;
+
+
 static void
-command_started (const mongoc_apm_command_started_t *started)
+observe_event (entity_t *entity,
+               command_callback_funcs_t funcs,
+               const char *type,
+               const void *apm_command)
 {
-   entity_t *entity = NULL;
-   event_t *event = NULL;
+   BSON_ASSERT_PARAM (type);
+   BSON_ASSERT_PARAM (apm_command);
 
-   entity = (entity_t *) mongoc_apm_command_started_get_context (started);
-   event = event_new ("commandStartedEvent");
-   event->command =
-      bson_copy (mongoc_apm_command_started_get_command (started));
-   event->command_name =
-      bson_strdup (mongoc_apm_command_started_get_command_name (started));
+   BSON_ASSERT (funcs.get_context);
+   event_t *const event = event_new (type);
 
-   event->database_name =
-      bson_strdup (mongoc_apm_command_started_get_database_name (started));
-
-   if (mongoc_apm_command_started_get_service_id (started)) {
-      bson_oid_copy (mongoc_apm_command_started_get_service_id (started),
-                     &event->service_id);
+   if (funcs.get_command) {
+      event->command = bson_copy (funcs.get_command (apm_command));
    }
 
-   event->server_connection_id = started->server_connection_id;
+   if (funcs.get_reply) {
+      event->reply = bson_copy (funcs.get_reply (apm_command));
+   }
+
+   BSON_ASSERT (funcs.get_command_name);
+   event->command_name = bson_strdup (funcs.get_command_name (apm_command));
+
+   if (funcs.get_database_name) {
+      event->database_name =
+         bson_strdup (funcs.get_database_name (apm_command));
+   }
+
+   if (funcs.get_service_id (apm_command)) {
+      bson_oid_copy (funcs.get_service_id (apm_command), &event->service_id);
+   }
+
+   BSON_ASSERT (funcs.get_server_connection_id);
+   event->server_connection_id = funcs.get_server_connection_id (apm_command);
 
    if (should_ignore_event (entity, event)) {
       event_destroy (event);
@@ -213,60 +268,172 @@ command_started (const mongoc_apm_command_started_t *started)
    }
 
    LL_APPEND (entity->events, event);
+}
+
+
+static void
+store_event_to_entities (entity_t *entity, const char *type)
+{
+   BSON_ASSERT_PARAM (entity);
+   BSON_ASSERT_PARAM (type);
+
+   BSON_ASSERT (entity->entity_map);
+
+   entity_map_t *const em = entity->entity_map;
+
+   store_event_t *const begin = (store_event_t *) entity->store_events.data;
+   store_event_t *const end = begin + entity->store_events.len;
+
+   const int64_t usecs = usecs_since_epoch ();
+   const double secs = (double) usecs / 1000000.0;
+
+   bson_error_t error = {0};
+
+   for (store_event_t *iter = begin; iter != end; ++iter) {
+      if (strcmp (iter->type, type) == 0) {
+         mongoc_array_t *arr =
+            entity_map_get_bson_array (em, iter->entity_id, &error);
+         ASSERT_OR_PRINT (arr, error);
+
+         bson_t *doc = bson_new ();
+         BSON_APPEND_UTF8 (doc, "name", type);
+         BSON_APPEND_DOUBLE (doc, "observedAt", secs);
+
+         _mongoc_array_append_val (arr, doc); // Transfer ownership.
+      }
+   }
+}
+
+
+static void
+apm_command_callback (command_callback_funcs_t funcs,
+                      const char *type,
+                      const void *apm_command)
+{
+   BSON_ASSERT_PARAM (type);
+   BSON_ASSERT_PARAM (apm_command);
+
+   BSON_ASSERT (funcs.get_context);
+   entity_t *const entity = (entity_t *) funcs.get_context (apm_command);
+
+   observe_event (entity, funcs, type, apm_command);
+   store_event_to_entities (entity, type);
+}
+
+
+static void
+command_started (const mongoc_apm_command_started_t *started)
+{
+   command_callback_funcs_t funcs = {
+      .get_context =
+         (get_context_func_t) mongoc_apm_command_started_get_context,
+      .get_command =
+         (get_command_func_t) mongoc_apm_command_started_get_command,
+      .get_reply = NULL,
+      .get_command_name =
+         (get_command_name_func_t) mongoc_apm_command_started_get_command_name,
+      .get_database_name = (get_database_name_func_t)
+         mongoc_apm_command_started_get_database_name,
+      .get_service_id =
+         (get_service_id_func_t) mongoc_apm_command_started_get_service_id,
+      .get_server_connection_id = (get_server_connection_id_func_t)
+         mongoc_apm_command_started_get_server_connection_id,
+   };
+
+   apm_command_callback (funcs, "commandStartedEvent", started);
 }
 
 static void
 command_failed (const mongoc_apm_command_failed_t *failed)
 {
-   entity_t *entity = NULL;
-   event_t *event = NULL;
+   command_callback_funcs_t funcs = {
+      .get_context = (get_context_func_t) mongoc_apm_command_failed_get_context,
+      .get_command = NULL,
+      .get_reply = (get_reply_func_t) mongoc_apm_command_failed_get_reply,
+      .get_command_name =
+         (get_command_name_func_t) mongoc_apm_command_failed_get_command_name,
+      .get_database_name = NULL,
+      .get_service_id =
+         (get_service_id_func_t) mongoc_apm_command_failed_get_service_id,
+      .get_server_connection_id = (get_server_connection_id_func_t)
+         mongoc_apm_command_failed_get_server_connection_id,
+   };
 
-   entity = (entity_t *) mongoc_apm_command_failed_get_context (failed);
-   event = event_new ("commandFailedEvent");
-   event->reply = bson_copy (mongoc_apm_command_failed_get_reply (failed));
-   event->command_name =
-      bson_strdup (mongoc_apm_command_failed_get_command_name (failed));
-
-   if (mongoc_apm_command_failed_get_service_id (failed)) {
-      bson_oid_copy (mongoc_apm_command_failed_get_service_id (failed),
-                     &event->service_id);
-   }
-
-   event->server_connection_id = failed->server_connection_id;
-
-   if (should_ignore_event (entity, event)) {
-      event_destroy (event);
-      return;
-   }
-   LL_APPEND (entity->events, event);
+   apm_command_callback (funcs, "commandFailedEvent", failed);
 }
 
 static void
 command_succeeded (const mongoc_apm_command_succeeded_t *succeeded)
 {
-   entity_t *entity = NULL;
-   event_t *event = NULL;
+   command_callback_funcs_t funcs = {
+      .get_context =
+         (get_context_func_t) mongoc_apm_command_succeeded_get_context,
+      .get_command = NULL,
+      .get_reply = (get_reply_func_t) mongoc_apm_command_succeeded_get_reply,
+      .get_command_name = (get_command_name_func_t)
+         mongoc_apm_command_succeeded_get_command_name,
+      .get_database_name = NULL,
+      .get_service_id =
+         (get_service_id_func_t) mongoc_apm_command_succeeded_get_service_id,
+      .get_server_connection_id = (get_server_connection_id_func_t)
+         mongoc_apm_command_succeeded_get_server_connection_id,
+   };
 
-   entity = (entity_t *) mongoc_apm_command_succeeded_get_context (succeeded);
-   event = event_new ("commandSucceededEvent");
-   event->reply =
-      bson_copy (mongoc_apm_command_succeeded_get_reply (succeeded));
-   event->command_name =
-      bson_strdup (mongoc_apm_command_succeeded_get_command_name (succeeded));
-
-   if (mongoc_apm_command_succeeded_get_service_id (succeeded)) {
-      bson_oid_copy (mongoc_apm_command_succeeded_get_service_id (succeeded),
-                     &event->service_id);
-   }
-
-   event->server_connection_id = succeeded->server_connection_id;
-
-   if (should_ignore_event (entity, event)) {
-      event_destroy (event);
-      return;
-   }
-   LL_APPEND (entity->events, event);
+   apm_command_callback (funcs, "commandSucceededEvent", succeeded);
 }
+
+// Note: multiple invocations of this function is okay, since all it does
+// is set the appropriate pointer in `callbacks`, and the callback function(s)
+// being used is always the same for a given type.
+static void
+set_command_callback (mongoc_apm_callbacks_t *callbacks, const char *type)
+{
+   typedef void (*cb_t) (const void *);
+   typedef void (*set_func_t) (mongoc_apm_callbacks_t *, cb_t);
+
+   typedef struct _command_to_cb_t {
+      const char *type;
+      set_func_t set;
+      cb_t cb;
+   } command_to_cb_t;
+
+   const command_to_cb_t commands[] = {
+      {.type = "commandStartedEvent",
+       .set = (set_func_t) mongoc_apm_set_command_started_cb,
+       .cb = (cb_t) command_started},
+      {.type = "commandFailedEvent",
+       .set = (set_func_t) mongoc_apm_set_command_failed_cb,
+       .cb = (cb_t) command_failed},
+      {.type = "commandSucceededEvent",
+       .set = (set_func_t) mongoc_apm_set_command_succeeded_cb,
+       .cb = (cb_t) command_succeeded},
+      {.type = NULL, .set = NULL, .cb = NULL},
+   };
+
+   for (const command_to_cb_t *iter = commands; iter->type; ++iter) {
+      if (strcmp (type, iter->type) == 0) {
+         iter->set (callbacks, iter->cb);
+         return;
+      }
+   }
+}
+
+static void
+add_observe_event (entity_t *entity, const char *type)
+{
+   observe_event_t event = {.type = type};
+
+   _mongoc_array_append_val (&entity->observe_events, event);
+}
+
+static void
+add_store_event (entity_t *entity, const char *type, const char *entity_id)
+{
+   store_event_t event = {.type = type, .entity_id = entity_id};
+
+   _mongoc_array_append_val (&entity->store_events, event);
+}
+
 
 entity_t *
 entity_client_new (entity_map_t *em, bson_t *bson, bson_error_t *error)
@@ -283,8 +450,9 @@ entity_client_new (entity_map_t *em, bson_t *bson, bson_error_t *error)
    mongoc_server_api_t *api = NULL;
    char *errpath = NULL;
    char *err = NULL;
+   const char *store_entity_id = NULL;
 
-   entity = entity_new ("client");
+   entity = entity_new (em, "client");
    callbacks = mongoc_apm_callbacks_new ();
 
    bsonParse ( //
@@ -312,15 +480,15 @@ entity_client_new (entity_map_t *em, bson_t *bson, bson_error_t *error)
                when (not(type (utf8)),
                      error ("Every 'observeEvents' element must be a string")),
                // Dispatch based on the event name:
-               when (strEqual ("commandStartedEvent"),
-                     do (mongoc_apm_set_command_started_cb (callbacks,
-                                                            command_started))),
-               when (strEqual ("commandFailedEvent"),
-                     do (mongoc_apm_set_command_failed_cb (callbacks,
-                                                           command_failed))),
-               when (strEqual ("commandSucceededEvent"),
-                     do (mongoc_apm_set_command_succeeded_cb (
-                        callbacks, command_succeeded))),
+               when (anyOf (strEqual ("commandStartedEvent"),
+                            strEqual ("commandFailedEvent"),
+                            strEqual ("commandSucceededEvent")),
+                     do ({
+                        const char *const type =
+                           bson_iter_utf8 (&bsonVisitIter, NULL);
+                        set_command_callback (callbacks, type);
+                        add_observe_event (entity, type);
+                     })),
                // Unsupported (but known) event names:
                when (eval (is_unsupported_event_type (
                         bson_iter_utf8 (&bsonVisitIter, NULL))),
@@ -375,14 +543,45 @@ entity_client_new (entity_map_t *em, bson_t *bson, bson_error_t *error)
                *p = bsonAs (bool);
             })),
       // Which events should be available as entities:
-      find (key ("storeEventsAsEntities"),
-            if (not(type (array)),
-                then (error ("'storeEventsAsEntities' must be an array"))),
-            visitEach (if (not(type (utf8)),
-                           then (error ("Every 'storeEventsAsEntities' element "
-                                        "must be a string")))),
-            /* TODO: CDRIVER-3867 Comprehensive Atlas Testing */
-            error ("'storeEventsAsEntities' is not yet supported")),
+      find (
+         key ("storeEventsAsEntities"),
+         if (not(type (array)),
+             then (error ("'storeEventsAsEntities' must be an array"))),
+         visitEach (parse (
+            find (keyWithType ("id", utf8), storeStrRef (store_entity_id), do ({
+                     if (!entity_map_add_bson_array (
+                            em, store_entity_id, error)) {
+                        test_error ("failed to create storeEventsAsEntities "
+                                    "entity '%s': %s",
+                                    store_entity_id,
+                                    error->message);
+                     }
+                  })),
+            find (keyWithType ("events", array),
+                  visitEach (case (
+                     when (not(type (utf8)),
+                           error ("Every 'storeEventsAsEntities.events' "
+                                  "element must be a string")),
+                     when (anyOf (iStrEqual ("commandStartedEvent"),
+                                  iStrEqual ("commandFailedEvent"),
+                                  iStrEqual ("commandSucceededEvent")),
+                           do ({
+                              const char *const type =
+                                 bson_iter_utf8 (&bsonVisitIter, NULL);
+                              set_command_callback (callbacks, type);
+                              add_store_event (entity, type, store_entity_id);
+                           })),
+                     when (eval (is_unsupported_event_type (
+                              bson_iter_utf8 (&bsonVisitIter, NULL))),
+                           do (MONGOC_DEBUG (
+                              "Skipping unsupported event type '%s'",
+                              bsonAs (cstr)))),
+                     else (do (test_error ("Unknown event type '%s'",
+                                           bsonAs (cstr))))))),
+            visitOthers (
+               errorf (err,
+                       "Unexpected field '%s' in storeEventsAsEntities",
+                       bson_iter_key (&bsonVisitIter)))))),
       visitOthers (dupPath (errpath),
                    errorf (err,
                            "At [%s]: Unknown key '%s' given in entity options",
@@ -873,7 +1072,7 @@ entity_client_encryption_new (entity_map_t *entity_map,
                               bson_t *bson,
                               bson_error_t *error)
 {
-   entity_t *const entity = entity_new ("clientEncryption");
+   entity_t *const entity = entity_new (entity_map, "clientEncryption");
    bson_parser_t *const parser = bson_parser_new ();
    mongoc_client_encryption_opts_t *const ce_opts =
       mongoc_client_encryption_opts_new ();
@@ -1031,7 +1230,7 @@ entity_database_new (entity_map_t *entity_map,
    bson_t *database_opts = NULL;
    coll_or_db_opts_t *coll_or_db_opts = NULL;
 
-   entity = entity_new ("database");
+   entity = entity_new (entity_map, "database");
    parser = bson_parser_new ();
    bson_parser_utf8 (parser, "id", &entity->id);
    bson_parser_utf8 (parser, "client", &client_id);
@@ -1097,7 +1296,7 @@ entity_collection_new (entity_map_t *entity_map,
    bson_t *collection_opts = NULL;
    coll_or_db_opts_t *coll_or_db_opts = NULL;
 
-   entity = entity_new ("collection");
+   entity = entity_new (entity_map, "collection");
    parser = bson_parser_new ();
    bson_parser_utf8 (parser, "id", &entity->id);
    bson_parser_utf8 (parser, "database", &database_id);
@@ -1226,7 +1425,7 @@ entity_session_new (entity_map_t *entity_map, bson_t *bson, bson_error_t *error)
    bool ret = false;
    mongoc_client_session_t *session = NULL;
 
-   entity = entity_new ("session");
+   entity = entity_new (entity_map, "session");
    parser = bson_parser_new ();
    bson_parser_utf8 (parser, "id", &entity->id);
    bson_parser_utf8 (parser, "client", &client_id);
@@ -1287,7 +1486,7 @@ entity_bucket_new (entity_map_t *entity_map, bson_t *bson, bson_error_t *error)
    mongoc_write_concern_t *wc = NULL;
    bson_t *opts = NULL;
 
-   entity = entity_new ("bucket");
+   entity = entity_new (entity_map, "bucket");
    parser = bson_parser_new ();
    bson_parser_utf8 (parser, "id", &entity->id);
    bson_parser_utf8 (parser, "database", &database_id);
@@ -1496,6 +1695,8 @@ entity_destroy (entity_t *entity)
       event_destroy (event);
    }
 
+   _mongoc_array_destroy (&entity->observe_events);
+   _mongoc_array_destroy (&entity->store_events);
    bson_destroy (entity->ignore_command_monitoring_events);
    bson_free (entity->type);
    bson_free (entity->id);
@@ -1737,7 +1938,7 @@ _entity_map_add (entity_map_t *em,
       return false;
    }
 
-   entity = entity_new (type);
+   entity = entity_new (em, type);
    entity->value = value;
    entity->id = bson_strdup (id);
    LL_PREPEND (em->entities, entity);

--- a/src/libmongoc/tests/unified/entity-map.c
+++ b/src/libmongoc/tests/unified/entity-map.c
@@ -186,7 +186,7 @@ should_ignore_event (entity_t *client_entity, event_t *event)
       bool is_observed = false;
 
       for (observe_event_t *iter = begin; iter != end; ++iter) {
-         if (strcmp (iter->type, event->type) == 0) {
+         if (bson_strcasecmp (iter->type, event->type) == 0) {
             is_observed = true;
             break;
          }
@@ -290,7 +290,7 @@ store_event_to_entities (entity_t *entity, const char *type)
    bson_error_t error = {0};
 
    for (store_event_t *iter = begin; iter != end; ++iter) {
-      if (strcmp (iter->type, type) == 0) {
+      if (bson_strcasecmp (iter->type, type) == 0) {
          mongoc_array_t *arr =
             entity_map_get_bson_array (em, iter->entity_id, &error);
          ASSERT_OR_PRINT (arr, error);
@@ -411,7 +411,7 @@ set_command_callback (mongoc_apm_callbacks_t *callbacks, const char *type)
    };
 
    for (const command_to_cb_t *iter = commands; iter->type; ++iter) {
-      if (strcmp (type, iter->type) == 0) {
+      if (bson_strcasecmp (type, iter->type) == 0) {
          iter->set (callbacks, iter->cb);
          return;
       }
@@ -480,9 +480,9 @@ entity_client_new (entity_map_t *em, bson_t *bson, bson_error_t *error)
                when (not(type (utf8)),
                      error ("Every 'observeEvents' element must be a string")),
                // Dispatch based on the event name:
-               when (anyOf (strEqual ("commandStartedEvent"),
-                            strEqual ("commandFailedEvent"),
-                            strEqual ("commandSucceededEvent")),
+               when (anyOf (iStrEqual ("commandStartedEvent"),
+                            iStrEqual ("commandFailedEvent"),
+                            iStrEqual ("commandSucceededEvent")),
                      do ({
                         const char *const type =
                            bson_iter_utf8 (&bsonVisitIter, NULL);

--- a/src/libmongoc/tests/unified/entity-map.h
+++ b/src/libmongoc/tests/unified/entity-map.h
@@ -34,6 +34,15 @@ typedef struct _event_t {
    struct _event_t *next;
 } event_t;
 
+typedef struct _observe_event_t {
+   const char *type; // Non-owning. Type of event to observe.
+} observe_event_t;
+
+typedef struct _store_event_t {
+   const char *entity_id; // Non-owning. Target entity to store event.
+   const char *type;      // Non-owning. Type of event to store.
+} store_event_t;
+
 typedef struct _entity_t {
    char *id;
    char *type;
@@ -42,6 +51,9 @@ typedef struct _entity_t {
    bool *observe_sensitive_commands;
    struct _entity_t *next;
    event_t *events;
+   struct _entity_map_t *entity_map; // Parent entity map.
+   mongoc_array_t observe_events;    // observe_event_t [N].
+   mongoc_array_t store_events;      // store_event_t [N].
    bson_t *lsid;
    char *session_client_id;
 } entity_t;
@@ -53,7 +65,7 @@ typedef struct _entity_findcursor_t entity_findcursor_t;
  * 1. Uniqueness. Attempting to create two entries with the same id is an error.
  * 2. Referential integrity. Attempting to get with an unknown id is an error.
  */
-typedef struct {
+typedef struct _entity_map_t {
    entity_t *entities;
    bool reduced_heartbeat;
 } entity_map_t;

--- a/src/libmongoc/tests/unified/entity-map.h
+++ b/src/libmongoc/tests/unified/entity-map.h
@@ -96,6 +96,13 @@ entity_map_add_bson_array (entity_map_t *em,
                            const char *id,
                            bson_error_t *error);
 
+/* Steals ownership of value. */
+bool
+entity_map_add_size_t (entity_map_t *em,
+                       const char *id,
+                       size_t *value,
+                       bson_error_t *error);
+
 /* Returns NULL and sets @error if @id does not map to an entry. */
 entity_t *
 entity_map_get (entity_map_t *em, const char *id, bson_error_t *error);
@@ -156,6 +163,11 @@ mongoc_array_t *
 entity_map_get_bson_array (entity_map_t *entity_map,
                            const char *id,
                            bson_error_t *error);
+
+size_t *
+entity_map_get_size_t (entity_map_t *entity_map,
+                       const char *id,
+                       bson_error_t *error);
 
 mongoc_gridfs_bucket_t *
 entity_map_get_bucket (entity_map_t *entity_map,

--- a/src/libmongoc/tests/unified/entity-map.h
+++ b/src/libmongoc/tests/unified/entity-map.h
@@ -91,6 +91,11 @@ entity_map_add_bson (entity_map_t *em,
                      bson_val_t *val,
                      bson_error_t *error);
 
+bool
+entity_map_add_bson_array (entity_map_t *em,
+                           const char *id,
+                           bson_error_t *error);
+
 /* Returns NULL and sets @error if @id does not map to an entry. */
 entity_t *
 entity_map_get (entity_map_t *em, const char *id, bson_error_t *error);
@@ -146,6 +151,11 @@ bson_val_t *
 entity_map_get_bson (entity_map_t *entity_map,
                      const char *id,
                      bson_error_t *error);
+
+mongoc_array_t *
+entity_map_get_bson_array (entity_map_t *entity_map,
+                           const char *id,
+                           bson_error_t *error);
 
 mongoc_gridfs_bucket_t *
 entity_map_get_bucket (entity_map_t *entity_map,

--- a/src/libmongoc/tests/unified/operation.c
+++ b/src/libmongoc/tests/unified/operation.c
@@ -3318,7 +3318,7 @@ append_loop_error (entity_map_t *em,
 
 // Expected to be set by a SIGINT (on Linux and OS X) or CTRL_BREAK_EVENT (on
 // Windows) handler when test suite is being executed by test-atlas-executor.
-bool operation_loop_terminated = false;
+volatile sig_atomic_t operation_loop_terminated = false;
 
 static bool
 operation_loop (test_t *test,

--- a/src/libmongoc/tests/unified/operation.c
+++ b/src/libmongoc/tests/unified/operation.c
@@ -19,6 +19,7 @@
 #include "mongoc-array-private.h"
 #include "result.h"
 #include "test-diagnostics.h"
+#include "test-libmongoc.h"
 #include "util.h"
 #include "utlist.h"
 
@@ -3202,17 +3203,278 @@ operation_assert_session_unpinned (test_t *test,
 }
 
 static bool
+create_loop_bson_array_entity (entity_map_t *em,
+                               const char *id,
+                               bson_error_t *error)
+{
+   BSON_ASSERT_PARAM (em);
+   BSON_ASSERT (id || true);
+   BSON_ASSERT (error || true);
+
+   if (!id) {
+      // Nothing to do.
+      return true;
+   }
+
+   const entity_t *const entity = entity_map_get (em, id, error);
+
+   // If the entity does not exist, the test runner MUST create it with the
+   // type of BSON array.
+   if (!entity) {
+      return entity_map_add_bson_array (em, id, error);
+   }
+
+   // If the entity exists and is of type BSON array, the test runner MUST do
+   // nothing.
+   else if (strcmp (entity->type, "bson_array") == 0) {
+      return true;
+   }
+
+   // If the entity exists and is of a different type, the test runner MUST
+   // raise an error.
+   else {
+      test_set_error (
+         error, "loop entity %s exists but is not of type BSON array", id);
+      return false;
+   }
+}
+
+static bool
+create_loop_size_t_entity (entity_map_t *em,
+                           const char *id,
+                           bson_error_t *error)
+{
+   BSON_ASSERT_PARAM (em);
+   BSON_ASSERT (id || true);
+   BSON_ASSERT (error || true);
+
+   if (!id) {
+      return true;
+   }
+
+   const entity_t *const entity = entity_map_get (em, id, error);
+
+   // If the entity of the specified name already exists, the test runner MUST
+   // raise an error.
+   if (entity) {
+      test_set_error (
+         error, "loop entity %s already exists when it should not", id);
+      return false;
+   }
+
+   return entity_map_add_size_t (em, id, bson_malloc0 (sizeof (size_t)), error);
+}
+
+static void
+increment_loop_counter (entity_map_t *em, const char *id)
+{
+   BSON_ASSERT_PARAM (em);
+   BSON_ASSERT (id || true);
+
+   if (id) {
+      bson_error_t error = {0};
+      size_t *const counter = entity_map_get_size_t (em, id, &error);
+
+      // Entity should always be valid at this point.
+      ASSERT_OR_PRINT (counter, error);
+
+      *counter += 1u;
+   }
+}
+
+static bool
+append_loop_error (entity_map_t *em,
+                   const char *id,
+                   bson_error_t *op_error,
+                   bson_error_t *error)
+{
+   BSON_ASSERT_PARAM (em);
+   BSON_ASSERT (id || true);
+   BSON_ASSERT_PARAM (op_error);
+   BSON_ASSERT (error || true);
+
+   if (!id) {
+      return true;
+   }
+
+   mongoc_array_t *array = entity_map_get_bson_array (em, id, error);
+
+   if (!array) {
+      return false;
+   }
+
+   const int64_t usecs = usecs_since_epoch ();
+   const double secs = (double) usecs / 1000000.0;
+
+   bson_t *doc = bson_new ();
+   BSON_APPEND_UTF8 (doc, "error", op_error->message);
+   BSON_APPEND_DOUBLE (doc, "time", secs);
+
+   _mongoc_array_append_val (array, doc); // Transfer ownership.
+
+   return true;
+}
+
+// Expected to be set by a SIGINT (on Linux and OS X) or CTRL_BREAK_EVENT (on
+// Windows) handler when test suite is being executed by test-atlas-executor.
+bool operation_loop_terminated = false;
+
+static bool
 operation_loop (test_t *test,
                 operation_t *op,
                 result_t *result,
                 bson_error_t *error)
 {
-   BSON_UNUSED (test);
-   BSON_UNUSED (op);
-   BSON_UNUSED (result);
-   /* TODO: CDRIVER-3867 Comprehensive Atlas Testing */
-   test_set_error (error, "Loop operation not implemented");
-   return false;
+   bool ret = false;
+
+   BSON_ASSERT_PARAM (test);
+   BSON_ASSERT_PARAM (op);
+   BSON_ASSERT_PARAM (result);
+   BSON_ASSERT_PARAM (error);
+
+   if (test->loop_operation_executed) {
+      test_set_error (error,
+                      "test should not contain more than one loop operation");
+      return false;
+   } else {
+      test->loop_operation_executed = true;
+   }
+
+   if (!op->object || strcmp (op->object, "testRunner") != 0) {
+      test_set_error (error, "loop operation object should be \"testRunner\"");
+      return false;
+   }
+
+   bson_t *operations = NULL;
+   char *errors_as_entity = NULL;
+   char *failures_as_entity = NULL;
+   char *successes_as_entity = NULL;
+   char *iterations_as_entity = NULL;
+
+   bson_parser_t *const parser = bson_parser_new ();
+
+   bson_parser_array (parser, "operations", &operations);
+   bson_parser_utf8_optional (parser, "storeErrorsAsEntity", &errors_as_entity);
+   bson_parser_utf8_optional (
+      parser, "storeFailuresAsEntity", &failures_as_entity);
+   bson_parser_utf8_optional (
+      parser, "storeSuccessesAsEntity", &successes_as_entity);
+   bson_parser_utf8_optional (
+      parser, "storeIterationsAsEntity", &iterations_as_entity);
+
+   if (!bson_parser_parse (parser, op->arguments, error)) {
+      goto done;
+   }
+
+   // If the test runner propagates an error or failure (e.g. it is not captured
+   // by the loop or occurs outside of the loop), it MUST be reported by the
+   // workload executor.
+   const bool should_propagate = !failures_as_entity && !errors_as_entity;
+
+   // Guarantee propagation of errors if captures are not defined by the loop.
+   if (should_propagate) {
+      // Ensure any errors or failures are still reported.
+      errors_as_entity = bson_strdup ("errors");
+   }
+
+   // If only one of errors or failures is provided, all failures and errors
+   // must be stored in the provided entity.
+   if ((errors_as_entity ? 1 : 0) != (failures_as_entity ? 1 : 0)) {
+      if (errors_as_entity) {
+         failures_as_entity = bson_strdup (errors_as_entity);
+      } else {
+         errors_as_entity = bson_strdup (failures_as_entity);
+      }
+   }
+
+   if (!create_loop_bson_array_entity (
+          test->entity_map, errors_as_entity, error)) {
+      goto done;
+   }
+
+   if (!create_loop_bson_array_entity (
+          test->entity_map, failures_as_entity, error)) {
+      goto done;
+   }
+
+   if (!create_loop_size_t_entity (
+          test->entity_map, successes_as_entity, error)) {
+      goto done;
+   }
+
+   if (!create_loop_size_t_entity (
+          test->entity_map, iterations_as_entity, error)) {
+      goto done;
+   }
+
+   MONGOC_DEBUG ("running loop operations...");
+   // `operation_loop_terminated` may be set to true within the loop if
+   // `should_propagate` is true on error/failure or by test-atlas-executor upon
+   // receiving a termination request.
+   while (!operation_loop_terminated) {
+      // Clear any prior errors that may have occurred.
+      error->code = 0;
+
+      increment_loop_counter (test->entity_map, iterations_as_entity);
+
+      bson_iter_t iter;
+      BSON_FOREACH (operations, iter)
+      {
+         bson_t op_bson;
+         bson_iter_bson (&iter, &op_bson);
+
+         bson_error_t op_error = {0};
+
+         // Execute the loop sub-operation.
+         const bool res = operation_run (test, &op_bson, &op_error);
+
+         if (res) {
+            increment_loop_counter (test->entity_map, successes_as_entity);
+         } else {
+            // Categorize errors triggered by a sub-operation as a "failure".
+            // If this operation fails, categorize as an "error" instead.
+            (void) append_loop_error (
+               test->entity_map, failures_as_entity, &op_error, error);
+
+            // If neither storeErrorsAsEntity nor storeFailuresAsEntity are
+            // specified, the loop MUST terminate and raise the error/failure
+            // (i.e. the error/failure will interrupt the test).
+            operation_loop_terminated =
+               operation_loop_terminated || should_propagate;
+
+            // If, in the course of executing sub-operations, a sub-operation
+            // yields an error or failure, the test runner MUST NOT execute
+            // subsequent sub-operations in the same loop iteration.
+            break;
+         }
+      } // End of loop sub-operations, but *not* end of loop iterations.
+
+      // Categorize errors triggered outside of sub-operation execution as
+      // "errors".
+      if (error->code != 0) {
+         // We have a problem if we can't store errors without triggering a new
+         // error. Terminate the test suite early instead of looping with an
+         // irrecoverable state.
+         ASSERT_OR_PRINT (append_loop_error (
+                             test->entity_map, errors_as_entity, error, error),
+                          (*error));
+
+         // If neither storeErrorsAsEntity nor storeFailuresAsEntity are
+         // specified, the loop MUST terminate and raise the error/failure
+         // (i.e. the error/failure will interrupt the test).
+         operation_loop_terminated =
+            operation_loop_terminated || should_propagate;
+      }
+   }
+   MONGOC_DEBUG ("running loop operations... done.");
+
+   result_from_ok (result);
+   ret = true;
+
+done:
+   bson_parser_destroy_with_parsed_fields (parser);
+
+   return ret;
 }
 
 static bool
@@ -3258,11 +3520,11 @@ operation_rename (test_t *test,
    }
    // We only support collections so far
    if (0 != strcmp (ent->type, "collection")) {
-      test_set_error (
-         error,
-         "'rename' is only supported for collection objects '%s' has type '%s'",
-         object,
-         ent->type);
+      test_set_error (error,
+                      "'rename' is only supported for collection objects "
+                      "'%s' has type '%s'",
+                      object,
+                      ent->type);
       goto done;
    }
 

--- a/src/libmongoc/tests/unified/operation.c
+++ b/src/libmongoc/tests/unified/operation.c
@@ -3668,7 +3668,10 @@ operation_run (test_t *test, bson_t *op_bson, bson_error_t *error)
       op->session = session;
    }
 
-   MONGOC_DEBUG ("running operation: %s", tmp_json (op_bson));
+   // Avoid spamming output with sub-operations when executing loop operation.
+   if (!test->loop_operation_executed || operation_loop_terminated) {
+      MONGOC_DEBUG ("running operation: %s", tmp_json (op_bson));
+   }
 
    num_ops = sizeof (op_to_fn_map) / sizeof (op_to_fn_t);
    result = result_new ();

--- a/src/libmongoc/tests/unified/operation.h
+++ b/src/libmongoc/tests/unified/operation.h
@@ -23,4 +23,7 @@
 bool
 operation_run (test_t *test, bson_t *bson, bson_error_t *error);
 
+// Should only be used by test-atlas-executor.
+extern bool operation_loop_terminated;
+
 #endif /* UNIFIED_OPERATION_H */

--- a/src/libmongoc/tests/unified/operation.h
+++ b/src/libmongoc/tests/unified/operation.h
@@ -20,10 +20,12 @@
 #include "runner.h"
 #include "test-diagnostics.h"
 
+#include <signal.h>
+
 bool
 operation_run (test_t *test, bson_t *bson, bson_error_t *error);
 
 // Should only be used by test-atlas-executor.
-extern bool operation_loop_terminated;
+extern volatile sig_atomic_t operation_loop_terminated;
 
 #endif /* UNIFIED_OPERATION_H */

--- a/src/libmongoc/tests/unified/runner.c
+++ b/src/libmongoc/tests/unified/runner.c
@@ -1047,7 +1047,7 @@ test_check_event (test_t *test,
    bson_iter_init (&iter, expected);
    bson_iter_next (&iter);
    expected_event_type = bson_iter_key (&iter);
-   if (0 != strcmp (expected_event_type, actual->type)) {
+   if (0 != bson_strcasecmp (expected_event_type, actual->type)) {
       test_set_error (error,
                       "expected event type: %s, but got: %s",
                       expected_event_type,

--- a/src/libmongoc/tests/unified/runner.c
+++ b/src/libmongoc/tests/unified/runner.c
@@ -1498,6 +1498,8 @@ test_generate_atlas_results (test_t *test, bson_error_t *error)
       return true;
    }
 
+   MONGOC_DEBUG ("generating events.json and results.json files...");
+
    size_t *const iterations =
       entity_map_get_size_t (test->entity_map, "iterations", NULL);
    size_t *const successes =
@@ -1560,6 +1562,8 @@ test_generate_atlas_results (test_t *test, bson_error_t *error)
 
    bson_destroy (&events_doc);
    bson_destroy (&results_doc);
+
+   MONGOC_DEBUG ("generating events.json and results.json files... done.");
 
    return true;
 }

--- a/src/libmongoc/tests/unified/runner.c
+++ b/src/libmongoc/tests/unified/runner.c
@@ -1521,12 +1521,18 @@ test_generate_atlas_results (test_t *test, bson_error_t *error)
    append_size_t (&results_doc, "numIterations", iterations ? *iterations : 0u);
    append_size_t (&results_doc, "numSuccesses", successes ? *successes : 0u);
 
+#ifdef WIN32
+   const int perms = _S_IWRITE;
+#else
+   const int perms = S_IRWXU;
+#endif
+
    mongoc_stream_t *const events_file = mongoc_stream_file_new_for_path (
-      "events.json", O_CREAT | O_WRONLY | O_TRUNC, S_IRWXU);
+      "events.json", O_CREAT | O_WRONLY | O_TRUNC, perms);
    ASSERT_WITH_MSG (events_file, "could not open events.json");
 
    mongoc_stream_t *const results_file = mongoc_stream_file_new_for_path (
-      "results.json", O_CREAT | O_WRONLY | O_TRUNC, S_IRWXU);
+      "results.json", O_CREAT | O_WRONLY | O_TRUNC, perms);
    ASSERT_WITH_MSG (results_file, "could not open results.json");
 
    size_t events_json_len = 0u;

--- a/src/libmongoc/tests/unified/runner.h
+++ b/src/libmongoc/tests/unified/runner.h
@@ -61,6 +61,7 @@ typedef struct {
    bson_t *outcome;
    entity_map_t *entity_map;
    failpoint_t *failpoints;
+   bool loop_operation_executed;
 } test_t;
 
 /* Set server_id to 0 if the failpoint was not against a pinned mongos. */

--- a/src/libmongoc/tests/unified/runner.h
+++ b/src/libmongoc/tests/unified/runner.h
@@ -74,4 +74,7 @@ register_failpoint (test_t *test,
 void
 run_unified_tests (TestSuite *suite, const char *base, const char *subdir);
 
+void
+run_one_test_file (bson_t *bson);
+
 #endif /* UNIFIED_RUNNER_H */

--- a/src/libmongoc/tests/unified/test-diagnostics.c
+++ b/src/libmongoc/tests/unified/test-diagnostics.c
@@ -86,7 +86,9 @@ handle_abort (int signo)
 {
    BSON_UNUSED (signo);
    MONGOC_ERROR ("abort handler entered");
-   fprintf (stderr, "%s", test_diagnostics_error_string (NULL));
+   char *const msg = test_diagnostics_error_string (NULL);
+   fprintf (stderr, "%s", msg);
+   bson_free (msg);
 }
 
 void

--- a/src/libmongoc/tests/unified/util.c
+++ b/src/libmongoc/tests/unified/util.c
@@ -185,7 +185,7 @@ is_unsupported_event_type (const char *event_type)
    char **iter;
 
    for (iter = unsupported_event_types; *iter != NULL; iter++) {
-      if (0 == strcmp (event_type, *iter)) {
+      if (0 == bson_strcasecmp (event_type, *iter)) {
          return true;
       }
    }

--- a/src/libmongoc/tests/unified/util.c
+++ b/src/libmongoc/tests/unified/util.c
@@ -170,5 +170,5 @@ usecs_since_epoch (void)
    BSON_ASSERT (INT64_MAX / factor >= secs);
    BSON_ASSERT (INT64_MAX - (factor * secs) >= usecs);
 
-   return tv.tv_sec * factor + usecs;
+   return secs * factor + usecs;
 }

--- a/src/libmongoc/tests/unified/util.c
+++ b/src/libmongoc/tests/unified/util.c
@@ -191,3 +191,23 @@ is_unsupported_event_type (const char *event_type)
    }
    return false;
 }
+
+int64_t
+usecs_since_epoch (void)
+{
+   struct timeval tv;
+   BSON_ASSERT (bson_gettimeofday (&tv) == 0);
+
+   BSON_ASSERT (bson_in_range_signed (int64_t, tv.tv_sec));
+   BSON_ASSERT (bson_in_range_signed (int64_t, tv.tv_usec));
+
+   const int64_t secs = (int64_t) tv.tv_sec;
+   const int64_t usecs = (int64_t) tv.tv_usec;
+
+   const int64_t factor = 1000000;
+
+   BSON_ASSERT (INT64_MAX / factor >= secs);
+   BSON_ASSERT (INT64_MAX - (factor * secs) >= usecs);
+
+   return tv.tv_sec * factor + usecs;
+}

--- a/src/libmongoc/tests/unified/util.h
+++ b/src/libmongoc/tests/unified/util.h
@@ -34,7 +34,12 @@ bson_type_from_string (const char *in);
 const char *
 bson_type_to_string (bson_type_t btype);
 
-/* Returns true if this is an event type (part of observeEvents or expectedEvents) that is unsupported and not emitted by the C driver. */
-bool is_unsupported_event_type (const char* event_type);
+/* Returns true if this is an event type (part of observeEvents or
+ * expectedEvents) that is unsupported and not emitted by the C driver. */
+bool
+is_unsupported_event_type (const char *event_type);
+
+int64_t
+usecs_since_epoch (void);
 
 #endif /* UNIFIED_UTIL_H */


### PR DESCRIPTION
## Description

This PR introduces the `test-atlas-executor` binary to be used by the [Drivers Atlas Testing](https://github.com/mongodb-labs/drivers-atlas-testing) integration scripts for the C Driver and implements the `loop` unified test runner operation.

Addresses CDRIVER-2964 and is related to https://github.com/mongodb-labs/drivers-atlas-testing/pull/164.

Verified by [this patch](https://spruce.mongodb.com/version/640f8e347742aee833e8e489/tasks).

## Unified Test Runner

The [Atlas Planned Maintenance Test Scenario Format](https://mongodb-labs.github.io/drivers-atlas-testing/spec-test-format.html) reuses the [Unified Test Format](https://github.com/mongodb/specifications/blob/ed45dc95ca174a5832d653adec5a842184b7a82f/source/unified-test-format/unified-test-format.rst) specification but in an environment incompatible with many assumptions made by the C Driver. This necessated several refactors of the unified test runner implementation to support both normal test execution (via the existing `test-libmongoc` binary) and Atlas Testing (via the new `test-atlas-executor` binary).

### test-libmongoc-lib

First and foremost, the `main()` function for `test-libmongoc` was separated from the `test-libmongoc` library into a new `test-libmongoc-main.c`. This permits defining a separate `main()` for the new `test-atlas-executor` executable while reusing the same unified test runner implementation. Both executables now link to a common `test-libmongoc-lib` static library (whereas prior the sources `${test-libmongoc-sources}` were passed directly to compilation of the old `test-libmongoc` target). Two new functions `test_libmongoc_init` and `test_libmongoc_destroy` were introduced to maintain correct initialization behavior of `test-libmongoc-lib` globals.

### test-atlas-executor

The new `test-atlas-executor` implements a unique, barebones `TestSuite` environment designed specifically to work according to the behavior of the [Atlas Testing workload executor](https://mongodb-labs.github.io/drivers-atlas-testing/spec-workload-executor.html).

The workload executor script passes the `connection-string` via the `MONGOC_TEST_URI` environment variable (reusing existing test API) and passes the `workload-spec` as `argv[1]`. The provided `workload-spec` is converted to a BSON object as-if it were a unified spec test file via `workload_spec_to_bson`, then directly executed via `TestSuite_Run_Atlas` as the sole test to be executed by the test suite.

The only other notable feature of `test-atlas-executor` is the `SIGINT` handler. This is explained in the section below concerning the `loop` operation.

### New Unified Test Runner Entities

Two new entity types were required to support the `store.*AsEntity` parameters of the new `loop` operation: a BSON array entity to store events/failures/errors and a "counter" entity to keep track of iterations/successes.

The BSON array entity was implemented as a `mongoc_array_t` of `bson_t*` objects rather than a `bson_t` storing a BSON array. This is to simplify append and iteration operations on the array of BSON objects, which is cumbersome when done via a `bson_t` object. The BSON object containing a BSON array as required by the spec is created on-demand in `test_generate_atlas_results`. The element type is `bson_t *` rather than `bson_t` to avoid potential memory management complications caused by by-value copying `bson_t` objects into the array.

The "counter" entity was implemented as a simple `size_t`.

### usecs_since_epoch

A new `usecs_since_epoch` utility function was added, supplementing `_mongoc_get_real_time_ms`, as millisecond precision was observed to be a bit too low for the floating-point timestamps in the elements of the events/failures/errors arrays, which occasionally led to multiple events with identical timestamps.

### Entity Map

The entity map's handling of event handlers required refactoring to support the specification of _either_ `observeEvents` or `storeEventsAsEntities` or both.

New arrays `observe_events` and `store_events` were added to `entity_t` that indicate which event types were requested to be "observed" or "stored". These arrays are populated during parsing and creation of a "client" entity. When any (supported) event type is specified, the `set_command_callback` function is invoked, registering the appropriate callback function via `mongoc_apm_set_.*_cb`. When invoked, the registered callback function invokes both `observe_event` and `store_event_to_entities`, each of which inspect the `observe_events` and `store_events` arrays respectively to determine whether or not to record the given event.

These changes were also accompanied by an update of command type string comparison to be case-insensitive to support both `commandStartedEvent` and `CommandStartedEvent` syntax (was not a problem prior, but the casing is inconsistent for Atlas Testing workload specs).

### Miscellaneous Behavior Exceptions

The unified test runner library makes assumptions about the environment that do not apply when executed by the Atlas Testing workload executor. These assumptions (and corresponding workarounds) include:

- If defined, `MONGOC_TEST_URI` always starts with `mongodb://`.
- If provided, username and password is only ever specified via `MONGOC_TEST_USER` and `MONGOC_TEST_PASSWORD`.
- If there is a live server, its URI always satisfies a certain format (see `call_hello_with_host_and_port`).

These assumptions are handled (avoided) by querying the presence of a new `MONGOC_TEST_ATLAS` environment variable. Grepping for `MONGOC_TEST_ATLAS` should reveal where prior assumptions are not compatible with the Atlas Testing environment with corresponding comments documentation rationale, including the conditional invocation of `test_generate_atlas_results` prior to returning from `test_run` (before destruction of recorded events).

### serverSelectionTryOnce=false

This URI option was being set in `test_framework_get_uri_str_no_auth` (typically invoked as `test_framework_get_uri`) for convenience. When run as `test-atlas-executor`, this option is required to ensure correct behavior during maintenance scenarios (keep looking for the server instead of failing on first attempt).

## `loop` Operation

All the changes to the unified test runner above were to permit the implementation of the new `loop` operation. Due to the complexity of the `loop` operation's expected behavior, most behavior and rationale is documented with inline comments.

The only major point to note is that the `loop` operation is implemented assuming it is _only_ executed when run by `test-atlas-executor`, not `test-libmongoc`. This assumption is primarily motivated by the `operation_loop_terminated` global variable that is set by the `SIGINT` signal handler registered by `test-atlas-executor`. This signal handler is required to "gracefully" cease execution of further loop iterations as may be requested by the workload executor. Similar handling could be added to `test-libmongoc` but was omitted on grounds of unnecessary complexity (not an expected use case).