### PR TITLE
CDRIVER-4635 Reset speculative_auth_response when resetting auth state

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
@@ -421,6 +421,10 @@ _begin_hello_cmd (mongoc_topology_scanner_node_t *node,
       ssl_opts = ts->ssl_opts;
 #endif
 
+      // _mongoc_topology_scanner_add_speculative_authentication is called with
+      // NULL for the scram_cache argument. The scram cache is not used for
+      // speculative authentication in the topology scanner. This is planned to
+      // be improved in CDRIVER-3642.
       _mongoc_topology_scanner_add_speculative_authentication (
          &cmd, ts->uri, ssl_opts, NULL, &node->scram);
    }

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
@@ -606,10 +606,6 @@ mongoc_topology_scanner_node_disconnect (mongoc_topology_scanner_node_t *node,
       }
 
       node->stream = NULL;
-      memset (
-         &node->sasl_supported_mechs, 0, sizeof (node->sasl_supported_mechs));
-      node->negotiated_sasl_supported_mechs = false;
-      bson_reinit (&node->speculative_auth_response);
    }
    mongoc_server_description_destroy (node->handshake_sd);
    node->handshake_sd = NULL;

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
@@ -1104,6 +1104,7 @@ mongoc_topology_scanner_node_setup (mongoc_topology_scanner_node_t *node,
    {
       node->has_auth = false;
       bson_reinit (&node->speculative_auth_response);
+      node->scram.step = 0;
       memset (
          &node->sasl_supported_mechs, 0, sizeof (node->sasl_supported_mechs));
       node->negotiated_sasl_supported_mechs = false;

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
@@ -1099,6 +1099,16 @@ mongoc_topology_scanner_node_setup (mongoc_topology_scanner_node_t *node,
 
    BSON_ASSERT (!node->retired);
 
+   // If a new stream is needed, reset state authentication state.
+   // Authentication state is tied to a stream.
+   {
+      node->has_auth = false;
+      bson_reinit (&node->speculative_auth_response);
+      memset (
+         &node->sasl_supported_mechs, 0, sizeof (node->sasl_supported_mechs));
+      node->negotiated_sasl_supported_mechs = false;
+   }
+
    if (node->ts->initiator) {
       stream = node->ts->initiator (
          node->ts->uri, &node->host, node->ts->initiator_context, error);
@@ -1129,8 +1139,6 @@ mongoc_topology_scanner_node_setup (mongoc_topology_scanner_node_t *node,
       node->ts->setup_err_cb (node->id, node->ts->cb_data, error);
       return;
    }
-
-   node->has_auth = false;
 }
 
 /*

--- a/src/libmongoc/tests/test-mongoc-client.c
+++ b/src/libmongoc/tests/test-mongoc-client.c
@@ -4265,7 +4265,11 @@ test_client_install (TestSuite *suite)
                       test_mongoc_client_authenticate_cached_single,
                       NULL,
                       NULL,
-                      test_framework_skip_if_no_auth);
+                      test_framework_skip_if_no_auth,
+                      // speculativeAuthentication in single-threaded clients
+                      // does not use the scram cache. speculativeAuthentication
+                      // was introduced in server 4.4 (maxWireVersion=9)
+                      test_framework_skip_if_max_wire_version_more_than_8);
    TestSuite_AddFull (suite,
                       "/Client/authenticate_failure",
                       test_mongoc_client_authenticate_failure,

--- a/src/libmongoc/tests/test-mongoc-speculative-auth.c
+++ b/src/libmongoc/tests/test-mongoc-speculative-auth.c
@@ -385,7 +385,172 @@ test_mongoc_speculative_auth_request_x509_pool (void)
 
    bson_destroy (response);
 }
-#endif /* MONGOC_ENABLE_SSL_* */
+
+// test_mongoc_speculative_auth_request_x509_network_error is a regression test
+// for CDRIVER-4635.
+static void
+test_mongoc_speculative_auth_request_x509_network_error (void)
+{
+   // Start mock server.
+   mock_server_t *server;
+   {
+      mongoc_ssl_opt_t server_ssl_opts = {0};
+      server_ssl_opts.ca_file = CERT_CA;
+      server_ssl_opts.pem_file = CERT_SERVER;
+      server = mock_server_new ();
+      mock_server_set_ssl_opts (server, &server_ssl_opts);
+      mock_server_run (server);
+   }
+
+   // Create URI configured for X509 authentication.
+   mongoc_uri_t *uri;
+   {
+      uri = mongoc_uri_copy (mock_server_get_uri (server));
+      mongoc_uri_set_option_as_int32 (
+         uri, MONGOC_URI_HEARTBEATFREQUENCYMS, 15000);
+      _setup_speculative_auth_x_509 (uri);
+   }
+
+   // Create single threaded client.
+   mongoc_client_t *client;
+   {
+      mongoc_ssl_opt_t client_ssl_opts = {0};
+      client_ssl_opts.ca_file = CERT_CA;
+      client_ssl_opts.pem_file = CERT_CLIENT;
+      client = test_framework_client_new_from_uri (uri, NULL);
+      ASSERT (client);
+      mongoc_client_set_ssl_opts (client, &client_ssl_opts);
+   }
+
+   // Send a ping, and receive a network error.
+   {
+      bson_error_t error;
+
+      // Send ping.
+      future_t *future = future_client_command_simple (
+         client, "admin", tmp_bson ("{'ping': 1}"), NULL, NULL, &error);
+
+      // Expect a hello including speculativeAuthenticate field.
+      {
+         request_t *request = mock_server_receives_any_hello (server);
+         ASSERT (request);
+         const bson_t *request_doc = request_get_doc (request, 0);
+         ASSERT (request_doc);
+         char *request_str =
+            bson_as_canonical_extended_json (request_doc, NULL);
+         ASSERT_WITH_MSG (
+            bson_has_field (request_doc, "speculativeAuthenticate"),
+            "expected hello to contain 'speculativeAuthenticate', got: %s",
+            request_str);
+         // Respond with a non-empty document "speculativeAuthenticate" field.
+         // The C driver will interpret this as a successful X509
+         // authentication.
+         bson_t *response = BCON_NEW ("ok",
+                                      BCON_INT32 (1),
+                                      "isWritablePrimary",
+                                      BCON_BOOL (true),
+                                      "minWireVersion",
+                                      BCON_INT32 (WIRE_VERSION_MIN),
+                                      "maxWireVersion",
+                                      BCON_INT32 (WIRE_VERSION_MAX),
+                                      "speculativeAuthenticate",
+                                      "{",
+                                      "foo",
+                                      "bar",
+                                      "}");
+
+         char *response_str = bson_as_canonical_extended_json (response, NULL);
+         mock_server_replies_simple (request, response_str);
+         bson_free (response_str);
+         bson_destroy (response);
+         bson_free (request_str);
+         request_destroy (request);
+      }
+
+      // Expect a ping command. Respond with a network error.
+      {
+         request_t *request = mock_server_receives_msg (
+            server, MONGOC_MSG_NONE, tmp_bson ("{'ping': 1}"));
+         ASSERT (request);
+         // Cause a network error.
+         mock_server_hangs_up (request);
+         request_destroy (request);
+      }
+
+      // Expect error.
+      ASSERT (!future_get_bool (future));
+      ASSERT_ERROR_CONTAINS (error,
+                             MONGOC_ERROR_STREAM,
+                             MONGOC_ERROR_STREAM_SOCKET,
+                             "socket error");
+      future_destroy (future);
+   }
+
+   // Send another ping, expect another "speculativeAuthenticate" attempt.
+   {
+      bson_error_t error;
+
+      // Send ping.
+      future_t *future = future_client_command_simple (
+         client, "admin", tmp_bson ("{'ping': 1}"), NULL, NULL, &error);
+
+      // Expect a hello including speculativeAuthenticate field.
+      {
+         request_t *request = mock_server_receives_any_hello (server);
+         ASSERT (request);
+         const bson_t *request_doc = request_get_doc (request, 0);
+         ASSERT (request_doc);
+         char *request_str =
+            bson_as_canonical_extended_json (request_doc, NULL);
+         ASSERT_WITH_MSG (
+            bson_has_field (request_doc, "speculativeAuthenticate"),
+            "expected hello to contain 'speculativeAuthenticate', got: %s",
+            request_str);
+         // Respond with a non-empty document "speculativeAuthenticate" field.
+         // The C driver will interpret this as a successful X509
+         // authentication.
+         bson_t *response = BCON_NEW ("ok",
+                                      BCON_INT32 (1),
+                                      "isWritablePrimary",
+                                      BCON_BOOL (true),
+                                      "minWireVersion",
+                                      BCON_INT32 (WIRE_VERSION_MIN),
+                                      "maxWireVersion",
+                                      BCON_INT32 (WIRE_VERSION_MAX),
+                                      "speculativeAuthenticate",
+                                      "{",
+                                      "foo",
+                                      "bar",
+                                      "}");
+
+         char *response_str = bson_as_canonical_extended_json (response, NULL);
+         mock_server_replies_simple (request, response_str);
+         bson_free (response_str);
+         bson_destroy (response);
+         request_destroy (request);
+         bson_free (request_str);
+      }
+
+      // Expect a ping command. Respond with {"ok": 1}.
+      {
+         request_t *request = mock_server_receives_msg (
+            server, MONGOC_MSG_NONE, tmp_bson ("{'ping': 1}"));
+         ASSERT (request);
+         mock_server_replies_ok_and_destroys (request);
+      }
+
+      // Expect success.
+      ASSERT_OR_PRINT (future_get_bool (future), error);
+      future_destroy (future);
+   }
+
+   mongoc_client_destroy (client);
+   mongoc_uri_destroy (uri);
+   mock_server_destroy (server);
+}
+
+#endif // defined(MONGOC_ENABLE_SSL_OPENSSL) ||
+       // defined(MONGOC_ENABLE_SSL_SECURE_TRANSPORT)
 
 
 static void
@@ -452,6 +617,10 @@ test_speculative_auth_install (TestSuite *suite)
    TestSuite_AddMockServerTest (suite,
                                 "/speculative_auth_pool/request_x509",
                                 test_mongoc_speculative_auth_request_x509_pool);
+   TestSuite_AddMockServerTest (
+      suite,
+      "/speculative_auth/request_x509/network_error",
+      test_mongoc_speculative_auth_request_x509_network_error);
 #endif /* MONGOC_ENABLE_SSL_* */
    TestSuite_AddMockServerTest (
       suite,


### PR DESCRIPTION
This PR fixes an issue where the result of a previous speculative authentication is kept around despite the authentication state being reset. This causes single-threaded clients to assume a connection is authenticated when it isn't. Due to a speculative authentication response being present, subsequent handshakes will not attempt speculative authentication. However, when checking the response of the handshake, the previous speculative authentication response is reused.

When using SCRAM authentication, the previous result is no longer valid and continuing the SCRAM conversation will immediately fail as the server rejects the contents. This leads to authentication being reset and a regular authentication cycle to commence.

When using X.509, the presence of a `speculativeAuthenticate` field in the handshake response indicates successful authentication. Due to the previous result being kept around, any subsequent handshakes assume a successful authentication, even when the handshake didn't include speculative authentication. As a result, the client assumes the connection is authenticated, but the server will reject commands. This PR fixes this issue.

Note that there is an additional component to this buggy behaviour: when sending a command while not authenticated, the server responds with the following reply (in this case to a `find` command);
```json
{
  "ok": 0,
  "errmsg": "command find requires authentication",
  "code": 13,
  "codeName": "Unauthorized"
}
```

While the message indicates "unauthenticated", the error code is "unauthorised". This contradiction prevents us from acting upon this response: "unauthenticated" suggests we should attempt to authenticate, whereas "unauthorised" indicates that authenticating with the same credentials presented previously would not result in a successful command execution. This means that we can't act upon this response, as we can only use error codes to check server errors, but not error messages. If the server had a separate code for indicating this state, the client could have attempted X.509 authentication again. As it is, the client was kept in the state of wrongly assuming the connection to be authenticated, leading to repeated command failures until the program was restarted and authentication was attempted once again.