### PR TITLE
CDRIVER-4645 add `mock-server-test` variant

### DIFF
--- a/.evergreen/config_generator/components/mock_server.py
+++ b/.evergreen/config_generator/components/mock_server.py
@@ -1,0 +1,48 @@
+from shrub.v3.evg_build_variant import BuildVariant
+from shrub.v3.evg_command import EvgCommandType
+from shrub.v3.evg_task import EvgTaskRef
+
+from config_generator.components.funcs.fetch_det import FetchDET
+from config_generator.components.funcs.run_simple_http_server import RunSimpleHTTPServer
+from config_generator.etc.utils import Task
+from config_generator.etc.utils import bash_exec
+
+def tasks():
+    return [
+        Task(
+            name="mock-server-test",
+            run_on="ubuntu2204-small",
+            commands=[
+                # Call fetch-det to define PYTHON3_BINARY expansion required for run-simple-http-server.
+                FetchDET.call(),
+                RunSimpleHTTPServer.call(),
+                bash_exec(
+                    command_type=EvgCommandType.TEST,
+                    add_expansions_to_env=True,
+                    working_dir='mongoc',
+                    script='.evergreen/scripts/compile.sh',
+                ),
+                bash_exec(
+                    command_type=EvgCommandType.TEST,
+                    working_dir='mongoc',
+                    script='.evergreen/scripts/run-mock-server-tests.sh',
+                )
+            ],
+        )
+    ]
+
+def variants():
+    return [
+        BuildVariant(
+            name="mock-server-test",
+            display_name="Mock Server Test",
+            tasks=[EvgTaskRef(name='mock-server-test')],
+            expansions={
+                'CC': 'gcc',
+                'ASAN': 'on',
+                'CFLAGS': '-fno-omit-frame-pointer',
+                'EXTRA_CONFIGURE_FLAGS': '-DENABLE_EXTRA_ALIGNMENT=OFF',
+                'SANITIZE': 'address,undefined',
+            }
+        ),
+    ]

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -1036,24 +1036,6 @@ tasks:
         set -o errexit
         env CFLAGS="-Werror -Wno-cast-align" DEBUG="ON" bash .evergreen/scripts/compile.sh
   - func: upload-build
-- name: debug-compile-sasl-openssl-cse
-  tags:
-  - client-side-encryption
-  - debug-compile
-  - openssl
-  - sasl
-  - special
-  commands:
-  - command: shell.exec
-    type: test
-    params:
-      working_dir: mongoc
-      add_expansions_to_env: true
-      shell: bash
-      script: |-
-        set -o errexit
-        env COMPILE_LIBMONGOCRYPT="ON" DEBUG="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON" SASL="AUTO" SSL="OPENSSL" bash .evergreen/scripts/compile.sh
-  - func: upload-build
 - name: debug-compile-sasl-openssl-static-cse
   tags:
   - client-side-encryption

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -1485,19 +1485,6 @@ tasks:
       BUILD_NAME: debug-compile-sasl-openssl
   - func: prepare-kerberos
   - func: run auth tests
-- name: authentication-tests-openssl-static
-  tags:
-  - authentication-tests
-  - openssl-static
-  - sasl
-  depends_on:
-    name: debug-compile-sasl-openssl-static
-  commands:
-  - func: fetch-build
-    vars:
-      BUILD_NAME: debug-compile-sasl-openssl-static
-  - func: prepare-kerberos
-  - func: run auth tests
 - name: authentication-tests-darwinssl
   tags:
   - authentication-tests

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -1038,24 +1038,6 @@ tasks:
         set -o errexit
         env COMPILE_LIBMONGOCRYPT="ON" DEBUG="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON" SASL="AUTO" SSL="OPENSSL_STATIC" bash .evergreen/scripts/compile.sh
   - func: upload-build
