### PR TITLE
CDRIVER-4603 Apply fallback for packaging -> pkg_resources -> distutils

### DIFF
--- a/.evergreen/config_generator/components/funcs/fetch_source.py
+++ b/.evergreen/config_generator/components/funcs/fetch_source.py
@@ -16,6 +16,7 @@ class FetchSource(Function):
             working_dir='mongoc',
             script='''\
                 set -o errexit
+                set -o pipefail
                 if [ -n "${github_pr_number}" -o "${is_patch}" = "true" ]; then
                     # This is a GitHub PR or patch build, probably branched from master
                     if command -v python3 2>/dev/null; then

--- a/.evergreen/config_generator/components/funcs/fetch_source.py
+++ b/.evergreen/config_generator/components/funcs/fetch_source.py
@@ -19,7 +19,7 @@ class FetchSource(Function):
                 set -o pipefail
                 if [ -n "${github_pr_number}" -o "${is_patch}" = "true" ]; then
                     # This is a GitHub PR or patch build, probably branched from master
-                    if command -v python3 2>/dev/null; then
+                    if command -v python3 &>/dev/null; then
                         # Prefer python3 if it is available
                         echo $(python3 ./build/calc_release_version.py --next-minor) > VERSION_CURRENT
                     else

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -204,7 +204,7 @@ functions:
             set -o pipefail
             if [ -n "${github_pr_number}" -o "${is_patch}" = "true" ]; then
                 # This is a GitHub PR or patch build, probably branched from master
-                if command -v python3 2>/dev/null; then
+                if command -v python3 &>/dev/null; then
                     # Prefer python3 if it is available
                     echo $(python3 ./build/calc_release_version.py --next-minor) > VERSION_CURRENT
                 else

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -201,6 +201,7 @@ functions:
           - -c
           - |
             set -o errexit
+            set -o pipefail
             if [ -n "${github_pr_number}" -o "${is_patch}" = "true" ]; then
                 # This is a GitHub PR or patch build, probably branched from master
                 if command -v python3 2>/dev/null; then

--- a/build/calc_release_version.py
+++ b/build/calc_release_version.py
@@ -26,14 +26,20 @@ import datetime
 import re
 import subprocess
 import sys
-if sys.version_info < (3, 9):
-    from distutils.version import LooseVersion as Version
-    from distutils.version import LooseVersion as parse_version
-else:
-    # on newer versions of Python use setuptools rather than distutils
-    # (which has been deprecated)
-    from pkg_resources.extern.packaging.version import Version
-    from pkg_resources import parse_version
+
+try:
+    # Prefer newer `packaging` over deprecated packages.
+    from packaging.version import Version as Version
+    from packaging.version import parse as parse_version
+except ImportError:
+    # Fallback to deprecated pkg_resources.
+    try:
+        from pkg_resources.extern.packaging.version import Version
+        from pkg_resources import parse_version
+    except ImportError:
+        # Fallback to deprecated distutils.
+        from distutils.version import LooseVersion as Version
+        from distutils.version import LooseVersion as parse_version
 
 DEBUG = len(sys.argv) > 1 and '-d' in sys.argv
 if DEBUG:


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1281. Verified by [this patch](https://spruce.mongodb.com/version/6477be24c9ec4461a977c483).

Rather than dealing with Python binary detection in the EVG `fetch-source` function (which is complicated by the fact that it is run as a pre command before `fetch-det`, `tools/python.sh` does not cover all the required use cases, and we do not want to re-implement the `find-python3.sh` DET script here), implement a fallback strategy to attempt to use the newest, recommended package `packaging` before alternatives.

Note: attempts to [ensure `packaging` is installed](https://parsley.mongodb.com/evergreen/mongo_c_driver_clang35_debug_compile_nosasl_openssl_patch_6cbb08bd7cdd1dd7e7d30d374212a002955d0789_6477ba130ae6064cdc9864c5_23_05_31_21_20_21/0/task?bookmarks=0,150&shareLine=31) were complicated by the variety of Python 3 binary versions available across distros. Rather than complicating the `fetch-source` definition, opted to instead handle version-dependent behavior in `calc_release_version.py` instead.