### PR TITLE
Replace use of mock server *_replies_to_find when replying to OP_MSG requests

### DIFF
--- a/src/libmongoc/tests/mock_server/mock-rs.c
+++ b/src/libmongoc/tests/mock_server/mock-rs.c
@@ -492,42 +492,6 @@ mock_rs_receives_query (mock_rs_t *rs,
    return request;
 }
 
-
-/*--------------------------------------------------------------------------
- *
- * mock_server_reply_to_find --
- *
- *       Receive an OP_QUERY or a find command and reply to it.
- *
- *       Pop a client request if one is enqueued, or wait up to
- *       request_timeout_ms for the client to send a request.
- *
- * Side effects:
- *       Logs and aborts if the current request is not a query or find command
- *       matching "flags".
- *
- *--------------------------------------------------------------------------
- */
-/*
-
-void
-mock_rs_reply_to_find (mock_rs_t           *rs,
-                       mongoc_query_flags_t flags,
-                       int64_t              cursor_id,
-                       int32_t              number_returned,
-                       const char          *reply_json,
-                       bool                 is_command)
-{
-   request_t *request;
-
-   request = mock_rs_receives_request (rs);
-   BSON_ASSERT (request);
-
-   mock_server_reply_to_find (request, flags, cursor_id, number_returned,
-                              reply_json, is_command);
-}
-*/
-
 /*--------------------------------------------------------------------------
  *
  * mock_rs_receives_command --
@@ -703,28 +667,6 @@ _mock_rs_receives_msg (mock_rs_t *rs, uint32_t flags, ...)
 
 /*--------------------------------------------------------------------------
  *
- * mock_rs_hangs_up --
- *
- *       Hang up on a client request.
- *
- * Returns:
- *       None.
- *
- * Side effects:
- *       Causes a network error on the client side.
- *
- *--------------------------------------------------------------------------
- */
-
-void
-mock_rs_hangs_up (request_t *request)
-{
-   mock_server_hangs_up (request);
-}
-
-
-/*--------------------------------------------------------------------------
- *
  * mock_rs_receives_kill_cursors --
  *
  *       Pop a client request if one is enqueued, or wait up to
@@ -760,40 +702,6 @@ mock_rs_receives_kill_cursors (mock_rs_t *rs, int64_t cursor_id)
 }
 
 
-/*--------------------------------------------------------------------------
- *
- * mock_rs_replies --
- *
- *       Respond to a client request.
- *
- * Returns:
- *       None.
- *
- * Side effects:
- *       Sends an OP_REPLY to the client.
- *
- *--------------------------------------------------------------------------
- */
-
-void
-mock_rs_replies (request_t *request,
-                 uint32_t flags,
-                 int64_t cursor_id,
-                 int32_t starting_from,
-                 int32_t number_returned,
-                 const char *docs_json)
-{
-   mock_server_replies (
-      request, flags, cursor_id, starting_from, number_returned, docs_json);
-}
-
-void
-mock_rs_replies_opmsg (request_t *request, uint32_t flags, const bson_t *doc)
-{
-   mock_server_replies_opmsg (request, flags, doc);
-}
-
-
 static mongoc_server_description_type_t
 _mock_rs_server_type (mock_rs_t *rs, uint16_t port)
 {
@@ -814,59 +722,6 @@ _mock_rs_server_type (mock_rs_t *rs, uint16_t port)
    }
 
    return MONGOC_SERVER_UNKNOWN;
-}
-
-
-/*--------------------------------------------------------------------------
- *
- * mock_rs_replies_simple --
- *
- *       Respond to a client request.
- *
- * Returns:
- *       None.
- *
- * Side effects:
- *       Sends an OP_REPLY to the client.
- *
- *--------------------------------------------------------------------------
- */
-
-void
-mock_rs_replies_simple (request_t *request, const char *docs_json)
-{
-   mock_rs_replies (request, 0, 0, 0, 1, docs_json);
-}
-
-
-/*--------------------------------------------------------------------------
- *
- * mock_rs_replies_to_find --
- *
- *       Receive an OP_QUERY or "find" command and reply appropriately.
- *
- * Returns:
- *       None.
- *
- * Side effects:
- *       Very roughly validates the query or "find" command or aborts.
- *       The intent is not to test the driver's query or find command
- *       implementation here, see _test_kill_cursors for example use.
- *
- *--------------------------------------------------------------------------
- */
-
-void
-mock_rs_replies_to_find (request_t *request,
-                         mongoc_query_flags_t flags,
-                         int64_t cursor_id,
-                         int32_t number_returned,
-                         const char *ns,
-                         const char *reply_json,
-                         bool is_command)
-{
-   mock_server_replies_to_find (
-      request, flags, cursor_id, number_returned, ns, reply_json, is_command);
 }
 
 

--- a/src/libmongoc/tests/mock_server/mock-rs.c
+++ b/src/libmongoc/tests/mock_server/mock-rs.c
@@ -787,6 +787,12 @@ mock_rs_replies (request_t *request,
       request, flags, cursor_id, starting_from, number_returned, docs_json);
 }
 
+void
+mock_rs_replies_opmsg (request_t *request, uint32_t flags, const bson_t *doc)
+{
+   mock_server_replies_opmsg (request, flags, doc);
+}
+
 
 static mongoc_server_description_type_t
 _mock_rs_server_type (mock_rs_t *rs, uint16_t port)

--- a/src/libmongoc/tests/mock_server/mock-rs.h
+++ b/src/libmongoc/tests/mock_server/mock-rs.h
@@ -88,33 +88,6 @@ _mock_rs_receives_msg (mock_rs_t *rs, uint32_t flags, ...);
 #define mock_rs_receives_msg(_rs, _flags, ...) \
    _mock_rs_receives_msg (_rs, _flags, __VA_ARGS__, NULL)
 
-void
-mock_rs_replies (request_t *request,
-                 uint32_t flags,
-                 int64_t cursor_id,
-                 int32_t starting_from,
-                 int32_t number_returned,
-                 const char *docs_json);
-
-void
-mock_rs_replies_opmsg (request_t *request, uint32_t flags, const bson_t *doc);
-
-void
-mock_rs_replies_simple (request_t *request, const char *docs_json);
-
-void
-mock_rs_replies_to_find (request_t *request,
-                         mongoc_query_flags_t flags,
-                         int64_t cursor_id,
-                         int32_t number_returned,
-                         const char *ns,
-                         const char *reply_json,
-                         bool is_command);
-
-void
-mock_rs_hangs_up (request_t *request);
-
-
 bool
 mock_rs_request_is_to_primary (mock_rs_t *rs, request_t *request);
 

--- a/src/libmongoc/tests/mock_server/mock-rs.h
+++ b/src/libmongoc/tests/mock_server/mock-rs.h
@@ -25,9 +25,9 @@ typedef struct _mock_rs_t mock_rs_t;
 
 mock_rs_t *
 mock_rs_with_auto_hello (int32_t max_wire_version,
-                           bool has_primary,
-                           int n_secondaries,
-                           int n_arbiters);
+                         bool has_primary,
+                         int n_secondaries,
+                         int n_arbiters);
 
 
 void
@@ -95,6 +95,9 @@ mock_rs_replies (request_t *request,
                  int32_t starting_from,
                  int32_t number_returned,
                  const char *docs_json);
+
+void
+mock_rs_replies_opmsg (request_t *request, uint32_t flags, const bson_t *doc);
 
 void
 mock_rs_replies_simple (request_t *request, const char *docs_json);

--- a/src/libmongoc/tests/mock_server/mock-server.c
+++ b/src/libmongoc/tests/mock_server/mock-server.c
@@ -242,7 +242,7 @@ hangup (request_t *request, void *ctx)
 {
    BSON_UNUSED (ctx);
 
-   mock_server_hangs_up (request);
+   reply_to_request_with_hang_up (request);
    request_destroy (request);
 
    return true;
@@ -573,7 +573,7 @@ auto_hello (request_t *request, void *data)
       _mongoc_usleep ((int64_t) (rand () % 10) * 1000);
    }
 
-   mock_server_replies (request, MONGOC_REPLY_NONE, 0, 0, 1, response_json);
+   reply_to_request (request, MONGOC_REPLY_NONE, 0, 0, 1, response_json);
 
    bson_destroy (&response);
    bson_free (response_json);
@@ -654,7 +654,7 @@ auto_endsessions (request_t *request, void *data)
       return false;
    }
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    return true;
 }
 
@@ -1578,7 +1578,7 @@ mock_server_receives_kill_cursors (mock_server_t *server, int64_t cursor_id)
 
 /*--------------------------------------------------------------------------
  *
- * mock_server_hangs_up --
+ * reply_to_request_with_hang_up --
  *
  *       Hang up on a client request.
  *
@@ -1592,7 +1592,7 @@ mock_server_receives_kill_cursors (mock_server_t *server, int64_t cursor_id)
  */
 
 void
-mock_server_hangs_up (request_t *request)
+reply_to_request_with_hang_up (request_t *request)
 {
    reply_t *reply;
    test_suite_mock_server_log ("%5.2f  %hu <- %hu \thang up!",
@@ -1607,7 +1607,7 @@ mock_server_hangs_up (request_t *request)
 
 /*--------------------------------------------------------------------------
  *
- * mock_server_resets --
+ * reply_to_request_with_reset --
  *
  *       Forcefully reset a connection from the client.
  *
@@ -1621,7 +1621,7 @@ mock_server_hangs_up (request_t *request)
  */
 
 void
-mock_server_resets (request_t *request)
+reply_to_request_with_reset (request_t *request)
 {
    reply_t *reply;
    test_suite_mock_server_log ("%5.2f  %hu <- %hu \treset!",
@@ -1637,7 +1637,7 @@ mock_server_resets (request_t *request)
 
 /*--------------------------------------------------------------------------
  *
- * mock_server_replies --
+ * reply_to_request --
  *
  *       Respond to a client request.
  *
@@ -1651,12 +1651,12 @@ mock_server_resets (request_t *request)
  */
 
 void
-mock_server_replies (request_t *request,
-                     mongoc_reply_flags_t flags,
-                     int64_t cursor_id,
-                     int32_t starting_from,
-                     int32_t number_returned,
-                     const char *docs_json)
+reply_to_request (request_t *request,
+                  mongoc_reply_flags_t flags,
+                  int64_t cursor_id,
+                  int32_t starting_from,
+                  int32_t number_returned,
+                  const char *docs_json)
 {
    char *quotes_replaced;
    bson_t doc;
@@ -1681,14 +1681,14 @@ mock_server_replies (request_t *request,
       return;
    }
 
-   mock_server_reply_multi (request, flags, &doc, 1, cursor_id);
+   reply_to_request_with_mutiple_docs (request, flags, &doc, 1, cursor_id);
    bson_destroy (&doc);
 }
 
 
 /*--------------------------------------------------------------------------
  *
- * mock_server_replies_simple --
+ * reply_to_request_simple --
  *
  *       Respond to a client request.
  *
@@ -1702,16 +1702,16 @@ mock_server_replies (request_t *request,
  */
 
 void
-mock_server_replies_simple (request_t *request, const char *docs_json)
+reply_to_request_simple (request_t *request, const char *docs_json)
 {
-   mock_server_replies (request, MONGOC_REPLY_NONE, 0, 0, 1, docs_json);
+   reply_to_request (request, MONGOC_REPLY_NONE, 0, 0, 1, docs_json);
 }
 
 /* To specify additional flags for OP_MSG replies. */
 void
-mock_server_replies_opmsg (request_t *request,
-                           mongoc_op_msg_flags_t flags,
-                           const bson_t *doc)
+reply_to_op_msg (request_t *request,
+                 mongoc_op_msg_flags_t flags,
+                 const bson_t *doc)
 {
    reply_t *reply;
 
@@ -1735,7 +1735,7 @@ mock_server_replies_opmsg (request_t *request,
 
 /*--------------------------------------------------------------------------
  *
- * mock_server_replies_ok_and_destroys --
+ * reply_to_request_with_ok_and_destroy --
  *
  *       Respond to a client request.
  *
@@ -1749,16 +1749,16 @@ mock_server_replies_opmsg (request_t *request,
  */
 
 void
-mock_server_replies_ok_and_destroys (request_t *request)
+reply_to_request_with_ok_and_destroy (request_t *request)
 {
-   mock_server_replies (request, MONGOC_REPLY_NONE, 0, 0, 1, "{'ok': 1}");
+   reply_to_request (request, MONGOC_REPLY_NONE, 0, 0, 1, "{'ok': 1}");
    request_destroy (request);
 }
 
 
 /*--------------------------------------------------------------------------
  *
- * mock_server_replies_to_find --
+ * reply_to_find_request --
  *
  *       Receive an OP_QUERY or "find" command and reply appropriately.
  *
@@ -1774,13 +1774,13 @@ mock_server_replies_ok_and_destroys (request_t *request)
  */
 
 void
-mock_server_replies_to_find (request_t *request,
-                             mongoc_query_flags_t flags,
-                             int64_t cursor_id,
-                             int32_t number_returned,
-                             const char *ns,
-                             const char *reply_json,
-                             bool is_command)
+reply_to_find_request (request_t *request,
+                       mongoc_query_flags_t flags,
+                       int64_t cursor_id,
+                       int32_t number_returned,
+                       const char *ns,
+                       const char *reply_json,
+                       bool is_command)
 {
    char *find_reply;
    char *db;
@@ -1811,10 +1811,10 @@ mock_server_replies_to_find (request_t *request,
                              ns,
                              reply_json);
 
-      mock_server_replies_simple (request, find_reply);
+      reply_to_request_simple (request, find_reply);
       bson_free (find_reply);
    } else {
-      mock_server_replies (
+      reply_to_request (
          request, MONGOC_REPLY_NONE, cursor_id, 0, number_returned, reply_json);
    }
    bson_free (db);
@@ -2189,11 +2189,11 @@ failure:
 
 /* enqueue server reply for this connection's worker thread to send to client */
 void
-mock_server_reply_multi (request_t *request,
-                         mongoc_reply_flags_t flags,
-                         const bson_t *docs,
-                         int n_docs,
-                         int64_t cursor_id)
+reply_to_request_with_mutiple_docs (request_t *request,
+                                    mongoc_reply_flags_t flags,
+                                    const bson_t *docs,
+                                    int n_docs,
+                                    int64_t cursor_id)
 {
    reply_t *reply;
    int i;

--- a/src/libmongoc/tests/mock_server/mock-server.c
+++ b/src/libmongoc/tests/mock_server/mock-server.c
@@ -1681,7 +1681,7 @@ reply_to_request (request_t *request,
       return;
    }
 
-   reply_to_request_with_mutiple_docs (request, flags, &doc, 1, cursor_id);
+   reply_to_request_with_multiple_docs (request, flags, &doc, 1, cursor_id);
    bson_destroy (&doc);
 }
 
@@ -2189,11 +2189,11 @@ failure:
 
 /* enqueue server reply for this connection's worker thread to send to client */
 void
-reply_to_request_with_mutiple_docs (request_t *request,
-                                    mongoc_reply_flags_t flags,
-                                    const bson_t *docs,
-                                    int n_docs,
-                                    int64_t cursor_id)
+reply_to_request_with_multiple_docs (request_t *request,
+                                     mongoc_reply_flags_t flags,
+                                     const bson_t *docs,
+                                     int n_docs,
+                                     int64_t cursor_id)
 {
    reply_t *reply;
    int i;

--- a/src/libmongoc/tests/mock_server/mock-server.c
+++ b/src/libmongoc/tests/mock_server/mock-server.c
@@ -1709,9 +1709,9 @@ reply_to_request_simple (request_t *request, const char *docs_json)
 
 /* To specify additional flags for OP_MSG replies. */
 void
-reply_to_op_msg (request_t *request,
-                 mongoc_op_msg_flags_t flags,
-                 const bson_t *doc)
+reply_to_op_msg_request (request_t *request,
+                         mongoc_op_msg_flags_t flags,
+                         const bson_t *doc)
 {
    reply_t *reply;
 

--- a/src/libmongoc/tests/mock_server/mock-server.h
+++ b/src/libmongoc/tests/mock_server/mock-server.h
@@ -242,11 +242,11 @@ reply_to_op_msg_request (request_t *request,
                          const bson_t *doc);
 
 void
-reply_to_request_with_mutiple_docs (request_t *request,
-                                    mongoc_reply_flags_t flags,
-                                    const bson_t *docs,
-                                    int n_docs,
-                                    int64_t cursor_id);
+reply_to_request_with_multiple_docs (request_t *request,
+                                     mongoc_reply_flags_t flags,
+                                     const bson_t *docs,
+                                     int n_docs,
+                                     int64_t cursor_id);
 
 void
 mock_server_destroy (mock_server_t *server);

--- a/src/libmongoc/tests/mock_server/mock-server.h
+++ b/src/libmongoc/tests/mock_server/mock-server.h
@@ -237,9 +237,9 @@ reply_to_find_request (request_t *request,
                        bool is_command);
 
 void
-reply_to_op_msg (request_t *request,
-                 mongoc_op_msg_flags_t flags,
-                 const bson_t *doc);
+reply_to_op_msg_request (request_t *request,
+                         mongoc_op_msg_flags_t flags,
+                         const bson_t *doc);
 
 void
 reply_to_request_with_mutiple_docs (request_t *request,

--- a/src/libmongoc/tests/mock_server/mock-server.h
+++ b/src/libmongoc/tests/mock_server/mock-server.h
@@ -208,45 +208,45 @@ mock_server_receives_bulk_msg (mock_server_t *server,
                                size_t n_docs);
 
 void
-mock_server_hangs_up (request_t *request);
+reply_to_request_with_hang_up (request_t *request);
 
 void
-mock_server_resets (request_t *request);
+reply_to_request_with_reset (request_t *request);
 
 void
-mock_server_replies (request_t *request,
-                     mongoc_reply_flags_t flags,
-                     int64_t cursor_id,
-                     int32_t starting_from,
-                     int32_t number_returned,
-                     const char *docs_json);
+reply_to_request (request_t *request,
+                  mongoc_reply_flags_t flags,
+                  int64_t cursor_id,
+                  int32_t starting_from,
+                  int32_t number_returned,
+                  const char *docs_json);
 
 void
-mock_server_replies_simple (request_t *request, const char *docs_json);
+reply_to_request_simple (request_t *request, const char *docs_json);
 
 void
-mock_server_replies_ok_and_destroys (request_t *request);
+reply_to_request_with_ok_and_destroy (request_t *request);
 
 void
-mock_server_replies_to_find (request_t *request,
-                             mongoc_query_flags_t flags,
-                             int64_t cursor_id,
-                             int32_t number_returned,
-                             const char *ns,
-                             const char *reply_json,
-                             bool is_command);
+reply_to_find_request (request_t *request,
+                       mongoc_query_flags_t flags,
+                       int64_t cursor_id,
+                       int32_t number_returned,
+                       const char *ns,
+                       const char *reply_json,
+                       bool is_command);
 
 void
-mock_server_replies_opmsg (request_t *request,
-                           mongoc_op_msg_flags_t flags,
-                           const bson_t *doc);
+reply_to_op_msg (request_t *request,
+                 mongoc_op_msg_flags_t flags,
+                 const bson_t *doc);
 
 void
-mock_server_reply_multi (request_t *request,
-                         mongoc_reply_flags_t flags,
-                         const bson_t *docs,
-                         int n_docs,
-                         int64_t cursor_id);
+reply_to_request_with_mutiple_docs (request_t *request,
+                                    mongoc_reply_flags_t flags,
+                                    const bson_t *docs,
+                                    int n_docs,
+                                    int64_t cursor_id);
 
 void
 mock_server_destroy (mock_server_t *server);

--- a/src/libmongoc/tests/test-mongoc-aggregate.c
+++ b/src/libmongoc/tests/test-mongoc-aggregate.c
@@ -39,12 +39,12 @@ _test_query_flag (mongoc_query_flags_t flag, bson_t *opt)
                                           " 'pipeline': [ ],"
                                           " 'tailable': {'$exists': false}}"));
    ASSERT (request);
-   mock_server_replies_simple (request,
-                               "{'ok': 1,"
-                               " 'cursor': {"
-                               "    'id': {'$numberLong': '123'},"
-                               "    'ns': 'db.collection',"
-                               "    'nextBatch': [{}]}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "    'id': {'$numberLong': '123'},"
+                            "    'ns': 'db.collection',"
+                            "    'nextBatch': [{}]}}");
    ASSERT (future_get_bool (future));
    request_destroy (request);
    future_destroy (future);
@@ -58,12 +58,12 @@ _test_query_flag (mongoc_query_flags_t flag, bson_t *opt)
                                           " 'collection': 'collection',"
                                           " 'tailable': {'$exists': false}}"));
    ASSERT (request);
-   mock_server_replies_simple (request,
-                               "{'ok': 1,"
-                               " 'cursor': {"
-                               "    'id': {'$numberLong': '0'},"
-                               "    'ns': 'db.collection',"
-                               "    'nextBatch': [{}]}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "    'id': {'$numberLong': '0'},"
+                            "    'ns': 'db.collection',"
+                            "    'nextBatch': [{}]}}");
 
    ASSERT (future_get_bool (future));
 

--- a/src/libmongoc/tests/test-mongoc-async.c
+++ b/src/libmongoc/tests/test-mongoc-async.c
@@ -176,7 +176,7 @@ test_hello_impl (bool with_ssl)
                              WIRE_VERSION_MAX,
                              server_id);
 
-      mock_server_replies_simple (request, reply);
+      reply_to_request_simple (request, reply);
       bson_free (reply);
       request_destroy (request);
    }

--- a/src/libmongoc/tests/test-mongoc-background-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-background-monitoring.c
@@ -200,8 +200,8 @@ auto_respond_polling_hello (request_t *request, void *ctx)
 
       doc = request_get_doc ((request), 0);
       if (!bson_has_field (doc, "topologyVersion")) {
-         mock_server_replies_simple (request,
-                                     "{'ok': 1, 'topologyVersion': " TV " }");
+         reply_to_request_simple (request,
+                                  "{'ok': 1, 'topologyVersion': " TV " }");
          request_destroy (request);
          return true;
       }
@@ -379,7 +379,7 @@ test_connect_succeeds (void)
    request = mock_server_receives_legacy_hello (tf->server, NULL);
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 1);
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
 
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 1);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_failed == 0);
@@ -401,7 +401,7 @@ test_connect_hangup (void)
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 1);
    OBSERVE (tf, !tf->observations->awaited);
