### PR TITLE
CDRIVER-2928 assert returned values of `bson_init_static`

### DIFF
--- a/src/libbson/src/bson/bson-dsl.h
+++ b/src/libbson/src/bson/bson-dsl.h
@@ -613,7 +613,7 @@ BSON_IF_GNU_LIKE (_Pragma ("GCC diagnostic ignored \"-Wshadow\""))
          break;                                                                \
       }                                                                        \
       bson_t inner;                                                            \
-      bson_init_static (&inner, data, len);                                    \
+      BSON_ASSERT (bson_init_static (&inner, data, len));                      \
       _bsonVisitEach (inner, __VA_ARGS__);                                     \
    } while (0);                                                                \
    _bsonDSL_end
@@ -633,7 +633,7 @@ BSON_IF_GNU_LIKE (_Pragma ("GCC diagnostic ignored \"-Wshadow\""))
          break;                                                           \
       }                                                                   \
       bson_t inner;                                                       \
-      bson_init_static (&inner, data, len);                               \
+      BSON_ASSERT (bson_init_static (&inner, data, len));                 \
       _bsonParse (inner, __VA_ARGS__);                                    \
    } while (0);
 
@@ -1072,7 +1072,7 @@ _bson_dsl_iter_as_doc (bson_t *into, const bson_iter_t *it)
       bson_iter_document (it, &len, &dataptr);
    }
    if (dataptr) {
-      bson_init_static (into, dataptr, len);
+      BSON_ASSERT (bson_init_static (into, dataptr, len));
    }
 }
 

--- a/src/libbson/src/bson/bson-dsl.h
+++ b/src/libbson/src/bson/bson-dsl.h
@@ -22,10 +22,10 @@ enum {
 };
 
 #define _bson_thread_local \
-   BSON_IF_GNU_LIKE (__thread) BSON_IF_MSVC (__declspec(thread))
+   BSON_IF_GNU_LIKE (__thread) BSON_IF_MSVC (__declspec (thread))
 
-#define _bson_comdat                       \
-   BSON_IF_WINDOWS (__declspec(selectany)) \
+#define _bson_comdat                        \
+   BSON_IF_WINDOWS (__declspec (selectany)) \
    BSON_IF_POSIX (__attribute__ ((weak)))
 
 #ifdef __GNUC__
@@ -89,7 +89,7 @@ BSON_IF_GNU_LIKE (_Pragma ("GCC diagnostic ignored \"-Wshadow\""))
 #define _bsonDSL_end   \
    --_bson_dsl_indent; \
    }                   \
-   else((void) 0)
+   else ((void) 0)
 
 /**
  * @brief Expands to a call to bson_append_{Kind}, with the three first
@@ -286,7 +286,7 @@ BSON_IF_GNU_LIKE (_Pragma ("GCC diagnostic ignored \"-Wshadow\""))
    const bool _bvHalt = false; /* Required for _bsonVisitEach() */           \
    _bsonVisitEach (                                                          \
       OtherBSON,                                                             \
-      if (Pred, then (do(_bsonDocOperation_iterElement (bsonVisitIter)))));  \
+      if (Pred, then (do (_bsonDocOperation_iterElement (bsonVisitIter))))); \
    _bsonDSL_end
 
 #define _bsonDocOperation_insertFromIter(Iter, Pred)                   \
@@ -312,16 +312,16 @@ BSON_IF_GNU_LIKE (_Pragma ("GCC diagnostic ignored \"-Wshadow\""))
 
 /// Insert the given BSON document into the parent array. Keys of the given
 /// document are discarded and it is treated as an array of values.
