### PR TITLE
CDRIVER-4255 Add asserts for functions with client and pool parameters

### DIFF
--- a/build/opts_templates/mongoc-opts.c.template
+++ b/build/opts_templates/mongoc-opts.c.template
@@ -19,6 +19,8 @@ _{{ struct_name }}_parse (
 {
    bson_iter_t iter;
 
+   BSON_ASSERT_PARAM (client);
+
 {% for path, opt_name, info in paths(description) %}
 {% if info['type'] == 'bool' %}
    {{ struct_name }}->{{ path }} = {{ description.default(opt_name, 'false') }};

--- a/src/libmongoc/examples/client-side-encryption-schema-map.c
+++ b/src/libmongoc/examples/client-side-encryption-schema-map.c
@@ -24,8 +24,6 @@ create_schema_file (bson_t *kms_providers,
    FILE *outfile = NULL;
    bool ret = false;
 
-   BSON_ASSERT_PARAM (keyvault_client);
-
    client_encryption_opts = mongoc_client_encryption_opts_new ();
    mongoc_client_encryption_opts_set_kms_providers (client_encryption_opts,
                                                     kms_providers);
@@ -155,6 +153,8 @@ main (void)
    /* Set up the key vault for this example. */
    keyvault_client = mongoc_client_new (
       "mongodb://localhost/?appname=client-side-encryption-keyvault");
+   BSON_ASSERT (keyvault_client);
+
    keyvault_coll = mongoc_client_get_collection (
       keyvault_client, KEYVAULT_DB, KEYVAULT_COLL);
    mongoc_collection_drop (keyvault_coll, NULL);
@@ -229,6 +229,7 @@ main (void)
 
    client =
       mongoc_client_new ("mongodb://localhost/?appname=client-side-encryption");
+   BSON_ASSERT (client);
 
    /* Enable automatic encryption. It will determine that encryption is
     * necessary from the schema map instead of relying on the server to provide
@@ -258,6 +259,8 @@ main (void)
 
    unencrypted_client = mongoc_client_new (
       "mongodb://localhost/?appname=client-side-encryption-unencrypted");
+   BSON_ASSERT (unencrypted_client);
+
    unencrypted_coll = mongoc_client_get_collection (
       unencrypted_client, ENCRYPTED_DB, ENCRYPTED_COLL);
    printf ("encrypted document: ");

--- a/src/libmongoc/examples/client-side-encryption-schema-map.c
+++ b/src/libmongoc/examples/client-side-encryption-schema-map.c
@@ -24,6 +24,8 @@ create_schema_file (bson_t *kms_providers,
    FILE *outfile = NULL;
    bool ret = false;
 
+   BSON_ASSERT_PARAM (keyvault_client);
+
    client_encryption_opts = mongoc_client_encryption_opts_new ();
    mongoc_client_encryption_opts_set_kms_providers (client_encryption_opts,
                                                     kms_providers);

--- a/src/libmongoc/examples/client-side-encryption-server-schema.c
+++ b/src/libmongoc/examples/client-side-encryption-server-schema.c
@@ -21,8 +21,6 @@ create_schema (bson_t *kms_providers,
    char *keyaltnames[] = {"mongoc_encryption_example_2"};
    bson_t *schema = NULL;
 
-   BSON_ASSERT_PARAM (keyvault_client);
-
    client_encryption_opts = mongoc_client_encryption_opts_new ();
    mongoc_client_encryption_opts_set_kms_providers (client_encryption_opts,
                                                     kms_providers);
@@ -140,6 +138,8 @@ main (void)
    /* Set up the key vault for this example. */
    keyvault_client = mongoc_client_new (
       "mongodb://localhost/?appname=client-side-encryption-keyvault");
+   BSON_ASSERT (keyvault_client);
+
    keyvault_coll = mongoc_client_get_collection (
       keyvault_client, KEYVAULT_DB, KEYVAULT_COLL);
    mongoc_collection_drop (keyvault_coll, NULL);
@@ -196,6 +196,8 @@ main (void)
 
    client =
       mongoc_client_new ("mongodb://localhost/?appname=client-side-encryption");
+   BSON_ASSERT (client);
+
    ret = mongoc_client_enable_auto_encryption (
       client, auto_encryption_opts, &error);
    if (!ret) {
@@ -244,6 +246,8 @@ main (void)
 
    unencrypted_client = mongoc_client_new (
       "mongodb://localhost/?appname=client-side-encryption-unencrypted");
+   BSON_ASSERT (unencrypted_client);
+
    unencrypted_coll = mongoc_client_get_collection (
       unencrypted_client, ENCRYPTED_DB, ENCRYPTED_COLL);
    printf ("encrypted document: ");

--- a/src/libmongoc/examples/client-side-encryption-server-schema.c
+++ b/src/libmongoc/examples/client-side-encryption-server-schema.c
@@ -21,6 +21,8 @@ create_schema (bson_t *kms_providers,
    char *keyaltnames[] = {"mongoc_encryption_example_2"};
    bson_t *schema = NULL;
 
+   BSON_ASSERT_PARAM (keyvault_client);
+
    client_encryption_opts = mongoc_client_encryption_opts_new ();
    mongoc_client_encryption_opts_set_kms_providers (client_encryption_opts,
                                                     kms_providers);

--- a/src/libmongoc/examples/mongoc-dump.c
+++ b/src/libmongoc/examples/mongoc-dump.c
@@ -49,8 +49,6 @@ mongoc_dump_collection (mongoc_client_t *client,
    char *path;
    int ret = EXIT_SUCCESS;
 
-   BSON_ASSERT_PARAM (client);
-
    path = bson_strdup_printf ("dump/%s/%s.bson", database, collection);
 #ifdef _WIN32
    _unlink (path);

--- a/src/libmongoc/examples/mongoc-dump.c
+++ b/src/libmongoc/examples/mongoc-dump.c
@@ -49,6 +49,8 @@ mongoc_dump_collection (mongoc_client_t *client,
    char *path;
    int ret = EXIT_SUCCESS;
 
+   BSON_ASSERT_PARAM (client);
+
    path = bson_strdup_printf ("dump/%s/%s.bson", database, collection);
 #ifdef _WIN32
    _unlink (path);
@@ -101,6 +103,7 @@ mongoc_dump_database (mongoc_client_t *client,
    int ret = EXIT_SUCCESS;
    int i;
 
+   BSON_ASSERT_PARAM (client);
    BSON_ASSERT (database);
 
    path = bson_strdup_printf ("dump/%s", database);
@@ -141,6 +144,8 @@ mongoc_dump (mongoc_client_t *client,
    bson_error_t error;
    char **str;
    int i;
+
+   BSON_ASSERT_PARAM (client);
 
    if (!mongoc_dump_mkdir_p ("dump", 0750)) {
       perror ("Failed to create directory \"dump\"");

--- a/src/libmongoc/src/mongoc/mongoc-client-pool.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-pool.c
@@ -315,7 +315,7 @@ again:
    if (!(client = (mongoc_client_t *) _mongoc_queue_pop_head (&pool->queue))) {
       if (pool->size < pool->max_pool_size) {
          client = _mongoc_client_new_from_topology (pool->topology);
-         BSON_ASSERT_PARAM (client);
+         BSON_ASSERT (client);
          _initialize_new_client (pool, client);
          pool->size++;
       } else {

--- a/src/libmongoc/src/mongoc/mongoc-client-pool.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-pool.c
@@ -60,6 +60,8 @@ void
 mongoc_client_pool_set_ssl_opts (mongoc_client_pool_t *pool,
                                  const mongoc_ssl_opt_t *opts)
 {
+   BSON_ASSERT_PARAM (pool);
+
    bson_mutex_lock (&pool->mutex);
 
    _mongoc_ssl_opts_cleanup (&pool->ssl_opts,
@@ -83,6 +85,8 @@ void
 _mongoc_client_pool_set_internal_tls_opts (
    mongoc_client_pool_t *pool, _mongoc_internal_tls_opts_t *internal)
 {
+   BSON_ASSERT_PARAM (pool);
+
    bson_mutex_lock (&pool->mutex);
    if (!pool->ssl_opts_set) {
       bson_mutex_unlock (&pool->mutex);
@@ -207,6 +211,7 @@ mongoc_client_pool_destroy (mongoc_client_pool_t *pool)
    mongoc_client_t *client;
 
    ENTRY;
+   BSON_ASSERT_PARAM (pool);
 
    if (!pool) {
       EXIT;
@@ -252,6 +257,8 @@ mongoc_client_pool_destroy (mongoc_client_pool_t *pool)
 static void
 _start_scanner_if_needed (mongoc_client_pool_t *pool)
 {
+   BSON_ASSERT_PARAM (pool);
+
    if (!pool->topology->single_threaded) {
       _mongoc_topology_background_monitoring_start (pool->topology);
    }
@@ -260,6 +267,9 @@ _start_scanner_if_needed (mongoc_client_pool_t *pool)
 static void
 _initialize_new_client (mongoc_client_pool_t *pool, mongoc_client_t *client)
 {
+   BSON_ASSERT_PARAM (pool);
+   BSON_ASSERT_PARAM (client);
+
    /* for tests */
    mongoc_client_set_stream_initiator (
       client,
@@ -292,7 +302,7 @@ mongoc_client_pool_pop (mongoc_client_pool_t *pool)
 
    ENTRY;
 
-   BSON_ASSERT (pool);
+   BSON_ASSERT_PARAM (pool);
 
    wait_queue_timeout_ms = mongoc_uri_get_option_as_int32 (
       pool->uri, MONGOC_URI_WAITQUEUETIMEOUTMS, -1);
@@ -306,7 +316,7 @@ again:
    if (!(client = (mongoc_client_t *) _mongoc_queue_pop_head (&pool->queue))) {
       if (pool->size < pool->max_pool_size) {
          client = _mongoc_client_new_from_topology (pool->topology);
-         BSON_ASSERT (client);
+         BSON_ASSERT_PARAM (client);
          _initialize_new_client (pool, client);
          pool->size++;
       } else {
@@ -343,7 +353,7 @@ mongoc_client_pool_try_pop (mongoc_client_pool_t *pool)
 
    ENTRY;
 
-   BSON_ASSERT (pool);
+   BSON_ASSERT_PARAM (pool);
 
    bson_mutex_lock (&pool->mutex);
 
@@ -370,8 +380,8 @@ mongoc_client_pool_push (mongoc_client_pool_t *pool, mongoc_client_t *client)
 {
    ENTRY;
 
-   BSON_ASSERT (pool);
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (pool);
+   BSON_ASSERT_PARAM (client);
 
    bson_mutex_lock (&pool->mutex);
    _mongoc_queue_push_head (&pool->queue, client);
@@ -398,6 +408,8 @@ _mongoc_client_pool_set_stream_initiator (mongoc_client_pool_t *pool,
                                           mongoc_stream_initiator_t si,
                                           void *context)
 {
+   BSON_ASSERT_PARAM (pool);
+
    mongoc_topology_scanner_set_stream_initiator (
       pool->topology->scanner, si, context);
 }
@@ -409,6 +421,7 @@ mongoc_client_pool_get_size (mongoc_client_pool_t *pool)
    size_t size = 0;
 
    ENTRY;
+   BSON_ASSERT_PARAM (pool);
 
    bson_mutex_lock (&pool->mutex);
    size = pool->size;
@@ -424,6 +437,7 @@ mongoc_client_pool_num_pushed (mongoc_client_pool_t *pool)
    size_t num_pushed = 0;
 
    ENTRY;
+   BSON_ASSERT_PARAM (pool);
 
    bson_mutex_lock (&pool->mutex);
    num_pushed = pool->queue.length;
@@ -436,6 +450,8 @@ mongoc_client_pool_num_pushed (mongoc_client_pool_t *pool)
 mongoc_topology_t *
 _mongoc_client_pool_get_topology (mongoc_client_pool_t *pool)
 {
+   BSON_ASSERT_PARAM (pool);
+
    return pool->topology;
 }
 
@@ -444,6 +460,7 @@ void
 mongoc_client_pool_max_size (mongoc_client_pool_t *pool, uint32_t max_pool_size)
 {
    ENTRY;
+   BSON_ASSERT_PARAM (pool);
 
    bson_mutex_lock (&pool->mutex);
    pool->max_pool_size = max_pool_size;
@@ -456,6 +473,7 @@ void
 mongoc_client_pool_min_size (mongoc_client_pool_t *pool, uint32_t min_pool_size)
 {
    ENTRY;
+   BSON_ASSERT_PARAM (pool);
 
    MONGOC_WARNING (
       "mongoc_client_pool_min_size is deprecated; its behavior does not match"
@@ -473,6 +491,8 @@ mongoc_client_pool_set_apm_callbacks (mongoc_client_pool_t *pool,
                                       mongoc_apm_callbacks_t *callbacks,
                                       void *context)
 {
+   BSON_ASSERT_PARAM (pool);
+
    mongoc_topology_t *const topology = BSON_ASSERT_PTR_INLINE (pool)->topology;
    mc_tpld_modification tdmod;
 
@@ -510,6 +530,8 @@ mongoc_client_pool_set_error_api (mongoc_client_pool_t *pool, int32_t version)
       return false;
    }
 
+   BSON_ASSERT_PARAM (pool);
+
    if (pool->error_api_set) {
       MONGOC_ERROR ("Can only set Error API Version once");
       return false;
@@ -526,6 +548,8 @@ mongoc_client_pool_set_appname (mongoc_client_pool_t *pool, const char *appname)
 {
    bool ret;
 
+   BSON_ASSERT_PARAM (pool);
+
    bson_mutex_lock (&pool->mutex);
    ret = _mongoc_topology_set_appname (pool->topology, appname);
    bson_mutex_unlock (&pool->mutex);
@@ -538,6 +562,8 @@ mongoc_client_pool_enable_auto_encryption (mongoc_client_pool_t *pool,
                                            mongoc_auto_encryption_opts_t *opts,
                                            bson_error_t *error)
 {
+   BSON_ASSERT_PARAM (pool);
+
    return _mongoc_cse_client_pool_enable_auto_encryption (
       pool->topology, opts, error);
 }

--- a/src/libmongoc/src/mongoc/mongoc-client-pool.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-pool.c
@@ -211,7 +211,6 @@ mongoc_client_pool_destroy (mongoc_client_pool_t *pool)
    mongoc_client_t *client;
 
    ENTRY;
-   BSON_ASSERT_PARAM (pool);
 
    if (!pool) {
       EXIT;

--- a/src/libmongoc/src/mongoc/mongoc-client-session.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-session.c
@@ -1382,6 +1382,7 @@ _mongoc_client_session_from_iter (mongoc_client_t *client,
                                   bson_error_t *error)
 {
    ENTRY;
+   BSON_ASSERT_PARAM (client);
 
    /* must be int64 that fits in uint32 */
    if (!BSON_ITER_HOLDS_INT64 (iter) || bson_iter_int64 (iter) > 0xffffffff) {

--- a/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
@@ -88,8 +88,6 @@ void
 mongoc_auto_encryption_opts_set_keyvault_client (
    mongoc_auto_encryption_opts_t *opts, mongoc_client_t *client)
 {
-   BSON_ASSERT_PARAM (client);
-
    if (!opts) {
       return;
    }
@@ -101,8 +99,6 @@ void
 mongoc_auto_encryption_opts_set_keyvault_client_pool (
    mongoc_auto_encryption_opts_t *opts, mongoc_client_pool_t *pool)
 {
-   BSON_ASSERT_PARAM (pool);
-
    if (!opts) {
       return;
    }
@@ -270,8 +266,6 @@ void
 mongoc_client_encryption_opts_set_keyvault_client (
    mongoc_client_encryption_opts_t *opts, mongoc_client_t *keyvault_client)
 {
-   BSON_ASSERT_PARAM (keyvault_client);
-
    if (!opts) {
       return;
    }

--- a/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
@@ -88,6 +88,8 @@ void
 mongoc_auto_encryption_opts_set_keyvault_client (
    mongoc_auto_encryption_opts_t *opts, mongoc_client_t *client)
 {
+   BSON_ASSERT_PARAM (client);
+
    if (!opts) {
       return;
    }
@@ -99,6 +101,8 @@ void
 mongoc_auto_encryption_opts_set_keyvault_client_pool (
    mongoc_auto_encryption_opts_t *opts, mongoc_client_pool_t *pool)
 {
+   BSON_ASSERT_PARAM (pool);
+
    if (!opts) {
       return;
    }
@@ -266,6 +270,8 @@ void
 mongoc_client_encryption_opts_set_keyvault_client (
    mongoc_client_encryption_opts_t *opts, mongoc_client_t *keyvault_client)
 {
+   BSON_ASSERT_PARAM (keyvault_client);
+
    if (!opts) {
       return;
    }
@@ -1070,6 +1076,8 @@ _prep_for_auto_encryption (const mongoc_cmd_t *cmd, bson_t *out)
 mongoc_client_t *
 _get_mongocryptd_client (mongoc_client_t *client_encrypted)
 {
+   BSON_ASSERT_PARAM (client_encrypted);
+
    if (client_encrypted->topology->single_threaded) {
       return client_encrypted->topology->mongocryptd_client;
    }
@@ -1081,6 +1089,9 @@ void
 _release_mongocryptd_client (mongoc_client_t *client_encrypted,
                              mongoc_client_t *mongocryptd_client)
 {
+   BSON_ASSERT_PARAM (client_encrypted);
+   BSON_ASSERT_PARAM (mongocryptd_client);
+
    if (!mongocryptd_client) {
       return;
    }
@@ -1103,6 +1114,8 @@ _release_mongocryptd_client (mongoc_client_t *client_encrypted,
 mongoc_collection_t *
 _get_keyvault_coll (mongoc_client_t *client_encrypted)
 {
+   BSON_ASSERT_PARAM (client_encrypted);
+
    mongoc_write_concern_t *const wc = mongoc_write_concern_new ();
    mongoc_read_concern_t *const rc = mongoc_read_concern_new ();
 
@@ -1148,6 +1161,8 @@ _release_keyvault_coll (mongoc_client_t *client_encrypted,
                         mongoc_collection_t *keyvault_coll)
 {
    mongoc_client_t *keyvault_client;
+
+   BSON_ASSERT_PARAM (client_encrypted);
 
    if (!keyvault_coll) {
       return;
@@ -1206,6 +1221,7 @@ _mongoc_cse_auto_encrypt (mongoc_client_t *client_encrypted,
 
    ENTRY;
 
+   BSON_ASSERT_PARAM (client_encrypted);
    bson_init (encrypted);
 
    if (client_encrypted->topology->bypass_auto_encryption) {
@@ -1315,6 +1331,7 @@ _mongoc_cse_auto_decrypt (mongoc_client_t *client_encrypted,
 
    ENTRY;
 
+   BSON_ASSERT_PARAM (client_encrypted);
    BSON_UNUSED (db_name);
 
    keyvault_coll = _get_keyvault_coll (client_encrypted);
@@ -2920,6 +2937,8 @@ fail:
 bool
 _mongoc_cse_is_enabled (mongoc_client_t *client)
 {
+   BSON_ASSERT_PARAM (client);
+
    while (1) {
       mongoc_topology_cse_state_t state = bson_atomic_int_fetch (
          (int *) &client->topology->cse_state, bson_memory_order_relaxed);
@@ -3203,6 +3222,8 @@ mongoc_client_encryption_get_crypt_shared_version (
 const char *
 mongoc_client_get_crypt_shared_version (const mongoc_client_t *client)
 {
+   BSON_ASSERT_PARAM (client);
+
 #ifdef MONGOC_ENABLE_CLIENT_SIDE_ENCRYPTION
    if (!client->topology->crypt) {
       return NULL;

--- a/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
@@ -1090,7 +1090,6 @@ _release_mongocryptd_client (mongoc_client_t *client_encrypted,
                              mongoc_client_t *mongocryptd_client)
 {
    BSON_ASSERT_PARAM (client_encrypted);
-   BSON_ASSERT_PARAM (mongocryptd_client);
 
    if (!mongocryptd_client) {
       return;

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -944,7 +944,7 @@ _mongoc_client_create_stream (mongoc_client_t *client,
                               const mongoc_host_list_t *host,
                               bson_error_t *error)
 {
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
    BSON_ASSERT (host);
 
    return client->initiator (client->uri, host, client->initiator_data, error);
@@ -974,7 +974,7 @@ _mongoc_client_recv (mongoc_client_t *client,
                      mongoc_server_stream_t *server_stream,
                      bson_error_t *error)
 {
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
    BSON_ASSERT (rpc);
    BSON_ASSERT (buffer);
    BSON_ASSERT (server_stream);
@@ -1033,6 +1033,7 @@ void
 _mongoc_client_set_internal_tls_opts (mongoc_client_t *client,
                                       _mongoc_internal_tls_opts_t *internal)
 {
+   BSON_ASSERT_PARAM (client);
    if (!client->use_ssl) {
       return;
    }
@@ -1047,7 +1048,7 @@ void
 mongoc_client_set_ssl_opts (mongoc_client_t *client,
                             const mongoc_ssl_opt_t *opts)
 {
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
    BSON_ASSERT (opts);
 
    _mongoc_ssl_opts_cleanup (&client->ssl_opts,
@@ -1200,6 +1201,8 @@ _mongoc_client_new_from_topology (mongoc_topology_t *topology)
 void
 mongoc_client_destroy (mongoc_client_t *client)
 {
+   BSON_ASSERT_PARAM (client);
+
    if (client) {
       if (client->topology->single_threaded) {
          _mongoc_client_end_sessions (client);
@@ -1245,7 +1248,7 @@ mongoc_client_destroy (mongoc_client_t *client)
 const mongoc_uri_t *
 mongoc_client_get_uri (const mongoc_client_t *client)
 {
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
 
    return client->uri;
 }
@@ -1274,6 +1277,8 @@ mongoc_client_start_session (mongoc_client_t *client,
                              const mongoc_session_opt_t *opts,
                              bson_error_t *error)
 {
+   BSON_ASSERT_PARAM (client);
+
    mongoc_server_session_t *ss;
    mongoc_client_session_t *cs;
    uint32_t csid;
@@ -1336,7 +1341,7 @@ mongoc_client_start_session (mongoc_client_t *client,
 mongoc_database_t *
 mongoc_client_get_database (mongoc_client_t *client, const char *name)
 {
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
    BSON_ASSERT (name);
 
    return _mongoc_database_new (client,
@@ -1372,7 +1377,7 @@ mongoc_client_get_default_database (mongoc_client_t *client)
 {
    const char *db;
 
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
    db = mongoc_uri_get_database (client->uri);
 
    if (db) {
@@ -1413,7 +1418,7 @@ mongoc_client_get_collection (mongoc_client_t *client,
                               const char *db,
                               const char *collection)
 {
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
    BSON_ASSERT (db);
    BSON_ASSERT (collection);
 
@@ -1455,7 +1460,7 @@ mongoc_client_get_gridfs (mongoc_client_t *client,
                           const char *prefix,
                           bson_error_t *error)
 {
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
    BSON_ASSERT (db);
 
    if (!prefix) {
@@ -1485,7 +1490,7 @@ mongoc_client_get_gridfs (mongoc_client_t *client,
 const mongoc_write_concern_t *
 mongoc_client_get_write_concern (const mongoc_client_t *client)
 {
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
 
    return client->write_concern;
 }
@@ -1511,7 +1516,7 @@ void
 mongoc_client_set_write_concern (mongoc_client_t *client,
                                  const mongoc_write_concern_t *write_concern)
 {
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
 
    if (write_concern != client->write_concern) {
       if (client->write_concern) {
@@ -1543,7 +1548,7 @@ mongoc_client_set_write_concern (mongoc_client_t *client,
 const mongoc_read_concern_t *
 mongoc_client_get_read_concern (const mongoc_client_t *client)
 {
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
 
    return client->read_concern;
 }
@@ -1569,7 +1574,7 @@ void
 mongoc_client_set_read_concern (mongoc_client_t *client,
                                 const mongoc_read_concern_t *read_concern)
 {
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
 
    if (read_concern != client->read_concern) {
       if (client->read_concern) {
@@ -1601,7 +1606,7 @@ mongoc_client_set_read_concern (mongoc_client_t *client,
 const mongoc_read_prefs_t *
 mongoc_client_get_read_prefs (const mongoc_client_t *client)
 {
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
 
    return client->read_prefs;
 }
@@ -1627,7 +1632,7 @@ void
 mongoc_client_set_read_prefs (mongoc_client_t *client,
                               const mongoc_read_prefs_t *read_prefs)
 {
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
 
    if (read_prefs != client->read_prefs) {
       if (client->read_prefs) {
@@ -1659,7 +1664,7 @@ mongoc_client_command (mongoc_client_t *client,
    BSON_UNUSED (batch_size);
    BSON_UNUSED (fields);
 
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
    BSON_ASSERT (db_name);
    BSON_ASSERT (query);
 
@@ -1694,6 +1699,7 @@ _mongoc_client_retryable_write_command_with_stream (
 
    ENTRY;
 
+   BSON_ASSERT_PARAM (client);
    BSON_ASSERT (parts->is_retryable_write);
 
    /* increment the transaction number for the first attempt of each retryable
@@ -1797,6 +1803,7 @@ _mongoc_client_retryable_read_command_with_stream (
    bool ret;
    bson_t reply_local;
 
+   BSON_ASSERT_PARAM (client);
    BSON_UNUSED (server_stream);
 
    if (reply == NULL) {
@@ -1863,6 +1870,7 @@ _mongoc_client_command_with_stream (mongoc_client_t *client,
 {
    ENTRY;
 
+   BSON_ASSERT_PARAM (client);
    BSON_UNUSED (read_prefs);
 
    parts->assembled.operation_id = ++client->cluster.operation_id;
@@ -1901,7 +1909,7 @@ mongoc_client_command_simple (mongoc_client_t *client,
 
    ENTRY;
 
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
    BSON_ASSERT (db_name);
    BSON_ASSERT (command);
 
@@ -1993,7 +2001,7 @@ _mongoc_client_command_with_opts (mongoc_client_t *client,
 
    ENTRY;
 
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
    BSON_ASSERT (db_name);
    BSON_ASSERT (command);
 
@@ -2249,7 +2257,7 @@ mongoc_client_command_simple_with_server_id (
 
    ENTRY;
 
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
    BSON_ASSERT (db_name);
    BSON_ASSERT (command);
 
@@ -2305,7 +2313,7 @@ _mongoc_client_kill_cursor (mongoc_client_t *client,
 
    ENTRY;
 
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
    BSON_ASSERT (cursor_id);
 
    /* don't attempt reconnect if server unavailable, and ignore errors */
@@ -2587,6 +2595,8 @@ _mongoc_client_killcursors_command (mongoc_cluster_t *cluster,
 void
 mongoc_client_kill_cursor (mongoc_client_t *client, int64_t cursor_id)
 {
+   BSON_ASSERT_PARAM (client);
+
    mongoc_topology_t *const topology =
       BSON_ASSERT_PTR_INLINE (client)->topology;
    mongoc_server_description_t const *selected_server;
@@ -2653,7 +2663,7 @@ mongoc_client_get_database_names_with_opts (mongoc_client_t *client,
    const bson_t *doc;
    bson_t cmd = BSON_INITIALIZER;
 
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
    BSON_APPEND_INT32 (&cmd, "listDatabases", 1);
    BSON_APPEND_BOOL (&cmd, "nameOnly", true);
 
@@ -2684,6 +2694,7 @@ mongoc_client_get_database_names_with_opts (mongoc_client_t *client,
 mongoc_cursor_t *
 mongoc_client_find_databases (mongoc_client_t *client, bson_error_t *error)
 {
+   BSON_ASSERT_PARAM (client);
    BSON_UNUSED (error);
 
    /* existing bug in this deprecated API: error pointer is unused */
@@ -2698,7 +2709,7 @@ mongoc_client_find_databases_with_opts (mongoc_client_t *client,
    bson_t cmd = BSON_INITIALIZER;
    mongoc_cursor_t *cursor;
 
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
    BSON_APPEND_INT32 (&cmd, "listDatabases", 1);
    cursor = _mongoc_cursor_array_new (client, "admin", &cmd, opts, "databases");
    bson_destroy (&cmd);
@@ -2709,7 +2720,7 @@ mongoc_client_find_databases_with_opts (mongoc_client_t *client,
 int32_t
 mongoc_client_get_max_message_size (mongoc_client_t *client) /* IN */
 {
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
 
    return mongoc_cluster_get_max_msg_size (&client->cluster);
 }
@@ -2718,7 +2729,7 @@ mongoc_client_get_max_message_size (mongoc_client_t *client) /* IN */
 int32_t
 mongoc_client_get_max_bson_size (mongoc_client_t *client) /* IN */
 {
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
 
    return mongoc_cluster_get_max_bson_obj_size (&client->cluster);
 }
@@ -2733,7 +2744,7 @@ mongoc_client_get_server_status (mongoc_client_t *client,         /* IN */
    bson_t cmd = BSON_INITIALIZER;
    bool ret = false;
 
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
 
    BSON_APPEND_INT32 (&cmd, "serverStatus", 1);
    ret = mongoc_client_command_simple (
@@ -2749,7 +2760,7 @@ mongoc_client_set_stream_initiator (mongoc_client_t *client,
                                     mongoc_stream_initiator_t initiator,
                                     void *user_data)
 {
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
 
    if (!initiator) {
       initiator = mongoc_client_default_stream_initiator;
@@ -2773,6 +2784,8 @@ _mongoc_client_set_apm_callbacks_private (mongoc_client_t *client,
                                           mongoc_apm_callbacks_t *callbacks,
                                           void *context)
 {
+   BSON_ASSERT_PARAM (client);
+
    if (callbacks) {
       memcpy (
          &client->apm_callbacks, callbacks, sizeof (mongoc_apm_callbacks_t));
@@ -2802,6 +2815,8 @@ mongoc_client_set_apm_callbacks (mongoc_client_t *client,
                                  mongoc_apm_callbacks_t *callbacks,
                                  void *context)
 {
+   BSON_ASSERT_PARAM (client);
+
    if (!client->topology->single_threaded) {
       MONGOC_ERROR ("Cannot set callbacks on a pooled client, use "
                     "mongoc_client_pool_set_apm_callbacks");
@@ -2815,6 +2830,8 @@ mongoc_server_description_t *
 mongoc_client_get_server_description (mongoc_client_t *client,
                                       uint32_t server_id)
 {
+   BSON_ASSERT_PARAM (client);
+
    mongoc_server_description_t *ret;
    mc_shared_tpld td = mc_tpld_take_ref (client->topology);
    mongoc_server_description_t const *sd =
@@ -2830,6 +2847,8 @@ mongoc_server_description_t **
 mongoc_client_get_server_descriptions (const mongoc_client_t *client,
                                        size_t *n /* OUT */)
 {
+   BSON_ASSERT_PARAM (client);
+
    mc_shared_tpld td =
       mc_tpld_take_ref (BSON_ASSERT_PTR_INLINE (client)->topology);
    mongoc_server_description_t **const sds =
@@ -2860,6 +2879,8 @@ mongoc_client_select_server (mongoc_client_t *client,
                              const mongoc_read_prefs_t *prefs,
                              bson_error_t *error)
 {
+   BSON_ASSERT_PARAM (client);
+
    mongoc_ss_optype_t optype = for_writes ? MONGOC_SS_WRITE : MONGOC_SS_READ;
    mongoc_server_description_t *sd;
 
@@ -2900,6 +2921,8 @@ mongoc_client_select_server (mongoc_client_t *client,
 bool
 mongoc_client_set_error_api (mongoc_client_t *client, int32_t version)
 {
+   BSON_ASSERT_PARAM (client);
+
    if (!client->topology->single_threaded) {
       MONGOC_ERROR ("Cannot set Error API Version on a pooled client, use "
                     "mongoc_client_pool_set_error_api");
@@ -2926,6 +2949,8 @@ mongoc_client_set_error_api (mongoc_client_t *client, int32_t version)
 bool
 mongoc_client_set_appname (mongoc_client_t *client, const char *appname)
 {
+   BSON_ASSERT_PARAM (client);
+
    if (!client->topology->single_threaded) {
       MONGOC_ERROR ("Cannot call set_appname on a client from a pool");
       return false;
@@ -2937,6 +2962,8 @@ mongoc_client_set_appname (mongoc_client_t *client, const char *appname)
 mongoc_server_session_t *
 _mongoc_client_pop_server_session (mongoc_client_t *client, bson_error_t *error)
 {
+   BSON_ASSERT_PARAM (client);
+
    return _mongoc_topology_pop_server_session (client->topology, error);
 }
 
@@ -2966,6 +2993,7 @@ _mongoc_client_lookup_session (const mongoc_client_t *client,
                                bson_error_t *error /* OUT */)
 {
    ENTRY;
+   BSON_ASSERT_PARAM (client);
 
    *cs = mongoc_set_get (client->client_sessions, client_session_id);
 
@@ -2985,6 +3013,8 @@ void
 _mongoc_client_unregister_session (mongoc_client_t *client,
                                    mongoc_client_session_t *session)
 {
+   BSON_ASSERT_PARAM (client);
+
    mongoc_set_rm (client->client_sessions, session->client_session_id);
 }
 
@@ -2992,6 +3022,8 @@ void
 _mongoc_client_push_server_session (mongoc_client_t *client,
                                     mongoc_server_session_t *server_session)
 {
+   BSON_ASSERT_PARAM (client);
+
    _mongoc_topology_push_server_session (client->topology, server_session);
 }
 
@@ -3021,6 +3053,8 @@ _mongoc_client_end_sessions (mongoc_client_t *client)
    mongoc_cmd_parts_t parts;
    mongoc_cluster_t *cluster = &client->cluster;
    bool r;
+
+   BSON_ASSERT_PARAM (client);
 
    while (!mongoc_server_session_pool_is_empty (t->session_pool)) {
       prefs = mongoc_read_prefs_new (MONGOC_READ_PRIMARY_PREFERRED);
@@ -3081,7 +3115,7 @@ _mongoc_client_end_sessions (mongoc_client_t *client)
 void
 mongoc_client_reset (mongoc_client_t *client)
 {
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
 
    client->generation++;
 
@@ -3112,6 +3146,8 @@ mongoc_client_enable_auto_encryption (mongoc_client_t *client,
                                       mongoc_auto_encryption_opts_t *opts,
                                       bson_error_t *error)
 {
+   BSON_ASSERT_PARAM (client);
+
    if (!client->topology->single_threaded) {
       bson_set_error (error,
                       MONGOC_ERROR_CLIENT,
@@ -3162,6 +3198,7 @@ mongoc_client_get_handshake_description (mongoc_client_t *client,
    mongoc_server_stream_t *server_stream;
    mongoc_server_description_t *sd;
 
+   BSON_ASSERT_PARAM (client);
    BSON_UNUSED (opts);
 
    server_stream = mongoc_cluster_stream_for_server (&client->cluster,
@@ -3182,11 +3219,15 @@ mongoc_client_get_handshake_description (mongoc_client_t *client,
 bool
 mongoc_client_uses_server_api (const mongoc_client_t *client)
 {
+   BSON_ASSERT_PARAM (client);
+
    return mongoc_topology_uses_server_api (client->topology);
 }
 
 bool
 mongoc_client_uses_loadbalanced (const mongoc_client_t *client)
 {
+   BSON_ASSERT_PARAM (client);
+
    return mongoc_topology_uses_loadbalanced (client->topology);
 }

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -1201,8 +1201,6 @@ _mongoc_client_new_from_topology (mongoc_topology_t *topology)
 void
 mongoc_client_destroy (mongoc_client_t *client)
 {
-   BSON_ASSERT_PARAM (client);
-
    if (client) {
       if (client->topology->single_threaded) {
          _mongoc_client_end_sessions (client);

--- a/src/libmongoc/src/mongoc/mongoc-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-cmd.c
@@ -33,6 +33,8 @@ mongoc_cmd_parts_init (mongoc_cmd_parts_t *parts,
                        mongoc_query_flags_t user_query_flags,
                        const bson_t *command_body)
 {
+   BSON_ASSERT_PARAM (client);
+
    parts->body = command_body;
    parts->user_query_flags = user_query_flags;
    parts->read_prefs = NULL;

--- a/src/libmongoc/src/mongoc/mongoc-crypt.c
+++ b/src/libmongoc/src/mongoc/mongoc-crypt.c
@@ -1466,6 +1466,8 @@ _mongoc_crypt_auto_encrypt (_mongoc_crypt_t *crypt,
    mongocrypt_binary_t *cmd_bin = NULL;
    bool ret = false;
 
+   BSON_ASSERT_PARAM (mongocryptd_client);
+   BSON_ASSERT_PARAM (collinfo_client);
    bson_init (cmd_out);
 
    state_machine = _state_machine_new (crypt);

--- a/src/libmongoc/src/mongoc/mongoc-crypt.c
+++ b/src/libmongoc/src/mongoc/mongoc-crypt.c
@@ -1466,7 +1466,6 @@ _mongoc_crypt_auto_encrypt (_mongoc_crypt_t *crypt,
    mongocrypt_binary_t *cmd_bin = NULL;
    bool ret = false;
 
-   BSON_ASSERT_PARAM (mongocryptd_client);
    BSON_ASSERT_PARAM (collinfo_client);
    bson_init (cmd_out);
 

--- a/src/libmongoc/src/mongoc/mongoc-cursor-array.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor-array.c
@@ -92,6 +92,8 @@ _mongoc_cursor_array_new (mongoc_client_t *client,
                           const bson_t *opts,
                           const char *field_name)
 {
+   BSON_ASSERT_PARAM (client);
+
    mongoc_cursor_t *cursor = _mongoc_cursor_new_with_opts (
       client, db_and_coll, opts, NULL, NULL, NULL);
    data_array_t *data = BSON_ALIGNED_ALLOC0 (data_array_t);

--- a/src/libmongoc/src/mongoc/mongoc-cursor-change-stream.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor-change-stream.c
@@ -120,7 +120,7 @@ _mongoc_cursor_change_stream_new (mongoc_client_t *client,
    mongoc_cursor_t *cursor;
    _data_change_stream_t *data;
 
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
    BSON_ASSERT (reply);
 
    data = BSON_ALIGNED_ALLOC0 (_data_change_stream_t);

--- a/src/libmongoc/src/mongoc/mongoc-cursor-cmd-deprecated.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor-cmd-deprecated.c
@@ -87,6 +87,8 @@ _mongoc_cursor_cmd_deprecated_new (mongoc_client_t *client,
                                    const bson_t *cmd,
                                    const mongoc_read_prefs_t *read_prefs)
 {
+   BSON_ASSERT_PARAM (client);
+
    mongoc_cursor_t *cursor =
       _mongoc_cursor_new_with_opts (client,
                                     db_and_coll,

--- a/src/libmongoc/src/mongoc/mongoc-cursor-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor-cmd.c
@@ -169,6 +169,8 @@ _mongoc_cursor_cmd_new (mongoc_client_t *client,
                         const mongoc_read_prefs_t *default_prefs,
                         const mongoc_read_concern_t *read_concern)
 {
+   BSON_ASSERT_PARAM (client);
+
    mongoc_cursor_t *cursor;
    data_cmd_t *data = BSON_ALIGNED_ALLOC0 (data_cmd_t);
 
@@ -193,6 +195,8 @@ _mongoc_cursor_cmd_new_from_reply (mongoc_client_t *client,
                                    const bson_t *opts,
                                    bson_t *reply)
 {
+   BSON_ASSERT_PARAM (client);
+
    mongoc_cursor_t *cursor =
       _mongoc_cursor_cmd_new (client, NULL, cmd, opts, NULL, NULL, NULL);
    data_cmd_t *data = (data_cmd_t *) cursor->impl.data;

--- a/src/libmongoc/src/mongoc/mongoc-cursor-find.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor-find.c
@@ -91,6 +91,8 @@ _mongoc_cursor_find_new (mongoc_client_t *client,
                          const mongoc_read_prefs_t *default_prefs,
                          const mongoc_read_concern_t *read_concern)
 {
+   BSON_ASSERT_PARAM (client);
+
    mongoc_cursor_t *cursor;
    data_find_t *data = BSON_ALIGNED_ALLOC0 (data_find_t);
    cursor = _mongoc_cursor_new_with_opts (

--- a/src/libmongoc/src/mongoc/mongoc-cursor.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor.c
@@ -247,7 +247,7 @@ _mongoc_cursor_new_with_opts (mongoc_client_t *client,
 
    ENTRY;
 
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
 
    cursor = BSON_ALIGNED_ALLOC0 (mongoc_cursor_t);
    cursor->client = client;
@@ -1584,7 +1584,7 @@ mongoc_cursor_new_from_command_reply (mongoc_client_t *client,
    bson_t cmd = BSON_INITIALIZER;
    bson_t opts = BSON_INITIALIZER;
 
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
    BSON_ASSERT (reply);
    /* options are passed through by adding them to reply. */
    bsonBuildAppend (
@@ -1614,7 +1614,7 @@ mongoc_cursor_new_from_command_reply_with_opts (mongoc_client_t *client,
    mongoc_cursor_t *cursor;
    bson_t cmd = BSON_INITIALIZER;
 
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
    BSON_ASSERT (reply);
 
    cursor = _mongoc_cursor_cmd_new_from_reply (client, &cmd, opts, reply);

--- a/src/libmongoc/src/mongoc/mongoc-database.c
+++ b/src/libmongoc/src/mongoc/mongoc-database.c
@@ -1193,6 +1193,8 @@ _mongoc_get_encryptedFields_from_map (mongoc_client_t *client,
                                       bson_t *encryptedFields,
                                       bson_error_t *error)
 {
+   BSON_ASSERT_PARAM (client);
+
    const bson_t *efMap = client->topology->encrypted_fields_map;
 
    bson_init (encryptedFields);
@@ -1226,6 +1228,8 @@ _mongoc_get_encryptedFields_from_server (mongoc_client_t *client,
                                          bson_t *encryptedFields,
                                          bson_error_t *error)
 {
+   BSON_ASSERT_PARAM (client);
+
    mongoc_database_t *db = mongoc_client_get_database (client, dbName);
    bson_t *opts = BCON_NEW ("filter", "{", "name", BCON_UTF8 (collName), "}");
    mongoc_cursor_t *cursor;

--- a/src/libmongoc/src/mongoc/mongoc-gridfs-bucket.c
+++ b/src/libmongoc/src/mongoc/mongoc-gridfs-bucket.c
@@ -161,7 +161,7 @@ mongoc_gridfs_bucket_open_upload_stream_with_id (mongoc_gridfs_bucket_t *bucket,
    BSON_ASSERT (filename);
 
    if (!_mongoc_gridfs_bucket_upload_opts_parse (
-          NULL /* not needed. */, opts, &gridfs_opts, error)) {
+          bucket->files->client, opts, &gridfs_opts, error)) {
       _mongoc_gridfs_bucket_upload_opts_cleanup (&gridfs_opts);
       return NULL;
    }

--- a/src/libmongoc/src/mongoc/mongoc-gridfs.c
+++ b/src/libmongoc/src/mongoc/mongoc-gridfs.c
@@ -104,7 +104,7 @@ _mongoc_gridfs_new (mongoc_client_t *client,
 
    ENTRY;
 
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
    BSON_ASSERT (db);
 
    if (!prefix) {

--- a/src/libmongoc/src/mongoc/mongoc-opts.c
+++ b/src/libmongoc/src/mongoc/mongoc-opts.c
@@ -129,8 +129,9 @@ _mongoc_insert_many_opts_parse (
    bson_error_t *error)
 {
    bson_iter_t iter;
-   
+
    BSON_ASSERT_PARAM (client);
+
    mongoc_insert_many_opts->crud.writeConcern = NULL;
    mongoc_insert_many_opts->crud.write_concern_owned = false;
    mongoc_insert_many_opts->crud.client_session = NULL;
@@ -667,7 +668,7 @@ _mongoc_update_many_opts_parse (
 {
    bson_iter_t iter;
 
-    BSON_ASSERT_PARAM (client);
+   BSON_ASSERT_PARAM (client);
 
    mongoc_update_many_opts->update.crud.writeConcern = NULL;
    mongoc_update_many_opts->update.crud.write_concern_owned = false;
@@ -2027,6 +2028,7 @@ _mongoc_gridfs_bucket_upload_opts_parse (
 {
    bson_iter_t iter;
 
+   BSON_ASSERT_PARAM (client);
 
    mongoc_gridfs_bucket_upload_opts->chunkSizeBytes = 0;
    bson_init (&mongoc_gridfs_bucket_upload_opts->metadata);

--- a/src/libmongoc/src/mongoc/mongoc-opts.c
+++ b/src/libmongoc/src/mongoc/mongoc-opts.c
@@ -23,6 +23,8 @@ _mongoc_insert_one_opts_parse (
 {
    bson_iter_t iter;
 
+   BSON_ASSERT_PARAM (client);
+
    mongoc_insert_one_opts->crud.writeConcern = NULL;
    mongoc_insert_one_opts->crud.write_concern_owned = false;
    mongoc_insert_one_opts->crud.client_session = NULL;
@@ -127,7 +129,8 @@ _mongoc_insert_many_opts_parse (
    bson_error_t *error)
 {
    bson_iter_t iter;
-
+   
+   BSON_ASSERT_PARAM (client);
    mongoc_insert_many_opts->crud.writeConcern = NULL;
    mongoc_insert_many_opts->crud.write_concern_owned = false;
    mongoc_insert_many_opts->crud.client_session = NULL;
@@ -242,6 +245,8 @@ _mongoc_delete_one_opts_parse (
    bson_error_t *error)
 {
    bson_iter_t iter;
+
+   BSON_ASSERT_PARAM (client);
 
    mongoc_delete_one_opts->delete.crud.writeConcern = NULL;
    mongoc_delete_one_opts->delete.crud.write_concern_owned = false;
@@ -371,6 +376,8 @@ _mongoc_delete_many_opts_parse (
 {
    bson_iter_t iter;
 
+   BSON_ASSERT_PARAM (client);
+
    mongoc_delete_many_opts->delete.crud.writeConcern = NULL;
    mongoc_delete_many_opts->delete.crud.write_concern_owned = false;
    mongoc_delete_many_opts->delete.crud.client_session = NULL;
@@ -498,6 +505,8 @@ _mongoc_update_one_opts_parse (
    bson_error_t *error)
 {
    bson_iter_t iter;
+
+   BSON_ASSERT_PARAM (client);
 
    mongoc_update_one_opts->update.crud.writeConcern = NULL;
    mongoc_update_one_opts->update.crud.write_concern_owned = false;
@@ -658,6 +667,8 @@ _mongoc_update_many_opts_parse (
 {
    bson_iter_t iter;
 
+    BSON_ASSERT_PARAM (client);
+
    mongoc_update_many_opts->update.crud.writeConcern = NULL;
    mongoc_update_many_opts->update.crud.write_concern_owned = false;
    mongoc_update_many_opts->update.crud.client_session = NULL;
@@ -817,6 +828,8 @@ _mongoc_replace_one_opts_parse (
 {
    bson_iter_t iter;
 
+   BSON_ASSERT_PARAM (client);
+
    mongoc_replace_one_opts->update.crud.writeConcern = NULL;
    mongoc_replace_one_opts->update.crud.write_concern_owned = false;
    mongoc_replace_one_opts->update.crud.client_session = NULL;
@@ -965,6 +978,8 @@ _mongoc_bulk_opts_parse (
 {
    bson_iter_t iter;
 
+   BSON_ASSERT_PARAM (client);
+
    mongoc_bulk_opts->writeConcern = NULL;
    mongoc_bulk_opts->write_concern_owned = false;
    mongoc_bulk_opts->ordered = true;
@@ -1066,6 +1081,8 @@ _mongoc_bulk_insert_opts_parse (
 {
    bson_iter_t iter;
 
+   BSON_ASSERT_PARAM (client);
+
    mongoc_bulk_insert_opts->validate = _mongoc_default_insert_vflags;
    bson_init (&mongoc_bulk_insert_opts->extra);
 
@@ -1118,6 +1135,8 @@ _mongoc_bulk_update_one_opts_parse (
    bson_error_t *error)
 {
    bson_iter_t iter;
+
+   BSON_ASSERT_PARAM (client);
 
    mongoc_bulk_update_one_opts->update.validate = _mongoc_default_update_vflags;
    bson_init (&mongoc_bulk_update_one_opts->update.collation);
@@ -1225,6 +1244,8 @@ _mongoc_bulk_update_many_opts_parse (
 {
    bson_iter_t iter;
 
+   BSON_ASSERT_PARAM (client);
+
    mongoc_bulk_update_many_opts->update.validate = _mongoc_default_update_vflags;
    bson_init (&mongoc_bulk_update_many_opts->update.collation);
    memset (&mongoc_bulk_update_many_opts->update.hint, 0, sizeof (bson_value_t));
@@ -1331,6 +1352,8 @@ _mongoc_bulk_replace_one_opts_parse (
 {
    bson_iter_t iter;
 
+   BSON_ASSERT_PARAM (client);
+
    mongoc_bulk_replace_one_opts->update.validate = _mongoc_default_replace_vflags;
    bson_init (&mongoc_bulk_replace_one_opts->update.collation);
    memset (&mongoc_bulk_replace_one_opts->update.hint, 0, sizeof (bson_value_t));
@@ -1426,6 +1449,8 @@ _mongoc_bulk_remove_one_opts_parse (
 {
    bson_iter_t iter;
 
+   BSON_ASSERT_PARAM (client);
+
    bson_init (&mongoc_bulk_remove_one_opts->remove.collation);
    memset (&mongoc_bulk_remove_one_opts->remove.hint, 0, sizeof (bson_value_t));
    mongoc_bulk_remove_one_opts->remove.limit = 1;
@@ -1501,6 +1526,8 @@ _mongoc_bulk_remove_many_opts_parse (
 {
    bson_iter_t iter;
 
+   BSON_ASSERT_PARAM (client);
+
    bson_init (&mongoc_bulk_remove_many_opts->remove.collation);
    memset (&mongoc_bulk_remove_many_opts->remove.hint, 0, sizeof (bson_value_t));
    mongoc_bulk_remove_many_opts->remove.limit = 0;
@@ -1575,6 +1602,8 @@ _mongoc_change_stream_opts_parse (
    bson_error_t *error)
 {
    bson_iter_t iter;
+
+   BSON_ASSERT_PARAM (client);
 
    mongoc_change_stream_opts->batchSize = 0;
    bson_init (&mongoc_change_stream_opts->resumeAfter);
@@ -1717,6 +1746,8 @@ _mongoc_create_index_opts_parse (
 {
    bson_iter_t iter;
 
+   BSON_ASSERT_PARAM (client);
+
    mongoc_create_index_opts->writeConcern = NULL;
    mongoc_create_index_opts->write_concern_owned = false;
    mongoc_create_index_opts->client_session = NULL;
@@ -1790,6 +1821,8 @@ _mongoc_read_write_opts_parse (
    bson_error_t *error)
 {
    bson_iter_t iter;
+
+   BSON_ASSERT_PARAM (client);
 
    bson_init (&mongoc_read_write_opts->readConcern);
    mongoc_read_write_opts->writeConcern = NULL;
@@ -1897,6 +1930,8 @@ _mongoc_gridfs_bucket_opts_parse (
 {
    bson_iter_t iter;
 
+   BSON_ASSERT_PARAM (client);
+
    mongoc_gridfs_bucket_opts->bucketName = "fs";
    mongoc_gridfs_bucket_opts->chunkSizeBytes = 261120;
    mongoc_gridfs_bucket_opts->writeConcern = NULL;
@@ -1992,6 +2027,7 @@ _mongoc_gridfs_bucket_upload_opts_parse (
 {
    bson_iter_t iter;
 
+
    mongoc_gridfs_bucket_upload_opts->chunkSizeBytes = 0;
    bson_init (&mongoc_gridfs_bucket_upload_opts->metadata);
    bson_init (&mongoc_gridfs_bucket_upload_opts->extra);
@@ -2060,6 +2096,8 @@ _mongoc_aggregate_opts_parse (
    bson_error_t *error)
 {
    bson_iter_t iter;
+
+   BSON_ASSERT_PARAM (client);
 
    mongoc_aggregate_opts->readConcern = NULL;
    mongoc_aggregate_opts->writeConcern = NULL;
@@ -2223,6 +2261,8 @@ _mongoc_find_and_modify_appended_opts_parse (
 {
    bson_iter_t iter;
 
+   BSON_ASSERT_PARAM (client);
+
    mongoc_find_and_modify_appended_opts->writeConcern = NULL;
    mongoc_find_and_modify_appended_opts->write_concern_owned = false;
    mongoc_find_and_modify_appended_opts->client_session = NULL;
@@ -2329,6 +2369,8 @@ _mongoc_count_document_opts_parse (
    bson_error_t *error)
 {
    bson_iter_t iter;
+
+   BSON_ASSERT_PARAM (client);
 
    bson_init (&mongoc_count_document_opts->readConcern);
    mongoc_count_document_opts->client_session = NULL;

--- a/src/libmongoc/src/mongoc/mongoc-write-command.c
+++ b/src/libmongoc/src/mongoc/mongoc-write-command.c
@@ -615,7 +615,7 @@ _mongoc_write_opmsg (mongoc_write_command_t *command,
    ENTRY;
 
    BSON_ASSERT (command);
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
    BSON_ASSERT (database);
    BSON_ASSERT (server_stream);
    BSON_ASSERT (collection);
@@ -870,7 +870,7 @@ _mongoc_write_command_execute (
    ENTRY;
 
    BSON_ASSERT (command);
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
    BSON_ASSERT (server_stream);
    BSON_ASSERT (database);
    BSON_ASSERT (collection);
@@ -916,7 +916,7 @@ _mongoc_write_command_execute_idl (mongoc_write_command_t *command,
    ENTRY;
 
    BSON_ASSERT (command);
-   BSON_ASSERT (client);
+   BSON_ASSERT_PARAM (client);
    BSON_ASSERT (server_stream);
    BSON_ASSERT (database);
    BSON_ASSERT (collection);

--- a/src/libmongoc/tests/debug-stream.c
+++ b/src/libmongoc/tests/debug-stream.c
@@ -202,6 +202,8 @@ void
 test_framework_set_debug_stream (mongoc_client_t *client,
                                  debug_stream_stats_t *stats)
 {
+   BSON_ASSERT_PARAM (client);
+
    stats->client = client;
    mongoc_client_set_stream_initiator (client, debug_stream_initiator, stats);
 }

--- a/src/libmongoc/tests/json-test-monitoring.c
+++ b/src/libmongoc/tests/json-test-monitoring.c
@@ -262,7 +262,6 @@ set_apm_callbacks (json_test_ctx_t *ctx, mongoc_client_t *client)
 {
    mongoc_apm_callbacks_t *callbacks;
 
-   ASSERT (client);
    BSON_UNUSED (client);
 
    callbacks = mongoc_apm_callbacks_new ();

--- a/src/libmongoc/tests/json-test-monitoring.c
+++ b/src/libmongoc/tests/json-test-monitoring.c
@@ -262,6 +262,7 @@ set_apm_callbacks (json_test_ctx_t *ctx, mongoc_client_t *client)
 {
    mongoc_apm_callbacks_t *callbacks;
 
+   ASSERT (client);
    BSON_UNUSED (client);
 
    callbacks = mongoc_apm_callbacks_new ();
@@ -280,6 +281,8 @@ void
 set_apm_callbacks_pooled (json_test_ctx_t *ctx, mongoc_client_pool_t *pool)
 {
    mongoc_apm_callbacks_t *callbacks;
+
+   ASSERT (pool);
 
    callbacks = mongoc_apm_callbacks_new ();
    mongoc_apm_set_command_started_cb (callbacks, started_cb);

--- a/src/libmongoc/tests/json-test-operations.c
+++ b/src/libmongoc/tests/json-test-operations.c
@@ -175,6 +175,8 @@ json_test_ctx_init (json_test_ctx_t *ctx,
    int i;
    bson_error_t error;
 
+   ASSERT (client);
+
    memset (ctx, 0, sizeof (*ctx));
 
    ctx->client = client;
@@ -1765,7 +1767,7 @@ list_databases (mongoc_client_t *client,
    mongoc_cursor_t *cursor;
    bson_t opts;
 
-   BSON_ASSERT (client);
+   ASSERT (client);
    bson_init (&opts);
    append_session (session, &opts);
 
@@ -1790,7 +1792,7 @@ list_database_names (mongoc_client_t *client,
    bson_t opts;
    bson_error_t error;
 
-   BSON_ASSERT (client);
+   ASSERT (client);
    bson_init (&opts);
    append_session (session, &opts);
 
@@ -2057,6 +2059,8 @@ collection_exists (mongoc_client_t *client, const bson_t *operation)
    bool found = false;
    uint32_t i;
 
+   ASSERT (client);
+
    bson_lookup_doc (operation, "arguments", &args);
    database_name = bson_lookup_utf8 (&args, "database");
    collection_name = bson_lookup_utf8 (&args, "collection");
@@ -2095,6 +2099,8 @@ index_exists (mongoc_client_t *client, const bson_t *operation)
    bson_iter_t index;
    const bson_t *doc;
    bool found = false;
+
+   ASSERT (client);
 
    bson_lookup_doc (operation, "arguments", &args);
    database_name = bson_lookup_utf8 (&args, "database");

--- a/src/libmongoc/tests/json-test.c
+++ b/src/libmongoc/tests/json-test.c
@@ -1199,6 +1199,8 @@ execute_test (const json_test_config_t *config,
    mongoc_client_t *outcome_client;
    mongoc_collection_t *outcome_coll;
 
+   ASSERT (client);
+
    if (test_suite_debug_output ()) {
       const char *description = bson_lookup_utf8 (test, "description");
       printf ("  - %s\n", description);
@@ -1296,7 +1298,7 @@ activate_fail_point (mongoc_client_t *client,
    bson_error_t error;
    bool r;
 
-   BSON_ASSERT (client);
+   ASSERT (client);
 
    bson_lookup_doc (test, key, &command);
 
@@ -1333,6 +1335,8 @@ deactivate_fail_points (mongoc_client_t *client, uint32_t server_id)
    bson_t *command;
    bool r;
    bson_error_t error;
+
+   ASSERT (client);
 
    if (server_id) {
       sd = mongoc_client_get_server_description (client, server_id);
@@ -1440,6 +1444,8 @@ set_auto_encryption_opts (mongoc_client_t *client, bson_t *test)
    bson_error_t error;
    bool ret;
    bson_t extra;
+
+   ASSERT (client);
 
    if (!bson_has_field (test, "clientOptions.autoEncryptOpts")) {
       return;

--- a/src/libmongoc/tests/test-awsauth.c
+++ b/src/libmongoc/tests/test-awsauth.c
@@ -175,6 +175,8 @@ caching_expected (const mongoc_uri_t *uri)
 static bool
 do_find (mongoc_client_t *client, bson_error_t *error)
 {
+   ASSERT (client);
+
    bson_t *filter = bson_new ();
    mongoc_collection_t *coll =
       mongoc_client_get_collection (client, "aws", "coll");

--- a/src/libmongoc/tests/test-conveniences.c
+++ b/src/libmongoc/tests/test-conveniences.c
@@ -642,6 +642,8 @@ bson_lookup_session_opts (const bson_t *b, const char *key)
 mongoc_client_session_t *
 bson_lookup_session (const bson_t *b, const char *key, mongoc_client_t *client)
 {
+   ASSERT (client);
+
    mongoc_session_opt_t *opts;
    mongoc_client_session_t *session;
    bson_error_t error;
@@ -1608,7 +1610,7 @@ init_huge_string (mongoc_client_t *client)
 {
    int32_t max_bson_size;
 
-   BSON_ASSERT (client);
+   ASSERT (client);
 
    test_conveniences_init ();
 
@@ -1627,6 +1629,7 @@ init_huge_string (mongoc_client_t *client)
 const char *
 huge_string (mongoc_client_t *client)
 {
+   ASSERT (client);
    init_huge_string (client);
    return gHugeString;
 }
@@ -1635,6 +1638,7 @@ huge_string (mongoc_client_t *client)
 size_t
 huge_string_length (mongoc_client_t *client)
 {
+   ASSERT (client);
    init_huge_string (client);
    return gHugeStringLength;
 }
@@ -1913,6 +1917,8 @@ server_semver (mongoc_client_t *client, semver_t *out)
    bson_t reply;
    bson_error_t error;
    const char *server_version_str;
+
+   ASSERT (client);
 
    ASSERT_OR_PRINT (
       mongoc_client_command_simple (

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -246,6 +246,7 @@ gen_collection_name (const char *str)
 mongoc_collection_t *
 get_test_collection (mongoc_client_t *client, const char *prefix)
 {
+   ASSERT (client);
    mongoc_collection_t *ret;
    char *str;
 
@@ -1459,7 +1460,7 @@ test_framework_server_count (void)
 void
 test_framework_set_ssl_opts (mongoc_client_t *client)
 {
-   BSON_ASSERT (client);
+   ASSERT (client);
 
    if (test_framework_get_ssl ()) {
 #ifndef MONGOC_ENABLE_SSL
@@ -1846,6 +1847,8 @@ test_framework_server_is_secondary (mongoc_client_t *client, uint32_t server_id)
    bson_error_t error;
    bool ret;
 
+   ASSERT (client);
+
    sd = mongoc_topology_description_server_by_id_const (
       client->topology->_shared_descr_.ptr, server_id, &error);
    ASSERT_OR_PRINT (sd, error);
@@ -2176,6 +2179,8 @@ test_framework_get_server_version_with_client (mongoc_client_t *client)
    bson_t reply;
    bson_error_t error;
    server_version_t ret = 0;
+
+   ASSERT (client);
 
    ASSERT_OR_PRINT (
       mongoc_client_command_simple (

--- a/src/libmongoc/tests/test-mongoc-bulk.c
+++ b/src/libmongoc/tests/test-mongoc-bulk.c
@@ -4072,6 +4072,8 @@ server_id_for_read_mode (mongoc_client_t *client, mongoc_read_mode_t read_mode)
    bson_error_t error;
    uint32_t server_id;
 
+   ASSERT (client);
+
    prefs = mongoc_read_prefs_new (read_mode);
    sd = mongoc_topology_select (
       client->topology, MONGOC_SS_READ, prefs, NULL, &error);

--- a/src/libmongoc/tests/test-mongoc-change-stream.c
+++ b/src/libmongoc/tests/test-mongoc-change-stream.c
@@ -91,6 +91,8 @@ drop_and_get_coll (mongoc_client_t *client,
                    const char *db_name,
                    const char *coll_name)
 {
+   ASSERT (client);
+
    mongoc_collection_t *coll =
       mongoc_client_get_collection (client, db_name, coll_name);
    mongoc_collection_drop (coll, NULL);

--- a/src/libmongoc/tests/test-mongoc-client-session.c
+++ b/src/libmongoc/tests/test-mongoc-client-session.c
@@ -806,6 +806,8 @@ test_end_sessions_pooled (void *ctx)
 static void
 send_ping (mongoc_client_t *client, mongoc_client_session_t *client_session)
 {
+   ASSERT (client);
+
    bson_t ping_cmd = BSON_INITIALIZER;
    bson_t opts = BSON_INITIALIZER;
    bson_error_t error;

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -1253,6 +1253,8 @@ _endpoint_setup (mongoc_client_t *keyvault_client,
    mongoc_client_encryption_opts_t *client_encryption_opts_invalid;
    bson_error_t error;
 
+   ASSERT (keyvault_client);
+
    char *mongoc_test_aws_access_key_id =
       test_framework_getenv_required ("MONGOC_TEST_AWS_ACCESS_KEY_ID");
    char *mongoc_test_aws_secret_access_key =
@@ -2141,6 +2143,8 @@ _reset (mongoc_client_pool_t **pool,
    bson_t *schema;
    bson_t *schema_map;
 
+   ASSERT (pool);
+
    mongoc_auto_encryption_opts_destroy (*opts);
    *opts = mongoc_auto_encryption_opts_new ();
    {
@@ -2214,6 +2218,8 @@ _perform_op (mongoc_client_t *client_encrypted)
    bson_error_t error;
    mongoc_collection_t *coll;
 
+   ASSERT (client_encrypted);
+
    coll = mongoc_client_get_collection (client_encrypted, "db", "coll");
    ret = mongoc_collection_insert_one (coll,
                                        tmp_bson ("{'encrypted_string': 'abc'}"),
@@ -2228,6 +2234,8 @@ static void
 _perform_op_pooled (mongoc_client_pool_t *client_pool_encrypted)
 {
    mongoc_client_t *client_encrypted;
+
+   ASSERT (client_pool_encrypted);
 
    client_encrypted = mongoc_client_pool_pop (client_pool_encrypted);
    _perform_op (client_encrypted);
@@ -2788,6 +2796,8 @@ _make_kms_certificate_client_encryption (mongoc_client_t *client,
 {
    mongoc_client_encryption_t *client_encryption;
 
+   ASSERT (client);
+
    mongoc_client_encryption_opts_t *client_encryption_opts =
       mongoc_client_encryption_opts_new ();
 
@@ -2992,6 +3002,8 @@ _tls_test_make_client_encryption (mongoc_client_t *keyvault_client,
    bson_error_t error = {0};
    mongoc_client_encryption_t *client_encryption;
    bson_t *tls_opts = NULL;
+
+   ASSERT (keyvault_client);
 
    char *mongoc_test_aws_access_key_id =
       test_framework_getenv_required ("MONGOC_TEST_AWS_ACCESS_KEY_ID");
@@ -6432,6 +6444,8 @@ test_create_encrypted_collection_no_encryptedFields_helper (
    bson_error_t error = {0};
    bson_t *const kmsProviders = _make_kms_providers (true, true);
    bson_t *const tlsOptions = _make_tls_opts ();
+
+   ASSERT (client);
 
    // Drop prior data
    {

--- a/src/libmongoc/tests/test-mongoc-client.c
+++ b/src/libmongoc/tests/test-mongoc-client.c
@@ -2994,6 +2994,8 @@ _cmd (mock_server_t *server,
    request_t *request;
    bool r;
 
+   ASSERT (client);
+
    future = future_client_command_simple (
       client, "db", tmp_bson ("{'cmd': 1}"), NULL, NULL, error);
    request = mock_server_receives_msg (
@@ -3222,6 +3224,8 @@ static future_t *
 _force_hello_with_ping (mongoc_client_t *client, int heartbeat_ms)
 {
    future_t *future;
+
+   BSON_ASSERT_PARAM (client);
 
    /* Wait until we're overdue to send a hello */
    _mongoc_usleep (heartbeat_ms * 2 * 1000);

--- a/src/libmongoc/tests/test-mongoc-cluster.c
+++ b/src/libmongoc/tests/test-mongoc-cluster.c
@@ -585,6 +585,8 @@ client_command (mongoc_client_t *client, bson_error_t *error)
    const bson_t *doc;
    bool r;
 
+   ASSERT (client);
+
    cursor = mongoc_client_command (client,
                                    "test",
                                    MONGOC_QUERY_NONE,
@@ -649,6 +651,8 @@ aggregate (mongoc_client_t *client, bson_error_t *error)
    const bson_t *doc;
    bool r;
 
+   ASSERT (client);
+
    collection = mongoc_client_get_collection (client, "test", "collection");
    cursor = mongoc_collection_aggregate (
       collection, MONGOC_QUERY_NONE, tmp_bson ("{}"), NULL, NULL);
@@ -686,6 +690,7 @@ cursor_next (mongoc_client_t *client, bson_error_t *error)
    const bson_t *doc;
    bool r;
 
+   ASSERT (client);
    collection = get_test_collection (client, "test_cluster_time_cursor");
    cursor = mongoc_collection_find_with_opts (
       collection, tmp_bson ("{'ping': 1}"), NULL, NULL);
@@ -720,6 +725,8 @@ insert (mongoc_client_t *client, bson_error_t *error)
 {
    mongoc_collection_t *collection;
    bool r;
+
+   ASSERT (client);
 
    collection = get_test_collection (client, "test_cluster_time_cursor");
    r = mongoc_collection_insert_one (
@@ -1104,6 +1111,8 @@ future_command_private (mongoc_client_t *client)
 {
    bson_error_t error;
    mongoc_server_stream_t *server_stream;
+
+   ASSERT (client);
 
    server_stream =
       mongoc_cluster_stream_for_writes (&client->cluster, NULL, NULL, &error);

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -1920,6 +1920,8 @@ storage_engine (mongoc_client_t *client)
    bson_t cmd = BSON_INITIALIZER;
    bson_t reply;
 
+   ASSERT (client);
+
    /* NOTE: this default will change eventually */
    char *engine = bson_strdup ("mmapv1");
 

--- a/src/libmongoc/tests/test-mongoc-command-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-command-monitoring.c
@@ -847,6 +847,8 @@ set_cmd_test_callbacks (mongoc_client_t *client, void *context)
 {
    mongoc_apm_callbacks_t *callbacks;
 
+   ASSERT (client);
+
    callbacks = mongoc_apm_callbacks_new ();
    mongoc_apm_set_command_started_cb (callbacks, cmd_started_cb);
    mongoc_apm_set_command_succeeded_cb (callbacks, cmd_succeeded_cb);

--- a/src/libmongoc/tests/test-mongoc-counters.c
+++ b/src/libmongoc/tests/test-mongoc-counters.c
@@ -98,6 +98,9 @@ _drop_and_populate_coll (mongoc_client_t *client)
    bool ret;
    bson_error_t err;
    int i;
+
+   ASSERT (client);
+
    coll = mongoc_client_get_collection (client, "test", "test");
    mongoc_collection_drop (coll, NULL); /* don't care if ns not found. */
    for (i = 0; i < 3; i++) {
@@ -114,6 +117,9 @@ _ping (mongoc_client_t *client)
 {
    bool ret;
    bson_error_t err;
+
+   ASSERT (client);
+
    ret = mongoc_client_command_simple (
       client, "test", tmp_bson ("{'ping': 1}"), NULL, NULL, &err);
    ASSERT_OR_PRINT (ret, err);

--- a/src/libmongoc/tests/test-mongoc-cursor.c
+++ b/src/libmongoc/tests/test-mongoc-cursor.c
@@ -1418,6 +1418,8 @@ test_cursor_hint_errors (void)
 static uint32_t
 server_id_for_read_mode (mongoc_client_t *client, mongoc_read_mode_t read_mode)
 {
+   ASSERT (client);
+
    mongoc_read_prefs_t *prefs;
    mongoc_server_description_t *sd;
    bson_error_t error;

--- a/src/libmongoc/tests/test-mongoc-dns.c
+++ b/src/libmongoc/tests/test-mongoc-dns.c
@@ -666,6 +666,8 @@ _prose_test_ping (mongoc_client_t *client)
    bson_error_t error;
    bson_t *cmd = BCON_NEW ("ping", BCON_INT32 (1));
 
+   ASSERT (client);
+
    if (!mongoc_client_command_simple (
           client, "admin", cmd, NULL, NULL, &error)) {
       test_error ("ping failed: %s", error.message);

--- a/src/libmongoc/tests/test-mongoc-exhaust.c
+++ b/src/libmongoc/tests/test-mongoc-exhaust.c
@@ -35,6 +35,8 @@ get_generation (mongoc_client_t *client, mongoc_cursor_t *cursor)
    uint32_t generation;
    mongoc_server_description_t const *sd;
    bson_error_t error;
+   ASSERT (client);
+
    mc_shared_tpld td = mc_tpld_take_ref (client->topology);
 
    server_id = mongoc_cursor_get_hint (cursor);
@@ -56,6 +58,8 @@ get_connection_count (mongoc_client_t *client)
    bson_t reply;
    bool res;
    int conns;
+
+   ASSERT (client);
 
    BSON_APPEND_INT32 (&cmd, "serverStatus", 1);
    res = mongoc_client_command_simple (
@@ -468,6 +472,8 @@ _check_error (mongoc_client_t *client,
 {
    uint32_t server_id;
    bson_error_t error;
+
+   ASSERT (client);
 
    server_id = mongoc_cursor_get_hint (cursor);
    ASSERT (server_id);

--- a/src/libmongoc/tests/test-mongoc-loadbalanced.c
+++ b/src/libmongoc/tests/test-mongoc-loadbalanced.c
@@ -113,6 +113,8 @@ set_client_callbacks (mongoc_client_t *client)
    mongoc_apm_callbacks_t *cbs;
    stats_t *stats;
 
+   ASSERT (client);
+
    stats = bson_malloc0 (sizeof (stats_t));
    cbs = make_callbacks ();
    mongoc_client_set_apm_callbacks (client, cbs, stats);
@@ -125,6 +127,8 @@ set_client_pool_callbacks (mongoc_client_pool_t *pool)
 {
    mongoc_apm_callbacks_t *cbs;
    stats_t *stats;
+
+   ASSERT (pool);
 
    stats = bson_malloc0 (sizeof (stats_t));
    cbs = make_callbacks ();

--- a/src/libmongoc/tests/test-mongoc-long-namespace.c
+++ b/src/libmongoc/tests/test-mongoc-long-namespace.c
@@ -402,6 +402,8 @@ _check_existence (mongoc_client_t *client,
    char **iter;
    bson_error_t error;
 
+   ASSERT (client);
+
    db = mongoc_client_get_database (client, ns_db);
    db_names = mongoc_client_get_database_names_with_opts (
       client, NULL /* opts */, &error);

--- a/src/libmongoc/tests/test-mongoc-max-staleness.c
+++ b/src/libmongoc/tests/test-mongoc-max-staleness.c
@@ -18,6 +18,8 @@ get_max_staleness (const mongoc_client_t *client)
 {
    const mongoc_read_prefs_t *prefs;
 
+   ASSERT (client);
+
    prefs = mongoc_client_get_read_prefs (client);
 
    return mongoc_read_prefs_get_max_staleness_seconds (prefs);

--- a/src/libmongoc/tests/test-mongoc-opts.c
+++ b/src/libmongoc/tests/test-mongoc-opts.c
@@ -96,6 +96,8 @@ func_ctx_init (func_ctx_t *ctx,
                const mongoc_read_prefs_t *prefs,
                const bson_t *opts)
 {
+   ASSERT (client);
+
    ctx->test = test;
    ctx->client = client;
    ctx->db = db;

--- a/src/libmongoc/tests/test-mongoc-primary-stepdown.c
+++ b/src/libmongoc/tests/test-mongoc-primary-stepdown.c
@@ -31,6 +31,8 @@ _setup_test_with_client (mongoc_client_t *client)
    bson_error_t error;
    bson_t *opts;
 
+   ASSERT (client);
+
    wc = mongoc_write_concern_new ();
    mongoc_write_concern_set_wmajority (wc, -1);
    opts = bson_new ();
@@ -65,6 +67,8 @@ _connection_count (mongoc_client_t *client, uint32_t server_id)
    bson_t reply;
    bool res;
    int conns;
+
+   ASSERT (client);
 
    BSON_APPEND_INT32 (&cmd, "serverStatus", 1);
 
@@ -131,6 +135,8 @@ test_getmore_iteration (mongoc_client_t *client)
    int conn_count;
    int i;
    uint32_t primary_id;
+
+   ASSERT (client);
 
    wc = mongoc_write_concern_new ();
    mongoc_write_concern_set_wmajority (wc, -1);
@@ -217,6 +223,8 @@ test_not_primary_keep_pool (mongoc_client_t *client)
    int conn_count;
    uint32_t primary_id;
 
+   ASSERT (client);
+
    /* Configure fail points */
    db = mongoc_client_get_database (client, "admin");
    /* Store the primary ID. After step down, the primary may be a different
@@ -286,6 +294,8 @@ test_not_primary_reset_pool (mongoc_client_t *client)
    bool res;
    int conn_count;
    uint32_t primary_id;
+
+   ASSERT (client);
 
    /* Configure fail points */
    read_prefs = mongoc_read_prefs_new (MONGOC_READ_PRIMARY);
@@ -362,6 +372,8 @@ test_shutdown_reset_pool (mongoc_client_t *client)
    int conn_count;
    uint32_t primary_id;
 
+   ASSERT (client);
+
    /* Configure fail points */
    read_prefs = mongoc_read_prefs_new (MONGOC_READ_PRIMARY);
    db = mongoc_client_get_database (client, "admin");
@@ -430,6 +442,8 @@ test_interrupted_shutdown_reset_pool (mongoc_client_t *client)
    bool res;
    int conn_count;
    uint32_t primary_id;
+
+   ASSERT (client);
 
    /* Configure fail points */
    read_prefs = mongoc_read_prefs_new (MONGOC_READ_PRIMARY);

--- a/src/libmongoc/tests/test-mongoc-retryable-reads.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-reads.c
@@ -70,6 +70,8 @@ _set_failpoint (mongoc_client_t *client)
                 " 'mode': {'times': 1},"
                 " 'data': {'errorCode': 10107, 'failCommands': ['count']}}");
 
+   ASSERT (client);
+
    ASSERT_OR_PRINT (
       mongoc_client_command_simple (client, "admin", cmd, NULL, NULL, &error),
       error);

--- a/src/libmongoc/tests/test-mongoc-retryable-writes.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-writes.c
@@ -632,6 +632,9 @@ set_up_original_error_test (mongoc_apm_callbacks_t *callbacks,
 {
    uint32_t server_id;
    bson_error_t error;
+
+   ASSERT (client);
+
    // clean up in case a previous test aborted
    server_id = mongoc_topology_select_server_id (
       client->topology, MONGOC_SS_WRITE, NULL, NULL, &error);
@@ -669,6 +672,8 @@ cleanup_original_error_test (mongoc_client_t *client,
                              mongoc_collection_t *coll,
                              mongoc_apm_callbacks_t *callbacks)
 {
+   ASSERT (client);
+
    deactivate_fail_points (client, server_id); // disable the fail point
    bson_destroy (reply);
    mongoc_collection_destroy (coll);

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -3016,6 +3016,8 @@ test_sample_causal_consistency (mongoc_client_t *client)
    uint32_t increment;
    bson_error_t error;
    bool res;
+   
+   ASSERT (client);
 
    if (!test_framework_skip_if_no_txns ()) {
       return;
@@ -3525,6 +3527,8 @@ insert_employee (mongoc_client_t *client, int employee)
    mongoc_collection_t *events;
    bson_error_t error;
    bool r;
+   
+   ASSERT (client);
 
    employees = mongoc_client_get_collection (client, "hr", "employees");
    mongoc_collection_drop (employees, NULL);
@@ -3720,6 +3724,8 @@ example_func (mongoc_client_t *client)
    bson_error_t error;
    bool r;
 
+   ASSERT (client);
+
    cs = mongoc_client_start_session (client, NULL, &error);
    if (!cs) {
       MONGOC_ERROR ("Could not start session: %s", error.message);
@@ -3741,6 +3747,8 @@ test_sample_txn_commands (mongoc_client_t *client)
 {
    mongoc_collection_t *employees;
    mongoc_collection_t *events;
+
+   ASSERT (client);
 
    if (!test_framework_skip_if_no_txns ()) {
       return;

--- a/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
@@ -398,6 +398,8 @@ client_set_topology_event_callbacks (mongoc_client_t *client,
 {
    mongoc_apm_callbacks_t *callbacks;
 
+   ASSERT (client);
+
    callbacks = topology_event_callbacks ();
    mongoc_client_set_apm_callbacks (client, callbacks, (void *) context);
    mongoc_apm_callbacks_destroy (callbacks);
@@ -408,6 +410,8 @@ pool_set_topology_event_callbacks (mongoc_client_pool_t *pool,
                                    context_t *context)
 {
    mongoc_apm_callbacks_t *callbacks;
+
+   ASSERT (pool);
 
    callbacks = topology_event_callbacks ();
    mongoc_client_pool_set_apm_callbacks (pool, callbacks, (void *) context);
@@ -436,6 +440,8 @@ client_set_heartbeat_event_callbacks (mongoc_client_t *client,
 {
    mongoc_apm_callbacks_t *callbacks;
 
+   ASSERT (client);
+
    callbacks = heartbeat_event_callbacks ();
    mongoc_client_set_apm_callbacks (client, callbacks, (void *) context);
    mongoc_apm_callbacks_destroy (callbacks);
@@ -446,6 +452,8 @@ pool_set_heartbeat_event_callbacks (mongoc_client_pool_t *pool,
                                     context_t *context)
 {
    mongoc_apm_callbacks_t *callbacks;
+
+   ASSERT (pool);
 
    callbacks = heartbeat_event_callbacks ();
    mongoc_client_pool_set_apm_callbacks (pool, callbacks, (void *) context);

--- a/src/libmongoc/tests/test-mongoc-sdam.c
+++ b/src/libmongoc/tests/test-mongoc-sdam.c
@@ -316,6 +316,8 @@ sdam_json_test_ctx_init (json_test_ctx_t *ctx,
    const char *db_name;
    const char *coll_name;
 
+   ASSERT (pool);
+
    memset (ctx, 0, sizeof (*ctx));
    ctx->config = config;
    bson_init (&ctx->events);
@@ -374,6 +376,8 @@ deactivate_failpoints_on_all_servers (mongoc_client_t *client)
    bson_t cmd;
    bson_error_t error;
    mc_shared_tpld td;
+
+   ASSERT (client);
 
    bson_init (&cmd);
    BCON_APPEND (&cmd, "configureFailPoint", "failCommand", "mode", "off");

--- a/src/libmongoc/tests/test-mongoc-server-stream.c
+++ b/src/libmongoc/tests/test-mongoc-server-stream.c
@@ -59,6 +59,8 @@ run_delete_with_hint_and_wc0 (bool expect_error,
    future_t *future;
    request_t *request;
 
+   ASSERT (client);
+
    coll = mongoc_client_get_collection (client, "db", "coll");
 
    wc = mongoc_write_concern_new ();

--- a/src/libmongoc/tests/test-mongoc-speculative-auth.c
+++ b/src/libmongoc/tests/test-mongoc-speculative-auth.c
@@ -43,6 +43,8 @@ _force_hello_with_ping (mongoc_client_t *client)
 {
    future_t *future;
 
+   ASSERT (client);
+
    /* Send a ping */
    future = future_client_command_simple (
       client, "admin", tmp_bson ("{'ping': 1}"), NULL, NULL, NULL);

--- a/src/libmongoc/tests/test-mongoc-streamable-hello.c
+++ b/src/libmongoc/tests/test-mongoc-streamable-hello.c
@@ -27,6 +27,8 @@ _force_scan (mongoc_client_t *client, mock_server_t *server, const char *hello)
    future_t *future;
    mongoc_server_description_t *sd;
 
+   ASSERT (client);
+
    /* Mark the topology as "stale" to trigger a scan. */
    client->topology->stale = true;
    future =

--- a/src/libmongoc/tests/test-mongoc-topology-reconcile.c
+++ b/src/libmongoc/tests/test-mongoc-topology-reconcile.c
@@ -69,6 +69,8 @@ selects_server (mongoc_client_t *client,
    mongoc_server_description_t *sd;
    bool result;
 
+   ASSERT (client);
+
    sd = mongoc_topology_select (
       client->topology, MONGOC_SS_READ, read_prefs, NULL, &error);
 

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -1424,6 +1424,8 @@ has_known_server (mongoc_client_t *client)
    mongoc_server_description_t *sd;
    bool r;
 
+   ASSERT (client);
+
    /* in this test we know the server id is always 1 */
    sd = mongoc_client_get_server_description (client, 1);
    r = (sd->type != MONGOC_SERVER_UNKNOWN);

--- a/src/libmongoc/tests/test-mongoc-write-commands.c
+++ b/src/libmongoc/tests/test-mongoc-write-commands.c
@@ -438,6 +438,8 @@ _configure_failpoint (mongoc_client_t *client,
    bool ret;
    bson_error_t error;
 
+   ASSERT (client);
+
    ret = mongoc_client_command_simple (
       client,
       "admin",

--- a/src/libmongoc/tests/unified/runner.c
+++ b/src/libmongoc/tests/unified/runner.c
@@ -555,6 +555,8 @@ get_topology_type (mongoc_client_t *client)
    bson_error_t error;
    const char *topology_type = "single";
 
+   ASSERT (client);
+
    if (test_framework_is_loadbalanced ()) {
       return "load-balanced";
    }
@@ -1578,7 +1580,8 @@ run_distinct_on_each_mongos (test_t *test,
    cmd = BCON_NEW ("distinct", coll_name, "key", "x", "query", "{", "}");
 
    for (size_t i = 0u; i < runner->server_ids.len; i++) {
-      const uint32_t server_id = _mongoc_array_index (&runner->server_ids, uint32_t, i);
+      const uint32_t server_id =
+         _mongoc_array_index (&runner->server_ids, uint32_t, i);
       if (!mongoc_client_command_simple_with_server_id (
              test->test_file->test_runner->internal_client,
              db_name,


### PR DESCRIPTION
- Looked up every instance of a function that has a `mongoc_client_t` or `mongoc_client_pool_t` parameter and added an assert to ensure that the respective function would not segfault when one of the parameters is `NULL`
- Decided to use `BSON_ASSERT_PARAM` so that the error message that will print out when the assert fails is specific to issue
- Used plain `ASSERT` in the test files
- In functions where one of the parameters I was looking for was marked as `BSON_UNUSED`, I did not add an assert as it seemed counterintuitive and there are some test cases where a client or pool is passed through to the function as NULL
- In functions where it was clear that the client or pool was not being dereferenced (such as one line functions that just call another functions), I did not add an assert
