### PR TITLE
CDRIVER-4598 Support optional checksum in OP_MSG

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-rpc-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-rpc-private.h
@@ -74,6 +74,7 @@ typedef struct _mongoc_rpc_section_t {
    const uint8_t *_name;        \
    int32_t _name##_len;
 #define BSON_OPTIONAL(_check, _code) _code
+#define CHECKSUM_FIELD(_name) uint32_t _name;
 
 
 #pragma pack(1)
@@ -129,6 +130,7 @@ BSON_STATIC_ASSERT2 (sizeof_reply_header,
 #undef SECTION_ARRAY_FIELD
 #undef BSON_OPTIONAL
 #undef RAW_BUFFER_FIELD
+#undef CHECKSUM_FIELD
 
 
 void

--- a/src/libmongoc/src/mongoc/mongoc-rpc.c
+++ b/src/libmongoc/src/mongoc/mongoc-rpc.c
@@ -47,6 +47,7 @@
    iov.iov_len = 4;                          \
    header->msg_len += (int32_t) iov.iov_len; \
    _mongoc_array_append_val (array, iov);
+#define CHECKSUM_FIELD(_name) // Do not include optional checksum.
 #define ENUM_FIELD INT32_FIELD
 #define INT64_FIELD(_name)                   \
    iov.iov_base = (void *) &rpc->_name;      \
@@ -176,6 +177,7 @@
 #undef SECTION_ARRAY_FIELD
 #undef RAW_BUFFER_FIELD
 #undef BSON_OPTIONAL
+#undef CHECKSUM_FIELD
 
 
 #if BSON_BYTE_ORDER == BSON_BIG_ENDIAN
@@ -188,6 +190,7 @@
    }
 #define UINT8_FIELD(_name)
 #define INT32_FIELD(_name) rpc->_name = BSON_UINT32_FROM_LE (rpc->_name);
+#define CHECKSUM_FIELD(_name) rpc->_name = BSON_UINT32_FROM_LE (rpc->_name);
 #define ENUM_FIELD INT32_FIELD
 #define INT64_FIELD(_name) rpc->_name = BSON_UINT64_FROM_LE (rpc->_name);
 #define CSTRING_FIELD(_name)
@@ -262,6 +265,7 @@
 #undef SECTION_ARRAY_FIELD
 #undef BSON_OPTIONAL
 #undef RAW_BUFFER_FIELD
+#undef CHECKSUM_FIELD
 
 #endif /* BSON_BYTE_ORDER == BSON_BIG_ENDIAN */
 
@@ -273,7 +277,9 @@
       _code                                                             \
    }
 #define UINT8_FIELD(_name) printf ("  " #_name " : %u\n", rpc->_name);
-#define INT32_FIELD(_name) printf ("  " #_name " : %d\n", rpc->_name);
+#define INT32_FIELD(_name) printf ("  " #_name " : %" PRId32 "\n", rpc->_name);
+#define CHECKSUM_FIELD(_name) \
+   printf ("  " #_name " : %" PRIu32 "\n", rpc->_name);
 #define ENUM_FIELD(_name) printf ("  " #_name " : %u\n", rpc->_name);
 #define INT64_FIELD(_name) \
    printf ("  " #_name " : %" PRIi64 "\n", (int64_t) rpc->_name);
@@ -408,6 +414,7 @@
 #undef SECTION_ARRAY_FIELD
 #undef BSON_OPTIONAL
 #undef RAW_BUFFER_FIELD
+#undef CHECKSUM_FIELD
 
 
 #define RPC(_name, _code)                                             \
@@ -433,6 +440,12 @@
    memcpy (&rpc->_name, buf, 4); \
    buflen -= 4;                  \
    buf += 4;
+#define CHECKSUM_FIELD(_name)       \
+   if (buflen >= 4) {               \
+      memcpy (&rpc->_name, buf, 4); \
+      buflen -= 4;                  \
+      buf += 4;                     \
+   }
 #define ENUM_FIELD INT32_FIELD
 #define INT64_FIELD(_name)       \
    if (buflen < 8) {             \
@@ -561,6 +574,7 @@
 #undef SECTION_ARRAY_FIELD
 #undef BSON_OPTIONAL
 #undef RAW_BUFFER_FIELD
+#undef CHECKSUM_FIELD
 
 
 /*

--- a/src/libmongoc/src/mongoc/mongoc-rpc.c
+++ b/src/libmongoc/src/mongoc/mongoc-rpc.c
@@ -540,7 +540,7 @@
       buf += __l;                                                           \
       buflen -= __l;                                                        \
       rpc->n_##_name++;                                                     \
-   } while (buflen);
+   } while (buflen > 4); // Only optional checksum can come after data sections.
 #define RAW_BUFFER_FIELD(_name)         \
    rpc->_name = (void *) buf;           \
    rpc->_name##_len = (int32_t) buflen; \

--- a/src/libmongoc/src/mongoc/op-msg.def
+++ b/src/libmongoc/src/mongoc/op-msg.def
@@ -6,4 +6,5 @@ RPC(
   INT32_FIELD(opcode)
   ENUM_FIELD(flags)
   SECTION_ARRAY_FIELD(sections)
+  CHECKSUM_FIELD(checksum)
 )


### PR DESCRIPTION
Resolves CDRIVER-4598; see ticket for details. Verified by [this patch](https://spruce.mongodb.com/version/643ea3d757e85a236fa3d8f6).

Introduced a dedicated `CHECKSUM_FIELD` X macro that unconditional excludes/ignores the checksum value in `_mongoc_rpc_gather_msg`. It still sets the checksum field in `_mongoc_rpc_scatter_msg`, even if it is ultimately never used, which allows tests to verify the field was parsed correctly.

Added regression test `/Rpc/msg/checksum` that validates correct scatter/gather behavior when the optional checksum may be present. The new test coverage exposed an additional bug in `_mongoc_rpc_reply_get_first_msg` where it [unconditionally returns `true`](https://github.com/mongodb/mongo-c-driver/blob/7ae8fd3c33a9a7a21c1057091378bf3bd5f7d96e/src/libmongoc/src/mongoc/mongoc-rpc.c#L1028) despite potential BSON document initialization failure. For consistency with `_mongoc_rpc_reply_get_first`, the function was updated to ensure `_mongoc_rpc_get_first_document` correctly returns `false` on `OP_MSG` document parse failure.