### PR TITLE
CDRIVER-4394 fix function names in range index docs

### DIFF
--- a/src/libmongoc/doc/mongoc_client_encryption_encrypt_range_opts_set_min_max.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_encrypt_range_opts_set_min_max.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
     void
-    mongoc_client_encryption_encrypt_opts_set_min_max (
+    mongoc_client_encryption_encrypt_range_opts_set_min_max (
          mongoc_client_encryption_encrypt_range_opts_t *range_opts, 
          const bson_value_t *min,
          const bson_value_t *max);

--- a/src/libmongoc/doc/mongoc_client_encryption_encrypt_range_opts_set_precision.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_encrypt_range_opts_set_precision.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
     void
-    mongoc_client_encryption_encrypt_opts_set_precision (
+    mongoc_client_encryption_encrypt_range_opts_set_precision (
          mongoc_client_encryption_encrypt_range_opts_t *range_opts, int32_t precision);
 
 .. important:: The |qenc:range-is-experimental| |qenc:api-is-experimental|

--- a/src/libmongoc/doc/mongoc_client_encryption_encrypt_range_opts_set_sparsity.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_encrypt_range_opts_set_sparsity.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
     void
-    mongoc_client_encryption_encrypt_opts_set_sparsity (
+    mongoc_client_encryption_encrypt_range_opts_set_sparsity (
          mongoc_client_encryption_encrypt_range_opts_t *range_opts, int64_t sparsity);
 
 .. important:: The |qenc:range-is-experimental| |qenc:api-is-experimental|


### PR DESCRIPTION
Fixes typos dating back to https://github.com/mongodb/mongo-c-driver/commit/7a6b6369eb918bc2698fd6dc3aeab12845176a36 for #1152.