### PR TITLE
Revert Sphinx parallel build of HTML docs

### DIFF
--- a/build/cmake/SphinxBuild.cmake
+++ b/build/cmake/SphinxBuild.cmake
@@ -33,11 +33,6 @@ function (sphinx_build_html target_name doc_dir)
       list (APPEND doc_htmls ${html})
    endforeach ()
 
-   # Speed things up with parallel Sphinx builders:
-   include (ProcessorCount)
-   ProcessorCount (jobs)
-   math (EXPR jobs "${jobs} + 2")
-
    # Set PYTHONDONTWRITEBYTECODE to prevent .pyc clutter in the source directory
    add_custom_command (OUTPUT ${doc_htmls}
       ${SPHINX_HTML_DIR}/.nojekyll ${SPHINX_HTML_DIR}/objects.inv
@@ -45,7 +40,7 @@ function (sphinx_build_html target_name doc_dir)
       ${CMAKE_COMMAND} -E env
          "PYTHONDONTWRITEBYTECODE=1"
       ${SPHINX_EXECUTABLE}
-         -qEnW -j "${jobs}" -b html
+         -qEnW -b html
          -c "${CMAKE_CURRENT_SOURCE_DIR}"
          "${CMAKE_CURRENT_SOURCE_DIR}"
          "${SPHINX_HTML_DIR}"
@@ -137,8 +132,6 @@ function (sphinx_build_man target_name)
       COMMAND
       ${CMAKE_COMMAND} -E env
          "PYTHONDONTWRITEBYTECODE=1"
-      # No parallelism for Sphinx here, as the Man builder has trouble with it
-      # in our Sphinx version.
       ${SPHINX_EXECUTABLE}
          -qEW -b man
          -c "${CMAKE_CURRENT_SOURCE_DIR}"
@@ -166,4 +159,3 @@ function (sphinx_build_man target_name)
    set (doc_DIST_rsts ${doc_rsts} PARENT_SCOPE)
    set (doc_DIST_mans ${doc_mans} PARENT_SCOPE)
 endfunction ()
-


### PR DESCRIPTION
The [make-release-archive](https://parsley.mongodb.com/evergreen/mongo_c_driver_releng_make_release_archive_cf8755017c4716ff28d3d88aff3fb11aa579ce58_23_05_26_00_03_16/0/task?bookmarks=0,641&shareLine=520) task is currently flaky on waterfall and blocking most of the Release variant tasks due to the following error:
```
Exception occurred:
  File "/home/ubuntu/.cache/pypoetry/virtualenvs/mongo-c-driver-jXmnJTn7-py3.10/lib/python3.10/site-packages/sphinx/environment/__init__.py", line 612, in get_doctree
    doctree = pickle.load(f)
EOFError: Ran out of input
```
An attempt was made to upgrade Sphinx to 3.1.1 due to [documented fixes to parallel builds](https://www.sphinx-doc.org/en/master/changes.html#release-3-1-1-released-jun-14-2020), but failed due to the [following error](https://parsley.mongodb.com/evergreen/mongo_c_driver_releng_make_release_archive_patch_7aaf826cd766483b45a7e20168cd98dd68ae1f72_6478e9b3c9ec4406ad3b5b13_23_06_01_18_55_49/0/task?bookmarks=0,265&shareLine=218):
```
Warning, treated as error:
node class 'meta' is already registered, its visitors will be overridden
```
Attempting to address this [docutils compatibility issue](https://github.com/sphinx-doc/sphinx/issues/9841#issuecomment-971739437) by applying `docutils<0.18` still failed with the [following error](https://parsley.mongodb.com/evergreen/mongo_c_driver_releng_make_release_archive_patch_7aaf826cd766483b45a7e20168cd98dd68ae1f72_6478f9f10ae606f9e94a9c45_23_06_01_20_05_06/0/task?bookmarks=0,3733&shareLine=3668):
```
Error copying file "cmake_build/_cmake_build/src/libbson/doc/html/_static/ajax-loader.gif" to "mongo-c-driver-1.24.0-20230601+git7aaf826cd7/src/libbson/doc/html/_static/ajax-loader.gif".
CMake Error at [...]/MakeDist.cmake:64 (message):
  Copy of
  cmake_build/_cmake_build/src/libbson/doc/html/_static/ajax-loader.gif
  to dist dir 'mongo-c-driver-1.24.0-20230601+git7aaf826cd7' failed.
Call Stack (most recent call first):
  [...]/MakeDist.cmake:103 (make_dist)
```
Thus this PR recommends reverting the Sphinx parallel builds of HTML docs introduced in https://github.com/mongodb/mongo-c-driver/commit/cf8755017c4716ff28d3d88aff3fb11aa579ce58. Verified by [this patch](https://spruce.mongodb.com/version/6478e86b3e8e8627c9be408e).