-- name: debug-compile-sasl-winssl-cse
-  tags:
-  - client-side-encryption
-  - debug-compile
-  - sasl
-  - special
-  - winssl
-  commands:
-  - command: shell.exec
-    type: test
-    params:
-      working_dir: mongoc
-      add_expansions_to_env: true
-      shell: bash
-      script: |-
-        set -o errexit
-        env COMPILE_LIBMONGOCRYPT="ON" DEBUG="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON" SASL="AUTO" SSL="WINDOWS" bash .evergreen/scripts/compile.sh
-  - func: upload-build
 - name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: install ssl

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -1072,24 +1072,6 @@ tasks:
         set -o errexit
         env COMPILE_LIBMONGOCRYPT="ON" DEBUG="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON" SASL="AUTO" SSL="OPENSSL_STATIC" bash .evergreen/scripts/compile.sh
   - func: upload-build
-- name: debug-compile-sasl-darwinssl-cse
-  tags:
-  - client-side-encryption
-  - darwinssl
-  - debug-compile
-  - sasl
-  - special
-  commands:
-  - command: shell.exec
-    type: test
-    params:
-      working_dir: mongoc
-      add_expansions_to_env: true
-      shell: bash
-      script: |-
-        set -o errexit
-        env COMPILE_LIBMONGOCRYPT="ON" DEBUG="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON" SASL="AUTO" SSL="DARWIN" bash .evergreen/scripts/compile.sh
-  - func: upload-build
 - name: debug-compile-sasl-winssl-cse
   tags:
   - client-side-encryption

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -1108,22 +1108,6 @@ tasks:
         set -o errexit
         env COMPILE_LIBMONGOCRYPT="ON" DEBUG="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON" SASL="AUTO" SSL="WINDOWS" bash .evergreen/scripts/compile.sh
   - func: upload-build
-- name: debug-compile-asan-openssl-cse
-  tags:
-  - asan-clang
-  - client-side-encryption
-  - debug-compile
-  commands:
-  - command: shell.exec
-    type: test
-    params:
-      working_dir: mongoc
-      add_expansions_to_env: true
-      shell: bash
-      script: |-
-        set -o errexit
-        env CFLAGS="-fno-omit-frame-pointer" CHECK_LOG="ON" COMPILE_LIBMONGOCRYPT="ON" DEBUG="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_EXTRA_ALIGNMENT=OFF" PATH="/usr/lib/llvm-3.8/bin:$PATH" SANITIZE="address" SSL="OPENSSL" bash .evergreen/scripts/compile.sh
-  - func: upload-build
 - name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: install ssl

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -1438,19 +1438,6 @@ tasks:
       BUILD_NAME: debug-compile-nosasl-openssl
   - func: prepare-kerberos
   - func: run auth tests
-- name: test-asan-memcheck-mock-server
-  tags:
-  - test-asan
-  depends_on:
-    name: debug-compile-asan-clang
-  commands:
-  - func: fetch-build
-    vars:
-      BUILD_NAME: debug-compile-asan-clang
-  - func: run mock server tests
-    vars:
-      ASAN: 'on'
-      SSL: ssl
 - name: test-mongohouse
   depends_on:
     name: debug-compile-sasl-openssl

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -640,22 +640,6 @@ tasks:
         set -o errexit
         env DEBUG="ON" SASL="AUTO" SSL="DARWIN" bash .evergreen/scripts/compile.sh
   - func: upload-build
-- name: debug-compile-sasl-winssl
-  tags:
-  - debug-compile
-  - sasl
-  - winssl
-  commands:
-  - command: shell.exec
-    type: test
-    params:
-      working_dir: mongoc
-      add_expansions_to_env: true
-      shell: bash
-      script: |-
-        set -o errexit
-        env DEBUG="ON" SASL="CYRUS" SSL="WINDOWS" bash .evergreen/scripts/compile.sh
-  - func: upload-build
 - name: debug-compile-sspi-nossl
   tags:
   - debug-compile

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -81,16 +81,6 @@ functions:
       script: |-
         set -o errexit
         bash .evergreen/scripts/run-auth-tests.sh
