### PR TITLE
CDRIVER-4556 Remove use of `collStats`

### DIFF
--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -1144,6 +1144,9 @@ if (ENABLE_EXAMPLES)
       mongoc_add_example (client-side-encryption-auto-decryption ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-auto-decryption.c ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-helpers.c)
       mongoc_add_example (client-side-encryption-doc-snippets ${PROJECT_SOURCE_DIR}/examples/client-side-encryption-doc-snippets.c)
    endif ()
+
+   # examples/tutorial
+   mongoc_add_example (executing ${PROJECT_SOURCE_DIR}/examples/tutorial/executing.c)
 endif ()
 
 file (COPY ${PROJECT_SOURCE_DIR}/tests/binary DESTINATION ${PROJECT_BINARY_DIR}/tests)

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -1114,6 +1114,7 @@ if (ENABLE_EXAMPLES)
    mongoc_add_example (mongoc-dump ${PROJECT_SOURCE_DIR}/examples/mongoc-dump.c)
    mongoc_add_example (mongoc-ping ${PROJECT_SOURCE_DIR}/examples/mongoc-ping.c)
    mongoc_add_example (mongoc-tail ${PROJECT_SOURCE_DIR}/examples/mongoc-tail.c)
+   mongoc_add_example (example-collection-command ${PROJECT_SOURCE_DIR}/examples/example-collection-command.c)
 
    # examples/aggregation/
    mongoc_add_example (aggregation1 ${PROJECT_SOURCE_DIR}/examples/aggregation/aggregation1.c)

--- a/src/libmongoc/doc/mongoc_collection_command_simple.rst
+++ b/src/libmongoc/doc/mongoc_collection_command_simple.rst
@@ -50,33 +50,7 @@ Example
 
 The following is an example of executing the collection stats command.
 
-.. code-block:: c
-
-  #include <bson/bson.h>
-  #include <mongoc/mongoc.h>
-  #include <stdio.h>
-
-  static void
-  print_collection_stats (mongoc_collection_t *collection)
-  {
-     bson_error_t error;
-     const char *name;
-     bson_t *cmd;
-     bson_t reply;
-
-     name = mongoc_collection_get_name (collection);
-     cmd = BCON_NEW ("collStats", BCON_UTF8 (name));
-
-     if (mongoc_collection_command_simple (
-            collection, cmd, NULL, &reply, &error)) {
-        str = bson_as_canonical_extended_json (&reply, NULL);
-        printf ("%s\n", str);
-        bson_free (str);
-     } else {
-        fprintf (stderr, "%s\n", error.message);
-     }
-
-     bson_destroy (&reply);
-     bson_destroy (cmd);
-  }
-
+.. literalinclude:: ../examples/example-collection-command.c
+   :caption: Example use of mongoc_collection_command
+   :start-after: BEGIN:mongoc_collection_command
+   :end-before: END:mongoc_collection_command

--- a/src/libmongoc/doc/mongoc_collection_command_simple.rst
+++ b/src/libmongoc/doc/mongoc_collection_command_simple.rst
@@ -51,6 +51,5 @@ Example
 The following is an example of executing the ``ping`` command.
 
 .. literalinclude:: ../examples/example-collection-command.c
-   :caption: Example use of mongoc_collection_command
    :start-after: BEGIN:mongoc_collection_command
    :end-before: END:mongoc_collection_command

--- a/src/libmongoc/doc/mongoc_collection_command_simple.rst
+++ b/src/libmongoc/doc/mongoc_collection_command_simple.rst
@@ -48,7 +48,7 @@ This function does not check the server response for a write concern error or wr
 Example
 -------
 
-The following is an example of executing the collection stats command.
+The following is an example of executing the ``ping`` command.
 
 .. literalinclude:: ../examples/example-collection-command.c
    :caption: Example use of mongoc_collection_command

--- a/src/libmongoc/doc/mongoc_collection_stats.rst
+++ b/src/libmongoc/doc/mongoc_collection_stats.rst
@@ -17,7 +17,7 @@ Synopsis
 Deprecated
 ----------
 
-This helper function is deprecated and should not be used in new code. Run the `collStats <https://docs.mongodb.com/manual/reference/command/collStats/>`_ command directly with :symbol:`mongoc_client_read_command_with_opts()` instead.
+This helper function is deprecated and should not be used in new code. Use the `$collStats aggregation pipeline stage <https://www.mongodb.com/docs/manual/reference/operator/aggregation/collStats/>`_ with :symbol:`mongoc_collection_aggregate()` instead.
 
 Parameters
 ----------

