### PR TITLE
CDRIVER-4620: Changed bson_iter_as_double documentation to return double instead of bool

### DIFF
--- a/src/libbson/doc/bson_iter_as_double.rst
+++ b/src/libbson/doc/bson_iter_as_double.rst
@@ -8,7 +8,7 @@ Synopsis
 
 .. code-block:: c
 
-  bool
+  double
   bson_iter_as_double (const bson_iter_t *iter);
 
 Parameters


### PR DESCRIPTION
Fixed the bson_iter_as_double documentation to display the correct return type.