### PR TITLE
Fix coverage filter to ignore test directories

### DIFF
--- a/.evergreen/.codecov.yml
+++ b/.evergreen/.codecov.yml
@@ -1,4 +1,5 @@
 ignore:
   - "src/kms-message"
   - "src/zlib-*"
-  - "src/*/tests"
+  - "src/libbson/tests"
+  - "src/libmongoc/tests"


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1257. Updates the filter list to properly exclude the `tests` directory under `src/libbson` and `src/libmongoc`, as `src/*/tests` does not behave as intended.