### PR TITLE
Reduce internal component dependencies for mongoc-rpc

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-async-cmd-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-async-cmd-private.h
@@ -25,6 +25,7 @@
 #include "mongoc-async-private.h"
 #include "mongoc-array-private.h"
 #include "mongoc-buffer-private.h"
+#include "mongoc-cmd-private.h"
 #include "mongoc-rpc-private.h"
 #include "mongoc-stream.h"
 

--- a/src/libmongoc/src/mongoc/mongoc-async-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-async-cmd.c
@@ -20,6 +20,7 @@
 #include "mongoc-client.h"
 #include "mongoc-async-cmd-private.h"
 #include "mongoc-async-private.h"
+#include "mongoc-cluster-private.h"
 #include "mongoc-error.h"
 #include "mongoc-opcode.h"
 #include "mongoc-rpc-private.h"

--- a/src/libmongoc/src/mongoc/mongoc-cluster-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-private.h
@@ -257,6 +257,19 @@ _mongoc_cluster_get_auth_cmd_scram (mongoc_crypto_hash_algorithm_t algo,
                                     bson_error_t *error /* OUT */);
 #endif /* MONGOC_ENABLE_CRYPTO */
 
+char *
+_mongoc_rpc_compress (struct _mongoc_cluster_t *cluster,
+                      int32_t compressor_id,
+                      mongoc_rpc_t *rpc_le,
+                      bson_error_t *error);
+bool
+_mongoc_rpc_decompress (mongoc_rpc_t *rpc_le, uint8_t *buf, size_t buflen);
+
+bool
+_mongoc_rpc_decompress_if_necessary (mongoc_rpc_t *rpc,
+                                     mongoc_buffer_t *buffer /* IN/OUT */,
+                                     bson_error_t *error /* OUT */);
+
 BSON_END_DECLS
 
 

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -264,96 +264,6 @@ _mongoc_rpc_prep_command (mongoc_rpc_t *rpc,
 /*
  *--------------------------------------------------------------------------
  *
- * _mongoc_rpc_compress --
- *
- *       Takes a (little endian) rpc struct and creates a OP_COMPRESSED
- *       compressed opcode based on the provided compressor_id.
- *       The in-place updated rpc struct remains little endian.
- *
- * Side effects:
- *       Overwrites the RPC, and clears and overwrites the cluster buffer
- *       with the compressed results.
- *
- *--------------------------------------------------------------------------
- */
-
-static char *
-_mongoc_rpc_compress (struct _mongoc_cluster_t *cluster,
-                      int32_t compressor_id,
-                      mongoc_rpc_t *rpc_le,
-                      bson_error_t *error)
-{
-   const size_t allocate = BSON_UINT32_FROM_LE (rpc_le->header.msg_len) - 16u;
-   BSON_ASSERT (allocate > 0u);
-
-   char *const data = bson_malloc0 (allocate);
-   const size_t size = _mongoc_cluster_buffer_iovec (
-      cluster->iov.data, cluster->iov.len, 16, data);
-   size_t output_length =
-      mongoc_compressor_max_compressed_length (compressor_id, size);
-
-   if (!output_length) {
-      bson_set_error (error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "Could not determine compression bounds for %s",
-                      mongoc_compressor_id_to_name (compressor_id));
-      bson_free (data);
-      return NULL;
-   }
-
-   int32_t compression_level = -1;
-
-   if (compressor_id == MONGOC_COMPRESSOR_ZLIB_ID) {
-      compression_level = mongoc_uri_get_option_as_int32 (
-         cluster->uri, MONGOC_URI_ZLIBCOMPRESSIONLEVEL, -1);
-   }
-
-   BSON_ASSERT (size > 0u);
-
-   char *const output = (char *) bson_malloc0 (output_length);
-   if (mongoc_compress (compressor_id,
-                        compression_level,
-                        data,
-                        size,
-                        output,
-                        &output_length)) {
-      rpc_le->header.msg_len = 0;
-      rpc_le->compressed.original_opcode =
-         BSON_UINT32_FROM_LE (rpc_le->header.opcode);
-      rpc_le->header.opcode = MONGOC_OPCODE_COMPRESSED;
-      rpc_le->header.request_id =
-         BSON_UINT32_FROM_LE (rpc_le->header.request_id);
-      rpc_le->header.response_to =
-         BSON_UINT32_FROM_LE (rpc_le->header.response_to);
-
-      BSON_ASSERT (bson_in_range_unsigned (int32_t, size));
-      BSON_ASSERT (bson_in_range_unsigned (int32_t, output_length));
-
-      rpc_le->compressed.uncompressed_size = (int32_t) size;
-      rpc_le->compressed.compressor_id = compressor_id;
-      rpc_le->compressed.compressed_message = (const uint8_t *) output;
-      rpc_le->compressed.compressed_message_len = (int32_t) output_length;
-      bson_free (data);
-
-
-      _mongoc_array_destroy (&cluster->iov);
-      _mongoc_array_init (&cluster->iov, sizeof (mongoc_iovec_t));
-      _mongoc_rpc_gather (rpc_le, &cluster->iov);
-      _mongoc_rpc_swab_to_le (rpc_le);
-      return output;
-   } else {
-      MONGOC_WARNING ("Could not compress data with %s",
-                      mongoc_compressor_id_to_name (compressor_id));
-   }
-   bson_free (data);
-   bson_free (output);
-   return NULL;
-}
-
-/*
- *--------------------------------------------------------------------------
- *
  * mongoc_cluster_run_command_opquery --
  *
  *       Internal function to run a command on a given stream. @error and
@@ -3829,4 +3739,180 @@ mongoc_cluster_run_opmsg (mongoc_cluster_t *cluster,
    bson_free (output);
 
    return ok;
+}
+
+
+/*
+ *--------------------------------------------------------------------------
+ *
+ * _mongoc_rpc_compress --
+ *
+ *       Takes a (little endian) rpc struct and creates a OP_COMPRESSED
+ *       compressed opcode based on the provided compressor_id.
+ *       The in-place updated rpc struct remains little endian.
+ *
+ * Side effects:
+ *       Overwrites the RPC, and clears and overwrites the cluster buffer
+ *       with the compressed results.
+ *
+ *--------------------------------------------------------------------------
+ */
+
+char *
+_mongoc_rpc_compress (struct _mongoc_cluster_t *cluster,
+                      int32_t compressor_id,
+                      mongoc_rpc_t *rpc_le,
+                      bson_error_t *error)
+{
+   const size_t allocate = BSON_UINT32_FROM_LE (rpc_le->header.msg_len) - 16u;
+   BSON_ASSERT (allocate > 0u);
+
+   char *const data = bson_malloc0 (allocate);
+   const size_t size = _mongoc_cluster_buffer_iovec (
+      cluster->iov.data, cluster->iov.len, 16, data);
+   size_t output_length =
+      mongoc_compressor_max_compressed_length (compressor_id, size);
+
+   if (!output_length) {
+      bson_set_error (error,
+                      MONGOC_ERROR_COMMAND,
+                      MONGOC_ERROR_COMMAND_INVALID_ARG,
+                      "Could not determine compression bounds for %s",
+                      mongoc_compressor_id_to_name (compressor_id));
+      bson_free (data);
+      return NULL;
+   }
+
+   int32_t compression_level = -1;
+
+   if (compressor_id == MONGOC_COMPRESSOR_ZLIB_ID) {
+      compression_level = mongoc_uri_get_option_as_int32 (
+         cluster->uri, MONGOC_URI_ZLIBCOMPRESSIONLEVEL, -1);
+   }
+
+   BSON_ASSERT (size > 0u);
+
+   char *const output = (char *) bson_malloc0 (output_length);
+   if (mongoc_compress (compressor_id,
+                        compression_level,
+                        data,
+                        size,
+                        output,
+                        &output_length)) {
+      rpc_le->header.msg_len = 0;
+      rpc_le->compressed.original_opcode =
+         BSON_UINT32_FROM_LE (rpc_le->header.opcode);
+      rpc_le->header.opcode = MONGOC_OPCODE_COMPRESSED;
+      rpc_le->header.request_id =
+         BSON_UINT32_FROM_LE (rpc_le->header.request_id);
+      rpc_le->header.response_to =
+         BSON_UINT32_FROM_LE (rpc_le->header.response_to);
+
+      BSON_ASSERT (bson_in_range_unsigned (int32_t, size));
+      BSON_ASSERT (bson_in_range_unsigned (int32_t, output_length));
+
+      rpc_le->compressed.uncompressed_size = (int32_t) size;
+      rpc_le->compressed.compressor_id = compressor_id;
+      rpc_le->compressed.compressed_message = (const uint8_t *) output;
+      rpc_le->compressed.compressed_message_len = (int32_t) output_length;
+      bson_free (data);
+
+
+      _mongoc_array_destroy (&cluster->iov);
+      _mongoc_array_init (&cluster->iov, sizeof (mongoc_iovec_t));
+      _mongoc_rpc_gather (rpc_le, &cluster->iov);
+      _mongoc_rpc_swab_to_le (rpc_le);
+      return output;
+   } else {
+      MONGOC_WARNING ("Could not compress data with %s",
+                      mongoc_compressor_id_to_name (compressor_id));
+   }
+   bson_free (data);
+   bson_free (output);
+   return NULL;
+}
+
+/*
+ *--------------------------------------------------------------------------
+ *
+ * _mongoc_rpc_decompress --
+ *
+ *       Takes a (little endian) rpc struct assumed to be OP_COMPRESSED
+ *       and decompresses the opcode into its original opcode.
+ *       The in-place updated rpc struct remains little endian.
+ *
+ * Side effects:
+ *       Overwrites the RPC, along with the provided buf with the
+ *       compressed results.
+ *
+ *--------------------------------------------------------------------------
+ */
+
+bool
+_mongoc_rpc_decompress (mongoc_rpc_t *rpc_le, uint8_t *buf, size_t buflen)
+{
+   size_t uncompressed_size =
+      BSON_UINT32_FROM_LE (rpc_le->compressed.uncompressed_size);
+   bool ok;
+   size_t msg_len = BSON_UINT32_TO_LE (buflen);
+   const size_t original_uncompressed_size = uncompressed_size;
+
+   BSON_ASSERT (uncompressed_size <= buflen);
+   memcpy (buf, (void *) (&msg_len), 4);
+   memcpy (buf + 4, (void *) (&rpc_le->header.request_id), 4);
+   memcpy (buf + 8, (void *) (&rpc_le->header.response_to), 4);
+   memcpy (buf + 12, (void *) (&rpc_le->compressed.original_opcode), 4);
+
+   ok = mongoc_uncompress (rpc_le->compressed.compressor_id,
+                           rpc_le->compressed.compressed_message,
+                           rpc_le->compressed.compressed_message_len,
+                           buf + 16,
+                           &uncompressed_size);
+
+   BSON_ASSERT (original_uncompressed_size == uncompressed_size);
+
+   if (ok) {
+      return _mongoc_rpc_scatter (rpc_le, buf, buflen);
+   }
+
+   return false;
+}
+
+/* If rpc is OP_COMPRESSED, decompress it into buffer.
+ *
+ * Assumes rpc is still in network little-endian representation (i.e.
+ * _mongoc_rpc_swab_to_le has not been called).
+ * Returns true if rpc is not OP_COMPRESSED (and is a no-op) or if decompression
+ * succeeds.
+ * Return false and sets error otherwise.
+ */
+bool
+_mongoc_rpc_decompress_if_necessary (mongoc_rpc_t *rpc,
+                                     mongoc_buffer_t *buffer /* IN/OUT */,
+                                     bson_error_t *error /* OUT */)
+{
+   uint8_t *buf = NULL;
+   size_t len;
+
+   if (BSON_UINT32_FROM_LE (rpc->header.opcode) != MONGOC_OPCODE_COMPRESSED) {
+      return true;
+   }
+
+   len = BSON_UINT32_FROM_LE (rpc->compressed.uncompressed_size) +
+         sizeof (mongoc_rpc_header_t);
+
+   buf = bson_malloc0 (len);
+   if (!_mongoc_rpc_decompress (rpc, buf, len)) {
+      bson_free (buf);
+      bson_set_error (error,
+                      MONGOC_ERROR_PROTOCOL,
+                      MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
+                      "Could not decompress server reply");
+      return false;
+   }
+
+   _mongoc_buffer_destroy (buffer);
+   _mongoc_buffer_init (buffer, buf, len, NULL, NULL);
+
+   return true;
 }

--- a/src/libmongoc/src/mongoc/mongoc-rpc-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-rpc-private.h
@@ -14,21 +14,19 @@
  * limitations under the License.
  */
 
-#include "mongoc-prelude.h"
-
 #ifndef MONGOC_RPC_PRIVATE_H
 #define MONGOC_RPC_PRIVATE_H
 
-#include <bson/bson.h>
-#include <stddef.h>
+#include "mongoc-prelude.h"
 
 #include "mongoc-array-private.h"
-#include "mongoc-cmd-private.h"
 #include "mongoc-iovec.h"
-#include "mongoc-write-concern.h"
-#include "mongoc-flags.h"
-/* forward declaration */
-struct _mongoc_cluster_t;
+
+#include <bson/bson.h>
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 
 BSON_BEGIN_DECLS
 
@@ -156,11 +154,6 @@ bool
 _mongoc_rpc_reply_get_first (mongoc_rpc_reply_t *reply, bson_t *bson);
 bool
 _mongoc_rpc_reply_get_first_msg (mongoc_rpc_msg_t *reply, bson_t *bson);
-
-void
-_mongoc_rpc_prep_command (mongoc_rpc_t *rpc,
-                          const char *cmd_ns,
-                          mongoc_cmd_t *cmd);
 bool
 _mongoc_rpc_check_ok (mongoc_rpc_t *rpc,
                       int32_t error_api_version,
@@ -178,17 +171,6 @@ _mongoc_cmd_check_ok_no_wce (const bson_t *doc,
 
 bool
 _mongoc_rpc_decompress (mongoc_rpc_t *rpc_le, uint8_t *buf, size_t buflen);
-
-char *
-_mongoc_rpc_compress (struct _mongoc_cluster_t *cluster,
-                      int32_t compressor_id,
-                      mongoc_rpc_t *rpc_le,
-                      bson_error_t *error);
-
-bool
-_mongoc_rpc_decompress_if_necessary (mongoc_rpc_t *rpc,
-                                     mongoc_buffer_t *buffer,
-                                     bson_error_t *error);
 
 BSON_END_DECLS
 

--- a/src/libmongoc/src/mongoc/mongoc-rpc-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-rpc-private.h
@@ -169,9 +169,6 @@ _mongoc_cmd_check_ok_no_wce (const bson_t *doc,
                              int32_t error_api_version,
                              bson_error_t *error);
 
-bool
-_mongoc_rpc_decompress (mongoc_rpc_t *rpc_le, uint8_t *buf, size_t buflen);
-
 BSON_END_DECLS
 
 

--- a/src/libmongoc/src/mongoc/mongoc-rpc.c
+++ b/src/libmongoc/src/mongoc/mongoc-rpc.c
@@ -15,15 +15,11 @@
  */
 
 
-#include <bson/bson.h>
-
-#include "mongoc.h"
 #include "mongoc-rpc-private.h"
+
+#include "mongoc-compression-private.h"
 #include "mongoc-counters-private.h"
 #include "mongoc-trace-private.h"
-#include "mongoc-util-private.h"
-#include "mongoc-compression-private.h"
-#include "mongoc-cluster-private.h"
 
 
 #define RPC(_name, _code)                                               \
@@ -875,96 +871,6 @@ _mongoc_rpc_decompress (mongoc_rpc_t *rpc_le, uint8_t *buf, size_t buflen)
 /*
  *--------------------------------------------------------------------------
  *
- * _mongoc_rpc_compress --
- *
- *       Takes a (little endian) rpc struct and creates a OP_COMPRESSED
- *       compressed opcode based on the provided compressor_id.
- *       The in-place updated rpc struct remains little endian.
- *
- * Side effects:
- *       Overwrites the RPC, and clears and overwrites the cluster buffer
- *       with the compressed results.
- *
- *--------------------------------------------------------------------------
- */
-
-char *
-_mongoc_rpc_compress (struct _mongoc_cluster_t *cluster,
-                      int32_t compressor_id,
-                      mongoc_rpc_t *rpc_le,
-                      bson_error_t *error)
-{
-   const size_t allocate = BSON_UINT32_FROM_LE (rpc_le->header.msg_len) - 16u;
-   BSON_ASSERT (allocate > 0u);
-
-   char *const data = bson_malloc0 (allocate);
-   const size_t size = _mongoc_cluster_buffer_iovec (
-      cluster->iov.data, cluster->iov.len, 16, data);
-   size_t output_length =
-      mongoc_compressor_max_compressed_length (compressor_id, size);
-
-   if (!output_length) {
-      bson_set_error (error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "Could not determine compression bounds for %s",
-                      mongoc_compressor_id_to_name (compressor_id));
-      bson_free (data);
-      return NULL;
-   }
-
-   int32_t compression_level = -1;
-
-   if (compressor_id == MONGOC_COMPRESSOR_ZLIB_ID) {
-      compression_level = mongoc_uri_get_option_as_int32 (
-         cluster->uri, MONGOC_URI_ZLIBCOMPRESSIONLEVEL, -1);
-   }
-
-   BSON_ASSERT (size > 0u);
-
-   char *const output = (char *) bson_malloc0 (output_length);
-   if (mongoc_compress (compressor_id,
-                        compression_level,
-                        data,
-                        size,
-                        output,
-                        &output_length)) {
-      rpc_le->header.msg_len = 0;
-      rpc_le->compressed.original_opcode =
-         BSON_UINT32_FROM_LE (rpc_le->header.opcode);
-      rpc_le->header.opcode = MONGOC_OPCODE_COMPRESSED;
-      rpc_le->header.request_id =
-         BSON_UINT32_FROM_LE (rpc_le->header.request_id);
-      rpc_le->header.response_to =
-         BSON_UINT32_FROM_LE (rpc_le->header.response_to);
-
-      BSON_ASSERT (bson_in_range_unsigned (int32_t, size));
-      BSON_ASSERT (bson_in_range_unsigned (int32_t, output_length));
-
-      rpc_le->compressed.uncompressed_size = (int32_t) size;
-      rpc_le->compressed.compressor_id = compressor_id;
-      rpc_le->compressed.compressed_message = (const uint8_t *) output;
-      rpc_le->compressed.compressed_message_len = (int32_t) output_length;
-      bson_free (data);
-
-
-      _mongoc_array_destroy (&cluster->iov);
-      _mongoc_array_init (&cluster->iov, sizeof (mongoc_iovec_t));
-      _mongoc_rpc_gather (rpc_le, &cluster->iov);
-      _mongoc_rpc_swab_to_le (rpc_le);
-      return output;
-   } else {
-      MONGOC_WARNING ("Could not compress data with %s",
-                      mongoc_compressor_id_to_name (compressor_id));
-   }
-   bson_free (data);
-   bson_free (output);
-   return NULL;
-}
-
-/*
- *--------------------------------------------------------------------------
- *
  * _mongoc_rpc_scatter --
  *
  *       Takes a (little endian) rpc struct and scatters the buffer.
@@ -1098,46 +1004,6 @@ _mongoc_rpc_reply_get_first (mongoc_rpc_reply_t *reply, bson_t *bson)
    }
 
    return bson_init_static (bson, reply->documents, len);
-}
-
-
-/*
- *--------------------------------------------------------------------------
- *
- * _mongoc_rpc_prep_command --
- *
- *       Prepare an RPC for mongoc_cluster_run_command_rpc. @cmd_ns and
- *       @cmd must not be freed or modified while the RPC is in use.
- *
- * Side effects:
- *       Fills out the RPC, including pointers into @cmd_ns and @command.
- *
- *--------------------------------------------------------------------------
- */
-
-void
-_mongoc_rpc_prep_command (mongoc_rpc_t *rpc,
-                          const char *cmd_ns,
-                          mongoc_cmd_t *cmd)
-
-{
-   rpc->header.msg_len = 0;
-   rpc->header.request_id = 0;
-   rpc->header.response_to = 0;
-   rpc->header.opcode = MONGOC_OPCODE_QUERY;
-   rpc->query.collection = cmd_ns;
-   rpc->query.skip = 0;
-   rpc->query.n_return = -1;
-   rpc->query.fields = NULL;
-   rpc->query.query = bson_get_data (cmd->command);
-
-   /* Find, getMore And killCursors Commands Spec: "When sending a find command
-    * rather than a legacy OP_QUERY find, only the secondaryOk flag is honored."
-    * For other cursor-typed commands like aggregate, only secondaryOk can be
-    * set. Clear bits except secondaryOk; leave secondaryOk set only if it is
-    * already.
-    */
-   rpc->query.flags = cmd->query_flags & MONGOC_QUERY_SECONDARY_OK;
 }
 
 
@@ -1419,43 +1285,4 @@ _mongoc_rpc_check_ok (mongoc_rpc_t *rpc,
 
 
    RETURN (true);
-}
-
-/* If rpc is OP_COMPRESSED, decompress it into buffer.
- *
- * Assumes rpc is still in network little-endian representation (i.e.
- * _mongoc_rpc_swab_to_le has not been called).
- * Returns true if rpc is not OP_COMPRESSED (and is a no-op) or if decompression
- * succeeds.
- * Return false and sets error otherwise.
- */
-bool
-_mongoc_rpc_decompress_if_necessary (mongoc_rpc_t *rpc,
-                                     mongoc_buffer_t *buffer /* IN/OUT */,
-                                     bson_error_t *error /* OUT */)
-{
-   uint8_t *buf = NULL;
-   size_t len;
-
-   if (BSON_UINT32_FROM_LE (rpc->header.opcode) != MONGOC_OPCODE_COMPRESSED) {
-      return true;
-   }
-
-   len = BSON_UINT32_FROM_LE (rpc->compressed.uncompressed_size) +
-         sizeof (mongoc_rpc_header_t);
-
-   buf = bson_malloc0 (len);
-   if (!_mongoc_rpc_decompress (rpc, buf, len)) {
-      bson_free (buf);
-      bson_set_error (error,
-                      MONGOC_ERROR_PROTOCOL,
-                      MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
-                      "Could not decompress server reply");
-      return false;
-   }
-
-   _mongoc_buffer_destroy (buffer);
-   _mongoc_buffer_init (buffer, buf, len, NULL, NULL);
-
-   return true;
 }

--- a/src/libmongoc/src/mongoc/mongoc-server-monitor.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-monitor.c
@@ -210,6 +210,46 @@ _server_monitor_append_cluster_time (mongoc_server_monitor_t *server_monitor,
    }
    mc_tpld_drop_ref (&td);
 }
+
+/* If rpc is OP_COMPRESSED, decompress it into buffer.
+ *
+ * Assumes rpc is still in network little-endian representation (i.e.
+ * _mongoc_rpc_swab_to_le has not been called).
+ * Returns true if rpc is not OP_COMPRESSED (and is a no-op) or if decompression
+ * succeeds.
+ * Return false and sets error otherwise.
+ */
+static bool
+_mongoc_rpc_decompress_if_necessary (mongoc_rpc_t *rpc,
+                                     mongoc_buffer_t *buffer /* IN/OUT */,
+                                     bson_error_t *error /* OUT */)
+{
+   uint8_t *buf = NULL;
+   size_t len;
+
+   if (BSON_UINT32_FROM_LE (rpc->header.opcode) != MONGOC_OPCODE_COMPRESSED) {
+      return true;
+   }
+
+   len = BSON_UINT32_FROM_LE (rpc->compressed.uncompressed_size) +
+         sizeof (mongoc_rpc_header_t);
+
+   buf = bson_malloc0 (len);
+   if (!_mongoc_rpc_decompress (rpc, buf, len)) {
+      bson_free (buf);
+      bson_set_error (error,
+                      MONGOC_ERROR_PROTOCOL,
+                      MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
+                      "Could not decompress server reply");
+      return false;
+   }
+
+   _mongoc_buffer_destroy (buffer);
+   _mongoc_buffer_init (buffer, buf, len, NULL, NULL);
+
+   return true;
+}
+
 static bool
 _server_monitor_send_and_recv_hello_opmsg (
    mongoc_server_monitor_t *server_monitor,


### PR DESCRIPTION
Motivated by CDRIVER-4625. Moves the `_mongoc_rpc_prep_command`, `_mongoc_rpc_compress`, and `_mongoc_rpc_decompress_if_necessary` functions into the components where they are actually required. This significantly reduces the internal component dependencies required by the mongoc-rpc component.