### PR TITLE
CDRIVER-4582 sync timeseries-collection.json test

### DIFF
--- a/src/libmongoc/tests/json/collection-management/timeseries-collection.json
+++ b/src/libmongoc/tests/json/collection-management/timeseries-collection.json
@@ -250,6 +250,71 @@
           ]
         }
       ]
+    },
+    {
+      "description": "createCollection with bucketing options",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "7.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "timeseries": {
+              "timeField": "time",
+              "bucketMaxSpanSeconds": 3600,
+              "bucketRoundingSeconds": 3600
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "ts-tests",
+            "collectionName": "test"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "test"
+                },
+                "databaseName": "ts-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "create": "test",
+                  "timeseries": {
+                    "timeField": "time",
+                    "bucketMaxSpanSeconds": 3600,
+                    "bucketRoundingSeconds": 3600
+                  }
+                },
+                "databaseName": "ts-tests"
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
# Summary

- sync timeseries-collection.json test to https://github.com/mongodb/specifications/commit/0fa17f36d4bd4def1dd5acd30264f0e2cc026d6d

# Background & Motivation

DRIVERS-2546 notes there are two new options for the `create` command:
> Note this project will require DBX changes (at least in some drivers) to add the new "timeseries.bucketMaxSpanSeconds" and "timeseries.bucketRoundingSeconds" fields for the [create command](https://www.mongodb.com/docs/v6.0/reference/command/create/#command-fields)

New options to the `create` command do not require code or documentation changes in the C driver. `mongoc_database_create_collection` accepts a `bson_t` argument for options and passes options to the `create` command with [the call to `_mongoc_client_command_with_opts`](https://github.com/mongodb/mongo-c-driver/blob/9c14bae958b741a94547aeff1797a7ed2aa5f2eb/src/libmongoc/src/mongoc/mongoc-database.c#L985).