### PR TITLE
CDRIVER-4134 Use simple HTTP server for /http tests

### DIFF
--- a/.evergreen/config_generator/components/funcs/fetch_det.py
+++ b/.evergreen/config_generator/components/funcs/fetch_det.py
@@ -1,4 +1,5 @@
 from shrub.v3.evg_command import EvgCommandType
+from shrub.v3.evg_command import expansions_update
 
 from config_generator.etc.function import Function
 from config_generator.etc.utils import bash_exec
@@ -14,6 +15,21 @@ class FetchDET(Function):
                     git clone --depth=1 git@github.com:mongodb-labs/drivers-evergreen-tools.git
                 fi
             ''',
+        ),
+
+        # python is used frequently enough by many tasks that it is worth
+        # running find_python3 once here and reusing the result.
+        bash_exec(
+            command_type=EvgCommandType.SETUP,
+            script='''\
+                set -o errexit
+                . drivers-evergreen-tools/.evergreen/find-python3.sh
+                echo "PYTHON3_BINARY: $(find_python3)" >|python3_binary.yml
+            ''',
+        ),
+        expansions_update(
+            command_type=EvgCommandType.SETUP,
+            file='python3_binary.yml',
         ),
     ]
 

--- a/.evergreen/config_generator/components/funcs/run_simple_http_server.py
+++ b/.evergreen/config_generator/components/funcs/run_simple_http_server.py
@@ -15,7 +15,8 @@ class RunSimpleHTTPServer(Function):
             script='''\
                 set -o errexit
                 echo "Starting simple HTTP server..."