-#define _bsonArrayOperation_insert(OtherArr, Pred)                          \
-   _bsonDSL_begin ("Insert other array: [%s]", _bsonDSL_str (OtherArr));    \
-   _bsonVisitEach (                                                         \
-      OtherArr,                                                             \
-      if (Pred, then (do(_bsonArrayOperation_iterValue (bsonVisitIter))))); \
+#define _bsonArrayOperation_insert(OtherArr, Pred)                           \
+   _bsonDSL_begin ("Insert other array: [%s]", _bsonDSL_str (OtherArr));     \
+   _bsonVisitEach (                                                          \
+      OtherArr,                                                              \
+      if (Pred, then (do (_bsonArrayOperation_iterValue (bsonVisitIter))))); \
    _bsonDSL_end
 
 #define _bsonArrayAppendValue(ValueOperation)               \
    _bsonDSL_begin ("[%d] => [%s]",                          \
-                  (int) bsonBuildContext.index,                  \
+                   (int) bsonBuildContext.index,            \
                    _bsonDSL_strElide (30, ValueOperation)); \
    /* Set the doc key to the array index as a string: */    \
    _bsonBuild_setKeyToArrayIndex (bsonBuildContext.index);  \
@@ -396,9 +396,11 @@ BSON_IF_GNU_LIKE (_Pragma ("GCC diagnostic ignored \"-Wshadow\""))
       _bsonValueOperationIf_##Else;                                     \
    }
 
-#define _bsonBuild_setKeyToArrayIndex(Idx)                                    \
-   _bbCtx.key_len = bson_snprintf (                                           \
-      _bbCtx.index_key_str, sizeof _bbCtx.index_key_str, "%d",(int) _bbCtx.index); \
+#define _bsonBuild_setKeyToArrayIndex(Idx)                      \
+   _bbCtx.key_len = bson_snprintf (_bbCtx.index_key_str,        \
+                                   sizeof _bbCtx.index_key_str, \
+                                   "%d",                        \
+                                   (int) _bbCtx.index);         \
    _bbCtx.key = _bbCtx.index_key_str
 
 /// Handle an element of array()
@@ -716,19 +718,19 @@ BSON_IF_GNU_LIKE (_Pragma ("GCC diagnostic ignored \"-Wshadow\""))
    (NthInt < _bpNumVisitBitInts &&              \
     (_bpVisitBits[NthInt] & (UINT64_C (1) << NthBit)))
 
-#define _bsonParseOperation_find(Predicate, ...)                   \
-   _bsonDSL_begin ("find(%s)", _bsonDSL_str (Predicate));          \
-   _bpFoundElement = false;                                        \
-   _bsonVisitEach (                                                \
-      *_bpDoc,                                                     \
-      if (Predicate,                                               \
-          then (do(_bsonParseMarkVisited (bsonVisitContext.index); \
-                   _bpFoundElement = true),                        \
-                __VA_ARGS__,                                       \
-                break)));                                          \
-   if (!_bpFoundElement && !bsonParseError) {                      \
-      _bsonDSLDebug ("[not found]");                               \
-   }                                                               \
+#define _bsonParseOperation_find(Predicate, ...)                    \
+   _bsonDSL_begin ("find(%s)", _bsonDSL_str (Predicate));           \
+   _bpFoundElement = false;                                         \
+   _bsonVisitEach (                                                 \
+      *_bpDoc,                                                      \
+      if (Predicate,                                                \
+          then (do (_bsonParseMarkVisited (bsonVisitContext.index); \
+                    _bpFoundElement = true),                        \
+                __VA_ARGS__,                                        \
+                break)));                                           \
+   if (!_bpFoundElement && !bsonParseError) {                       \
+      _bsonDSLDebug ("[not found]");                                \
+   }                                                                \
    _bsonDSL_end
 
 #define _bsonParseOperation_require(Predicate, ...)                      \
