### PR TITLE
CDRIVER-4654 move wire version check after state collection creation

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-database.c
+++ b/src/libmongoc/src/mongoc/mongoc-database.c
@@ -1095,15 +1095,6 @@ create_collection_with_encryptedFields (mongoc_database_t *database,
    mongoc_collection_t *dataCollection = NULL;
    bool ok = false;
    bson_t *cc_opts = NULL;
-   bool state_collections_ok =
-      create_encField_state_collection (
-         database, encryptedFields, name, "esc", error) &&
-      create_encField_state_collection (
-         database, encryptedFields, name, "ecoc", error);
-   if (!state_collections_ok) {
-      // Failed to create one or more state collections
-      goto fail;
-   }
 
    // Check the wire version to ensure server is 7.0.0 or newer.
    {
@@ -1131,6 +1122,15 @@ create_collection_with_encryptedFields (mongoc_database_t *database,
       mongoc_server_stream_cleanup (stream);
    }
 
+   bool state_collections_ok =
+      create_encField_state_collection (
+         database, encryptedFields, name, "esc", error) &&
+      create_encField_state_collection (
+         database, encryptedFields, name, "ecoc", error);
+   if (!state_collections_ok) {
+      // Failed to create one or more state collections
+      goto fail;
+   }
 
    /* Create data collection. */
    cc_opts = bson_copy (opts);

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-CreateCollection-OldServer.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-CreateCollection-OldServer.json
@@ -55,6 +55,38 @@
           "result": {
             "errorContains": "Driver support of Queryable Encryption is incompatible with server. Upgrade server to use Queryable Encryption."
           }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
         }
       ]
     }


### PR DESCRIPTION
# Summary

- Move wire version check after state collection creation.

# Background & Motivation

In [cf45741](https://github.com/mongodb/mongo-c-driver/commit/cf45741cef8a26b77ae8dda557e49af311a6d66d#diff-890d69eed0bfc41edfb7e60721e1dd6d01820d6ba808f2ccbe89064f887a2e9bR1108) for CDRIVER-4563, the state collections for QEv2 are created *before* the wire version check for MongoDB 7.0+. 

https://github.com/mongodb/specifications/pull/1428 includes the new assertions in fle2v2-CreateCollection-OldServer.json