### PR TITLE
CDRIVER-4659 Add extended json output capability for `bson_array_as_json`

### DIFF
--- a/src/libbson/doc/bson_array_as_canonical_extended_json.rst
+++ b/src/libbson/doc/bson_array_as_canonical_extended_json.rst
@@ -1,7 +1,7 @@
-:man_page: bson_array_as_json
+:man_page: bson_array_as_canonical_extended_json
 
-bson_array_as_json()
-====================
+bson_array_as_canonical_extended_json()
+=================================
 
 Synopsis
 --------
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   char *
-  bson_array_as_json (const bson_t *bson, size_t *length);
+  bson_array_as_canonical_extended_json (const bson_t *bson, size_t *length);
 
 Parameters
 ----------
@@ -20,11 +20,9 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_array_as_json()` function shall encode ``bson`` as a UTF-8
-string using libbson's legacy JSON format, except the outermost element is
-encoded as a JSON array, rather than a JSON document. This function is superseded by :symbol:`bson_array_as_canonical_extended_json()` and :symbol:`bson_array_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
-The caller is responsible for freeing the resulting UTF-8 encoded string by
-calling :symbol:`bson_free()` with the result.
+The :symbol:`bson_array_as_canonical_extended_json()` encodes ``bson`` as a UTF-8 string in the canonical `MongoDB Extended JSON format`_, except the outermost element is encoded as a JSON array, rather than a JSON document.
+
+The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 
 If non-NULL, ``length`` will be set to the length of the result in bytes.
 
@@ -51,12 +49,12 @@ Example
      /* BSON array is a normal BSON document with integer values for the keys,
       * starting with 0 and continuing sequentially
       */
-     BSON_APPEND_UTF8 (&bson, "0", "foo");
+     BSON_APPEND_UTF8 (&bson, "0", 1);
      BSON_APPEND_UTF8 (&bson, "1", "bar");
 
-     str = bson_array_as_json (&bson, NULL);
+     str = bson_array_as_canonical_extended_json (&bson, NULL);
      /* Prints
-      * [ "foo", "bar" ]
+      * [ { "$numberInt" : 1 }, "bar" ]
       */
      printf ("%s\n", str);
      bson_free (str);
@@ -68,3 +66,5 @@ Example
 .. only:: html
 
   .. include:: includes/seealso/bson-as-json.txt
+
+.. _MongoDB Extended JSON format: https://github.com/mongodb/specifications/blob/master/source/extended-json.rst

--- a/src/libbson/doc/bson_array_as_canonical_extended_json.rst
+++ b/src/libbson/doc/bson_array_as_canonical_extended_json.rst
@@ -50,7 +50,7 @@ Example
       * starting with 0 and continuing sequentially
       */
      BSON_APPEND_INT32 (&bson, "0", 1);
-     BSON_APPEND_INT32 (&bson, "1", "bar");
+     BSON_APPEND_UTF8 (&bson, "1", "bar");
 
      str = bson_array_as_canonical_extended_json (&bson, NULL);
      /* Prints

--- a/src/libbson/doc/bson_array_as_canonical_extended_json.rst
+++ b/src/libbson/doc/bson_array_as_canonical_extended_json.rst
@@ -49,8 +49,8 @@ Example
      /* BSON array is a normal BSON document with integer values for the keys,
       * starting with 0 and continuing sequentially
       */
