### PR TITLE
Export a va_list version of mongoc_log as mongoc_vlog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,20 @@ if(ENABLE_MAINTAINER_FLAGS)
 
    if (NOT ((CMAKE_C_COMPILER_ID STREQUAL "Clang") OR (CMAKE_C_COMPILER_ID STREQUAL "AppleClang")))
       # Clang throws a false positive warning for the function mongoc_vlog while GCC does not
+      #
+      # The following trick which was done for mongoc_log only works for varargs and does not
+      # work for a va_list function, i.e., the trick below results in the following error:
+      #
+      # MONGOC_EXPORT (void)
+      # mongoc_vlog (mongoc_log_level_t log_level,
+      #              const char *log_domain,
+      #              const char *format,
+      #              va_list args) __attribute__ ((format (printf, 3, 4)));
+      #
+      # error:
+      # /mongo-c-driver/src/libmongoc/src/mongoc/mongoc-log.h:105:1: error: format attribute requires variadic function
+      # mongoc_vlog (mongoc_log_level_t log_level,
+      # ^
       mongoc_add_warning_options(gnu-like:-Wformat-nonliteral)
    endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,7 +244,6 @@ if(ENABLE_MAINTAINER_FLAGS)
       gnu-like:-Wempty-body
       gnu:not-gcc-lt7:-Wexpansion-to-defined
       gnu-like:-Wformat
-      gnu-like:-Wformat-nonliteral
       gnu-like:-Wformat-security
       gnu-like:-Winit-self
       gnu-like:-Wmissing-include-dirs
@@ -258,6 +257,11 @@ if(ENABLE_MAINTAINER_FLAGS)
       # Disabled, for now:
       gnu-like:-Wno-strict-aliasing
    )
+
+   if (NOT ((CMAKE_C_COMPILER_ID STREQUAL "Clang") OR (CMAKE_C_COMPILER_ID STREQUAL "AppleClang")))
+      # Clang throws a false positive warning for the function mongoc_vlog while GCC does not
+      mongoc_add_warning_options(gnu-like:-Wformat-nonliteral)
+   endif()
 endif()
 
 # Enable CCache, if possible

--- a/src/libmongoc/src/mongoc/mongoc-log.h
+++ b/src/libmongoc/src/mongoc/mongoc-log.h
@@ -90,6 +90,30 @@ mongoc_log_set_handler (mongoc_log_func_t log_func, void *user_data);
  * @log_domain: The log domain (such as "client").
  * @format: The format string for the log message.
  *
+ * This function differs from `mongoc_log` only in that it takes a va_list as an
+ * argument rather than being a variable arg function. `mongoc_log` is a wrapper
+ * calling this function.
+ *
+ * Logs a message using the currently configured logger.
+ *
+ * This method will hold a logging lock to prevent concurrent calls to the
+ * logging infrastructure. It is important that your configured log function
+ * does not re-enter the logging system or deadlock will occur.
+ *
+ */
+MONGOC_EXPORT (void)
+mongoc_vlog (mongoc_log_level_t log_level,
+             const char *log_domain,
+             const char *format,
+             va_list args);
+
+
+/**
+ * mongoc_log:
+ * @log_level: The log level.
+ * @log_domain: The log domain (such as "client").
+ * @format: The format string for the log message.
+ *
  * Logs a message using the currently configured logger.
  *
  * This method will hold a logging lock to prevent concurrent calls to the


### PR DESCRIPTION
The C++ driver's libmongoc namespace mocking system doesn't play well with varargs.

Adding a `va_list` variant of the `mongoc_log` function allows one to wrap this function in the C++ driver.

This pattern of having a var args function call a va_list function is a common pattern in C. For example, every major libc implementation follows this pattern for printf, see below:
- [GNU libc](https://github.com/lattera/glibc/blob/master/stdio-common/printf.c)
- [musl libc](http://git.musl-libc.org/cgit/musl/tree/src/stdio/printf.c)
- [FreeBSD](https://github.com/freebsd/freebsd-src/blob/main/lib/libc/stdio/printf.c)
- [OpenBSD](https://github.com/openbsd/src/blob/master/lib/libc/stdio/printf.c)

The naming convention of `mongoc_vlog` is consistent with the C standard library naming with `vprintf` being the `va_list` form of `printf`.