### PR TITLE
CDRIVER-4173 clarify the `reply` contains the full server reply

### DIFF
--- a/src/libmongoc/doc/conf.py
+++ b/src/libmongoc/doc/conf.py
@@ -75,6 +75,9 @@ rst_prolog = '''
 
     Range algorithm is experimental only and not intended for public use. It is subject to breaking changes.
 
+.. _the findAndModify command:
+    https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+
 '''
 
 

--- a/src/libmongoc/doc/mongoc_collection_find_and_modify.rst
+++ b/src/libmongoc/doc/mongoc_collection_find_and_modify.rst
@@ -45,6 +45,8 @@ As of MongoDB 3.2, the :symbol:`mongoc_write_concern_t` specified on the :symbol
 
 ``reply`` is always initialized, and must be freed with :symbol:`bson:bson_destroy()`.
 
+On success, the output ``reply`` contains the full server reply to the ``findAndModify`` command. See the `MongoDB Manual page for findAndModify <https://www.mongodb.com/docs/manual/reference/command/findAndModify/#output>`_ for the expected server reply.
+
 Errors
 ------
 

--- a/src/libmongoc/doc/mongoc_collection_find_and_modify.rst
+++ b/src/libmongoc/doc/mongoc_collection_find_and_modify.rst
@@ -55,7 +55,7 @@ Errors are propagated via the ``error`` parameter.
 Returns
 -------
 
-Returns either the document before or after modification based on the ``_new`` parameter.
+Returns ``true`` if successful. Returns ``false`` and sets ``error`` if there are invalid arguments or a server or network error.
 
 A write concern timeout or write concern error is considered a failure.
 

--- a/src/libmongoc/doc/mongoc_collection_find_and_modify.rst
+++ b/src/libmongoc/doc/mongoc_collection_find_and_modify.rst
@@ -55,8 +55,7 @@ Errors are propagated via the ``error`` parameter.
 Returns
 -------
 
-Returns ``true`` if successful. Returns ``false`` and sets ``error`` if there are invalid arguments or a server or network error.
-
+If given invalid arguments or a server/network error occurs, returns ``false`` and sets ``error``. Otherwise, succeeds and returns ``true``.
 A write concern timeout or write concern error is considered a failure.
 
 .. seealso::

--- a/src/libmongoc/doc/mongoc_collection_find_and_modify.rst
+++ b/src/libmongoc/doc/mongoc_collection_find_and_modify.rst
@@ -41,7 +41,7 @@ Update and return an object.
 
 This is a thin wrapper around the ``findAndModify`` command. Either ``update`` or ``_remove`` arguments are required.
 
-As of MongoDB 3.2, the :symbol:`mongoc_write_concern_t` specified on the :symbol:`mongoc_collection_t` will be used, if any.
+The :symbol:`mongoc_write_concern_t` specified on the :symbol:`mongoc_collection_t` will be used, if any.
 
 ``reply`` is always initialized, and must be freed with :symbol:`bson:bson_destroy()`.
 

--- a/src/libmongoc/doc/mongoc_collection_find_and_modify.rst
+++ b/src/libmongoc/doc/mongoc_collection_find_and_modify.rst
@@ -41,7 +41,7 @@ Update and return an object.
 
 This is a thin wrapper around the ``findAndModify`` command. Either ``update`` or ``_remove`` arguments are required.
 
-The :symbol:`mongoc_write_concern_t` specified on the :symbol:`mongoc_collection_t` will be used, if any.
+As of MongoDB 3.2, the :symbol:`mongoc_write_concern_t` specified on the :symbol:`mongoc_collection_t` will be used, if any.
 
 ``reply`` is always initialized, and must be freed with :symbol:`bson:bson_destroy()`.
 

--- a/src/libmongoc/doc/mongoc_collection_find_and_modify_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_collection_find_and_modify_with_opts.rst
@@ -34,6 +34,8 @@ Update and return an object.
 
 If an unacknowledged write concern is set (through :symbol:`mongoc_find_and_modify_opts_append`), the output ``reply`` is always an empty document.
 
+On success, the output ``reply`` contains the full server reply to the ``findAndModify`` command. See the `MongoDB Manual page for findAndModify <https://www.mongodb.com/docs/manual/reference/command/findAndModify/#output>`_ for the expected server reply.
+
 Errors
 ------
 

--- a/src/libmongoc/doc/mongoc_find_and_modify_opts_append.rst
+++ b/src/libmongoc/doc/mongoc_find_and_modify_opts_append.rst
@@ -16,12 +16,12 @@ Parameters
 ----------
 
 * ``opts``: A :symbol:`mongoc_find_and_modify_opts_t`.
-* ``extra``: A :symbol:`bson:bson_t` with fields and values to append directly to the findAndModify command sent to the server.
+* ``extra``: A :symbol:`bson:bson_t` with fields and values to append directly to `the findAndModify command`_ sent to the server.
 
 Description
 -----------
 