--- a/src/libmongoc/doc/tutorial.rst
+++ b/src/libmongoc/doc/tutorial.rst
@@ -784,7 +784,7 @@ Executing Commands
 
 The driver provides helper functions for executing MongoDB commands on client, database and collection structures. These functions return :doc:`cursors <mongoc_cursor_t>`; the ``_simple`` variants return booleans indicating success or failure.
 
-This example executes the `collStats <https://docs.mongodb.org/manual/reference/command/collStats/>`_ command against the collection "mycoll" in database "mydb".
+This example executes the `ping <https://docs.mongodb.org/manual/reference/command/ping/>`_ command against the collection "mycoll" in database "mydb".
 
 .. literalinclude:: ../examples/tutorial/executing.c
    :caption: Example of executing a command
@@ -795,9 +795,7 @@ Compile the code and run it:
 
   $ gcc -o executing executing.c $(pkg-config --cflags --libs libmongoc-1.0)
   $ ./executing
-  { "ns" : "mydb.mycoll", "count" : 1, "size" : 48, "avgObjSize" : 48, "numExtents" : 1, "storageSize" : 8192,
-  "lastExtentSize" : 8192.000000, "paddingFactor" : 1.000000, "userFlags" : 1, "capped" : false, "nindexes" : 1,
-  "indexDetails" : {  }, "totalIndexSize" : 8176, "indexSizes" : { "_id_" : 8176 }, "ok" : 1.000000 }
+  { "ok" : { "$numberDouble" : "1.0" }, "$clusterTime" : { "clusterTime" : { "$timestamp" : { "t" : 1682609211, "i" : 1 } }, "signature" : { "hash" : { "$binary" : { "base64" : "AAAAAAAAAAAAAAAAAAAAAAAAAAA=", "subType" : "00" } }, "keyId" : { "$numberLong" : "0" } } }, "operationTime" : { "$timestamp" : { "t" : 1682609211, "i" : 1 } } }
 
 On Windows:
 
@@ -805,9 +803,7 @@ On Windows:
 
   C:\> cl.exe /IC:\mongo-c-driver\include\libbson-1.0 /IC:\mongo-c-driver\include\libmongoc-1.0 executing.c
   C:\> executing
-  { "ns" : "mydb.mycoll", "count" : 1, "size" : 48, "avgObjSize" : 48, "numExtents" : 1, "storageSize" : 8192,
-  "lastExtentSize" : 8192.000000, "paddingFactor" : 1.000000, "userFlags" : 1, "capped" : false, "nindexes" : 1,
-  "indexDetails" : {  }, "totalIndexSize" : 8176, "indexSizes" : { "_id_" : 8176 }, "ok" : 1.000000 }
+  { "ok" : { "$numberDouble" : "1.0" }, "$clusterTime" : { "clusterTime" : { "$timestamp" : { "t" : 1682609211, "i" : 1 } }, "signature" : { "hash" : { "$binary" : { "base64" : "AAAAAAAAAAAAAAAAAAAAAAAAAAA=", "subType" : "00" } }, "keyId" : { "$numberLong" : "0" } } }, "operationTime" : { "$timestamp" : { "t" : 1682609211, "i" : 1 } } }
 
 Threading
 ---------

--- a/src/libmongoc/doc/tutorial.rst
+++ b/src/libmongoc/doc/tutorial.rst
@@ -787,7 +787,6 @@ The driver provides helper functions for executing MongoDB commands on client, d
 This example executes the `ping <https://docs.mongodb.org/manual/reference/command/ping/>`_ command against the database "mydb".
 
 .. literalinclude:: ../examples/tutorial/executing.c
-   :caption: Example of executing a command
 
 Compile the code and run it:
 

--- a/src/libmongoc/doc/tutorial.rst
+++ b/src/libmongoc/doc/tutorial.rst
@@ -786,46 +786,8 @@ The driver provides helper functions for executing MongoDB commands on client, d
 
 This example executes the `collStats <https://docs.mongodb.org/manual/reference/command/collStats/>`_ command against the collection "mycoll" in database "mydb".
 