-     BSON_APPEND_UTF8 (&bson, "0", 1);
-     BSON_APPEND_UTF8 (&bson, "1", "bar");
+     BSON_APPEND_INT32 (&bson, "0", 1);
+     BSON_APPEND_INT32 (&bson, "1", "bar");
 
      str = bson_array_as_canonical_extended_json (&bson, NULL);
      /* Prints

--- a/src/libbson/doc/bson_array_as_canonical_extended_json.rst
+++ b/src/libbson/doc/bson_array_as_canonical_extended_json.rst
@@ -1,7 +1,7 @@
 :man_page: bson_array_as_canonical_extended_json
 
 bson_array_as_canonical_extended_json()
-=================================
+=======================================
 
 Synopsis
 --------

--- a/src/libbson/doc/bson_array_as_json.rst
+++ b/src/libbson/doc/bson_array_as_json.rst
@@ -22,7 +22,10 @@ Description
 
 The :symbol:`bson_array_as_json()` function shall encode ``bson`` as a UTF-8
 string using libbson's legacy JSON format, except the outermost element is
-encoded as a JSON array, rather than a JSON document. This function is superseded by :symbol:`bson_array_as_canonical_extended_json()` and :symbol:`bson_array_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
+encoded as a JSON array, rather than a JSON document. This function is
+superseded by :symbol:`bson_array_as_canonical_extended_json()` and
+:symbol:`bson_array_as_relaxed_extended_json()`, which use the same 
+`MongoDB Extended JSON format`_ as all other MongoDB drivers.
 The caller is responsible for freeing the resulting UTF-8 encoded string by
 calling :symbol:`bson_free()` with the result.
 
@@ -68,3 +71,5 @@ Example
 .. only:: html
 
   .. include:: includes/seealso/bson-as-json.txt
+
+.. _MongoDB Extended JSON format: https://github.com/mongodb/specifications/blob/master/source/extended-json.rst

--- a/src/libbson/doc/bson_array_as_relaxed_extended_json.rst
+++ b/src/libbson/doc/bson_array_as_relaxed_extended_json.rst
@@ -1,7 +1,7 @@
 :man_page: bson_array_as_relaxed_extended_json
 
 bson_array_as_relaxed_extended_json()
-===============================
+=====================================
 
 Synopsis
 --------

--- a/src/libbson/doc/bson_array_as_relaxed_extended_json.rst
+++ b/src/libbson/doc/bson_array_as_relaxed_extended_json.rst
@@ -1,7 +1,7 @@
-:man_page: bson_array_as_json
+:man_page: bson_array_as_relaxed_extended_json
 
-bson_array_as_json()
-====================
+bson_array_as_relaxed_extended_json()
+===============================
 
 Synopsis
 --------
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   char *
-  bson_array_as_json (const bson_t *bson, size_t *length);
+  bson_array_as_relaxed_extended_json (const bson_t *bson, size_t *length);
 
 Parameters
 ----------
@@ -20,11 +20,9 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_array_as_json()` function shall encode ``bson`` as a UTF-8
-string using libbson's legacy JSON format, except the outermost element is
-encoded as a JSON array, rather than a JSON document. This function is superseded by :symbol:`bson_array_as_canonical_extended_json()` and :symbol:`bson_array_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
-The caller is responsible for freeing the resulting UTF-8 encoded string by
-calling :symbol:`bson_free()` with the result.
+The :symbol:`bson_as_relaxed_extended_json()` encodes ``bson`` as a UTF-8 string in the relaxed `MongoDB Extended JSON format`_, except the outermost element is encoded as a JSON array, rather than a JSON document.
+
+The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 
 If non-NULL, ``length`` will be set to the length of the result in bytes.
 
@@ -51,12 +49,12 @@ Example
      /* BSON array is a normal BSON document with integer values for the keys,
       * starting with 0 and continuing sequentially
       */
-     BSON_APPEND_UTF8 (&bson, "0", "foo");
+     BSON_APPEND_UTF8 (&bson, "0", 3.14);
      BSON_APPEND_UTF8 (&bson, "1", "bar");
 
-     str = bson_array_as_json (&bson, NULL);
+     str = bson_array_as_canonical_extended_json (&bson, NULL);
      /* Prints
-      * [ "foo", "bar" ]
+      * [ 3.14, "bar" ]
       */
      printf ("%s\n", str);
      bson_free (str);
@@ -68,3 +66,5 @@ Example
 .. only:: html
 
   .. include:: includes/seealso/bson-as-json.txt
+
+.. _MongoDB Extended JSON format: https://github.com/mongodb/specifications/blob/master/source/extended-json.rst

--- a/src/libbson/doc/bson_array_as_relaxed_extended_json.rst
+++ b/src/libbson/doc/bson_array_as_relaxed_extended_json.rst
@@ -49,10 +49,10 @@ Example
      /* BSON array is a normal BSON document with integer values for the keys,
       * starting with 0 and continuing sequentially
       */
