### PR TITLE
Reducing Warnings - Implicit signed conversions in bson-iter.h

### DIFF
--- a/src/libbson/src/bson/bson-iter.h
+++ b/src/libbson/src/bson/bson-iter.h
@@ -109,11 +109,15 @@ bson_iter_value (bson_iter_t *iter);
 static BSON_INLINE uint32_t
 bson_iter_utf8_len_unsafe (const bson_iter_t *iter)
 {
-   int32_t val;
+   uint32_t raw;
+   memcpy (&raw, iter->raw + iter->d1, sizeof (raw));
 
-   memcpy (&val, iter->raw + iter->d1, sizeof (val));
-   val = BSON_UINT32_FROM_LE (val);
-   return BSON_MAX (0, val - 1);
+   const uint32_t native = BSON_UINT32_FROM_LE (raw);
+
+   int32_t len;
+   memcpy (&len, &native, sizeof (len));
+
+   return len <= 0 ? 0u : (uint32_t) (len - 1);
 }
 
 
@@ -242,10 +246,14 @@ bson_iter_int32 (const bson_iter_t *iter);
 static BSON_INLINE int32_t
 bson_iter_int32_unsafe (const bson_iter_t *iter)
 {
-   int32_t val;
+   uint32_t raw;
+   memcpy (&raw, iter->raw + iter->d1, sizeof (raw));
 
-   memcpy (&val, iter->raw + iter->d1, sizeof (val));
-   return BSON_UINT32_FROM_LE (val);
+   const uint32_t native = BSON_UINT32_FROM_LE (raw);
+
+   int32_t res;
+   memcpy (&res, &native, sizeof (res));
+   return res;
 }
 
 
@@ -268,10 +276,14 @@ bson_iter_as_int64 (const bson_iter_t *iter);
 static BSON_INLINE int64_t
 bson_iter_int64_unsafe (const bson_iter_t *iter)
 {
-   int64_t val;
+   uint64_t raw;
+   memcpy (&raw, iter->raw + iter->d1, sizeof (raw));
 
-   memcpy (&val, iter->raw + iter->d1, sizeof (val));
-   return BSON_UINT64_FROM_LE (val);
+   const uint64_t native = BSON_UINT64_FROM_LE (raw);
+
+   int64_t res;
+   memcpy (&res, &native, sizeof (res));
+   return res;
 }
 
 
@@ -407,7 +419,7 @@ bson_iter_time_t (const bson_iter_t *iter);
 static BSON_INLINE time_t
 bson_iter_time_t_unsafe (const bson_iter_t *iter)
 {
-   return (time_t) (bson_iter_int64_unsafe (iter) / 1000UL);
+   return (time_t) (bson_iter_int64_unsafe (iter) / 1000);
 }
 
 
@@ -511,7 +523,8 @@ bson_iter_overwrite_double (bson_iter_t *iter, double value);
 
 
 BSON_EXPORT (void)
-bson_iter_overwrite_decimal128 (bson_iter_t *iter, const bson_decimal128_t *value);
+bson_iter_overwrite_decimal128 (bson_iter_t *iter,
+                                const bson_decimal128_t *value);
 
 
 BSON_EXPORT (void)


### PR DESCRIPTION
Addresses several implicit conversion warnings primarily due to the use of `BSON_UINT<N>_FROM_LE`.

Using the same local environment as described in prior Reducing Warnings PRs, this PR reduces total warnings by:

- GCC: 4086 -> 2711 (-33.7%)
- Clang: 3803 -> 1708 (-55.1%)

and reduces unique warnings by:

- GCC: 944 -> 939 (-0.5%)
- Clang: 1106 -> 1101 (-0.5%)