### PR TITLE
remove `scan-build-ubuntu1404-clang` task

### DIFF
--- a/.evergreen/config_generator/components/scan_build.py
+++ b/.evergreen/config_generator/components/scan_build.py
@@ -18,7 +18,6 @@ TAG = 'scan-build-matrix'
 # fmt: off
 MATRIX = [
     ('macos-1100',       'clang', None  ),
-    ('ubuntu1404',       'clang', None  ),
     ('ubuntu1604-arm64', 'clang', None  ),
     ('ubuntu1604',       'clang', 'i686'),
     ('ubuntu1604',       'clang', None  ),

--- a/.evergreen/config_generator/components/scan_build.py
+++ b/.evergreen/config_generator/components/scan_build.py
@@ -83,7 +83,7 @@ def tasks():
 
     # TODO: remove once BUILD-16814 is resolved.
     for task in res:
-         if task.run_on == 'macos-1014':
+        if task.run_on == 'macos-1014':
             task.disable = True
 
     return res

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -3304,14 +3304,6 @@ tasks:
         vars:
           CC: clang
       - func: upload scan artifacts
-  - name: scan-build-ubuntu1404-clang
-    run_on: ubuntu1404-large
-    tags: [scan-build-matrix, ubuntu1404, clang]
-    commands:
-      - func: scan-build
-        vars:
-          CC: clang
-      - func: upload scan artifacts
   - name: scan-build-ubuntu1604-arm64-clang
     run_on: ubuntu1604-arm64-large
     tags: [scan-build-matrix, ubuntu1604-arm64, clang]


### PR DESCRIPTION
The `scan-build-ubuntu1404-clang` has been [failing in Evergreen](https://spruce.mongodb.com/task/mongo_c_driver_scan_build_matrix_scan_build_ubuntu1404_clang_4249c975ac2835a9e4329996e48986c368c81776_23_04_26_13_03_02/) attempting to clone libmongocrypt:

```
[2023/04/26 13:05:28.278] fatal: unable to access 'https://github.com/mongodb/libmongocrypt/': server certificate verification failed. CAfile: /etc/ssl/certs/ca-certificates.crt CRLfile: none
[2023/04/26 13:05:28.279] Command 'subprocess.exec' in function 'scan-build' failed: process encountered problem: exit code 128.
```

I expect the distro needs to be updated to install necessary CA certificates (similar to BUILD-14189).

This PR proposes removing the `scan-build-ubuntu1404-clang` task. I expect this task does not add much (if any) value over the `scan-build-ubuntu1604-clang` task.