### PR TITLE
CDRIVER-4679 Prefer XSI-compliant strerror_r when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,7 +394,7 @@ endif ()
 # Enable POSIX features up to POSIX.1-2008 plus the XSI extension and BSD-derived definitions.
 # Both _BSD_SOURCE and _DEFAULT_SOURCE are defined for backwards-compatibility with glibc 2.19 and earlier.
 # _BSD_SOURCE and _DEFAULT_SOURCE are required by `getpagesize`, `h_errno`, etc.
-# _XOPEN_SOURCE=700 is required by `strnlen`, etc.
+# _XOPEN_SOURCE=700 is required by `strnlen`, `strerror_r`, etc.
 add_definitions (-D_XOPEN_SOURCE=700 -D_BSD_SOURCE -D_DEFAULT_SOURCE)
 list (APPEND CMAKE_REQUIRED_DEFINITIONS -D_XOPEN_SOURCE=700 -D_BSD_SOURCE -D_DEFAULT_SOURCE)
 

--- a/src/libbson/CMakeLists.txt
+++ b/src/libbson/CMakeLists.txt
@@ -120,16 +120,17 @@ else ()
 endif ()
 
 # 1. Normally, `defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 600` should be enough
-#    to detect if XSI-compliant strerror_r is available.
-# 2. However, GNU provides an incompatible strerror_r as an extension, requiring
-#    an additional test for `defined(_GNU_SOURCE)`.
+#    to detect if an XSI-compliant `strerror_r` is available.
+# 2. However, GNU provides an incompatible `strerror_r` as an extension,
+#    requiring an additional test for `!defined(_GNU_SOURCE)`.
 # 3. However, musl does not support the GNU extension even when `_GNU_SOURCE` is
-#    defined, preventing `defined(_GNU_SOURCE)` as a XSI-compliance test.
+#    defined, preventing `!defined(_GNU_SOURCE)` from being a portable
+#    XSI-compliance test.
 # 4. However, musl does not provide a feature test macro to detect compilation
 #    with musl, and workarounds that use internal glibc feature test macros such