-   mock_server_hangs_up (request);
+   reply_to_request_with_hang_up (request);
    request_destroy (request);
 
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 0);
@@ -426,7 +426,7 @@ test_connect_badreply (void)
    request = mock_server_receives_legacy_hello (tf->server, NULL);
    OBSERVE (tf, request);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_started == 1);
-   mock_server_replies_simple (request, "{'ok': 0}");
+   reply_to_request_simple (request, "{'ok': 0}");
    request_destroy (request);
 
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 0);
@@ -456,7 +456,7 @@ test_connect_shutdown (void)
 
    /* Reply (or hang up) so the request does not wait for connectTimeoutMS to
     * time out. */
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
 
    /* Heartbeat succeeds, but server description is not updated. */
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 1);
@@ -478,7 +478,7 @@ test_connect_requestscan (void)
    OBSERVE (tf, request);
    /* Before the mock server replies, request a scan. */
    _request_scan (tf);
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
 
    /* Because the request occurred during the scan, no subsequent scan occurs.
     */
@@ -504,7 +504,7 @@ test_retry_succeeds (void)
    request = mock_server_receives_legacy_hello (tf->server, NULL);
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 1);
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
 
    /* Heartbeat succeeds, but server description is not updated. */
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 1);
@@ -518,7 +518,7 @@ test_retry_succeeds (void)
    request = mock_server_receives_legacy_hello (tf->server, NULL);
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
-   mock_server_hangs_up (request);
+   reply_to_request_with_hang_up (request);
    request_destroy (request);
 
    /* Server is marked as unknown, but not for long. Next scan is immediate. */
@@ -530,7 +530,7 @@ test_retry_succeeds (void)
    request = mock_server_receives_legacy_hello (tf->server, NULL);
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 3);
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 2);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_failed == 1);
    OBSERVE_SOON (tf, tf->observations->sd_type == MONGOC_SERVER_STANDALONE);
@@ -550,7 +550,7 @@ test_retry_hangup (void)
    request = mock_server_receives_legacy_hello (tf->server, NULL);
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 1);
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
 
    /* Heartbeat succeeds, but server description is not updated. */
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 1);
@@ -564,7 +564,7 @@ test_retry_hangup (void)
    request = mock_server_receives_legacy_hello (tf->server, NULL);
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
-   mock_server_hangs_up (request);
+   reply_to_request_with_hang_up (request);
    request_destroy (request);
 
    /* Server is marked as unknown. Next scan is immediate. */
@@ -576,7 +576,7 @@ test_retry_hangup (void)
    request = mock_server_receives_legacy_hello (tf->server, NULL);
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 3);
-   mock_server_hangs_up (request);
+   reply_to_request_with_hang_up (request);
    request_destroy (request);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 1);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_failed == 2);
@@ -597,7 +597,7 @@ test_retry_badreply (void)
    request = mock_server_receives_legacy_hello (tf->server, NULL);
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 1);
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
 
    /* Heartbeat succeeds, but server description is not updated. */
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 1);
@@ -611,7 +611,7 @@ test_retry_badreply (void)
    request = mock_server_receives_legacy_hello (tf->server, NULL);
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
-   mock_server_hangs_up (request);
+   reply_to_request_with_hang_up (request);
    request_destroy (request);
 
    /* Server is marked unknown. Next scan is immediate. */
@@ -623,7 +623,7 @@ test_retry_badreply (void)
    request = mock_server_receives_legacy_hello (tf->server, NULL);
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 3);
-   mock_server_replies_simple (request, "{'ok': 0}");
+   reply_to_request_simple (request, "{'ok': 0}");
    request_destroy (request);
    /* Heartbeat fails. */
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 1);
@@ -645,7 +645,7 @@ test_retry_shutdown (void)
    request = mock_server_receives_legacy_hello (tf->server, NULL);
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 1);
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
 
    /* Heartbeat succeeds, but server description is not updated. */
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 1);
@@ -657,7 +657,7 @@ test_retry_shutdown (void)
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
    _signal_shutdown (tf);
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
 
    /* No retry occurs. */
    WAIT_TWO_MIN_HEARTBEAT_MS;
@@ -682,7 +682,7 @@ test_flip_flop (void)
    for (i = 1; i < 100; i++) {
       request = mock_server_receives_legacy_hello (tf->server, NULL);
       OBSERVE (tf, request);
-      mock_server_replies_ok_and_destroys (request);
+      reply_to_request_with_ok_and_destroy (request);
       _signal_shutdown (tf);
       OBSERVE_SOON (tf, tf->observations->n_heartbeat_started == i);
       OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == i);
@@ -712,7 +712,7 @@ test_repeated_requestscan (void)
    }
    WAIT_TWO_MIN_HEARTBEAT_MS;
    OBSERVE (tf, tf->observations->n_heartbeat_started == 1);
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 1);
 
    tf_destroy (tf);
@@ -729,7 +729,7 @@ test_sleep_after_scan (void)
    _request_scan (tf);
    request = mock_server_receives_legacy_hello (tf->server, NULL);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 1);
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 1);
    WAIT_TWO_MIN_HEARTBEAT_MS;
    /* No subsequent command send. */
@@ -751,7 +751,7 @@ test_streaming_succeeds (void)
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
    OBSERVE (tf, tf->observations->awaited);
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
 
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 2);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_failed == 0);
@@ -776,7 +776,7 @@ test_streaming_hangup (void)
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
    OBSERVE (tf, tf->observations->awaited);
-   mock_server_hangs_up (request);
+   reply_to_request_with_hang_up (request);
    request_destroy (request);
 
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_failed == 1);
@@ -803,7 +803,7 @@ test_streaming_badreply (void)
       tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
-   mock_server_replies_simple (request, "{'ok': 0}");
+   reply_to_request_simple (request, "{'ok': 0}");
    request_destroy (request);
 
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 1);
@@ -877,7 +877,7 @@ test_streaming_cancel (void)
       tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 4);
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 3);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_failed == 1);
    OBSERVE_SOON (tf, tf->observations->n_server_changed == 2);
@@ -898,10 +898,9 @@ test_moretocome_succeeds (void)
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
    OBSERVE (tf, tf->observations->awaited);
-   mock_server_replies_opmsg (
-      request,
-      MONGOC_MSG_MORE_TO_COME,
-      tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
+   reply_to_op_msg (request,
+                    MONGOC_MSG_MORE_TO_COME,
+                    tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
 
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 2);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_failed == 0);
@@ -910,17 +909,15 @@ test_moretocome_succeeds (void)
    OBSERVE (tf, tf->observations->awaited);
 
    /* Server monitor is still streaming replies. */
-   mock_server_replies_opmsg (
-      request,
-      MONGOC_MSG_MORE_TO_COME,
-      tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
+   reply_to_op_msg (request,
+                    MONGOC_MSG_MORE_TO_COME,
+                    tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 3);
    OBSERVE (tf, tf->observations->awaited);
    /* Reply with no moretocome flag. */
-   mock_server_replies_opmsg (
-      request,
-      MONGOC_MSG_NONE,
-      tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
+   reply_to_op_msg (request,
+                    MONGOC_MSG_NONE,
+                    tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 4);
    OBSERVE (tf, tf->observations->awaited);
    request_destroy (request);
@@ -954,10 +951,9 @@ test_moretocome_hangup (void)
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
    OBSERVE (tf, tf->observations->awaited);
-   mock_server_replies_opmsg (
-      request,
-      MONGOC_MSG_MORE_TO_COME,
-      tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
+   reply_to_op_msg (request,
+                    MONGOC_MSG_MORE_TO_COME,
+                    tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
 
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 2);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_failed == 0);
@@ -966,7 +962,7 @@ test_moretocome_hangup (void)
    OBSERVE (tf, tf->observations->awaited);
 
    /* Server monitor is still streaming replies. */
-   mock_server_hangs_up (request);
+   reply_to_request_with_hang_up (request);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_failed == 1);
    /* Due to network error, server monitor immediately proceeds and performs
     * handshake. */
@@ -992,10 +988,9 @@ test_moretocome_badreply (void)
       tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
-   mock_server_replies_opmsg (
-      request,
-      MONGOC_MSG_MORE_TO_COME,
-      tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
+   reply_to_op_msg (request,
+                    MONGOC_MSG_MORE_TO_COME,
+                    tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
 
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 2);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_failed == 0);
@@ -1003,7 +998,7 @@ test_moretocome_badreply (void)
    OBSERVE_SOON (tf, tf->observations->sd_type == MONGOC_SERVER_STANDALONE);
 
    /* Server monitor is still streaming replies. */
-   mock_server_replies_simple (request, "{'ok': 0}");
+   reply_to_request_simple (request, "{'ok': 0}");
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 2);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_failed == 1);
    OBSERVE_SOON (tf, tf->observations->n_server_changed == 2);
@@ -1032,10 +1027,9 @@ test_moretocome_shutdown (void)
       tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
-   mock_server_replies_opmsg (
-      request,
-      MONGOC_MSG_MORE_TO_COME,
-      tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
+   reply_to_op_msg (request,
+                    MONGOC_MSG_MORE_TO_COME,
+                    tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
 
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 2);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_failed == 0);
@@ -1067,10 +1061,9 @@ test_moretocome_cancel (void)
       tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
-   mock_server_replies_opmsg (
-      request,
-      MONGOC_MSG_MORE_TO_COME,
-      tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
+   reply_to_op_msg (request,
+                    MONGOC_MSG_MORE_TO_COME,
+                    tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
 
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 2);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_failed == 0);
@@ -1106,10 +1099,9 @@ test_moretocome_cancel (void)
       tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 5);
-   mock_server_replies_opmsg (
-      request,
-      MONGOC_MSG_NONE,
-      tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
+   reply_to_op_msg (request,
+                    MONGOC_MSG_NONE,
+                    tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 4);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_failed == 1);
    OBSERVE_SOON (tf, tf->observations->n_server_changed == 1);
@@ -1124,10 +1116,9 @@ test_moretocome_cancel (void)
       tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 6);
-   mock_server_replies_opmsg (
-      request,
-      MONGOC_MSG_NONE,
-      tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
+   reply_to_op_msg (request,
+                    MONGOC_MSG_NONE,
+                    tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 5);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_failed == 1);
    OBSERVE_SOON (tf, tf->observations->n_server_changed == 1);

--- a/src/libmongoc/tests/test-mongoc-background-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-background-monitoring.c
@@ -898,9 +898,9 @@ test_moretocome_succeeds (void)
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
    OBSERVE (tf, tf->observations->awaited);
-   reply_to_op_msg (request,
-                    MONGOC_MSG_MORE_TO_COME,
-                    tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
+   reply_to_op_msg_request (request,
+                            MONGOC_MSG_MORE_TO_COME,
+                            tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
 
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 2);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_failed == 0);
@@ -909,15 +909,15 @@ test_moretocome_succeeds (void)
    OBSERVE (tf, tf->observations->awaited);
 
    /* Server monitor is still streaming replies. */
-   reply_to_op_msg (request,
-                    MONGOC_MSG_MORE_TO_COME,
-                    tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
+   reply_to_op_msg_request (request,
+                            MONGOC_MSG_MORE_TO_COME,
+                            tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 3);
    OBSERVE (tf, tf->observations->awaited);
    /* Reply with no moretocome flag. */
-   reply_to_op_msg (request,
-                    MONGOC_MSG_NONE,
-                    tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
+   reply_to_op_msg_request (request,
+                            MONGOC_MSG_NONE,
+                            tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 4);
    OBSERVE (tf, tf->observations->awaited);
    request_destroy (request);
@@ -951,9 +951,9 @@ test_moretocome_hangup (void)
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
    OBSERVE (tf, tf->observations->awaited);
-   reply_to_op_msg (request,
-                    MONGOC_MSG_MORE_TO_COME,
-                    tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
+   reply_to_op_msg_request (request,
+                            MONGOC_MSG_MORE_TO_COME,
+                            tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
 
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 2);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_failed == 0);
@@ -988,9 +988,9 @@ test_moretocome_badreply (void)
       tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
-   reply_to_op_msg (request,
-                    MONGOC_MSG_MORE_TO_COME,
-                    tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
+   reply_to_op_msg_request (request,
+                            MONGOC_MSG_MORE_TO_COME,
+                            tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
 
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 2);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_failed == 0);
@@ -1027,9 +1027,9 @@ test_moretocome_shutdown (void)
       tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
-   reply_to_op_msg (request,
-                    MONGOC_MSG_MORE_TO_COME,
-                    tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
+   reply_to_op_msg_request (request,
+                            MONGOC_MSG_MORE_TO_COME,
+                            tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
 
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 2);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_failed == 0);
@@ -1061,9 +1061,9 @@ test_moretocome_cancel (void)
       tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 2);
-   reply_to_op_msg (request,
-                    MONGOC_MSG_MORE_TO_COME,
-                    tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
+   reply_to_op_msg_request (request,
+                            MONGOC_MSG_MORE_TO_COME,
+                            tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
 
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 2);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_failed == 0);
@@ -1099,9 +1099,9 @@ test_moretocome_cancel (void)
       tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 5);
-   reply_to_op_msg (request,
-                    MONGOC_MSG_NONE,
-                    tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
+   reply_to_op_msg_request (request,
+                            MONGOC_MSG_NONE,
+                            tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 4);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_failed == 1);
    OBSERVE_SOON (tf, tf->observations->n_server_changed == 1);
@@ -1116,9 +1116,9 @@ test_moretocome_cancel (void)
       tmp_bson ("{'topologyVersion': { '$exists': true}}"));
    OBSERVE (tf, request);
    OBSERVE (tf, tf->observations->n_heartbeat_started == 6);
-   reply_to_op_msg (request,
-                    MONGOC_MSG_NONE,
-                    tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
+   reply_to_op_msg_request (request,
+                            MONGOC_MSG_NONE,
+                            tmp_bson ("{'ok': 1, 'topologyVersion': " TV "}"));
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_succeeded == 5);
    OBSERVE_SOON (tf, tf->observations->n_heartbeat_failed == 1);
    OBSERVE_SOON (tf, tf->observations->n_server_changed == 1);

--- a/src/libmongoc/tests/test-mongoc-client-session.c
+++ b/src/libmongoc/tests/test-mongoc-client-session.c
@@ -503,7 +503,7 @@ _test_mock_end_sessions (bool pooled)
 
    request = mock_server_receives_msg (
       server, 0, tmp_bson ("{'ping': 1, 'lsid': {'$exists': true}}"));
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
 
    BSON_ASSERT (future_get_bool (future));
    future_destroy (future);
@@ -526,7 +526,7 @@ _test_mock_end_sessions (bool pooled)
 
    /* check that we got the expected endSessions cmd */
    request = mock_server_receives_msg (server, 0, expected_cmd);
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    future_wait (future);
    future_destroy (future);
 

--- a/src/libmongoc/tests/test-mongoc-client.c
+++ b/src/libmongoc/tests/test-mongoc-client.c
@@ -72,7 +72,7 @@ test_client_cmd_w_server_id (void)
                                       " 'serverId': {'$exists': false}}"));
 
    ASSERT (mock_rs_request_is_to_secondary (rs, request));
-   mock_rs_replies_simple (request, "{'ok': 1}");
+   reply_to_request_simple (request, "{'ok': 1}");
    ASSERT_OR_PRINT (future_get_bool (future), error);
 
    bson_destroy (&reply);
@@ -115,7 +115,7 @@ test_client_cmd_w_server_id_sharded (void)
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'db', 'ping': 1, 'serverId': {'$exists': false}}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
 
    bson_destroy (&reply);
@@ -278,7 +278,7 @@ test_client_cmd_write_concern (void)
    request = mock_server_receives_msg (server, MONGOC_MSG_NONE, cmd);
    BSON_ASSERT (request);
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    BSON_ASSERT (future_get_bool (future));
 
    future_destroy (future);
@@ -290,10 +290,9 @@ test_client_cmd_write_concern (void)
    request = mock_server_receives_msg (server, MONGOC_MSG_NONE, cmd);
    BSON_ASSERT (request);
 
-   mock_server_replies_simple (
-      request,
-      "{ 'ok' : 0, 'errmsg' : 'cannot use w > 1 when a "
-      "host is not replicated', 'code' : 2 }");
+   reply_to_request_simple (request,
+                            "{ 'ok' : 0, 'errmsg' : 'cannot use w > 1 when a "
+                            "host is not replicated', 'code' : 2 }");
 
    BSON_ASSERT (!future_get_bool (future));
    future_destroy (future);
@@ -304,7 +303,7 @@ test_client_cmd_write_concern (void)
    future =
       future_client_command_simple (client, "test", cmd, NULL, &reply, &error);
    request = mock_server_receives_msg (server, MONGOC_MSG_NONE, cmd);
-   mock_server_replies_simple (
+   reply_to_request_simple (
       request,
       "{ 'ok' : 1, 'n': 1, "
       "'writeConcernError': {'code': 17, 'errmsg': 'foo'}}");
@@ -348,7 +347,7 @@ test_client_cmd_write_concern_fam (void)
       tmp_bson ("{'$db': 'test', 'findAndModify': 'collection', "
                 "'writeConcern': {'w': 2}}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    BSON_ASSERT (future_get_bool (future));
 
    bson_destroy (&reply);
@@ -1078,7 +1077,7 @@ _test_command_read_prefs (bool simple, bool pooled)
       request = mock_server_receives_msg (
          server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'db', 'foo': 1}"));
 
-      mock_server_replies_ok_and_destroys (request);
+      reply_to_request_with_ok_and_destroy (request);
       ASSERT_OR_PRINT (future_get_bool (future), error);
       future_destroy (future);
 
@@ -1092,7 +1091,7 @@ _test_command_read_prefs (bool simple, bool pooled)
          tmp_bson ("{'$db': 'db',"
                    " 'foo': 1,"
                    " '$readPreference': {'mode': 'secondary'}}"));
-      mock_server_replies_ok_and_destroys (request);
+      reply_to_request_with_ok_and_destroy (request);
       ASSERT_OR_PRINT (future_get_bool (future), error);
       future_destroy (future);
    } else {
@@ -1103,7 +1102,7 @@ _test_command_read_prefs (bool simple, bool pooled)
       request = mock_server_receives_msg (
          server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'db', 'foo': 1}"));
 
-      mock_server_replies_ok_and_destroys (request);
+      reply_to_request_with_ok_and_destroy (request);
       ASSERT (future_get_bool (future));
       future_destroy (future);
       mongoc_cursor_destroy (cursor);
@@ -1119,7 +1118,7 @@ _test_command_read_prefs (bool simple, bool pooled)
                    " 'foo': 1,"
                    " '$readPreference': {'mode': 'secondary'}}"));
 
-      mock_server_replies_ok_and_destroys (request);
+      reply_to_request_with_ok_and_destroy (request);
       ASSERT (future_get_bool (future));
       future_destroy (future);
       mongoc_cursor_destroy (cursor);
@@ -1243,7 +1242,7 @@ test_command_with_opts_read_prefs (void)
    request = mock_server_receives_msg (
       server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'admin', 'create': 'db'}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 
@@ -1261,7 +1260,7 @@ test_command_with_opts_read_prefs (void)
                 " 'count': 'collection',"
                 " '$readPreference': {'mode': 'secondary'}}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 
@@ -1279,7 +1278,7 @@ test_command_with_opts_read_prefs (void)
                 " 'readConcern': {'level': 'majority'},"
                 " '$readPreference': {'$exists': false}}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 
@@ -1319,7 +1318,7 @@ test_read_write_cmd_with_opts (void)
       rs, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'db', 'ping': 1}"));
 
    ASSERT (mock_rs_request_is_to_primary (rs, request));
-   mock_rs_replies_simple (request, "{'ok': 1}");
+   reply_to_request_simple (request, "{'ok': 1}");
    ASSERT_OR_PRINT (future_get_bool (future), error);
 
    bson_destroy (&reply);
@@ -1362,7 +1361,7 @@ test_read_command_with_opts (void)
       tmp_bson (
          "{'$db': 'admin', 'create': 'db', 'collation': {'locale': 'en_US'}}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 
@@ -1377,7 +1376,7 @@ test_read_command_with_opts (void)
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'admin', 'create': 'db', 'writeConcern': {'w': 1}}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 
@@ -1393,7 +1392,7 @@ test_read_command_with_opts (void)
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'admin', 'create': 'db', 'writeConcern': {'w': 1}}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 
@@ -1411,7 +1410,7 @@ test_read_command_with_opts (void)
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'admin', 'create': 'db', 'writeConcern': {'w': 2}}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 
@@ -1431,7 +1430,7 @@ test_read_command_with_opts (void)
                 " 'count': 'collection',"
                 " 'readConcern': {'level': 'local'}}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 
@@ -1447,7 +1446,7 @@ test_read_command_with_opts (void)
                 " 'count': 'collection',"
                 " 'readConcern': {'level': 'local'}}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 
@@ -1502,7 +1501,7 @@ test_command_with_opts (void)
                 " 'readConcern': {'$exists': false},"
                 " 'writeConcern': {'$exists': false}}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 
@@ -1521,7 +1520,7 @@ test_command_with_opts (void)
                 " 'readConcern': {'level':'majority'},"
                 " '$readPreference': {'mode':'secondary'}}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 
@@ -1582,7 +1581,7 @@ test_command_with_opts_op_msg (void)
                 "   'writeConcern': {'$exists': false}"
                 "}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 
@@ -1604,7 +1603,7 @@ test_command_with_opts_op_msg (void)
                 "   }"
                 "}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 
