### PR TITLE
CDRIVER-4291 do not pass username to SSPI when password is not set

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-sspi.c
+++ b/src/libmongoc/src/mongoc/mongoc-sspi.c
@@ -204,7 +204,7 @@ _mongoc_sspi_auth_sspi_client_init (WCHAR *service,
                                        /* LogonID (We don't use this) */
                                        NULL,
                                        /* AuthData */
-                                       user ? &authIdentity : NULL,
+                                       password ? &authIdentity : NULL,
                                        /* Always NULL */
                                        NULL,
                                        /* Always NULL */


### PR DESCRIPTION
# Summary

Do not pass username to SSPI when password is not set

# Background & Motivation

This is intended to fix an [observed error](https://jira.mongodb.org/browse/HELP-24935?focusedCommentId=5412230&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-5412230) when authenticating with GSSAPI with Windows SSPI. This appears to be the caused by the issue described in DRIVERS-2180.

The URI for GSSAPI may omit the password. The [Auth specification for GSSAPI](https://github.com/mongodb/specifications/blob/840e6d49c354656bff11b2622f0d3001b39d9403/source/auth/auth.rst#gssapi) notes:

> password
> MAY be specified. If omitted, drivers MUST NOT pass the username without password to SSPI on Windows and instead use the default credentials.

When the username is set and password omited from the URI, the C driver [passes the pAuthData to AcquireCredentialsHandleW](https://github.com/mongodb/mongo-c-driver/blob/d83922ba19fa38f57aa9c1a6317caad5fb4071f1/src/libmongoc/src/mongoc/mongoc-sspi.c#L207). This appears to result in an error `AcquireCredentialsHandle: No credentials are available in the security package`.

When the username is set and password omited from the URI, the legacy `mongo` shell [passes NULL for pAuthData to AcquireCredentialsHandleW](https://github.com/mongodb/mongo/blob/51f7854c4a91fcc029aebc578941e6b225dcb3bc/src/mongo/client/sasl_sspi.cpp#L183).