### PR TITLE
Address more scan-build warnings

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-aggregate.c
+++ b/src/libmongoc/src/mongoc/mongoc-aggregate.c
@@ -95,7 +95,7 @@ _make_agg_cmd (const char *ns,
 {
    const char *const dot = strstr (ns, ".");
    const char *error = NULL;
-   const char *error_hint = "";
+   const char *error_hint = NULL;
 
    bsonBuild (
       *command,

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -2339,14 +2339,14 @@ test_framework_skip_if_not_replset (void)
 
 /* convenience skip functions based on the wire version. */
 #define WIRE_VERSION_CHECKS(wv)                                         \
-   int test_framework_skip_if_max_wire_version_more_than_##wv ()        \
+   int test_framework_skip_if_max_wire_version_more_than_##wv (void)    \
    {                                                                    \
       if (!TestSuite_CheckLive ()) {                                    \
          return 0;                                                      \
       }                                                                 \
       return test_framework_max_wire_version_at_least (wv + 1) ? 0 : 1; \
    }                                                                    \
-   int test_framework_skip_if_max_wire_version_less_than_##wv ()        \
+   int test_framework_skip_if_max_wire_version_less_than_##wv (void)    \
    {                                                                    \
       if (!TestSuite_CheckLive ()) {                                    \
          return 0;                                                      \

--- a/src/libmongoc/tests/test-mongoc-client-pool.c
+++ b/src/libmongoc/tests/test-mongoc-client-pool.c
@@ -367,15 +367,13 @@ test_client_pool_destroy_without_pushing (void)
 static void
 command_started_cb (const mongoc_apm_command_started_t *event)
 {
-   int *count;
-
    if (strcmp (mongoc_apm_command_started_get_command_name (event),
                "endSessions") != 0) {
       return;
    }
 
-   count = (int *) mongoc_apm_command_started_get_context (event);
-   count++;
+   int *const count = (int *) mongoc_apm_command_started_get_context (event);
+   (*count)++;
 }
 
 /* tests that creating and destroying an unused session

--- a/src/libmongoc/tests/test-mongoc-connection-uri.c
+++ b/src/libmongoc/tests/test-mongoc-connection-uri.c
@@ -283,7 +283,6 @@ test_connection_uri_cb (bson_t *scenario)
    bson_t auth;
    bson_t options;
    bool valid;
-   int c = 0;
 
    BSON_ASSERT (scenario);
 
@@ -296,7 +295,6 @@ test_connection_uri_cb (bson_t *scenario)
       bson_t test_case;
 
       bson_iter_bson (&tests_iter, &test_case);
-      c++;
 
       if (test_suite_debug_output ()) {
          bson_iter_t test_case_iter;

--- a/src/libmongoc/tests/test-mongoc-gssapi.c
+++ b/src/libmongoc/tests/test-mongoc-gssapi.c
@@ -38,8 +38,9 @@ _getenv (const char *name)
       return NULL;
    }
 #else
-   if (getenv (name) && strlen (getenv (name))) {
-      return bson_strdup (getenv (name));
+   char *const value = getenv (name);
+   if (value && strlen (value)) {
+      return bson_strdup (value);
    } else {
       return NULL;
    }


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1236. Verified by [this patch](https://spruce.mongodb.com/version/643d52282fbabe0436e90c00).

Addresses a [missed -Wstrict-prototypes instance](https://parsley.mongodb.com/evergreen/mongo_c_driver_scan_build_matrix_scan_build_macos_1100_clang_510c1c3f40f0ea701be881f7af24fe2241fb9602_23_04_14_21_44_19/0/task?bookmarks=0,1013&shareLine=757) due to preprocessor syntax interfering with the search pattern used to detect them.

Additionally addresses a few more warnings emitted during scan-build compilation.