@@ -1687,7 +1686,7 @@ test_command_no_errmsg (void)
 
    /* auth errors have $err, not errmsg. we'd raised "Unknown command error",
     * see CDRIVER-1928 */
-   mock_server_replies_simple (request, "{'ok': 0, 'code': 7, '$err': 'bad!'}");
+   reply_to_request_simple (request, "{'ok': 0, 'code': 7, '$err': 'bad!'}");
    ASSERT (!future_get_bool (future));
    ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_SERVER, 7, "bad!");
 
@@ -1780,7 +1779,7 @@ responder (request_t *request, void *data)
    BSON_UNUSED (data);
 
    if (!strcmp (request->command_name, "foo")) {
-      mock_server_replies_ok_and_destroys (request);
+      reply_to_request_with_ok_and_destroy (request);
       return true;
    }
 
@@ -2137,7 +2136,7 @@ test_get_database_names (void)
       server,
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'admin', 'listDatabases': 1, 'nameOnly': true}"));
-   mock_server_replies (
+   reply_to_request (
       request,
       0,
       0,
@@ -2158,7 +2157,7 @@ test_get_database_names (void)
       server,
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'admin', 'listDatabases': 1, 'nameOnly': true}"));
-   mock_server_replies (
+   reply_to_request (
       request, 0, 0, 0, 1, "{'ok': 0.0, 'code': 17, 'errmsg': 'err'}");
 
    names = future_get_char_ptr_ptr (future);
@@ -2315,7 +2314,7 @@ test_mongoc_client_mismatched_me (void)
                                mock_server_get_host_and_port (server));
 
    capture_logs (true);
-   mock_server_replies_simple (request, reply);
+   reply_to_request_simple (request, reply);
 
    BSON_ASSERT (!future_get_bool (future));
    ASSERT_ERROR_CONTAINS (error,
@@ -2838,7 +2837,7 @@ _test_mongoc_client_select_server_retry (bool retry_succeeds)
    /* first selection succeeds */
    future = future_client_select_server (client, true, NULL, &error);
    request = mock_server_receives_any_hello (server);
-   mock_server_replies_simple (request, hello);
+   reply_to_request_simple (request, hello);
    request_destroy (request);
    sd = future_get_mongoc_server_description_ptr (future);
    ASSERT_OR_PRINT (sd, error);
@@ -2854,18 +2853,18 @@ _test_mongoc_client_select_server_retry (bool retry_succeeds)
    request = mock_server_receives_msg (
       server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'admin', 'ping': 1}"));
 
-   mock_server_hangs_up (request);
+   reply_to_request_with_hang_up (request);
    request_destroy (request);
 
    /* mongoc_client_select_server retries once */
    request = mock_server_receives_any_hello (server);
    if (retry_succeeds) {
-      mock_server_replies_simple (request, hello);
+      reply_to_request_simple (request, hello);
       sd = future_get_mongoc_server_description_ptr (future);
       ASSERT_OR_PRINT (sd, error);
       mongoc_server_description_destroy (sd);
    } else {
-      mock_server_hangs_up (request);
+      reply_to_request_with_hang_up (request);
       sd = future_get_mongoc_server_description_ptr (future);
       BSON_ASSERT (sd == NULL);
    }
@@ -2922,12 +2921,12 @@ _test_mongoc_client_fetch_stream_retry (bool retry_succeeds)
    future = future_client_command_simple (
       client, "db", tmp_bson ("{'cmd': 1}"), NULL, NULL, &error);
    request = mock_server_receives_any_hello (server);
-   mock_server_replies_simple (request, hello);
+   reply_to_request_simple (request, hello);
    request_destroy (request);
 
    request = mock_server_receives_msg (
       server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'db', 'cmd': 1}"));
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
 
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
@@ -2942,22 +2941,22 @@ _test_mongoc_client_fetch_stream_retry (bool retry_succeeds)
    request = mock_server_receives_msg (
       server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'admin', 'ping': 1}"));
 
-   mock_server_hangs_up (request);
+   reply_to_request_with_hang_up (request);
    request_destroy (request);
 
    /* mongoc_client_select_server retries once */
    request = mock_server_receives_any_hello (server);
    if (retry_succeeds) {
-      mock_server_replies_simple (request, hello);
+      reply_to_request_simple (request, hello);
       request_destroy (request);
 
       request = mock_server_receives_msg (
          server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'db', 'cmd': 1}"));
 
-      mock_server_replies_simple (request, "{'ok': 1}");
+      reply_to_request_simple (request, "{'ok': 1}");
       ASSERT_OR_PRINT (future_get_bool (future), error);
    } else {
-      mock_server_hangs_up (request);
+      reply_to_request_with_hang_up (request);
       BSON_ASSERT (!future_get_bool (future));
    }
 
@@ -3002,7 +3001,7 @@ _cmd (mock_server_t *server,
    ASSERT (request);
 
    if (server_replies) {
-      mock_server_replies_simple (request, "{'ok': 1}");
+      reply_to_request_simple (request, "{'ok': 1}");
    }
 
    r = future_get_bool (future);
@@ -3246,7 +3245,7 @@ _respond_to_ping (future_t *future, mock_server_t *server)
    request = mock_server_receives_msg (
       server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'admin', 'ping': 1}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
 
    ASSERT (future_get_bool (future));
    future_destroy (future);
@@ -3282,7 +3281,7 @@ test_mongoc_handshake_pool (void)
    client1 = mongoc_client_pool_pop (pool);
    request1 = mock_server_receives_legacy_hello (server, NULL);
    _assert_hello_valid (request1, true);
-   mock_server_replies_simple (request1, server_reply);
+   reply_to_request_simple (request1, server_reply);
    request_destroy (request1);
 
    client2 = mongoc_client_pool_pop (pool);
@@ -3291,12 +3290,12 @@ test_mongoc_handshake_pool (void)
 
    request2 = mock_server_receives_legacy_hello (server, NULL);
    _assert_hello_valid (request2, true);
-   mock_server_replies_simple (request2, server_reply);
+   reply_to_request_simple (request2, server_reply);
    request_destroy (request2);
 
    request2 = mock_server_receives_msg (
       server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'test'}"));
-   mock_server_replies_ok_and_destroys (request2);
+   reply_to_request_with_ok_and_destroy (request2);
    ASSERT (future_get_bool (future));
    future_destroy (future);
 
@@ -3349,7 +3348,7 @@ _test_client_sends_handshake (bool pooled)
 
    /* Make sure the hello request has a "client" field: */
    _assert_hello_valid (request, true);
-   mock_server_replies_simple (request, server_reply);
+   reply_to_request_simple (request, server_reply);
    request_destroy (request);
 
    if (!pooled) {
@@ -3362,7 +3361,7 @@ _test_client_sends_handshake (bool pooled)
    request = mock_server_receives_any_hello (server);
    _assert_hello_valid (request, false);
 
-   mock_server_replies_simple (request, server_reply);
+   reply_to_request_simple (request, server_reply);
    request_destroy (request);
 
    if (!pooled) {
@@ -3374,13 +3373,13 @@ _test_client_sends_handshake (bool pooled)
     * time the server hangs up */
    request = mock_server_receives_any_hello (server);
    _assert_hello_valid (request, false);
-   mock_server_hangs_up (request);
+   reply_to_request_with_hang_up (request);
    request_destroy (request);
 
    /* Client retries once (CDRIVER-2075) */
    request = mock_server_receives_any_hello (server);
    _assert_hello_valid (request, true);
-   mock_server_hangs_up (request);
+   reply_to_request_with_hang_up (request);
    request_destroy (request);
 
    if (!pooled) {
@@ -3399,7 +3398,7 @@ _test_client_sends_handshake (bool pooled)
    request = mock_server_receives_any_hello (server);
    _assert_hello_valid (request, true);
 
-   mock_server_replies_simple (request, server_reply);
+   reply_to_request_simple (request, server_reply);
    request_destroy (request);
 
    if (!pooled) {
@@ -3482,7 +3481,7 @@ test_client_appname (bool pooled, bool use_uri)
                                                  "    'application': {"
                                                  "       'name': 'testapp'}}}");
 
-   mock_server_replies_simple (request, server_reply);
+   reply_to_request_simple (request, server_reply);
    if (!pooled) {
       _respond_to_ping (future, server);
    }
@@ -3557,7 +3556,7 @@ _test_null_error_pointer (bool pooled)
       client, "test", tmp_bson ("{'ping': 1}"), NULL, NULL, NULL);
    request = mock_server_receives_msg (
       server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'test', 'ping': 1}"));
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT (future_get_bool (future));
    future_destroy (future);
 
@@ -3670,7 +3669,7 @@ test_client_reset_sessions (void)
 
    request = mock_server_receives_msg (
       server, 0, tmp_bson ("{'ping': 1, 'lsid': {'$exists': true}}"));
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
 
    ASSERT (future_get_bool (future));
 
@@ -3731,12 +3730,12 @@ test_client_reset_cursors (void)
    request = mock_server_receives_msg (
       server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'test', 'find': 'test'}"));
 
-   mock_server_replies_simple (request,
-                               "{'ok': 1,"
-                               " 'cursor': {"
-                               "    'id': 4,"
-                               "    'ns': 'test.test',"
-                               "    'firstBatch': [{}]}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "    'id': 4,"
+                            "    'ns': 'test.test',"
+                            "    'firstBatch': [{}]}}");
 
    BSON_ASSERT (future_get_bool (future));
    ASSERT (cursor->cursor_id);
@@ -3765,7 +3764,7 @@ test_client_reset_cursors (void)
 
    request = mock_server_receives_msg (
       server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'admin', 'ping': 1}"));
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
 
    ASSERT (future_get_bool (future));
 
@@ -3828,7 +3827,7 @@ test_client_reset_connections (void)
    request = mock_server_receives_msg (
       server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'admin', 'ping': 1}"));
    BSON_ASSERT (request);
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
 
    ASSERT (future_get_bool (future));
 
@@ -3971,7 +3970,7 @@ test_mongoc_client_recv_network_error (void)
                                           NULL /* reply */,
                                           &error);
    request = mock_server_receives_request (server);
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    future_wait (future);
    future_destroy (future);
 
@@ -4177,7 +4176,7 @@ test_mongoc_client_resends_handshake_on_network_error (void)
       "': 1, 'client': {'application': {'name': 'foo'}}}",
       "{'" HANDSHAKE_CMD_LEGACY_HELLO
       "': 1, 'client': {'application': {'name': 'foo'}}}");
-   mock_server_replies_simple (
+   reply_to_request_simple (
       request,
       tmp_str ("{'ok': 1, 'minWireVersion': %d, 'maxWireVersion': %d}",
                WIRE_VERSION_MIN,
@@ -4185,7 +4184,7 @@ test_mongoc_client_resends_handshake_on_network_error (void)
    request_destroy (request);
    request = mock_server_receives_msg (
       server, MONGOC_QUERY_NONE, tmp_bson ("{'ping': 1}"));
-   mock_server_hangs_up (request);
+   reply_to_request_with_hang_up (request);
    future_wait (future);
    future_destroy (future);
    ASSERT_ERROR_CONTAINS (error,
@@ -4204,7 +4203,7 @@ test_mongoc_client_resends_handshake_on_network_error (void)
       "': 1, 'client': {'application': {'name': 'foo'}}}",
       "{'" HANDSHAKE_CMD_LEGACY_HELLO
       "': 1, 'client': {'application': {'name': 'foo'}}}");
-   mock_server_replies_simple (
+   reply_to_request_simple (
       request,
       tmp_str ("{'ok': 1, 'minWireVersion': %d, 'maxWireVersion': %d }",
                WIRE_VERSION_MIN,
@@ -4213,7 +4212,7 @@ test_mongoc_client_resends_handshake_on_network_error (void)
 
    request = mock_server_receives_msg (
       server, MONGOC_QUERY_NONE, tmp_bson ("{'ping': 1}"));
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT (future_get_bool (future));
    future_destroy (future);
 

--- a/src/libmongoc/tests/test-mongoc-cluster.c
+++ b/src/libmongoc/tests/test-mongoc-cluster.c
@@ -778,7 +778,7 @@ replies_with_cluster_time (request_t *request,
                 t,
                 i));
 
-   reply_to_request_with_mutiple_docs (
+   reply_to_request_with_multiple_docs (
       request, MONGOC_REPLY_NONE, &doc, 1, 0 /* cursor id */);
 
    bson_destroy (&doc);

--- a/src/libmongoc/tests/test-mongoc-cluster.c
+++ b/src/libmongoc/tests/test-mongoc-cluster.c
@@ -1222,13 +1222,13 @@ _test_dollar_query (void *ctx)
 
    future = future_cursor_next (cursor, &doc);
    request = mock_server_receives_msg (server, 0, tmp_bson (test->e));
-   reply_to_op_msg (request,
-                    MONGOC_MSG_NONE,
-                    tmp_bson ("{'ok': 1,"
-                              " 'cursor': {"
-                              "    'id': {'$numberLong': '0'},"
-                              "    'ns': 'db.collection',"
-                              "    'firstBatch': []}}"));
+   reply_to_op_msg_request (request,
+                            MONGOC_MSG_NONE,
+                            tmp_bson ("{'ok': 1,"
+                                      " 'cursor': {"
+                                      "    'id': {'$numberLong': '0'},"
+                                      "    'ns': 'db.collection',"
+                                      "    'firstBatch': []}}"));
 
    BSON_ASSERT (!future_get_bool (future));
    ASSERT_OR_PRINT (!mongoc_cursor_error (cursor, &error), error);
@@ -1509,13 +1509,13 @@ test_advanced_cluster_time_not_sent_to_standalone (void)
                 "   'find': 'collection', 'filter': {},"
                 "   '$clusterTime': {'$exists': false}"
                 "}"));
-   reply_to_op_msg (request,
-                    MONGOC_MSG_NONE,
-                    tmp_bson ("{'ok': 1,"
-                              " 'cursor': {"
-                              "    'id': {'$numberLong': '0'},"
-                              "    'ns': 'db.collection',"
-                              "    'firstBatch': []}}"));
+   reply_to_op_msg_request (request,
+                            MONGOC_MSG_NONE,
+                            tmp_bson ("{'ok': 1,"
+                                      " 'cursor': {"
+                                      "    'id': {'$numberLong': '0'},"
+                                      "    'ns': 'db.collection',"
+                                      "    'firstBatch': []}}"));
 
    BSON_ASSERT (!future_get_bool (future));
    ASSERT_OR_PRINT (!mongoc_cursor_error (cursor, &error), error);

--- a/src/libmongoc/tests/test-mongoc-cluster.c
+++ b/src/libmongoc/tests/test-mongoc-cluster.c
@@ -1222,8 +1222,13 @@ _test_dollar_query (void *ctx)
 
    future = future_cursor_next (cursor, &doc);
    request = mock_server_receives_msg (server, 0, tmp_bson (test->e));
-   mock_server_replies_to_find (
-      request, MONGOC_QUERY_NONE, 0, 0, "db.collection", "", true);
+   mock_server_replies_opmsg (request,
+                              MONGOC_MSG_NONE,
+                              tmp_bson ("{'ok': 1,"
+                                        " 'cursor': {"
+                                        "    'id': {'$numberLong': '0'},"
+                                        "    'ns': 'db.collection',"
+                                        "    'firstBatch': []}}"));
 
    BSON_ASSERT (!future_get_bool (future));
    ASSERT_OR_PRINT (!mongoc_cursor_error (cursor, &error), error);
@@ -1504,8 +1509,13 @@ test_advanced_cluster_time_not_sent_to_standalone (void)
                 "   'find': 'collection', 'filter': {},"
                 "   '$clusterTime': {'$exists': false}"
                 "}"));
-   mock_server_replies_to_find (
-      request, MONGOC_QUERY_NONE, 0, 0, "db.collection", "", true);
+   mock_server_replies_opmsg (request,
+                              MONGOC_MSG_NONE,
+                              tmp_bson ("{'ok': 1,"
+                                        " 'cursor': {"
+                                        "    'id': {'$numberLong': '0'},"
+                                        "    'ns': 'db.collection',"
+                                        "    'firstBatch': []}}"));
 
    BSON_ASSERT (!future_get_bool (future));
    ASSERT_OR_PRINT (!mongoc_cursor_error (cursor, &error), error);

--- a/src/libmongoc/tests/test-mongoc-cmd.c
+++ b/src/libmongoc/tests/test-mongoc-cmd.c
@@ -66,7 +66,7 @@ test_client_cmd_options (void)
       MONGOC_QUERY_NONE,
       tmp_bson ("{'readConcern': { '$exists': true }}"));
 
-   mock_server_replies_simple (request, "{'ok': 1, 'n': 1}");
+   reply_to_request_simple (request, "{'ok': 1, 'n': 1}");
    ASSERT_OR_PRINT (future_get_bool (future), error);
 
    request_destroy (request);

--- a/src/libmongoc/tests/test-mongoc-collection-find-with-opts.c
+++ b/src/libmongoc/tests/test-mongoc-collection-find-with-opts.c
@@ -63,12 +63,12 @@ _test_collection_find_command (test_collection_find_with_opts_t *test_data)
    request = mock_server_receives_msg (
       server, MONGOC_MSG_NONE, tmp_bson (test_data->expected_find_command));
    ASSERT (request);
-   mock_server_replies_simple (request,
-                               "{'ok': 1,"
-                               " 'cursor': {"
-                               "    'id': 0,"
-                               "    'ns': 'db.collection',"
-                               "    'firstBatch': [{}]}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "    'id': 0,"
+                            "    'ns': 'db.collection',"
+                            "    'firstBatch': [{}]}}");
    ASSERT (future_get_bool (future));
 
    request_destroy (request);
@@ -484,14 +484,13 @@ test_exhaust (void)
     * fallback to existing OP_QUERY wire protocol messages."
     */
    request = mock_server_receives_request (server);
-   mock_server_replies_to_find (request,
-                                MONGOC_QUERY_SECONDARY_OK |
-                                   MONGOC_QUERY_EXHAUST,
-                                0,
-                                0,
-                                "db.collection",
-                                "{}",
-                                false /* is_command */);
+   reply_to_find_request (request,
+                          MONGOC_QUERY_SECONDARY_OK | MONGOC_QUERY_EXHAUST,
+                          0,
+                          0,
+                          "db.collection",
+                          "{}",
+                          false /* is_command */);
 
    ASSERT (future_get_bool (future));
    ASSERT_OR_PRINT (!mongoc_cursor_error (cursor, &error), error);
@@ -543,12 +542,12 @@ test_getmore_cmd_await (void)
                 " 'maxAwaitTimeMS': {'$exists': false}}"));
 
    ASSERT (request);
-   mock_server_replies_simple (request,
-                               "{'ok': 1,"
-                               " 'cursor': {"
-                               "    'id': {'$numberLong': '123'},"
-                               "    'ns': 'db.collection',"
-                               "    'firstBatch': [{}]}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "    'id': {'$numberLong': '123'},"
+                            "    'ns': 'db.collection',"
+                            "    'firstBatch': [{}]}}");
 
    ASSERT (future_get_bool (future));
    request_destroy (request);
@@ -568,12 +567,12 @@ test_getmore_cmd_await (void)
                 " 'maxTimeMS': {'$numberLong': '9999'}}"));
 
    ASSERT (request);
-   mock_server_replies_simple (request,
-                               "{'ok': 1,"
-                               " 'cursor': {"
-                               "    'id': {'$numberLong': '0'},"
-                               "    'ns': 'db.collection',"
-                               "    'nextBatch': [{}]}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "    'id': {'$numberLong': '0'},"
+                            "    'ns': 'db.collection',"
+                            "    'nextBatch': [{}]}}");
 
    ASSERT (future_get_bool (future));
 
@@ -622,11 +621,11 @@ test_find_w_server_id (void)
                 " '$readPreference': {'mode': 'primaryPreferred'}}"));
 
    ASSERT (mock_rs_request_is_to_secondary (rs, request));
-   mock_rs_replies_simple (request,
-                           "{'ok': 1,"
-                           " 'cursor': {"
-                           "   'ns': 'db.collection',"
-                           "   'firstBatch': [{}]}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "   'ns': 'db.collection',"
+                            "   'firstBatch': [{}]}}");
    ASSERT_OR_PRINT (future_get_bool (future), cursor->error);
 
    future_destroy (future);
@@ -678,12 +677,12 @@ test_find_cmd_w_server_id (void)
                                       " 'serverId': {'$exists': false}}"));
 
    ASSERT (mock_rs_request_is_to_secondary (rs, request));
-   mock_rs_replies_simple (request,
-                           "{'ok': 1,"
-                           " 'cursor': {"
-                           "    'id': 0,"
-                           "    'ns': 'db.collection',"
-                           "    'firstBatch': [{}]}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "    'id': 0,"
+                            "    'ns': 'db.collection',"
+                            "    'firstBatch': [{}]}}");
 
    ASSERT_OR_PRINT (future_get_bool (future), error);
 
@@ -731,12 +730,12 @@ test_find_w_server_id_sharded (void)
                 " 'filter': {},"
                 " '$readPreference': {'$exists': false}}"));
 
-   mock_server_replies_simple (request,
-                               "{'ok': 1,"
-                               " 'cursor': {"
-                               "    'id': 0,"
-                               "    'ns': 'db.collection',"
-                               "    'firstBatch': [{}]}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "    'id': 0,"
+                            "    'ns': 'db.collection',"
+                            "    'firstBatch': [{}]}}");
    ASSERT_OR_PRINT (future_get_bool (future), error);
 
    future_destroy (future);
@@ -784,12 +783,12 @@ test_find_cmd_w_server_id_sharded (void)
                                           " 'readConcern': {'level': 'local'},"
                                           " 'serverId': {'$exists': false}}"));
 
-   mock_rs_replies_simple (request,
-                           "{'ok': 1,"
-                           " 'cursor': {"
-                           "    'id': 0,"
-                           "    'ns': 'db.collection',"
-                           "    'firstBatch': [{}]}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "    'id': 0,"
+                            "    'ns': 'db.collection',"
+                            "    'firstBatch': [{}]}}");
 
    ASSERT_OR_PRINT (future_get_bool (future), error);
 

