### PR TITLE
CDRIVER-4557 add int64 `connection_id` functions

### DIFF
--- a/src/libmongoc/doc/mongoc_apm_command_failed_get_server_connection_id.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_failed_get_server_connection_id.rst
@@ -10,7 +10,9 @@ Synopsis
 
   int32_t
   mongoc_apm_command_failed_get_server_connection_id (
-     const mongoc_apm_command_failed_t *event);
+    const mongoc_apm_command_failed_t *event)
+    BSON_GNUC_DEPRECATED_FOR (
+        "mongoc_apm_command_failed_get_server_connection_id_int64");
 
 Returns this event's context.
 
@@ -18,6 +20,12 @@ Returns the server connection ID for the command. The server connection ID is
 distinct from the server ID (:symbol:`mongoc_apm_command_failed_get_server_id`)
 and is returned by the hello or legacy hello response as "connectionId" from the
 server on 4.2+.
+
+Deprecated
+----------
+
+  This function is deprecated. Please use
+  :symbol:`mongoc_apm_command_failed_get_server_connection_id_int64` in new code.
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_apm_command_failed_get_server_connection_id_int64.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_failed_get_server_connection_id_int64.rst
@@ -1,0 +1,35 @@
+:man_page: mongoc_apm_command_failed_get_server_connection_id_int64
+
+mongoc_apm_command_failed_get_server_connection_id_int64()
+==========================================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  int64_t
+  mongoc_apm_command_failed_get_server_connection_id_int64 (
+    const mongoc_apm_command_failed_t *event);
+
+Returns this event's context.
+
+Returns the server connection ID for the command. The server connection ID is
+distinct from the server ID (:symbol:`mongoc_apm_command_failed_get_server_id`)
+and is returned by the hello or legacy hello response as "connectionId" from the
+server on 4.2+.
+
+Parameters
+----------
+
+* ``event``: A :symbol:`mongoc_apm_command_failed_t`.
+
+Returns
+-------
+
+The server connection ID as a positive integer or -1 if it is not available.
+
+.. seealso::
+
+  | :doc:`Introduction to Application Performance Monitoring <application-performance-monitoring>`
+

--- a/src/libmongoc/doc/mongoc_apm_command_failed_t.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_failed_t.rst
@@ -30,6 +30,7 @@ An event notification sent when the driver fails to execute a MongoDB command.
     mongoc_apm_command_failed_get_server_id
     mongoc_apm_command_failed_get_service_id
     mongoc_apm_command_failed_get_server_connection_id
+    mongoc_apm_command_failed_get_server_connection_id_int64
 
 .. seealso::
 

--- a/src/libmongoc/doc/mongoc_apm_command_started_get_server_connection_id.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_started_get_server_connection_id.rst
@@ -10,12 +10,20 @@ Synopsis
 
   int32_t
   mongoc_apm_command_started_get_server_connection_id (
-     const mongoc_apm_command_started_t *event);
+    const mongoc_apm_command_started_t *event)
+    BSON_GNUC_DEPRECATED_FOR (
+        "mongoc_apm_command_started_get_server_connection_id_int64");
 
 Returns the server connection ID for the command. The server connection ID is
 distinct from the server ID (:symbol:`mongoc_apm_command_started_get_server_id`)
 and is returned by the hello or legacy hello response as "connectionId" from the
 server on 4.2+.
+
+Deprecated
+----------
+
+  This function is deprecated. Please use
+  :symbol:`mongoc_apm_command_started_get_server_connection_id_int64` in new code.
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_apm_command_started_get_server_connection_id_int64.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_started_get_server_connection_id_int64.rst
@@ -1,0 +1,33 @@
+:man_page: mongoc_apm_command_started_get_server_connection_id_int64
+
+mongoc_apm_command_started_get_server_connection_id_int64()
+===========================================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  int64_t
+  mongoc_apm_command_started_get_server_connection_id_int64 (
+    const mongoc_apm_command_started_t *event);
+
+Returns the server connection ID for the command. The server connection ID is
+distinct from the server ID (:symbol:`mongoc_apm_command_started_get_server_id`)
+and is returned by the hello or legacy hello response as "connectionId" from the
+server on 4.2+.
+
+Parameters
+----------
+
+* ``event``: A :symbol:`mongoc_apm_command_started_t`.
+
+Returns
+-------
+
+The server connection ID as a positive integer or -1 if it is not available.
+
+.. seealso::
+
+  | :doc:`Introduction to Application Performance Monitoring <application-performance-monitoring>`
+

--- a/src/libmongoc/doc/mongoc_apm_command_started_t.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_started_t.rst
@@ -33,4 +33,5 @@ An event notification sent when the driver begins executing a MongoDB command.
     mongoc_apm_command_started_get_server_id
     mongoc_apm_command_started_get_service_id
     mongoc_apm_command_started_get_server_connection_id
