### PR TITLE
CDRIVER-4121 Ensure OP_MSG is used for authentication

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-counters-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-counters-private.h
@@ -178,9 +178,23 @@ enum {
          bson_atomic_int64_exchange (counter, 0, bson_memory_order_seq_cst);   \
       }                                                                        \
       bson_atomic_thread_fence ();                                             \
+   }                                                                           \
+   static BSON_INLINE int32_t mongoc_counter_##ident##_count (void)            \
+   {                                                                           \
+      int32_t _sum = 0;                                                        \
+      uint32_t _i;                                                             \
+      for (_i = 0; _i < _mongoc_get_cpu_count (); _i++) {                      \
+         const int64_t *counter =                                              \
+            &BSON_CONCAT (__mongoc_counter_, ident)                            \
+                .cpus[_i]                                                      \
+                .slots[BSON_CONCAT (COUNTER_, ident) % SLOTS_PER_CACHELINE];   \
+         _sum += bson_atomic_int64_fetch (counter, bson_memory_order_seq_cst); \
+      }                                                                        \
+      return _sum;                                                             \
    }
 #include "mongoc-counters.defs"
 #undef COUNTER
+
 #else
 /* when counters are disabled, these functions are no-ops */
 #define COUNTER(ident, Category, Name, Description)                   \


### PR DESCRIPTION
## Description

Resolves CDRIVER-4121. Verified by [this patch](https://spruce.mongodb.com/version/6441a6e93e8e8676d012a6c3).

## OP_MSG for Authentication

Noting that `WIRE_VERSION_MIN` is currently set to 6 for the C Driver (meaning _all_ currently supported MongoDB server versions support OP_MSG, thus we should _never_ be using OP_QUERY for authentication), I believe there are _four_ possible code paths by which the OP_MSG protocol may used for authentication handshake requests (and where OP_QUERY should _not_ be used):

- `_mongoc_cluster_auth_node` via `_cluster_fetch_stream_single`
- `_mongoc_cluster_auth_node` via `_cluster_fetch_stream_pooled`
- `_mongoc_cluster_finish_speculative_auth` via `_cluster_fetch_stream_single`
- `_mongoc_cluster_finish_speculative_auth` via `_cluster_fetch_stream_pooled`

Which code path is selected thus depends on two factors:

1) is speculative authentication enabled or disabled?
2) is the client being used single or from a pool?

In all four cases, it seems that the C Driver is correctly selecting the OP_MSG protocol. This selection occurs in [`mongoc_cluster_run_command_private`](https://github.com/mongodb/mongo-c-driver/blob/46a010f28d3052b3721e316b0bdecce47de519f1/src/libmongoc/src/mongoc/mongoc-cluster.c#L687), which is invoked by all four code paths listed above via `_mongoc_cluster_run_scram_command`, which in turn is invoked either via `_mongoc_cluster_auth_scram_start` or `_mongoc_cluster_auth_scram_continue` depending on the stage and method of authentication.

## /counters/auth_with_op_msg

CDRIVER-4121 discusses the viability of implementing a test to validate this behavior. This PR implements such a test by relying on the "shared memory (performance) counters" (aka SHM counters) provided by [mongoc-counters-private.h](https://github.com/mongodb/mongo-c-driver/blob/46a010f28d3052b3721e316b0bdecce47de519f1/src/libmongoc/src/mongoc/mongoc-counters-private.h) to determine the exact number of OP_QUERY and OP_MSG requests sent by the C Driver when the `ENABLE_SHM_COUNTERS` CMake configuration variable is set to `AUTO` ([default](https://github.com/mongodb/mongo-c-driver/blob/46a010f28d3052b3721e316b0bdecce47de519f1/CMakeLists.txt#L27)) or `ON`.

This test assumes the number of OP_QUERY and OP_MSG requests sent during an authentication handshake (including the initial handshake connection) deterministic and consistent for each of the four possible code paths described above for a given authentication mechanism. SCRAM-SHA-1 was chosen due to availability on all server versions currently supported and the mechanism requiring multiple authentication steps to guarantee at least one OP_MSG request is required regardless of pooling or speculative authentication. The expected request count for each set of conditions is thoroughly documented in the test definition.

Note, this test is only run if the server is a replica set and authentication is enabled; otherwise it is skipped. It also assumes _exactly_ three members in the replica set (corresponding assertion included).

I considered augmenting tests in test-mongoc-scram.c and test-mongoc-speculative-auth.c with SHM counter assertions, but decided against it due to the complexity of deriving expected request counts based on varying authentication mechanisms and success/failure behavior. Decided to add a specialized test to test-mongoc-counters.c instead given its use of SHM counters for consistency (all SHM counter tests are defined in test-mongoc-counters.c).

## mongoc_counter_##ident##_count()

As a drive-by improvement (motivated by prior attempts to define tests in test-mongoc-scram.c and test-mongoc-speculative-auth.c as mentioned above), this series of helper functions were moved from test-mongoc-counters.c into mongoc-counters-private.h due to its general applicability. Note, it is currently still only being used by test-mongoc-counters.c.