--- a/src/libmongoc/tests/test-mongoc-collection-find.c
+++ b/src/libmongoc/tests/test-mongoc-collection-find.c
@@ -170,7 +170,7 @@ _reply_to_find_command (request_t *request, test_collection_find_t *test_data)
                                     "    'firstBatch': %s}}",
                                     result_json);
 
-   mock_server_replies_simple (request, reply_json);
+   reply_to_request_simple (request, reply_json);
 
    bson_free (reply_json);
 }
@@ -715,14 +715,13 @@ test_exhaust (void)
     * fallback to existing OP_QUERY wire protocol messages."
     */
    request = mock_server_receives_request (server);
-   mock_server_replies_to_find (request,
-                                MONGOC_QUERY_SECONDARY_OK |
-                                   MONGOC_QUERY_EXHAUST,
-                                0,
-                                0,
-                                "db.collection",
-                                "{}",
-                                false /* is_command */);
+   reply_to_find_request (request,
+                          MONGOC_QUERY_SECONDARY_OK | MONGOC_QUERY_EXHAUST,
+                          0,
+                          0,
+                          "db.collection",
+                          "{}",
+                          false /* is_command */);
 
    ASSERT (future_get_bool (future));
    ASSERT_OR_PRINT (!mongoc_cursor_error (cursor, &error), error);
@@ -784,12 +783,12 @@ test_getmore_batch_size (void)
                                                     " 'batchSize': %s}",
                                                     batch_size_json));
 
-      mock_server_replies_simple (request,
-                                  "{'ok': 1,"
-                                  " 'cursor': {"
-                                  "    'id': 0,"
-                                  "    'ns': 'db.collection',"
-                                  "    'firstBatch': []}}");
+      reply_to_request_simple (request,
+                               "{'ok': 1,"
+                               " 'cursor': {"
+                               "    'id': 0,"
+                               "    'ns': 'db.collection',"
+                               "    'firstBatch': []}}");
 
       /* no result */
       ASSERT (!future_get_bool (future));
@@ -840,12 +839,12 @@ test_getmore_invalid_reply (void *ctx)
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'db', 'find': 'collection', 'filter': {}}"));
 
-   mock_server_replies_simple (request,
-                               "{'ok': 1,"
-                               " 'cursor': {"
-                               "    'id': {'$numberLong': '123'},"
-                               "    'ns': 'db.collection',"
-                               "    'firstBatch': [{}]}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "    'id': {'$numberLong': '123'},"
+                            "    'ns': 'db.collection',"
+                            "    'firstBatch': [{}]}}");
 
    ASSERT (future_get_bool (future));
 
@@ -861,7 +860,7 @@ test_getmore_invalid_reply (void *ctx)
                                           " 'collection': 'collection'}"));
 
    /* missing "cursor" */
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
 
    ASSERT (!future_get_bool (future));
    ASSERT (mongoc_cursor_error (cursor, &error));
@@ -933,12 +932,12 @@ test_getmore_await (void)
                    " 'maxAwaitTimeMS': {'$exists': false}}"));
 
       /* reply with cursor id 1 */
-      mock_server_replies_simple (request,
-                                  "{'ok': 1,"
-                                  " 'cursor': {"
-                                  "    'id': 1,"
-                                  "    'ns': 'db.collection',"
-                                  "    'firstBatch': [{}]}}");
+      reply_to_request_simple (request,
+                               "{'ok': 1,"
+                               " 'cursor': {"
+                               "    'id': 1,"
+                               "    'ns': 'db.collection',"
+                               "    'firstBatch': [{}]}}");
 
       /* no result or error */
       ASSERT (future_get_bool (future));
@@ -967,12 +966,12 @@ test_getmore_await (void)
 
       BSON_ASSERT (request);
       /* reply with cursor id 0 */
-      mock_server_replies_simple (request,
-                                  "{'ok': 1,"
-                                  " 'cursor': {"
-                                  "    'id': 0,"
-                                  "    'ns': 'db.collection',"
-                                  "    'nextBatch': []}}");
+      reply_to_request_simple (request,
+                               "{'ok': 1,"
+                               " 'cursor': {"
+                               "    'id': 0,"
+                               "    'ns': 'db.collection',"
+                               "    'nextBatch': []}}");
 
       /* no result or error */
       ASSERT (!future_get_bool (future));

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -135,7 +135,7 @@ test_aggregate_inherit_collection (void)
                 " 'readConcern': {'level': 'majority'},"
                 " 'writeConcern': {'w': 2}}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
 
    ASSERT (!future_get_bool (future));
 
@@ -165,7 +165,7 @@ test_aggregate_inherit_collection (void)
                 " 'readConcern': {'level': 'local'},"
                 " 'writeConcern': {'w': 3}}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
 
    ASSERT (!future_get_bool (future));
 
@@ -187,7 +187,7 @@ test_aggregate_inherit_collection (void)
                 " 'readConcern': {'level': 'majority'},"
                 " 'writeConcern': {'w': 2}}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
 
    ASSERT (!future_get_bool (future));
 
@@ -213,7 +213,7 @@ test_aggregate_inherit_collection (void)
                 " 'readConcern': {'level': 'local'},"
                 " 'writeConcern': {'$exists': false}}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT (!future_get_bool (future));
 
    future_destroy (future);
@@ -267,7 +267,7 @@ _batch_size_test (bson_t *pipeline,
          tmp_bson ("{ 'cursor' : { 'batchSize' : { '$exists': false } } }"));
    }
 
-   mock_server_replies_simple (request, "{'ok': 1}");
+   reply_to_request_simple (request, "{'ok': 1}");
 
    request_destroy (request);
    future_wait (future);
@@ -953,7 +953,7 @@ test_insert_command_keys (void)
                                 tmp_bson ("{'_id': 1}"),
                                 tmp_bson ("{'_id': 2}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
 
    ASSERT_OR_PRINT (future_get_uint32_t (future), error);
 
@@ -2051,7 +2051,7 @@ test_count_read_pref (void)
                 " 'count': 'collection',"
                 " '$readPreference': {'mode': 'secondary'}}"));
 
-   mock_server_replies_simple (request, "{'ok': 1, 'n': 1}");
+   reply_to_request_simple (request, "{'ok': 1, 'n': 1}");
    ASSERT_OR_PRINT (1 == future_get_int64_t (future), error);
 
    request_destroy (request);
@@ -2094,7 +2094,7 @@ test_count_read_concern (void)
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'test', 'count': 'test', 'query': {}}"));
 
-   mock_server_replies_simple (request, "{ 'n' : 42, 'ok' : 1 } ");
+   reply_to_request_simple (request, "{ 'n' : 42, 'ok' : 1 } ");
    count = future_get_int64_t (future);
    ASSERT_OR_PRINT (count == 42, error);
    request_destroy (request);
@@ -2117,7 +2117,7 @@ test_count_read_concern (void)
                 " 'query': {},"
                 " 'readConcern': {'level': 'majority'}}"));
 
-   mock_server_replies_simple (request, "{ 'n' : 43, 'ok' : 1 } ");
+   reply_to_request_simple (request, "{ 'n' : 43, 'ok' : 1 } ");
    count = future_get_int64_t (future);
    ASSERT_OR_PRINT (count == 43, error);
    mongoc_read_concern_destroy (rc);
@@ -2141,7 +2141,7 @@ test_count_read_concern (void)
                 " 'query': {},"
                 " 'readConcern': {'level': 'local'}}"));
 
-   mock_server_replies_simple (request, "{ 'n' : 44, 'ok' : 1 } ");
+   reply_to_request_simple (request, "{ 'n' : 44, 'ok' : 1 } ");
    count = future_get_int64_t (future);
    ASSERT_OR_PRINT (count == 44, error);
    mongoc_read_concern_destroy (rc);
@@ -2165,7 +2165,7 @@ test_count_read_concern (void)
                 " 'query': {},"
                 " 'readConcern': {'level': 'futureCompatible'}}"));
 
-   mock_server_replies_simple (request, "{ 'n' : 45, 'ok' : 1 } ");
+   reply_to_request_simple (request, "{ 'n' : 45, 'ok' : 1 } ");
    count = future_get_int64_t (future);
    ASSERT_OR_PRINT (count == 45, error);
    mongoc_read_concern_destroy (rc);
@@ -2189,7 +2189,7 @@ test_count_read_concern (void)
                 " 'query': {},"
                 " 'readConcern': { '$exists': false }}"));
 
-   mock_server_replies_simple (request, "{ 'n' : 46, 'ok' : 1 } ");
+   reply_to_request_simple (request, "{ 'n' : 46, 'ok' : 1 } ");
    count = future_get_int64_t (future);
    ASSERT_OR_PRINT (count == 46, error);
    mongoc_read_concern_destroy (rc);
@@ -2212,7 +2212,7 @@ test_count_read_concern (void)
                 " 'query': {},"
                 " 'readConcern': { '$exists': false }}"));
 
-   mock_server_replies_simple (request, "{ 'n' : 47, 'ok' : 1 } ");
+   reply_to_request_simple (request, "{ 'n' : 47, 'ok' : 1 } ");
    count = future_get_int64_t (future);
    ASSERT_OR_PRINT (count == 47, error);
 
@@ -2367,7 +2367,7 @@ test_count_with_opts (void)
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'db', 'count': 'collection', 'opt': 1}"));
 
-   mock_server_replies_simple (request, "{'ok': 1, 'n': 1}");
+   reply_to_request_simple (request, "{'ok': 1, 'n': 1}");
    ASSERT_OR_PRINT (1 == future_get_int64_t (future), error);
 
    request_destroy (request);
@@ -2411,7 +2411,7 @@ test_count_with_collation (void)
                                 tmp_bson ("{'$db': 'db',"
                                           " 'count': 'collection',"
                                           " 'collation': {'locale': 'en'}}"));
-   mock_server_replies_simple (request, "{'ok': 1, 'n': 1}");
+   reply_to_request_simple (request, "{'ok': 1, 'n': 1}");
    ASSERT_OR_PRINT (1 == future_get_int64_t (future), error);
    request_destroy (request);
 
@@ -2456,7 +2456,7 @@ test_count_documents (void)
       tmp_bson ("{'aggregate': 'coll', 'pipeline': [{'$match': "
                 "{'x': 1}}, {'$skip': 1}, {'$limit': 2}, {'$group': "
                 "{'n': {'$sum': 1}}}]}"));
-   mock_server_replies_simple (request, server_reply);
+   reply_to_request_simple (request, server_reply);
    ASSERT_OR_PRINT (123 == future_get_int64_t (future), error);
    ASSERT_MATCH (&reply, server_reply);
 
@@ -2479,7 +2479,7 @@ test_count_documents (void)
       tmp_bson ("{'aggregate': 'coll', 'pipeline': [{'$match': {}}, {'$skip': "
                 "1}, {'$limit': 2}, {'$group': "
                 "{'n': {'$sum': 1}}}]}"));
-   mock_server_replies_simple (request, server_reply);
+   reply_to_request_simple (request, server_reply);
    ASSERT_OR_PRINT (123 == future_get_int64_t (future), error);
    ASSERT_MATCH (&reply, server_reply);
    bson_destroy (&reply);
@@ -2499,7 +2499,7 @@ test_count_documents (void)
       0,
       tmp_bson ("{'aggregate': 'coll', 'pipeline': [{'$match': {}}, {'$group': "
                 "{'n': {'$sum': 1}}}], 'maxTimeMS': 123}"));
-   mock_server_replies_simple (request, server_reply);
+   reply_to_request_simple (request, server_reply);
    ASSERT_OR_PRINT (123 == future_get_int64_t (future), error);
    ASSERT_MATCH (&reply, server_reply);
    bson_destroy (&reply);
@@ -2559,7 +2559,7 @@ test_estimated_document_count (void)
 
    request = mock_server_receives_msg (
       server, 0, tmp_bson ("{'count': 'coll', 'limit': 2, 'skip': 1}"));
-   mock_server_replies_simple (request, server_reply);
+   reply_to_request_simple (request, server_reply);
    ASSERT_OR_PRINT (123 == future_get_int64_t (future), error);
    ASSERT_MATCH (&reply, server_reply);
 
@@ -3047,13 +3047,13 @@ test_aggregate_modern (void *data)
                                          : "{'$empty': true}",
                 context->with_options ? ", 'foo': 1" : ""));
 
-   mock_server_replies_simple (request,
-                               "{'ok': 1,"
-                               " 'cursor': {"
-                               "    'id': 42,"
-                               "    'ns': 'db.collection',"
-                               "    'firstBatch': [{'_id': 123}]"
-                               "}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "    'id': 42,"
+                            "    'ns': 'db.collection',"
+                            "    'firstBatch': [{'_id': 123}]"
+                            "}}");
 
    ASSERT (future_get_bool (future));
    ASSERT_MATCH (doc, "{'_id': 123}");
@@ -3073,12 +3073,12 @@ test_aggregate_modern (void *data)
                 context->with_batch_size ? "{'$numberLong': '11'}"
                                          : "{'$exists': false}"));
 
-   mock_server_replies_simple (request,
-                               "{'ok': 1,"
-                               " 'cursor': {"
-                               "   'id': 0,"
-                               "   'ns': 'db.collection',"
-                               "   'nextBatch': [{'_id': 123}]}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "   'id': 0,"
+                            "   'ns': 'db.collection',"
+                            "   'nextBatch': [{'_id': 123}]}}");
 
    ASSERT (future_get_bool (future));
    ASSERT_MATCH (doc, "{'_id': 123}");
@@ -3131,11 +3131,11 @@ test_aggregate_w_server_id (void)
                                       " 'serverId': {'$exists': false}}"));
 
    ASSERT (mock_rs_request_is_to_secondary (rs, request));
-   mock_rs_replies_simple (request,
-                           "{'ok': 1,"
-                           " 'cursor': {"
-                           "    'ns': 'db.collection',"
-                           "    'firstBatch': [{}]}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "    'ns': 'db.collection',"
+                            "    'firstBatch': [{}]}}");
    ASSERT_OR_PRINT (future_get_bool (future), cursor->error);
 
    future_destroy (future);
@@ -3179,11 +3179,11 @@ test_aggregate_w_server_id_sharded (void)
                                           " 'aggregate': 'collection',"
                                           " 'serverId': {'$exists': false}}"));
 
-   mock_server_replies_simple (request,
-                               "{'ok': 1,"
-                               " 'cursor': {"
-                               "    'ns': 'db.collection',"
-                               "    'firstBatch': [{}]}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "    'ns': 'db.collection',"
+                            "    'firstBatch': [{}]}}");
 
    ASSERT_OR_PRINT (future_get_bool (future), cursor->error);
 
@@ -3490,7 +3490,7 @@ test_stats_read_pref (void)
                 " 'collStats': 'collection',"
                 " '$readPreference': {'mode': 'secondary'}}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
 
    future_destroy (future);
@@ -3559,7 +3559,7 @@ test_find_and_modify_write_concern (void)
                 " 'new' : true,"
                 " 'writeConcern': {'w': 42}}"));
 
-   mock_server_replies_simple (request, "{ 'value' : null, 'ok' : 1 }");
+   reply_to_request_simple (request, "{ 'value' : null, 'ok' : 1 }");
    ASSERT_OR_PRINT (future_get_bool (future), error);
 
    future_destroy (future);
@@ -3975,7 +3975,7 @@ test_find_limit (void)
                                           " 'filter': {},"
                                           " 'limit': {'$numberLong': '2'}}"));
 
-   mock_server_replies_simple (
+   reply_to_request_simple (
       request,
       "{'ok': 1, 'cursor': {'id': 0, 'ns': 'test.test', 'firstBatch': [{}]}}");
    BSON_ASSERT (future_get_bool (future));
@@ -3999,7 +3999,7 @@ test_find_limit (void)
                                           " 'filter': {},"
                                           " 'limit': {'$numberLong': '2'}}"));
 
-   mock_server_replies_simple (
+   reply_to_request_simple (
       request,
       "{'ok': 1, 'cursor': {'id': 0, 'ns': 'test.test', 'firstBatch': [{}]}}");
    BSON_ASSERT (future_get_bool (future));
@@ -4051,7 +4051,7 @@ test_find_batch_size (void)
                 " 'filter': {},"
                 " 'batchSize': {'$numberLong': '2'}}"));
 
-   mock_server_replies_simple (
+   reply_to_request_simple (
       request,
       "{'ok': 1, 'cursor': {'id': 0, 'ns': 'test.test', 'firstBatch': [{}]}}");
    BSON_ASSERT (future_get_bool (future));
@@ -4075,7 +4075,7 @@ test_find_batch_size (void)
                 " 'filter': {},"
                 " 'batchSize': {'$numberLong': '2'}}"));
 
-   mock_server_replies_simple (
+   reply_to_request_simple (
       request,
       "{'ok': 1, 'cursor': {'id': 0, 'ns': 'test.test', 'firstBatch': [{}]}}");
    BSON_ASSERT (future_get_bool (future));
@@ -4327,8 +4327,8 @@ test_find_indexes_err (void)
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'db', 'listIndexes': 'collection'}"));
 
-   mock_server_replies_simple (request,
-                               "{'ok': 0, 'code': 1234567, 'errmsg': 'foo'}");
+   reply_to_request_simple (request,
+                            "{'ok': 0, 'code': 1234567, 'errmsg': 'foo'}");
    cursor = future_get_mongoc_cursor_ptr (future);
    BSON_ASSERT (mongoc_cursor_error (cursor, &error));
    ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_SERVER, 1234567, "foo");
@@ -4405,12 +4405,12 @@ test_find_read_concern (void)
       server,
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'test', 'find': 'test', 'filter': {}}"));
-   mock_server_replies_simple (request,
-                               "{'ok': 1,"
-                               " 'cursor': {"
-                               "    'id': 0,"
-                               "    'ns': 'test.test',"
-                               "    'firstBatch': [{'_id': 123}]}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "    'id': 0,"
+                            "    'ns': 'test.test',"
+                            "    'firstBatch': [{'_id': 123}]}}");
    ASSERT (future_get_bool (future));
    future_destroy (future);
    request_destroy (request);
@@ -4437,12 +4437,12 @@ test_find_read_concern (void)
                 " 'find': 'test',"
                 " 'filter': {},"
                 " 'readConcern': {'level': 'local'}}"));
-   mock_server_replies_simple (request,
-                               "{'ok': 1,"
-                               " 'cursor': {"
-                               "    'id': 0,"
-                               "    'ns': 'test.test',"
-                               "    'firstBatch': [{'_id': 123}]}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "    'id': 0,"
+                            "    'ns': 'test.test',"
+                            "    'firstBatch': [{'_id': 123}]}}");
    ASSERT (future_get_bool (future));
    future_destroy (future);
    request_destroy (request);
@@ -4470,12 +4470,12 @@ test_find_read_concern (void)
                 " 'find': 'test',"
                 " 'filter': {},"
                 " 'readConcern': {'level': 'random'}}"));
-   mock_server_replies_simple (request,
-                               "{'ok': 1,"
-                               " 'cursor': {"
-                               "    'id': 0,"
-                               "    'ns': 'test.test',"
-                               "    'firstBatch': [{'_id': 123}]}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "    'id': 0,"
+                            "    'ns': 'test.test',"
+                            "    'firstBatch': [{'_id': 123}]}}");
    ASSERT (future_get_bool (future));
    future_destroy (future);
    request_destroy (request);
@@ -4502,12 +4502,12 @@ test_find_read_concern (void)
                 " 'find': 'test',"
                 " 'filter': {},"
                 " 'readConcern': {'$exists': false}}"));
-   mock_server_replies_simple (request,
-                               "{'ok': 1,"
-                               " 'cursor': {"
-                               "    'id': 0,"
-                               "    'ns': 'test.test',"
-                               "    'firstBatch': [{'_id': 123}]}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "    'id': 0,"
+                            "    'ns': 'test.test',"
+                            "    'firstBatch': [{'_id': 123}]}}");
    ASSERT (future_get_bool (future));
    future_destroy (future);
    request_destroy (request);
@@ -4535,12 +4535,12 @@ test_find_read_concern (void)
                 " 'find': 'test',"
                 " 'filter': {},"
                 " 'readConcern': {'$exists': false}}"));
-   mock_server_replies_simple (request,
-                               "{'ok': 1,"
-                               " 'cursor': {"
-                               "    'id': 0,"
-                               "    'ns': 'test.test',"
-                               "    'firstBatch': [{'_id': 123}]}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "    'id': 0,"
+                            "    'ns': 'test.test',"
+                            "    'firstBatch': [{'_id': 123}]}}");
    ASSERT (future_get_bool (future));
 
    future_destroy (future);
@@ -4673,12 +4673,12 @@ test_aggregate_secondary_sharded (void)
                 " 'pipeline': [],"
                 " '$readPreference': {'mode': 'secondary'}}"));
 
-   mock_server_replies_simple (request,
-                               "{ 'ok':1,"
-                               "  'cursor': {"
-                               "     'id': 0,"
-                               "     'ns': 'db.collection',"
-                               "     'firstBatch': []}}");
+   reply_to_request_simple (request,
+                            "{ 'ok':1,"
+                            "  'cursor': {"
+                            "     'id': 0,"
+                            "     'ns': 'db.collection',"
+                            "     'firstBatch': []}}");
 
    ASSERT (!future_get_bool (future)); /* cursor_next returns false */
    ASSERT_OR_PRINT (!mongoc_cursor_error (cursor, &error), error);
@@ -4727,13 +4727,13 @@ test_aggregate_read_concern (void)
                 " 'cursor': {},"
                 " 'readConcern': {'$exists': false}}"));
 