+    mongoc_apm_command_started_get_server_connection_id_int64
 

--- a/src/libmongoc/doc/mongoc_apm_command_succeeded_get_server_connection_id.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_succeeded_get_server_connection_id.rst
@@ -10,12 +10,20 @@ Synopsis
 
   int32_t
   mongoc_apm_command_succeeded_get_server_connection_id (
-     const mongoc_apm_command_succeeded_t *event);
+    const mongoc_apm_command_succeeded_t *event)
+    BSON_GNUC_DEPRECATED_FOR (
+        "mongoc_apm_command_succeeded_get_server_connection_id_int64");
 
 Returns the server connection ID for the command. The server connection ID is
 distinct from the server ID
 (:symbol:`mongoc_apm_command_succeeded_get_server_id`) and is returned by the
 hello or legacy hello response as "connectionId" from the server on 4.2+.
+
+Deprecated
+----------
+
+  This function is deprecated. Please use
+  :symbol:`mongoc_apm_command_succeeded_get_server_connection_id_int64` in new code.
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_apm_command_succeeded_get_server_connection_id_int64.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_succeeded_get_server_connection_id_int64.rst
@@ -1,0 +1,33 @@
+:man_page: mongoc_apm_command_succeeded_get_server_connection_id_int64
+
+mongoc_apm_command_succeeded_get_server_connection_id_int64()
+=============================================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  int64_t
+  mongoc_apm_command_succeeded_get_server_connection_id_int64 (
+    const mongoc_apm_command_succeeded_t *event);
+
+Returns the server connection ID for the command. The server connection ID is
+distinct from the server ID
+(:symbol:`mongoc_apm_command_succeeded_get_server_id`) and is returned by the
+hello or legacy hello response as "connectionId" from the server on 4.2+.
+
+Parameters
+----------
+
+* ``event``: A :symbol:`mongoc_apm_command_succeeded_t`.
+
+Returns
+-------
+
+The server connection ID as a positive integer or -1 if it is not available.
+
+.. seealso::
+
+  | :doc:`Introduction to Application Performance Monitoring <application-performance-monitoring>`
+

--- a/src/libmongoc/doc/mongoc_apm_command_succeeded_t.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_succeeded_t.rst
@@ -33,4 +33,5 @@ An event notification sent when the driver successfully executes a MongoDB comma
     mongoc_apm_command_succeeded_get_server_id
     mongoc_apm_command_succeeded_get_service_id
     mongoc_apm_command_succeeded_get_server_connection_id
+    mongoc_apm_command_succeeded_get_server_connection_id_int64
 