-#    as `__USE_GNU` are explicitly forbidden by glibc documentation.
-# 5. Therefore, give up on using feature test macros: instead, use
-#    CheckCSourceCompiles to test if the current `strerror_r` is XSI-compliant.
+#    as `defined(__USE_GNU)` are explicitly forbidden by glibc documentation.
+# 5. Therefore, give up on using feature test macros: use `CheckCSourceCompiles`
+#    to test if the current `strerror_r` is XSI-compliant if present.
 if (NOT WIN32)
    CHECK_C_SOURCE_COMPILES(
       [[

--- a/src/libbson/CMakeLists.txt
+++ b/src/libbson/CMakeLists.txt
@@ -14,12 +14,14 @@ include (MongoC-Warnings)
 
 set (BSON_OUTPUT_BASENAME "bson" CACHE STRING "Output bson library base name")
 
+include (CheckCSourceCompiles)
 include (CheckFunctionExists)
 include (CheckIncludeFile)
+include (CheckIncludeFiles)
 include (CheckStructHasMember)
 include (CheckSymbolExists)
-include (TestBigEndian)
 include (InstallRequiredSystemLibraries)
+include (TestBigEndian)
 
 set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/build/cmake)
 
@@ -83,8 +85,6 @@ else ()
    set (BSON_OS 1)
 endif ()
 
-include (CheckIncludeFiles)
-
 CHECK_INCLUDE_FILE (strings.h BSON_HAVE_STRINGS_H)
 if (NOT BSON_HAVE_STRINGS_H)
    set (BSON_HAVE_STRINGS_H 0)
@@ -117,6 +117,37 @@ if (BSON_BIG_ENDIAN)
    set (BSON_BYTE_ORDER 4321)
 else ()
    set (BSON_BYTE_ORDER 1234)
+endif ()
+
+# 1. Normally, `defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 600` should be enough
+#    to detect if XSI-compliant strerror_r is available.
+# 2. However, GNU provides an incompatible strerror_r as an extension, requiring
+#    an additional test for `defined(_GNU_SOURCE)`.
+# 3. However, musl does not support the GNU extension even when `_GNU_SOURCE` is
+#    defined, preventing `defined(_GNU_SOURCE)` as a XSI-compliance test.
+# 4. However, musl does not provide a feature test macro to detect compilation
+#    with musl, and workarounds that use internal glibc feature test macros such
+#    as `__USE_GNU` are explicitly forbidden by glibc documentation.
+# 5. Therefore, give up on using feature test macros: instead, use
+#    CheckCSourceCompiles to test if the current `strerror_r` is XSI-compliant.
+if (NOT WIN32)
+   CHECK_C_SOURCE_COMPILES(
+      [[
+         #include <string.h>
+         int test(int errnum, char *buf, size_t buflen) {
+            return strerror_r (errnum, buf, buflen);
+         }
+         int main(void) {}
+      ]]
+      BSON_HAVE_XSI_STRERROR_R
+      FAIL_REGEX "int-conversion"
+   )
+endif ()
+
+if (BSON_HAVE_XSI_STRERROR_R)
+   set(BSON_HAVE_XSI_STRERROR_R 1)
+else()
+   set(BSON_HAVE_XSI_STRERROR_R 0)
 endif ()
 
 configure_file (

--- a/src/libbson/src/bson/bson-config.h.in
+++ b/src/libbson/src/bson/bson-config.h.in
@@ -122,4 +122,13 @@
 # undef BSON_HAVE_STRLCPY
 #endif
 
+
+/*
+ * Define to 1 if you have an XSI-compliant strerror_r on your platform.
+ */
+#define BSON_HAVE_XSI_STRERROR_R @BSON_HAVE_XSI_STRERROR_R@
+#if BSON_HAVE_XSI_STRERROR_R != 1
+# undef BSON_HAVE_XSI_STRERROR_R
+#endif
+
 #endif /* BSON_CONFIG_H */

--- a/src/libbson/src/bson/bson-error.c
+++ b/src/libbson/src/bson/bson-error.c
@@ -109,14 +109,11 @@ bson_strerror_r (int err_code,  /* IN */
    if (strerror_s (buf, buflen, err_code) != 0) {
       ret = buf;
    }
-#elif defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 600 && !defined(_GNU_SOURCE)
-   // The presence of _GNU_SOURCE determines whether the POSIX
-   // XSI-conforming version or the GNU extension is available.
+#elif defined(BSON_HAVE_XSI_STRERROR_R)
    if (strerror_r (err_code, buf, buflen) == 0) {
       ret = buf;
    }
 #elif defined(_GNU_SOURCE)
-   // Fallback to GNU extension.
    ret = strerror_r (err_code, buf, buflen);
 #else
    #error "Unable to find a supported strerror_r candidate"

--- a/src/libbson/src/bson/bson-error.c
+++ b/src/libbson/src/bson/bson-error.c
@@ -109,12 +109,17 @@ bson_strerror_r (int err_code,  /* IN */
    if (strerror_s (buf, buflen, err_code) != 0) {
       ret = buf;
    }
-#elif defined(__GNUC__) && defined(_GNU_SOURCE)
-   ret = strerror_r (err_code, buf, buflen);
-#else /* XSI strerror_r */
+#elif defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 600 && !defined(_GNU_SOURCE)
+   // The presence of _GNU_SOURCE determines whether the POSIX
+   // XSI-conforming version or the GNU extension is available.
    if (strerror_r (err_code, buf, buflen) == 0) {
       ret = buf;
    }
+#elif defined(_GNU_SOURCE)
+   // Fallback to GNU extension.
+   ret = strerror_r (err_code, buf, buflen);
+#else
+   #error "Unable to find a supported strerror_r candidate"
 #endif
 
    if (!ret) {


### PR DESCRIPTION
Attempts to resolve CDRIVER-4679 by preferring the XSI-compliant version of `strerror_r` when available by using a more accurate feature test macros condition. The GNU extension is used as a fallback instead. An additional `#error` was added to hopefully improve the resulting compilation error if a supported `strerror_r` implementation cannot be found.

Verified by [this patch](https://spruce.mongodb.com/version/64b8210ac9ec44c255145475). Note: _not_ yet verified on Alpine Linux as described in CDRIVER-4679 as the corresponding EVG distro is not available, so not entirely confident this actually addresses the originally reported issue.