-     BSON_APPEND_UTF8 (&bson, "0", 3.14);
+     BSON_APPEND_DOUBLE (&bson, "0", 3.14);
      BSON_APPEND_UTF8 (&bson, "1", "bar");
 
-     str = bson_array_as_canonical_extended_json (&bson, NULL);
+     str = bson_array_as_relaxed_extended_json (&bson, NULL);
      /* Prints
       * [ 3.14, "bar" ]
       */

--- a/src/libbson/doc/bson_json_opts_set_outermost_array.rst
+++ b/src/libbson/doc/bson_json_opts_set_outermost_array.rst
@@ -1,0 +1,23 @@
+:man_page: bson_json_opts_set_outermost_array
+
+bson_json_opts_set_outermost_array()
+====================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  void 
+  bson_json_opts_set_outermost_array (bson_json_opts_t *opts, bool is_outermost_array);
+
+Parameters
+----------
+
+* ``opts``: A bson_json_opts_t.
+* ``is_outermost_array``: A value determining what we want to set the is_outermost_array variable to.
+
+Description
+-----------
+
+The :symbol:`bson_json_opts_set_outermost_array()` function shall set the `is_outermost_array` variable on the `bson_json_opts_t` parameter using the boolean provided.

--- a/src/libbson/doc/bson_json_opts_set_outermost_array.rst
+++ b/src/libbson/doc/bson_json_opts_set_outermost_array.rst
@@ -14,7 +14,7 @@ Synopsis
 Parameters
 ----------
 
-* ``opts``: A ``bson_json_opts_t``.
+* ``opts``: A :symbol:`bson_json_opts_t`.
 * ``is_outermost_array``: A value determining what we want to set the is_outermost_array variable to.
 
 Description

--- a/src/libbson/doc/bson_json_opts_set_outermost_array.rst
+++ b/src/libbson/doc/bson_json_opts_set_outermost_array.rst
@@ -1,7 +1,7 @@
 :man_page: bson_json_opts_set_outermost_array
 
 bson_json_opts_set_outermost_array()
-====================
+====================================
 
 Synopsis
 --------
@@ -14,10 +14,10 @@ Synopsis
 Parameters
 ----------
 
-* ``opts``: A bson_json_opts_t.
+* ``opts``: A ``bson_json_opts_t``.
 * ``is_outermost_array``: A value determining what we want to set the is_outermost_array variable to.
 
 Description
 -----------
 
-The :symbol:`bson_json_opts_set_outermost_array()` function shall set the `is_outermost_array` variable on the `bson_json_opts_t` parameter using the boolean provided.
+The :symbol:`bson_json_opts_set_outermost_array()` function shall set the ``is_outermost_array`` variable on the :symbol:`bson_json_opts_t` parameter using the boolean provided.

--- a/src/libbson/doc/bson_json_opts_t.rst
+++ b/src/libbson/doc/bson_json_opts_t.rst
@@ -48,4 +48,4 @@ The ``max_len`` member holds a maximum length for the resulting JSON string. Enc
 
 	     bson_json_opts_new
 	     bson_json_opts_destroy
-       bson_json_opts_set_outermost_array
+	     bson_json_opts_set_outermost_array

--- a/src/libbson/doc/bson_json_opts_t.rst
+++ b/src/libbson/doc/bson_json_opts_t.rst
@@ -48,3 +48,4 @@ The ``max_len`` member holds a maximum length for the resulting JSON string. Enc
 
 	     bson_json_opts_new
 	     bson_json_opts_destroy
+       bson_json_opts_set_outermost_array

--- a/src/libbson/doc/bson_t.rst
+++ b/src/libbson/doc/bson_t.rst
@@ -190,7 +190,9 @@ BSON document contains duplicate keys.
     bson_append_undefined
     bson_append_utf8
     bson_append_value
+    bson_array_as_canonical_extended_json
     bson_array_as_json
+    bson_array_as_relaxed_extended_json
     bson_as_canonical_extended_json
     bson_as_json
     bson_as_json_with_opts

--- a/src/libbson/doc/includes/seealso/bson-as-json.txt
+++ b/src/libbson/doc/includes/seealso/bson-as-json.txt
@@ -1,6 +1,9 @@
 .. seealso::
