### PR TITLE
CDRIVER-3717 show dev packages in install instructions

### DIFF
--- a/src/libmongoc/doc/installing.rst
+++ b/src/libmongoc/doc/installing.rst
@@ -32,7 +32,9 @@ The libmongoc package is available on recent versions of Debian and Ubuntu.
 
 .. code-block:: none
 
-  $ apt-get install libmongoc-1.0-0
+  $ apt-get install libmongoc-dev
+
+The ``libmongoc-dev`` package includes headers required to build applications using libmongoc. To check which version is available, see `https://packages.debian.org/stable/libmongoc-dev <https://packages.debian.org/stable/libmongoc-dev>`_. To only install the libraries without headers, install the ``libmongoc-1.0-0`` package.
 
 On Fedora, a mongo-c-driver package is available in the default repositories and can be installed with:
 
@@ -62,7 +64,9 @@ The libbson package is available on recent versions of Debian and Ubuntu. If you
 
 .. code-block:: none
 
-  $ apt-get install libbson-1.0-0
+  $ apt-get install libbson-dev
+
+The ``libbson-dev`` package includes headers required to build applications using libbson. To check which version is available, see `https://packages.debian.org/stable/libbson-dev <https://packages.debian.org/stable/libbson-dev>`_. To only install the libraries without headers, install the ``libbson-1.0-0`` package.
 
 On Fedora, a libbson package is available in the default repositories and can be installed with:
 

--- a/src/libmongoc/doc/installing.rst
+++ b/src/libmongoc/doc/installing.rst
@@ -34,7 +34,7 @@ The libmongoc package is available on recent versions of Debian and Ubuntu.
 
   $ apt-get install libmongoc-dev
 
-The ``libmongoc-dev`` package includes headers required to build applications using libmongoc. To check which version is available, see `https://packages.debian.org/stable/libmongoc-dev <https://packages.debian.org/stable/libmongoc-dev>`_. To only install the libraries without headers, install the ``libmongoc-1.0-0`` package.
+The ``libmongoc-dev`` package includes headers required to build applications using libmongoc. To check which version is available, see https://packages.debian.org/stable/libmongoc-dev. To only install the libraries without headers, install the ``libmongoc-1.0-0`` package.
 
 On Fedora, a mongo-c-driver package is available in the default repositories and can be installed with:
 
@@ -42,7 +42,7 @@ On Fedora, a mongo-c-driver package is available in the default repositories and
 
   $ dnf install mongo-c-driver-devel
 
-The ``mongo-c-driver-devel`` package includes headers required to build applications using libmongoc. To check which version is available, see `https://packages.fedoraproject.org/pkgs/mongo-c-driver/mongo-c-driver-devel/ <https://packages.fedoraproject.org/pkgs/mongo-c-driver/mongo-c-driver-devel/>`_. To only install the libraries without headers, install the ``mongo-c-driver`` package.
+The ``mongo-c-driver-devel`` package includes headers required to build applications using libmongoc. To check which version is available, see https://packages.fedoraproject.org/pkgs/mongo-c-driver/mongo-c-driver-devel. To only install the libraries without headers, install the ``mongo-c-driver`` package.
 
 On recent Red Hat systems, such as CentOS and RHEL 7, a mongo-c-driver-devel package is available in the `EPEL <https://fedoraproject.org/wiki/EPEL>`_ repository. The package can be installed with:
 
@@ -68,7 +68,7 @@ The libbson package is available on recent versions of Debian and Ubuntu. If you
 
   $ apt-get install libbson-dev
 
-The ``libbson-dev`` package includes headers required to build applications using libbson. To check which version is available, see `https://packages.debian.org/stable/libbson-dev <https://packages.debian.org/stable/libbson-dev>`_. To only install the libraries without headers, install the ``libbson-1.0-0`` package.
+The ``libbson-dev`` package includes headers required to build applications using libbson. To check which version is available, see https://packages.debian.org/stable/libbson-dev. To only install the libraries without headers, install the ``libbson-1.0-0`` package.
 
 On Fedora, a libbson package is available in the default repositories and can be installed with:
 
@@ -77,7 +77,7 @@ On Fedora, a libbson package is available in the default repositories and can be
   $ dnf install libbson-devel
 
 The ``libbson-devel`` package includes headers required to build applications using libbson. To check
