### PR TITLE
CDRIVER-4586: Add missing docs for v_decimal128 in bson_value_t

### DIFF
--- a/src/libbson/doc/bson_decimal128_t.rst
+++ b/src/libbson/doc/bson_decimal128_t.rst
@@ -29,8 +29,13 @@ Synopsis
 Description
 -----------
 
-The :symbol:`bson_decimal128_t` structure
-represents the IEEE-754 Decimal128 data type.
+The :symbol:`bson_decimal128_t` structure represents the IEEE-754 Decimal128
+data type. The type ``bson_decimal128_t`` is an aggregate that contains two
+``uint64_t``\ s, named ``high`` and ``low``. The declaration and layout order
+between them depends on the endian order of the target platform: ``low`` will
+always correspond to the low-order bits of the Decimal128 object, while ``high``
+corresponds to the high-order bits. The ``bson_decimal128_t`` always has a size
+of sixteen (``16``), and can be bit-cast to/from a ``_Decimal128``.
 
 .. only:: html
 

--- a/src/libbson/doc/bson_value_t.rst
+++ b/src/libbson/doc/bson_value_t.rst
@@ -62,6 +62,7 @@ Synopsis
            uint32_t len;
            char *symbol;
         } v_symbol;
+        bson_decimal128_t v_decimal128;
      } value;
   } bson_value_t;
 


### PR DESCRIPTION
Refer: CDRIVER-4586

Also clarify the meaning and structure of bson_decimal128_t