-   mock_server_replies_simple (request,
-                               "{'ok': 1,"
-                               " 'cursor': {"
-                               "    'id': 0,"
-                               "    'ns': 'db.collection',"
-                               "    'firstBatch': [{'_id': 123}]"
-                               "}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "    'id': 0,"
+                            "    'ns': 'db.collection',"
+                            "    'firstBatch': [{'_id': 123}]"
+                            "}}");
 
    ASSERT (future_get_bool (future));
    ASSERT_MATCH (doc, "{'_id': 123}");
@@ -4763,13 +4763,13 @@ test_aggregate_read_concern (void)
                 " 'cursor': {},"
                 " 'readConcern': {'level': 'majority'}}"));
 
-   mock_server_replies_simple (request,
-                               "{'ok': 1,"
-                               " 'cursor': {"
-                               "    'id': 0,"
-                               "    'ns': 'db.collection',"
-                               "    'firstBatch': [{'_id': 123}]"
-                               "}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "    'id': 0,"
+                            "    'ns': 'db.collection',"
+                            "    'firstBatch': [{'_id': 123}]"
+                            "}}");
 
    ASSERT (future_get_bool (future));
    ASSERT_MATCH (doc, "{'_id': 123}");
@@ -4821,13 +4821,13 @@ test_aggregate_with_collation (void)
                                           " 'pipeline': [{'a': 1}],"
                                           " 'collation': {'locale': 'en'}}"));
 
-   mock_server_replies_simple (request,
-                               "{'ok': 1,"
-                               " 'cursor': {"
-                               "    'id': 0,"
-                               "    'ns': 'db.collection',"
-                               "    'firstBatch': [{'_id': 123}]"
-                               "}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "    'id': 0,"
+                            "    'ns': 'db.collection',"
+                            "    'firstBatch': [{'_id': 123}]"
+                            "}}");
    ASSERT (future_get_bool (future));
    ASSERT_MATCH (doc, "{'_id': 123}");
    /* cursor is completed */
@@ -4882,7 +4882,7 @@ test_index_with_collation (void)
                 "   'name': 'hello_1',"
                 "   'collation': {'locale': 'en', 'strength': 2}}]}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT (future_get_bool (future));
 
    bson_destroy (&reply);
@@ -5799,7 +5799,7 @@ _test_delete_collation (bool is_multi)
                 " 'delete': 'collection'}"),
       tmp_bson ("{'q': {}, 'limit': %d, 'collation': {'locale': 'en'}}",
                 is_multi ? 0 : 1));
-   mock_server_replies_simple (request, "{'ok': 1, 'n': 1}");
+   reply_to_request_simple (request, "{'ok': 1, 'n': 1}");
    ASSERT_OR_PRINT (future_get_bool (future), error);
    request_destroy (request);
 
@@ -5867,7 +5867,7 @@ _test_update_or_replace_with_collation (bool is_replace, bool is_multi)
       tmp_bson ("{'$db': 'db', 'update': 'collection'}"),
       tmp_bson ("{'q': {}, 'u': {}, 'collation': {'locale': 'en'}%s}",
                 is_multi ? ", 'multi': true" : ""));
-   mock_server_replies_simple (request, "{'ok': 1, 'n': 1}");
+   reply_to_request_simple (request, "{'ok': 1, 'n': 1}");
    ASSERT_OR_PRINT (future_get_bool (future), error);
    request_destroy (request);
 
@@ -5926,7 +5926,7 @@ _test_update_hint (bool is_replace, bool is_multi, const char *hint)
                 hint,
                 is_multi ? ", 'multi': true" : ""));
 
-   mock_server_replies_simple (request, "{'ok': 1, 'n': 1}");
+   reply_to_request_simple (request, "{'ok': 1, 'n': 1}");
    ASSERT_OR_PRINT (future_get_bool (future), error);
    request_destroy (request);
 

--- a/src/libmongoc/tests/test-mongoc-command-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-command-monitoring.c
@@ -143,8 +143,7 @@ test_get_error (void)
       client, "db", tmp_bson ("{'foo': 1}"), NULL, NULL, NULL);
    request = mock_server_receives_msg (
       server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'db', 'foo': 1}"));
-   mock_server_replies_simple (request,
-                               "{'ok': 0, 'errmsg': 'foo', 'code': 42}");
+   reply_to_request_simple (request, "{'ok': 0, 'errmsg': 'foo', 'code': 42}");
    ASSERT (!future_get_bool (future));
    ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_QUERY, 42, "foo");
 
@@ -684,13 +683,13 @@ _test_query_operation_id (bool pooled)
 
    future = future_cursor_next (cursor, &doc);
    request = mock_server_receives_request (server);
-   mock_server_replies_opmsg (request,
-                              MONGOC_MSG_NONE,
-                              tmp_bson ("{'ok': 1,"
-                                        " 'cursor': {"
-                                        "    'id': {'$numberLong': '123'},"
-                                        "    'ns': 'db.collection',"
-                                        "    'firstBatch': [{}]}}"));
+   reply_to_op_msg (request,
+                    MONGOC_MSG_NONE,
+                    tmp_bson ("{'ok': 1,"
+                              " 'cursor': {"
+                              "    'id': {'$numberLong': '123'},"
+                              "    'ns': 'db.collection',"
+                              "    'firstBatch': [{}]}}"));
 
    ASSERT (future_get_bool (future));
    future_destroy (future);
@@ -701,8 +700,7 @@ _test_query_operation_id (bool pooled)
 
    future = future_cursor_next (cursor, &doc);
    request = mock_server_receives_request (server);
-   mock_server_replies_simple (request,
-                               "{'ok': 0, 'code': 42, 'errmsg': 'bad!'}");
+   reply_to_request_simple (request, "{'ok': 0, 'code': 42, 'errmsg': 'bad!'}");
 
    ASSERT (!future_get_bool (future));
    future_destroy (future);
@@ -1114,8 +1112,7 @@ test_command_failed_reply_mock (void)
 
    future = future_cursor_next (cursor, &doc);
    request = mock_server_receives_request (server);
-   mock_server_replies_simple (request,
-                               "{'ok': 0, 'code': 42, 'errmsg': 'bad!'}");
+   reply_to_request_simple (request, "{'ok': 0, 'code': 42, 'errmsg': 'bad!'}");
 
    ASSERT (!future_get_bool (future));
    future_destroy (future);
@@ -1172,12 +1169,11 @@ test_command_failed_reply_hangup (void)
 
    future = future_cursor_next (cursor, &doc);
    request = mock_server_receives_request (server);
-   mock_server_replies_simple (request,
-                               "{'ok': 0, 'code': 42, 'errmsg': 'bad!'}");
+   reply_to_request_simple (request, "{'ok': 0, 'code': 42, 'errmsg': 'bad!'}");
 
    ASSERT (!future_get_bool (future));
    future_destroy (future);
-   mock_server_hangs_up (request);
+   reply_to_request_with_hang_up (request);
    request_destroy (request);
 
    ASSERT_MATCH (&test.reply, "{}");
@@ -1292,7 +1288,7 @@ _test_service_id (bool is_loadbalanced)
    if (is_loadbalanced) {
       request = mock_server_receives_any_hello_with_match (
          server, "{'loadBalanced': true}", "{'loadBalanced': true}");
-      mock_server_replies_simple (
+      reply_to_request_simple (
          request,
          tmp_str ("{'ismaster': true,"
                   " 'minWireVersion': %d,"
@@ -1306,18 +1302,18 @@ _test_service_id (bool is_loadbalanced)
          server,
          "{'loadBalanced': { '$exists': false }}",
          "{'loadBalanced': { '$exists': false }}");
-      mock_server_replies_simple (request,
-                                  tmp_str ("{'ismaster': true,"
-                                           " 'minWireVersion': %d,"
-                                           " 'maxWireVersion': %d,"
-                                           " 'msg': 'isdbgrid'}",
-                                           WIRE_VERSION_MIN,
-                                           WIRE_VERSION_5_0));
+      reply_to_request_simple (request,
+                               tmp_str ("{'ismaster': true,"
+                                        " 'minWireVersion': %d,"
+                                        " 'maxWireVersion': %d,"
+                                        " 'msg': 'isdbgrid'}",
+                                        WIRE_VERSION_MIN,
+                                        WIRE_VERSION_5_0));
    }
    request_destroy (request);
 
    request = mock_server_receives_msg (server, 0, tmp_bson ("{'ping': 1}"));
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
 
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
@@ -1330,8 +1326,8 @@ _test_service_id (bool is_loadbalanced)
                                           &error);
 
    request = mock_server_receives_msg (server, 0, tmp_bson ("{'ping': 1}"));
-   mock_server_replies_simple (
-      request, "{'ok': 0, 'code': 8, 'errmsg': 'UnknownError'}");
+   reply_to_request_simple (request,
+                            "{'ok': 0, 'code': 8, 'errmsg': 'UnknownError'}");
    request_destroy (request);
 
    ASSERT (!future_get_bool (future));

--- a/src/libmongoc/tests/test-mongoc-command-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-command-monitoring.c
@@ -684,13 +684,13 @@ _test_query_operation_id (bool pooled)
 
    future = future_cursor_next (cursor, &doc);
    request = mock_server_receives_request (server);
-   mock_server_replies_to_find (request,
-                                MONGOC_QUERY_NONE,
-                                123 /* cursor id */,
-                                1,
-                                "db.collection",
-                                "{}",
-                                true);
+   mock_server_replies_opmsg (request,
+                              MONGOC_MSG_NONE,
+                              tmp_bson ("{'ok': 1,"
+                                        " 'cursor': {"
+                                        "    'id': {'$numberLong': '123'},"
+                                        "    'ns': 'db.collection',"
+                                        "    'firstBatch': [{}]}}"));
 
    ASSERT (future_get_bool (future));
    future_destroy (future);

--- a/src/libmongoc/tests/test-mongoc-command-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-command-monitoring.c
@@ -683,13 +683,13 @@ _test_query_operation_id (bool pooled)
 
    future = future_cursor_next (cursor, &doc);
    request = mock_server_receives_request (server);
-   reply_to_op_msg (request,
-                    MONGOC_MSG_NONE,
-                    tmp_bson ("{'ok': 1,"
-                              " 'cursor': {"
-                              "    'id': {'$numberLong': '123'},"
-                              "    'ns': 'db.collection',"
-                              "    'firstBatch': [{}]}}"));
+   reply_to_op_msg_request (request,
+                            MONGOC_MSG_NONE,
+                            tmp_bson ("{'ok': 1,"
+                                      " 'cursor': {"
+                                      "    'id': {'$numberLong': '123'},"
+                                      "    'ns': 'db.collection',"
+                                      "    'firstBatch': [{}]}}"));
 
    ASSERT (future_get_bool (future));
    future_destroy (future);

--- a/src/libmongoc/tests/test-mongoc-counters.c
+++ b/src/libmongoc/tests/test-mongoc-counters.c
@@ -588,13 +588,13 @@ test_counters_rpc_op_egress_autoresponder (request_t *request, void *data)
 
    if (strcmp (request->command_name, HANDSHAKE_CMD_HELLO) == 0 ||
        strcmp (request->command_name, HANDSHAKE_CMD_LEGACY_HELLO) == 0) {
-      mock_server_replies_simple (request, ar_data->hello);
+      reply_to_request_simple (request, ar_data->hello);
       request_destroy (request);
    } else {
       ASSERT_WITH_MSG (request->is_command,
                        "expected only handshakes and commands, but got: %s",
                        request->as_str);
-      mock_server_replies_ok_and_destroys (request);
+      reply_to_request_with_ok_and_destroy (request);
    }
 
    return true;
@@ -673,7 +673,7 @@ _test_counters_rpc_op_egress_cluster_single (bool with_op_msg)
          expected.op_egress_total += 1;
          ASSERT_RPC_OP_EGRESS_COUNTERS_CURRENT (expected);
 
-         mock_server_replies_simple (request, hello);
+         reply_to_request_simple (request, hello);
          request_destroy (request);
       }
 
@@ -691,7 +691,7 @@ _test_counters_rpc_op_egress_cluster_single (bool with_op_msg)
          expected.op_egress_total += 1;
          ASSERT_RPC_OP_EGRESS_COUNTERS_CURRENT (expected);
 
-         mock_server_replies_ok_and_destroys (request);
+         reply_to_request_with_ok_and_destroy (request);
       }
 
       ASSERT_OR_PRINT (future_get_bool (ping), error);
@@ -782,7 +782,7 @@ test_counters_rpc_op_egress_cluster_legacy (void)
          expected.op_egress_total += 1;
          ASSERT_RPC_OP_EGRESS_COUNTERS_CURRENT (expected);
 
-         mock_server_replies_simple (request, hello);
+         reply_to_request_simple (request, hello);
 
          request_destroy (request);
       }
@@ -801,7 +801,7 @@ test_counters_rpc_op_egress_cluster_legacy (void)
          expected.op_egress_total += 1;
          ASSERT_RPC_OP_EGRESS_COUNTERS_CURRENT (expected);
 
-         mock_server_replies_ok_and_destroys (request);
+         reply_to_request_with_ok_and_destroy (request);
       }
 
       ASSERT_OR_PRINT (future_get_bool (ping), error);
@@ -913,7 +913,7 @@ _test_counters_rpc_op_egress_cluster_pooled (bool with_op_msg)
       expected.op_egress_total += 1;
       ASSERT_RPC_OP_EGRESS_COUNTERS_CURRENT (expected);
 
-      mock_server_replies_simple (request, hello);
+      reply_to_request_simple (request, hello);
       request_destroy (request);
    }
 
@@ -947,7 +947,7 @@ _test_counters_rpc_op_egress_cluster_pooled (bool with_op_msg)
          expected.op_egress_total += 1;
          ASSERT_RPC_OP_EGRESS_COUNTERS_CURRENT (expected);
 
-         mock_server_replies_simple (request, hello);
+         reply_to_request_simple (request, hello);
          request_destroy (request);
       }
 
@@ -965,7 +965,7 @@ _test_counters_rpc_op_egress_cluster_pooled (bool with_op_msg)
          expected.op_egress_total += 1;
          ASSERT_RPC_OP_EGRESS_COUNTERS_CURRENT (expected);
 
-         mock_server_replies_ok_and_destroys (request);
+         reply_to_request_with_ok_and_destroy (request);
       }
 
       ASSERT_OR_PRINT (future_get_bool (ping), error);
@@ -1081,7 +1081,7 @@ _test_counters_rpc_op_egress_awaitable_hello (bool with_op_msg)
                              request->as_str);
          }
 
-         mock_server_replies_simple (request, hello);
+         reply_to_request_simple (request, hello);
          request_destroy (request);
       }
    }
@@ -1164,7 +1164,7 @@ _test_counters_rpc_op_egress_awaitable_hello (bool with_op_msg)
          expected.op_egress_total += 1;
          ASSERT_RPC_OP_EGRESS_COUNTERS_CURRENT (expected);
 
-         mock_server_replies_simple (request, hello);
+         reply_to_request_simple (request, hello);
          request_destroy (request);
       }
 
@@ -1182,7 +1182,7 @@ _test_counters_rpc_op_egress_awaitable_hello (bool with_op_msg)
          expected.op_egress_total += 1;
          ASSERT_RPC_OP_EGRESS_COUNTERS_CURRENT (expected);
 
-         mock_server_replies_ok_and_destroys (request);
+         reply_to_request_with_ok_and_destroy (request);
       }
 
       ASSERT_OR_PRINT (future_get_bool (ping), error);
@@ -1205,7 +1205,7 @@ _test_counters_rpc_op_egress_awaitable_hello (bool with_op_msg)
 
       // Reply to awaitable hello after destroying the client pool to avoid
       // triggering additional awaitable hello requests.
-      mock_server_replies_simple (awaitable_hello, hello);
+      reply_to_request_simple (awaitable_hello, hello);
       request_destroy (awaitable_hello);
 
       mock_server_destroy (server);
@@ -1260,7 +1260,7 @@ _test_counters_rpc_op_egress_mock_server (bool with_op_msg)
       const bson_t *const command = tmp_bson ("{'ping': 1}");
       future_t *const future = future_client_command_simple (
          client, "db", command, NULL, NULL, &error);
-      mock_server_replies_ok_and_destroys (
+      reply_to_request_with_ok_and_destroy (
          mock_server_receives_msg (server, MONGOC_MSG_NONE, command));
       ASSERT_OR_PRINT (future_get_bool (future), error);
       future_destroy (future);

--- a/src/libmongoc/tests/test-mongoc-cursor.c
+++ b/src/libmongoc/tests/test-mongoc-cursor.c
@@ -773,13 +773,13 @@ _test_kill_cursors (bool pooled)
 
    future = future_cursor_next (cursor, &doc);
    request = mock_rs_receives_request (rs);
-   reply_to_op_msg (request,
-                    MONGOC_MSG_NONE,
-                    tmp_bson ("{'ok': 1,"
-                              " 'cursor': {"
-                              "    'id': {'$numberLong': '123'},"
-                              "    'ns': 'db.collection',"
-                              "    'firstBatch': [{'b': 1}]}}"));
+   reply_to_op_msg_request (request,
+                            MONGOC_MSG_NONE,
+                            tmp_bson ("{'ok': 1,"
+                                      " 'cursor': {"
+                                      "    'id': {'$numberLong': '123'},"
+                                      "    'ns': 'db.collection',"
+                                      "    'firstBatch': [{'b': 1}]}}"));
 
    if (!future_get_bool (future)) {
       mongoc_cursor_error (cursor, &error);
@@ -1134,13 +1134,13 @@ test_cursor_new_tailable_await (void)
                 " 'collection': 'collection',"
                 " 'maxTimeMS': {'$numberLong': '100'}}"));
 
-   reply_to_op_msg (request,
-                    MONGOC_MSG_NONE,
-                    tmp_bson ("{'ok': 1,"
-                              " 'cursor': {"
-                              "    'id': {'$numberLong': '0'},"
-                              "    'ns': 'db.collection',"
-                              "    'firstBatch': [{'_id': 1}]}}"));
+   reply_to_op_msg_request (request,
+                            MONGOC_MSG_NONE,
+                            tmp_bson ("{'ok': 1,"
+                                      " 'cursor': {"
+                                      "    'id': {'$numberLong': '0'},"
+                                      "    'ns': 'db.collection',"
+                                      "    'firstBatch': [{'_id': 1}]}}"));
 
    BSON_ASSERT (future_get_bool (future));
    ASSERT_MATCH (doc, "{'_id': 1}");
@@ -1204,13 +1204,13 @@ test_cursor_int64_t_maxtimems (void)
                 ms_int64));
 
 
-   reply_to_op_msg (request,
-                    MONGOC_MSG_NONE,
-                    tmp_bson ("{'ok': 1,"
-                              " 'cursor': {"
-                              "    'id': {'$numberLong': '0'},"
-                              "    'ns': 'db.collection',"
-                              "    'firstBatch': [{'_id': 1}]}}"));
+   reply_to_op_msg_request (request,
+                            MONGOC_MSG_NONE,
+                            tmp_bson ("{'ok': 1,"
+                                      " 'cursor': {"
+                                      "    'id': {'$numberLong': '0'},"
+                                      "    'ns': 'db.collection',"
+                                      "    'firstBatch': [{'_id': 1}]}}"));
 
    BSON_ASSERT (future_get_bool (future));
    ASSERT_MATCH (doc, "{'_id': 1}");
@@ -1490,13 +1490,13 @@ _test_cursor_hint (bool pooled, bool use_primary)
       BSON_ASSERT (mock_rs_request_is_to_secondary (rs, request));
    }
 
-   reply_to_op_msg (request,
-                    MONGOC_MSG_NONE,
-                    tmp_bson ("{'ok': 1,"
-                              " 'cursor': {"
-                              "    'id': {'$numberLong': '0'},"
-                              "    'ns': 'test.test',"
-                              "    'firstBatch': [{'b': 1}]}}"));
+   reply_to_op_msg_request (request,
+                            MONGOC_MSG_NONE,
+                            tmp_bson ("{'ok': 1,"
+                                      " 'cursor': {"
+                                      "    'id': {'$numberLong': '0'},"
+                                      "    'ns': 'test.test',"
+                                      "    'firstBatch': [{'b': 1}]}}"));
    BSON_ASSERT (future_get_bool (future));
    ASSERT_MATCH (doc, "{'b': 1}");
 
@@ -2134,13 +2134,13 @@ test_empty_final_batch (void)
    request = mock_server_receives_msg (
       server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'db'}"));
 
-   reply_to_op_msg (request,
-                    MONGOC_MSG_NONE,
-                    tmp_bson ("{'ok': 1,"
-                              " 'cursor': {"
-                              "    'id': {'$numberLong': '1234'},"
-                              "    'ns': 'db.coll',"
-                              "    'firstBatch': [{}]}}"));
+   reply_to_op_msg_request (request,
+                            MONGOC_MSG_NONE,
+                            tmp_bson ("{'ok': 1,"
+                                      " 'cursor': {"
+                                      "    'id': {'$numberLong': '1234'},"
+                                      "    'ns': 'db.coll',"
+                                      "    'firstBatch': [{}]}}"));
 
    ASSERT (future_get_bool (future));
    future_destroy (future);
@@ -2153,13 +2153,13 @@ test_empty_final_batch (void)
    request = mock_server_receives_msg (
       server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'db'}"));
 
-   reply_to_op_msg (request,
-                    MONGOC_MSG_NONE,
-                    tmp_bson ("{'ok': 1,"
-                              " 'cursor': {"
-                              "    'id': {'$numberLong': '1234'},"
-                              "    'ns': 'db.coll',"
-                              "    'firstBatch': []}}"));
+   reply_to_op_msg_request (request,
+                            MONGOC_MSG_NONE,
+                            tmp_bson ("{'ok': 1,"
+                                      " 'cursor': {"
+                                      "    'id': {'$numberLong': '1234'},"
+                                      "    'ns': 'db.coll',"
+                                      "    'firstBatch': []}}"));
 
    ASSERT (!future_get_bool (future));
    ASSERT_OR_PRINT (!mongoc_cursor_error (cursor, &error), error);
