### PR TITLE
CDRIVER-4699 fix leak on repeated attempts to authenticate

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
@@ -1094,7 +1094,8 @@ mongoc_topology_scanner_node_setup (mongoc_topology_scanner_node_t *node,
    {
       node->has_auth = false;
       bson_reinit (&node->speculative_auth_response);
-      node->scram.step = 0;
+      // Destroy and zero `node->scram`.
+      _mongoc_scram_destroy (&node->scram);
       memset (
          &node->sasl_supported_mechs, 0, sizeof (node->sasl_supported_mechs));
       node->negotiated_sasl_supported_mechs = false;

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
@@ -1094,8 +1094,10 @@ mongoc_topology_scanner_node_setup (mongoc_topology_scanner_node_t *node,
    {
       node->has_auth = false;
       bson_reinit (&node->speculative_auth_response);
+#ifdef MONGOC_ENABLE_CRYPTO
       // Destroy and zero `node->scram`.
       _mongoc_scram_destroy (&node->scram);
+#endif
       memset (
          &node->sasl_supported_mechs, 0, sizeof (node->sasl_supported_mechs));
       node->negotiated_sasl_supported_mechs = false;


### PR DESCRIPTION
# Summary

- Fix leak on repeated attempts to authenticate.

Verified with this patch build: https://spruce.mongodb.com/version/64c404bf61837d707d406bd7/

# Background & Motivation

This PR is a follow up to https://github.com/mongodb/mongo-c-driver/pull/1258 to free fields in `node->scram` when resetting the authentication state.

Without the included fix, the newly added `/Client/failure_to_auth` test reports leaks with LSan:

```
=================================================================
==22270==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 4096 byte(s) in 1 object(s) allocated from:
    #0 0x104e095b0 in wrap_malloc+0x8c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x515b0) (BuildId: 2d3005610c2a36e7a5269cbe22ab009f32000000200000000100000000000b00)
    #1 0x1031edb2c in bson_malloc bson-memory.c:100
    #2 0x1028c5228 in _mongoc_scram_start mongoc-scram.c:306
    #3 0x1028c4cd8 in _mongoc_scram_step mongoc-scram.c:1022
    #4 0x102a1fb54 in _mongoc_cluster_get_auth_cmd_scram mongoc-cluster.c:1454
    #5 0x1029cb208 in _mongoc_topology_scanner_add_speculative_authentication mongoc-topology-scanner.c:211
    #6 0x1029d0cc8 in _begin_hello_cmd mongoc-topology-scanner.c:418
    #7 0x1029d03a4 in mongoc_topology_scanner_node_setup_tcp mongoc-topology-scanner.c:969
    #8 0x1029ceb5c in mongoc_topology_scanner_node_setup mongoc-topology-scanner.c:1119
    #9 0x1029d229c in mongoc_topology_scanner_start mongoc-topology-scanner.c:1238
    #10 0x1029f675c in mongoc_topology_scan_once mongoc-topology.c:899
    #11 0x1029f6444 in _mongoc_topology_do_blocking_scan mongoc-topology.c:925
    #12 0x1029f78f4 in mongoc_topology_select_server_id mongoc-topology.c:1214
    #13 0x102a36a70 in _mongoc_cluster_select_server_id mongoc-cluster.c:2820
    #14 0x102a22b9c in _mongoc_cluster_stream_for_optype mongoc-cluster.c:2875
    #15 0x102a223c8 in mongoc_cluster_stream_for_reads mongoc-cluster.c:2985
    #16 0x102a85650 in mongoc_client_command_simple mongoc-client.c:1923
    #17 0x102d5d3c0 in test_failure_to_auth test-mongoc-client.c:4254
    #18 0x1030e7714 in TestSuite_AddHelper TestSuite.c:261
    #19 0x1030eca00 in TestSuite_RunTest TestSuite.c:648
    #20 0x1030ea560 in TestSuite_RunAll TestSuite.c:1094
    #21 0x1030e940c in TestSuite_Run TestSuite.c:1139
    #22 0x102827238 in main test-libmongoc-main.c:157
    #23 0x1040c9088 in start+0x204 (dyld:arm64+0x5088) (BuildId: a2ee361189123e1dbf8bfed54862d4c932000000200000000100000000060c00)
    #24 0xae00fffffffffffc  (<unknown module>)

Direct leak of 4 byte(s) in 1 object(s) allocated from:
    #0 0x104e095b0 in wrap_malloc+0x8c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x515b0) (BuildId: 2d3005610c2a36e7a5269cbe22ab009f32000000200000000100000000000b00)
    #1 0x1031edb2c in bson_malloc bson-memory.c:100
    #2 0x1032185d8 in bson_strdup bson-string.c:331
    #3 0x1028c4394 in _mongoc_scram_set_user mongoc-scram.c:186
    #4 0x1028fb2c4 in _mongoc_uri_init_scram mongoc-uri.c:3209
    #5 0x1029cb1d0 in _mongoc_topology_scanner_add_speculative_authentication mongoc-topology-scanner.c:205
    #6 0x1029d0cc8 in _begin_hello_cmd mongoc-topology-scanner.c:418
    #7 0x1029d03a4 in mongoc_topology_scanner_node_setup_tcp mongoc-topology-scanner.c:969
    #8 0x1029ceb5c in mongoc_topology_scanner_node_setup mongoc-topology-scanner.c:1119
    #9 0x1029d229c in mongoc_topology_scanner_start mongoc-topology-scanner.c:1238
    #10 0x1029f675c in mongoc_topology_scan_once mongoc-topology.c:899
    #11 0x1029f6444 in _mongoc_topology_do_blocking_scan mongoc-topology.c:925
    #12 0x1029f78f4 in mongoc_topology_select_server_id mongoc-topology.c:1214
    #13 0x102a36a70 in _mongoc_cluster_select_server_id mongoc-cluster.c:2820
    #14 0x102a22b9c in _mongoc_cluster_stream_for_optype mongoc-cluster.c:2875
    #15 0x102a223c8 in mongoc_cluster_stream_for_reads mongoc-cluster.c:2985
    #16 0x102a85650 in mongoc_client_command_simple mongoc-client.c:1923
    #17 0x102d5d3c0 in test_failure_to_auth test-mongoc-client.c:4254
    #18 0x1030e7714 in TestSuite_AddHelper TestSuite.c:261
    #19 0x1030eca00 in TestSuite_RunTest TestSuite.c:648
    #20 0x1030ea560 in TestSuite_RunAll TestSuite.c:1094
    #21 0x1030e940c in TestSuite_Run TestSuite.c:1139
    #22 0x102827238 in main test-libmongoc-main.c:157
    #23 0x1040c9088 in start+0x204 (dyld:arm64+0x5088) (BuildId: a2ee361189123e1dbf8bfed54862d4c932000000200000000100000000060c00)
    #24 0xae00fffffffffffc  (<unknown module>)

Direct leak of 4 byte(s) in 1 object(s) allocated from:
    #0 0x104e095b0 in wrap_malloc+0x8c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x515b0) (BuildId: 2d3005610c2a36e7a5269cbe22ab009f32000000200000000100000000000b00)
    #1 0x1031edb2c in bson_malloc bson-memory.c:100
    #2 0x1032185d8 in bson_strdup bson-string.c:331
    #3 0x1028c41f4 in _mongoc_scram_set_pass mongoc-scram.c:176
    #4 0x1028fb2a8 in _mongoc_uri_init_scram mongoc-uri.c:3208
    #5 0x1029cb1d0 in _mongoc_topology_scanner_add_speculative_authentication mongoc-topology-scanner.c:205
    #6 0x1029d0cc8 in _begin_hello_cmd mongoc-topology-scanner.c:418
    #7 0x1029d03a4 in mongoc_topology_scanner_node_setup_tcp mongoc-topology-scanner.c:969
    #8 0x1029ceb5c in mongoc_topology_scanner_node_setup mongoc-topology-scanner.c:1119
    #9 0x1029d229c in mongoc_topology_scanner_start mongoc-topology-scanner.c:1238
    #10 0x1029f675c in mongoc_topology_scan_once mongoc-topology.c:899
    #11 0x1029f6444 in _mongoc_topology_do_blocking_scan mongoc-topology.c:925
    #12 0x1029f78f4 in mongoc_topology_select_server_id mongoc-topology.c:1214
    #13 0x102a36a70 in _mongoc_cluster_select_server_id mongoc-cluster.c:2820
    #14 0x102a22b9c in _mongoc_cluster_stream_for_optype mongoc-cluster.c:2875
    #15 0x102a223c8 in mongoc_cluster_stream_for_reads mongoc-cluster.c:2985
    #16 0x102a85650 in mongoc_client_command_simple mongoc-client.c:1923
    #17 0x102d5d3c0 in test_failure_to_auth test-mongoc-client.c:4254
    #18 0x1030e7714 in TestSuite_AddHelper TestSuite.c:261
    #19 0x1030eca00 in TestSuite_RunTest TestSuite.c:648
    #20 0x1030ea560 in TestSuite_RunAll TestSuite.c:1094
    #21 0x1030e940c in TestSuite_Run TestSuite.c:1139
    #22 0x102827238 in main test-libmongoc-main.c:157
    #23 0x1040c9088 in start+0x204 (dyld:arm64+0x5088) (BuildId: a2ee361189123e1dbf8bfed54862d4c932000000200000000100000000060c00)
    #24 0xae00fffffffffffc  (<unknown module>)
```