### PR TITLE
Find and replace all -Wstrict-prototypes violations

### DIFF
--- a/build/future_function_templates/future-value.c.template
+++ b/build/future_function_templates/future-value.c.template
@@ -3,7 +3,7 @@
 {{ header_comment }}
 
 future_value_t *
-future_value_new ()
+future_value_new (void)
 {
    return (future_value_t *) bson_malloc0 (sizeof (future_value_t));
 }

--- a/src/kms-message/src/kms_crypto_none.c
+++ b/src/kms-message/src/kms_crypto_none.c
@@ -19,13 +19,13 @@
 #ifndef KMS_MESSAGE_ENABLE_CRYPTO
 
 int
-kms_crypto_init ()
+kms_crypto_init (void)
 {
    return 0;
 }
 
 void
-kms_crypto_cleanup ()
+kms_crypto_cleanup (void)
 {
 }
 

--- a/src/kms-message/src/kms_crypto_windows.c
+++ b/src/kms-message/src/kms_crypto_windows.c
@@ -43,7 +43,7 @@ static BCRYPT_ALG_HANDLE _algoSHA256 = 0;
 static BCRYPT_ALG_HANDLE _algoSHA256Hmac = 0;
 
 int
-kms_crypto_init ()
+kms_crypto_init (void)
 {
    if (BCryptOpenAlgorithmProvider (
           &_algoSHA256, BCRYPT_SHA256_ALGORITHM, MS_PRIMITIVE_PROVIDER, 0) !=
@@ -63,7 +63,7 @@ kms_crypto_init ()
 }
 
 void
-kms_crypto_cleanup ()
+kms_crypto_cleanup (void)
 {
    (void) BCryptCloseAlgorithmProvider (_algoSHA256, 0);
    (void) BCryptCloseAlgorithmProvider (_algoSHA256Hmac, 0);

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl-bio.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl-bio.c
@@ -74,7 +74,7 @@ BIO_set_init (BIO *b, int init)
 }
 
 BIO_METHOD *
-mongoc_stream_tls_openssl_bio_meth_new ()
+mongoc_stream_tls_openssl_bio_meth_new (void)
 {
    BIO_METHOD *meth = NULL;
 

--- a/src/libmongoc/tests/bsonutil/bson-match.c
+++ b/src/libmongoc/tests/bsonutil/bson-match.c
@@ -329,7 +329,7 @@ evaluate_special (bson_matcher_t *matcher,
 
 
 bson_matcher_t *
-bson_matcher_new ()
+bson_matcher_new (void)
 {
    bson_matcher_t *matcher = bson_malloc0 (sizeof (bson_matcher_t));
    /* Add default special functions. */

--- a/src/libmongoc/tests/mock_server/future-value.c
+++ b/src/libmongoc/tests/mock_server/future-value.c
@@ -10,7 +10,7 @@
 /* clang-format off */
 
 future_value_t *
-future_value_new ()
+future_value_new (void)
 {
    return (future_value_t *) bson_malloc0 (sizeof (future_value_t));
 }
@@ -601,4 +601,3 @@ future_value_get_const_mongoc_write_concern_ptr (future_value_t *future_value)
    BSON_ASSERT (future_value->type == future_value_const_mongoc_write_concern_ptr_type);
    return future_value->value.const_mongoc_write_concern_ptr_value;
 }
-

--- a/src/libmongoc/tests/mock_server/mock-server.c
+++ b/src/libmongoc/tests/mock_server/mock-server.c
@@ -129,7 +129,7 @@ get_port (mongoc_socket_t *sock);
  */
 
 mock_server_t *
-mock_server_new ()
+mock_server_new (void)
 {
    mock_server_t *server =
       (mock_server_t *) bson_malloc0 (sizeof (mock_server_t));

--- a/src/libmongoc/tests/mock_server/sync-queue.c
+++ b/src/libmongoc/tests/mock_server/sync-queue.c
@@ -28,7 +28,7 @@ struct _sync_queue_t {
 
 
 sync_queue_t *
-q_new ()
+q_new (void)
 {
    sync_queue_t *q = (sync_queue_t *) bson_malloc (sizeof (sync_queue_t));
 

--- a/src/libmongoc/tests/test-conveniences.c
+++ b/src/libmongoc/tests/test-conveniences.c
@@ -46,7 +46,7 @@ static char *gFourMBString;
 
 
 void
-test_conveniences_init ()
+test_conveniences_init (void)
 {
    if (!gConveniencesInitialized) {
       _mongoc_array_init (&gTmpBsonArray, sizeof (bson_t *));
@@ -1655,7 +1655,7 @@ init_four_mb_string (void)
 
 
 const char *
-four_mb_string ()
+four_mb_string (void)
 {
    init_four_mb_string ();
    return gFourMBString;
@@ -1737,7 +1737,7 @@ match_in_array (const bson_t *doc, const bson_t *array, match_ctx_t *ctx)
 }
 
 bson_t *
-bson_with_all_types ()
+bson_with_all_types (void)
 {
    bson_t *bson = tmp_bson ("{}");
    bson_oid_t oid;
@@ -1776,7 +1776,7 @@ bson_with_all_types ()
 }
 
 const char *
-json_with_all_types ()
+json_with_all_types (void)
 {
    const char *json = "{\n"
                       "    \"double\": {\n"

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -189,7 +189,7 @@ print_captured_logs (const char *prefix)
 #define DEFAULT_FUTURE_TIMEOUT_MS 10 * 1000
 
 int64_t
-get_future_timeout_ms ()
+get_future_timeout_ms (void)
 {
    return test_framework_getenv_int64 ("MONGOC_TEST_FUTURE_TIMEOUT_MS",
                                        DEFAULT_FUTURE_TIMEOUT_MS);
@@ -758,7 +758,7 @@ test_framework_add_user_password_from_env (const char *uri_str)
  *--------------------------------------------------------------------------
  */
 char *
-test_framework_get_compressors ()
+test_framework_get_compressors (void)
 {
    return test_framework_getenv ("MONGOC_TEST_COMPRESSORS");
 }
@@ -848,7 +848,7 @@ test_framework_get_ssl (void)
  *--------------------------------------------------------------------------
  */
 char *
-test_framework_get_unix_domain_socket_uri_str ()
+test_framework_get_unix_domain_socket_uri_str (void)
 {
    char *path;
    char *test_uri_str;
@@ -1161,7 +1161,7 @@ test_framework_get_uri_str_no_auth (const char *database_name)
  *--------------------------------------------------------------------------
  */
 char *
-test_framework_get_uri_str ()
+test_framework_get_uri_str (void)
 {
    char *uri_str_no_auth;
    char *uri_str;
@@ -1198,7 +1198,7 @@ test_framework_get_uri_str ()
  *--------------------------------------------------------------------------
  */
 mongoc_uri_t *
-test_framework_get_uri ()
+test_framework_get_uri (void)
 {
    bson_error_t error = {0};
 
@@ -1212,7 +1212,7 @@ test_framework_get_uri ()
 }
 
 mongoc_uri_t *
-test_framework_get_uri_multi_mongos_loadbalanced ()
+test_framework_get_uri_multi_mongos_loadbalanced (void)
 {
    char *uri_str_no_auth;
    char *uri_str;
@@ -1489,7 +1489,7 @@ test_framework_set_ssl_opts (mongoc_client_t *client)
  *--------------------------------------------------------------------------
  */
 mongoc_client_t *
-test_framework_new_default_client ()
+test_framework_new_default_client (void)
 {
    char *test_uri_str = test_framework_get_uri_str ();
    mongoc_client_t *client = test_framework_client_new (test_uri_str, NULL);
@@ -1519,7 +1519,7 @@ test_framework_new_default_client ()
  *--------------------------------------------------------------------------
  */
 mongoc_client_t *
-test_framework_client_new_no_server_api ()
+test_framework_client_new_no_server_api (void)
 {
    mongoc_uri_t *uri = test_framework_get_uri ();
    mongoc_client_t *client = mongoc_client_new_from_uri (uri);
@@ -1721,7 +1721,7 @@ test_framework_set_pool_ssl_opts (mongoc_client_pool_t *pool)
  *--------------------------------------------------------------------------
  */
 mongoc_client_pool_t *
-test_framework_new_default_client_pool ()
+test_framework_new_default_client_pool (void)
 {
    mongoc_uri_t *test_uri = test_framework_get_uri ();
    mongoc_client_pool_t *pool =

--- a/src/libmongoc/tests/unified/test-diagnostics.c
+++ b/src/libmongoc/tests/unified/test-diagnostics.c
@@ -92,7 +92,7 @@ handle_abort (int signo)
 }
 
 void
-test_diagnostics_init ()
+test_diagnostics_init (void)
 {
    test_diagnostics_t *td = &diagnostics;
    memset (td, 0, sizeof (test_diagnostics_t));


### PR DESCRIPTION
Addresses the current [scan-build-macos-1100-clang](https://spruce.mongodb.com/task/mongo_c_driver_scan_build_matrix_scan_build_macos_1100_clang_abb0bb7da8230d342dac5061623c1e4936ed46d9_23_04_14_14_11_58/logs?execution=1) task failure.

This warning seems to be emitted only on occasion as the codebase changes (inconsistent scan-build behavior?). This PR does a thorough find-and-replace of _all_ instances (except those in bundled zlib) to hopefully squash this warning for good.