### PR TITLE
CDRIVER-4694 calculate payload length for kms_request_append_payload()

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
@@ -1242,7 +1242,7 @@ _client_second (mongoc_cluster_t *cluster,
       AUTH_ERROR_AND_FAIL ("Failed to parse server nonce");
    }
 
-   if (!kms_request_append_payload (request, body, -1)) {
+   if (!kms_request_append_payload (request, body, strlen(body))) {
       AUTH_ERROR_AND_FAIL ("Failed to append payload");
    }
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-4694

This fixes an assert failure during MONGODB-AWS auth when an application is bundled with both libmongoc and libmongocrypt, and libmongocrypt's KMS library is used.

---

Note: this is pending test with the PHP driver. I'll follow up once I confirm it resolves the issue.