-Adds arbitrary options to a `findAndModify <https://www.mongodb.com/docs/manual/reference/command/findAndModify/>`_ command.
+Adds arbitrary options to `the findAndModify command`_.
 
 ``extra`` does not have to remain valid after calling this function.
 

--- a/src/libmongoc/doc/mongoc_find_and_modify_opts_set_bypass_document_validation.rst
+++ b/src/libmongoc/doc/mongoc_find_and_modify_opts_set_bypass_document_validation.rst
@@ -12,6 +12,8 @@ Synopsis
   mongoc_find_and_modify_opts_set_bypass_document_validation (
      mongoc_find_and_modify_opts_t *opts, bool bypass);
 
+This option is only available when talking to MongoDB 3.2 and later.
+
 Parameters
 ----------
 

--- a/src/libmongoc/doc/mongoc_find_and_modify_opts_set_bypass_document_validation.rst
+++ b/src/libmongoc/doc/mongoc_find_and_modify_opts_set_bypass_document_validation.rst
@@ -12,8 +12,6 @@ Synopsis
   mongoc_find_and_modify_opts_set_bypass_document_validation (
      mongoc_find_and_modify_opts_t *opts, bool bypass);
 
-This option is only available when talking to MongoDB 3.2 and later.
-
 Parameters
 ----------
 

--- a/src/libmongoc/doc/mongoc_find_and_modify_opts_t.rst
+++ b/src/libmongoc/doc/mongoc_find_and_modify_opts_t.rst
@@ -12,7 +12,7 @@ Synopsis
 
 It was created to be able to accommodate new arguments to the MongoDB find_and_modify command.
 
-As of MongoDB 3.2, the :symbol:`mongoc_write_concern_t` specified on the :symbol:`mongoc_collection_t` will be used, if any.
+The :symbol:`mongoc_write_concern_t` specified on the :symbol:`mongoc_collection_t` will be used, if any.
 
 .. _mongoc_collection_find_and_modify_with_opts_example:
 

--- a/src/libmongoc/doc/mongoc_find_and_modify_opts_t.rst
+++ b/src/libmongoc/doc/mongoc_find_and_modify_opts_t.rst
@@ -10,7 +10,7 @@ Synopsis
 
 ``mongoc_find_and_modify_opts_t`` is a builder interface to construct a `find_and_modify <https://www.mongodb.com/docs/manual/reference/command/findAndModify/>`_ command.
 
-It was created to be able to accommodate new arguments to the MongoDB find_and_modify command.
+It was created to be able to accommodate new arguments to the `MongoDB findAndModify command <https://www.mongodb.com/docs/manual/reference/command/findAndModify/>`_.
 
 The :symbol:`mongoc_write_concern_t` specified on the :symbol:`mongoc_collection_t` will be used, if any.
 

--- a/src/libmongoc/doc/mongoc_find_and_modify_opts_t.rst
+++ b/src/libmongoc/doc/mongoc_find_and_modify_opts_t.rst
@@ -12,7 +12,7 @@ Synopsis
 
 It was created to be able to accommodate new arguments to the `MongoDB findAndModify command <https://www.mongodb.com/docs/manual/reference/command/findAndModify/>`_.
 
-The :symbol:`mongoc_write_concern_t` specified on the :symbol:`mongoc_collection_t` will be used, if any.
+As of MongoDB 3.2, the :symbol:`mongoc_write_concern_t` specified on the :symbol:`mongoc_collection_t` will be used, if any.
 
 .. _mongoc_collection_find_and_modify_with_opts_example:
 

--- a/src/libmongoc/doc/mongoc_find_and_modify_opts_t.rst
+++ b/src/libmongoc/doc/mongoc_find_and_modify_opts_t.rst
@@ -8,9 +8,9 @@ find_and_modify abstraction
 Synopsis
 --------
 
-``mongoc_find_and_modify_opts_t`` is a builder interface to construct a `find_and_modify <https://www.mongodb.com/docs/manual/reference/command/findAndModify/>`_ command.
+``mongoc_find_and_modify_opts_t`` is a builder interface to construct `the findAndModify command`_.
 
-It was created to be able to accommodate new arguments to the `MongoDB findAndModify command <https://www.mongodb.com/docs/manual/reference/command/findAndModify/>`_.
+It was created to be able to accommodate new arguments to `the findAndModify command`_.
 
 As of MongoDB 3.2, the :symbol:`mongoc_write_concern_t` specified on the :symbol:`mongoc_collection_t` will be used, if any.
 


### PR DESCRIPTION
# Summary

Update the documentation of `mongoc_collection_find_and_modify` and `mongoc_collection_find_and_modify_with_opts` to clarify the `reply` contains the full server reply.

# Background & Motivation

See CDRIVER-4173. The current documentation suggested:

> Returns either the document before or after modification based on the _new parameter.

This is really referring to the `value` field inside the server reply:

```js
{
	"lastErrorObject": {
		"n": 1,
		"updatedExisting": true
	},
	"value": "<here is the document>",
	"ok": 1.0
}
```