@@ -2178,13 +2178,13 @@ test_empty_final_batch (void)
       ==,
       (int64_t) 1);
 
-   reply_to_op_msg (request,
-                    MONGOC_MSG_NONE,
-                    tmp_bson ("{'ok': 1,"
-                              " 'cursor': {"
-                              "    'id': {'$numberLong': '0'},"
-                              "    'ns': 'db.coll',"
-                              "    'firstBatch': []}}"));
+   reply_to_op_msg_request (request,
+                            MONGOC_MSG_NONE,
+                            tmp_bson ("{'ok': 1,"
+                                      " 'cursor': {"
+                                      "    'id': {'$numberLong': '0'},"
+                                      "    'ns': 'db.coll',"
+                                      "    'firstBatch': []}}"));
 
    ASSERT (!future_get_bool (future));
    ASSERT_OR_PRINT (!mongoc_cursor_error (cursor, &error), error);

--- a/src/libmongoc/tests/test-mongoc-cursor.c
+++ b/src/libmongoc/tests/test-mongoc-cursor.c
@@ -1495,7 +1495,7 @@ _test_cursor_hint (bool pooled, bool use_primary)
                           tmp_bson ("{'ok': 1,"
                                     " 'cursor': {"
                                     "    'id': {'$numberLong': '0'},"
-                                    "    'ns': 'db.collection',"
+                                    "    'ns': 'test.test',"
                                     "    'firstBatch': [{'b': 1}]}}"));
    BSON_ASSERT (future_get_bool (future));
    ASSERT_MATCH (doc, "{'b': 1}");

--- a/src/libmongoc/tests/test-mongoc-cursor.c
+++ b/src/libmongoc/tests/test-mongoc-cursor.c
@@ -773,13 +773,13 @@ _test_kill_cursors (bool pooled)
 
    future = future_cursor_next (cursor, &doc);
    request = mock_rs_receives_request (rs);
-   mock_rs_replies_opmsg (request,
-                          MONGOC_MSG_NONE,
-                          tmp_bson ("{'ok': 1,"
-                                    " 'cursor': {"
-                                    "    'id': {'$numberLong': '123'},"
-                                    "    'ns': 'db.collection',"
-                                    "    'firstBatch': [{'b': 1}]}}"));
+   reply_to_op_msg (request,
+                    MONGOC_MSG_NONE,
+                    tmp_bson ("{'ok': 1,"
+                              " 'cursor': {"
+                              "    'id': {'$numberLong': '123'},"
+                              "    'ns': 'db.collection',"
+                              "    'firstBatch': [{'b': 1}]}}"));
 
    if (!future_get_bool (future)) {
       mongoc_cursor_error (cursor, &error);
@@ -811,7 +811,7 @@ _test_kill_cursors (bool pooled)
    ASSERT_CMPSTR ("collection", ns_out);
    ASSERT_CMPINT64 ((int64_t) 123, ==, cursor_id_out);
 
-   mock_rs_replies_simple (request, "{'ok': 1}");
+   reply_to_request_simple (request, "{'ok': 1}");
 
    /* OP_KILLCURSORS was sent to the right secondary */
    ASSERT_CMPINT (request_get_server_port (kill_cursors),
@@ -884,7 +884,7 @@ _test_client_kill_cursor (bool has_primary)
                 " '$readPreference': {'mode': 'secondary'},"
                 " 'foo': 1}"));
 
-   mock_rs_replies_simple (request, "{'ok': 1}");
+   reply_to_request_simple (request, "{'ok': 1}");
    ASSERT_OR_PRINT (future_get_bool (future), error);
    request_destroy (request);
    future_destroy (future);
@@ -1134,13 +1134,13 @@ test_cursor_new_tailable_await (void)
                 " 'collection': 'collection',"
                 " 'maxTimeMS': {'$numberLong': '100'}}"));
 
-   mock_server_replies_opmsg (request,
-                              MONGOC_MSG_NONE,
-                              tmp_bson ("{'ok': 1,"
-                                        " 'cursor': {"
-                                        "    'id': {'$numberLong': '0'},"
-                                        "    'ns': 'db.collection',"
-                                        "    'firstBatch': [{'_id': 1}]}}"));
+   reply_to_op_msg (request,
+                    MONGOC_MSG_NONE,
+                    tmp_bson ("{'ok': 1,"
+                              " 'cursor': {"
+                              "    'id': {'$numberLong': '0'},"
+                              "    'ns': 'db.collection',"
+                              "    'firstBatch': [{'_id': 1}]}}"));
 
    BSON_ASSERT (future_get_bool (future));
    ASSERT_MATCH (doc, "{'_id': 1}");
@@ -1204,13 +1204,13 @@ test_cursor_int64_t_maxtimems (void)
                 ms_int64));
 
 
-   mock_server_replies_opmsg (request,
-                              MONGOC_MSG_NONE,
-                              tmp_bson ("{'ok': 1,"
-                                        " 'cursor': {"
-                                        "    'id': {'$numberLong': '0'},"
-                                        "    'ns': 'db.collection',"
-                                        "    'firstBatch': [{'_id': 1}]}}"));
+   reply_to_op_msg (request,
+                    MONGOC_MSG_NONE,
+                    tmp_bson ("{'ok': 1,"
+                              " 'cursor': {"
+                              "    'id': {'$numberLong': '0'},"
+                              "    'ns': 'db.collection',"
+                              "    'firstBatch': [{'_id': 1}]}}"));
 
    BSON_ASSERT (future_get_bool (future));
    ASSERT_MATCH (doc, "{'_id': 1}");
@@ -1490,13 +1490,13 @@ _test_cursor_hint (bool pooled, bool use_primary)
       BSON_ASSERT (mock_rs_request_is_to_secondary (rs, request));
    }
 
-   mock_rs_replies_opmsg (request,
-                          MONGOC_MSG_NONE,
-                          tmp_bson ("{'ok': 1,"
-                                    " 'cursor': {"
-                                    "    'id': {'$numberLong': '0'},"
-                                    "    'ns': 'test.test',"
-                                    "    'firstBatch': [{'b': 1}]}}"));
+   reply_to_op_msg (request,
+                    MONGOC_MSG_NONE,
+                    tmp_bson ("{'ok': 1,"
+                              " 'cursor': {"
+                              "    'id': {'$numberLong': '0'},"
+                              "    'ns': 'test.test',"
+                              "    'firstBatch': [{'b': 1}]}}"));
    BSON_ASSERT (future_get_bool (future));
    ASSERT_MATCH (doc, "{'b': 1}");
 
@@ -1596,12 +1596,12 @@ test_cursor_hint_mongos (void)
          MONGOC_MSG_NONE,
          tmp_bson ("{'$db': 'test', 'find': 'test', 'filter': {}}"));
 
-      mock_server_replies_simple (request,
-                                  "{'ok':1,"
-                                  " 'cursor': {"
-                                  "   'id': 0,"
-                                  "   'ns': 'test.test',"
-                                  "   'firstBatch': [{}]}}");
+      reply_to_request_simple (request,
+                               "{'ok':1,"
+                               " 'cursor': {"
+                               "   'id': 0,"
+                               "   'ns': 'test.test',"
+                               "   'firstBatch': [{}]}}");
       BSON_ASSERT (future_get_bool (future));
 
       request_destroy (request);
@@ -1649,12 +1649,12 @@ test_cursor_hint_mongos_cmd (void)
       request = mock_server_receives_msg (
          server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'test', 'find': 'test'}"));
 
-      mock_server_replies_simple (request,
-                                  "{'ok': 1,"
-                                  " 'cursor': {"
-                                  "    'id': 0,"
-                                  "    'ns': 'test.test',"
-                                  "    'firstBatch': [{}]}}");
+      reply_to_request_simple (request,
+                               "{'ok': 1,"
+                               " 'cursor': {"
+                               "    'id': 0,"
+                               "    'ns': 'test.test',"
+                               "    'firstBatch': [{}]}}");
 
       BSON_ASSERT (future_get_bool (future));
 
@@ -1880,7 +1880,7 @@ _test_cursor_n_return_find_cmd (mongoc_cursor_t *cursor,
 
    reply = bson_string_new (NULL);
    _make_reply_batch (reply, (uint32_t) test->reply_length[0], true, false);
-   mock_server_replies_simple (request, reply->str);
+   reply_to_request_simple (request, reply->str);
    bson_string_free (reply, true);
 
    ASSERT (future_get_bool (future));
@@ -1918,7 +1918,7 @@ _test_cursor_n_return_find_cmd (mongoc_cursor_t *cursor,
                          false,
                          cursor_finished);
 
-      mock_server_replies_simple (request, reply->str);
+      reply_to_request_simple (request, reply->str);
       bson_string_free (reply, true);
 
       ASSERT (future_get_bool (future));
@@ -2134,13 +2134,13 @@ test_empty_final_batch (void)
    request = mock_server_receives_msg (
       server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'db'}"));
 
-   mock_server_replies_opmsg (request,
-                              MONGOC_MSG_NONE,
-                              tmp_bson ("{'ok': 1,"
-                                        " 'cursor': {"
-                                        "    'id': {'$numberLong': '1234'},"
-                                        "    'ns': 'db.coll',"
-                                        "    'firstBatch': [{}]}}"));
+   reply_to_op_msg (request,
+                    MONGOC_MSG_NONE,
+                    tmp_bson ("{'ok': 1,"
+                              " 'cursor': {"
+                              "    'id': {'$numberLong': '1234'},"
+                              "    'ns': 'db.coll',"
+                              "    'firstBatch': [{}]}}"));
 
    ASSERT (future_get_bool (future));
    future_destroy (future);
@@ -2153,13 +2153,13 @@ test_empty_final_batch (void)
    request = mock_server_receives_msg (
       server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'db'}"));
 
-   mock_server_replies_opmsg (request,
-                              MONGOC_MSG_NONE,
-                              tmp_bson ("{'ok': 1,"
-                                        " 'cursor': {"
-                                        "    'id': {'$numberLong': '1234'},"
-                                        "    'ns': 'db.coll',"
-                                        "    'firstBatch': []}}"));
+   reply_to_op_msg (request,
+                    MONGOC_MSG_NONE,
+                    tmp_bson ("{'ok': 1,"
+                              " 'cursor': {"
+                              "    'id': {'$numberLong': '1234'},"
+                              "    'ns': 'db.coll',"
+                              "    'firstBatch': []}}"));
 
    ASSERT (!future_get_bool (future));
    ASSERT_OR_PRINT (!mongoc_cursor_error (cursor, &error), error);
@@ -2178,13 +2178,13 @@ test_empty_final_batch (void)
       ==,
       (int64_t) 1);
 
-   mock_server_replies_opmsg (request,
-                              MONGOC_MSG_NONE,
-                              tmp_bson ("{'ok': 1,"
-                                        " 'cursor': {"
-                                        "    'id': {'$numberLong': '0'},"
-                                        "    'ns': 'db.coll',"
-                                        "    'firstBatch': []}}"));
+   reply_to_op_msg (request,
+                    MONGOC_MSG_NONE,
+                    tmp_bson ("{'ok': 1,"
+                              " 'cursor': {"
+                              "    'id': {'$numberLong': '0'},"
+                              "    'ns': 'db.coll',"
+                              "    'firstBatch': []}}"));
 
    ASSERT (!future_get_bool (future));
    ASSERT_OR_PRINT (!mongoc_cursor_error (cursor, &error), error);

--- a/src/libmongoc/tests/test-mongoc-database.c
+++ b/src/libmongoc/tests/test-mongoc-database.c
@@ -73,7 +73,7 @@ test_aggregate_inherit_database (void)
                 "  'readConcern' : { 'level' : 'majority' },"
                 "  'writeConcern' : { 'w' : 2 } }"));
 
-   mock_server_replies_simple (request, "{'ok': 1}");
+   reply_to_request_simple (request, "{'ok': 1}");
 
    ASSERT (!future_get_bool (future));
 
@@ -104,7 +104,7 @@ test_aggregate_inherit_database (void)
                 "  'readConcern' : { 'level' : 'local' },"
                 "  'writeConcern' : { 'w' : 3 } }"));
 
-   mock_server_replies_simple (request, "{'ok': 1}");
+   reply_to_request_simple (request, "{'ok': 1}");
 
    ASSERT (!future_get_bool (future));
 
@@ -127,7 +127,7 @@ test_aggregate_inherit_database (void)
                 "  'readConcern' : { 'level' : 'majority' },"
                 "  'writeConcern' : { 'w' : 2 } }"));
 
-   mock_server_replies_simple (request, "{'ok': 1}");
+   reply_to_request_simple (request, "{'ok': 1}");
 
    ASSERT (!future_get_bool (future));
 
@@ -153,7 +153,7 @@ test_aggregate_inherit_database (void)
                 "  'readConcern' : { 'level' : 'local' },"
                 "  'writeConcern' : { '$exists' : false } }"));
 
-   mock_server_replies_simple (request, "{'ok': 1}");
+   reply_to_request_simple (request, "{'ok': 1}");
    ASSERT (!future_get_bool (future));
 
    request_destroy (request);
@@ -415,7 +415,7 @@ _test_db_command_read_prefs (bool simple, bool pooled)
       request = mock_server_receives_msg (
          server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'db', 'foo': 1}"));
 
-      mock_server_replies_simple (request, "{'ok': 1}");
+      reply_to_request_simple (request, "{'ok': 1}");
       ASSERT_OR_PRINT (future_get_bool (future), error);
       future_destroy (future);
       request_destroy (request);
@@ -430,7 +430,7 @@ _test_db_command_read_prefs (bool simple, bool pooled)
          tmp_bson ("{'$db': 'db',"
                    " 'foo': 1,"
                    " '$readPreference': {'mode': 'secondary'}}"));
-      mock_server_replies_simple (request, "{'ok': 1}");
+      reply_to_request_simple (request, "{'ok': 1}");
       ASSERT_OR_PRINT (future_get_bool (future), error);
       future_destroy (future);
       request_destroy (request);
@@ -442,7 +442,7 @@ _test_db_command_read_prefs (bool simple, bool pooled)
       request = mock_server_receives_msg (
          server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'db', 'foo': 1}"));
 
-      mock_server_replies_simple (request, "{'ok': 1}");
+      reply_to_request_simple (request, "{'ok': 1}");
       ASSERT (future_get_bool (future));
       future_destroy (future);
       request_destroy (request);
@@ -459,7 +459,7 @@ _test_db_command_read_prefs (bool simple, bool pooled)
                    " 'foo': 1,"
                    " '$readPreference': {'mode': 'secondary'}}"));
 
-      mock_server_replies_simple (request, "{'ok': 1}");
+      reply_to_request_simple (request, "{'ok': 1}");
       ASSERT (future_get_bool (future));
       future_destroy (future);
       request_destroy (request);
@@ -870,12 +870,12 @@ _test_get_collection_info_getmore (void)
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'db', 'listCollections': 1, 'nameOnly': true}"));
 
-   mock_server_replies_simple (request,
-                               "{'ok': 1,"
-                               " 'cursor': {"
-                               "   'id': {'$numberLong': '123'},"
-                               "   'ns': 'db.$cmd.listCollections',"
-                               "   'firstBatch': [{'name': 'a'}]}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "   'id': {'$numberLong': '123'},"
+                            "   'ns': 'db.$cmd.listCollections',"
+                            "   'firstBatch': [{'name': 'a'}]}}");
    request_destroy (request);
    request = mock_server_receives_msg (
       server,
@@ -884,12 +884,12 @@ _test_get_collection_info_getmore (void)
                 " 'getMore': {'$numberLong': '123'},"
                 " 'collection': '$cmd.listCollections'}"));
 
-   mock_server_replies_simple (request,
-                               "{'ok': 1,"
-                               " 'cursor': {"
-                               "    'id': {'$numberLong': '0'},"
-                               "    'ns': 'db.$cmd.listCollections',"
-                               "    'nextBatch': []}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "    'id': {'$numberLong': '0'},"
+                            "    'ns': 'db.$cmd.listCollections',"
+                            "    'nextBatch': []}}");
    request_destroy (request);
    names = future_get_char_ptr_ptr (future);
    BSON_ASSERT (names);
@@ -1098,7 +1098,7 @@ test_get_collection_names_error (void)
       server,
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'test', 'listCollections': 1, 'nameOnly': true}"));
-   mock_server_hangs_up (request);
+   reply_to_request_with_hang_up (request);
    names = future_get_char_ptr_ptr (future);
    BSON_ASSERT (!names);
    ASSERT_CMPINT (MONGOC_ERROR_STREAM, ==, error.domain);

--- a/src/libmongoc/tests/test-mongoc-error.c
+++ b/src/libmongoc/tests/test-mongoc-error.c
@@ -87,8 +87,7 @@ _test_command_error (int32_t error_api_version)
       client, "db", tmp_bson ("{'foo': 1}"), NULL, &reply, &error);
    request = mock_server_receives_msg (
       server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'db', 'foo': 1}"));
-   mock_server_replies_simple (request,
-                               "{'ok': 0, 'code': 42, 'errmsg': 'foo'}");
+   reply_to_request_simple (request, "{'ok': 0, 'code': 42, 'errmsg': 'foo'}");
    ASSERT (!future_get_bool (future));
 
    if (error_api_version >= 2) {

--- a/src/libmongoc/tests/test-mongoc-exhaust.c
+++ b/src/libmongoc/tests/test-mongoc-exhaust.c
@@ -450,14 +450,14 @@ static void
 _request_error (request_t *request, exhaust_error_type_t error_type)
 {
    if (error_type == NETWORK_ERROR) {
-      mock_server_resets (request);
+      reply_to_request_with_reset (request);
    } else {
-      mock_server_replies (request,
-                           MONGOC_REPLY_QUERY_FAILURE,
-                           123,
-                           0,
-                           0,
-                           "{'$err': 'uh oh', 'code': 4321}");
+      reply_to_request (request,
+                        MONGOC_REPLY_QUERY_FAILURE,
+                        123,
+                        0,
+                        0,
+                        "{'$err': 'uh oh', 'code': 4321}");
    }
 }
 
@@ -544,7 +544,7 @@ _mock_test_exhaust (bool pooled,
 
    if (error_when == SECOND_BATCH) {
       /* initial query succeeds, gets a doc and cursor id of 123 */
-      mock_server_replies (request, MONGOC_REPLY_NONE, 123, 1, 1, "{'a': 1}");
+      reply_to_request (request, MONGOC_REPLY_NONE, 123, 1, 1, "{'a': 1}");
       ASSERT (future_get_bool (future));
       assert_match_bson (doc, tmp_bson ("{'a': 1}"), false);
       ASSERT_CMPINT64 ((int64_t) 123, ==, mongoc_cursor_get_id (cursor));

--- a/src/libmongoc/tests/test-mongoc-find-and-modify.c
+++ b/src/libmongoc/tests/test-mongoc-find-and-modify.c
@@ -102,7 +102,7 @@ test_find_and_modify_bypass (bool bypass)
                    "'new': true }"));
    }
 
-   mock_server_replies_simple (request, "{ 'value' : null, 'ok' : 1 }");
+   reply_to_request_simple (request, "{ 'value' : null, 'ok' : 1 }");
    ASSERT_OR_PRINT (future_get_bool (future), error);
 
    future_destroy (future);
@@ -186,7 +186,7 @@ test_find_and_modify_write_concern (void)
                 " 'new': true,"
                 " 'writeConcern': {'w': 42}}"));
 
-   mock_server_replies_simple (request, "{ 'value' : null, 'ok' : 1 }");
+   reply_to_request_simple (request, "{ 'value' : null, 'ok' : 1 }");
    ASSERT_OR_PRINT (future_get_bool (future), error);
 
    future_destroy (future);
@@ -376,7 +376,7 @@ test_find_and_modify_opts (void)
                                           " 'findAndModify': 'collection',"
                                           " 'maxTimeMS': 42,"
                                           " 'foo': 1}"));
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
 
    future_destroy (future);
@@ -426,7 +426,7 @@ test_find_and_modify_opts_write_concern (void)
                                 tmp_bson ("{'$db': 'db',"
                                           " 'findAndModify': 'collection',"
                                           " 'writeConcern': {'w': 2}}"));
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 
@@ -442,7 +442,7 @@ test_find_and_modify_opts_write_concern (void)
                                 tmp_bson ("{'$db': 'db',"
                                           " 'findAndModify': 'collection',"
                                           " 'writeConcern': {'w': 2}}"));
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 
@@ -494,7 +494,7 @@ test_find_and_modify_collation (void)
       tmp_bson ("{'$db': 'db',"
                 " 'findAndModify': 'collection',"
                 " 'collation': {'locale': 'en_US', 'caseFirst': 'lower'}}"));
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 

--- a/src/libmongoc/tests/test-mongoc-gridfs.c
+++ b/src/libmongoc/tests/test-mongoc-gridfs.c
@@ -444,13 +444,15 @@ test_find_one_with_opts_limit (void)
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'db', 'find': 'fs.files', 'filter': {}, 'limit': 1}"));
 
-   mock_server_replies_to_find (request,
-                                MONGOC_QUERY_NONE,
-                                0 /* cursor_id */,
-                                1 /* num returned */,
-                                "db.fs.files",
-                                "{'_id': 1, 'length': 1, 'chunkSize': 1}",
-                                true /* is_command */);
+   mock_server_replies_opmsg (
+      request,
+      MONGOC_MSG_NONE,
+      tmp_bson (
+         "{'ok': 1,"
+         " 'cursor': {"
+         "    'id': {'$numberLong': '0'},"
+         "    'ns': 'db.fs.files',"
+         "    'firstBatch': [{'_id': 1, 'length': 1, 'chunkSize': 1}]}}"));
 
    file = future_get_mongoc_gridfs_file_ptr (future);
    ASSERT (file);
@@ -467,13 +469,15 @@ test_find_one_with_opts_limit (void)
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'db', 'find': 'fs.files', 'filter': {}, 'limit': 1}"));
 
