### PR TITLE
CDRIVER-4498 return error if `masterKey` is set, but `provider` is not set

### DIFF
--- a/src/libmongoc/doc/mongoc_client_encryption_rewrap_many_datakey.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_rewrap_many_datakey.rst
@@ -24,7 +24,7 @@ A ``NULL`` argument for ``filter`` is equivalent to being given an empty
 document (match all).
 
 If ``provider`` is ``NULL``, rewraps matching data keys with their current KMS
-provider.
+provider and master key.
 
 If ``provider`` is not ``NULL``, rewraps matching data keys with the new KMS
 provider as described by ``master_key``. The ``master_key`` document must

--- a/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
@@ -2283,6 +2283,15 @@ mongoc_client_encryption_rewrap_many_datakey (
 
    bson_reinit (bulk_write_result);
 
+   if (master_key && !provider) {
+      bson_set_error (
+         error,
+         MONGOC_ERROR_CLIENT,
+         MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
+         "expected 'provider' to be set to identify type of 'master_key'");
+      GOTO (fail);
+   }
+
    if (!_mongoc_crypt_rewrap_many_datakey (client_encryption->crypt,
                                            client_encryption->keyvault_coll,
                                            filter,

--- a/src/libmongoc/src/mongoc/mongoc-crypt.c
+++ b/src/libmongoc/src/mongoc/mongoc-crypt.c
@@ -2001,6 +2001,12 @@ _mongoc_crypt_rewrap_many_datakey (_mongoc_crypt_t *crypt,
    mongocrypt_binary_t *filter_bin = NULL;
    bool ret = false;
 
+   if (master_key) {
+      // Caller must verify that `provider` is not-NULL when `master_key` is
+      // not-NULL.
+      BSON_ASSERT_PARAM (provider);
+   }
+
    bson_init (doc_out);
    state_machine = _state_machine_new (crypt);
    state_machine->keyvault_coll = keyvault_coll;

--- a/src/libmongoc/src/mongoc/mongoc-crypt.c
+++ b/src/libmongoc/src/mongoc/mongoc-crypt.c
@@ -2001,11 +2001,8 @@ _mongoc_crypt_rewrap_many_datakey (_mongoc_crypt_t *crypt,
    mongocrypt_binary_t *filter_bin = NULL;
    bool ret = false;
 
-   if (master_key) {
-      // Caller must verify that `provider` is not-NULL when `master_key` is
-      // not-NULL.
-      BSON_ASSERT_PARAM (provider);
-   }
+   // Caller must ensure `provider` is provided alongside `master_key`.
+   BSON_ASSERT (!master_key || provider);
 
    bson_init (doc_out);
    state_machine = _state_machine_new (crypt);

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -5768,13 +5768,13 @@ test_rewrap_without_provider (void *unused)
    // 2. Call ``clientEncryption.rewrapManyDataKey`` with an empty ``filter``
    // and these options: (see below).
    {
-      bool ok = mongoc_client_encryption_rewrap_many_datakey (
-         clientEncryption,
-         NULL /* filter */,
-         NULL /* kms_provider */,
-         tmp_bson ("{'foo': 'bar'}"),
-         NULL /* result */,
-         &error);
+      bool ok =
+         mongoc_client_encryption_rewrap_many_datakey (clientEncryption,
+                                                       NULL /* filter */,
+                                                       NULL /* kms_provider */,
+                                                       tmp_bson ("{}"),
+                                                       NULL /* result */,
+                                                       &error);
       // Assert an error is returned from the driver suggesting that the
       // ``provider`` option is required.
       ASSERT (!ok && "expected error, but got success");

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -5693,7 +5693,7 @@ _test_rewrap_with_separate_client_encryption (const char *src_provider,
    mongoc_client_destroy (src_client);
 }
 
-/* Prose Test 16: Rewrap with separate ClientEncryption */
+/* Prose Test 16: Case 1: Rewrap with separate ClientEncryption */
 static void
 test_rewrap_with_separate_client_encryption (void *unused)
 {
@@ -5715,6 +5715,81 @@ test_rewrap_with_separate_client_encryption (void *unused)
          _test_rewrap_with_separate_client_encryption (src, dst);
       }
    }
+}
+
+/* Prose Test 16: Case 2: Rewrap returns error if masterKey is set, but provider
+ * is not set */
+static void
+test_rewrap_without_provider (void *unused)
+{
+   BSON_UNUSED (unused);
+
+   mongoc_uri_t *const uri = test_framework_get_uri ();
+   mongoc_client_encryption_opts_t *const ce_opts =
+      mongoc_client_encryption_opts_new ();
+   mongoc_client_t *const key_vault_client =
+      test_framework_client_new_from_uri (uri, NULL);
+
+   bson_error_t error = {0};
+
+   BSON_ASSERT (uri);
+   BSON_ASSERT (ce_opts);
+   BSON_ASSERT (key_vault_client);
+
+   test_framework_set_ssl_opts (key_vault_client);
+
+   {
+      mongoc_client_encryption_opts_set_keyvault_client (ce_opts,
+                                                         key_vault_client);
+      mongoc_client_encryption_opts_set_keyvault_namespace (
+         ce_opts, "keyvault", "datakeys");
+
+      {
+         bson_t *const kms_providers = _make_kms_providers (true, true);
+         BSON_ASSERT (kms_providers);
+         mongoc_client_encryption_opts_set_kms_providers (ce_opts,
+                                                          kms_providers);
+         bson_destroy (kms_providers);
+      }
+
+      {
+         bson_t *const tls_opts = _make_tls_opts ();
+         BSON_ASSERT (tls_opts);
+         mongoc_client_encryption_opts_set_tls_opts (ce_opts, tls_opts);
+         bson_destroy (tls_opts);
+      }
+   }
+
+   // 1. Create a ClientEncryption object named clientEncryption with these
+   // options: (see ce_opts).
+   mongoc_client_encryption_t *clientEncryption =
+      mongoc_client_encryption_new (ce_opts, &error);
+   ASSERT_OR_PRINT (clientEncryption, error);
+
+   // 2. Call ``clientEncryption.rewrapManyDataKey`` with an empty ``filter``
+   // and these options: (see below).
+   {
+      bool ok = mongoc_client_encryption_rewrap_many_datakey (
+         clientEncryption,
+         NULL /* filter */,
+         NULL /* kms_provider */,
+         tmp_bson ("{'foo': 'bar'}"),
+         NULL /* result */,
+         &error);
+      // Assert an error is returned from the driver suggesting that the
+      // ``provider`` option is required.
+      ASSERT (!ok && "expected error, but got success");
+      ASSERT_ERROR_CONTAINS (
+         error,
+         MONGOC_ERROR_CLIENT,
+         MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
+         "expected 'provider' to be set to identify type of 'master_key'");
+   }
+
+   mongoc_client_encryption_destroy (clientEncryption);
+   mongoc_client_encryption_opts_destroy (ce_opts);
+   mongoc_uri_destroy (uri);
+   mongoc_client_destroy (key_vault_client);
 }
 
 /* test_qe_docs_example tests the documentation example requested in
@@ -6921,13 +6996,20 @@ test_client_side_encryption_install (TestSuite *suite)
                       test_framework_skip_if_no_client_side_encryption,
                       test_framework_skip_if_max_wire_version_less_than_8);
    TestSuite_AddFull (suite,
-                      "/client_side_encryption/prose_test_16",
+                      "/client_side_encryption/prose_test_16/case1",
                       test_rewrap_with_separate_client_encryption,
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,
                       test_framework_skip_if_max_wire_version_less_than_8,
                       test_framework_skip_if_slow);
+   TestSuite_AddFull (suite,
+                      "/client_side_encryption/prose_test_16/case2",
+                      test_rewrap_without_provider,
+                      NULL,
+                      NULL,
+                      test_framework_skip_if_no_client_side_encryption,
+                      test_framework_skip_if_max_wire_version_less_than_8);
 
    /* Other, C driver specific, tests. */
    TestSuite_AddFull (suite,

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -5717,8 +5717,7 @@ test_rewrap_with_separate_client_encryption (void *unused)
    }
 }
 
-/* Prose Test 16: Case 2: Rewrap returns error if masterKey is set, but provider
- * is not set */
+/* Prose Test 16: Case 2: RewrapManyDataKeyOpts.provider is not optional. */
 static void
 test_rewrap_without_provider (void *unused)
 {

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -5777,7 +5777,7 @@ test_rewrap_without_provider (void *unused)
                                                        &error);
       // Assert an error is returned from the driver suggesting that the
       // ``provider`` option is required.
-      ASSERT (!ok && "expected error, but got success");
+      ASSERT_WITH_MSG (!ok, "expected error, but got success");
       ASSERT_ERROR_CONTAINS (
          error,
          MONGOC_ERROR_CLIENT,


### PR DESCRIPTION
# Summary
- return error if `masterKey` is set, but `provider` is not set for `rewrapManyDataKey`
- add prose test specified in DRIVERS-2441

# Background & Motivation

The specified API for `rewrapManyDataKey` does not permit calling with a set `masterKey` without a `provider`.

```typescript
    class ClientEncryption {
        rewrapManyDataKey(filter: Document, opts: RewrapManyDataKeyOpts | null): RewrapManyDataKeyResult;
    }
    class RewrapManyDataKeyOpts {
        provider: String
        masterKey: Optional<Document>
    }
```

Some driver implementations do not represent `RewrapManyDataKeyOpts` as a separate type. Instead, the `provider` and `masterKey` are both optional arguments to `RewrapManyDataKey`.

The C driver API permits setting `masterKey` without `provider`:
```c
MONGOC_EXPORT (bool)
mongoc_client_encryption_rewrap_many_datakey (
   mongoc_client_encryption_t *client_encryption,
   const bson_t *filter,
   const char *provider,
   const bson_t *master_key,
   mongoc_client_encryption_rewrap_many_datakey_result_t *result,
   bson_error_t *error);
```

The current behavior of `mongoc_client_encryption_rewrap_many_datakey` silently ignores the `master_key` option if `provider` is NULL.

This may result in unexpected behavior. A user may be attempting to rewrap keys with a new `master_key` and mistakenly passed a NULL `provider`. A NULL `provider` results in rewrapping with the same `master_key`.

The Java driver had similar behavior, which was fixed in [JAVA-4717](https://jira.mongodb.org/browse/JAVA-4717).
