### PR TITLE
Don't guess a target's filepath for the install rule

### DIFF
--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -850,9 +850,9 @@ target_link_libraries (mongoc-stat mongoc_shared ${LIBRARIES})
 
 # mongoc-stat works if shared memory performance counters are enabled.
 if (ENABLE_SHM_COUNTERS STREQUAL "ON")
-   install (PROGRAMS ${PROJECT_BINARY_DIR}/mongoc-stat
-      DESTINATION ${CMAKE_INSTALL_BINDIR}
-   )
+   install (TARGETS mongoc-stat
+            EXPORT mongoc_targets
+            RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 endif ()
 
 set (test-libmongoc-sources


### PR DESCRIPTION
This fixes installation when the target file's destination is not at the guessed location (e.g. multiconf installs)