-   mock_server_replies_to_find (request,
-                                MONGOC_QUERY_NONE,
-                                0 /* cursor_id */,
-                                1 /* num returned */,
-                                "db.fs.files",
-                                "{'_id': 1, 'length': 1, 'chunkSize': 1}",
-                                true /* is_command */);
+   mock_server_replies_opmsg (
+      request,
+      MONGOC_MSG_NONE,
+      tmp_bson (
+         "{'ok': 1,"
+         " 'cursor': {"
+         "    'id': {'$numberLong': '0'},"
+         "    'ns': 'db.fs.files',"
+         "    'firstBatch': [{'_id': 1, 'length': 1, 'chunkSize': 1}]}}"));
 
    file = future_get_mongoc_gridfs_file_ptr (future);
    ASSERT (file);

--- a/src/libmongoc/tests/test-mongoc-gridfs.c
+++ b/src/libmongoc/tests/test-mongoc-gridfs.c
@@ -96,7 +96,7 @@ _get_gridfs (mock_server_t *server,
       server,
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'db', 'listIndexes': 'fs.chunks'}"));
-   mock_server_replies_simple (
+   reply_to_request_simple (
       request,
       "{ 'ok' : 0, 'errmsg' : 'ns does not exist: db.fs.chunks', 'code' : 26, "
       "'codeName' : 'NamespaceNotFound' }");
@@ -107,13 +107,13 @@ _get_gridfs (mock_server_t *server,
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'db', 'createIndexes': 'fs.chunks'}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
 
    request = mock_server_receives_msg (
       server,
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'db', 'listIndexes': 'fs.files'}"));
-   mock_server_replies_simple (
+   reply_to_request_simple (
       request,
       "{ 'ok' : 0, 'errmsg' : 'ns does not exist: db.fs.files', 'code' : 26, "
       "'codeName' : 'NamespaceNotFound' }");
@@ -124,7 +124,7 @@ _get_gridfs (mock_server_t *server,
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'db', 'createIndexes': 'fs.files'}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
 
    gridfs = future_get_mongoc_gridfs_ptr (future);
    ASSERT (gridfs);
@@ -444,7 +444,7 @@ test_find_one_with_opts_limit (void)
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'db', 'find': 'fs.files', 'filter': {}, 'limit': 1}"));
 
-   mock_server_replies_opmsg (
+   reply_to_op_msg (
       request,
       MONGOC_MSG_NONE,
       tmp_bson (
@@ -469,7 +469,7 @@ test_find_one_with_opts_limit (void)
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'db', 'find': 'fs.files', 'filter': {}, 'limit': 1}"));
 
-   mock_server_replies_opmsg (
+   reply_to_op_msg (
       request,
       MONGOC_MSG_NONE,
       tmp_bson (
@@ -1457,7 +1457,7 @@ test_inherit_client_config (void)
                 " 'readConcern': {'level': 'majority'},"
                 " '$readPreference': {'mode': 'secondary'}}"));
 
-   mock_server_replies_simple (
+   reply_to_request_simple (
       request,
       "{'ok': 1, 'cursor': {'ns': 'fs.files', 'firstBatch': [{'_id': 1}]}}");
 
@@ -1477,7 +1477,7 @@ test_inherit_client_config (void)
          "{'$db': 'db', 'delete': 'fs.files', 'writeConcern': {'w': 2}}"),
       tmp_bson ("{'q': {'_id': 1}, 'limit': 1}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
 
    request = mock_server_receives_msg (
       server,
@@ -1486,7 +1486,7 @@ test_inherit_client_config (void)
          "{'$db': 'db', 'delete': 'fs.chunks', 'writeConcern': {'w': 2}}"),
       tmp_bson ("{'q': {'files_id': 1}, 'limit': 0}"));
 
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT (future_get_bool (future));
    future_destroy (future);
 
@@ -1528,15 +1528,15 @@ responder (request_t *request, void *data)
    BSON_UNUSED (data);
 
    if (!strcasecmp (request->command_name, "createIndexes")) {
-      mock_server_replies_ok_and_destroys (request);
+      reply_to_request_with_ok_and_destroy (request);
       return true;
    }
 
    if (!strcasecmp (request->command_name, "listIndexes")) {
-      mock_server_replies_simple (request,
-                                  "{ 'ok' : 0, 'errmsg' : 'ns does not exist: "
-                                  "db.fs.chunks', 'code' : 26, "
-                                  "'codeName' : 'NamespaceNotFound' }");
+      reply_to_request_simple (request,
+                               "{ 'ok' : 0, 'errmsg' : 'ns does not exist: "
+                               "db.fs.chunks', 'code' : 26, "
+                               "'codeName' : 'NamespaceNotFound' }");
       request_destroy (request);
       return true;
    }

--- a/src/libmongoc/tests/test-mongoc-gridfs.c
+++ b/src/libmongoc/tests/test-mongoc-gridfs.c
@@ -444,7 +444,7 @@ test_find_one_with_opts_limit (void)
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'db', 'find': 'fs.files', 'filter': {}, 'limit': 1}"));
 
-   reply_to_op_msg (
+   reply_to_op_msg_request (
       request,
       MONGOC_MSG_NONE,
       tmp_bson (
@@ -469,7 +469,7 @@ test_find_one_with_opts_limit (void)
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'db', 'find': 'fs.files', 'filter': {}, 'limit': 1}"));
 
-   reply_to_op_msg (
+   reply_to_op_msg_request (
       request,
       MONGOC_MSG_NONE,
       tmp_bson (

--- a/src/libmongoc/tests/test-mongoc-handshake.c
+++ b/src/libmongoc/tests/test-mongoc-handshake.c
@@ -257,7 +257,7 @@ test_mongoc_handshake_data_append_success (void)
       ASSERT (strstr (val, platform) != NULL);
    }
 
-   mock_server_replies_simple (request, "{'ok': 1, 'isWritablePrimary': true}");
+   reply_to_request_simple (request, "{'ok': 1, 'isWritablePrimary': true}");
    request_destroy (request);
 
    /* Cleanup */
@@ -367,7 +367,7 @@ test_mongoc_handshake_data_append_null_args (void)
       ASSERT (strstr (val, "null") == NULL);
    }
 
-   mock_server_replies_simple (request, "{'ok': 1, 'isWritablePrimary': true}");
+   reply_to_request_simple (request, "{'ok': 1, 'isWritablePrimary': true}");
    request_destroy (request);
 
    /* Cleanup */
@@ -525,7 +525,7 @@ test_mongoc_handshake_too_big (void)
    /* Should have truncated the platform field so it fits exactly */
    ASSERT (len == HANDSHAKE_MAX_SIZE);
 
-   mock_server_replies_simple (
+   reply_to_request_simple (
       request,
       tmp_str ("{'ok': 1, 'minWireVersion': %d, 'maxWireVersion': %d}",
                WIRE_VERSION_MIN,
@@ -535,7 +535,7 @@ test_mongoc_handshake_too_big (void)
    request = mock_server_receives_msg (
       server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'admin', 'ping': 1}"));
 
-   mock_server_replies_simple (request, "{'ok': 1}");
+   reply_to_request_simple (request, "{'ok': 1}");
    ASSERT (future_get_bool (future));
 
    future_destroy (future);
@@ -685,13 +685,13 @@ test_mongoc_handshake_cannot_send (void)
    ASSERT (request_doc);
    ASSERT (!bson_has_field (request_doc, HANDSHAKE_FIELD));
 
-   mock_server_replies_simple (request, server_reply);
+   reply_to_request_simple (request, server_reply);
    request_destroy (request);
 
    /* Cause failure on client side */
    request = mock_server_receives_any_hello (server);
    ASSERT (request);
-   mock_server_hangs_up (request);
+   reply_to_request_with_hang_up (request);
    request_destroy (request);
 
    /* Make sure the hello request still DOESN'T have a handshake field
@@ -702,7 +702,7 @@ test_mongoc_handshake_cannot_send (void)
    ASSERT (request_doc);
    ASSERT (!bson_has_field (request_doc, HANDSHAKE_FIELD));
 
-   mock_server_replies_simple (request, server_reply);
+   reply_to_request_simple (request, server_reply);
    request_destroy (request);
 
    /* cleanup */

--- a/src/libmongoc/tests/test-mongoc-hedged-reads.c
+++ b/src/libmongoc/tests/test-mongoc-hedged-reads.c
@@ -61,7 +61,7 @@ test_mongos_hedged_reads_read_pref (void)
       tmp_bson ("{'$db': 'db',"
                 " '$readPreference': {'mode': 'secondaryPreferred'}}"));
 
-   mock_server_replies_simple (request, "{'ok': 1, 'n': 1}");
+   reply_to_request_simple (request, "{'ok': 1, 'n': 1}");
    ASSERT_OR_PRINT (1 == future_get_int64_t (future), error);
 
    request_destroy (request);
@@ -84,7 +84,7 @@ test_mongos_hedged_reads_read_pref (void)
                                           "   'mode': 'secondaryPreferred',"
                                           "   'hedge': {'enabled': true}}}"));
 
-   mock_server_replies_simple (request, "{'ok': 1, 'n': 1}");
+   reply_to_request_simple (request, "{'ok': 1, 'n': 1}");
    ASSERT_OR_PRINT (1 == future_get_int64_t (future), error);
 
    request_destroy (request);

--- a/src/libmongoc/tests/test-mongoc-loadbalanced.c
+++ b/src/libmongoc/tests/test-mongoc-loadbalanced.c
@@ -467,11 +467,11 @@ test_loadbalanced_handshake_sends_loadbalanced (void)
                                           &error);
    request = mock_server_receives_any_hello_with_match (
       server, "{'loadBalanced': true}", "{'loadBalanced': true}");
-   mock_server_replies_simple (request, LB_HELLO);
+   reply_to_request_simple (request, LB_HELLO);
    request_destroy (request);
 
    request = mock_server_receives_msg (server, 0, tmp_bson ("{'ping': 1}"));
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
 
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
@@ -529,7 +529,7 @@ test_loadbalanced_handshake_rejects_non_loadbalanced (void)
                                           &error);
    request = mock_server_receives_any_hello_with_match (
       server, "{'loadBalanced': true}", "{'loadBalanced': true}");
-   mock_server_replies_simple (request, NON_LB_HELLO);
+   reply_to_request_simple (request, NON_LB_HELLO);
    request_destroy (request);
    BSON_ASSERT (!future_get_bool (future));
    future_destroy (future);
@@ -582,12 +582,12 @@ test_pre_handshake_error_does_not_clear_pool (void)
       request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
 
    BSON_ASSERT (request);
-   mock_server_replies_simple (request, LB_HELLO);
+   reply_to_request_simple (request, LB_HELLO);
    request_destroy (request);
    /* The "ping" command is sent. */
    request = mock_server_receives_msg (server, 0, tmp_bson ("{'ping': 1}"));
    BSON_ASSERT (request);
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 
@@ -605,7 +605,7 @@ test_pre_handshake_error_does_not_clear_pool (void)
       request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
    BSON_ASSERT (request);
    capture_logs (true); /* hide Failed to buffer logs. */
-   mock_server_hangs_up (request);
+   reply_to_request_with_hang_up (request);
    request_destroy (request);
    BSON_ASSERT (!future_get_bool (future));
    ASSERT_ERROR_CONTAINS (
@@ -624,7 +624,7 @@ test_pre_handshake_error_does_not_clear_pool (void)
     * connection. The next command is the "ping". */
    request = mock_server_receives_msg (server, 0, tmp_bson ("{'ping': 1}"));
    BSON_ASSERT (request);
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 
@@ -693,12 +693,12 @@ test_post_handshake_error_clears_pool (void)
    ASSERT (
       request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
    BSON_ASSERT (request);
-   mock_server_replies_simple (request, LB_HELLO_A);
+   reply_to_request_simple (request, LB_HELLO_A);
    request_destroy (request);
    /* The "ping" command is sent. */
    request = mock_server_receives_msg (server, 0, tmp_bson ("{'ping': 1}"));
    BSON_ASSERT (request);
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 
@@ -715,12 +715,12 @@ test_post_handshake_error_clears_pool (void)
    ASSERT (
       request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
    BSON_ASSERT (request);
-   mock_server_replies_simple (request, LB_HELLO_A);
+   reply_to_request_simple (request, LB_HELLO_A);
    request_destroy (request);
    /* The "ping" command is sent. */
    request = mock_server_receives_msg (server, 0, tmp_bson ("{'ping': 1}"));
    BSON_ASSERT (request);
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 
@@ -737,12 +737,12 @@ test_post_handshake_error_clears_pool (void)
    ASSERT (
       request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
    BSON_ASSERT (request);
-   mock_server_replies_simple (request, LB_HELLO_B);
+   reply_to_request_simple (request, LB_HELLO_B);
    request_destroy (request);
    /* The "ping" command is sent. */
    request = mock_server_receives_msg (server, 0, tmp_bson ("{'ping': 1}"));
    BSON_ASSERT (request);
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 
@@ -757,7 +757,7 @@ test_post_handshake_error_clears_pool (void)
    request = mock_server_receives_msg (server, 0, tmp_bson ("{'ping': 1}"));
    BSON_ASSERT (request);
    capture_logs (true); /* hide Failed to buffer logs. */
-   mock_server_hangs_up (request);
+   reply_to_request_with_hang_up (request);
    request_destroy (request);
    BSON_ASSERT (!future_get_bool (future));
    ASSERT_ERROR_CONTAINS (
@@ -781,12 +781,12 @@ test_post_handshake_error_clears_pool (void)
    ASSERT (
       request_matches_msg (request, MONGOC_MSG_NONE, &match_loadBalanced, 1));
    BSON_ASSERT (request);
-   mock_server_replies_simple (request, LB_HELLO_A);
+   reply_to_request_simple (request, LB_HELLO_A);
    request_destroy (request);
    /* The "ping" command is sent. */
    request = mock_server_receives_msg (server, 0, tmp_bson ("{'ping': 1}"));
    BSON_ASSERT (request);
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 
@@ -800,7 +800,7 @@ test_post_handshake_error_clears_pool (void)
    /* The "ping" command is sent. */
    request = mock_server_receives_msg (server, 0, tmp_bson ("{'ping': 1}"));
    BSON_ASSERT (request);
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 

--- a/src/libmongoc/tests/test-mongoc-max-staleness.c
+++ b/src/libmongoc/tests/test-mongoc-max-staleness.c
@@ -149,7 +149,7 @@ test_mongos_max_staleness_read_pref (void)
                 "   'mode': 'secondary',"
                 "   'maxStalenessSeconds': {'$exists': false}}}"));
 
-   mock_server_replies_simple (request, "{'ok': 1, 'n': 1}");
+   reply_to_request_simple (request, "{'ok': 1, 'n': 1}");
    ASSERT_OR_PRINT (1 == future_get_int64_t (future), error);
 
    request_destroy (request);
@@ -171,7 +171,7 @@ test_mongos_max_staleness_read_pref (void)
                 "   'mode': 'secondary',"
                 "   'maxStalenessSeconds': {'$numberLong': '1'}}}"));
 
-   mock_server_replies_simple (request, "{'ok': 1, 'n': 1}");
+   reply_to_request_simple (request, "{'ok': 1, 'n': 1}");
    ASSERT_OR_PRINT (1 == future_get_int64_t (future), error);
 
    request_destroy (request);
@@ -191,7 +191,7 @@ test_mongos_max_staleness_read_pref (void)
       tmp_bson (
          "{'$db': 'db', '$readPreference': {'mode': 'secondaryPreferred'}}"));
 
-   mock_server_replies_simple (request, "{'ok': 1, 'n': 1}");
+   reply_to_request_simple (request, "{'ok': 1, 'n': 1}");
    ASSERT_OR_PRINT (1 == future_get_int64_t (future), error);
 
    request_destroy (request);
@@ -212,7 +212,7 @@ test_mongos_max_staleness_read_pref (void)
                 "   'mode': 'secondaryPreferred',"
                 "   'maxStalenessSeconds': {'$numberLong': '1'}}}"));
 
-   mock_server_replies_simple (request, "{'ok': 1, 'n': 1}");
+   reply_to_request_simple (request, "{'ok': 1, 'n': 1}");
    ASSERT_OR_PRINT (1 == future_get_int64_t (future), error);
 
    request_destroy (request);

--- a/src/libmongoc/tests/test-mongoc-opts.c
+++ b/src/libmongoc/tests/test-mongoc-opts.c
@@ -852,19 +852,19 @@ test_func_inherits_opts (void *ctx)
       }
 
       if (func_ctx.cursor) {
-         mock_server_replies_simple (request,
-                                     "{'ok': 1,"
-                                     " 'cursor': {"
-                                     "    'id': 0,"
-                                     "    'ns': 'db.collection',"
-                                     "    'firstBatch': []}}");
+         reply_to_request_simple (request,
+                                  "{'ok': 1,"
+                                  " 'cursor': {"
+                                  "    'id': 0,"
+                                  "    'ns': 'db.collection',"
+                                  "    'firstBatch': []}}");
 
          BSON_ASSERT (!future_get_bool (future));
          future_destroy (future);
          ASSERT_OR_PRINT (!mongoc_cursor_error (func_ctx.cursor, &error),
                           error);
       } else {
-         mock_server_replies_simple (request, "{'ok': 1}");
+         reply_to_request_simple (request, "{'ok': 1}");
          cleanup_future (future);
       }
 

--- a/src/libmongoc/tests/test-mongoc-read-concern.c
+++ b/src/libmongoc/tests/test-mongoc-read-concern.c
@@ -158,8 +158,8 @@ _test_read_concern_wire_version (bool explicit)
       server,
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'db', 'readConcern': {'level': 'foo'}}"));
-   mock_server_replies_simple (
-      request, "{'ok': 1, 'cursor': {'id': 0, 'firstBatch': []}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1, 'cursor': {'id': 0, 'firstBatch': []}}");
    request_destroy (request);
    BSON_ASSERT (future_wait (future));
    ASSERT_OR_PRINT (!mongoc_cursor_error (cursor, &error), error);
@@ -175,7 +175,7 @@ _test_read_concern_wire_version (bool explicit)
       server,
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'db', 'readConcern': {'level': 'foo'}}"));
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    BSON_ASSERT (future_get_bool (future));
 
    future_destroy (future);
@@ -195,7 +195,7 @@ _test_read_concern_wire_version (bool explicit)
       server,
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'db', 'readConcern': {'level': 'foo'}}"));
-   mock_server_replies_simple (request, "{'ok': 1, 'n': 1}");
+   reply_to_request_simple (request, "{'ok': 1, 'n': 1}");
    request_destroy (request);
    ASSERT_CMPINT64 (future_get_int64_t (future), ==, (int64_t) 1);
 

--- a/src/libmongoc/tests/test-mongoc-read-prefs.c
+++ b/src/libmongoc/tests/test-mongoc-read-prefs.c
@@ -45,12 +45,12 @@ _test_op_msg (const mongoc_uri_t *uri,
 
    future = future_cursor_next (cursor, &doc);
    request = mock_server_receives_msg (server, 0, tmp_bson (expected_find));
-   mock_server_replies_simple (request,
-                               "{'ok': 1,"
-                               " 'cursor': {"
-                               "    'id': 0,"
-                               "    'ns': 'db.collection',"
-                               "    'firstBatch': [{'a': 1}]}}");
+   reply_to_request_simple (request,
+                            "{'ok': 1,"
+                            " 'cursor': {"
+                            "    'id': 0,"
+                            "    'ns': 'db.collection',"
+                            "    'firstBatch': [{'a': 1}]}}");
 
    /* mongoc_cursor_next returned true */
    BSON_ASSERT (future_get_bool (future));
@@ -97,12 +97,12 @@ _test_command (const mongoc_uri_t *uri,
    request = mock_server_receives_msg (
       server, MONGOC_MSG_NONE, tmp_bson (expected_cmd));
 
-   mock_server_replies (request,
-                        MONGOC_REPLY_NONE, /* flags */
-                        0,                 /* cursorId */
-                        0,                 /* startingFrom */
-                        1,                 /* numberReturned */
-                        "{'ok': 1}");
+   reply_to_request (request,
+                     MONGOC_REPLY_NONE, /* flags */
+                     0,                 /* cursorId */
+                     0,                 /* startingFrom */
+                     1,                 /* numberReturned */
+                     "{'ok': 1}");
 
    /* mongoc_cursor_next returned true */
    BSON_ASSERT (future_get_bool (future));
@@ -137,12 +137,12 @@ _test_command_simple (const mongoc_uri_t *uri,
    request = mock_server_receives_msg (
       server, MONGOC_MSG_NONE, tmp_bson (expected_cmd));
 
-   mock_server_replies (request,
-                        MONGOC_REPLY_NONE, /* flags */
-                        0,                 /* cursorId */
-                        0,                 /* startingFrom */
-                        1,                 /* numberReturned */
-                        "{'ok': 1}");
+   reply_to_request (request,
+                     MONGOC_REPLY_NONE, /* flags */
+                     0,                 /* cursorId */
+                     0,                 /* startingFrom */
+                     1,                 /* numberReturned */
+                     "{'ok': 1}");
 
    /* mongoc_cursor_next returned true */
    BSON_ASSERT (future_get_bool (future));
@@ -611,14 +611,13 @@ test_read_prefs_mongos_max_staleness (void)
       "                     'maxStalenessSeconds': 120}}",
       "{}");
 
-   mock_server_replies_to_find (request,
-                                MONGOC_QUERY_EXHAUST |
-                                   MONGOC_QUERY_SECONDARY_OK,
-                                0,
-                                1,
-                                "test.test",
-                                "{}",
-                                false);
+   reply_to_find_request (request,
+                          MONGOC_QUERY_EXHAUST | MONGOC_QUERY_SECONDARY_OK,
+                          0,
+                          1,
+                          "test.test",
+                          "{}",
+                          false);
 
    /* mongoc_cursor_next returned true */
    BSON_ASSERT (future_get_bool (future));
@@ -673,14 +672,13 @@ test_read_prefs_mongos_hedged_reads (void)
       "                     'hedge': {'enabled': true}}}",
       "{}");
 
-   mock_server_replies_to_find (request,
-                                MONGOC_QUERY_EXHAUST |
-                                   MONGOC_QUERY_SECONDARY_OK,
-                                0,
-                                1,
-                                "test.test",
-                                "{}",
-                                false);
+   reply_to_find_request (request,
+                          MONGOC_QUERY_EXHAUST | MONGOC_QUERY_SECONDARY_OK,
+                          0,
+                          1,
+                          "test.test",
+                          "{}",
+                          false);
 
    /* mongoc_cursor_next returned true */
    BSON_ASSERT (future_get_bool (future));
@@ -732,13 +730,13 @@ test_mongos_read_concern (void)
                 " '$readPreference': {'mode': 'secondary'},"
                 " 'readConcern': {'level': 'foo'}}"));
 
