### PR TITLE
CDRIVER-4593: Handle doulbe type connectionId

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -737,7 +737,7 @@ mongoc_server_description_handle_hello (mongoc_server_description_t *sd,
             GOTO (typefailure);
          bson_oid_copy_unsafe (bson_iter_oid (&iter), &sd->service_id);
       } else if (strcmp ("connectionId", bson_iter_key (&iter)) == 0) {
-         if (!BSON_ITER_HOLDS_INT (&iter))
+         if (!BSON_ITER_HOLDS_NUMBER (&iter))
             GOTO (typefailure);
          sd->server_connection_id = bson_iter_as_int64 (&iter);
       }


### PR DESCRIPTION

This change validates the Int32, Int64 and **Double** type connectionId from the hello or ismater response from mongo. We see C-Drivers(1.23.1 & 1.23.2) are fail to connect mongo because of type check failure for double type connectionId. Please refer [CDRIVER-4593](https://jira.mongodb.org/browse/CDRIVER-4593) for more details.