### PR TITLE
CDRIVER-4638 Remove "Public Technical Preview" from Queryable Encryption Equality API

### DIFF
--- a/.evergreen/scripts/compile-libmongocrypt.sh
+++ b/.evergreen/scripts/compile-libmongocrypt.sh
@@ -5,7 +5,7 @@ compile_libmongocrypt() {
   declare -r mongoc_dir="${2:?}"
   declare -r install_dir="${3:?}"
 
-  git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.8.0-alpha1 || return
+  git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.8.0 || return
 
   declare -a crypt_cmake_flags=(
     "-DMONGOCRYPT_MONGOC_DIR=${mongoc_dir}"

--- a/src/libmongoc/doc/mongoc_auto_encryption_opts_set_bypass_query_analysis.rst
+++ b/src/libmongoc/doc/mongoc_auto_encryption_opts_set_bypass_query_analysis.rst
@@ -12,7 +12,6 @@ Synopsis
    mongoc_auto_encryption_opts_set_bypass_query_analysis (
       mongoc_auto_encryption_opts_t *opts, bool bypass_query_analysis);
 
-.. important:: |qenc:api-is-experimental|
 .. versionadded:: 1.22.0
 
 Parameters

--- a/src/libmongoc/doc/mongoc_auto_encryption_opts_set_encrypted_fields_map.rst
+++ b/src/libmongoc/doc/mongoc_auto_encryption_opts_set_encrypted_fields_map.rst
@@ -12,7 +12,6 @@ Synopsis
    mongoc_auto_encryption_opts_set_encrypted_fields_map (
       mongoc_auto_encryption_opts_t *opts, const bson_t *encrypted_fields_map);
 
-.. important:: |qenc:api-is-experimental|
 .. versionadded:: 1.22.0
 
 Parameters

--- a/src/libmongoc/doc/mongoc_client_encryption_create_encrypted_collection.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_create_encrypted_collection.rst
@@ -24,7 +24,6 @@ Create a new collection with :doc:`Queryable Encryption </queryable-encryption>`
 enabled. Requires a valid :symbol:`mongoc_client_encryption_t` object to
 operate.
 
-.. important:: |qenc:api-is-experimental|
 .. versionadded:: 1.24.0
 
 .. seealso::

--- a/src/libmongoc/doc/mongoc_client_encryption_encrypt.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_encrypt.rst
@@ -28,7 +28,7 @@ analysis with :symbol:`mongoc_auto_encryption_opts_set_bypass_query_analysis`.
 The :symbol:`mongoc_auto_encryption_opts_t` must not be configured to bypass
 automatic encryption with
 :symbol:`mongoc_auto_encryption_opts_set_bypass_auto_encryption`. **Note** that
-the ``"Indexed"`` and ``"RangePreview"`` payload type |qenc:is-experimental|. The |qenc:range-is-experimental| 
+the ``"RangePreview"`` payload type |qenc:is-experimental|. The |qenc:range-is-experimental| 
 
 To insert with a ``RangePreview`` payload 
 :symbol:`mongoc_client_encryption_encrypt_range_opts_t` must be set in ``opts``.

--- a/src/libmongoc/doc/mongoc_client_encryption_encrypt_opts_set_algorithm.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_encrypt_opts_set_algorithm.rst
@@ -35,13 +35,9 @@ Identifies the algorithm to use for encryption. Valid values of ``algorithm`` ar
 
    for indexed encryption. Specific to the :doc:`queryable-encryption` feature.
 
-   .. note:: |qenc:opt-is-experimental|
-
 ``"Unindexed"``
 
    for unindexed encryption. Specific to the :doc:`queryable-encryption` feature.
-
-   .. note:: |qenc:opt-is-experimental|
 
 ``"RangePreview"``
 

--- a/src/libmongoc/doc/mongoc_client_encryption_encrypt_opts_set_contention_factor.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_encrypt_opts_set_contention_factor.rst
@@ -12,7 +12,6 @@ Synopsis
     mongoc_client_encryption_encrypt_opts_set_contention_factor (
         mongoc_client_encryption_encrypt_opts_t *opts, int64_t contention_factor);
 
-.. important:: |qenc:api-is-experimental|
 .. versionadded:: 1.22.0
 
 Sets a contention factor for explicit encryption.

--- a/src/libmongoc/doc/mongoc_client_encryption_encrypt_opts_set_query_type.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_encrypt_opts_set_query_type.rst
@@ -15,7 +15,6 @@ Synopsis
     mongoc_client_encryption_encrypt_opts_set_query_type (
         mongoc_client_encryption_encrypt_opts_t *opts, const char* query_type);
 
-.. important:: |qenc:api-is-experimental|
 .. versionadded:: 1.22.0
 
 Sets a query type for explicit encryption. Currently, the supported values

--- a/src/libmongoc/doc/queryable-encryption.rst
+++ b/src/libmongoc/doc/queryable-encryption.rst
@@ -1,6 +1,6 @@
-##################################
-Experimental: Queryable Encryption
-##################################
+####################
+Queryable Encryption
+####################
 
 Using Queryable Encryption requires MongoDB Server 7.0 or higher.
 

--- a/src/libmongoc/doc/queryable-encryption.rst
+++ b/src/libmongoc/doc/queryable-encryption.rst
@@ -6,6 +6,23 @@ Using Queryable Encryption requires MongoDB Server 7.0 or higher.
 
 API related to the "rangePreview" algorithm is still experimental and subject to breaking changes!
 
+Queryable Encryption in older MongoDB Server versions
+-----------------------------------------------------
+
+MongoDB Server 6.0 introduced Queryable Encryption as a Public Technical
+Preview. MongoDB Server 7.0 includes backwards breaking changes to the Queryable
+Encryption protocol.
+
+The backwards breaking changes are applied in the client protocol in
+libmongocrypt 1.8.0. libmongoc 1.24.0 requires libmongocrypt 1.8.0 or newer.
+libmongoc 1.24.0 no longer supports Queryable Encryption in MongoDB Server <7.0.
+Using Queryable Encryption libmongoc 1.24.0 and higher requires MongoDB Server
+>=7.0.
+
+Using Queryable Encryption with libmongocrypt<1.8.0 on a MongoDB Server>=7.0, or
+using libmongocrypt>=1.8.0 on a MongoDB Server<6.0 will result in a server error
+when using the incompatible protocol.
+
 .. seealso::
 
     | The MongoDB Manual for `Queryable Encryption <https://www.mongodb.com/docs/manual/core/queryable-encryption/>`_

--- a/src/libmongoc/doc/queryable-encryption.rst
+++ b/src/libmongoc/doc/queryable-encryption.rst
@@ -2,11 +2,9 @@
 Experimental: Queryable Encryption
 ##################################
 
-MongoDB 6.0 introduces *Queryable Encryption* as a Public Technical Preview.
-This API is still experimental and subject to breaking changes!
+Using Queryable Encryption requires MongoDB Server 7.0 or higher.
 
-APIs that are part of Queryable Encryption will be marked as experimental, and
-one should not rely on their stability.
+API related to the "rangePreview" algorithm is still experimental and subject to breaking changes!
 
 .. seealso::
 

--- a/src/libmongoc/doc/queryable-encryption.rst
+++ b/src/libmongoc/doc/queryable-encryption.rst
@@ -4,6 +4,10 @@ Queryable Encryption
 
 Using Queryable Encryption requires MongoDB Server 7.0 or higher.
 
+See the MongoDB Manual for `Queryable Encryption
+<https://www.mongodb.com/docs/manual/core/queryable-encryption/>`_ for more
+information about the feature.
+
 API related to the "rangePreview" algorithm is still experimental and subject to breaking changes!
 
 Queryable Encryption in older MongoDB Server versions


### PR DESCRIPTION
# Summary

- update libmongocrypt test dependency to 1.8.0
- remove "Public Technical Preview" from QE API for equality
- revise Queryable Encryption page to document backwards break

# Background & Motivation

Changes are requested in the "Downstream Changes Summary" of DRIVERS-2614