+  | :symbol: `bson_array_as_canonical_extended_json()`
 
   | :symbol:`bson_array_as_json()`
+
+  | :symbol: `bson_array_as_relaxed_extended_json()`
 
   | :symbol:`bson_as_canonical_extended_json()`
 

--- a/src/libbson/src/bson/bson-json-private.h
+++ b/src/libbson/src/bson/bson-json-private.h
@@ -23,6 +23,7 @@
 struct _bson_json_opts_t {
    bson_json_mode_t mode;
    int32_t max_len;
+   bool is_outermost_array;
 };
 
 

--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -2335,6 +2335,14 @@ bson_json_reader_destroy (bson_json_reader_t *reader) /* IN */
 }
 
 
+void
+bson_json_opts_set_outermost_array (bson_json_opts_t *opts,
+                                    bool is_outermost_array)
+{
+   opts->is_outermost_array = is_outermost_array;
+}
+
+
 typedef struct {
    const uint8_t *data;
    size_t len;

--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -394,8 +394,11 @@ bson_json_opts_new (bson_json_mode_t mode, int32_t max_len)
    bson_json_opts_t *opts;
 
    opts = (bson_json_opts_t *) bson_malloc (sizeof *opts);
-   opts->mode = mode;
-   opts->max_len = max_len;
+   *opts = (bson_json_opts_t){
+      .mode = mode,
+      .max_len = max_len,
+      .is_outermost_array = false,
+   };
 
    return opts;
 }

--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -389,16 +389,13 @@ _noop (void)
 
 
 bson_json_opts_t *
-bson_json_opts_new (bson_json_mode_t mode,
-                    int32_t max_len,
-                    bool is_outermost_array)
+bson_json_opts_new (bson_json_mode_t mode, int32_t max_len)
 {
    bson_json_opts_t *opts;
 
    opts = (bson_json_opts_t *) bson_malloc (sizeof *opts);
    opts->mode = mode;
    opts->max_len = max_len;
-   opts->is_outermost_array = is_outermost_array;
 
    return opts;
 }

--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -389,13 +389,16 @@ _noop (void)
 
 
 bson_json_opts_t *
-bson_json_opts_new (bson_json_mode_t mode, int32_t max_len)
+bson_json_opts_new (bson_json_mode_t mode,
+                    int32_t max_len,
+                    bool is_outermost_array)
 {
    bson_json_opts_t *opts;
 
    opts = (bson_json_opts_t *) bson_malloc (sizeof *opts);
    opts->mode = mode;
    opts->max_len = max_len;
+   opts->is_outermost_array = is_outermost_array;
 
    return opts;
 }

