### PR TITLE
bson_atomic_int32_fetch_add uses a header declared type for the int32_t argument

### DIFF
--- a/src/libbson/src/bson/bson-atomic.c
+++ b/src/libbson/src/bson/bson-atomic.c
@@ -25,7 +25,7 @@
 int32_t
 bson_atomic_int_add (volatile int32_t *p, int32_t n)
 {
-   return n + bson_atomic_int32_fetch_add (p, n, bson_memory_order_seq_cst);
+   return n + bson_atomic_int32_fetch_add ((DECL_ATOMIC_INTEGRAL_INT32 *) p, n, bson_memory_order_seq_cst);
 }
 
 int64_t

--- a/src/libbson/src/bson/bson-atomic.h
+++ b/src/libbson/src/bson/bson-atomic.h
@@ -381,7 +381,7 @@ DECL_ATOMIC_INTEGRAL (int, int, )
 #endif
 
 #ifndef DECL_ATOMIC_INTEGRAL_INT32
-#define DECL_ATOMIC_INTEGRAL_INT32 int32
+#define DECL_ATOMIC_INTEGRAL_INT32 int32_t
 #endif
    
 BSON_EXPORT (int64_t)

--- a/src/libbson/src/bson/bson-atomic.h
+++ b/src/libbson/src/bson/bson-atomic.h
@@ -380,6 +380,10 @@ DECL_ATOMIC_INTEGRAL (int, int, )
 #endif
 #endif
 
+#ifndef DECL_ATOMIC_INTEGRAL_INT32
+#define DECL_ATOMIC_INTEGRAL_INT32 int32
+#endif
+   
 BSON_EXPORT (int64_t)
 _bson_emul_atomic_int64_fetch_add (int64_t volatile *val,
                                    int64_t v,

--- a/src/libbson/src/bson/bson-context.c
+++ b/src/libbson/src/bson/bson-context.c
@@ -62,7 +62,7 @@ _bson_context_set_oid_seq32 (bson_context_t *context, /* IN */
                              bson_oid_t *oid)         /* OUT */
 {
    uint32_t seq = (uint32_t) bson_atomic_int32_fetch_add (
-      (int32_t *) &context->seq32, 1, bson_memory_order_seq_cst);
+      (DECL_ATOMIC_INTEGRAL_INT32 *) &context->seq32, 1, bson_memory_order_seq_cst);
    seq = BSON_UINT32_TO_BE (seq);
    memcpy (&oid->bytes[BSON_OID_SEQ32_OFFSET],
            ((uint8_t *) &seq) + 1,


### PR DESCRIPTION
bson_atomic_int32_fetch_add  is generated with the type DECL_ATOMIC_INTEGRAL_INT32, but is coded as int32_t in two places. This results in an incompatible pointer types error when MSVC is true from the bson-atomic.h file.

This patch resolves the error, tested and resolved with clang-cl for compatibility.