### PR TITLE
CDRIVER-4698 remove excess duplicate call

### DIFF
--- a/src/libmongoc/src/mongoc/mcd-azure.c
+++ b/src/libmongoc/src/mongoc/mcd-azure.c
@@ -180,7 +180,6 @@ mcd_azure_access_token_from_imds (mcd_azure_access_token *const out,
       &req, opt_imds_host, opt_port, opt_extra_headers);
 
    if (!_mongoc_http_send (&req.req, 3 * 1000, false, NULL, &resp, error)) {
-      _mongoc_http_response_cleanup (&resp);
       goto fail;
    }
 


### PR DESCRIPTION
# Summary
- remove excess duplicate call to `_mongoc_http_response_cleanup`

# Background & Motivation
Addresses Coverity issues with CIDs: 133796, 133795

This issue was flagged by Coverity as a possible "Double free". But I expect the duplicate call to `_mongoc_http_response_cleanup` does not result in a double free.

`_mongoc_http_send` [zeroes the output `res`](https://github.com/mongodb/mongo-c-driver/blob/ba5ab6de26a874d33b0abc3d2b46961a69380e7a/src/libmongoc/src/mongoc/mongoc-http.c#L121). Fields in `res` are [set at the end](https://github.com/mongodb/mongo-c-driver/blob/ba5ab6de26a874d33b0abc3d2b46961a69380e7a/src/libmongoc/src/mongoc/mongoc-http.c#L306-L321) of the call when success is guaranteed.

Nonetheless, removing the duplicate call to `_mongoc_http_response_cleanup` seems like an improvement. If future changes result in `_mongoc_http_send` possibly failing after setting fields in `res`, this may result in a double free.