### PR TITLE
sync RPM spec file from downstream

### DIFF
--- a/.evergreen/etc/mongo-c-driver.spec
+++ b/.evergreen/etc/mongo-c-driver.spec
@@ -10,7 +10,7 @@
 %global gh_project   mongo-c-driver
 %global libname      libmongoc
 %global libver       1.0
-%global up_version   1.23.4
+%global up_version   1.23.5
 #global up_prever    rc0
 # disabled as require a MongoDB server
 %bcond_with          tests
@@ -236,6 +236,9 @@ exit $ret
 
 
 %changelog
+* Wed Jun  7 2023 Remi Collet <remi@remirepo.net> - 1.23.5-1
+- update to 1.23.5
+
 * Tue May  9 2023 Remi Collet <remi@remirepo.net> - 1.23.4-1
 - update to 1.23.4
 

--- a/.evergreen/etc/spec.patch
+++ b/.evergreen/etc/spec.patch
@@ -4,7 +4,7 @@
  %global gh_project   mongo-c-driver
  %global libname      libmongoc
  %global libver       1.0
--%global up_version   1.23.4
+-%global up_version   1.23.5
 +%global up_version   1.24.0
  #global up_prever    rc0
  # disabled as require a MongoDB server

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -9673,7 +9673,7 @@ buildvariants:
   - debian-package-build
   - name: rpm-package-build
     distros:
-    - rhel82-arm64-small
+    - rhel90-arm64-small
   batchtime: 1440
 - name: versioned-api
   display_name: Versioned API Tests

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -487,7 +487,7 @@ all_variants = [
         "ubuntu1804-test",
         [
             "debian-package-build",
-            OD([("name", "rpm-package-build"), ("distros", ["rhel82-arm64-small"])]),
+            OD([("name", "rpm-package-build"), ("distros", ["rhel90-arm64-small"])]),
         ],
         {},
         batchtime=days(1),


### PR DESCRIPTION
also, use image rhel90-arm64-small for rpm-package-build

Evergreen patch build: https://spruce.mongodb.com/version/6484c2f93e8e86f9718410d6/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

The switch to rhel90-arm64-small  also turns the task green again.