### PR TITLE
CDRIVER-4584 use libmongocrypt 1.8.0-alpha1

### DIFF
--- a/.evergreen/scripts/compile-libmongocrypt.sh
+++ b/.evergreen/scripts/compile-libmongocrypt.sh
@@ -5,7 +5,7 @@ compile_libmongocrypt() {
   declare -r mongoc_dir="${2:?}"
   declare -r install_dir="${3:?}"
 
-  git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.8.0-alpha0 || return
+  git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.8.0-alpha1 || return
 
   declare -a crypt_cmake_flags=(
     "-DMONGOCRYPT_MONGOC_DIR=${mongoc_dir}"

--- a/src/libmongoc/src/mongoc/mongoc-crypt.c
+++ b/src/libmongoc/src/mongoc/mongoc-crypt.c
@@ -1329,12 +1329,6 @@ _mongoc_crypt_new (const bson_t *kms_providers,
    crypt = bson_malloc0 (sizeof (*crypt));
    crypt->handle = mongocrypt_new ();
 
-   // Enable the QEv2 protocol.
-   if (!mongocrypt_setopt_fle2v2 (crypt->handle, true)) {
-      _crypt_check_error (crypt->handle, error, true);
-      goto fail;
-   }
-
    // Stash away a copy of the user's kmsProviders in case we need to lazily
    // load credentials.
    bson_copy_to (kms_providers, &crypt->kms_providers);


### PR DESCRIPTION
# Summary

- use libmongocrypt 1.8.0-alpha1
- remove use of `mongocrypt_setopt_fle2v2`

Verified with this patch: https://spruce.mongodb.com/version/645000960305b9b9e28f5371

# Background & Motivation

This PR is a follow-up to https://github.com/mongodb/mongo-c-driver/pull/1228

Queryable Encryption v2 is enabled by default in libmongocrypt 1.8.0-alpha1. libmongocrypt 1.8.0-alpha1 removes the symbol `mongocrypt_setopt_fle2v2` from the public API. `mongocrypt_setopt_fle2v2` was added in libmongocrypt 1.8.0-alpha0.