### PR TITLE
CDRIVER-4621 Replace codecov-bash with new Codecov Uploader

### DIFF
--- a/.evergreen/.codecov.yml
+++ b/.evergreen/.codecov.yml
@@ -1,3 +1,4 @@
 ignore:
-  - "src/libmongoc/tests/mock_server"
-  - "src/zlib-1.2.13"
+  - "src/kms-message"
+  - "src/zlib-*"
+  - "src/*/tests"

--- a/.evergreen/config_generator/etc/cse/compile.py
+++ b/.evergreen/config_generator/etc/cse/compile.py
@@ -27,7 +27,7 @@ class CompileCommon(Function):
             expansions_update(updates=updates),
             bash_exec(
                 command_type=EvgCommandType.TEST,
-                script='EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON -DENABLE_CLIENT_SIDE_ENCRYPTION=ON ${EXTRA_CONFIGURE_FLAGS}" .evergreen/scripts/compile.sh',
+                script='EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON ${EXTRA_CONFIGURE_FLAGS}" .evergreen/scripts/compile.sh',
                 working_dir='mongoc',
                 add_expansions_to_env=True,
                 env={

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -87,7 +87,7 @@ functions:
           COMPILE_LIBMONGOCRYPT: "ON"
         args:
           - -c
-          - EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON -DENABLE_CLIENT_SIDE_ENCRYPTION=ON ${EXTRA_CONFIGURE_FLAGS}" .evergreen/scripts/compile.sh
+          - EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON ${EXTRA_CONFIGURE_FLAGS}" .evergreen/scripts/compile.sh
   cse-sasl-cyrus-openssl-compile:
     - command: expansions.update
       params:
@@ -104,7 +104,7 @@ functions:
           COMPILE_LIBMONGOCRYPT: "ON"
         args:
           - -c
-          - EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON -DENABLE_CLIENT_SIDE_ENCRYPTION=ON ${EXTRA_CONFIGURE_FLAGS}" .evergreen/scripts/compile.sh
+          - EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON ${EXTRA_CONFIGURE_FLAGS}" .evergreen/scripts/compile.sh
   cse-sasl-cyrus-winssl-compile:
     - command: expansions.update
       params:
@@ -121,7 +121,7 @@ functions:
           COMPILE_LIBMONGOCRYPT: "ON"
         args:
           - -c
-          - EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON -DENABLE_CLIENT_SIDE_ENCRYPTION=ON ${EXTRA_CONFIGURE_FLAGS}" .evergreen/scripts/compile.sh
+          - EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON ${EXTRA_CONFIGURE_FLAGS}" .evergreen/scripts/compile.sh
   early-termination:
     - command: subprocess.exec
       params:

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -182,8 +182,16 @@ functions:
       shell: bash
       script: |-
         set -o errexit
-        export CODECOV_TOKEN=${codecov_token}
-        curl -s https://codecov.io/bash | bash
+        # Note: coverage is currently only enabled on the ubuntu1804 distro.
+        # This script does not support MacOS, Windows, or non-x86_64 distros.
+        # Update accordingly if code coverage is expanded to other distros.
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
+        chmod +x codecov
+        # -Z: Exit with a non-zero value if error.
+        # -g: Run with gcov support.
+        # -t: Codecov upload token.
+        # perl: filter verbose "Found" list and "Processing" messages.
+        ./codecov -Zgt "${codecov_token}"
   compile coverage:
   - command: shell.exec
     type: test

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -1052,7 +1052,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env COMPILE_LIBMONGOCRYPT="ON" DEBUG="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON -DENABLE_CLIENT_SIDE_ENCRYPTION=ON" SASL="AUTO" SSL="OPENSSL" bash .evergreen/scripts/compile.sh
+        env COMPILE_LIBMONGOCRYPT="ON" DEBUG="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON" SASL="AUTO" SSL="OPENSSL" bash .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-sasl-openssl-static-cse
   tags:
@@ -1070,7 +1070,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env COMPILE_LIBMONGOCRYPT="ON" DEBUG="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON -DENABLE_CLIENT_SIDE_ENCRYPTION=ON" SASL="AUTO" SSL="OPENSSL_STATIC" bash .evergreen/scripts/compile.sh
+        env COMPILE_LIBMONGOCRYPT="ON" DEBUG="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON" SASL="AUTO" SSL="OPENSSL_STATIC" bash .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-sasl-darwinssl-cse
   tags:
@@ -1088,7 +1088,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env COMPILE_LIBMONGOCRYPT="ON" DEBUG="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON -DENABLE_CLIENT_SIDE_ENCRYPTION=ON" SASL="AUTO" SSL="DARWIN" bash .evergreen/scripts/compile.sh
+        env COMPILE_LIBMONGOCRYPT="ON" DEBUG="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON" SASL="AUTO" SSL="DARWIN" bash .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-sasl-winssl-cse
   tags:
@@ -1106,7 +1106,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env COMPILE_LIBMONGOCRYPT="ON" DEBUG="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON -DENABLE_CLIENT_SIDE_ENCRYPTION=ON" SASL="AUTO" SSL="WINDOWS" bash .evergreen/scripts/compile.sh
+        env COMPILE_LIBMONGOCRYPT="ON" DEBUG="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON" SASL="AUTO" SSL="WINDOWS" bash .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-asan-openssl-cse
   tags:
@@ -1122,7 +1122,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env CFLAGS="-fno-omit-frame-pointer" CHECK_LOG="ON" COMPILE_LIBMONGOCRYPT="ON" DEBUG="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_CLIENT_SIDE_ENCRYPTION=ON -DENABLE_EXTRA_ALIGNMENT=OFF" PATH="/usr/lib/llvm-3.8/bin:$PATH" SANITIZE="address" SSL="OPENSSL" bash .evergreen/scripts/compile.sh
+        env CFLAGS="-fno-omit-frame-pointer" CHECK_LOG="ON" COMPILE_LIBMONGOCRYPT="ON" DEBUG="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_EXTRA_ALIGNMENT=OFF" PATH="/usr/lib/llvm-3.8/bin:$PATH" SANITIZE="address" SSL="OPENSSL" bash .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-nosasl-openssl-1.0.1
   commands:

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -1156,9 +1156,8 @@ tasks:
       script: |-
         set -o errexit
         bash ./.evergreen/scripts/build-and-test-with-toolchain.sh
-- name: test-coverage-latest-replica-set-auth-sasl-openssl-cse
+- name: test-coverage-latest-replica-set-auth-sasl-openssl
   tags:
-  - client-side-encryption
   - latest
   - test-coverage
   commands:
@@ -1174,7 +1173,33 @@ tasks:
       SSL: openssl
       TOPOLOGY: replica_set
   - func: run-simple-http-server
+  - func: run-tests
+    vars:
+      AUTH: auth
+      COVERAGE: 'ON'
+      SSL: openssl
+  - func: upload coverage
+  - func: update codecov.io
+- name: test-coverage-latest-replica-set-auth-sasl-openssl-cse
+  tags:
+  - client-side-encryption
+  - latest
+  - test-coverage
+  commands:
+  - func: compile coverage
+    vars:
+      COMPILE_LIBMONGOCRYPT: 'ON'
+      EXTRA_CONFIGURE_FLAGS: EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON"
+      SASL: AUTO
+      SSL: OPENSSL
   - func: fetch-det
+  - func: bootstrap-mongo-orchestration
+    vars:
+      AUTH: auth
+      MONGODB_VERSION: latest
+      SSL: openssl
+      TOPOLOGY: replica_set
+  - func: run-simple-http-server
   - func: run-mock-kms-servers
   - func: run-tests
     vars:

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -191,7 +191,7 @@ functions:
         # -g: Run with gcov support.
         # -t: Codecov upload token.
         # perl: filter verbose "Found" list and "Processing" messages.
-        ./codecov -Zgt "${codecov_token}"
+        ./codecov -Zgt "${codecov_token}" | perl -lne 'print if not m|^.*\.gcov(\.\.\.)?$|'
   compile coverage:
   - command: shell.exec
     type: test

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/functions.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/functions.py
@@ -138,7 +138,7 @@ all_functions = OD([
         # -g: Run with gcov support.
         # -t: Codecov upload token.
         # perl: filter verbose "Found" list and "Processing" messages.
-        ./codecov -Zgt "${codecov_token}"
+        ./codecov -Zgt "${codecov_token}" | perl -lne 'print if not m|^.*\.gcov(\.\.\.)?$|'
         ''', test=False),
     )),
     ('compile coverage', Function(

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/functions.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/functions.py
@@ -129,8 +129,16 @@ all_functions = OD([
     )),
     ('update codecov.io', Function(
         shell_mongoc(r'''
-        export CODECOV_TOKEN=${codecov_token}
-        curl -s https://codecov.io/bash | bash
+        # Note: coverage is currently only enabled on the ubuntu1804 distro.
+        # This script does not support MacOS, Windows, or non-x86_64 distros.
+        # Update accordingly if code coverage is expanded to other distros.
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
+        chmod +x codecov
+        # -Z: Exit with a non-zero value if error.
+        # -g: Run with gcov support.
+        # -t: Codecov upload token.
+        # perl: filter verbose "Found" list and "Processing" messages.
+        ./codecov -Zgt "${codecov_token}"
         ''', test=False),
     )),
     ('compile coverage', Function(

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -389,7 +389,7 @@ class CoverageTask(MatrixTask):
                ('auth', [True]),
                ('sasl', ['sasl']),
                ('ssl', ['openssl']),
-               ('cse', [True])])
+               ('cse', [False, True])])
 
     def __init__(self, *args, **kwargs):
         super(CoverageTask, self).__init__(*args, **kwargs)
@@ -419,13 +419,17 @@ class CoverageTask(MatrixTask):
     def to_dict(self):
         task = super(CoverageTask, self).to_dict()
         commands = task['commands']
-        if self.depends_on:
-            commands.append(
-                func('fetch-build', BUILD_NAME=self.depends_on['name']))
 
-        # Limit coverage tests to test-coverage-latest-replica-set-auth-sasl-openssl-cse.
-        commands.append(
-            func('compile coverage', SASL='AUTO', SSL='OPENSSL'))
+        if self.cse:
+            commands.append(func('compile coverage',
+                                 SASL='AUTO',
+                                 SSL='OPENSSL',
+                                 COMPILE_LIBMONGOCRYPT='ON',
+                                 EXTRA_CONFIGURE_FLAGS='EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON"'))
+        else:
+            commands.append(func('compile coverage',
+                                 SASL='AUTO',
+                                 SSL='OPENSSL'))
 
         commands.append(func('fetch-det'))
         commands.append(func('bootstrap-mongo-orchestration',
@@ -433,14 +437,14 @@ class CoverageTask(MatrixTask):
                              TOPOLOGY=self.topology,
                              AUTH='auth' if self.auth else 'noauth',
                              SSL=self.display('ssl')))
-        extra = {}
+        extra = {
+            'COVERAGE': 'ON'
+        }
 
         commands.append(func('run-simple-http-server'))
         if self.cse:
             extra["CLIENT_SIDE_ENCRYPTION"] = "on"
-            commands.append(func('fetch-det'))
             commands.append(func('run-mock-kms-servers'))
-        extra["COVERAGE"] = 'ON'
         commands.append(func('run-tests',
                              AUTH=self.display('auth'),
                              SSL=self.display('ssl'),
@@ -451,12 +455,11 @@ class CoverageTask(MatrixTask):
         return task
 
     def _check_allowed(self):
-        # Limit coverage tests to test-coverage-latest-replica-set-auth-sasl-openssl-cse.
+        # Limit coverage tests to test-coverage-latest-replica-set-auth-sasl-openssl (+ cse).
         require(self.topology == 'replica_set')
         require(self.auth)
         require(self.sasl == 'sasl')
         require(self.ssl == 'openssl')
-        require(self.cse)
         require(self.version == 'latest')
 
         # Address sanitizer only with auth+SSL or no auth + no SSL.

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -96,7 +96,7 @@ class CompileWithClientSideEncryption(CompileTask):
         # Compiling with ClientSideEncryption support requires linking against the library libmongocrypt.
         super(CompileWithClientSideEncryption, self).__init__(*args,
                                                               COMPILE_LIBMONGOCRYPT="ON",
-                                                              EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON -DENABLE_CLIENT_SIDE_ENCRYPTION=ON",
+                                                              EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON",
                                                               **kwargs)
         self.add_tags('client-side-encryption', 'special')
 
@@ -109,7 +109,7 @@ class CompileWithClientSideEncryptionAsan(CompileTask):
                                                                   CHECK_LOG="ON",
                                                                   sanitize=[
                                                                       'address'],
-                                                                  EXTRA_CONFIGURE_FLAGS="-DENABLE_CLIENT_SIDE_ENCRYPTION=ON -DENABLE_EXTRA_ALIGNMENT=OFF",
+                                                                  EXTRA_CONFIGURE_FLAGS="-DENABLE_EXTRA_ALIGNMENT=OFF",
                                                                   PATH='/usr/lib/llvm-3.8/bin:$PATH',
                                                                   **kwargs)
         self.add_tags('client-side-encryption')

--- a/.evergreen/scripts/run-tests.sh
+++ b/.evergreen/scripts/run-tests.sh
@@ -285,14 +285,16 @@ if [[ "${COVERAGE}" == "ON" ]]; then
     "--no-external"
   )
 
-  case "${CC}" in
-  clang)
-    lcov --gcov-tool "$(pwd)/.evergreen/scripts/llvm-gcov.sh" "${coverage_args[@]}"
-    ;;
-  *)
-    lcov --gcov-tool gcov "${coverage_args[@]}"
-    ;;
-  esac
+  {
+    case "${CC}" in
+    clang)
+      lcov --gcov-tool "$(pwd)/.evergreen/scripts/llvm-gcov.sh" "${coverage_args[@]}"
+      ;;
+    *)
+      lcov --gcov-tool gcov "${coverage_args[@]}"
+      ;;
+    esac
 
-  genhtml .coverage.lcov --legend --title "mongoc code coverage" --output-directory coverage
+    genhtml .coverage.lcov --legend --title "mongoc code coverage" --output-directory coverage
+  } | perl -lne 'print if not m|Processing |'
 fi


### PR DESCRIPTION
## Description

Resolves CDRIVER-4621. Verified by [this patch](https://spruce.mongodb.com/version/6452b700a4cf47cc42d991bf).

Replaced the deprecated codecov-bash command with the new Codecov Uploader. Also applied verbosity-reduction filters to reduce the output of code coverage commands.

## Fixes and Improvements

Fixed the coverage task so it actually compiles with CSE enabled before running CSE tests. The coverage task currently skips most of the CSE tests it's supposed to run due to CSE being disabled, producing an abysmal coverage report. 🥴

Added `test-coverage-latest-replica-set-auth-sasl-openssl` to account for the `-cse` task limiting tests to CSE tests only (since https://github.com/mongodb/mongo-c-driver/pull/1201).

Removed `-DENABLE_CLIENT_SIDE_ENCRYPTION=ON` in `EXTRA_CONFIGURE_FLAGS` for CSE tasks, as it is automatically set when `COMPILE_LIBMONGOCRYPT=ON` in `compile-*.sh`.

Updated Codecov filters to ignore kms-message (vendored), zlib (bundled), and test code (do not test the tests).