-                .evergreen/scripts/simple_http_server.py
+                command -V "${PYTHON3_BINARY}" >/dev/null
+                "${PYTHON3_BINARY}" .evergreen/scripts/simple_http_server.py
                 echo "Starting simple HTTP server... done."
             ''',
         ),

--- a/.evergreen/config_generator/components/funcs/run_simple_http_server.py
+++ b/.evergreen/config_generator/components/funcs/run_simple_http_server.py
@@ -1,0 +1,30 @@
+from shrub.v3.evg_command import EvgCommandType
+
+from config_generator.etc.function import Function
+from config_generator.etc.utils import bash_exec
+
+
+class RunSimpleHTTPServer(Function):
+    name = 'run-simple-http-server'
+    command_type = EvgCommandType.SETUP
+    commands = [
+        bash_exec(
+            command_type=command_type,
+            background=True,
+            working_dir='mongoc',
+            script='''\
+                set -o errexit
+                echo "Starting simple HTTP server..."
+                .evergreen/scripts/simple_http_server.py
+                echo "Starting simple HTTP server... done."
+            ''',
+        ),
+    ]
+
+    @classmethod
+    def call(cls, **kwargs):
+        return cls.default_call(**kwargs)
+
+
+def functions():
+    return RunSimpleHTTPServer.defn()

--- a/.evergreen/config_generator/etc/sanitizers/test.py
+++ b/.evergreen/config_generator/etc/sanitizers/test.py
@@ -31,7 +31,10 @@ def generate_test_tasks(SSL, TAG, MATRIX, MORE_COMPILE_TAGS=None, MORE_TEST_TAGS
     MORE_VARS = MORE_VARS if MORE_VARS else {}
 
     for distro_name, compiler, arch, sasl, auths, topologies, server_vers in MATRIX:
-        tags = [TAG, 'test', distro_name, compiler, f'sasl-{sasl}'] + MORE_COMPILE_TAGS
+        tags = [
+            TAG, 'test', distro_name, compiler, f'sasl-{sasl}'
+        ] + MORE_COMPILE_TAGS
+
         test_distro = find_small_distro(distro_name)
 
         compile_vars = []

--- a/.evergreen/config_generator/etc/sanitizers/test.py
+++ b/.evergreen/config_generator/etc/sanitizers/test.py
@@ -12,6 +12,7 @@ from config_generator.etc.utils import Task
 from config_generator.components.funcs.bootstrap_mongo_orchestration import BootstrapMongoOrchestration
 from config_generator.components.funcs.fetch_build import FetchBuild
 from config_generator.components.funcs.fetch_det import FetchDET
+from config_generator.components.funcs.run_simple_http_server import RunSimpleHTTPServer
 from config_generator.components.funcs.run_mock_kms_servers import RunMockKMSServers
 from config_generator.components.funcs.run_tests import RunTests
 
@@ -77,6 +78,7 @@ def generate_test_tasks(SSL, TAG, MATRIX, MORE_COMPILE_TAGS=None, MORE_TEST_TAGS
             test_commands.append(expansions_update(updates=updates))
             test_commands.append(FetchDET.call())
             test_commands.append(BootstrapMongoOrchestration.call())
+            test_commands.append(RunSimpleHTTPServer.call())
 
             if 'cse' in MORE_COMPILE_TAGS:
                 test_commands.append(RunMockKMSServers.call())

--- a/.evergreen/config_generator/etc/sasl/test.py
+++ b/.evergreen/config_generator/etc/sasl/test.py
@@ -12,6 +12,7 @@ from config_generator.etc.utils import Task
 from config_generator.components.funcs.bootstrap_mongo_orchestration import BootstrapMongoOrchestration
 from config_generator.components.funcs.fetch_build import FetchBuild
 from config_generator.components.funcs.fetch_det import FetchDET
+from config_generator.components.funcs.run_simple_http_server import RunSimpleHTTPServer
 from config_generator.components.funcs.run_tests import RunTests
 
 
@@ -56,6 +57,7 @@ def generate_test_tasks(SSL, TAG, MATRIX):
             test_commands.append(expansions_update(updates=updates))
             test_commands.append(FetchDET.call())
             test_commands.append(BootstrapMongoOrchestration.call())
+            test_commands.append(RunSimpleHTTPServer.call())
             test_commands.append(RunTests.call())
 
             res.append(

--- a/.evergreen/config_generator/requirements.txt
+++ b/.evergreen/config_generator/requirements.txt
@@ -1,5 +1,6 @@
 -e git+https://github.com/mongodb-labs/drivers-evergreen-tools#egg=evergreen_config_generator&subdirectory=evergreen_config_generator
 git-url-parse==1.2.2
+packaging==23.1
 pbr==5.11.1
 pydantic==1.10.4
 PyYAML==5.4.1

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -318,6 +318,20 @@ functions:
             python -u kms_kmip_server.py &
             deactivate
             echo "Starting mock KMS TLS servers... done."
+  run-simple-http-server:
+    - command: subprocess.exec
+      type: setup
+      params:
+        binary: bash
+        working_dir: mongoc
+        background: true
+        args:
+          - -c
+          - |
+            set -o errexit
+            echo "Starting simple HTTP server..."
+            .evergreen/scripts/simple_http_server.py
+            echo "Starting simple HTTP server... done."
   run-tests:
     - command: subprocess.exec
       type: test

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -173,6 +173,20 @@ functions:
             if [[ ! -d drivers-evergreen-tools ]]; then
                 git clone --depth=1 git@github.com:mongodb-labs/drivers-evergreen-tools.git
             fi
+    - command: subprocess.exec
+      type: setup
+      params:
+        binary: bash
+        args:
+          - -c
+          - |
+            set -o errexit
+            . drivers-evergreen-tools/.evergreen/find-python3.sh
+            echo "PYTHON3_BINARY: $(find_python3)" >|python3_binary.yml
+    - command: expansions.update
+      type: setup
+      params:
+        file: python3_binary.yml
   fetch-source:
     - command: git.get_project
       type: setup
@@ -330,7 +344,8 @@ functions:
           - |
             set -o errexit
             echo "Starting simple HTTP server..."
-            .evergreen/scripts/simple_http_server.py
+            command -V "${PYTHON3_BINARY}" >/dev/null
+            "${PYTHON3_BINARY}" .evergreen/scripts/simple_http_server.py
             echo "Starting simple HTTP server... done."
   run-tests:
     - command: subprocess.exec

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -1165,6 +1165,7 @@ tasks:
       MONGODB_VERSION: latest
       SSL: openssl
       TOPOLOGY: replica_set
+  - func: run-simple-http-server
   - func: fetch-det
   - func: run-mock-kms-servers
   - func: run-tests
@@ -1326,6 +1327,7 @@ tasks:
       AUTH: noauth
       ORCHESTRATION_FILE: zlib
       SSL: nossl
+  - func: run-simple-http-server
   - func: run-tests
     vars:
       AUTH: noauth
@@ -1348,6 +1350,7 @@ tasks:
       AUTH: noauth
       ORCHESTRATION_FILE: snappy
       SSL: nossl
+  - func: run-simple-http-server
   - func: run-tests
     vars:
       AUTH: noauth
@@ -1370,6 +1373,7 @@ tasks:
       AUTH: noauth
       ORCHESTRATION_FILE: zstd
       SSL: nossl
+  - func: run-simple-http-server
   - func: run-tests
     vars:
       AUTH: noauth
@@ -1394,6 +1398,7 @@ tasks:
       AUTH: noauth
       ORCHESTRATION_FILE: snappy-zlib-zstd
       SSL: nossl
+  - func: run-simple-http-server
   - func: run-tests
     vars:
       AUTH: noauth
@@ -1411,6 +1416,7 @@ tasks:
     vars:
       MONGODB_VERSION: latest
       TOPOLOGY: server
+  - func: run-simple-http-server
   - func: run-tests
     vars:
       URI: mongodb://localhost/?retryWrites=true
@@ -1429,6 +1435,7 @@ tasks:
     vars:
       MONGODB_VERSION: latest
       TOPOLOGY: server
+  - func: run-simple-http-server
   - func: run-tests
     vars:
       URI: null
@@ -1556,6 +1563,7 @@ tasks:
       REQUIRE_API_VERSION: 'true'
       SSL: ssl
       TOPOLOGY: server
+  - func: run-simple-http-server
   - func: run-tests
     vars:
       AUTH: auth
@@ -1578,6 +1586,7 @@ tasks:
       ORCHESTRATION_FILE: versioned-api-testing
       SSL: nossl
       TOPOLOGY: server
+  - func: run-simple-http-server
   - func: run-tests
     vars:
       AUTH: noauth
@@ -1718,6 +1727,7 @@ tasks:
   - func: bootstrap-mongo-orchestration
     vars:
       IPV4_ONLY: 'off'
+  - func: run-simple-http-server
   - func: run-tests
     vars:
       IPV4_ONLY: 'off'
@@ -1739,6 +1749,7 @@ tasks:
   - func: bootstrap-mongo-orchestration
     vars:
       IPV4_ONLY: 'off'
+  - func: run-simple-http-server
   - func: run-tests
     vars:
       IPV4_ONLY: 'off'
@@ -1760,6 +1771,7 @@ tasks:
   - func: bootstrap-mongo-orchestration
     vars:
       IPV4_ONLY: 'on'
+  - func: run-simple-http-server
   - func: run-tests
     vars:
       IPV4_ONLY: 'on'
@@ -1781,6 +1793,7 @@ tasks:
   - func: bootstrap-mongo-orchestration
     vars:
       IPV4_ONLY: 'on'
+  - func: run-simple-http-server
   - func: run-tests
     vars:
       IPV4_ONLY: 'on'
@@ -8958,6 +8971,7 @@ tasks:
       MONGODB_VERSION: '5.0'
       SSL: ssl
       TOPOLOGY: sharded_cluster
+  - func: run-simple-http-server
   - func: start load balancer
     vars:
       MONGODB_URI: mongodb://localhost:27017,localhost:27018
@@ -8985,6 +8999,7 @@ tasks:
       MONGODB_VERSION: latest
       SSL: ssl
       TOPOLOGY: sharded_cluster
+  - func: run-simple-http-server
   - func: start load balancer
     vars:
       MONGODB_URI: mongodb://localhost:27017,localhost:27018
@@ -9012,6 +9027,7 @@ tasks:
       MONGODB_VERSION: '5.0'
       SSL: nossl
       TOPOLOGY: sharded_cluster
+  - func: run-simple-http-server
   - func: start load balancer
     vars:
       MONGODB_URI: mongodb://localhost:27017,localhost:27018
@@ -9039,6 +9055,7 @@ tasks:
       MONGODB_VERSION: latest
       SSL: nossl
       TOPOLOGY: sharded_cluster
+  - func: run-simple-http-server
   - func: start load balancer
     vars:
       MONGODB_URI: mongodb://localhost:27017,localhost:27018

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -29,6 +29,7 @@ tasks:
             - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-mock-kms-servers
       - func: run-tests
   - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-4.2-server-auth-with-mongocrypt
@@ -51,6 +52,7 @@ tasks:
             - { key: SKIP_CRYPT_SHARED_LIB, value: "on" }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-mock-kms-servers
       - func: run-tests
   - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-4.4-server-auth
@@ -72,6 +74,7 @@ tasks:
             - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-mock-kms-servers
       - func: run-tests
   - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-4.4-server-auth-with-mongocrypt
@@ -94,6 +97,7 @@ tasks:
             - { key: SKIP_CRYPT_SHARED_LIB, value: "on" }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-mock-kms-servers
       - func: run-tests
   - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-5.0-server-auth
@@ -115,6 +119,7 @@ tasks:
             - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-mock-kms-servers
       - func: run-tests
   - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-5.0-server-auth-with-mongocrypt
@@ -137,6 +142,7 @@ tasks:
             - { key: SKIP_CRYPT_SHARED_LIB, value: "on" }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-mock-kms-servers
       - func: run-tests
   - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-6.0-replica-auth
@@ -158,6 +164,7 @@ tasks:
             - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-mock-kms-servers
       - func: run-tests
   - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-6.0-replica-auth-with-mongocrypt
@@ -180,6 +187,7 @@ tasks:
             - { key: SKIP_CRYPT_SHARED_LIB, value: "on" }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-mock-kms-servers
       - func: run-tests
   - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-6.0-server-auth
@@ -201,6 +209,7 @@ tasks:
             - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-mock-kms-servers
       - func: run-tests
   - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-6.0-server-auth-with-mongocrypt
@@ -223,6 +232,7 @@ tasks:
             - { key: SKIP_CRYPT_SHARED_LIB, value: "on" }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-mock-kms-servers
       - func: run-tests
   - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-latest-replica-auth
@@ -244,6 +254,7 @@ tasks:
             - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-mock-kms-servers
       - func: run-tests
   - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-latest-replica-auth-with-mongocrypt
@@ -266,6 +277,7 @@ tasks:
             - { key: SKIP_CRYPT_SHARED_LIB, value: "on" }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-mock-kms-servers
       - func: run-tests
   - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-latest-server-auth
@@ -287,6 +299,7 @@ tasks:
             - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-mock-kms-servers
       - func: run-tests
   - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-latest-server-auth-with-mongocrypt
@@ -309,6 +322,7 @@ tasks:
             - { key: SKIP_CRYPT_SHARED_LIB, value: "on" }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-mock-kms-servers
       - func: run-tests
   - name: asan-sasl-cyrus-openssl-ubuntu1604-clang-compile
@@ -337,6 +351,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: asan-sasl-cyrus-openssl-ubuntu1604-clang-test-3.6-server-auth
     run_on: ubuntu1604-small
@@ -356,6 +371,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: asan-sasl-cyrus-openssl-ubuntu1604-clang-test-3.6-sharded-auth
     run_on: ubuntu1604-small
@@ -375,6 +391,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile
     run_on: ubuntu1804-large
@@ -402,6 +419,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.0-server-auth
     run_on: ubuntu1804-small
@@ -421,6 +439,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.0-sharded-auth
     run_on: ubuntu1804-small
@@ -440,6 +459,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.2-replica-auth
     run_on: ubuntu1804-small
@@ -459,6 +479,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.2-server-auth
     run_on: ubuntu1804-small
@@ -478,6 +499,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.2-sharded-auth
     run_on: ubuntu1804-small
@@ -497,6 +519,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.4-replica-auth
     run_on: ubuntu1804-small
@@ -516,6 +539,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.4-server-auth
     run_on: ubuntu1804-small
@@ -535,6 +559,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.4-sharded-auth
     run_on: ubuntu1804-small
@@ -554,6 +579,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-5.0-replica-auth
     run_on: ubuntu1804-small
@@ -573,6 +599,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-5.0-server-auth
     run_on: ubuntu1804-small
@@ -592,6 +619,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-5.0-sharded-auth
     run_on: ubuntu1804-small
@@ -611,6 +639,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-6.0-replica-auth
     run_on: ubuntu1804-small
@@ -630,6 +659,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-6.0-server-auth
     run_on: ubuntu1804-small
@@ -649,6 +679,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-6.0-sharded-auth
     run_on: ubuntu1804-small
@@ -668,6 +699,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-latest-replica-auth
     run_on: ubuntu1804-small
@@ -687,6 +719,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-latest-server-auth
     run_on: ubuntu1804-small
@@ -706,6 +739,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-latest-sharded-auth
     run_on: ubuntu1804-small
@@ -725,6 +759,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: check-headers
     commands:
@@ -1787,6 +1822,7 @@ tasks:
             - { key: SSL, value: darwinssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-darwinssl-macos-1100-clang-test-4.0-server-auth
     run_on: macos-1100
@@ -1806,6 +1842,7 @@ tasks:
             - { key: SSL, value: darwinssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-darwinssl-macos-1100-clang-test-4.2-server-auth
     run_on: macos-1100
@@ -1825,6 +1862,7 @@ tasks:
             - { key: SSL, value: darwinssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-darwinssl-macos-1100-clang-test-4.4-server-auth
     run_on: macos-1100
@@ -1844,6 +1882,7 @@ tasks:
             - { key: SSL, value: darwinssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-darwinssl-macos-1100-clang-test-5.0-server-auth
     run_on: macos-1100
@@ -1863,6 +1902,7 @@ tasks:
             - { key: SSL, value: darwinssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-darwinssl-macos-1100-clang-test-latest-server-auth
     run_on: macos-1100
@@ -1882,6 +1922,7 @@ tasks:
             - { key: SSL, value: darwinssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-archlinux-clang-compile
     run_on: archlinux-large
@@ -1989,6 +2030,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-rhel81-power8-gcc-test-4.4-server-auth
     run_on: rhel81-power8-small
@@ -2008,6 +2050,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-rhel81-power8-gcc-test-5.0-server-auth
     run_on: rhel81-power8-small
@@ -2027,6 +2070,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-rhel81-power8-gcc-test-6.0-server-auth
     run_on: rhel81-power8-small
@@ -2046,6 +2090,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-rhel81-power8-gcc-test-latest-server-auth
     run_on: rhel81-power8-small
@@ -2065,6 +2110,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-rhel83-zseries-gcc-compile
     run_on: rhel83-zseries-large
@@ -2092,6 +2138,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-rhel83-zseries-gcc-test-6.0-server-auth
     run_on: rhel83-zseries-small
@@ -2111,6 +2158,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-rhel83-zseries-gcc-test-latest-server-auth
     run_on: rhel83-zseries-small
@@ -2130,6 +2178,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-ubuntu1404-clang-compile
     run_on: ubuntu1404-large
@@ -2173,6 +2222,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-ubuntu1604-clang-compile
     run_on: ubuntu1604-large
@@ -2208,6 +2258,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-4.4-server-auth
     run_on: ubuntu1804-arm64-small
@@ -2227,6 +2278,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-5.0-server-auth
     run_on: ubuntu1804-arm64-small
@@ -2246,6 +2298,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-6.0-server-auth
     run_on: ubuntu1804-arm64-small
@@ -2265,6 +2318,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-latest-server-auth
     run_on: ubuntu1804-arm64-small
@@ -2284,6 +2338,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-ubuntu1804-gcc-compile
     run_on: ubuntu1804-large
@@ -2311,6 +2366,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-4.0-server-auth
     run_on: ubuntu1804-small
@@ -2330,6 +2386,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-4.2-replica-auth
     run_on: ubuntu1804-small
@@ -2349,6 +2406,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-4.2-server-auth
     run_on: ubuntu1804-small
@@ -2368,6 +2426,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-4.4-replica-auth
     run_on: ubuntu1804-small
@@ -2387,6 +2446,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-4.4-server-auth
     run_on: ubuntu1804-small
@@ -2406,6 +2466,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-5.0-replica-auth
     run_on: ubuntu1804-small
@@ -2425,6 +2486,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-5.0-server-auth
     run_on: ubuntu1804-small
@@ -2444,6 +2506,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-6.0-replica-auth
     run_on: ubuntu1804-small
@@ -2463,6 +2526,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-6.0-server-auth
     run_on: ubuntu1804-small
@@ -2482,6 +2546,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-latest-replica-auth
     run_on: ubuntu1804-small
@@ -2501,6 +2566,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-latest-server-auth
     run_on: ubuntu1804-small
@@ -2520,6 +2586,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-openssl-ubuntu2004-gcc-compile
     run_on: ubuntu2004-large
@@ -2555,6 +2622,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-winssl-vs2013-x64-compile
     run_on: windows-64-vs2013-large
@@ -2598,6 +2666,7 @@ tasks:
             - { key: SSL, value: winssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-winssl-vs2017-x64-test-4.0-server-auth
     run_on: windows-64-vs2017-small
@@ -2617,6 +2686,7 @@ tasks:
             - { key: SSL, value: winssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-winssl-vs2017-x64-test-4.2-server-auth
     run_on: windows-64-vs2017-small
@@ -2636,6 +2706,7 @@ tasks:
             - { key: SSL, value: winssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-winssl-vs2017-x64-test-4.4-server-auth
     run_on: windows-64-vs2017-small
@@ -2655,6 +2726,7 @@ tasks:
             - { key: SSL, value: winssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-winssl-vs2017-x64-test-5.0-server-auth
     run_on: windows-64-vs2017-small
@@ -2674,6 +2746,7 @@ tasks:
             - { key: SSL, value: winssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-winssl-vs2017-x64-test-6.0-server-auth
     run_on: windows-64-vs2017-small
@@ -2693,6 +2766,7 @@ tasks:
             - { key: SSL, value: winssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-cyrus-winssl-vs2017-x64-test-latest-server-auth
     run_on: windows-64-vs2017-small
@@ -2712,6 +2786,7 @@ tasks:
             - { key: SSL, value: winssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-off-nossl-macos-1014-clang-compile
     run_on: macos-1014
@@ -2747,6 +2822,7 @@ tasks:
             - { key: SSL, value: nossl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-off-nossl-ubuntu1604-gcc-test-3.6-server-noauth
     run_on: ubuntu1604-small
@@ -2766,6 +2842,7 @@ tasks:
             - { key: SSL, value: nossl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-off-nossl-ubuntu1604-gcc-test-3.6-sharded-noauth
     run_on: ubuntu1604-small
@@ -2785,6 +2862,7 @@ tasks:
             - { key: SSL, value: nossl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-off-nossl-ubuntu1804-gcc-compile
     run_on: ubuntu1804-large
@@ -2812,6 +2890,7 @@ tasks:
             - { key: SSL, value: nossl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-off-nossl-ubuntu1804-gcc-test-4.0-server-noauth
     run_on: ubuntu1804-small
@@ -2831,6 +2910,7 @@ tasks:
             - { key: SSL, value: nossl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-off-nossl-ubuntu1804-gcc-test-4.0-sharded-noauth
     run_on: ubuntu1804-small
@@ -2850,6 +2930,7 @@ tasks:
             - { key: SSL, value: nossl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-off-nossl-ubuntu1804-gcc-test-4.2-replica-noauth
     run_on: ubuntu1804-small
@@ -2869,6 +2950,7 @@ tasks:
             - { key: SSL, value: nossl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-off-nossl-ubuntu1804-gcc-test-4.2-server-noauth
     run_on: ubuntu1804-small
@@ -2888,6 +2970,7 @@ tasks:
             - { key: SSL, value: nossl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-off-nossl-ubuntu1804-gcc-test-4.2-sharded-noauth
     run_on: ubuntu1804-small
@@ -2907,6 +2990,7 @@ tasks:
             - { key: SSL, value: nossl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-off-nossl-ubuntu1804-gcc-test-4.4-replica-noauth
     run_on: ubuntu1804-small
@@ -2926,6 +3010,7 @@ tasks:
             - { key: SSL, value: nossl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-off-nossl-ubuntu1804-gcc-test-4.4-server-noauth
     run_on: ubuntu1804-small
@@ -2945,6 +3030,7 @@ tasks:
             - { key: SSL, value: nossl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-off-nossl-ubuntu1804-gcc-test-4.4-sharded-noauth
     run_on: ubuntu1804-small
@@ -2964,6 +3050,7 @@ tasks:
             - { key: SSL, value: nossl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-off-nossl-ubuntu1804-gcc-test-5.0-replica-noauth
     run_on: ubuntu1804-small
@@ -2983,6 +3070,7 @@ tasks:
             - { key: SSL, value: nossl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-off-nossl-ubuntu1804-gcc-test-5.0-server-noauth
     run_on: ubuntu1804-small
@@ -3002,6 +3090,7 @@ tasks:
             - { key: SSL, value: nossl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-off-nossl-ubuntu1804-gcc-test-5.0-sharded-noauth
     run_on: ubuntu1804-small
@@ -3021,6 +3110,7 @@ tasks:
             - { key: SSL, value: nossl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-off-nossl-ubuntu1804-gcc-test-latest-replica-noauth
     run_on: ubuntu1804-small
@@ -3040,6 +3130,7 @@ tasks:
             - { key: SSL, value: nossl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-off-nossl-ubuntu1804-gcc-test-latest-server-noauth
     run_on: ubuntu1804-small
@@ -3059,6 +3150,7 @@ tasks:
             - { key: SSL, value: nossl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-off-nossl-ubuntu1804-gcc-test-latest-sharded-noauth
     run_on: ubuntu1804-small
@@ -3078,6 +3170,7 @@ tasks:
             - { key: SSL, value: nossl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-off-nossl-vs2017-x64-compile
     run_on: windows-64-vs2017-large
@@ -3145,6 +3238,7 @@ tasks:
             - { key: SSL, value: winssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-sspi-winssl-vs2017-x64-compile
     run_on: windows-64-vs2017-large
@@ -3172,6 +3266,7 @@ tasks:
             - { key: SSL, value: winssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: sasl-sspi-winssl-vs2017-x86-compile
     run_on: windows-64-vs2017-large
@@ -3199,6 +3294,7 @@ tasks:
             - { key: SSL, value: winssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: scan-build-macos-1100-clang
     run_on: macos-1100
@@ -3406,6 +3502,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.0-server-auth
     run_on: ubuntu1804-small
@@ -3425,6 +3522,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.0-sharded-auth
     run_on: ubuntu1804-small
@@ -3444,6 +3542,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.2-replica-auth
     run_on: ubuntu1804-small
@@ -3463,6 +3562,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.2-server-auth
     run_on: ubuntu1804-small
@@ -3482,6 +3582,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.2-sharded-auth
     run_on: ubuntu1804-small
@@ -3501,6 +3602,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.4-replica-auth
     run_on: ubuntu1804-small
@@ -3520,6 +3622,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.4-server-auth
     run_on: ubuntu1804-small
@@ -3539,6 +3642,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.4-sharded-auth
     run_on: ubuntu1804-small
@@ -3558,6 +3662,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-5.0-replica-auth
     run_on: ubuntu1804-small
@@ -3577,6 +3682,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-5.0-server-auth
     run_on: ubuntu1804-small
@@ -3596,6 +3702,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-5.0-sharded-auth
     run_on: ubuntu1804-small
@@ -3615,6 +3722,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-6.0-replica-auth
     run_on: ubuntu1804-small
@@ -3634,6 +3742,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-6.0-server-auth
     run_on: ubuntu1804-small
@@ -3653,6 +3762,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-6.0-sharded-auth
     run_on: ubuntu1804-small
@@ -3672,6 +3782,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-latest-replica-auth
     run_on: ubuntu1804-small
@@ -3691,6 +3802,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-latest-server-auth
     run_on: ubuntu1804-small
@@ -3710,6 +3822,7 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-latest-sharded-auth
     run_on: ubuntu1804-small
@@ -3729,4 +3842,5 @@ tasks:
             - { key: SSL, value: openssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -435,6 +435,7 @@ class CoverageTask(MatrixTask):
                              SSL=self.display('ssl')))
         extra = {}
 
+        commands.append(func('run-simple-http-server'))
         if self.cse:
             extra["CLIENT_SIDE_ENCRYPTION"] = "on"
             commands.append(func('fetch-det'))
@@ -579,6 +580,7 @@ class CompressionTask(MatrixTask):
                              AUTH='noauth',
                              SSL='nossl',
                              ORCHESTRATION_FILE=orchestration_file))
+        commands.append(func('run-simple-http-server'))
         commands.append(func('run-tests',
                              AUTH='noauth',
                              SSL='nossl',
@@ -619,6 +621,7 @@ class SpecialIntegrationTask(NamedTask):
                     func('bootstrap-mongo-orchestration',
                          MONGODB_VERSION=version,
                          TOPOLOGY=topology),
+                    func('run-simple-http-server'),
                     func('run-tests', URI=uri)] + (suffix_commands or [])
         super(SpecialIntegrationTask, self).__init__(task_name,
                                                      commands=commands,
@@ -710,6 +713,7 @@ all_tasks = chain(all_tasks, [
         commands=[func('fetch-det'),
                   func('bootstrap-mongo-orchestration', TOPOLOGY='server', AUTH='auth',
                        SSL='ssl', MONGODB_VERSION='5.0', REQUIRE_API_VERSION='true'),
+                  func('run-simple-http-server'),
                   func('run-tests', MONGODB_API_VERSION=1, AUTH='auth', SSL='ssl')]),
     PostCompileTask(
         'test-versioned-api-accept-version-two',
@@ -718,6 +722,7 @@ all_tasks = chain(all_tasks, [
         commands=[func('fetch-det'),
                   func('bootstrap-mongo-orchestration', TOPOLOGY='server', AUTH='noauth',
                        SSL='nossl', MONGODB_VERSION='5.0', ORCHESTRATION_FILE='versioned-api-testing'),
+                  func('run-simple-http-server'),
                   func('run-tests', MONGODB_API_VERSION=1, AUTH='noauth', SSL='nossl')]),
 ])
 
@@ -787,6 +792,7 @@ class IPTask(MatrixTask):
             func("fetch-det"),
             func('bootstrap-mongo-orchestration',
                  IPV4_ONLY=self.on_off(server='ipv4')),
+            func('run-simple-http-server'),
             func('run-tests',
                  IPV4_ONLY=self.on_off(server='ipv4'),
                  URI={'ipv6': 'mongodb://[::1]/',
@@ -1010,6 +1016,7 @@ class LoadBalancedTask(MatrixTask):
                              MONGODB_VERSION=self.version,
                              LOAD_BALANCER='on')
         commands.append(orchestration)
+        commands.append(func('run-simple-http-server'))
         commands.append(func("start load balancer",
                              MONGODB_URI="mongodb://localhost:27017,localhost:27018"))
         commands.append(func('run-tests',

--- a/.evergreen/scripts/integration-tests.sh
+++ b/.evergreen/scripts/integration-tests.sh
@@ -95,7 +95,9 @@ export ORCHESTRATION_URL="http://localhost:8889/v1/${TOPOLOGY}s"
 export TMPDIR=$MONGO_ORCHESTRATION_HOME/db
 echo From shell `date` > $MONGO_ORCHESTRATION_HOME/server.log
 
-. ../drivers-evergreen-tools/.evergreen/find-python3.sh
+command -V "${PYTHON3_BINARY:?}" >/dev/null
+
+# shellcheck source=/dev/null
 . ../drivers-evergreen-tools/.evergreen/venv-utils.sh
 
 case "$OS" in
@@ -106,8 +108,7 @@ case "$OS" in
       echo "{ \"releases\": { \"default\": \"c:\\\\mongodb\\\\bin\" }}" > orchestration.config
 
       # Make sure MO is running latest version
-      venvcreate "$(find_python3)" venv
-      PYTHON="python"
+      venvcreate "${PYTHON3_BINARY}" venv
       cd venv
       rm -rf mongo-orchestration
       git clone --depth 1 git@github.com:10gen/mongo-orchestration.git
@@ -120,9 +121,7 @@ case "$OS" in
    *)
       echo "{ \"releases\": { \"default\": \"`pwd`/mongodb/bin\" } }" > orchestration.config
 
-      venvcreate "$(find_python3)" venv
-      PYTHON="python"
-      PIP="python -m pip"
+      venvcreate "${PYTHON3_BINARY}" venv
       cd venv
       rm -rf mongo-orchestration
       # Make sure MO is running latest version
@@ -133,7 +132,7 @@ case "$OS" in
          echo "Disabling pip cache"
          PIP_PARAM="--no-cache-dir"
       fi
-      $PIP $PIP_PARAM install .
+      python -m pip $PIP_PARAM install .
       cd ../..
       mongo-orchestration -f orchestration.config -e default --socket-timeout-ms=60000 --bind=127.0.0.1  --enable-majority-read-concern start > $MONGO_ORCHESTRATION_HOME/out.log 2> $MONGO_ORCHESTRATION_HOME/err.log < /dev/null &
       ;;

--- a/.evergreen/scripts/run-tests.sh
+++ b/.evergreen/scripts/run-tests.sh
@@ -159,29 +159,33 @@ check_mongocryptd() {
 
 export MONGOC_TEST_MONITORING_VERBOSE=on
 
-# Ensure mock KMS servers are running before starting tests.
+wait_for_server() {
+  declare name="${1:?"wait_for_server requires a server name"}"
+  declare port="${2:?"wait_for_server requires a server port"}"
+
+  for _ in $(seq 300); do
+    # Exit code 7: "Failed to connect to host".
+    if
+      curl -s --max-time 1 "localhost:${port}" >/dev/null
+      test ${?} -ne 7
+    then
+      return 0
+    else
+      sleep 1
+    fi
+  done
+  echo "Could not detect ${name} server on port ${port}" 1>&2
+  return 1
+}
+
+# Limit tests to execute and ensure required servers are running.
 if [[ "${CLIENT_SIDE_ENCRYPTION}" == "on" ]]; then
   echo "Waiting for mock KMS servers to start..."
-  wait_for_kms_server() {
-    for _ in $(seq 300); do
-      # Exit code 7: "Failed to connect to host".
-      if
-        curl -s --max-time 1 "localhost:${1:?}"
-        test ${?} -ne 7
-      then
-        return 0
-      else
-        sleep 1
-      fi
-    done
-    echo "Could not detect mock KMS server on port ${1}" 1>&2
-    return 1
-  }
-  wait_for_kms_server 8999
-  wait_for_kms_server 9000
-  wait_for_kms_server 9001
-  wait_for_kms_server 9002
-  wait_for_kms_server 5698
+  wait_for_server "mock KMS" 8999
+  wait_for_server "mock KMS" 9000
+  wait_for_server "mock KMS" 9001
+  wait_for_server "mock KMS" 9002
+  wait_for_server "mock KMIP" 5698
   echo "Waiting for mock KMS servers to start... done."
 
   # Check if tests should use the crypt_shared library.
@@ -205,8 +209,10 @@ if [[ "${LOADBALANCED}" != "noloadbalanced" ]]; then
     exit 1
   fi
 
+  # Limit tests executed to load balancer tests.
   export MONGOC_TEST_LOADBALANCED=ON
 
+  # Limit tests executed to load balancer tests.
   test_args+=("-l" "/unified/*")
   test_args+=("-l" "/retryable_reads/*")
   test_args+=("-l" "/retryable_writes/*")
@@ -220,6 +226,13 @@ if [[ "${LOADBALANCED}" != "noloadbalanced" ]]; then
   test_args+=("-l" "/change_streams/unified/*")
   test_args+=("-l" "/versioned_api/*")
   test_args+=("-l" "/command_monitoring/unified/*")
+fi
+
+if [[ ! "${test_args[*]}" =~ "-l" ]]; then
+  # /http tests are only run if the set of tests to execute were not limited.
+  echo "Waiting for simple HTTP server to start..."
+  wait_for_server "simple HTTP" 8000
+  echo "Waiting for simple HTTP server to start... done."
 fi
 
 declare ld_preload="${LD_PRELOAD:-}"

--- a/.evergreen/scripts/simple_http_server.py
+++ b/.evergreen/scripts/simple_http_server.py
@@ -5,6 +5,7 @@
 import http
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
+
 class Simple(BaseHTTPRequestHandler):
     def do_GET(self):
         self.send_response(http.HTTPStatus.OK)
@@ -20,8 +21,11 @@ class Simple(BaseHTTPRequestHandler):
         self.wfile.write(
             'Response to POST by simple HTTP server'.encode('utf-8'))
 
+
 def main():
-    HTTPServer(server_address=('', 8000), RequestHandlerClass=Simple).serve_forever()
+    HTTPServer(server_address=('', 8000),
+               RequestHandlerClass=Simple).serve_forever()
+
 
 if __name__ == '__main__':
     main()

--- a/.evergreen/scripts/simple_http_server.py
+++ b/.evergreen/scripts/simple_http_server.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+# A simple HTTP server used by /http tests.
+
+import http
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import logging
+
+class Simple(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(http.HTTPStatus.OK)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+        self.wfile.write(
+            'Response to GET by simple HTTP server'.encode('utf-8'))
+
+    def do_POST(self):
+        self.send_response(http.HTTPStatus.OK)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+        self.wfile.write(
+            'Response to POST by simple HTTP server'.encode('utf-8'))
+
+def main():
+    logging.basicConfig(level=logging.DEBUG)
+    HTTPServer(server_address=('', 8000), RequestHandlerClass=Simple).serve_forever()
+
+if __name__ == '__main__':
+    main()

--- a/.evergreen/scripts/simple_http_server.py
+++ b/.evergreen/scripts/simple_http_server.py
@@ -4,7 +4,6 @@
 
 import http
 from http.server import BaseHTTPRequestHandler, HTTPServer
-import logging
 
 class Simple(BaseHTTPRequestHandler):
     def do_GET(self):
@@ -22,7 +21,6 @@ class Simple(BaseHTTPRequestHandler):
             'Response to POST by simple HTTP server'.encode('utf-8'))
 
 def main():
-    logging.basicConfig(level=logging.DEBUG)
     HTTPServer(server_address=('', 8000), RequestHandlerClass=Simple).serve_forever()
 
 if __name__ == '__main__':

--- a/src/libmongoc/tests/test-mongoc-http.c
+++ b/src/libmongoc/tests/test-mongoc-http.c
@@ -34,20 +34,11 @@ test_mongoc_http_get (void *unused)
 
    /* Basic GET request */
    req.method = "GET";
-   req.host = "httpbin.org";
+   req.host = "localhost";
    req.path = "get";
-   req.port = 80;
+   req.port = 8000;
    r = _mongoc_http_send (&req, 10000, false, NULL, &res, &error);
    ASSERT_OR_PRINT (r, error);
-
-   if (res.status == 502) {
-      // This test occasionally fails due to 502 Bad Gateway.
-      // Automatically attempt a retry and hope the issue resolved itself.
-      // ¯\_(ツ)_/¯
-      _mongoc_http_response_cleanup (&res);
-      r = _mongoc_http_send (&req, 10000, false, NULL, &res, &error);
-      ASSERT_OR_PRINT (r, error);
-   }
 
    ASSERT_WITH_MSG (res.status == 200,
                     "unexpected status code %d\n"
@@ -75,20 +66,11 @@ test_mongoc_http_post (void *unused)
 
    /* Basic POST request with a body. */
    req.method = "POST";
-   req.host = "httpbin.org";
+   req.host = "localhost";
    req.path = "post";
-   req.port = 80;
+   req.port = 8000;
    r = _mongoc_http_send (&req, 10000, false, NULL, &res, &error);
    ASSERT_OR_PRINT (r, error);
-
-   if (res.status == 502) {
-      // This test occasionally fails due to 502 Bad Gateway.
-      // Automatically attempt a retry and hope the issue resolved itself.
-      // ¯\_(ツ)_/¯
-      _mongoc_http_response_cleanup (&res);
-      r = _mongoc_http_send (&req, 10000, false, NULL, &res, &error);
-      ASSERT_OR_PRINT (r, error);
-   }
 
    ASSERT_WITH_MSG (res.status == 200,
                     "unexpected status code %d\n"


### PR DESCRIPTION
## Description

Followup to https://github.com/mongodb/mongo-c-driver/pull/1179. Partially resolves CDRIVER-4134. Verified by [this patch](https://spruce.mongodb.com/version/6439af08850e6141fdb1a681).

Due to [continued failure](https://spruce.mongodb.com/version/mongo_c_driver_abb0bb7da8230d342dac5061623c1e4936ed46d9/tasks) of the `/http` tests, this PR replaces use of `httpbin.org` with a simple Python HTTP server we run instead.

~Note: some tasks still fail on the rhel70 and windows-64-vs2017 distros, but deliberately deferring them to a followup PR to unblock _most_ of the other tasks that currently fail that this PR addresses.~ Identified the issue being due to the absence of a `python3` binary when `simple_http_server.py` is directly invoked.

## Simple HTTP Server

Uses the Python `http` package. It is a simple HTTP server that runs on port 8000 and sends a response to GET and POST requests. The port number can be changed to something else if 8000 (a very common default) conflicts with another process.

## config-generator Dependency

As a drive-by fix, observed a missing package error for `packaging` when running the config generator with Python 3.10, so added it to the requirements list.

## EVG Config

Added the `run_simple_http_server` component to the config generator.

The `run-simple-http-server` EVG function is now invoked before all calls to the "run-tests" EVG function, excluding the DNS, CSE, and loadbalancer tasks which limit the tests executed (thus excluding the `/http` tests).

The simple HTTP server runs in the background in a manner similar to what is already being done for mock KMS servers. This is to avoid difficult "clean up background processes" logic in the `run-tests.sh` script which has been observed to lead to hanging tasks that timeout.

The `wait_for_kms_server` Bash function in `run-tests.sh` was refactored into a more general `wait_for_server` to accomodate both the simple HTTP server and the mock KMS servers.