### PR TITLE
CDRIVER-4657 Prohibit extra fields when matching `command` subdocuments

### DIFF
--- a/src/libmongoc/tests/json-test-monitoring.c
+++ b/src/libmongoc/tests/json-test-monitoring.c
@@ -336,7 +336,7 @@ apm_match_visitor (match_ctx_t *ctx,
       visitor_ctx->command_name = bson_strdup (bson_iter_key (doc_iter));
    }
 
-   // Subdocuments in `command` are expected not to not have extra fields.
+   // Subdocuments in `command` should not have extra fields.
    if (NULL != strstr (ctx->path, ".command") && doc_iter) {
       if (BSON_ITER_HOLDS_DOCUMENT (doc_iter) &&
           BSON_ITER_HOLDS_DOCUMENT (pattern_iter)) {
@@ -663,7 +663,7 @@ test_apm_matching (void)
 static void
 test_apm_matching_extra_fields (void)
 {
-   // An extra value in `command` is permitted.
+   // Extra fields are permitted in `command`.
    {
       apm_match_visitor_ctx_t match_visitor_ctx = {0};
       match_ctx_t match_ctx = {{0}};
@@ -682,7 +682,7 @@ test_apm_matching_extra_fields (void)
       apm_match_visitor_ctx_reset (&match_visitor_ctx);
    }
 
-   // A subdocument in `command` does not permit extra values.
+   // Extra fields are not permitted in `command` sub-documents.
    {
       apm_match_visitor_ctx_t match_visitor_ctx = {0};
       match_ctx_t match_ctx = {{0}};
@@ -703,7 +703,7 @@ test_apm_matching_extra_fields (void)
       apm_match_visitor_ctx_reset (&match_visitor_ctx);
    }
 
-   // A subdocument in a subarray in `command` does not permit extra values.
+   // Extra fields are not permitted in `command` sub-arrays.
    {
       apm_match_visitor_ctx_t match_visitor_ctx = {0};
       match_ctx_t match_ctx = {{0}};

--- a/src/libmongoc/tests/json-test-monitoring.c
+++ b/src/libmongoc/tests/json-test-monitoring.c
@@ -554,7 +554,7 @@ check_json_apm_events (json_test_ctx_t *ctx, const bson_t *expectations)
    match_ctx.retain_dots_in_keys = true;
    match_ctx.allow_placeholders = true;
    match_ctx.visitor_fn = apm_match_visitor;
-   match_ctx.visitor_ctx = (void *) &apm_match_visitor_ctx;
+   match_ctx.visitor_ctx = &apm_match_visitor_ctx;
 
    allow_subset = ctx->config->command_monitoring_allow_subset;
 
@@ -649,7 +649,7 @@ test_apm_matching (void)
                     "}";
 
    match_ctx.visitor_fn = apm_match_visitor;
-   match_ctx.visitor_ctx = (void *) &match_visitor_ctx;
+   match_ctx.visitor_ctx = &match_visitor_ctx;
 
    BSON_ASSERT (match_bson_with_ctx (tmp_bson (e1), tmp_bson (e1), &match_ctx));
    BSON_ASSERT (
@@ -674,7 +674,7 @@ test_apm_matching_extra_fields (void)
          BSON_STR ({"command_started_event" : {"command" : {"a" : 1}}});
 
       match_ctx.visitor_fn = apm_match_visitor;
-      match_ctx.visitor_ctx = (void *) &match_visitor_ctx;
+      match_ctx.visitor_ctx = &match_visitor_ctx;
 
       bool matched =
          match_bson_with_ctx (tmp_bson (event), tmp_bson (pattern), &match_ctx);
@@ -694,7 +694,7 @@ test_apm_matching_extra_fields (void)
          {"command_started_event" : {"command" : {"subdoc" : {"a" : 1}}}});
 
       match_ctx.visitor_fn = apm_match_visitor;
-      match_ctx.visitor_ctx = (void *) &match_visitor_ctx;
+      match_ctx.visitor_ctx = &match_visitor_ctx;
 
       bool matched =
          match_bson_with_ctx (tmp_bson (event), tmp_bson (pattern), &match_ctx);
@@ -717,7 +717,7 @@ test_apm_matching_extra_fields (void)
       });
 
       match_ctx.visitor_fn = apm_match_visitor;
-      match_ctx.visitor_ctx = (void *) &match_visitor_ctx;
+      match_ctx.visitor_ctx = &match_visitor_ctx;
 
       bool matched =
          match_bson_with_ctx (tmp_bson (event), tmp_bson (pattern), &match_ctx);

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-CreateCollection.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-CreateCollection.json
@@ -158,9 +158,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -343,9 +340,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -851,9 +845,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -1048,9 +1039,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -1367,9 +1355,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -1635,9 +1620,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",

--- a/src/libmongoc/tests/test-conveniences.c
+++ b/src/libmongoc/tests/test-conveniences.c
@@ -977,10 +977,14 @@ match_bson_with_ctx (const bson_t *doc, const bson_t *pattern, match_ctx_t *ctx)
          match_action_t action =
             ctx->visitor_fn (ctx, &pattern_iter, found ? &doc_iter : NULL);
          if (action == MATCH_ACTION_ABORT) {
+            // Visitor encountered a match error.
             goto fail;
          } else if (action == MATCH_ACTION_SKIP) {
+            // Visitor handled match of this field. Skip any additional matching
+            // of this field.
             goto next;
          }
+         ASSERT (action == MATCH_ACTION_CONTINUE);
       }
 
       if (value->value_type == BSON_TYPE_NULL && found) {
@@ -1306,10 +1310,14 @@ match_bson_arrays (const bson_t *array, const bson_t *pattern, match_ctx_t *ctx)
          match_action_t action =
             ctx->visitor_fn (ctx, &pattern_iter, &array_iter);
          if (action == MATCH_ACTION_ABORT) {
+            // Visitor encountered a match error.
             return false;
          } else if (action == MATCH_ACTION_SKIP) {
+            // Visitor handled match of this field. Skip any additional matching
+            // of this field.
             continue;
          }
+         ASSERT (action == MATCH_ACTION_CONTINUE);
       }
 
       if (!match_bson_value (array_value, pattern_value, &derived)) {

--- a/src/libmongoc/tests/test-conveniences.c
+++ b/src/libmongoc/tests/test-conveniences.c
@@ -1302,7 +1302,7 @@ match_bson_arrays (const bson_t *array, const bson_t *pattern, match_ctx_t *ctx)
 
       derive (ctx, &derived, bson_iter_key (&array_iter));
 
-      if (ctx->visitor_fn) {
+      if (ctx && ctx->visitor_fn) {
          match_action_t action =
             ctx->visitor_fn (ctx, &pattern_iter, &array_iter);
          if (action == MATCH_ACTION_ABORT) {

--- a/src/libmongoc/tests/test-conveniences.c
+++ b/src/libmongoc/tests/test-conveniences.c
@@ -1302,6 +1302,16 @@ match_bson_arrays (const bson_t *array, const bson_t *pattern, match_ctx_t *ctx)
 
       derive (ctx, &derived, bson_iter_key (&array_iter));
 
+      if (ctx->visitor_fn) {
+         match_action_t action =
+            ctx->visitor_fn (ctx, &pattern_iter, &array_iter);
+         if (action == MATCH_ACTION_ABORT) {
+            return false;
+         } else if (action == MATCH_ACTION_SKIP) {
+            continue;
+         }
+      }
+
       if (!match_bson_value (array_value, pattern_value, &derived)) {
          return false;
       }


### PR DESCRIPTION
# Summary
- Prohibit extra fields when matching `command` subdocuments in the legacy specification test runner
- Add missing call to `visitor_fn` when matching arrays
- Copy fle2v2-CreateCollection from https://github.com/mongodb/specifications/commit/e59a0ac6daa19e7605b0a1d2c667a67367d52edd

# Background & Motivation
## Prohibit extra fields when matching `command` subdocuments

Described in https://github.com/mongodb/specifications/pull/1429. The expected behavior for matching command-started events in the legacy Client-Side Encryption test format is to only allow extra fields at the top level of the `command` document.

Example expectation:
```json
{
    "command_started_event": {
        "command": {
            "create": "encryptedCollection",
            "encryptedFields": {
                "fields": [
                    {
                        "path": "firstName",
                        "bsonType": "string",
                        "keyId": {
                            "$binary": {
                                "subType": "04",
                                "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
                            }
                        }
                    }
                ]
            }
        },
        "command_name": "create",
        "database_name": "default"
    }
}
```

Example matching actual event:
```json
{
    "command_started_event": {
        "command": {
            "create": "encryptedCollection",
            "encryptedFields": {
                "fields": [
                    {
                        "path": "firstName",
                        "bsonType": "string",
                        "keyId": {
                            "$binary": {
                                "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
                                "subType": "04"
                            }
                        }
                    }
                ]
            },
            "lsid": {
                "id": {
                    "$binary": {
                        "base64": "RA6ru6SwSfm8XRl6wxPEgQ==",
                        "subType": "04"
                    }
                }
            },
            "$clusterTime": {
                "clusterTime": {
                    "$timestamp": {
                        "t": 1686066552,
                        "i": 4
                    }
                },
                "signature": {
                    "hash": {
                        "$binary": {
                            "base64": "AAAAAAAAAAAAAAAAAAAAAAAAAAA=",
                            "subType": "00"
                        }
                    },
                    "keyId": {
                        "$numberLong": "0"
                    }
                }
            },
            "$db": "default"
        },
        "command_name": "create",
        "database_name": "default",
        "operation_id": {
            "$numberLong": "136170890"
        }
    }
}
```


Extra fields in the actual event (e.g. `lsid`) are permitted at the top level of the `command` document. But extra fields are not permitted in nested documents (e.g. an extra field inside `encryptedFields` would be considered a mismatch)

The C driver permitted allowing extra fields at any level of the command document. This PR adds additional checks to `apm_match_visitor` to prohibit extra fields in `command` subdocuments.

