### PR TITLE
Address nounset errors in zseries and powerpc tasks

### DIFF
--- a/.evergreen/scripts/find-cmake-version.sh
+++ b/.evergreen/scripts/find-cmake-version.sh
@@ -193,7 +193,7 @@ find_cmake_version() {
     tmp_cmake_dir="$(make_tmpdir_in "${cache_dir}")" || return
   } 1>&2
 
-  if [[ -n "${platform}" ]]; then
+  if [[ -n "${platform:-}" ]]; then
     cmake_download_binary() (
       declare -r cmake_url="https://cmake.org/files/v${major}.${minor}/cmake-${version}-${platform}.${extension}"
 


### PR DESCRIPTION
Following https://github.com/mongodb/mongo-c-driver/pull/1276, `nounset` is indirectly set in `compile-unix.sh` via `use-tools.sh` -> `use.sh` -> `set -o nounset`, which causes [the following error](https://parsley.mongodb.com/evergreen/mongo_c_driver_zseries_rhel83_debug_compile_sasl_openssl_patch_39804dabb2a84ab62c293f164370300146c42ce6_6477729e0ae606d37f2aa86b_23_05_31_16_15_28/0/task?bookmarks=0,108,171&shareLine=130) when compiling on zseries and powerpc distros:

```
.evergreen/scripts/find-cmake-version.sh: line 196: platform: unbound variable
```

This is due to the `platform` variable being deliberately unset for zseries and powerpc distros to skip attempting to download nonexistent CMake prebuilt binaries for those platforms. No other variable in this file appears to be unset before use (verified by [this patch](https://spruce.mongodb.com/version/64778636850e615ebac79cd8)).