-which version is available, see `https://packages.fedoraproject.org/pkgs/mongo-c-driver/libbson-devel/ <https://packages.fedoraproject.org/pkgs/mongo-c-driver/libbson-devel/>`_. To only install the libraries without headers, install the ``libbson`` package.
+which version is available, see https://packages.fedoraproject.org/pkgs/mongo-c-driver/libbson-devel. To only install the libraries without headers, install the ``libbson`` package.
 
 On recent Red Hat systems, such as CentOS and RHEL 7, a libbson package is available in the `EPEL <https://fedoraproject.org/wiki/EPEL>`_ repository.
 The package can be installed with:

--- a/src/libmongoc/doc/installing.rst
+++ b/src/libmongoc/doc/installing.rst
@@ -40,13 +40,15 @@ On Fedora, a mongo-c-driver package is available in the default repositories and
 
 .. code-block:: none
 
-  $ dnf install mongo-c-driver
+  $ dnf install mongo-c-driver-devel
 
-On recent Red Hat systems, such as CentOS and RHEL 7, a mongo-c-driver package is available in the `EPEL <https://fedoraproject.org/wiki/EPEL>`_ repository. To check which version is available, see `https://packages.fedoraproject.org/pkgs/mongo-c-driver/mongo-c-driver/ <https://packages.fedoraproject.org/pkgs/mongo-c-driver/mongo-c-driver/>`_. The package can be installed with:
+The ``mongo-c-driver-devel`` package includes headers required to build applications using libmongoc. To check which version is available, see `https://packages.fedoraproject.org/pkgs/mongo-c-driver/mongo-c-driver-devel/ <https://packages.fedoraproject.org/pkgs/mongo-c-driver/mongo-c-driver-devel/>`_. To only install the libraries without headers, install the ``mongo-c-driver`` package.
+
+On recent Red Hat systems, such as CentOS and RHEL 7, a mongo-c-driver-devel package is available in the `EPEL <https://fedoraproject.org/wiki/EPEL>`_ repository. The package can be installed with:
 
 .. code-block:: none
 
-  $ yum install mongo-c-driver
+  $ yum install mongo-c-driver-devel
 
 On macOS systems with Homebrew, the mongo-c-driver package can be installed with:
 
@@ -72,16 +74,17 @@ On Fedora, a libbson package is available in the default repositories and can be
 
 .. code-block:: none
 
-  $ dnf install libbson
+  $ dnf install libbson-devel
 
-On recent Red Hat systems, such as CentOS and RHEL 7, a libbson package
-is available in the `EPEL <https://fedoraproject.org/wiki/EPEL>`_ repository. To check
-which version is available, see `https://packages.fedoraproject.org/pkgs/mongo-c-driver/libbson/ <https://packages.fedoraproject.org/pkgs/mongo-c-driver/libbson/>`_.
+The ``libbson-devel`` package includes headers required to build applications using libbson. To check
+which version is available, see `https://packages.fedoraproject.org/pkgs/mongo-c-driver/libbson-devel/ <https://packages.fedoraproject.org/pkgs/mongo-c-driver/libbson-devel/>`_. To only install the libraries without headers, install the ``libbson`` package.
+
+On recent Red Hat systems, such as CentOS and RHEL 7, a libbson package is available in the `EPEL <https://fedoraproject.org/wiki/EPEL>`_ repository.
 The package can be installed with:
 
 .. code-block:: none
 
-  $ yum install libbson
+  $ yum install libbson-devel
 
 Build environment
 -----------------

--- a/src/libmongoc/doc/installing.rst
+++ b/src/libmongoc/doc/installing.rst
@@ -34,7 +34,7 @@ The libmongoc package is available on recent versions of Debian and Ubuntu.
 
   $ apt-get install libmongoc-dev
 
-The ``libmongoc-dev`` package includes headers required to build applications using libmongoc. To check which version is available, see https://packages.debian.org/stable/libmongoc-dev. To only install the libraries without headers, install the ``libmongoc-1.0-0`` package.
+The ``libmongoc-dev`` package includes headers required to build applications using libmongoc. To check which version is available, run ``apt-cache policy libmongoc-dev``. To only install the libraries without headers, install the ``libmongoc-1.0-0`` package.
 
 On Fedora, a mongo-c-driver package is available in the default repositories and can be installed with:
 
@@ -68,7 +68,7 @@ The libbson package is available on recent versions of Debian and Ubuntu. If you
 
   $ apt-get install libbson-dev
 