-  run mock server tests:
-  - command: shell.exec
-    type: test
-    params:
-      working_dir: mongoc
-      add_expansions_to_env: true
-      shell: bash
-      script: |-
-        set -o errexit
-        bash .evergreen/scripts/run-mock-server-tests.sh
   link sample program:
   - command: shell.exec
     type: test

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -1743,6 +1743,28 @@ tasks:
       - func: upload-man-pages
       - func: upload-build
       - func: upload-release
+  - name: mock-server-test
+    run_on: ubuntu2204-small
+    commands:
+      - func: fetch-det
+      - func: run-simple-http-server
+      - command: subprocess.exec
+        type: test
+        params:
+          binary: bash
+          working_dir: mongoc
+          add_expansions_to_env: true
+          args:
+            - -c
+            - .evergreen/scripts/compile.sh
+      - command: subprocess.exec
+        type: test
+        params:
+          binary: bash
+          working_dir: mongoc
+          args:
+            - -c
+            - .evergreen/scripts/run-mock-server-tests.sh
   - name: openssl-static-compile-debian10-gcc
     run_on: debian10-large
     tags: [openssl-static-matrix, debian10, gcc]

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -20,6 +20,16 @@ buildvariants:
       DEBUG: "ON"
     tasks:
       - name: .cse-matrix-winssl
