### PR TITLE
CDRIVER-4679 Revert BSON_HAVE_XSI_STRERROR_R and use strerror_l instead

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,7 +394,7 @@ endif ()
 # Enable POSIX features up to POSIX.1-2008 plus the XSI extension and BSD-derived definitions.
 # Both _BSD_SOURCE and _DEFAULT_SOURCE are defined for backwards-compatibility with glibc 2.19 and earlier.
 # _BSD_SOURCE and _DEFAULT_SOURCE are required by `getpagesize`, `h_errno`, etc.
-# _XOPEN_SOURCE=700 is required by `strnlen`, etc.
+# _XOPEN_SOURCE=700 is required by `strnlen`, `strerror_l`, etc.
 add_definitions (-D_XOPEN_SOURCE=700 -D_BSD_SOURCE -D_DEFAULT_SOURCE)
 list (APPEND CMAKE_REQUIRED_DEFINITIONS -D_XOPEN_SOURCE=700 -D_BSD_SOURCE -D_DEFAULT_SOURCE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,7 +394,7 @@ endif ()
 # Enable POSIX features up to POSIX.1-2008 plus the XSI extension and BSD-derived definitions.
 # Both _BSD_SOURCE and _DEFAULT_SOURCE are defined for backwards-compatibility with glibc 2.19 and earlier.
 # _BSD_SOURCE and _DEFAULT_SOURCE are required by `getpagesize`, `h_errno`, etc.
-# _XOPEN_SOURCE=700 is required by `strnlen`, `strerror_r`, etc.
+# _XOPEN_SOURCE=700 is required by `strnlen`, etc.
 add_definitions (-D_XOPEN_SOURCE=700 -D_BSD_SOURCE -D_DEFAULT_SOURCE)
 list (APPEND CMAKE_REQUIRED_DEFINITIONS -D_XOPEN_SOURCE=700 -D_BSD_SOURCE -D_DEFAULT_SOURCE)
 

--- a/src/libbson/CMakeLists.txt
+++ b/src/libbson/CMakeLists.txt
@@ -14,14 +14,12 @@ include (MongoC-Warnings)
 
 set (BSON_OUTPUT_BASENAME "bson" CACHE STRING "Output bson library base name")
 
-include (CheckCSourceCompiles)
 include (CheckFunctionExists)
 include (CheckIncludeFile)
-include (CheckIncludeFiles)
 include (CheckStructHasMember)
 include (CheckSymbolExists)
-include (InstallRequiredSystemLibraries)
 include (TestBigEndian)
+include (InstallRequiredSystemLibraries)
 
 set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/build/cmake)
 
@@ -85,6 +83,8 @@ else ()
    set (BSON_OS 1)
 endif ()
 
+include (CheckIncludeFiles)
+
 CHECK_INCLUDE_FILE (strings.h BSON_HAVE_STRINGS_H)
 if (NOT BSON_HAVE_STRINGS_H)
    set (BSON_HAVE_STRINGS_H 0)
@@ -117,38 +117,6 @@ if (BSON_BIG_ENDIAN)
    set (BSON_BYTE_ORDER 4321)
 else ()
    set (BSON_BYTE_ORDER 1234)
