### PR TITLE
Move all MinGW tasks to windows-vsCurrent distro

### DIFF
--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -9240,7 +9240,7 @@ buildvariants:
     - macos-1014
   - name: link-with-bson-mingw
     distros:
-    - windows-64-vs2013-compile
+    - windows-vsCurrent-large
   - check-headers
   - install-uninstall-check
   - name: install-uninstall-check-mingw
@@ -9561,7 +9561,7 @@ buildvariants:
   display_name: MinGW-W64
   expansions:
     CC: mingw
-  run_on: windows-64-vs2013-compile
+  run_on: windows-vsCurrent-large
   tasks:
   - debug-compile-no-align
 - name: power8-rhel81

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -64,7 +64,7 @@ all_variants = [
             "link-with-bson",
             OD([("name", "link-with-bson-windows"), ("distros", ["windows-vsCurrent-large"])]),
             OD([("name", "link-with-bson-mac"), ("distros", ["macos-1014"])]),
-            OD([("name", "link-with-bson-mingw"), ("distros", ["windows-64-vs2013-compile"])]),
+            OD([("name", "link-with-bson-mingw"), ("distros", ["windows-vsCurrent-large"])]),
             "check-headers",
             "install-uninstall-check",
             OD([("name", "install-uninstall-check-mingw"), ("distros", ["windows-vsCurrent-large"])]),
@@ -380,7 +380,7 @@ all_variants = [
         ["debug-compile-nosasl-nossl", ".latest .nossl .nosasl .server"],
         {"CC": "mingw"},
     ),
-    Variant("mingw", "MinGW-W64", "windows-64-vs2013-compile", ["debug-compile-no-align"], {"CC": "mingw"}),
+    Variant("mingw", "MinGW-W64", "windows-vsCurrent-large", ["debug-compile-no-align"], {"CC": "mingw"}),
     Variant(
         "power8-rhel81",
         "Power8 (ppc64le) (RHEL 8.1)",


### PR DESCRIPTION
A small followup to https://github.com/mongodb/mongo-c-driver/pull/1294 that also migrates MinGW tasks in the legacy config to the `windows-vsCurrent` distro from `windows-64-vs2013` for consistency. Verified by [this patch](https://spruce.mongodb.com/version/647e0a587742ae93798b684f/tasks).