### PR TITLE
CDRIVER-4596 Reducing Warnings - MSVC and MinGW Warnings in libbson

### DIFF
--- a/src/libbson/CMakeLists.txt
+++ b/src/libbson/CMakeLists.txt
@@ -210,6 +210,13 @@ set (HEADERS_FORWARDING
 )
 
 add_library (bson_shared SHARED ${SOURCES} ${HEADERS} ${HEADERS_FORWARDING})
+if (MSVC AND MSVC_VERSION VERSION_LESS 1900)
+   message (STATUS "Disabling warning C4756 for VS 2013 and older")
+   # Macro constant INFINITY triggers constant arithmetic overflow warnings in
+   # VS 2013, but VS 2013 doesn't support inline warning suppression.
+   # Remove once support for VS 2013 is dropped.
+   target_compile_options(bson_shared PRIVATE /wd4756)
+endif ()
 set (CMAKE_CXX_VISIBILITY_PRESET hidden)
 target_compile_definitions (bson_shared
    PRIVATE
@@ -278,6 +285,13 @@ endif ()
 
 if (MONGOC_ENABLE_STATIC_BUILD)
    add_library (bson_static STATIC ${SOURCES} ${HEADERS} ${HEADERS_FORWARDING})
+   if (MSVC AND MSVC_VERSION VERSION_LESS 1900)
+      message (STATUS "Disabling warning C4756 for VS 2013 and older")
+      # Macro constant INFINITY triggers constant arithmetic overflow warnings in
+      # VS 2013, but VS 2013 doesn't support inline warning suppression.
+      # Remove once support for VS 2013 is dropped.
+      target_compile_options(bson_static PRIVATE /wd4756)
+   endif ()
    target_compile_definitions (bson_static
       PUBLIC
          BSON_STATIC

--- a/src/libbson/examples/bson-metrics.c
+++ b/src/libbson/examples/bson-metrics.c
@@ -81,8 +81,12 @@ static bson_metrics_state_t state;
 static int
 compar_bson_type_metrics (const void *a, const void *b)
 {
-   return (((bson_type_metrics_t *) b)->count -
-           ((bson_type_metrics_t *) a)->count);
+   const uint64_t a_count = ((bson_type_metrics_t *) b)->count;
+   const uint64_t b_count = ((bson_type_metrics_t *) a)->count;
+   if (a_count == b_count) {
+      return 0;
+   }
+   return a_count < b_count ? -1 : 1;
 }
 
 /*

--- a/src/libbson/examples/bson-metrics.c
+++ b/src/libbson/examples/bson-metrics.c
@@ -81,8 +81,8 @@ static bson_metrics_state_t state;
 static int
 compar_bson_type_metrics (const void *a, const void *b)
 {
-   const uint64_t a_count = ((bson_type_metrics_t *) b)->count;
-   const uint64_t b_count = ((bson_type_metrics_t *) a)->count;
+   const uint64_t a_count = ((bson_type_metrics_t *) a)->count;
+   const uint64_t b_count = ((bson_type_metrics_t *) b)->count;
    if (a_count == b_count) {
       return 0;
    }

--- a/src/libbson/src/bson/bson-decimal128.c
+++ b/src/libbson/src/bson/bson-decimal128.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <ctype.h>
 
+#include "bson-cmp.h"
 #include "bson-decimal128.h"
 #include "bson-types.h"
 #include "bson-macros.h"
@@ -628,7 +629,8 @@ bson_decimal128_from_string_w_len (const char *string,     /* IN */
        bson_cmp_greater_us (radix_position, exponent + (1 << 14))) {
       exponent = BSON_DECIMAL128_EXPONENT_MIN;
    } else {
-      exponent -= radix_position;
+      BSON_ASSERT (bson_in_range_unsigned (int32_t, radix_position));
+      exponent -= (int32_t) radix_position;
    }
 
    /* Attempt to normalize the exponent */

--- a/src/libbson/src/bson/bson-decimal128.c
+++ b/src/libbson/src/bson/bson-decimal128.c
@@ -155,8 +155,6 @@ bson_decimal128_to_string (const bson_decimal128_t *dec, /* IN  */
    uint8_t significand_msb; /* the most signifcant significand bits (50-46) */
    _bson_uint128_t
       significand128; /* temporary storage for significand decoding */
-   size_t i;          /* indexing variables */
-   int j, k;
 
    memset (significand_str, 0, sizeof (significand_str));
 
@@ -212,7 +210,7 @@ bson_decimal128_to_string (const bson_decimal128_t *dec, /* IN  */
        */
       is_zero = true;
    } else {
-      for (k = 3; k >= 0; k--) {
+      for (int k = 3; k >= 0; k--) {
          uint32_t least_digits = 0;
          _bson_uint128_divide1B (
             significand128, &significand128, &least_digits);
@@ -223,7 +221,7 @@ bson_decimal128_to_string (const bson_decimal128_t *dec, /* IN  */
             continue;
          }
 
-         for (j = 8; j >= 0; j--) {
+         for (int j = 8; j >= 0; j--) {
             significand[k * 9 + j] = least_digits % 10;
             least_digits /= 10;
          }
@@ -264,7 +262,8 @@ bson_decimal128_to_string (const bson_decimal128_t *dec, /* IN  */
          *(str_out++) = '.';
       }
 
-      for (i = 0; i < significand_digits && (str_out - str) < 36; i++) {
+      for (uint32_t i = 0; i < significand_digits && (str_out - str) < 36;
+           i++) {
          *(str_out++) = *(significand_read++) + '0';
       }
       /* Exponent */
@@ -273,7 +272,8 @@ bson_decimal128_to_string (const bson_decimal128_t *dec, /* IN  */
    } else {
       /* Regular format with no decimal place */
       if (exponent >= 0) {
-         for (i = 0; i < significand_digits && (str_out - str) < 36; i++) {
+         for (uint32_t i = 0; i < significand_digits && (str_out - str) < 36;
+              i++) {
             *(str_out++) = *(significand_read++) + '0';
          }
          *str_out = '\0';
@@ -281,7 +281,7 @@ bson_decimal128_to_string (const bson_decimal128_t *dec, /* IN  */
          int32_t radix_position = significand_digits + exponent;
 
          if (radix_position > 0) { /* non-zero digits before radix */
-            for (i = 0;
+            for (int32_t i = 0;
                  i < radix_position && (str_out - str) < BSON_DECIMAL128_STRING;
                  i++) {
                *(str_out++) = *(significand_read++) + '0';
@@ -295,8 +295,9 @@ bson_decimal128_to_string (const bson_decimal128_t *dec, /* IN  */
             *(str_out++) = '0';
          }
 
-         for (i = 0;
-              (i < significand_digits - BSON_MAX (radix_position - 1, 0)) &&
+         for (uint32_t i = 0;
+              bson_cmp_greater_us (significand_digits - i,
+                                   BSON_MAX (radix_position - 1, 0)) &&
               (str_out - str) < BSON_DECIMAL128_STRING;
               i++) {
             *(str_out++) = *(significand_read++) + '0';
@@ -623,7 +624,8 @@ bson_decimal128_from_string_w_len (const char *string,     /* IN */
    /* to represent user input */
 
    /* Overflow prevention */
-   if (exponent <= radix_position && radix_position - exponent > (1 << 14)) {
+   if (bson_cmp_less_equal_su (exponent, radix_position) &&
+       bson_cmp_greater_us (radix_position, exponent + (1 << 14))) {
       exponent = BSON_DECIMAL128_EXPONENT_MIN;
    } else {
       exponent -= radix_position;

--- a/src/libbson/src/bson/bson-iter.c
+++ b/src/libbson/src/bson/bson-iter.c
@@ -110,8 +110,13 @@ bson_iter_init_from_data (bson_iter_t *iter,   /* OUT */
       return false;
    }
 
+   if (BSON_UNLIKELY (!bson_in_range_unsigned (uint32_t, length))) {
+      memset (iter, 0, sizeof *iter);
+      return false;
+   }
+
    iter->raw = (uint8_t *) data;
-   iter->len = length;
+   iter->len = (uint32_t) length;
    iter->off = 0;
    iter->type = 0;
    iter->key = 0;

--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -741,26 +741,13 @@ _bson_json_parse_double (bson_json_reader_t *reader,
    *d = strtod (val, NULL);
 
 #ifdef _MSC_VER
-#ifdef INFINITY
    const double pos_inf = INFINITY;
    const double neg_inf = -pos_inf;
-#else
-   const unsigned long inf_rep[2] = {0x00000000, 0x7ff00000};
-   const double pos_inf = *(double *) inf;
-   const double neg_inf = -pos_inf;
-#endif
 
    /* Microsoft's strtod parses "NaN", "Infinity", "-Infinity" as 0 */
    if (*d == 0.0) {
       if (!_strnicmp (val, "nan", vlen)) {
-#ifdef NAN
          *d = NAN;
-#else
-         /* Visual Studio 2010 doesn't define NAN or INFINITY
-          * https://msdn.microsoft.com/en-us/library/w22adx1s(v=vs.100).aspx */
-         unsigned long nan[2] = {0xffffffff, 0x7fffffff};
-         *d = *(double *) nan;
-#endif
          return true;
       } else if (!_strnicmp (val, "infinity", vlen)) {
          *d = pos_inf;

--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -628,7 +628,13 @@ _bson_json_read_integer (bson_json_reader_t *reader, uint64_t val, int64_t sign)
          bson_append_int32 (
             STACK_BSON_CHILD, key, (int) len, (int) (val * sign));
       } else if (sign == -1) {
+#if defined(_WIN32) && !defined(__MINGW32__)
+         // Unary negation of unsigned integer is deliberate.
+#pragma warning(suppress : 4146)
          bson_append_int64 (STACK_BSON_CHILD, key, (int) len, (int64_t) -val);
+#else
+         bson_append_int64 (STACK_BSON_CHILD, key, (int) len, (int64_t) -val);
+#endif // defined(_WIN32) && !defined(__MINGW32__)
       } else {
          bson_append_int64 (STACK_BSON_CHILD, key, (int) len, (int64_t) val);
       }

--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -1186,8 +1186,9 @@ _bson_json_read_start_map (bson_json_reader_t *reader) /* IN */
           * expected a legacy Binary format. now we see the second "{", so
           * backtrack and parse $type query operator. */
          bson->read_state = BSON_JSON_IN_START_MAP;
+         BSON_ASSERT (bson_in_range_unsigned (int, len));
          STACK_PUSH_DOC (bson_append_document_begin (
-            STACK_BSON_PARENT, key, len, STACK_BSON_CHILD));
+            STACK_BSON_PARENT, key, (int) len, STACK_BSON_CHILD));
          _bson_json_save_map_key (bson, (const uint8_t *) "$type", 5);
          break;
       case BSON_JSON_LF_CODE:

--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -741,6 +741,15 @@ _bson_json_parse_double (bson_json_reader_t *reader,
    *d = strtod (val, NULL);
 
 #ifdef _MSC_VER
+#ifdef INFINITY
+   const double pos_inf = INFINITY;
+   const double neg_inf = -pos_inf;
+#else
+   const unsigned long inf_rep[2] = {0x00000000, 0x7ff00000};
+   const double pos_inf = *(double *) inf;
+   const double neg_inf = -pos_inf;
+#endif
+
    /* Microsoft's strtod parses "NaN", "Infinity", "-Infinity" as 0 */
    if (*d == 0.0) {
       if (!_strnicmp (val, "nan", vlen)) {
@@ -754,20 +763,10 @@ _bson_json_parse_double (bson_json_reader_t *reader,
 #endif
          return true;
       } else if (!_strnicmp (val, "infinity", vlen)) {
-#ifdef INFINITY
-         *d = INFINITY;
-#else
-         unsigned long inf[2] = {0x00000000, 0x7ff00000};
-         *d = *(double *) inf;
-#endif
+         *d = pos_inf;
          return true;
       } else if (!_strnicmp (val, "-infinity", vlen)) {
-#ifdef INFINITY
-         *d = -INFINITY;
-#else
-         unsigned long inf[2] = {0x00000000, 0xfff00000};
-         *d = *(double *) inf;
-#endif
+         *d = neg_inf;
          return true;
       }
    }

--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -831,7 +831,7 @@ static bool
 _unhexlify_uuid (const char *uuid, uint8_t *out, size_t max)
 {
    unsigned int byte;
-   int x = 0;
+   size_t x = 0;
    int i = 0;
 
    BSON_ASSERT (strlen (uuid) == 32);
@@ -2233,8 +2233,11 @@ bson_json_reader_read (bson_json_reader_t *reader, /* IN */
 
          /* accumulate a key or string value */
          if (reader->json_text_pos != -1) {
-            if (reader->json_text_pos < reader->json->pos) {
-               accum = BSON_MIN (reader->json->pos - reader->json_text_pos, r);
+            if (bson_cmp_less_su (reader->json_text_pos, reader->json->pos)) {
+               BSON_ASSERT (
+                  bson_in_range_unsigned (ssize_t, reader->json->pos));
+               accum = BSON_MIN (
+                  (ssize_t) reader->json->pos - reader->json_text_pos, r);
                /* if this chunk stopped mid-token, buf_offset is how far into
                 * our current chunk the token begins. */
                buf_offset = AT_LEAST_0 (reader->json_text_pos - start_pos);

--- a/src/libbson/src/bson/bson-memory.c
+++ b/src/libbson/src/bson/bson-memory.c
@@ -40,7 +40,10 @@ _aligned_alloc_impl (size_t alignment, size_t num_bytes)
 #elif defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
 {
    void *mem = NULL;
-   (void) posix_memalign (&mem, alignment, num_bytes);
+
+   // Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66425.
+   BSON_MAYBE_UNUSED int ret = posix_memalign (&mem, alignment, num_bytes);
+
    return mem;
 }
 #else

--- a/src/libbson/src/bson/bson-timegm.c
+++ b/src/libbson/src/bson/bson-timegm.c
@@ -233,7 +233,7 @@ gmtsub (const int64_t *const timep,
 static int64_t
 increment_overflow (int64_t *const ip, int64_t j);
 static int64_t
-leaps_thru_end_of (register const int64_t y) ATTRIBUTE_PURE;
+leaps_thru_end_of (const int64_t y) ATTRIBUTE_PURE;
 static int64_t
 increment_overflow32 (int_fast32_t *const lp, int64_t const m);
 static int64_t
@@ -268,11 +268,11 @@ time2sub (struct bson_tm *const tmp,
 static struct bson_tm *
 timesub (const int64_t *const timep,
          const int_fast32_t offset,
-         register const struct state *const sp,
-         register struct bson_tm *const tmp);
+         const struct state *const sp,
+         struct bson_tm *const tmp);
 static int64_t
-tmcomp (register const struct bson_tm *const atmp,
-        register const struct bson_tm *const btmp);
+tmcomp (const struct bson_tm *const atmp,
+        const struct bson_tm *const btmp);
 
 static struct state gmtmem;
 #define gmtptr (&gmtmem)
@@ -305,7 +305,7 @@ gmtsub (const int64_t *const timep,
         const int_fast32_t offset,
         struct bson_tm *const tmp)
 {
-   register struct bson_tm *result;
+   struct bson_tm *result;
 
    if (!gmt_is_set) {
       gmt_is_set = true;
@@ -329,7 +329,7 @@ gmtsub (const int64_t *const timep,
 */
 
 static int64_t
-leaps_thru_end_of (register const int64_t y)
+leaps_thru_end_of (const int64_t y)
 {
    return (y >= 0) ? (y / 4 - y / 100 + y / 400)
                    : -(leaps_thru_end_of (-(y + 1)) + 1);
@@ -338,18 +338,18 @@ leaps_thru_end_of (register const int64_t y)
 static struct bson_tm *
 timesub (const int64_t *const timep,
          const int_fast32_t offset,
-         register const struct state *const sp,
-         register struct bson_tm *const tmp)
+         const struct state *const sp,
+         struct bson_tm *const tmp)
 {
-   register const struct lsinfo *lp;
-   register int64_t tdays;
-   register int64_t idays; /* unsigned would be so 2003 */
-   register int_fast64_t rem;
+   const struct lsinfo *lp;
+   int64_t tdays;
+   int64_t idays; /* unsigned would be so 2003 */
+   int_fast64_t rem;
    int64_t y;
-   register const int (*ip)[MONSPERYEAR];
-   register int_fast64_t corr;
-   register int64_t hit;
-   register int64_t i;
+   const int (*ip)[MONSPERYEAR];
+   int_fast64_t corr;
+   int64_t hit;
+   int64_t i;
 
    corr = 0;
    hit = 0;
@@ -377,9 +377,9 @@ timesub (const int64_t *const timep,
    rem = *timep - tdays * SECSPERDAY;
    while (tdays < 0 || tdays >= year_lengths[isleap (y)]) {
       int64_t newy;
-      register int64_t tdelta;
-      register int64_t idelta;
-      register int64_t leapdays;
+      int64_t tdelta;
+      int64_t idelta;
+      int64_t leapdays;
 
       tdelta = tdays / DAYSPERLYEAR;
       idelta = tdelta;
@@ -394,7 +394,7 @@ timesub (const int64_t *const timep,
       y = newy;
    }
    {
-      register int_fast32_t seconds;
+      int_fast32_t seconds;
 
       seconds = (int_fast32_t) (tdays * SECSPERDAY);
       tdays = seconds / SECSPERDAY;
@@ -479,7 +479,7 @@ timesub (const int64_t *const timep,
 static int64_t
 increment_overflow (int64_t *const ip, int64_t j)
 {
-   register int64_t const i = *ip;
+   int64_t const i = *ip;
 
    /*
    ** If i >= 0 there can only be overflow if i + j > INT_MAX
@@ -496,7 +496,7 @@ increment_overflow (int64_t *const ip, int64_t j)
 static int64_t
 increment_overflow32 (int_fast32_t *const lp, int64_t const m)
 {
-   register int_fast32_t const l = *lp;
+   int_fast32_t const l = *lp;
 
    if ((l >= 0) ? (m > INT_FAST32_MAX - l) : (m < INT_FAST32_MIN - l))
       return true;
@@ -509,7 +509,7 @@ normalize_overflow (int64_t *const tensptr,
                     int64_t *const unitsptr,
                     const int64_t base)
 {
-   register int64_t tensdelta;
+   int64_t tensdelta;
 
    tensdelta =
       (*unitsptr >= 0) ? (*unitsptr / base) : (-1 - (-1 - *unitsptr) / base);
@@ -522,7 +522,7 @@ normalize_overflow32 (int_fast32_t *const tensptr,
                       int64_t *const unitsptr,
                       const int64_t base)
 {
-   register int64_t tensdelta;
+   int64_t tensdelta;
 
    tensdelta =
       (*unitsptr >= 0) ? (*unitsptr / base) : (-1 - (-1 - *unitsptr) / base);
@@ -531,10 +531,10 @@ normalize_overflow32 (int_fast32_t *const tensptr,
 }
 
 static int64_t
-tmcomp (register const struct bson_tm *const atmp,
-        register const struct bson_tm *const btmp)
+tmcomp (const struct bson_tm *const atmp,
+        const struct bson_tm *const btmp)
 {
-   register int64_t result;
+   int64_t result;
 
    if (atmp->tm_year != btmp->tm_year)
       return atmp->tm_year < btmp->tm_year ? -1 : 1;
@@ -555,13 +555,13 @@ time2sub (struct bson_tm *const tmp,
           int64_t *const okayp,
           const int64_t do_norm_secs)
 {
-   register const struct state *sp;
-   register int64_t dir;
-   register int64_t i, j;
-   register int64_t saved_seconds;
-   register int_fast32_t li;
-   register int64_t lo;
-   register int64_t hi;
+   const struct state *sp;
+   int64_t dir;
+   int64_t i, j;
+   int64_t saved_seconds;
+   int_fast32_t li;
+   int64_t lo;
+   int64_t hi;
    int_fast32_t y;
    int64_t newt;
    int64_t t;
@@ -743,12 +743,12 @@ time1 (struct bson_tm *const tmp,
                                        struct bson_tm *),
        const int_fast32_t offset)
 {
-   register int64_t t;
-   register const struct state *sp;
-   register int64_t samei, otheri;
-   register int64_t sameind, otherind;
-   register int64_t i;
-   register int64_t nseen;
+   int64_t t;
+   const struct state *sp;
+   int64_t samei, otheri;
+   int64_t sameind, otherind;
+   int64_t i;
+   int64_t nseen;
    int64_t seen[TZ_MAX_TYPES];
    int64_t types[TZ_MAX_TYPES];
    int64_t okay;

--- a/src/libbson/src/bson/bson-timegm.c
+++ b/src/libbson/src/bson/bson-timegm.c
@@ -225,47 +225,54 @@ struct rule {
 */
 
 static void
-gmtload (struct state *sp);
+gmtload (struct state *const sp);
 static struct bson_tm *
-gmtsub (const int64_t *timep, int_fast32_t offset, struct bson_tm *tmp);
+gmtsub (const int64_t *const timep,
+        const int_fast32_t offset,
+        struct bson_tm *const tmp);
 static int64_t
-increment_overflow (int64_t *number, int64_t delta);
+increment_overflow (int64_t *const ip, int64_t j);
 static int64_t
-leaps_thru_end_of (int64_t y) ATTRIBUTE_PURE;
+leaps_thru_end_of (register const int64_t y) ATTRIBUTE_PURE;
 static int64_t
-increment_overflow32 (int_fast32_t *number, int64_t delta);
+increment_overflow32 (int_fast32_t *const lp, int64_t const m);
 static int64_t
-normalize_overflow32 (int_fast32_t *tensptr, int64_t *unitsptr, int64_t base);
+normalize_overflow32 (int_fast32_t *const tensptr,
+                      int64_t *const unitsptr,
+                      const int64_t base);
 static int64_t
-normalize_overflow (int64_t *tensptr, int64_t *unitsptr, int64_t base);
+normalize_overflow (int64_t *const tensptr,
+                    int64_t *const unitsptr,
+                    const int64_t base);
 static int64_t
-time1 (struct bson_tm *tmp,
-       struct bson_tm *(*funcp) (const int64_t *,
-                                 int_fast32_t,
-                                 struct bson_tm *),
-       int_fast32_t offset);
+time1 (struct bson_tm *const tmp,
+       struct bson_tm *(*const funcp) (const int64_t *,
+                                       int_fast32_t,
+                                       struct bson_tm *),
+       const int_fast32_t offset);
 static int64_t
-time2 (struct bson_tm *tmp,
-       struct bson_tm *(*funcp) (const int64_t *,
-                                 int_fast32_t,
-                                 struct bson_tm *),
-       int_fast32_t offset,
-       int64_t *okayp);
+time2 (struct bson_tm *const tmp,
+       struct bson_tm *(*const funcp) (const int64_t *,
+                                       int_fast32_t,
+                                       struct bson_tm *),
+       const int_fast32_t offset,
+       int64_t *const okayp);
 static int64_t
-time2sub (struct bson_tm *tmp,
-          struct bson_tm *(*funcp) (const int64_t *,
-                                    int_fast32_t,
-                                    struct bson_tm *),
-          int_fast32_t offset,
-          int64_t *okayp,
-          int64_t do_norm_secs);
+time2sub (struct bson_tm *const tmp,
+          struct bson_tm *(*const funcp) (const int64_t *,
+                                          int_fast32_t,
+                                          struct bson_tm *),
+          const int_fast32_t offset,
+          int64_t *const okayp,
+          const int64_t do_norm_secs);
 static struct bson_tm *
-timesub (const int64_t *timep,
-         int_fast32_t offset,
-         const struct state *sp,
-         struct bson_tm *tmp);
+timesub (const int64_t *const timep,
+         const int_fast32_t offset,
+         register const struct state *const sp,
+         register struct bson_tm *const tmp);
 static int64_t
-tmcomp (const struct bson_tm *atmp, const struct bson_tm *btmp);
+tmcomp (register const struct bson_tm *const atmp,
+        register const struct bson_tm *const btmp);
 
 static struct state gmtmem;
 #define gmtptr (&gmtmem)

--- a/src/libbson/src/bson/bson-timegm.c
+++ b/src/libbson/src/bson/bson-timegm.c
@@ -500,7 +500,7 @@ increment_overflow32 (int_fast32_t *const lp, int64_t const m)
 
    if ((l >= 0) ? (m > INT_FAST32_MAX - l) : (m < INT_FAST32_MIN - l))
       return true;
-   *lp += m;
+   *lp += (int_fast32_t) m;
    return false;
 }
 

--- a/src/libbson/src/bson/bson-timegm.c
+++ b/src/libbson/src/bson/bson-timegm.c
@@ -271,8 +271,7 @@ timesub (const int64_t *const timep,
          const struct state *const sp,
          struct bson_tm *const tmp);
 static int64_t
-tmcomp (const struct bson_tm *const atmp,
-        const struct bson_tm *const btmp);
+tmcomp (const struct bson_tm *const atmp, const struct bson_tm *const btmp);
 
 static struct state gmtmem;
 #define gmtptr (&gmtmem)
@@ -531,8 +530,7 @@ normalize_overflow32 (int_fast32_t *const tensptr,
 }
 
 static int64_t
-tmcomp (const struct bson_tm *const atmp,
-        const struct bson_tm *const btmp)
+tmcomp (const struct bson_tm *const atmp, const struct bson_tm *const btmp)
 {
    int64_t result;
 

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -2993,12 +2993,13 @@ _bson_as_json_visit_after (const bson_iter_t *iter, const char *key, void *data)
       return false;
    }
 
-   if (state->str->len >= state->max_len) {
+   if (bson_cmp_greater_equal_us (state->str->len, state->max_len)) {
       state->max_len_reached = true;
 
-      if (state->str->len > state->max_len) {
+      if (bson_cmp_greater_us (state->str->len, state->max_len)) {
+         BSON_ASSERT (bson_in_range_signed (uint32_t, state->max_len));
          /* Truncate string to maximum length */
-         bson_string_truncate (state->str, state->max_len);
+         bson_string_truncate (state->str, (uint32_t) state->max_len);
       }
 
       return true;
@@ -3106,7 +3107,8 @@ _bson_as_json_visit_codewscope (const bson_iter_t *iter,
 
    /* Encode scope with the same mode */
    if (state->max_len != BSON_MAX_LEN_UNLIMITED) {
-      max_scope_len = BSON_MAX (0, state->max_len - state->str->len);
+      BSON_ASSERT (bson_in_range_unsigned (int32_t, state->str->len));
+      max_scope_len = BSON_MAX (0, state->max_len - (int32_t) state->str->len);
    }
 
    scope = _bson_as_json_visit_all (v_scope, NULL, state->mode, max_scope_len);
@@ -3165,7 +3167,9 @@ _bson_as_json_visit_document (const bson_iter_t *iter,
       child_state.mode = state->mode;
       child_state.max_len = BSON_MAX_LEN_UNLIMITED;
       if (state->max_len != BSON_MAX_LEN_UNLIMITED) {
-         child_state.max_len = BSON_MAX (0, state->max_len - state->str->len);
+         BSON_ASSERT (bson_in_range_unsigned (int32_t, state->str->len));
+         child_state.max_len =
+            BSON_MAX (0, state->max_len - (int32_t) state->str->len);
       }
 
       child_state.max_len_reached = child_state.max_len == 0;
@@ -3216,7 +3220,9 @@ _bson_as_json_visit_array (const bson_iter_t *iter,
       child_state.mode = state->mode;
       child_state.max_len = BSON_MAX_LEN_UNLIMITED;
       if (state->max_len != BSON_MAX_LEN_UNLIMITED) {
-         child_state.max_len = BSON_MAX (0, state->max_len - state->str->len);
+         BSON_ASSERT (bson_in_range_unsigned (int32_t, state->str->len));
+         child_state.max_len =
+            BSON_MAX (0, state->max_len - (int32_t) state->str->len);
       }
 
       child_state.max_len_reached = child_state.max_len == 0;

--- a/src/libbson/tests/test-b64.c
+++ b/src/libbson/tests/test-b64.c
@@ -36,7 +36,7 @@ _test_encode_helper (char *input,
    ASSERT_CMPSIZE_T (target_size, ==, (size_t) expected_output_len + 1);
    /* returned value does not count trailing NULL. */
    ret = mcommon_b64_ntop ((uint8_t *) input, input_len, output, target_size);
-   ASSERT_CMPINT (target_size - 1, ==, ret);
+   ASSERT (bson_cmp_equal_us (target_size - 1u, ret));
    ASSERT_CMPSTR (output, expected_output);
    bson_free (output);
 }

--- a/src/libbson/tests/test-iso8601.c
+++ b/src/libbson/tests/test-iso8601.c
@@ -11,7 +11,11 @@ test_date (const char *str, int64_t millis)
    int64_t v;
    bson_error_t error;
 
-   if (!_bson_iso8601_date_parse (str, strlen (str), &v, &error)) {
+   const size_t len = strlen (str);
+
+   BSON_ASSERT (bson_in_range_unsigned (int32_t, len));
+
+   if (!_bson_iso8601_date_parse (str, (int32_t) len, &v, &error)) {
       fprintf (stderr, "could not parse (%s)\n", str);
       abort ();
    }
@@ -56,7 +60,11 @@ test_date_should_fail (const char *str)
    int64_t v;
    bson_error_t error;
 
-   if (_bson_iso8601_date_parse (str, strlen (str), &v, &error)) {
+   const size_t len = strlen (str);
+
+   BSON_ASSERT (bson_in_range_unsigned (int32_t, len));
+
+   if (_bson_iso8601_date_parse (str, (int32_t) len, &v, &error)) {
       fprintf (stderr, "should not be able to parse (%s)\n", str);
       abort ();
    }

--- a/src/libbson/tests/test-json.c
+++ b/src/libbson/tests/test-json.c
@@ -3044,7 +3044,7 @@ test_bson_as_json_with_opts_array (void)
 static void
 test_bson_as_json_with_opts_binary (void)
 {
-   const uint8_t data[] = {1, 2.0, 3, 4};
+   const uint8_t data[] = {1, 2, 3, 4};
    bson_t *b;
 
    b = bson_new ();

--- a/src/libbson/tests/test-json.c
+++ b/src/libbson/tests/test-json.c
@@ -386,10 +386,13 @@ test_bson_as_json_double_nonfinite (void)
    char *str;
    char *expected;
 
+   const double pos_inf = INFINITY;
+   const double neg_inf = -pos_inf;
+
    b = bson_new ();
    BSON_ASSERT (bson_append_double (b, "nan", -1, NAN));
-   BSON_ASSERT (bson_append_double (b, "pos_inf", -1, INFINITY));
-   BSON_ASSERT (bson_append_double (b, "neg_inf", -1, -INFINITY));
+   BSON_ASSERT (bson_append_double (b, "pos_inf", -1, pos_inf));
+   BSON_ASSERT (bson_append_double (b, "neg_inf", -1, neg_inf));
    str = bson_as_json (b, &len);
 
    expected = bson_strdup_printf ("{"
@@ -397,8 +400,8 @@ test_bson_as_json_double_nonfinite (void)
                                   " \"pos_inf\" : %.20g,"
                                   " \"neg_inf\" : %.20g }",
                                   NAN,
-                                  INFINITY,
-                                  -INFINITY);
+                                  pos_inf,
+                                  neg_inf);
 
    ASSERT_CMPSTR (str, expected);
 

--- a/src/libbson/tests/test-json.c
+++ b/src/libbson/tests/test-json.c
@@ -2679,13 +2679,13 @@ test_bson_array_as_json (void)
 
    str = bson_array_as_json (&d, &len);
    ASSERT_CMPSTR (str, "[ ]");
-   ASSERT_CMPINT (len, ==, 3);
+   ASSERT_CMPSIZE_T (len, ==, 3u);
    bson_free (str);
 
    BSON_APPEND_INT32 (&d, "0", 1);
    str = bson_array_as_json (&d, &len);
    ASSERT_CMPSTR (str, "[ 1 ]");
-   ASSERT_CMPINT (len, ==, 5);
+   ASSERT_CMPSIZE_T (len, ==, 5u);
    bson_free (str);
 
    /* test corrupted bson */
@@ -2909,10 +2909,11 @@ test_bson_as_json_with_opts (bson_t *bson,
    char *str = bson_as_json_with_opts (bson, &json_len, opts);
 
    ASSERT_CMPSTR (str, expected);
-   ASSERT_CMPINT (json_len, ==, strlen (expected));
+   ASSERT_CMPSIZE_T (json_len, ==, strlen (expected));
 
    if (max_len != BSON_MAX_LEN_UNLIMITED) {
-      ASSERT_CMPINT (json_len, <=, max_len);
+      ASSERT (bson_in_range_signed (size_t, max_len));
+      ASSERT_CMPSIZE_T (json_len, <=, (size_t) max_len);
    }
 
    bson_free (str);
@@ -2936,12 +2937,16 @@ run_bson_as_json_with_opts_tests (bson_t *bson,
                                   bson_json_mode_t mode,
                                   const char *expected)
 {
-   size_t len = strlen (expected);
+   const size_t ulen = strlen (expected);
    char *truncated;
-   size_t i;
+
+   BSON_ASSERT (bson_in_range_unsigned (int, ulen));
+   const int len = (int) ulen;
 
    /* Test with 0 length (empty string). */
    test_bson_as_json_with_opts (bson, mode, 0, "");
+
+   BSON_ASSERT (INT_MAX - 2 >= len);
 
    /* Test with a limit that does not truncate the string. */
    test_bson_as_json_with_opts (bson, mode, len + 2, expected);
@@ -2950,8 +2955,8 @@ run_bson_as_json_with_opts_tests (bson_t *bson,
    test_bson_as_json_with_opts (bson, mode, BSON_MAX_LEN_UNLIMITED, expected);
 
    /* Test every possible limit from 0 to length. */
-   for (i = 0; i < len; i++) {
-      truncated = truncate_string (expected, i);
+   for (int i = 0; i < len; i++) {
+      truncated = truncate_string (expected, (size_t) i);
       test_bson_as_json_with_opts (bson, mode, i, truncated);
       bson_free (truncated);
    }

--- a/src/libbson/tests/test-json.c
+++ b/src/libbson/tests/test-json.c
@@ -377,7 +377,6 @@ test_bson_as_json_double (void)
 }
 
 
-#if defined(NAN) && defined(INFINITY)
 static void
 test_bson_as_json_double_nonfinite (void)
 {
@@ -409,7 +408,6 @@ test_bson_as_json_double_nonfinite (void)
    bson_free (str);
    bson_destroy (b);
 }
-#endif
 
 
 static void
@@ -3467,11 +3465,9 @@ test_json_install (TestSuite *suite)
    TestSuite_Add (suite, "/bson/as_json/int32", test_bson_as_json_int32);
    TestSuite_Add (suite, "/bson/as_json/int64", test_bson_as_json_int64);
    TestSuite_Add (suite, "/bson/as_json/double", test_bson_as_json_double);
-#if defined(NAN) && defined(INFINITY)
    TestSuite_Add (suite,
                   "/bson/as_json/double/nonfinite",
                   test_bson_as_json_double_nonfinite);
-#endif
    TestSuite_Add (suite, "/bson/as_json/code", test_bson_as_json_code);
    TestSuite_Add (
       suite, "/bson/as_json/date_time", test_bson_as_json_date_time);

--- a/src/libmongoc/src/mongoc/mongoc-util.c
+++ b/src/libmongoc/src/mongoc/mongoc-util.c
@@ -675,7 +675,7 @@ _mongoc_getenv (const char *name)
       return NULL;
    }
 #else
-   char* const var = getenv (name);
+   char *const var = getenv (name);
    if (var && strlen (var)) {
       return bson_strdup (var);
    } else {

--- a/src/libmongoc/src/mongoc/mongoc-util.c
+++ b/src/libmongoc/src/mongoc/mongoc-util.c
@@ -675,9 +675,9 @@ _mongoc_getenv (const char *name)
       return NULL;
    }
 #else
-
-   if (getenv (name) && strlen (getenv (name))) {
-      return bson_strdup (getenv (name));
+   char* const var = getenv (name);
+   if (var && strlen (var)) {
+      return bson_strdup (var);
    } else {
       return NULL;
    }


### PR DESCRIPTION
## Description

This PR is a belated followup to https://github.com/mongodb/mongo-c-driver/pull/960 that addresses various warnings emitted by MSVC and MinGW on Windows distros, mostly pertaining to signedness mismatch or implicit narrowing conversions of integral types.

Verified by [this patch](https://spruce.mongodb.com/version/641dc814d6d80ac9bbcb4055/tasks), which adds `/WX` or `-Werror` when compiling `bson_shared` and `bson_static` with MSVC or MinGW respectively (treat all warnings as errors). These flags are _not_ included in this PR.

The scope of this PR is limited to MSVC and MinGW warnings for the libbson library only (+ some libbson test files and misc. drive-by fixes). Followup PRs will address warnings emitted by MSVC and MinGW for the libmongoc library, example executables, and test executables. When able, warnings emitted by GCC and Clang (far more numerous) will be addressed after that.

## Stats

Warning statistics were obtained using the following local toolchain on Windows 10 and Ubuntu 20.04 (within WSL2):

- CMake 3.21.1
- GCC 12.1.0
- Clang 10.0.0
- MSVC 19.29.30133

and the following CMake configuration for GCC/Clang:

- CMAKE_BUILD_TYPE: Debug
- ENABLE_AUTOMATIC_INIT_AND_CLEANUP: OFF
- ENABLE_CLIENT_SIDE_ENCRYPTION: ON
- ENABLE_EXTRA_ALIGNMENT: OFF
- CMAKE_C_FLAGS: -Wall -Wextra -pedantic -Wconversion -Wsign-conversion

and for MSVC:

- CMAKE_BUILD_TYPE: Debug
- ENABLE_AUTOMATIC_INIT_AND_CLEANUP: OFF
- ENABLE_CLIENT_SIDE_ENCRYPTION: ON
- ENABLE_EXTRA_ALIGNMENT: OFF

Relative to https://github.com/mongodb/mongo-c-driver/commit/72cba009ec70fd734dc76426c5385487a1c6930d, this PR reduces the total number of warnings emitted by:

- GCC: 4442 -> 4368 (-1.67%)
- Clang: 4387 -> 4327 (-1.38%)
- MSVC: 265 -> 235 (-1.32%)

and the number of _unique_ warnings (by file, line, type, and message) by:

- GCC: 1348 -> 1313 (-2.60%)
- Clang: 1458 -> 1426 (-2.19%)
- MSVC: 171 -> 150 (-12.28%)

Note: the warning counts do _not_ include D9025 command line option override warnings generated by the `kms_message` and `zlib` libraries.

## Methodology

### C4018 Signedness Mismatch Warnings
Most signedness mismatch warnings are addressed by the use of `bson_cmp_*` utilities instead of simple comparison operators, e.g.:

```c
bool before(int32_t a, uint32_t b) {
  return a < b;
}

bool after(int32_t a, uint32_t b) {
  return bson_cmp_less_su(a, b);
}
```

Otherwise, either the type of relevant variables, parameters, or data members were adjusted to avoid signedness inconsistencies, or an assertion of `bson_in_range_*` was added prior to an explicit cast to the target type, e.g.:

```c
void usage(uint32_t param);

void before(int32_t value) {
  usage(value);
}

void after(int32_t value) {
  BSON_ASSERT(bson_in_range_signed(uint32_t, value));
  usage((uint32_t)value);
}
```

### C4028 Parameter Inconsistency Warnings

Several MSVC versions (pessimistically) warn when the type of a parameter in a function declaration differs from the definition, even when the difference is due to top-level `const`-qualifiers. The declarations were updated to match the definitions.

### C4146 Unsigned Unary Negation Warnings

Newer MSVC versions warn when the unary negation operator is used on an unsigned type, even if it has well-defined behavior. Added suppression of C4146 where appropriate.

### C4244 Narrowing Conversion Warnings

Most of these warnings are addressed by the addition of a range-check assertion as described above in C4018. For functions that return an error code or error messages, an appropriate error and/or return value is used instead of an assertion. If range checks already exist, only the explicit cast is added.

### C4267 size_t Conversion Warnings

MSVC has a separate warning type for size_t conversions than for other narrowing conversion warnings, but they are effectively the same as C4244 narrowing conversion warnings.

### C4756 Constant Arithmetic Overflow Warnings

VC 2013's definition of the `INFINITY` macro triggers overflow warnings despite being intentional behavior. Furthermore, VS 2013 does not appear to support inline warning suppression with `#pragma warning(suppress : ...)` or `#pragma warning(disable : ...)`. Therefore, the `/wd4756` compile option was added to `bson_shared` and `bson_static` when compiling with VS 2013 or older to disable the warning entirely, in favor of depending on other toolchain combinations to detect undesirable overflow conditions.

### Miscellaneous Warnings

As drive-by fixes and improvements not related to the above:

- replaced `(void)expr;` with `BSON_MAYBE_UNUSED int ret = expr;` in `_aligned_alloc_impl` to address GCC unused result warnings that were not being silenced by `(void)`. See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66425 for context.

- addressed a scan-build null pointer argument warning in `_mongoc_getenv` due to repeated calls to `getenv` defeating the static analyzer's ability to recognize the null pointer check.