### PR TITLE
Do not treat a WSL Linux environment as Windows

### DIFF
--- a/tools/platform.sh
+++ b/tools/platform.sh
@@ -24,7 +24,7 @@ case "$OSTYPE" in
     linux-*)
         if have-command cmd.exe; then
             _is_wsl=true
-            _is_windows=true
+            _is_unix_like=true
             _os_family=windows
         else
             _is_linux=true

--- a/tools/platform.sh
+++ b/tools/platform.sh
@@ -4,7 +4,7 @@
 #
 # * IS_DARWIN, IS_WINDOWS, IS_LINUX, IS_BSD, IS_WSL, IS_UNIX_LIKE
 #   • Set to either "true" or "false" depending on the host operating system.
-#     More than one value may be true (i.e. $IS_WSL and $IS_WINDOWS). Because
+#     More than one value may be true (i.e. $IS_WSL and $IS_UNIX_LIKE). Because
 #     "true" and "false" are Bash built-ins, these can be used in conditionals
 #     directly, as in "if $IS_WINDOWS || $IS_DARWIN; then …"
 # * OS_FAMILY


### PR DESCRIPTION
When in WSL, the environment is (for all intents and purposes) equivalent to being on the corresponding Linux OS. It is incorrect to treat the OS as Windows in such an environment.