-endif ()
-
-# 1. Normally, `defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 600` should be enough
-#    to detect if an XSI-compliant `strerror_r` is available.
-# 2. However, GNU provides an incompatible `strerror_r` as an extension,
-#    requiring an additional test for `!defined(_GNU_SOURCE)`.
-# 3. However, musl does not support the GNU extension even when `_GNU_SOURCE` is
-#    defined, preventing `!defined(_GNU_SOURCE)` from being a portable
-#    XSI-compliance test.
-# 4. However, musl does not provide a feature test macro to detect compilation
-#    with musl, and workarounds that use internal glibc feature test macros such
-#    as `defined(__USE_GNU)` are explicitly forbidden by glibc documentation.
-# 5. Therefore, give up on using feature test macros: use `CheckCSourceCompiles`
-#    to test if the current `strerror_r` is XSI-compliant if present.
-if (NOT WIN32)
-   CHECK_C_SOURCE_COMPILES(
-      [[
-         #include <string.h>
-         int test(int errnum, char *buf, size_t buflen) {
-            return strerror_r (errnum, buf, buflen);
-         }
-         int main(void) {}
-      ]]
-      BSON_HAVE_XSI_STRERROR_R
-      FAIL_REGEX "int-conversion"
-   )
-endif ()
-
-if (BSON_HAVE_XSI_STRERROR_R)
-   set(BSON_HAVE_XSI_STRERROR_R 1)
-else()
-   set(BSON_HAVE_XSI_STRERROR_R 0)
 endif ()
 
 configure_file (

--- a/src/libbson/src/bson/bson-config.h.in
+++ b/src/libbson/src/bson/bson-config.h.in
@@ -122,13 +122,4 @@
 # undef BSON_HAVE_STRLCPY
 #endif
 
-
-/*
- * Define to 1 if you have an XSI-compliant strerror_r on your platform.
- */
-#define BSON_HAVE_XSI_STRERROR_R @BSON_HAVE_XSI_STRERROR_R@
-#if BSON_HAVE_XSI_STRERROR_R != 1
-# undef BSON_HAVE_XSI_STRERROR_R
-#endif
-
 #endif /* BSON_CONFIG_H */

--- a/src/libbson/src/bson/bson-error.c
+++ b/src/libbson/src/bson/bson-error.c
@@ -121,8 +121,10 @@ bson_strerror_r (int err_code,                    /* IN */
    // the XSI-compliant `strerror_r`, but only when compiling with Apple Clang.
    // GNU extensions may still be a problem if we are being compiled with GCC on
    // Apple. Avoid the compatibility headaches with GNU extensions and the musl
-   // library by assuming QoI will not cause UB when reading the error message
-   // string even when `strerror_r` fails.
+   // library by assuming the implementation will not cause UB when reading the
+   // error message string even when `strerror_r` fails, as encouraged (but not
+   // required) by the POSIX spec (see:
+   // https://pubs.opengroup.org/onlinepubs/9699919799/functions/strerror.html#tag_16_574_08).
    (void) strerror_r (err_code, buf, buflen);
 #elif defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 700
    // The behavior (of `strerror_l`) is undefined if the locale argument to

--- a/src/libbson/src/bson/bson-error.c
+++ b/src/libbson/src/bson/bson-error.c
@@ -109,14 +109,12 @@ bson_strerror_r (int err_code,  /* IN */
    if (strerror_s (buf, buflen, err_code) != 0) {
       ret = buf;
    }
-#elif defined(BSON_HAVE_XSI_STRERROR_R)
+#elif defined(__GNUC__) && defined(_GNU_SOURCE)
+   ret = strerror_r (err_code, buf, buflen);
+#else /* XSI strerror_r */
    if (strerror_r (err_code, buf, buflen) == 0) {
       ret = buf;
    }
-#elif defined(_GNU_SOURCE)
-   ret = strerror_r (err_code, buf, buflen);
-#else
-   #error "Unable to find a supported strerror_r candidate"
 #endif
 
    if (!ret) {

--- a/src/libbson/src/bson/bson-error.c
+++ b/src/libbson/src/bson/bson-error.c
@@ -143,6 +143,7 @@ bson_strerror_r (int err_code,                    /* IN */
    // Unlikely, but continue supporting use of GNU extension in cases where the
    // C Driver is being built without _XOPEN_SOURCE=700.
    ret = strerror_r (err_code, buf, buflen);
+#else
 #error "Unable to find a supported strerror_r candidate"
 #endif
 


### PR DESCRIPTION
This PR reverts https://github.com/mongodb/mongo-c-driver/pull/1350 and re-addresses CDRIVER-4679 using a more nuanced solution. Given the information that [strerror_r is scheduled to be marked as obsolete](https://www.austingroupbugs.net/view.php?id=655) in the upcoming POSIX Issue, this PR favors using `strerror_l` instead of `strerror_r`, which is not susceptible to the GNU extension and musl library compatibility problems documented in https://github.com/mongodb/mongo-c-driver/pull/1350. Per the provided link:

> The strerror_r function is problematic because there are historically at least two versions, and at least one major implementation, the GNU C Library, seems committed to providing a version incompatible with the version specified in the standard. While an attempt is made in glibc to provide a conforming version when the proper feature test macros are defined, the workaround is header-based and is in fact non-conforming since it does not support applications that omit inclusion of string.h and declare the function manually.
> 
> The strerror_l function is mandatory beginning with issue 7, provides a much easier-to-use interface to the same functionality, and does not have incompatible historical versions of the interface that can interfere with application compatibility.

Unfortunately, the Apple platform does not seem to yet provide `strerror_l`. This PR proposes treating the Apple platform specially, as is already being done for the Windows platform, by unconditionally using `strerror_r` (as `strerror_s` on Windows). Furthermore, given the possibility of the C Driver being compiled with GCC on Apple, it is still susceptible to the `strerror_r` problems that are documented in https://github.com/mongodb/mongo-c-driver/pull/1350. This PR proposes a compromise _on the Apple platform only_ that deliberately ignores checking the return value for errors by depending on the quality of implementation to avoid undefined behavior, per the [POSIX Specification](https://pubs.opengroup.org/onlinepubs/9699919799/functions/strerror.html):

> If an invalid error number is supplied as the value of errnum, applications should be prepared to handle any of the following: [...] Since applications frequently use the return value of strerror() as an argument to functions like `fprintf()` (without checking the return value) and since applications have no way to parse an error message string to determine whether errnum represents a valid error number, implementations are encouraged to implement [the behavior where _errno_ is set to [EINVAL] and the return value points to a string like `"unknown error"` or `"error number xxx"` (where _xxx_ is the value of _errnum_)]. Similarly, implementations are encouraged to have `strerror_r()` return [EINVAL] and put a string like `"unknown error"` or `"error number xxx"` in the buffer pointed to by _strerrbuf_ when the value of _errnum_ is not a valid error number.

We will assume similar QoI for potential [ERANGE] errors.

Although we do not expect anyone to be compiling the C Driver _without_ `_XOPEN_SOURCE=700` on non-Windows or non-Apple platforms (per default), this PR leaves the `_GNU_SOURCE` condition in out of abundance of caution.