### PR TITLE
CDRIVER-4601 Bump maxWireVersion for MongoDB 7.0

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-client-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-private.h
@@ -79,7 +79,7 @@ BSON_BEGIN_DECLS
  * WIRE_VERSION_MAX must be accompanied by an update to
  * `_mongoc_wire_version_to_server_version`. */
 #define WIRE_VERSION_MIN 6  /* a.k.a. minWireVersion */
-#define WIRE_VERSION_MAX 17 /* a.k.a. maxWireVersion */
+#define WIRE_VERSION_MAX WIRE_VERSION_7_0 /* a.k.a. maxWireVersion */
 
 struct _mongoc_collection_t;
 

--- a/src/libmongoc/src/mongoc/mongoc-client-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-private.h
@@ -41,12 +41,6 @@
 
 BSON_BEGIN_DECLS
 
-/* Range of wire protocol versions this driver supports. Bumping
- * WIRE_VERSION_MAX must be accompanied by an update to
- * `_mongoc_wire_version_to_server_version`. */
-#define WIRE_VERSION_MIN 6  /* a.k.a. minWireVersion */
-#define WIRE_VERSION_MAX 17 /* a.k.a. maxWireVersion */
-
 /* version corresponding to server 4.0 release */
 #define WIRE_VERSION_4_0 7
 /* first version to support hint for "update" command */
@@ -80,6 +74,12 @@ BSON_BEGIN_DECLS
 #define WIRE_VERSION_6_0 17
 /* version corresponding to server 7.0 release */
 #define WIRE_VERSION_7_0 21
+
+/* Range of wire protocol versions this driver supports. Bumping
+ * WIRE_VERSION_MAX must be accompanied by an update to
+ * `_mongoc_wire_version_to_server_version`. */
+#define WIRE_VERSION_MIN 6  /* a.k.a. minWireVersion */
+#define WIRE_VERSION_MAX 17 /* a.k.a. maxWireVersion */
 
 struct _mongoc_collection_t;
 

--- a/src/libmongoc/src/mongoc/mongoc-client-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-private.h
@@ -41,6 +41,8 @@
 
 BSON_BEGIN_DECLS
 
+/* version corresponding to server 3.6 release */
+#define WIRE_VERSION_3_6 6
 /* version corresponding to server 4.0 release */
 #define WIRE_VERSION_4_0 7
 /* first version to support hint for "update" command */
@@ -78,7 +80,7 @@ BSON_BEGIN_DECLS
 /* Range of wire protocol versions this driver supports. Bumping
  * WIRE_VERSION_MAX must be accompanied by an update to
  * `_mongoc_wire_version_to_server_version`. */
-#define WIRE_VERSION_MIN 6  /* a.k.a. minWireVersion */
+#define WIRE_VERSION_MIN WIRE_VERSION_3_6 /* a.k.a. minWireVersion */
 #define WIRE_VERSION_MAX WIRE_VERSION_7_0 /* a.k.a. maxWireVersion */
 
 struct _mongoc_collection_t;


### PR DESCRIPTION
# Summary
- Increase `WIRE_VERSION_MAX` to `WIRE_VERSION_7_0`.
- Add macro for `WIRE_VERSION_3_6`.