--- a/src/libbson/src/bson/bson-json.h
+++ b/src/libbson/src/bson/bson-json.h
@@ -58,7 +58,9 @@ typedef enum {
 
 
 BSON_EXPORT (bson_json_opts_t *)
-bson_json_opts_new (bson_json_mode_t mode, int32_t max_len);
+bson_json_opts_new (bson_json_mode_t mode,
+                    int32_t max_len,
+                    bool is_outermost_array);
 BSON_EXPORT (void)
 bson_json_opts_destroy (bson_json_opts_t *opts);
 

--- a/src/libbson/src/bson/bson-json.h
+++ b/src/libbson/src/bson/bson-json.h
@@ -61,7 +61,9 @@ BSON_EXPORT (bson_json_opts_t *)
 bson_json_opts_new (bson_json_mode_t mode, int32_t max_len);
 BSON_EXPORT (void)
 bson_json_opts_destroy (bson_json_opts_t *opts);
-
+BSON_EXPORT (void)
+bson_json_opts_set_outermost_array (bson_json_opts_t *opts,
+                                    bool is_outermost_array);
 
 typedef ssize_t (*bson_json_reader_cb) (void *handle,
                                         uint8_t *buf,

--- a/src/libbson/src/bson/bson-json.h
+++ b/src/libbson/src/bson/bson-json.h
@@ -58,9 +58,7 @@ typedef enum {
 
 
 BSON_EXPORT (bson_json_opts_t *)
-bson_json_opts_new (bson_json_mode_t mode,
-                    int32_t max_len,
-                    bool is_outermost_array);
+bson_json_opts_new (bson_json_mode_t mode, int32_t max_len);
 BSON_EXPORT (void)
 bson_json_opts_destroy (bson_json_opts_t *opts);
 

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -3332,6 +3332,13 @@ bson_as_json_with_opts (const bson_t *bson,
       bson, length, opts->mode, opts->max_len, opts->is_outermost_array);
 }
 
+void
+bson_json_opts_set_outermost_array (bson_json_opts_t *opts,
+                                    bool is_outermost_array)
+{
+   opts->is_outermost_array = is_outermost_array;
+}
+
 
 char *
 bson_as_canonical_extended_json (const bson_t *bson, size_t *length)

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -3274,8 +3274,7 @@ _bson_as_json_visit_all (const bson_t *bson,
          *length = 3;
       }
 
-      char *res = is_outermost_array ? "[ ]" : "{ }";
-      return bson_strdup (res);
+      return bson_strdup (is_outermost_array ? "[ ]" : "{ }");
    }
 
    if (!bson_iter_init (&iter, bson)) {
@@ -3330,13 +3329,6 @@ bson_as_json_with_opts (const bson_t *bson,
 {
    return _bson_as_json_visit_all (
       bson, length, opts->mode, opts->max_len, opts->is_outermost_array);
-}
-
-void
-bson_json_opts_set_outermost_array (bson_json_opts_t *opts,
-                                    bool is_outermost_array)
-{
-   opts->is_outermost_array = is_outermost_array;
 }
 
 

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -3283,8 +3283,7 @@ _bson_as_json_visit_all (const bson_t *bson,
 
    state.count = 0;
    state.keys = !is_outermost_array;
-   state.str =
-      is_outermost_array ? bson_string_new ("[ ") : bson_string_new ("{ ");
+   state.str = bson_string_new (is_outermost_array ? "[ " : "{ ");
    state.depth = 0;
    state.err_offset = &err_offset;
    state.mode = mode;
@@ -3308,8 +3307,7 @@ _bson_as_json_visit_all (const bson_t *bson,
     */
    remaining = state.max_len - state.str->len;
    if (state.max_len == BSON_MAX_LEN_UNLIMITED || remaining > 1) {
-      is_outermost_array ? bson_string_append (state.str, " ]")
-                         : bson_string_append (state.str, " }");
+      bson_string_append (state.str, is_outermost_array ? " ]" : " }");
    } else if (remaining == 1) {
       bson_string_append (state.str, " ");
    }

--- a/src/libbson/src/bson/bson.h
+++ b/src/libbson/src/bson/bson.h
@@ -579,13 +579,6 @@ BSON_EXPORT (char *)
 bson_as_relaxed_extended_json (const bson_t *bson, size_t *length);
 
 
-/* like bson_as_json_with_opts but for outermost arrays. */
-BSON_EXPORT (char *)
-bson_array_as_json_with_opts (const bson_t *bson,
-                              size_t *length,
-                              const bson_json_opts_t *opts);
-
-
 /* like bson_as_json() but for outermost arrays. */
 BSON_EXPORT (char *) bson_array_as_json (const bson_t *bson, size_t *length);
 
@@ -593,6 +586,7 @@ BSON_EXPORT (char *) bson_array_as_json (const bson_t *bson, size_t *length);
 /* like bson_as_relaxed_extended_json() but for outermost arrays. */
 BSON_EXPORT (char *)
 bson_array_as_relaxed_extended_json (const bson_t *bson, size_t *length);
+
 
 /* like bson_as_canonical_extended_json() but for outermost arrays. */
 BSON_EXPORT (char *)

--- a/src/libbson/src/bson/bson.h
+++ b/src/libbson/src/bson/bson.h
@@ -579,10 +579,24 @@ BSON_EXPORT (char *)
 bson_as_relaxed_extended_json (const bson_t *bson, size_t *length);
 
 
-/* like bson_as_json() but for outermost arrays. */
+/* like bson_as_json_with_opts but for outermost arrays. */
 BSON_EXPORT (char *)
-bson_array_as_json (const bson_t *bson, size_t *length);
+bson_array_as_json_with_opts (const bson_t *bson,
+                              size_t *length,
+                              const bson_json_opts_t *opts);
 
+
+/* like bson_as_json() but for outermost arrays. */
+BSON_EXPORT (char *) bson_array_as_json (const bson_t *bson, size_t *length);
+
+
+/* like bson_as_relaxed_extended_json() but for outermost arrays. */
+BSON_EXPORT (char *)
+bson_array_as_relaxed_extended_json (const bson_t *bson, size_t *length);
+
+/* like bson_as_canonical_extended_json() but for outermost arrays. */
+BSON_EXPORT (char *)
+bson_array_as_canonical_extended_json (const bson_t *bson, size_t *length);
 
 BSON_EXPORT (bool)
 bson_append_value (bson_t *bson,

--- a/src/libbson/src/bson/bson.h
+++ b/src/libbson/src/bson/bson.h
@@ -517,6 +517,10 @@ bson_as_json_with_opts (const bson_t *bson,
                         size_t *length,
                         const bson_json_opts_t *opts);
 
+BSON_EXPORT (void)
+bson_json_opts_set_outermost_array (bson_json_opts_t *opts,
+                                    bool is_outermost_array);
+
 
 /**
  * bson_as_canonical_extended_json:

--- a/src/libbson/src/bson/bson.h
+++ b/src/libbson/src/bson/bson.h
@@ -517,10 +517,6 @@ bson_as_json_with_opts (const bson_t *bson,
                         size_t *length,
                         const bson_json_opts_t *opts);
 
-BSON_EXPORT (void)
-bson_json_opts_set_outermost_array (bson_json_opts_t *opts,
-                                    bool is_outermost_array);
-
 
 /**
  * bson_as_canonical_extended_json:

--- a/src/libbson/tests/test-json.c
+++ b/src/libbson/tests/test-json.c
@@ -2961,7 +2961,6 @@ test_bson_as_json_with_opts (bson_t *bson,
                              const char *expected)
 {
    bson_json_opts_t *opts = bson_json_opts_new (mode, max_len);
-   bson_json_opts_set_outermost_array (opts, false);
    size_t json_len;
    char *str = bson_as_json_with_opts (bson, &json_len, opts);
 

--- a/src/libbson/tests/test-json.c
+++ b/src/libbson/tests/test-json.c
@@ -2960,7 +2960,7 @@ test_bson_as_json_with_opts (bson_t *bson,
                              int max_len,
                              const char *expected)
 {
-   bson_json_opts_t *opts = bson_json_opts_new (mode, max_len);
+   bson_json_opts_t *opts = bson_json_opts_new (mode, max_len, false);
    size_t json_len;
    char *str = bson_as_json_with_opts (bson, &json_len, opts);
 

--- a/src/libbson/tests/test-json.c
+++ b/src/libbson/tests/test-json.c
@@ -2113,8 +2113,10 @@ test_bson_json_double (void)
    BSON_ASSERT (BSON_ITER_HOLDS_DOUBLE (&iter));
    ASSERT_CMPDOUBLE (bson_iter_double (&iter), ==, 0.0);
 
-/* check that "x" is -0.0. signbit not available on Solaris, FreeBSD, or VS 2010 */
-#if !defined(__sun) && !defined(__FreeBSD__) && (!defined(_MSC_VER) || (_MSC_VER >= 1800))
+/* check that "x" is -0.0. signbit not available on Solaris, FreeBSD, or VS 2010
+ */
+#if !defined(__sun) && !defined(__FreeBSD__) && \
+   (!defined(_MSC_VER) || (_MSC_VER >= 1800))
    BSON_ASSERT (signbit (bson_iter_double (&iter)));
 #endif
 
@@ -2672,7 +2674,7 @@ test_bson_json_timestamp (void)
 
 
 static void
-test_bson_array_as_json (void)
+test_bson_array_as_legacy_json (void)
 {
    bson_t d = BSON_INITIALIZER;
    size_t len;
@@ -2698,6 +2700,59 @@ test_bson_array_as_json (void)
    bson_destroy (&d);
 }
 
+static void
+test_bson_array_as_relaxed_json (void)
+{
+   bson_t d = BSON_INITIALIZER;
+   size_t len;
+   char *str;
+
+   str = bson_array_as_relaxed_extended_json (&d, &len);
+   ASSERT_CMPSTR (str, "[ ]");
+   ASSERT_CMPSIZE_T (len, ==, 3u);
+   bson_free (str);
+
+   BSON_APPEND_INT32 (&d, "0", 1);
+   str = bson_array_as_relaxed_extended_json (&d, &len);
+   ASSERT_CMPSTR (str, "[ 1 ]");
+   ASSERT_CMPSIZE_T (len, ==, 5u);
+   bson_free (str);
+
+   /* test corrupted bson */
+   BSON_APPEND_UTF8 (&d, "1", "\x80"); /* bad UTF-8 */
+   str = bson_array_as_relaxed_extended_json (&d, &len);
+   BSON_ASSERT (!str);
+   BSON_ASSERT (!len);
+
+   bson_destroy (&d);
+}
+
+static void
+test_bson_array_as_canonical_json (void)
+{
+   bson_t d = BSON_INITIALIZER;
+   size_t len;
+   char *str;
+
+   str = bson_array_as_canonical_extended_json (&d, &len);
+   ASSERT_CMPSTR (str, "[ ]");
+   ASSERT_CMPSIZE_T (len, ==, 3u);
+   bson_free (str);
+
+   BSON_APPEND_INT32 (&d, "0", 1);
+   str = bson_array_as_canonical_extended_json (&d, &len);
+   ASSERT_CMPSTR (str, "[ { \"$numberInt\" : \"1\" } ]");
+   ASSERT_CMPSIZE_T (len, ==, 26u);
+   bson_free (str);
+
+   /* test corrupted bson */
+   BSON_APPEND_UTF8 (&d, "1", "\x80"); /* bad UTF-8 */
+   str = bson_array_as_canonical_extended_json (&d, &len);
+   BSON_ASSERT (!str);
+   BSON_ASSERT (!len);
+
+   bson_destroy (&d);
+}
 
 static void
 test_bson_as_json_spacing (void)
@@ -3486,7 +3541,13 @@ test_json_install (TestSuite *suite)
    TestSuite_Add (
       suite, "/bson/as_json/corrupt_binary", test_bson_corrupt_binary);
    TestSuite_Add (suite, "/bson/as_json_spacing", test_bson_as_json_spacing);
-   TestSuite_Add (suite, "/bson/array_as_json", test_bson_array_as_json);
+   TestSuite_Add (
+      suite, "/bson/array_as_legacy_json", test_bson_array_as_legacy_json);
+   TestSuite_Add (
+      suite, "/bson/array_as_relaxed_json", test_bson_array_as_relaxed_json);
+   TestSuite_Add (suite,
+                  "/bson/array_as_canonical_json",
+                  test_bson_array_as_canonical_json);
    TestSuite_Add (
       suite, "/bson/json/allow_multiple", test_bson_json_allow_multiple);
    TestSuite_Add (

--- a/src/libbson/tests/test-json.c
+++ b/src/libbson/tests/test-json.c
@@ -2960,7 +2960,8 @@ test_bson_as_json_with_opts (bson_t *bson,
                              int max_len,
                              const char *expected)
 {
-   bson_json_opts_t *opts = bson_json_opts_new (mode, max_len, false);
+   bson_json_opts_t *opts = bson_json_opts_new (mode, max_len);
+   bson_json_opts_set_outermost_array (opts, false);
    size_t json_len;
    char *str = bson_as_json_with_opts (bson, &json_len, opts);
 


### PR DESCRIPTION
- Added functions to `bson_array_as_json` to mimic the functionality of `bson_as_json` and allow for legacy, relaxed, and canonical json output
- Added a new option to `bson_json_opts_t` to specify if the BSON is an outermost array
- Added a function to set this new option as we cannot change the `bson_json_opts_t` initializer
- Included necessary additional tests
- Tested in conjunction with https://github.com/mongodb/mongo-cxx-driver/pull/976