### PR TITLE
remove unused `node_id`

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-counters-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-counters-private.h
@@ -98,7 +98,7 @@ static BSON_INLINE unsigned
 _mongoc_sched_getcpu (void)
 {
    volatile uint32_t rax, rdx, rcx;
-   __asm__ volatile("rdtscp\n" : "=a"(rax), "=d"(rdx), "=c"(rcx) : :);
+   __asm__ volatile ("rdtscp\n" : "=a"(rax), "=d"(rdx), "=c"(rcx) : :);
    unsigned node_id, core_id;
    // node_id = (rcx & 0xFFF000)>>12;  // node_id is unused
    core_id = rcx & 0xFFF;
@@ -114,7 +114,7 @@ _mongoc_sched_getcpu (void)
    unsigned core_id;
    /* Get the current thread ID, not the core ID.
     * Getting the core ID requires privileged execution. */
-   __asm__ volatile("mrs %x0, tpidrro_el0" : "=r"(tls));
+   __asm__ volatile ("mrs %x0, tpidrro_el0" : "=r"(tls));
    /* In ARM, only 8 cores are manageable. */
    core_id = tls & 0x07u;
    return core_id;

--- a/src/libmongoc/src/mongoc/mongoc-counters-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-counters-private.h
@@ -99,8 +99,7 @@ _mongoc_sched_getcpu (void)
 {
    volatile uint32_t rax, rdx, rcx;
    __asm__ volatile ("rdtscp\n" : "=a"(rax), "=d"(rdx), "=c"(rcx) : :);
-   unsigned node_id, core_id;
-   // node_id = (rcx & 0xFFF000)>>12;  // node_id is unused
+   unsigned core_id;
    core_id = rcx & 0xFFF;
    return core_id;
 }


### PR DESCRIPTION
# Summary

- Remove unused `node_id`

Verified with this patch build: https://spruce.mongodb.com/version/64c95c603e8e86704a204ee4/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

# Background & Motivation

The `debug-compile-rdtscp` task currently fails with:

```
[2023/06/26 19:02:34.896] In file included from /data/mci/7e0200bd3a25f0d321bf1b204fdeb96e/mongoc/src/libmongoc/src/mongoc/mongoc-client.c:41:
[2023/06/26 19:02:34.896] /data/mci/7e0200bd3a25f0d321bf1b204fdeb96e/mongoc/src/libmongoc/src/mongoc/mongoc-counters-private.h:102:13: error: unused variable 'node_id' [-Werror,-Wunused-variable]
[2023/06/26 19:02:34.897]    unsigned node_id, core_id;
[2023/06/26 19:02:34.897]             ^
[2023/06/26 19:02:34.897] make[1]: *** [src/libmongoc/CMakeFiles/mongoc_static.dir/all] Error 2
```

This warning was [present on the last passing run](https://parsley.mongodb.com/evergreen/mongo_c_driver_darwin_debug_compile_rdtscp_0dc1a4e833a9339096009ec26e7197e87842f6f7_23_06_26_18_34_43/0/task?bookmarks=0,1204&shareLine=294). The task began to fail after changes of https://github.com/mongodb/mongo-c-driver/commit/550ab7914b4594c9107e1fcd01ffc3b1a27f5877 (possibly from addition of `-Werror`?).