-.. code-block:: c
-
-  #include <bson/bson.h>
-  #include <mongoc/mongoc.h>
-  #include <stdio.h>
-
-  int
-  main (int argc, char *argv[])
-  {
-     mongoc_client_t *client;
-     mongoc_collection_t *collection;
-     bson_error_t error;
-     bson_t *command;
-     bson_t reply;
-     char *str;
-
-     mongoc_init ();
-
-     client = mongoc_client_new (
-        "mongodb://localhost:27017/?appname=executing-example");
-     collection = mongoc_client_get_collection (client, "mydb", "mycoll");
-
-     command = BCON_NEW ("collStats", BCON_UTF8 ("mycoll"));
-     if (mongoc_collection_command_simple (
-            collection, command, NULL, &reply, &error)) {
-        str = bson_as_canonical_extended_json (&reply, NULL);
-        printf ("%s\n", str);
-        bson_free (str);
-     } else {
-        fprintf (stderr, "Failed to run command: %s\n", error.message);
-     }
-
-     bson_destroy (command);
-     bson_destroy (&reply);
-     mongoc_collection_destroy (collection);
-     mongoc_client_destroy (client);
-     mongoc_cleanup ();
-
-     return 0;
-  }
+.. literalinclude:: ../examples/tutorial/executing.c
+   :caption: Example of executing a command
 
 Compile the code and run it:
 

--- a/src/libmongoc/doc/tutorial.rst
+++ b/src/libmongoc/doc/tutorial.rst
@@ -784,7 +784,7 @@ Executing Commands
 
 The driver provides helper functions for executing MongoDB commands on client, database and collection structures. These functions return :doc:`cursors <mongoc_cursor_t>`; the ``_simple`` variants return booleans indicating success or failure.
 
-This example executes the `ping <https://docs.mongodb.org/manual/reference/command/ping/>`_ command against the collection "mycoll" in database "mydb".
+This example executes the `ping <https://docs.mongodb.org/manual/reference/command/ping/>`_ command against the database "mydb".
 
 .. literalinclude:: ../examples/tutorial/executing.c
    :caption: Example of executing a command

--- a/src/libmongoc/doc/tutorial.rst
+++ b/src/libmongoc/doc/tutorial.rst
@@ -782,7 +782,7 @@ On Windows:
 Executing Commands
 ------------------
 
-The driver provides helper functions for executing MongoDB commands on client, database and collection structures. These functions return :doc:`cursors <mongoc_cursor_t>`; the ``_simple`` variants return booleans indicating success or failure.
+The driver provides helper functions for executing MongoDB commands on client, database and collection structures. The ``_simple`` variants return booleans indicating success or failure.
 
 This example executes the `ping <https://docs.mongodb.org/manual/reference/command/ping/>`_ command against the database "mydb".
 

--- a/src/libmongoc/examples/example-collection-command.c
+++ b/src/libmongoc/examples/example-collection-command.c
@@ -10,6 +10,7 @@ print_collection_stats (mongoc_collection_t *collection)
    const char *name;
    bson_t *cmd;
    bson_t reply;
+   char *str;
 
    name = mongoc_collection_get_name (collection);
    cmd = BCON_NEW ("collStats", BCON_UTF8 (name));

--- a/src/libmongoc/examples/example-collection-command.c
+++ b/src/libmongoc/examples/example-collection-command.c
@@ -1,0 +1,71 @@
+// BEGIN:mongoc_collection_command_simple
+#include <bson/bson.h>
+#include <mongoc/mongoc.h>
+#include <stdio.h>
+
+static void
+print_collection_stats (mongoc_collection_t *collection)
+{
+   bson_error_t error;
+   const char *name;
+   bson_t *cmd;
+   bson_t reply;
+
+   name = mongoc_collection_get_name (collection);
+   cmd = BCON_NEW ("collStats", BCON_UTF8 (name));
+
+   if (mongoc_collection_command_simple (
+          collection, cmd, NULL, &reply, &error)) {
+      str = bson_as_canonical_extended_json (&reply, NULL);
+      printf ("Got reply: %s\n", str);
+      bson_free (str);
+   } else {
+      fprintf (stderr, "Got error: %s\n", error.message);
+   }
+
+   bson_destroy (&reply);
+   bson_destroy (cmd);
+}
+// END:mongoc_collection_command_simple
+
+int
+main (int argc, char **argv)
+{
+   bson_error_t error;
+   char *uri_string;
+   mongoc_uri_t *uri;
+   mongoc_client_t *client;
+   mongoc_collection_t *coll;
+
+   mongoc_init ();
+
+   if (argc != 2) {
+      MONGOC_ERROR ("Error: expected URI argument.\n"
+                    "Usage: %s <MongoDB URI>\n"
+                    "Example: %s mongodb://localhost:27017",
+                    argv[0],
+                    argv[0]);
+      return EXIT_FAILURE;
+   }
+   uri_string = argv[1];
+   uri = mongoc_uri_new_with_error (uri_string, &error);
+   if (!uri) {
+      MONGOC_ERROR (
+         "failed to parse URI: %s\nError: %s", uri_string, error.message);
+      return EXIT_FAILURE;
+   }
+
+   client = mongoc_client_new_from_uri (uri);
+   if (!client) {
+      MONGOC_ERROR ("failed to create client");
+      return EXIT_FAILURE;
+   }
+
+   coll = mongoc_client_get_collection (client, "db", "coll");
+   print_collection_stats (coll);
+   mongoc_collection_destroy (coll);
+   mongoc_uri_destroy (uri);
+   mongoc_client_destroy (client);
+   mongoc_cleanup ();
+   return EXIT_SUCCESS;
+}