@@ -737,8 +739,8 @@ BSON_IF_GNU_LIKE (_Pragma ("GCC diagnostic ignored \"-Wshadow\""))
    _bsonVisitEach (                                                      \
       *_bpDoc,                                                           \
       if (Predicate,                                                     \
-          then (do(_bsonParseMarkVisited (bsonVisitContext.index);       \
-                   _bpFoundElement = true),                              \
+          then (do (_bsonParseMarkVisited (bsonVisitContext.index);      \
+                    _bpFoundElement = true),                             \
                 __VA_ARGS__,                                             \
                 break)));                                                \
    if (!_bpFoundElement && !bsonParseError) {                            \
@@ -1140,7 +1142,7 @@ _bson_dsl_dupPath (char **into)
       char *prev = acc;
       if (ctx->parent && BSON_ITER_HOLDS_ARRAY (&ctx->parent->iter)) {
          // We're an array element
-         acc = bson_strdup_printf ("[%d]%s", (int)ctx->index, prev);
+         acc = bson_strdup_printf ("[%d]%s", (int) ctx->index, prev);
       } else {
          // We're a document element
          acc = bson_strdup_printf (".%s%s", bson_iter_key (&ctx->iter), prev);

--- a/src/libbson/tests/test-bson.c
+++ b/src/libbson/tests/test-bson.c
@@ -2519,7 +2519,7 @@ static void
 test_bson_dsl_parse (void)
 {
    // Do nothing:
-   bsonParse (*TMP_BSON_FROM_JSON ({}), do());
+   bsonParse (*TMP_BSON_FROM_JSON ({}), do ());
    BSON_ASSERT (!bsonParseError);
 
    // Generate an error
@@ -2527,13 +2527,13 @@ test_bson_dsl_parse (void)
    ASSERT_CMPSTR (bsonParseError, "failed 1");
 
    // Error is reset on each entry
-   bsonParse (*TMP_BSON_FROM_JSON ({}), do());
+   bsonParse (*TMP_BSON_FROM_JSON ({}), do ());
    BSON_ASSERT (!bsonParseError);
 
    // Find an element
    bson_t *simple_foo_bar = TMP_BSON_FROM_JSON ({"foo" : "bar"});
    bool found = false;
-   bsonParse (*simple_foo_bar, find (key ("foo"), do(found = true)));
+   bsonParse (*simple_foo_bar, find (key ("foo"), do (found = true)));
    BSON_ASSERT (found);
 
    // Store a reference to the string
@@ -2545,16 +2545,16 @@ test_bson_dsl_parse (void)
    found = false;
    bool not_found = false;
    bsonParse (*simple_foo_bar,
-              find (key ("bad"), do(found = true)),
-              else(do(not_found = true)));
+              find (key ("bad"), do (found = true)),
+              else (do (not_found = true)));
    BSON_ASSERT (!found);
    BSON_ASSERT (not_found);
 
    // We can find two items
    int32_t a = 0, b = 0;
    bsonParse (*TMP_BSON_FROM_JSON ({"foo" : 1729, "bar" : 42}),
-              find (key ("foo"), do(a = bsonAs (int32))),
-              find (key ("bar"), do(b = bsonAs (int32))));
+              find (key ("foo"), do (a = bsonAs (int32))),
+              find (key ("bar"), do (b = bsonAs (int32))));
    ASSERT_CMPINT (a, ==, 1729);
    ASSERT_CMPINT (b, ==, 42);
 
@@ -2562,7 +2562,7 @@ test_bson_dsl_parse (void)
    a = 91;
    found = false;
    bsonParse (*TMP_BSON_FROM_JSON ({"foo" : "string"}),
-              find (key ("foo"), do(found = true; a = bsonAs (int32))));
+              find (key ("foo"), do (found = true; a = bsonAs (int32))));
    BSON_ASSERT (found);
    ASSERT_CMPINT (a, ==, 0);
 
@@ -2570,7 +2570,7 @@ test_bson_dsl_parse (void)
    found = false;
    bsonParse (*TMP_BSON_FROM_JSON ({"foo" : null, "bar" : null}),
               find (key ("foo"), error ("got foo")),
-              find (key ("bar"), do(found = true)));
+              find (key ("bar"), do (found = true)));
    ASSERT_CMPSTR (bsonParseError, "got foo");
    BSON_ASSERT (!found);
 
@@ -2578,7 +2578,7 @@ test_bson_dsl_parse (void)
    found = false;
    bsonParse (*TMP_BSON_FROM_JSON ({"foo" : null, "bar" : null}),
               find (key ("foo"), halt),
-              find (key ("bar"), do(found = true)));
+              find (key ("bar"), do (found = true)));
    BSON_ASSERT (!bsonParseError);
    BSON_ASSERT (!found);
 