--- a/src/libmongoc/src/mongoc/mongoc-apm.c
+++ b/src/libmongoc/src/mongoc/mongoc-apm.c
@@ -392,6 +392,11 @@ mongoc_apm_command_started_get_server_connection_id (
 {
    if (event->server_connection_id > INT32_MAX ||
        event->server_connection_id < INT32_MIN) {
+      MONGOC_WARNING (
+         "Server connection ID %" PRId64
+         " is outside of int32 range. Returning -1. Use "
+         "mongoc_apm_command_started_get_server_connection_id_int64.",
+         event->server_connection_id);
       return MONGOC_NO_SERVER_CONNECTION_ID;
    }
 
@@ -492,6 +497,11 @@ mongoc_apm_command_succeeded_get_server_connection_id (
 {
    if (event->server_connection_id > INT32_MAX ||
        event->server_connection_id < INT32_MIN) {
+      MONGOC_WARNING (
+         "Server connection ID %" PRId64
+         " is outside of int32 range. Returning -1. Use "
+         "mongoc_apm_command_succeeded_get_server_connection_id_int64.",
+         event->server_connection_id);
       return MONGOC_NO_SERVER_CONNECTION_ID;
    }
 
@@ -596,6 +606,11 @@ mongoc_apm_command_failed_get_server_connection_id (
 {
    if (event->server_connection_id > INT32_MAX ||
        event->server_connection_id < INT32_MIN) {
+      MONGOC_WARNING (
+         "Server connection ID %" PRId64
+         " is outside of int32 range. Returning -1. Use "
+         "mongoc_apm_command_failed_get_server_connection_id_int64.",
+         event->server_connection_id);
       return MONGOC_NO_SERVER_CONNECTION_ID;
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-apm.c
+++ b/src/libmongoc/src/mongoc/mongoc-apm.c
@@ -399,6 +399,14 @@ mongoc_apm_command_started_get_server_connection_id (
 }
 
 
+int64_t
+mongoc_apm_command_started_get_server_connection_id_int64 (
+   const mongoc_apm_command_started_t *event)
+{
+   return event->server_connection_id;
+}
+
+
 void *
 mongoc_apm_command_started_get_context (
    const mongoc_apm_command_started_t *event)
@@ -488,6 +496,14 @@ mongoc_apm_command_succeeded_get_server_connection_id (
    }
 
    return (int32_t) event->server_connection_id;
+}
+
+
+int64_t
+mongoc_apm_command_succeeded_get_server_connection_id_int64 (
+   const mongoc_apm_command_succeeded_t *event)
+{
+   return event->server_connection_id;
 }
 
 
@@ -584,6 +600,14 @@ mongoc_apm_command_failed_get_server_connection_id (
    }
 
    return (int32_t) event->server_connection_id;
+}
+
+
+int64_t
+mongoc_apm_command_failed_get_server_connection_id_int64 (
+   const mongoc_apm_command_failed_t *event)
+{
+   return event->server_connection_id;
 }
 
 

--- a/src/libmongoc/src/mongoc/mongoc-apm.h
+++ b/src/libmongoc/src/mongoc/mongoc-apm.h
@@ -105,6 +105,9 @@ mongoc_apm_command_started_get_service_id (
 MONGOC_EXPORT (int32_t)
 mongoc_apm_command_started_get_server_connection_id (
    const mongoc_apm_command_started_t *event);
+MONGOC_EXPORT (int64_t)
+mongoc_apm_command_started_get_server_connection_id_int64 (
+   const mongoc_apm_command_started_t *event);
 MONGOC_EXPORT (void *)
 mongoc_apm_command_started_get_context (
    const mongoc_apm_command_started_t *event);
@@ -137,6 +140,9 @@ mongoc_apm_command_succeeded_get_service_id (
    const mongoc_apm_command_succeeded_t *event);
 MONGOC_EXPORT (int32_t)
 mongoc_apm_command_succeeded_get_server_connection_id (
+   const mongoc_apm_command_succeeded_t *event);
+MONGOC_EXPORT (int64_t)
+mongoc_apm_command_succeeded_get_server_connection_id_int64 (
    const mongoc_apm_command_succeeded_t *event);
 MONGOC_EXPORT (void *)
 mongoc_apm_command_succeeded_get_context (
@@ -172,6 +178,9 @@ mongoc_apm_command_failed_get_service_id (
    const mongoc_apm_command_failed_t *event);
 MONGOC_EXPORT (int32_t)
 mongoc_apm_command_failed_get_server_connection_id (
+   const mongoc_apm_command_failed_t *event);
+MONGOC_EXPORT (int64_t)
+mongoc_apm_command_failed_get_server_connection_id_int64 (
    const mongoc_apm_command_failed_t *event);
 MONGOC_EXPORT (void *)
 mongoc_apm_command_failed_get_context (

--- a/src/libmongoc/src/mongoc/mongoc-apm.h
+++ b/src/libmongoc/src/mongoc/mongoc-apm.h
@@ -104,7 +104,9 @@ mongoc_apm_command_started_get_service_id (
    const mongoc_apm_command_started_t *event);
 MONGOC_EXPORT (int32_t)
 mongoc_apm_command_started_get_server_connection_id (
-   const mongoc_apm_command_started_t *event);
+   const mongoc_apm_command_started_t *event)
+   BSON_GNUC_DEPRECATED_FOR (
+      "mongoc_apm_command_started_get_server_connection_id_int64");
 MONGOC_EXPORT (int64_t)
 mongoc_apm_command_started_get_server_connection_id_int64 (
    const mongoc_apm_command_started_t *event);
@@ -140,7 +142,9 @@ mongoc_apm_command_succeeded_get_service_id (
    const mongoc_apm_command_succeeded_t *event);
 MONGOC_EXPORT (int32_t)
 mongoc_apm_command_succeeded_get_server_connection_id (
-   const mongoc_apm_command_succeeded_t *event);
+   const mongoc_apm_command_succeeded_t *event)
+   BSON_GNUC_DEPRECATED_FOR (
+      "mongoc_apm_command_succeeded_get_server_connection_id_int64");
 MONGOC_EXPORT (int64_t)
 mongoc_apm_command_succeeded_get_server_connection_id_int64 (
    const mongoc_apm_command_succeeded_t *event);
@@ -178,7 +182,9 @@ mongoc_apm_command_failed_get_service_id (
    const mongoc_apm_command_failed_t *event);
 MONGOC_EXPORT (int32_t)
 mongoc_apm_command_failed_get_server_connection_id (
-   const mongoc_apm_command_failed_t *event);
+   const mongoc_apm_command_failed_t *event)
+   BSON_GNUC_DEPRECATED_FOR (
+      "mongoc_apm_command_failed_get_server_connection_id_int64");
 MONGOC_EXPORT (int64_t)
 mongoc_apm_command_failed_get_server_connection_id_int64 (
    const mongoc_apm_command_failed_t *event);

--- a/src/libmongoc/tests/unified/entity-map.c
+++ b/src/libmongoc/tests/unified/entity-map.c
@@ -227,7 +227,7 @@ typedef struct command_callback_funcs_t {
    apm_func_int64_t get_operation_id;
    apm_func_bson_oid_t get_service_id;
    apm_func_host_list_t get_host;
-   apm_func_int32_t get_server_connection_id;
+   apm_func_int64_t get_server_connection_id;
    apm_func_serialize_t serialize;
 } command_callback_funcs_t;
 
@@ -310,10 +310,10 @@ store_event_serialize_started (bson_t *doc,
       "connectionId",
       mongoc_apm_command_started_get_host (apm_command)->host_and_port);
 
-   BSON_APPEND_INT32 (
+   BSON_APPEND_INT64 (
       doc,
       "serverConnectionId",
-      mongoc_apm_command_started_get_server_connection_id (apm_command));
+      mongoc_apm_command_started_get_server_connection_id_int64 (apm_command));
 
    {
       const bson_oid_t *const service_id =
@@ -355,10 +355,10 @@ store_event_serialize_failed (bson_t *doc,
       "connectionId",
       mongoc_apm_command_failed_get_host (apm_command)->host_and_port);
 
-   BSON_APPEND_INT32 (
+   BSON_APPEND_INT64 (
       doc,
       "serverConnectionId",
-      mongoc_apm_command_failed_get_server_connection_id (apm_command));
+      mongoc_apm_command_failed_get_server_connection_id_int64 (apm_command));
 
    {
       const bson_oid_t *const service_id =
@@ -403,10 +403,11 @@ store_event_serialize_succeeded (
       "connectionId",
       mongoc_apm_command_succeeded_get_host (apm_command)->host_and_port);
 
-   BSON_APPEND_INT32 (
+   BSON_APPEND_INT64 (
       doc,
       "serverConnectionId",
-      mongoc_apm_command_succeeded_get_server_connection_id (apm_command));
+      mongoc_apm_command_succeeded_get_server_connection_id_int64 (
+         apm_command));
 
    {
       const bson_oid_t *const service_id =
@@ -498,8 +499,8 @@ command_started (const mongoc_apm_command_started_t *started)
       .get_service_id =
          (apm_func_bson_oid_t) mongoc_apm_command_started_get_service_id,
       .get_host = (apm_func_host_list_t) mongoc_apm_command_started_get_host,
-      .get_server_connection_id =
-         (apm_func_int32_t) mongoc_apm_command_started_get_server_connection_id,
+      .get_server_connection_id = (apm_func_int64_t)
+         mongoc_apm_command_started_get_server_connection_id_int64,
       .serialize = (apm_func_serialize_t) store_event_serialize_started,
    };
 
@@ -523,8 +524,8 @@ command_failed (const mongoc_apm_command_failed_t *failed)
       .get_service_id =
          (apm_func_bson_oid_t) mongoc_apm_command_failed_get_service_id,
       .get_host = (apm_func_host_list_t) mongoc_apm_command_failed_get_host,
-      .get_server_connection_id =
-         (apm_func_int32_t) mongoc_apm_command_failed_get_server_connection_id,
+      .get_server_connection_id = (apm_func_int64_t)
+         mongoc_apm_command_failed_get_server_connection_id_int64,
       .serialize = (apm_func_serialize_t) store_event_serialize_failed,
    };
 
@@ -548,8 +549,8 @@ command_succeeded (const mongoc_apm_command_succeeded_t *succeeded)
       .get_service_id =
          (apm_func_bson_oid_t) mongoc_apm_command_succeeded_get_service_id,
       .get_host = (apm_func_host_list_t) mongoc_apm_command_succeeded_get_host,
-      .get_server_connection_id = (apm_func_int32_t)
-         mongoc_apm_command_succeeded_get_server_connection_id,
+      .get_server_connection_id = (apm_func_int64_t)
+         mongoc_apm_command_succeeded_get_server_connection_id_int64,
       .serialize = (apm_func_serialize_t) store_event_serialize_succeeded,
    };
 


### PR DESCRIPTION
# Summary

- Add `connection_id` functions returning int64:
  - `mongoc_apm_command_started_get_server_connection_id_int64`
  - `mongoc_apm_command_succeeded_get_server_connection_id_int64`
  - `mongoc_apm_command_failed_get_server_connection_id_int64`
- Deprecate `connection_id` functions returning int32

# Background & Motivation

CDRIVER-4593 and CDRIVER-4557 applied fixes to parsing `connectionId` to handle `int32`, `int64`, and `double`. No further fix was needed.

This PR intends to satisfy the requirement of DRIVERS-2503:

> If the client and server connectionId fields are part of the driver's public API, you may have to add new int64 connectionId fields and deprecate the existing int32 fields.