--- a/src/libmongoc/examples/example-collection-command.c
+++ b/src/libmongoc/examples/example-collection-command.c
@@ -4,16 +4,14 @@
 #include <stdio.h>
 
 static void
-print_collection_stats (mongoc_collection_t *collection)
+do_ping (mongoc_collection_t *collection)
 {
    bson_error_t error;
-   const char *name;
    bson_t *cmd;
    bson_t reply;
    char *str;
 
-   name = mongoc_collection_get_name (collection);
-   cmd = BCON_NEW ("collStats", BCON_UTF8 (name));
+   cmd = BCON_NEW ("ping", BCON_INT32 (1));
 
    if (mongoc_collection_command_simple (
           collection, cmd, NULL, &reply, &error)) {
@@ -63,7 +61,7 @@ main (int argc, char **argv)
    }
 
    coll = mongoc_client_get_collection (client, "db", "coll");
-   print_collection_stats (coll);
+   do_ping (coll);
    mongoc_collection_destroy (coll);
    mongoc_uri_destroy (uri);
    mongoc_client_destroy (client);

--- a/src/libmongoc/examples/tutorial/executing.c
+++ b/src/libmongoc/examples/tutorial/executing.c
@@ -6,7 +6,6 @@ int
 main (int argc, char *argv[])
 {
    mongoc_client_t *client;
-   mongoc_collection_t *collection;
    bson_error_t error;
    bson_t *command;
    bson_t reply;
@@ -16,11 +15,10 @@ main (int argc, char *argv[])
 
    client = mongoc_client_new (
       "mongodb://localhost:27017/?appname=executing-example");
-   collection = mongoc_client_get_collection (client, "mydb", "mycoll");
 
    command = BCON_NEW ("ping", BCON_INT32 (1));
-   if (mongoc_collection_command_simple (
-          collection, command, NULL, &reply, &error)) {
+   if (mongoc_client_command_simple (
+          client, "mydb", command, NULL, &reply, &error)) {
       str = bson_as_canonical_extended_json (&reply, NULL);
       printf ("%s\n", str);
       bson_free (str);
@@ -30,7 +28,6 @@ main (int argc, char *argv[])
 
    bson_destroy (command);
    bson_destroy (&reply);
-   mongoc_collection_destroy (collection);
    mongoc_client_destroy (client);
    mongoc_cleanup ();
 

--- a/src/libmongoc/examples/tutorial/executing.c
+++ b/src/libmongoc/examples/tutorial/executing.c
@@ -1,0 +1,38 @@
+#include <bson/bson.h>
+#include <mongoc/mongoc.h>
+#include <stdio.h>
+
+int
+main (int argc, char *argv[])
+{
+   mongoc_client_t *client;
+   mongoc_collection_t *collection;
+   bson_error_t error;
+   bson_t *command;
+   bson_t reply;
+   char *str;
+
+   mongoc_init ();
+
+   client = mongoc_client_new (
+      "mongodb://localhost:27017/?appname=executing-example");
+   collection = mongoc_client_get_collection (client, "mydb", "mycoll");
+
+   command = BCON_NEW ("collStats", BCON_UTF8 ("mycoll"));
+   if (mongoc_collection_command_simple (
+          collection, command, NULL, &reply, &error)) {
+      str = bson_as_canonical_extended_json (&reply, NULL);
+      printf ("%s\n", str);
+      bson_free (str);
+   } else {
+      fprintf (stderr, "Failed to run command: %s\n", error.message);
+   }
+
+   bson_destroy (command);
+   bson_destroy (&reply);
+   mongoc_collection_destroy (collection);
+   mongoc_client_destroy (client);
+   mongoc_cleanup ();
+
+   return 0;
+}

--- a/src/libmongoc/examples/tutorial/executing.c
+++ b/src/libmongoc/examples/tutorial/executing.c
@@ -18,7 +18,7 @@ main (int argc, char *argv[])
       "mongodb://localhost:27017/?appname=executing-example");
    collection = mongoc_client_get_collection (client, "mydb", "mycoll");
 
-   command = BCON_NEW ("collStats", BCON_UTF8 ("mycoll"));
+   command = BCON_NEW ("ping", BCON_INT32 (1));
    if (mongoc_collection_command_simple (
           collection, command, NULL, &reply, &error)) {
       str = bson_as_canonical_extended_json (&reply, NULL);

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/bypassedCommand.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/bypassedCommand.json
@@ -78,7 +78,7 @@
       ]
     },
     {
-      "description": "current op is not bypassed",
+      "description": "kill op is not bypassed",
       "clientOptions": {
         "autoEncryptOpts": {
           "kmsProviders": {
@@ -90,14 +90,15 @@
         {
           "name": "runCommand",
           "object": "database",
-          "command_name": "currentOp",
+          "command_name": "killOp",
           "arguments": {
             "command": {
-              "currentOp": 1
+              "killOp": 1,
+              "op": 1234
             }
           },
           "result": {
-            "errorContains": "command not supported for auto encryption: currentOp"
+            "errorContains": "command not supported for auto encryption: killOp"
           }
         }
       ]

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -3402,8 +3402,9 @@ test_rename (void)
 
 
 static void
-test_stats (void)
+test_stats (void *unused)
 {
+   BSON_UNUSED (unused);
    mongoc_collection_t *collection;
    mongoc_client_t *client;
    bson_error_t error;
@@ -6296,7 +6297,14 @@ test_collection_install (TestSuite *suite)
                       NULL,
                       test_framework_skip_if_slow_or_live);
    TestSuite_AddLive (suite, "/Collection/rename", test_rename);
-   TestSuite_AddLive (suite, "/Collection/stats", test_stats);
+   // The collStats command is deprecated in MongoDB 6.0 (maxWireVersion=17) and
+   // may be removed in a future major release.
+   TestSuite_AddFull (suite,
+                      "/Collection/stats",
+                      test_stats,
+                      NULL,
+                      NULL,
+                      test_framework_skip_if_max_wire_version_more_than_17);
    TestSuite_AddMockServerTest (
       suite, "/Collection/stats/read_pref", test_stats_read_pref);
    TestSuite_AddMockServerTest (

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -3409,22 +3409,6 @@ test_sample_run_command (mongoc_database_t *db)
    bson_destroy (&reply);
    /* End runCommand Example 1 */
 
-   /* Start runCommand Example 2 */
-   run_command = BCON_NEW ("collStats", BCON_UTF8 ("restaurants"));
-
-   r = mongoc_database_write_command_with_opts (
-      db, run_command, NULL /* opts */, &reply, &error);
-   bson_destroy (run_command);
-
-   if (!r) {
-      MONGOC_ERROR ("%s\n", error.message);
-   }
-
-   /* Do something with reply here */
-
-   bson_destroy (&reply);
-   /* End runCommand Example 2 */
-
    ASSERT_NO_CAPTURED_LOGS ("sample runCommand examples");
 }
 


### PR DESCRIPTION
# Summary

- Remove use of `collStats`


# Background & Motivation

From DRIVERS-2232:
> For drivers that have helpers for collStats or currentOp, the helpers should be adjusted to use the $collStats / $currentOp aggregation pipeline stages.  Alternatively, drivers can deprecate these helpers for future removal.  This is left to the discretion of drivers.

`mongoc_collection_stats` is already deprecated. Examples using `mongoc_collection_stats` were updated to use aggregation with the `$collStats` pipeline stage. There is no helper for `currentOp`.

---
Example code was moved from .rst files into the `examples` directory and included with the `literalinclude` directive. This is intended to have the examples compile in Evergreen.

---
The `runCommand Example 2` example, which used `collStats`, was removed. This example was added for the documentation team in DRIVERS-448. [DOCSP-21320](https://jira.mongodb.org/browse/DOCSP-21320) requests removing `runCommand Example 2` from documentation.