@@ -2587,14 +2587,14 @@ test_bson_dsl_parse (void)
    b = 0;
    bsonParse (*TMP_BSON_FROM_JSON ({"foo" : 1, "bar" : 2}),
               if (a == 812,
-                  then (find (key ("foo"), do(b = bsonAs (int32)))),
-                  else(find (key ("bar"), do(b = bsonAs (int32))))));
+                  then (find (key ("foo"), do (b = bsonAs (int32)))),
+                  else (find (key ("bar"), do (b = bsonAs (int32))))));
    ASSERT_CMPINT (b, ==, 1);
    a = 4;
    bsonParse (*TMP_BSON_FROM_JSON ({"foo" : 1, "bar" : 2}),
               if (a == 812,
-                  then (find (key ("foo"), do(b = bsonAs (int32)))),
-                  else(find (key ("bar"), do(b = bsonAs (int32))))));
+                  then (find (key ("foo"), do (b = bsonAs (int32)))),
+                  else (find (key ("bar"), do (b = bsonAs (int32))))));
    ASSERT_CMPINT (b, ==, 2);
 
    bson_t tmp = BSON_INITIALIZER;
@@ -2603,7 +2603,7 @@ test_bson_dsl_parse (void)
    }
    BSON_APPEND_BOOL (&tmp, "final", true);
    int unvisited = 0;
-   bsonParse (tmp, find (key ("final"), nop), visitOthers (do(++unvisited)));
+   bsonParse (tmp, find (key ("final"), nop), visitOthers (do (++unvisited)));
    ASSERT_CMPINT (unvisited, ==, 1024);
    bson_destroy (&tmp);
 }
@@ -2613,15 +2613,15 @@ test_bson_dsl_visit (void)
 {
    // Count elements
    int count = 0;
-   bsonVisitEach (*TMP_BSON_FROM_JSON ({"foo" : 1, "bar" : 1}), do(++count));
+   bsonVisitEach (*TMP_BSON_FROM_JSON ({"foo" : 1, "bar" : 1}), do (++count));
    ASSERT_CMPINT (count, ==, 2);
 
    // Branch on keys
    int foo_val = 0;
    int bar_val = 0;
    bsonVisitEach (*TMP_BSON_FROM_JSON ({"foo" : 61, "bar" : 951}),
-                  if (key ("foo"), then (do(foo_val = bsonAs (int32)))),
-                  if (key ("bar"), then (do(bar_val = bsonAs (int32)))));
+                  if (key ("foo"), then (do (foo_val = bsonAs (int32)))),
+                  if (key ("bar"), then (do (bar_val = bsonAs (int32)))));
    ASSERT_CMPINT (foo_val, ==, 61);
    ASSERT_CMPINT (bar_val, ==, 951);
 
@@ -2630,7 +2630,7 @@ test_bson_dsl_visit (void)
    bsonVisitEach (*TMP_BSON_FROM_JSON ({"foo" : {"bar" : 42}}),
                   storeDocRef (subdoc));
    bar_val = 0;
-   bsonVisitEach (subdoc, do(bar_val = bsonAs (int32)));
+   bsonVisitEach (subdoc, do (bar_val = bsonAs (int32)));
    ASSERT_CMPINT (bar_val, ==, 42);
 
    // Visit subdocs directly
@@ -2692,21 +2692,21 @@ test_bson_dsl_predicate (void)
          require (type (doc)),
          visitEach (if (lastElement,
                         then (require (key ("b")), require (type (utf8))),
-                        else(require (key ("a")), require (type (null)))))),
+                        else (require (key ("a")), require (type (null)))))),
       require (
          key ("with_last"),
          visitEach (case (when (key ("a"), require (type (null))),
                           when (key ("b"), require (strEqual ("lastElement"))),
-                          else(do(abort ()))))),
+                          else (do (abort ()))))),
       require (key ("string"),
-               case (when (strEqual ("goodbye"), do(abort ())),
+               case (when (strEqual ("goodbye"), do (abort ())),
                      when (strEqual ("hello"), nop),
                      // Not eached since the prior case matched:
-                     when (strEqual ("hello"), do(abort ())),
-                     else(do(abort ())))),
+                     when (strEqual ("hello"), do (abort ())),
+                     else (do (abort ())))),
       visitOthers (if (key ("unhandled"),
-                       then (do(saw_other = true)),
-                       else(do(abort ())))));
+                       then (do (saw_other = true)),
+                       else (do (abort ())))));
    BSON_ASSERT (saw_other);
 }
 