+  - name: mock-server-test
+    display_name: Mock Server Test
+    expansions:
+      ASAN: "on"
+      CC: gcc
+      CFLAGS: -fno-omit-frame-pointer
+      EXTRA_CONFIGURE_FLAGS: -DENABLE_EXTRA_ALIGNMENT=OFF
+      SANITIZE: address,undefined
+    tasks:
+      - name: mock-server-test
   - name: openssl-static-matrix
     display_name: openssl-static-matrix
     tasks:

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/functions.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/functions.py
@@ -62,11 +62,6 @@ all_functions = OD([
         bash .evergreen/scripts/run-auth-tests.sh
         ''', add_expansions_to_env=True),
     )),
-    ('run mock server tests', Function(
-        shell_mongoc(r'''
-        bash .evergreen/scripts/run-mock-server-tests.sh
-        ''', add_expansions_to_env=True),
-    )),
     ('link sample program', Function(
         shell_mongoc(r'''
         # Compile a program that links dynamically or statically to libmongoc,

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -379,9 +379,6 @@ all_tasks = [
     ),
     CompileTask("debug-compile-with-warnings", CFLAGS="-Werror -Wno-cast-align"),
     CompileWithClientSideEncryption(
-        "debug-compile-sasl-openssl-cse", tags=["debug-compile", "sasl", "openssl"], SASL="AUTO", SSL="OPENSSL"
-    ),
-    CompileWithClientSideEncryption(
         "debug-compile-sasl-openssl-static-cse",
         tags=["debug-compile", "sasl", "openssl-static"],
         SASL="AUTO",

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -673,7 +673,7 @@ all_tasks = chain(
 
 
 class AuthTask(MatrixTask):
-    axes = OD([("sasl", ["sasl", "sspi", False]), ("ssl", ["openssl", "openssl-static", "darwinssl", "winssl"])])
+    axes = OD([("sasl", ["sasl", "sspi", False]), ("ssl", ["openssl", "darwinssl", "winssl"])])
 
     name_prefix = "authentication-tests"
 

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -388,9 +388,6 @@ all_tasks = [
         SSL="OPENSSL_STATIC",
     ),
     CompileWithClientSideEncryption(
-        "debug-compile-sasl-darwinssl-cse", tags=["debug-compile", "sasl", "darwinssl"], SASL="AUTO", SSL="DARWIN"
-    ),
-    CompileWithClientSideEncryption(
         "debug-compile-sasl-winssl-cse", tags=["debug-compile", "sasl", "winssl"], SASL="AUTO", SSL="WINDOWS"
     ),
     CompileTask(

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -393,9 +393,6 @@ all_tasks = [
     CompileWithClientSideEncryption(
         "debug-compile-sasl-winssl-cse", tags=["debug-compile", "sasl", "winssl"], SASL="AUTO", SSL="WINDOWS"
     ),
-    CompileWithClientSideEncryptionAsan(
-        "debug-compile-asan-openssl-cse", tags=["debug-compile", "asan-clang"], SSL="OPENSSL", sanitize=["address"]
-    ),
     CompileTask(
         "debug-compile-nosasl-openssl-1.0.1",
         prefix_commands=[func("install ssl", SSL="openssl-1.0.1u")],

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -377,9 +377,6 @@ all_tasks = [
         SASL="AUTO",
         SSL="OPENSSL_STATIC",
     ),
-    CompileWithClientSideEncryption(
-        "debug-compile-sasl-winssl-cse", tags=["debug-compile", "sasl", "winssl"], SASL="AUTO", SSL="WINDOWS"
-    ),
     CompileTask(
         "debug-compile-nosasl-openssl-1.0.1",
         prefix_commands=[func("install ssl", SSL="openssl-1.0.1u")],

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -96,8 +96,6 @@ class CompileTask(NamedTask):
             self.compile_sh_opt["ENABLE_RDTSCP"] = ENABLE_RDTSCP
         if SRV:
             self.compile_sh_opt["SRV"] = SRV
-        if TOPOLOGY:
-            self.compile_sh_opt["TOPOLOGY"] = TOPOLOGY
 
         if compression != "default":
             self.compile_sh_opt["SNAPPY"] = "ON" if compression in ("all", "snappy") else "OFF"

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -236,13 +236,6 @@ all_tasks = [
         SSL="OPENSSL_STATIC",
     ),
     CompileTask("debug-compile-sasl-darwinssl", tags=["debug-compile", "sasl", "darwinssl"], SASL="AUTO", SSL="DARWIN"),
-    CompileTask(
-        "debug-compile-sasl-winssl",
-        tags=["debug-compile", "sasl", "winssl"],
-        # Explicitly use CYRUS.
-        SASL="CYRUS",
-        SSL="WINDOWS",
-    ),
     CompileTask("debug-compile-sspi-nossl", tags=["debug-compile", "sspi", "nossl"], SASL="SSPI", SSL="OFF"),
     CompileTask("debug-compile-sspi-openssl", tags=["debug-compile", "sspi", "openssl"], SASL="SSPI", SSL="OPENSSL"),
     CompileTask(

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -705,12 +705,6 @@ all_tasks = chain(
     all_tasks,
     [
         PostCompileTask(
-            "test-asan-memcheck-mock-server",
-            tags=["test-asan"],
-            get_build="debug-compile-asan-clang",
-            commands=[func("run mock server tests", ASAN="on", SSL="ssl")],
-        ),
-        PostCompileTask(
             "test-mongohouse",
             tags=[],
             get_build="debug-compile-sasl-openssl",

--- a/src/libmongoc/tests/test-mongoc-counters.c
+++ b/src/libmongoc/tests/test-mongoc-counters.c
@@ -1555,13 +1555,15 @@ test_counters_install (TestSuite *suite)
                       test_counters_op_msg,
                       NULL,
                       NULL,
-                      test_framework_skip_if_compressors);
+                      test_framework_skip_if_compressors,
+                      TestSuite_CheckLive);
    TestSuite_AddFull (suite,
                       "/counters/op_compressed",
                       test_counters_op_compressed,
                       NULL,
                       NULL,
-                      test_framework_skip_if_no_compressors);
+                      test_framework_skip_if_no_compressors,
+                      TestSuite_CheckLive);
    TestSuite_AddLive (suite, "/counters/cursors", test_counters_cursors);
    TestSuite_AddLive (suite, "/counters/clients", test_counters_clients);
    TestSuite_AddFull (suite,

--- a/src/libmongoc/tests/test-mongoc-loadbalanced.c
+++ b/src/libmongoc/tests/test-mongoc-loadbalanced.c
@@ -578,8 +578,9 @@ test_pre_handshake_error_does_not_clear_pool (void)
    /* A new connection is opened. */
    request = mock_server_receives_hello_op_msg (server);
    const bson_t *match_loadBalanced = tmp_bson ("{'loadBalanced': true}");
-   ASSERT (request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
-   
+   ASSERT (
+      request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
+
    BSON_ASSERT (request);
    mock_server_replies_simple (request, LB_HELLO);
    request_destroy (request);
@@ -600,7 +601,8 @@ test_pre_handshake_error_does_not_clear_pool (void)
                                           &error);
    /* A new connection is opened. */
    request = mock_server_receives_hello_op_msg (server);
-   ASSERT (request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
+   ASSERT (
+      request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
    BSON_ASSERT (request);
    capture_logs (true); /* hide Failed to buffer logs. */
    mock_server_hangs_up (request);
@@ -688,7 +690,8 @@ test_post_handshake_error_clears_pool (void)
    /* A new connection is opened. */
    request = mock_server_receives_hello_op_msg (server);
    const bson_t *match_loadBalanced = tmp_bson ("{'loadBalanced': true}");
-   ASSERT (request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
+   ASSERT (
+      request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
    BSON_ASSERT (request);
    mock_server_replies_simple (request, LB_HELLO_A);
    request_destroy (request);
@@ -709,7 +712,8 @@ test_post_handshake_error_clears_pool (void)
                                           &error);
    /* A new connection is opened. */
    request = mock_server_receives_hello_op_msg (server);
-   ASSERT (request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
+   ASSERT (
+      request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
    BSON_ASSERT (request);
    mock_server_replies_simple (request, LB_HELLO_A);
    request_destroy (request);
@@ -730,7 +734,8 @@ test_post_handshake_error_clears_pool (void)
                                           &error);
    /* A new connection is opened. */
    request = mock_server_receives_hello_op_msg (server);
-   ASSERT (request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
+   ASSERT (
+      request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
    BSON_ASSERT (request);
    mock_server_replies_simple (request, LB_HELLO_B);
    request_destroy (request);
@@ -773,7 +778,8 @@ test_post_handshake_error_clears_pool (void)
                                           &error);
    /* A new connection is opened. */
    request = mock_server_receives_hello_op_msg (server);
-   ASSERT (request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
+   ASSERT (
+      request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
    BSON_ASSERT (request);
    mock_server_replies_simple (request, LB_HELLO_A);
    request_destroy (request);

--- a/src/libmongoc/tests/test-mongoc-loadbalanced.c
+++ b/src/libmongoc/tests/test-mongoc-loadbalanced.c
@@ -576,8 +576,10 @@ test_pre_handshake_error_does_not_clear_pool (void)
                                           NULL /* reply */,
                                           &error);
    /* A new connection is opened. */
-   request =
-      mock_server_receives_legacy_hello (server, "{'loadBalanced': true}");
+   request = mock_server_receives_hello_op_msg (server);
+   const bson_t *match_loadBalanced = tmp_bson ("{'loadBalanced': true}");
+   ASSERT (request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
+   
    BSON_ASSERT (request);
    mock_server_replies_simple (request, LB_HELLO);
    request_destroy (request);
@@ -597,8 +599,8 @@ test_pre_handshake_error_does_not_clear_pool (void)
                                           NULL /* reply */,
                                           &error);
    /* A new connection is opened. */
-   request =
-      mock_server_receives_legacy_hello (server, "{'loadBalanced': true}");
+   request = mock_server_receives_hello_op_msg (server);
+   ASSERT (request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
    BSON_ASSERT (request);
    capture_logs (true); /* hide Failed to buffer logs. */
    mock_server_hangs_up (request);
@@ -684,8 +686,9 @@ test_post_handshake_error_clears_pool (void)
                                           NULL /* reply */,
                                           &error);
    /* A new connection is opened. */
-   request =
-      mock_server_receives_legacy_hello (server, "{'loadBalanced': true}");
+   request = mock_server_receives_hello_op_msg (server);
+   const bson_t *match_loadBalanced = tmp_bson ("{'loadBalanced': true}");
+   ASSERT (request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
    BSON_ASSERT (request);
    mock_server_replies_simple (request, LB_HELLO_A);
    request_destroy (request);
@@ -705,8 +708,8 @@ test_post_handshake_error_clears_pool (void)
                                           NULL /* reply */,
                                           &error);
    /* A new connection is opened. */
-   request =
-      mock_server_receives_legacy_hello (server, "{'loadBalanced': true}");
+   request = mock_server_receives_hello_op_msg (server);
+   ASSERT (request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
    BSON_ASSERT (request);
    mock_server_replies_simple (request, LB_HELLO_A);
    request_destroy (request);
@@ -726,8 +729,8 @@ test_post_handshake_error_clears_pool (void)
                                           NULL /* reply */,
                                           &error);
    /* A new connection is opened. */
-   request =
-      mock_server_receives_legacy_hello (server, "{'loadBalanced': true}");
+   request = mock_server_receives_hello_op_msg (server);
+   ASSERT (request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
    BSON_ASSERT (request);
    mock_server_replies_simple (request, LB_HELLO_B);
    request_destroy (request);
@@ -769,8 +772,8 @@ test_post_handshake_error_clears_pool (void)
                                           NULL /* reply */,
                                           &error);
    /* A new connection is opened. */
-   request =
-      mock_server_receives_legacy_hello (server, "{'loadBalanced': true}");
+   request = mock_server_receives_hello_op_msg (server);
+   ASSERT (request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
    BSON_ASSERT (request);
    mock_server_replies_simple (request, LB_HELLO_A);
    request_destroy (request);

--- a/src/libmongoc/tests/test-mongoc-loadbalanced.c
+++ b/src/libmongoc/tests/test-mongoc-loadbalanced.c
@@ -558,6 +558,7 @@ test_pre_handshake_error_does_not_clear_pool (void)
    future_t *future;
    request_t *request;
    bson_error_t error;
+   const bson_t *match_loadBalanced = tmp_bson ("{'loadBalanced': true}");
 
    server = mock_server_new ();
    mock_server_auto_endsessions (server);
@@ -577,7 +578,6 @@ test_pre_handshake_error_does_not_clear_pool (void)
                                           &error);
    /* A new connection is opened. */
    request = mock_server_receives_hello_op_msg (server);
-   const bson_t *match_loadBalanced = tmp_bson ("{'loadBalanced': true}");
    ASSERT (
       request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
 
@@ -669,6 +669,7 @@ test_post_handshake_error_clears_pool (void)
    request_t *request;
    bson_error_t error;
    mongoc_server_description_t *monitor_sd;
+   const bson_t *match_loadBalanced = tmp_bson ("{'loadBalanced': true}");
 
    server = mock_server_new ();
    mock_server_auto_endsessions (server);
@@ -689,7 +690,6 @@ test_post_handshake_error_clears_pool (void)
                                           &error);
    /* A new connection is opened. */
    request = mock_server_receives_hello_op_msg (server);
-   const bson_t *match_loadBalanced = tmp_bson ("{'loadBalanced': true}");
    ASSERT (
       request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
    BSON_ASSERT (request);


### PR DESCRIPTION
# Summary

This PR partially resolves CDRIVER-4645.

- Remove some unused tasks from legacy Evergreen config.
- Add a `mock-server-test` variant.

Here is a patch build for the new `mock-server-test` variant: https://spruce.mongodb.com/version/646a3d470305b97abfa79790

## Unused tasks

[This validate.py script](https://gist.github.com/kevinAlbs/f6e45a6f9cbc16f95f87d2b789abb516) can print unused tasks. Before these changes, this is the output:

```
% evergreen evaluate ./.evergreen/config.yml > evaluated.yml
% python validate.py                                        
`tasks` not referenced in `buildvariants` or `task_groups`:
-authentication-tests-openssl-static
-debug-compile-asan-clang
-debug-compile-asan-clang-openssl
-debug-compile-asan-openssl-cse
-debug-compile-compression
-debug-compile-sasl-darwinssl-cse
-debug-compile-sasl-nossl
-debug-compile-sasl-openssl-cse
-debug-compile-sasl-openssl-static-cse
-debug-compile-sasl-winssl
-debug-compile-sasl-winssl-cse
-debug-compile-sspi-nossl
-debug-compile-sspi-openssl
-debug-compile-sspi-openssl-static
-test-asan-memcheck-mock-server
-test-aws-openssl-assume_role-5.0
-test-aws-openssl-ec2-5.0
-test-aws-openssl-ecs-5.0
-test-aws-openssl-lambda-5.0
-test-aws-openssl-regular-5.0
-test-latest-server-compression
-test-loadbalanced-asan-auth-openssl-5.0
-test-loadbalanced-asan-auth-openssl-latest
-test-loadbalanced-asan-noauth-nossl-5.0
-test-loadbalanced-asan-noauth-nossl-latest
```

Here is the rationale for the tasks that were removed in this PR:

- authentication-tests-openssl-static
    - Removed. Copying rationale from https://github.com/mongodb/mongo-c-driver/pull/1201#discussion_r1100603778:
    > IMO there is little value (if any) in testing both openssl and openssl_static. The only value would be from verifying the C driver can compile and link to both openssl and openssl_static.
- debug-compile-asan-openssl-cse
    - Seems redundant with `asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile`.
- debug-compile-sasl-darwinssl-cse
    - Seems redundant with `cse-sasl-cyrus-darwinssl-macos-1100-clang-compile`.
- debug-compile-sasl-openssl-cse
    - Seems redundant with `cse-sasl-cyrus-openssl-*` tasks.
- debug-compile-sasl-winssl
    - Seems redundant with `sasl-cyrus-winssl-*` tasks.
- debug-compile-sasl-winssl-cse
    - Seems redundant with `cse-sasl-cyrus-winssl-*` tasks.
- test-asan-memcheck-mock-server
    - Replaced by the new `mock-server-test` task.

The remaining tasks may still provide value and have not been removed. They may be used or migrated in a future PR.

## Adding the mock-server-test variant

The `mock-server-test` has been added to the new Evergreen config generator. It uses the `ubuntu2204-small` distro to agree with suggestions in [Guidelines around Evergreen distros](https://wiki.corp.mongodb.com/display/DBDEVPROD/Guidelines+around+Evergreen+distros). `gcc` is used since `clang` does not appear [installed on `ubuntu2204` distros](https://spruce.mongodb.com/task/mongo_c_driver_clang140ubuntu_debug_compile_asan_clang_patch_f5c6487c6c8728ca44a09f39cd162d08f23b7540_6467d599d6d80ae659c090ff_23_05_19_20_02_41/logs?execution=0):

```
[2023/05/19 20:05:04.811] CMake Error at /home/ubuntu/.cache/mongo-c-driver/tmp.vxxXctRSNK/cmake-3.25.2-linux-x86_64/share/cmake-3.25/Modules/CMakeDetermineCCompiler.cmake:49 (message):
[2023/05/19 20:05:04.811]   Could not find compiler set in environment variable CC:
[2023/05/19 20:05:04.811]   clang.
```

The `mock-server-test` variant has been added to the [GitHub Patch Definitions](https://spruce.mongodb.com/project/mongo-c-driver/settings/github-commitqueue) to run the task on each GitHub PR.