### PR TITLE
assert return of `mcd_rpc_message_to_iovecs`

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -3580,6 +3580,7 @@ _mongoc_cluster_run_opmsg_send (mongoc_cluster_t *cluster,
 
    size_t num_iovecs = 0u;
    mongoc_iovec_t *const iovecs = mcd_rpc_message_to_iovecs (rpc, &num_iovecs);
+   BSON_ASSERT (iovecs);
 
    mcd_rpc_message_egress (rpc);
    const bool res = _mongoc_stream_writev_full (server_stream->stream,

--- a/src/libmongoc/tests/mock_server/mock-server.c
+++ b/src/libmongoc/tests/mock_server/mock-server.c
@@ -2135,6 +2135,7 @@ _mock_server_reply_with_stream (mock_server_t *server,
 
    size_t iovcnt;
    mongoc_iovec_t *const iov = mcd_rpc_message_to_iovecs (rpc, &iovcnt);
+   BSON_ASSERT (iov);
 
    size_t expected = 0;
    for (size_t i = 0u; i < iovcnt; i++) {


### PR DESCRIPTION
# Summary
- assert return value of `mcd_rpc_message_to_iovecs`.

# Background & Motivation

Addresses Coverity issue with CID 138246: "Dereference null return value". I do not expect these calls to `mcd_rpc_message_to_iovecs` to possibly fail given the current implementation. The added `BSON_ASSERT` is consistent with other calls. If future changes to `mcd_rpc_message_to_iovecs` result in a condition where `mcd_rpc_message_to_iovecs` may return NULL, this may prevent a NULL dereference.