@@ -2738,7 +2738,7 @@ static void
 test_bson_dsl_build (void)
 {
    // Create a very simple empty document
-   bsonBuildDecl (doc, do());
+   bsonBuildDecl (doc, do ());
    BSON_ASSERT (!bsonBuildError);
    ASSERT_BSON_EQUAL (doc, {});
    bson_destroy (&doc);
@@ -2756,8 +2756,8 @@ test_bson_dsl_build (void)
    bson_destroy (&doc);
 
    // Conditional insert
-   bsonBuild (doc,
-              if (0, then (kv ("never", null)), else(kv ("truth", int32 (1)))));
+   bsonBuild (
+      doc, if (0, then (kv ("never", null)), else (kv ("truth", int32 (1)))));
    ASSERT_BSON_EQUAL (doc, {"truth" : 1});
    bson_destroy (&doc);
 

--- a/src/libbson/tests/test-bson.c
+++ b/src/libbson/tests/test-bson.c
@@ -1342,7 +1342,7 @@ test_bson_init_static (void)
    static const uint8_t data[5] = {5};
    bson_t b;
 
-   bson_init_static (&b, data, sizeof data);
+   ASSERT (bson_init_static (&b, data, sizeof data));
    BSON_ASSERT ((b.flags & BSON_FLAG_RDONLY));
    bson_destroy (&b);
 }

--- a/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
@@ -1053,7 +1053,8 @@ _prep_for_auto_encryption (const mongoc_cmd_t *cmd, bson_t *out)
 {
    /* If there is no type=1 payload, return the command unchanged. */
    if (!cmd->payload || !cmd->payload_size) {
-      bson_init_static (out, bson_get_data (cmd->command), cmd->command->len);
+      BSON_ASSERT (bson_init_static (
+         out, bson_get_data (cmd->command), cmd->command->len));
       return;
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-collection.c
+++ b/src/libmongoc/src/mongoc/mongoc-collection.c
@@ -1404,7 +1404,7 @@ _mongoc_collection_create_index_if_not_exists (mongoc_collection_t *collection,
       }
 
       bson_iter_document (&iter, &data_len, &data);
-      bson_init_static (&inner_doc, data, data_len);
+      BSON_ASSERT (bson_init_static (&inner_doc, data, data_len));
 
       if (_mongoc_collection_index_keys_equal (keys, &inner_doc)) {
          index_exists = true;

--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -728,7 +728,8 @@ mongoc_server_description_handle_hello (mongoc_server_description_t *sd,
          }
 
          bson_iter_document (&iter, &len, &bytes);
-         bson_init_static (&incoming_topology_version, bytes, len);
+         BSON_ASSERT (
+            bson_init_static (&incoming_topology_version, bytes, len));
          mongoc_server_description_set_topology_version (
             sd, &incoming_topology_version);
          bson_destroy (&incoming_topology_version);

--- a/src/libmongoc/src/mongoc/mongoc-topology-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description.c
@@ -2204,7 +2204,7 @@ mongoc_topology_description_handle_hello (
       uint32_t len;
 
       bson_iter_document (&iter, &len, &bytes);
-      bson_init_static (&incoming_topology_version, bytes, len);
+      BSON_ASSERT (bson_init_static (&incoming_topology_version, bytes, len));
 
       if (mongoc_server_description_topology_version_cmp (
              &sd->topology_version, &incoming_topology_version) == 1) {

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -1704,7 +1704,7 @@ _find_topology_version (const bson_t *reply, bson_t *topology_version)
       return;
    }
    bson_iter_document (&iter, &len, &bytes);
-   bson_init_static (topology_version, bytes, len);
+   BSON_ASSERT (bson_init_static (topology_version, bytes, len));
 }
 
 


### PR DESCRIPTION
# Summary
- assert returned values of `bson_init_static`

# Background & Motivation
Addresses Coverity issues with CIDs: 134030, 134029, 120108, and 120107.

The test macro `ASSERT` was used in test code. `BSON_ASSERT` was used in driver code.

`bson_init_static` returns false on failure. Failure may occur if the input BSON data is invalid. Callers ignoring the returned value have been updated to assert to result in an early error on invalid BSON data input.