### PR TITLE
CDRIVER-4603 use setuptools rather than distutils (deprecated) for version calc

### DIFF
--- a/build/calc_release_version.py
+++ b/build/calc_release_version.py
@@ -299,7 +299,11 @@ def previous(rel_ver):
             version_new['minor'] = int(previous_tag_match.group('vermin'))
             version_new['patch'] = int(previous_tag_match.group('verpatch'))
             version_new['prerelease'] = previous_tag_match.group('verpre')
-            new_version_str = tag
+            new_version_str = str(version_new['major']) + '.' + \
+                              str(version_new['minor']) + '.' + \
+                              str(version_new['patch'])
+            if version_new['prerelease'] is not None:
+                new_version_str += '-' + version_new['prerelease']
             new_version_parsed = parse_version(new_version_str)
             if new_version_parsed < rel_ver_parsed and new_version_parsed > version_parsed:
                 version_str = new_version_str

--- a/build/calc_release_version.py
+++ b/build/calc_release_version.py
@@ -26,7 +26,14 @@ import datetime
 import re
 import subprocess
 import sys
-from distutils.version import LooseVersion
+if sys.version_info < (3, 9):
+    from distutils.version import LooseVersion as Version
+    from distutils.version import LooseVersion as parse_version
+else:
+    # on newer versions of Python use setuptools rather than distutils
+    # (which has been deprecated)
+    from pkg_resources.extern.packaging.version import Version
+    from pkg_resources import parse_version
 
 DEBUG = len(sys.argv) > 1 and '-d' in sys.argv
 if DEBUG:
@@ -74,7 +81,8 @@ def check_head_tag():
     """
 
     found_tag = False
-    version_loose = LooseVersion('0.0.0')
+    version_str = '0.0.0'
+    version_parsed = parse_version(version_str)
 
     # have git tell us if any tags that look like release tags point at HEAD;
     # based on our policy, a commit should never have more than one release tag
@@ -87,17 +95,19 @@ def check_head_tag():
 
     release_tag_match = RELEASE_TAG_RE.match(tag)
     if release_tag_match:
-        new_version_loose = LooseVersion(release_tag_match.group('ver'))
-        if new_version_loose > version_loose:
+        new_version_str = release_tag_match.group('ver')
+        new_version_parsed = parse_version(new_version_str)
+        if new_version_parsed > version_parsed:
             if DEBUG:
-                print('HEAD release tag: ' + release_tag_match.group('ver'))
-            version_loose = new_version_loose
+                print('HEAD release tag: ' + new_version_str)
+            version_str = new_version_str
+            version_parsed = new_version_parsed
             found_tag = True
 
     if found_tag:
         if DEBUG:
-            print('Calculated version: ' + str(version_loose))
-        return str(version_loose)
+            print('Calculated version: ' + version_str)
+        return version_str
 
     return None
 
@@ -110,7 +120,8 @@ def get_next_minor(prerelease_marker):
         - Append a pre-release marker. (e.g. 1.22.0 becomes 1.22.0-20220201+gitf6e6a7025d)
     """
 
-    version_loose = LooseVersion('0.0.0')
+    version_str = '0.0.0'
+    version_parsed = parse_version(version_str)
 
     version_new = {}
     # Use refs (not branches) to get local branches plus remote branches
@@ -123,17 +134,19 @@ def get_next_minor(prerelease_marker):
             version_new['minor'] = int(release_branch_match.group('vermin')) + 1
             version_new['patch'] = 0
             version_new['prerelease'] = prerelease_marker
-            new_version_loose = LooseVersion(str(version_new['major']) + '.' +
-                                             str(version_new['minor']) + '.' +
-                                             str(version_new['patch']) + '-' +
-                                             version_new['prerelease'])
-            if new_version_loose > version_loose:
-                version_loose = new_version_loose
+            new_version_str = str(version_new['major']) + '.' + \
+                              str(version_new['minor']) + '.' + \
+                              str(version_new['patch']) + '-' + \
+                              version_new['prerelease']
+            new_version_parsed = parse_version(new_version_str)
+            if new_version_parsed > version_parsed:
+                version_str = new_version_str
+                version_parsed = new_version_parsed
                 if DEBUG:
