### PR TITLE
CDRIVER-4608 Reload expansions before deleting Azure resources

### DIFF
--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -9204,6 +9204,9 @@ task_groups:
     params:
       file: testazurekms-expansions.yml
   teardown_group:
+  - command: expansions.update
+    params:
+      file: testazurekms-expansions.yml
   - command: shell.exec
     params:
       shell: bash

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/testazurekms.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/testazurekms.py
@@ -124,6 +124,11 @@ def _create_task_group():
     ]
 
     task_group.teardown_group = [
+        # Load expansions again. The setup task may have failed before running `expansions.update`.
+        OD([('command', 'expansions.update'),
+            ('params', OD([
+                ('file', 'testazurekms-expansions.yml'),
+            ]))]),
         shell_exec(r'''
             DRIVERS_TOOLS=$(pwd)/drivers-evergreen-tools
                 export AZUREKMS_VMNAME=${AZUREKMS_VMNAME}


### PR DESCRIPTION
# Summary
- Reload expansions before deleting Azure resources

Verified by [this patch](https://spruce.mongodb.com/version/64304c203627e07ca0043a8d/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

# Background & Motivation

This is an improvement to the `testazurekms_task_group` added as part of DRIVERS-2400.

If `setup_group` fails before running `expansions.update`, the `teardown_group` will not have the required expansions to delete resources.

Here is an example [failure in `setup_group`](https://spruce.mongodb.com/version/643039a13e8e86a957ce70df/). The logs in `teardown_group` show the `delete-vm.sh` script [failing to run](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/b1abf2511c061eed5567e0bfc1fb9eb15fe4792f/.evergreen/csfle/azurekms/delete-vm.sh#L6-L13):
```
[2023/04/07 15:50:54.776] Please set the following required environment variables
[2023/04/07 15:50:54.776]  AZUREKMS_RESOURCEGROUP
[2023/04/07 15:50:54.776]  AZUREKMS_VMNAME
```
This results in the Azure resources not being deleted.

With changes in this PR, a failure in `setup_group` results in the [Azure resources being deleted](https://spruce.mongodb.com/task/mongo_c_driver_testazurekms_variant_testazurekms_task_patch_8aced03a963e70182b79d883e881f239766b09bf_64303ca7850e617765960ce3_23_04_07_15_54_17/logs?execution=0):

```
[2023/04/07 16:05:18.111] Deleting Virtual Machine vmname-CDRIVER-8130 ... begin
[2023/04/07 16:05:18.112] Deleting Virtual Machine vmname-CDRIVER-8130 ... end
[2023/04/07 16:05:18.112] Delete public IP vmname-CDRIVER-8130-PUBLIC-IP ... begin
[2023/04/07 16:05:40.172] Delete public IP vmname-CDRIVER-8130-PUBLIC-IP ... end
```