-The ``libbson-dev`` package includes headers required to build applications using libbson. To check which version is available, see https://packages.debian.org/stable/libbson-dev. To only install the libraries without headers, install the ``libbson-1.0-0`` package.
+The ``libbson-dev`` package includes headers required to build applications using libbson. To check which version is available, run ``apt-cache policy libbson-dev``. To only install the libraries without headers, install the ``libbson-1.0-0`` package.
 
 On Fedora, a libbson package is available in the default repositories and can be installed with:
 


### PR DESCRIPTION
# Summary
- Document install of `libmongoc-dev` and `libbson-dev` packages.
- Document install of `mongo-c-driver-devel` and `libbson-devel` packages.

# Background & Motivation

The [Install libmongoc with a Package Manager](https://mongoc.org/libmongoc/1.23.4/installing.html#install-libmongoc-with-a-package-manager) instructions show install of the `libmongoc-1.0-0` package.

The `libmongoc-1.0-0` package does not include headers:
```
# dpkg -L libmongoc-1.0-0
/.
/usr
/usr/lib
/usr/lib/x86_64-linux-gnu
/usr/lib/x86_64-linux-gnu/libmongoc-1.0.so.0.0.0
/usr/share
/usr/share/doc
/usr/share/doc/libmongoc-1.0-0
/usr/share/doc/libmongoc-1.0-0/NEWS.gz
/usr/share/doc/libmongoc-1.0-0/README.rst
/usr/share/doc/libmongoc-1.0-0/THIRD_PARTY_NOTICES.gz
/usr/share/doc/libmongoc-1.0-0/copyright
/usr/share/lintian
/usr/share/lintian/overrides
/usr/share/lintian/overrides/libmongoc-1.0-0
/usr/lib/x86_64-linux-gnu/libmongoc-1.0.so.0
/usr/share/doc/libmongoc-1.0-0/changelog.Debian.gz
```

As a result, users attempting to build an application after installing `libmongoc-1.0-0` may receive an error attempting to locate the cmake or pkg-config file. CDRIVER-3717 links to a Stack Overflow post referencing this issue: https://stackoverflow.com/questions/62289167/compiling-c-program-with-libmongoc-1-0/

The `libmongoc-dev` package includes headers:
```
# dpkg -L libmongoc-dev
/.
/usr
/usr/include
/usr/include/libmongoc-1.0
/usr/include/libmongoc-1.0/mongoc
/usr/include/libmongoc-1.0/mongoc/mongoc-apm.h
/usr/include/libmongoc-1.0/mongoc/mongoc-bulk-operation.h
/usr/include/libmongoc-1.0/mongoc/mongoc-change-stream.h
/usr/include/libmongoc-1.0/mongoc/mongoc-client-pool.h
/usr/include/libmongoc-1.0/mongoc/mongoc-client-session.h
/usr/include/libmongoc-1.0/mongoc/mongoc-client-side-encryption.h
/usr/include/libmongoc-1.0/mongoc/mongoc-client.h
/usr/include/libmongoc-1.0/mongoc/mongoc-collection.h
/usr/include/libmongoc-1.0/mongoc/mongoc-config.h
/usr/include/libmongoc-1.0/mongoc/mongoc-cursor.h
/usr/include/libmongoc-1.0/mongoc/mongoc-database.h
/usr/include/libmongoc-1.0/mongoc/mongoc-error.h
/usr/include/libmongoc-1.0/mongoc/mongoc-find-and-modify.h
/usr/include/libmongoc-1.0/mongoc/mongoc-flags.h
/usr/include/libmongoc-1.0/mongoc/mongoc-gridfs-bucket.h
/usr/include/libmongoc-1.0/mongoc/mongoc-gridfs-file-list.h
/usr/include/libmongoc-1.0/mongoc/mongoc-gridfs-file-page.h
/usr/include/libmongoc-1.0/mongoc/mongoc-gridfs-file.h
/usr/include/libmongoc-1.0/mongoc/mongoc-gridfs.h
/usr/include/libmongoc-1.0/mongoc/mongoc-handshake.h
/usr/include/libmongoc-1.0/mongoc/mongoc-host-list.h
/usr/include/libmongoc-1.0/mongoc/mongoc-index.h
/usr/include/libmongoc-1.0/mongoc/mongoc-init.h
/usr/include/libmongoc-1.0/mongoc/mongoc-iovec.h
/usr/include/libmongoc-1.0/mongoc/mongoc-log.h
/usr/include/libmongoc-1.0/mongoc/mongoc-macros.h
/usr/include/libmongoc-1.0/mongoc/mongoc-matcher.h
/usr/include/libmongoc-1.0/mongoc/mongoc-opcode.h
/usr/include/libmongoc-1.0/mongoc/mongoc-optional.h
/usr/include/libmongoc-1.0/mongoc/mongoc-prelude.h
/usr/include/libmongoc-1.0/mongoc/mongoc-rand.h
/usr/include/libmongoc-1.0/mongoc/mongoc-read-concern.h
/usr/include/libmongoc-1.0/mongoc/mongoc-read-prefs.h
/usr/include/libmongoc-1.0/mongoc/mongoc-server-api.h
/usr/include/libmongoc-1.0/mongoc/mongoc-server-description.h
/usr/include/libmongoc-1.0/mongoc/mongoc-socket.h
/usr/include/libmongoc-1.0/mongoc/mongoc-ssl.h
/usr/include/libmongoc-1.0/mongoc/mongoc-stream-buffered.h
/usr/include/libmongoc-1.0/mongoc/mongoc-stream-file.h
/usr/include/libmongoc-1.0/mongoc/mongoc-stream-gridfs.h
/usr/include/libmongoc-1.0/mongoc/mongoc-stream-socket.h
/usr/include/libmongoc-1.0/mongoc/mongoc-stream-tls-libressl.h
/usr/include/libmongoc-1.0/mongoc/mongoc-stream-tls-openssl.h
/usr/include/libmongoc-1.0/mongoc/mongoc-stream-tls.h
/usr/include/libmongoc-1.0/mongoc/mongoc-stream.h
/usr/include/libmongoc-1.0/mongoc/mongoc-topology-description.h
/usr/include/libmongoc-1.0/mongoc/mongoc-uri.h
/usr/include/libmongoc-1.0/mongoc/mongoc-version-functions.h
/usr/include/libmongoc-1.0/mongoc/mongoc-version.h
/usr/include/libmongoc-1.0/mongoc/mongoc-write-concern.h
/usr/include/libmongoc-1.0/mongoc/mongoc.h
/usr/include/libmongoc-1.0/mongoc.h
/usr/lib
/usr/lib/x86_64-linux-gnu
/usr/lib/x86_64-linux-gnu/cmake
/usr/lib/x86_64-linux-gnu/cmake/libmongoc-1.0
/usr/lib/x86_64-linux-gnu/cmake/libmongoc-1.0/libmongoc-1.0-config-version.cmake
/usr/lib/x86_64-linux-gnu/cmake/libmongoc-1.0/libmongoc-1.0-config.cmake
/usr/lib/x86_64-linux-gnu/cmake/libmongoc-static-1.0
/usr/lib/x86_64-linux-gnu/cmake/libmongoc-static-1.0/libmongoc-static-1.0-config-version.cmake
/usr/lib/x86_64-linux-gnu/cmake/libmongoc-static-1.0/libmongoc-static-1.0-config.cmake
/usr/lib/x86_64-linux-gnu/cmake/mongoc-1.0
/usr/lib/x86_64-linux-gnu/cmake/mongoc-1.0/mongoc-1.0-config-version.cmake
/usr/lib/x86_64-linux-gnu/cmake/mongoc-1.0/mongoc-1.0-config.cmake
/usr/lib/x86_64-linux-gnu/cmake/mongoc-1.0/mongoc-targets-none.cmake
/usr/lib/x86_64-linux-gnu/cmake/mongoc-1.0/mongoc-targets.cmake
/usr/lib/x86_64-linux-gnu/libmongoc-static-1.0.a
/usr/lib/x86_64-linux-gnu/pkgconfig
/usr/lib/x86_64-linux-gnu/pkgconfig/libmongoc-1.0.pc
/usr/lib/x86_64-linux-gnu/pkgconfig/libmongoc-ssl-1.0.pc
/usr/share
/usr/share/doc
/usr/share/doc/libmongoc-dev
/usr/share/doc/libmongoc-dev/copyright
/usr/lib/x86_64-linux-gnu/libmongoc-1.0.so
/usr/share/doc/libmongoc-dev/NEWS.gz
/usr/share/doc/libmongoc-dev/README.rst
/usr/share/doc/libmongoc-dev/changelog.Debian.gz
```

I expect the more common use case for a user reading the installation documentation is to develop an application.