### PR TITLE
Address nounset errors in OCSP tasks

### DIFF
--- a/.evergreen/scripts/run-ocsp-test.sh
+++ b/.evergreen/scripts/run-ocsp-test.sh
@@ -54,7 +54,7 @@ esac
 
 on_exit() {
   echo "Cleaning up"
-  if [[ -n "${responder_required}" ]]; then
+  if [[ -n "${responder_required:-}" ]]; then
     echo "Responder logs:"
     cat "${mongoc_dir}/responder.log"
     pkill -f "ocsp_mock" || true


### PR DESCRIPTION
Following https://github.com/mongodb/mongo-c-driver/pull/1276, `nounset` is indirectly set in `run-ocsp-test.sh` via `use-tools.sh` -> `use.sh` -> `set -o nounset`, which causes the following error in the [EVG waterfall](https://spruce.mongodb.com/version/mongo_c_driver_cf8755017c4716ff28d3d88aff3fb11aa579ce58) for OCSP tasks:

```
.evergreen/scripts/run-ocsp-test.sh: line 57: responder_required: unbound variable
```

No other variable in this file appears to be unset before use (verified by [this patch](https://spruce.mongodb.com/task/mongo_c_driver_ocsp_ocsp_openssl_soft_fail_test_rsa_nodelegate_latest_patch_39804dabb2a84ab62c293f164370300146c42ce6_647630e41e2d17e8970a49e1_23_05_30_17_22_46/logs?execution=0)).