-   mock_server_replies_opmsg (request,
-                              MONGOC_MSG_NONE,
-                              tmp_bson ("{'ok': 1,"
-                                        " 'cursor': {"
-                                        "    'id': {'$numberLong': '0'},"
-                                        "    'ns': 'db.collection',"
-                                        "    'firstBatch': [{}]}}"));
+   reply_to_op_msg (request,
+                    MONGOC_MSG_NONE,
+                    tmp_bson ("{'ok': 1,"
+                              " 'cursor': {"
+                              "    'id': {'$numberLong': '0'},"
+                              "    'ns': 'db.collection',"
+                              "    'firstBatch': [{}]}}"));
 
    /* mongoc_cursor_next returned true */
    BSON_ASSERT (future_get_bool (future));
@@ -815,7 +813,7 @@ _test_op_msg_direct_connection (bool is_mongos,
               "    'ns': 'db.collection',"
               "    'firstBatch': [{'a': 1}]}}";
 
-      mock_server_replies_simple (request, reply);
+      reply_to_request_simple (request, reply);
       BSON_ASSERT (future_get_bool (future));
       future_destroy (future);
       request_destroy (request);

--- a/src/libmongoc/tests/test-mongoc-read-prefs.c
+++ b/src/libmongoc/tests/test-mongoc-read-prefs.c
@@ -730,13 +730,13 @@ test_mongos_read_concern (void)
                 " '$readPreference': {'mode': 'secondary'},"
                 " 'readConcern': {'level': 'foo'}}"));
 
-   reply_to_op_msg (request,
-                    MONGOC_MSG_NONE,
-                    tmp_bson ("{'ok': 1,"
-                              " 'cursor': {"
-                              "    'id': {'$numberLong': '0'},"
-                              "    'ns': 'db.collection',"
-                              "    'firstBatch': [{}]}}"));
+   reply_to_op_msg_request (request,
+                            MONGOC_MSG_NONE,
+                            tmp_bson ("{'ok': 1,"
+                                      " 'cursor': {"
+                                      "    'id': {'$numberLong': '0'},"
+                                      "    'ns': 'db.collection',"
+                                      "    'firstBatch': [{}]}}"));
 
    /* mongoc_cursor_next returned true */
    BSON_ASSERT (future_get_bool (future));

--- a/src/libmongoc/tests/test-mongoc-read-prefs.c
+++ b/src/libmongoc/tests/test-mongoc-read-prefs.c
@@ -732,8 +732,13 @@ test_mongos_read_concern (void)
                 " '$readPreference': {'mode': 'secondary'},"
                 " 'readConcern': {'level': 'foo'}}"));
 
-   mock_server_replies_to_find (
-      request, MONGOC_QUERY_NONE, 0, 1, "db.collection", "{}", true);
+   mock_server_replies_opmsg (request,
+                              MONGOC_MSG_NONE,
+                              tmp_bson ("{'ok': 1,"
+                                        " 'cursor': {"
+                                        "    'id': {'$numberLong': '0'},"
+                                        "    'ns': 'db.collection',"
+                                        "    'firstBatch': [{}]}}"));
 
    /* mongoc_cursor_next returned true */
    BSON_ASSERT (future_get_bool (future));

--- a/src/libmongoc/tests/test-mongoc-retryable-writes.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-writes.c
@@ -91,7 +91,7 @@ test_rs_failover (void)
    future = future_collection_insert_one (collection, b, &opts, NULL, &error);
    request =
       mock_rs_receives_msg (rs, 0, tmp_bson ("{'insert': 'collection'}"), b);
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    BSON_ASSERT (future_get_bool (future));
    future_destroy (future);
 
@@ -106,19 +106,19 @@ test_rs_failover (void)
    request =
       mock_rs_receives_msg (rs, 0, tmp_bson ("{'insert': 'collection'}"), b);
    BSON_ASSERT (mock_rs_request_is_to_secondary (rs, request));
-   mock_server_replies_simple (request,
-                               "{"
-                               " 'ok': 0,"
-                               " 'code': 10107,"
-                               " 'errmsg': 'not primary',"
-                               " 'errorLabels': ['RetryableWriteError']"
-                               "}");
+   reply_to_request_simple (request,
+                            "{"
+                            " 'ok': 0,"
+                            " 'code': 10107,"
+                            " 'errmsg': 'not primary',"
+                            " 'errorLabels': ['RetryableWriteError']"
+                            "}");
    request_destroy (request);
 
    request =
       mock_rs_receives_msg (rs, 0, tmp_bson ("{'insert': 'collection'}"), b);
    BSON_ASSERT (mock_rs_request_is_to_primary (rs, request));
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    BSON_ASSERT (future_get_bool (future));
    future_destroy (future);
 
@@ -559,7 +559,7 @@ test_unsupported_storage_engine_error (void)
       &reply,
       &error);
    request = mock_rs_receives_request (rs);
-   mock_server_replies_simple (
+   reply_to_request_simple (
       request,
       "{'ok': 0, 'code': 20, 'errmsg': 'Transaction numbers are great'}");
    request_destroy (request);

--- a/src/libmongoc/tests/test-mongoc-scram.c
+++ b/src/libmongoc/tests/test-mongoc-scram.c
@@ -256,7 +256,7 @@ _check_mechanism (bool pooled,
    used_mech = bson_lookup_utf8 (sasl_doc, "mechanism");
    ASSERT_CMPSTR (used_mech, expected_used_mech);
    /* we're not actually going to auth, just hang up. */
-   mock_server_hangs_up (request);
+   reply_to_request_with_hang_up (request);
    future_wait (future);
    future_destroy (future);
    request_destroy (request);

--- a/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
@@ -662,7 +662,7 @@ responder (request_t *request, void *data)
    BSON_UNUSED (data);
 
    if (!strcmp (request->command_name, "foo")) {
-      mock_server_replies_simple (request, "{'ok': 1}");
+      reply_to_request_simple (request, "{'ok': 1}");
       request_destroy (request);
       return true;
    }
@@ -717,7 +717,7 @@ _test_heartbeat_events (bool pooled, bool succeeded)
    request = mock_server_receives_any_hello (server);
 
    if (succeeded) {
-      mock_server_replies (
+      reply_to_request (
          request,
          MONGOC_REPLY_NONE,
          0,
@@ -728,14 +728,14 @@ _test_heartbeat_events (bool pooled, bool succeeded)
                   WIRE_VERSION_MAX));
       request_destroy (request);
    } else {
-      mock_server_hangs_up (request);
+      reply_to_request_with_hang_up (request);
       request_destroy (request);
    }
 
    /* pooled client opens new socket, handshakes it by calling hello again */
    if (pooled && succeeded) {
       request = mock_server_receives_any_hello (server);
-      mock_server_replies (
+      reply_to_request (
          request,
          MONGOC_REPLY_NONE,
          0,
@@ -955,13 +955,13 @@ test_no_duplicates (void)
 
    /* Topology scanning thread starts, and sends a hello. */
    request = mock_server_receives_any_hello (server);
-   mock_server_replies_simple (request,
-                               tmp_str ("{'ok': 1.0,"
-                                        " 'isWritablePrimary': true, "
-                                        " 'minWireVersion': %d,"
-                                        " 'maxWireVersion': %d}",
-                                        WIRE_VERSION_MIN,
-                                        WIRE_VERSION_4_4));
+   reply_to_request_simple (request,
+                            tmp_str ("{'ok': 1.0,"
+                                     " 'isWritablePrimary': true, "
+                                     " 'minWireVersion': %d,"
+                                     " 'maxWireVersion': %d}",
+                                     WIRE_VERSION_MIN,
+                                     WIRE_VERSION_4_4));
    request_destroy (request);
 
    /* Perform a ping, which creates a new connection, which performs the
@@ -973,7 +973,7 @@ test_no_duplicates (void)
                                           NULL /* reply */,
                                           &error);
    request = mock_server_receives_any_hello (server);
-   mock_server_replies_simple (
+   reply_to_request_simple (
       request,
       tmp_str (
          "{'ok': 1.0,"
@@ -987,7 +987,7 @@ test_no_duplicates (void)
    request_destroy (request);
    request = mock_server_receives_msg (
       server, MONGOC_QUERY_NONE, tmp_bson ("{'ping': 1}"));
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 

--- a/src/libmongoc/tests/test-mongoc-server-stream.c
+++ b/src/libmongoc/tests/test-mongoc-server-stream.c
@@ -85,7 +85,7 @@ run_delete_with_hint_and_wc0 (bool expect_error,
                                           MONGOC_MSG_MORE_TO_COME,
                                           tmp_bson ("{ 'delete': 'coll' }"),
                                           tmp_bson ("{'q': {}, 'hint': {}}"));
-      mock_server_replies_ok_and_destroys (request);
+      reply_to_request_with_ok_and_destroy (request);
       r = future_get_bool (future);
       ASSERT (r);
    }
@@ -124,7 +124,7 @@ test_server_stream_ties_server_description_pooled (void *unused)
 
    /* Respond to the monitoring hello with server one hello. */
    request = mock_server_receives_any_hello (server);
-   mock_server_replies_simple (request, HELLO_SERVER_ONE);
+   reply_to_request_simple (request, HELLO_SERVER_ONE);
    request_destroy (request);
 
    /* Create a connection on client_one. */
@@ -136,11 +136,11 @@ test_server_stream_ties_server_description_pooled (void *unused)
                                           &error);
    /* The first command on a pooled client creates a new connection. */
    request = mock_server_receives_any_hello (server);
-   mock_server_replies_simple (request, HELLO_SERVER_ONE);
+   reply_to_request_simple (request, HELLO_SERVER_ONE);
    request_destroy (request);
    request = mock_server_receives_msg (
       server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'admin', 'ping': 1}"));
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 
@@ -153,11 +153,11 @@ test_server_stream_ties_server_description_pooled (void *unused)
                                           &error);
    /* The first command on a pooled client creates a new connection. */
    request = mock_server_receives_any_hello (server);
-   mock_server_replies_simple (request, HELLO_SERVER_TWO);
+   reply_to_request_simple (request, HELLO_SERVER_TWO);
    request_destroy (request);
    request = mock_server_receives_msg (
       server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'admin', 'ping': 1}"));
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 
@@ -216,11 +216,11 @@ test_server_stream_ties_server_description_single (void *unused)
                                           &error);
    /* The first command on a client creates a new connection. */
    request = mock_server_receives_any_hello (server);
-   mock_server_replies_simple (request, HELLO_SERVER_TWO);
+   reply_to_request_simple (request, HELLO_SERVER_TWO);
    request_destroy (request);
    request = mock_server_receives_msg (
       server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'admin', 'ping': 1}"));
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 
@@ -240,7 +240,7 @@ test_server_stream_ties_server_description_single (void *unused)
                                           &error);
    request = mock_server_receives_msg (
       server, MONGOC_MSG_NONE, tmp_bson ("{'$db': 'admin', 'ping': 1}"));
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 

--- a/src/libmongoc/tests/test-mongoc-speculative-auth.c
+++ b/src/libmongoc/tests/test-mongoc-speculative-auth.c
@@ -72,7 +72,7 @@ _respond_to_ping (future_t *future, mock_server_t *server, bool expect_ping)
 
    ASSERT (request);
 
-   mock_server_replies_simple (request, "{'ok': 1}");
+   reply_to_request_simple (request, "{'ok': 1}");
 
    ASSERT (future_get_bool (future));
    request_destroy (request);
@@ -105,7 +105,7 @@ _auto_hello_without_speculative_auth (request_t *request, void *data)
       _mongoc_usleep ((int64_t) (rand () % 10) * 1000);
    }
 
-   mock_server_replies (request, MONGOC_REPLY_NONE, 0, 0, 1, response_json);
+   reply_to_request (request, MONGOC_REPLY_NONE, 0, 0, 1, response_json);
 
    bson_free (quotes_replaced);
    request_destroy (request);
@@ -222,7 +222,7 @@ _test_mongoc_speculative_auth (bool pooled,
       }
 
       str = bson_as_canonical_extended_json (response, NULL);
-      mock_server_replies_simple (request, str);
+      reply_to_request_simple (request, str);
 
       bson_free (str);
       bson_destroy (response);
@@ -285,7 +285,7 @@ _post_hello_scram_invalid_auth_response (mock_server_t *srv)
 
    /* Let authentication fail directly since we won't be able to continue the
     * scram conversation. */
-   mock_server_replies_simple (
+   reply_to_request_simple (
       request, "{ 'ok': 1, 'errmsg': 'Cannot mock scram auth conversation' }");
 
    request_destroy (request);
@@ -460,7 +460,7 @@ test_mongoc_speculative_auth_request_x509_network_error (void)
                                       "}");
 
          char *response_str = bson_as_canonical_extended_json (response, NULL);
-         mock_server_replies_simple (request, response_str);
+         reply_to_request_simple (request, response_str);
          bson_free (response_str);
          bson_destroy (response);
          bson_free (request_str);
@@ -473,7 +473,7 @@ test_mongoc_speculative_auth_request_x509_network_error (void)
             server, MONGOC_MSG_NONE, tmp_bson ("{'ping': 1}"));
          ASSERT (request);
          // Cause a network error.
-         mock_server_hangs_up (request);
+         reply_to_request_with_hang_up (request);
          request_destroy (request);
       }
 
@@ -524,7 +524,7 @@ test_mongoc_speculative_auth_request_x509_network_error (void)
                                       "}");
 
          char *response_str = bson_as_canonical_extended_json (response, NULL);
-         mock_server_replies_simple (request, response_str);
+         reply_to_request_simple (request, response_str);
          bson_free (response_str);
          bson_destroy (response);
          request_destroy (request);
@@ -536,7 +536,7 @@ test_mongoc_speculative_auth_request_x509_network_error (void)
          request_t *request = mock_server_receives_msg (
             server, MONGOC_MSG_NONE, tmp_bson ("{'ping': 1}"));
          ASSERT (request);
-         mock_server_replies_ok_and_destroys (request);
+         reply_to_request_with_ok_and_destroy (request);
       }
 
       // Expect success.

--- a/src/libmongoc/tests/test-mongoc-streamable-hello.c
+++ b/src/libmongoc/tests/test-mongoc-streamable-hello.c
@@ -32,7 +32,7 @@ _force_scan (mongoc_client_t *client, mock_server_t *server, const char *hello)
    future =
       future_client_select_server (client, true /* for writes */, NULL, &error);
    request = mock_server_receives_any_hello (server);
-   mock_server_replies_simple (request, hello);
+   reply_to_request_simple (request, hello);
    sd = future_get_mongoc_server_description_ptr (future);
    BSON_ASSERT (sd);
 

--- a/src/libmongoc/tests/test-mongoc-topology-reconcile.c
+++ b/src/libmongoc/tests/test-mongoc-topology-reconcile.c
@@ -249,14 +249,14 @@ _test_topology_reconcile_sharded (bool pooled)
 
    /* mongos */
    request = mock_server_receives_any_hello (mongos);
-   mock_server_replies_simple (request,
-                               tmp_str ("{'ok': 1,"
-                                        " 'isWritablePrimary': true,"
-                                        " 'minWireVersion': %d,"
-                                        " 'maxWireVersion': %d,"
-                                        " 'msg': 'isdbgrid'}",
-                                        WIRE_VERSION_MIN,
-                                        WIRE_VERSION_MAX));
+   reply_to_request_simple (request,
+                            tmp_str ("{'ok': 1,"
+                                     " 'isWritablePrimary': true,"
+                                     " 'minWireVersion': %d,"
+                                     " 'maxWireVersion': %d,"
+                                     " 'msg': 'isdbgrid'}",
+                                     WIRE_VERSION_MIN,
+                                     WIRE_VERSION_MAX));
 
    request_destroy (request);
 
@@ -278,7 +278,7 @@ _test_topology_reconcile_sharded (bool pooled)
                           mock_server_get_host_and_port (mongos),
                           mock_server_get_host_and_port (secondary));
 
-   mock_server_replies_simple (request, secondary_response);
+   reply_to_request_simple (request, secondary_response);
 
    request_destroy (request);
 
@@ -533,7 +533,7 @@ test_topology_reconcile_retire_single (void)
       client, "admin", tmp_bson ("{'ping': 1}"), NULL, NULL, NULL, &error);
    request = mock_server_receives_msg (
       primary, MONGOC_QUERY_NONE, tmp_bson ("{'ping': 1}"));
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
 
    BSON_ASSERT (!has_server_description (
@@ -648,7 +648,7 @@ test_topology_reconcile_add_single (void)
       client, "admin", tmp_bson ("{'ping': 1}"), NULL, NULL, NULL, &error);
    request = mock_server_receives_msg (
       primary, MONGOC_QUERY_NONE, tmp_bson ("{'ping': 1}"));
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
 
    /* added server description */

--- a/src/libmongoc/tests/test-mongoc-topology-scanner.c
+++ b/src/libmongoc/tests/test-mongoc-topology-scanner.c
@@ -188,7 +188,7 @@ test_topology_scanner_discovery (void)
 
    /* a single scan discovers *and* checks the secondary */
    request = mock_server_receives_any_hello (primary);
-   mock_server_replies_simple (request, primary_response);
+   reply_to_request_simple (request, primary_response);
    request_destroy (request);
 
    /* let client process that response */
@@ -196,7 +196,7 @@ test_topology_scanner_discovery (void)
 
    /* a check of the secondary is scheduled in this scan */
    request = mock_server_receives_any_hello (secondary);
-   mock_server_replies_simple (request, secondary_response);
+   reply_to_request_simple (request, secondary_response);
 
    /* scan completes */
    ASSERT_OR_PRINT ((sd = future_get_mongoc_server_description_ptr (future)),
@@ -268,14 +268,14 @@ test_topology_scanner_oscillate (void)
 
    /* a single scan discovers servers 0 and 1 */
    request = mock_server_receives_any_hello (server0);
-   mock_server_replies_simple (request, server0_response);
+   reply_to_request_simple (request, server0_response);
    request_destroy (request);
 
    /* let client process that response */
    _mongoc_usleep (250 * 1000);
 
    request = mock_server_receives_any_hello (server1);
-   mock_server_replies_simple (request, server1_response);
+   reply_to_request_simple (request, server1_response);
 
    /* we don't schedule another check of server0 */
    _mongoc_usleep (250 * 1000);

--- a/src/libmongoc/tests/test-mongoc-transactions.c
+++ b/src/libmongoc/tests/test-mongoc-transactions.c
@@ -443,7 +443,7 @@ hangup_except_hello (request_t *request, void *data)
       return false;
    }
 
-   mock_server_hangs_up (request);
+   reply_to_request_with_hang_up (request);
    request_destroy (request);
    return true;
 }
@@ -663,7 +663,7 @@ test_unknown_commit_result (void)
       collection, tmp_bson ("{}"), &opts, NULL, &error);
    request = mock_server_receives_msg (
       server, 0, tmp_bson ("{'insert': 'collection'}"), tmp_bson ("{}"));
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    ASSERT_OR_PRINT (future_get_bool (future), error);
    future_destroy (future);
 

--- a/src/libmongoc/tests/test-mongoc-write-commands.c
+++ b/src/libmongoc/tests/test-mongoc-write-commands.c
@@ -413,7 +413,7 @@ test_disconnect_mid_batch (void)
    /* Mock server recieves first insert. */
    request = mock_server_receives_request (server);
    BSON_ASSERT (request);
-   mock_server_hangs_up (request);
+   reply_to_request_with_hang_up (request);
    request_destroy (request);
 
    BSON_ASSERT (!future_get_bool (future));

--- a/src/libmongoc/tests/test-mongoc-write-concern.c
+++ b/src/libmongoc/tests/test-mongoc-write-concern.c
@@ -437,7 +437,7 @@ _test_wc_request (future_t *future, mock_server_t *server, bson_error_t *error)
       server,
       MONGOC_MSG_NONE,
       tmp_bson ("{'$db': 'db', 'writeConcern': {'w': 2}}"));
-   mock_server_replies_ok_and_destroys (request);
+   reply_to_request_with_ok_and_destroy (request);
    BSON_ASSERT (future_get_bool (future));
 
    future_destroy (future);


### PR DESCRIPTION
Motivated by ongoing work on CDRIVER-4617 and CDRIVER-4630. Verified by [this patch](https://spruce.mongodb.com/version/646e1e2d0305b965763c3d37).

Improved validation and correctness checks for RPC message parsing in CDRIVER-4617 and CDRIVER-4630 (WIP) exposed several mock server tests that use `mock_(server|rs)_replies_to_find` to respond to OP_MSG requests. `mock_(server|rs)_replies_to_find` assumes the request is an OP_QUERY and unconditionally [accesses OP_QUERY flags](https://github.com/mongodb/mongo-c-driver/blob/master/src/libmongoc/tests/mock_server/mock-server.c#L2218) in the request even if it is actually an OP_MSG.

This PR replaces calls to `mock_(server|rs)_replies_to_find` that follow an OP_MSG request with `mock_server_replies_opmsg` or the new `mock_rs_replies_opmsg` function, that explicitly specifying the reply contents (e.g. `cursorId`, `firstBatch` contents, etc.) as was intended by invoking `*_replies_to_find` with `is_command == true`.