### PR TITLE
CDRIVER-2982 test and document duplicate key handling

### DIFF
--- a/src/libbson/doc/bson_iter_find.rst
+++ b/src/libbson/doc/bson_iter_find.rst
@@ -20,7 +20,7 @@ Parameters
 Description
 -----------
 
-The ``bson_iter_find()`` function shall advance ``iter`` to the element named ``key`` or exhaust all elements of ``iter``. If ``iter`` is exhausted, false is returned and ``iter`` should be considered invalid.
+The ``bson_iter_find()`` function shall advance ``iter`` to the first element named ``key`` or exhaust all elements of ``iter``. If ``iter`` is exhausted, false is returned and ``iter`` should be considered invalid.
 
 ``key`` is case-sensitive. For a case-folded version, see :symbol:`bson_iter_find_case()`.
 

--- a/src/libbson/doc/bson_iter_find_case.rst
+++ b/src/libbson/doc/bson_iter_find_case.rst
@@ -20,7 +20,7 @@ Parameters
 Description
 -----------
 
-Advances ``iter`` until it is observing an element matching the name of ``key`` or exhausting all elements.
+Advances ``iter`` to the first element matching the name of ``key`` or exhausting all elements.
 
 ``key`` is not case-sensitive. The keys will be case-folded to determine a match using the current locale.
 

--- a/src/libbson/doc/bson_iter_find_w_len.rst
+++ b/src/libbson/doc/bson_iter_find_w_len.rst
@@ -21,7 +21,7 @@ Parameters
 Description
 -----------
 
-The ``bson_iter_find_w_len()`` function shall advance ``iter`` to the element named ``key`` or exhaust all elements of ``iter``. If ``iter`` is exhausted, false is returned and ``iter`` should be considered invalid.
+The ``bson_iter_find_w_len()`` function shall advance ``iter`` to the first element named ``key`` or exhaust all elements of ``iter``. If ``iter`` is exhausted, false is returned and ``iter`` should be considered invalid.
 
 ``key`` is case-sensitive. For a case-folded version, see :symbol:`bson_iter_find_case()`.
 

--- a/src/libbson/doc/bson_t.rst
+++ b/src/libbson/doc/bson_t.rst
@@ -141,6 +141,15 @@ Performance Notes
 
 The :symbol:`bson_t` structure attempts to use an inline allocation within the structure to speed up performance of small documents. When this internal buffer has been exhausted, a heap allocated buffer will be dynamically allocated. Therefore, it is essential to call :symbol:`bson_destroy()` on allocated documents.
 
+Duplicate Keys
+--------------
+
+The `BSON specification <https://bsonspec.org>`_ allows BSON documents to have
+duplicate keys. Documents are stored as an ordered list of key-value pairs. A
+:symbol:`bson_t` may contain duplicate keys. Applications should refrain from
+generating such documents, because MongoDB server behavior is undefined when a
+BSON document contains duplicate keys.
+
 .. only:: html
 
   Functions


### PR DESCRIPTION
# Summary

- test bson_t behavior with duplicate keys
- note `bson_iter_find_*` advances to the first key
- note undefined server behavior with duplicate keys

# Background & Motivation

It is possible to constructing `bson_t` with duplicate keys by manually appending, reading BSON data, or parsing JSON. The [BSON specification](https://bsonspec.org) does not require keys be unique. The motivation for testing behavior of `bson_t` with duplicate keys was to ensure this behavior is not unintentionally changed in the future.

DRIVERS-612 notes:
> The documentation MUST mention that the server's behavior related to duplicate key names is undefined