### PR TITLE
CDRIVER-3008 fix possible leak in `run_json_general_test`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -296,7 +296,12 @@ Specification tests may be filtered by their description:
 
 * `MONGOC_JSON_SUBTEST=<string>`
 
-This can be useful in debugging a specific test case in a spec test file with multiple tests.
+This can be useful in debugging a specific test case in a spec test file with multiple tests. Example:
+
+```sh
+MONGOC_JSON_SUBTEST="Insert with randomized encryption, then find it" \
+  ./cmake-build/src/libmongoc/test-libmongoc -l "/client_side_encryption/legacy/basic"
+```
 
 To test with a declared API version, you can pass the API version using an environment variable:
 

--- a/src/libmongoc/tests/json-test.c
+++ b/src/libmongoc/tests/json-test.c
@@ -1824,6 +1824,7 @@ run_json_general_test (const json_test_config_t *config)
          bson_free (selected_test);
          continue;
       }
+      bson_free (selected_test);
 
       if (bson_has_field (&test, "skipReason")) {
          fprintf (stderr,
@@ -1861,8 +1862,6 @@ run_json_general_test (const json_test_config_t *config)
             continue;
          }
       }
-
-      bson_free (selected_test);
 
       uri = (config->uri_str != NULL) ? mongoc_uri_new (config->uri_str)
                                       : test_framework_get_uri ();


### PR DESCRIPTION
# Summary

- fix possible leak in `run_json_general_test`
- document example use of `MONGOC_JSON_SUBTEST`


# Background & Motivation

CDRIVER-3008 includes the reported leak discovered by Coverity. The leak can be reproduced with:
```
export MONGOC_JSON_SUBTEST="Aggregate with deterministic encryption"
./cmake-build/src/libmongoc/test-libmongoc -d --no-fork -l "/client_side_encryption/legacy/aggregate"
```

LSan reports:
```
==52500==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 40 byte(s) in 1 object(s) allocated from:
    #0 0x102f515b0 in wrap_malloc+0x8c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x515b0) (BuildId: 2d3005610c2a36e7a5269cbe22ab009f32000000200000000100000000000b00)
    #1 0x100fb4c90 in bson_malloc bson-memory.c:100
    #2 0x100fd6508 in bson_strdup bson-string.c:331
    #3 0x10087c818 in _mongoc_getenv mongoc-util.c:683
    #4 0x100a13f08 in test_framework_getenv test-libmongoc.c:264
    #5 0x1009e4890 in run_json_general_test json-test.c:1819
    #6 0x100f18840 in test_client_side_encryption_cb test-mongoc-client-side-encryption.c:108
    #7 0x100eb3e7c in TestSuite_RunTest TestSuite.c:648
    #8 0x100eb19dc in TestSuite_RunAll TestSuite.c:1094
    #9 0x100eb0888 in TestSuite_Run TestSuite.c:1139
    #10 0x100607680 in main test-libmongoc-main.c:157
    #11 0x101df1088 in start+0x204 (dyld:arm64+0x5088) (BuildId: a2ee361189123e1dbf8bfed54862d4c932000000200000000100000000060c00)
    #12 0x902efffffffffffc  (<unknown module>)
```