-                    print('Found new best version "' + str(version_loose) \
+                    print('Found new best version "' + version_str \
                             + '" based on branch "' \
                             + release_branch_match.group('brname') + '"')
-    return str(version_loose)
+    return version_str
 
 def get_branch_tags(active_branch_name):
     """
@@ -171,7 +184,7 @@ def get_branch_tags(active_branch_name):
 def process_and_sort_tags(tags):
     """
     Given a string (as returned from get_branch_tags), return a sorted list of
-    zero or more tags (sorted based on the LooseVersion comparison) which meet
+    zero or more tags (sorted based on the Version comparison) which meet
     the following criteria:
         - a final release tag (i.e., 1.x.y without any pre-release suffix)
         - a pre-release tag which is not superseded by a release tag (i.e.,
@@ -194,7 +207,7 @@ def process_and_sort_tags(tags):
         tag_parts = tag.split('-')
         if len(tag_parts) >= 2 and tag_parts[0] not in processed_and_sorted_tags:
             processed_and_sorted_tags.append(tag)
-    processed_and_sorted_tags.sort(key=LooseVersion)
+    processed_and_sorted_tags.sort(key=Version)
 
     return processed_and_sorted_tags
 
@@ -215,7 +228,8 @@ def main():
            patch version, and append a new pre-release marker
     """
 
-    version_loose = LooseVersion('0.0.0')
+    version_str = '0.0.0'
+    version_parsed = parse_version(version_str)
     head_commit_short = check_output(['git', 'rev-parse', '--revs-only',
                                       '--short=10', 'HEAD^{commit}']).strip()
     prerelease_marker = datetime.date.today().strftime('%Y%m%d') \
@@ -250,17 +264,19 @@ def main():
         version_new['minor'] = int(release_tag_match.group('vermin'))
         version_new['patch'] = int(release_tag_match.group('verpatch')) + 1
         version_new['prerelease'] = prerelease_marker
-        new_version_loose = LooseVersion(str(version_new['major']) + '.' +
-                                         str(version_new['minor']) + '.' +
-                                         str(version_new['patch']) + '-' +
-                                         version_new['prerelease'])
-        if new_version_loose > version_loose:
-            version_loose = new_version_loose
+        new_version_str = str(version_new['major']) + '.' + \
+                          str(version_new['minor']) + '.' + \
+                          str(version_new['patch']) + '-' + \
+                          version_new['prerelease']
+        new_version_parsed = parse_version(new_version_str)
+        if new_version_parsed > version_parsed:
+            version_str = new_version_str
+            version_parsed = new_version_parsed
             if DEBUG:
-                print('Found new best version "' + str(version_loose) \
+                print('Found new best version "' + version_str \
                         + '" from tag "' + release_tag_match.group('ver') + '"')
 
-    return str(version_loose)
+    return version_str
 
 def previous(rel_ver):
     """
@@ -269,8 +285,10 @@ def previous(rel_ver):
     """
     if DEBUG:
         print('Calculating previous release version (option -p was specified).')
-    version_loose = LooseVersion('0.0.0')
-    rel_ver_loose = LooseVersion(rel_ver)
+    version_str = '0.0.0'
+    version_parsed = parse_version(version_str)
+    rel_ver_str = rel_ver
+    rel_ver_parsed = parse_version(rel_ver_str)
     tags = check_output(['git', 'tag', '--list', '1.*'])
     processed_and_sorted_tags = process_and_sort_tags(tags)
     for tag in processed_and_sorted_tags:
@@ -281,14 +299,16 @@ def previous(rel_ver):
             version_new['minor'] = int(previous_tag_match.group('vermin'))
             version_new['patch'] = int(previous_tag_match.group('verpatch'))
             version_new['prerelease'] = previous_tag_match.group('verpre')
-            new_version_loose = LooseVersion(tag)
-            if new_version_loose < rel_ver_loose and new_version_loose > version_loose:
-                version_loose = new_version_loose
+            new_version_str = tag
+            new_version_parsed = parse_version(new_version_str)
+            if new_version_parsed < rel_ver_parsed and new_version_parsed > version_parsed:
+                version_str = new_version_str
+                version_parsed = new_version_parsed
                 if DEBUG:
-                    print('Found new best version "' + str(version_loose) \
+                    print('Found new best version "' + version_str \
                             + '" from tag "' + tag + '"')
 
-    return str(version_loose)
+    return version_str
 
 RELEASE_VER = previous(main()) if PREVIOUS else main()
 


### PR DESCRIPTION
Evergreen patch build: https://spruce.mongodb.com/version/646e3c8932f417f4c6dc9c06/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC