### PR TITLE
remove unnecessary cmake version checks

### DIFF
--- a/build/cmake/MongoC-Warnings.cmake
+++ b/build/cmake/MongoC-Warnings.cmake
@@ -57,14 +57,7 @@ function (mongoc_add_platform_compile_options)
    endforeach ()
 endfunction ()
 
-if (CMAKE_VERSION VERSION_LESS 3.3)
-   # On older CMake versions, we'll just always pass the warning options, even
-   # if the generate warnings for the C++ check file
-   set (is_c_lang "1")
-else ()
-   # $<COMPILE_LANGUAGE> is only valid in CMake 3.3+
-   set (is_c_lang "$<COMPILE_LANGUAGE:C>")
-endif ()
+set (is_c_lang "$<COMPILE_LANGUAGE:C>")
 
 # These below warnings should always be unconditional hard errors, as the code is
 # almost definitely broken

--- a/build/cmake/make_dist/MakeDist.cmake
+++ b/build/cmake/make_dist/MakeDist.cmake
@@ -17,9 +17,7 @@ include (MakeDistFiles)
 function (MAKE_DIST PACKAGE_PREFIX MONGOC_SOURCE_DIR BUILD_SOURCE_DIR)
 
    set (CMAKE_COMMAND_TMP "")
-   if (${CMAKE_VERSION} VERSION_GREATER 3.1)
-      set (CMAKE_COMMAND_TMP ${CMAKE_COMMAND} -E env)
-   endif ()
+   set (CMAKE_COMMAND_TMP ${CMAKE_COMMAND} -E env)
 
    # -- Remove any existing packaging directory.
 

--- a/build/cmake/make_dist/MakeDistCheck.cmake
+++ b/build/cmake/make_dist/MakeDistCheck.cmake
@@ -17,9 +17,7 @@ function (RUN_DIST_CHECK PACKAGE_PREFIX EXT)
    endif ()
 
    set (MY_CMAKE_COMMAND "")
-   if (${CMAKE_VERSION} VERSION_GREATER 3.1)
-      set (MY_CMAKE_COMMAND ${CMAKE_COMMAND} -E env)
-   endif ()
+   set (MY_CMAKE_COMMAND ${CMAKE_COMMAND} -E env)
 
    find_program (MAKE_COMMAND NAMES make gmake)
    if (${MAKE_COMMAND} STREQUAL "MAKE_COMMAND-NOTFOUND")

--- a/build/cmake/make_dist/MakeDistCheck.cmake
+++ b/build/cmake/make_dist/MakeDistCheck.cmake
@@ -16,7 +16,6 @@ function (RUN_DIST_CHECK PACKAGE_PREFIX EXT)
       set (TAR_OPTION "jxf")
    endif ()
 
-   set (MY_CMAKE_COMMAND "")
    set (MY_CMAKE_COMMAND ${CMAKE_COMMAND} -E env)
 
    find_program (MAKE_COMMAND NAMES make gmake)

--- a/build/cmake/make_dist/MakeDistFiles.cmake
+++ b/build/cmake/make_dist/MakeDistFiles.cmake
@@ -1,8 +1,3 @@
-
-if (${CMAKE_VERSION} VERSION_LESS 3.5)
-   include (CMakeParseArguments)
-endif ()
-
 function (SET_LOCAL_DIST output)
    set (dist_files "")
    foreach (file ${ARGN})

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -136,11 +136,7 @@ if (NOT ENABLE_ZSTD STREQUAL OFF)
 
       include_directories (${ZSTD_INCLUDE_DIRS})
       link_directories (${ZSTD_LIBRARY_DIRS})
-      if (${CMAKE_VERSION} VERSION_LESS "3.12.0")
-         set (MONGOC_ZSTD_LIBRARIES ${ZSTD_LIBRARIES})
-      else ()
-         set (MONGOC_ZSTD_LIBRARIES ${ZSTD_LINK_LIBRARIES})
-      endif ()
+      set (MONGOC_ZSTD_LIBRARIES ${ZSTD_LINK_LIBRARIES})
    endif()
 endif()
 
@@ -195,11 +191,6 @@ if (NOT ENABLE_SSL STREQUAL OFF)
 endif ()
 
 if (OPENSSL_FOUND)
-   if (WIN32 AND OPENSSL_VERSION VERSION_GREATER 1.1 AND
-         ${CMAKE_VERSION} VERSION_LESS 3.7)
-      message (FATAL_ERROR "Building against OpenSSL 1.1.0 and later requires CMake 3.7 or later (hint:"
-         " You can also compile against Windows Secure Transport with -DENABLE_SSL=WINDOWS")
-   endif ()
    if (APPLE AND NOT OPENSSL_ROOT_DIR)
       message (WARNING "Building with OpenSSL but OPENSSL_ROOT_DIR not defined. If build fails to link"
          " to OpenSSL, define OPENSSL_ROOT_DIR as the path to the OpenSSL installation directory.")

--- a/src/libmongoc/doc/advanced-connections.rst
+++ b/src/libmongoc/doc/advanced-connections.rst
@@ -164,7 +164,7 @@ data (if possible), but the server might still reply using ``snappy``,
 depending on how the server was configured.
 
 The driver must be built with zlib and/or snappy and/or zstd support to enable compression
-support, any unknown (or not compiled in) compressor value will be ignored. Note: to build with zstd requires cmake 3.12 or higher.
+support, any unknown (or not compiled in) compressor value will be ignored.
 
 Additional Connection Options
 -----------------------------


### PR DESCRIPTION
# Summary
Remove unnecessary cmake version checks.

# Background & Motivation
As of 3165a356473a1d50d1142d7071bd46bb5bb81c2a the minimum required cmake version has increased to 3.15. This PR removes cmake version checks and documentation that assumes older cmake versions could be used.
