### PR TITLE
CDRIVER-4493 do not override handshake arch in tests

### DIFF
--- a/src/libmongoc/tests/test-mongoc-handshake.c
+++ b/src/libmongoc/tests/test-mongoc-handshake.c
@@ -382,8 +382,6 @@ _override_host_platform_os (void)
    md->os_type = bson_strdup ("Linux");
    bson_free (md->os_name);
    md->os_name = bson_strdup ("mongoc");
-   bson_free (md->os_architecture);
-   md->os_architecture = bson_strdup ("x86_64");
    bson_free (md->driver_name);
    md->driver_name = bson_strdup ("test_e");
    bson_free (md->driver_version);


### PR DESCRIPTION
# Summary

- Do not override handshake arch in tests

Verified with this patch build: https://spruce.mongodb.com/version/64c960a3a4cf47d15d5590ab

# Background & Motivation

Intended to fix the `sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-7.0-server-auth` task failing with this log:

```
[2023/08/01 18:19:55.889] Begin /MongoDB/handshake/faas/valid_aws, seed 4162539160
[2023/08/01 18:19:55.989] FAIL
[2023/08/01 18:19:55.989] Assert Failure:
[2023/08/01 18:19:55.989]   "aarch64"
[2023/08/01 18:19:55.989]   !=
[2023/08/01 18:19:55.989]   "x86_64"
[2023/08/01 18:19:55.989]  /data/mci/40006473c9ffecd981bc61b252685b65/mongoc/src/libmongoc/tests/test-mongoc-handshake.c:145  _check_arch_string_valid()
```