### PR TITLE
Drop test collection with `writeConcern=majority`

### DIFF
--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -2250,7 +2250,8 @@ test_count_read_concern_live (void *unused)
    count = mongoc_collection_count (
       collection, MONGOC_QUERY_NONE, &b, 0, 0, NULL, &error);
    bson_destroy (&b);
-   ASSERT_OR_PRINT (count == 0, error);
+   ASSERT_OR_PRINT (count != -1, error);
+   ASSERT_CMPINT64 (count, ==, 0);
 
    /* Setting readConcern to NULL should not send readConcern */
    rc = mongoc_read_concern_new ();
@@ -2261,7 +2262,8 @@ test_count_read_concern_live (void *unused)
    count = mongoc_collection_count (
       collection, MONGOC_QUERY_NONE, &b, 0, 0, NULL, &error);
    bson_destroy (&b);
-   ASSERT_OR_PRINT (count == 0, error);
+   ASSERT_OR_PRINT (count != -1, error);
+   ASSERT_CMPINT64 (count, ==, 0);
    mongoc_read_concern_destroy (rc);
 
    /* readConcern: { level: local } should raise error pre 3.2 */
@@ -2273,7 +2275,8 @@ test_count_read_concern_live (void *unused)
    count = mongoc_collection_count (
       collection, MONGOC_QUERY_NONE, &b, 0, 0, NULL, &error);
    bson_destroy (&b);
-   ASSERT_OR_PRINT (count == 0, error);
+   ASSERT_OR_PRINT (count != -1, error);
+   ASSERT_CMPINT64 (count, ==, 0);
    mongoc_read_concern_destroy (rc);
 
    /* readConcern: { level: majority } should raise error pre 3.2 */
@@ -2285,7 +2288,8 @@ test_count_read_concern_live (void *unused)
    count = mongoc_collection_count (
       collection, MONGOC_QUERY_NONE, &b, 0, 0, NULL, &error);
    bson_destroy (&b);
-   ASSERT_OR_PRINT (count == 0, error);
+   ASSERT_OR_PRINT (count != -1, error);
+   ASSERT_CMPINT64 (count, ==, 0);
    mongoc_read_concern_destroy (rc);
 
    mongoc_collection_destroy (collection);

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -2243,8 +2243,24 @@ test_count_read_concern_live (void *unused)
    collection = mongoc_client_get_collection (client, "test", "test");
    ASSERT (collection);
 
-   /* don't care if ns not found. */
-   (void) mongoc_collection_drop (collection, &error);
+   // Drop collection.
+   // Use writeConcern=majority so later readConcern=majority observes dropped
+   // collection.
+   {
+      mongoc_write_concern_t *wc = mongoc_write_concern_new ();
+      mongoc_write_concern_set_w (wc, MONGOC_WRITE_CONCERN_W_MAJORITY);
+      bson_t drop_opts = BSON_INITIALIZER;
+      mongoc_write_concern_append (wc, &drop_opts);
+      if (!mongoc_collection_drop_with_opts (collection, &drop_opts, &error)) {
+         // Ignore an "ns not found" error.
+         if (NULL == strstr (error.message, "ns not found")) {
+            ASSERT_OR_PRINT (false, error);
+         }
+      }
+
+      bson_destroy (&drop_opts);
+      mongoc_write_concern_destroy (wc);
+   }
 
    bson_init (&b);
    count = mongoc_collection_count (


### PR DESCRIPTION
# Summary

- Drop test collection with `writeConcern=majority` in `test_count_read_concern_live`

Verified with this patch: https://spruce.mongodb.com/version/64306c5be3c331e640d0ec57

# Background & Motivation
This PR intends to address recently observed failures in the `/Collection/count/read_concern_live` test.

Here is an [example failure](https://spruce.mongodb.com/task/mongo_c_driver_sanitizers_matrix_asan_asan_sasl_cyrus_openssl_ubuntu1804_clang_test_latest_replica_auth_8aced03a963e70182b79d883e881f239766b09bf_23_04_06_18_37_29/logs?execution=0) with relevant logs:
```
[2023/04/06 19:22:39.014] FAIL:/data/mci/af9f1bf18f00ea2288ac8214a6caa522/mongoc/src/libmongoc/tests/test-mongoc-collection.c:2288  test_count_read_concern_live()
[2023/04/06 19:22:39.014]   count == 0
[2023/04/06 19:22:39.044] .evergreen/scripts/run-tests.sh: line 230: 22918 Aborted                 LD_LIBRARY_PATH="${openssl_lib_prefix}" LD_PRELOAD="${ld_preload:-}" ./src/libmongoc/test-libmongoc --no-fork "${test_args[@]}"
[2023/04/06 19:22:39.045] Command 'subprocess.exec' in function 'run-tests' failed: process encountered problem: exit code 134.
```

Using `ASSERT_CMPINT64` [shows the actual `count` value](https://spruce.mongodb.com/task/mongo_c_driver_sasl_matrix_nossl_sasl_off_nossl_ubuntu1804_gcc_test_latest_replica_noauth_patch_8aced03a963e70182b79d883e881f239766b09bf_64307346a4cf47f3343df486_23_04_07_19_47_20/logs?execution=0):

```
[2023/04/07 19:51:47.205] Begin /Collection/count/read_concern_live, seed 1170109232
[2023/04/07 19:51:47.209] FAIL
[2023/04/07 19:51:47.209] Assert Failure: 2 == 0
```

The failing call to `mongoc_collection_count` read uses `readConcern=majority`. This collection drop uses the default `writeConcern=1`. This suggests a race if the drop does not majority commit before the failing call. Using `writeConcern=majority` ensures the drop majority commits.
