### PR TITLE
CDRIVER-4682 log informational message for nongenuine hosts

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -335,7 +335,7 @@ _detect_nongenuine_hosts (const mongoc_host_list_t *hosts)
       if (mongoc_ends_with (host_lowercase, ".docdb.amazonaws.com") ||
           mongoc_ends_with (host_lowercase, ".docdb-elastic.amazonaws.com")) {
          MONGOC_INFO (
-            "You appear to be connected to a DoumentDB cluster. For more "
+            "You appear to be connected to a DocumentDB cluster. For more "
             "information regarding feature compatibility and support please "
             "visit https://www.mongodb.com/supportability/documentdb");
          bson_free (host_lowercase);

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -624,6 +624,7 @@ mongoc_topology_new (const mongoc_uri_t *uri, bool single_threaded)
 
       if (!found_nongenuine_host &&
           (found_nongenuine_host = _is_nongenuine_host (elem->host))) {
+         /* TODO: the final copy for this log message is TBD */
          MONGOC_INFO ("Nongenuine host detected");
       }
    }

--- a/src/libmongoc/src/mongoc/mongoc-uri.c
+++ b/src/libmongoc/src/mongoc/mongoc-uri.c
@@ -1526,6 +1526,23 @@ mongoc_uri_finalize_directconnection (mongoc_uri_t *uri, bson_error_t *error)
    return true;
 }
 
+static void
+mongoc_uri_check_for_genuine_hosts (const char *hosts)
+{
+   char *hosts_lowercase = lowercase_str_new (hosts);
+
+   if (strstr (hosts_lowercase, ".cosmos.azure.com")) {
+      MONGOC_INFO ("Azure Cosmos DB is not genuine");
+   }
+
+   if (strstr (hosts_lowercase, ".docdb.amazonaws.com") ||
+       strstr (hosts_lowercase, ".docdb-elastic.amazonaws.com")) {
+      MONGOC_INFO ("Amazon DocumentDB is not genuine");
+   }
+
+   bson_free (hosts_lowercase);
+}
+
 static bool
 mongoc_uri_parse_before_slash (mongoc_uri_t *uri,
                                const char *before_slash,
@@ -1550,6 +1567,8 @@ mongoc_uri_parse_before_slash (mongoc_uri_t *uri,
    } else {
       hosts = before_slash;
    }
+
+   mongoc_uri_check_for_genuine_hosts (hosts);
 
    if (uri->is_srv) {
       if (!mongoc_uri_parse_srv (uri, hosts, error)) {

--- a/src/libmongoc/src/mongoc/mongoc-util-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-util-private.h
@@ -125,6 +125,9 @@ _mongoc_validate_update (const bson_t *update,
                          bson_validate_flags_t vflags,
                          bson_error_t *error);
 
+bool
+mongoc_ends_with (const char *str, const char *suffix);
+
 void
 mongoc_lowercase (const char *src, char *buf /* OUT */);
 

--- a/src/libmongoc/src/mongoc/mongoc-util.c
+++ b/src/libmongoc/src/mongoc/mongoc-util.c
@@ -558,26 +558,17 @@ bson_copy_to_including_noinit (const bson_t *src,
 bool
 mongoc_ends_with (const char *str, const char *suffix)
 {
-   size_t str_len = strlen (str);
-   size_t suffix_len = strlen (suffix);
-   const char *s1, *s2;
+   BSON_ASSERT_PARAM (str);
+   BSON_ASSERT_PARAM (suffix);
+
+   const size_t str_len = strlen (str);
+   const size_t suffix_len = strlen (suffix);
 
    if (str_len < suffix_len) {
       return false;
    }
 
-   /* start at the ends of both strings */
-   s1 = str + str_len;
-   s2 = suffix + suffix_len;
-
-   /* until either pointer reaches start of its string, compare the pointers */
-   for (; s1 >= str && s2 >= suffix; s1--, s2--) {
-      if (*s1 != *s2) {
-         return false;
-      }
-   }
-
-   return true;
+   return strcmp (str + (str_len - suffix_len), suffix) == 0;
 }
 
 void

--- a/src/libmongoc/src/mongoc/mongoc-util.c
+++ b/src/libmongoc/src/mongoc/mongoc-util.c
@@ -546,6 +546,39 @@ bson_copy_to_including_noinit (const bson_t *src,
    va_end (args);
 }
 
+/*
+ *--------------------------------------------------------------------------
+ *
+ * mongoc_ends_with --
+ *
+ *       Return true if str ends with suffix.
+ *
+ *--------------------------------------------------------------------------
+ */
+bool
+mongoc_ends_with (const char *str, const char *suffix)
+{
+   size_t str_len = strlen (str);
+   size_t suffix_len = strlen (suffix);
+   const char *s1, *s2;
+
+   if (str_len < suffix_len) {
+      return false;
+   }
+
+   /* start at the ends of both strings */
+   s1 = str + str_len;
+   s2 = suffix + suffix_len;
+
+   /* until either pointer reaches start of its string, compare the pointers */
+   for (; s1 >= str && s2 >= suffix; s1--, s2--) {
+      if (*s1 != *s2) {
+         return false;
+      }
+   }
+
+   return true;
+}
 
 void
 mongoc_lowercase (const char *src, char *buf /* OUT */)

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -206,7 +206,7 @@ log_handler (mongoc_log_level_t log_level,
 
    suite = (TestSuite *) user_data;
 
-   if (log_level < MONGOC_LOG_LEVEL_INFO) {
+   if (log_level <= MONGOC_LOG_LEVEL_INFO) {
       bson_mutex_lock (&captured_logs_mutex);
       if (capturing_logs) {
          log_entry = log_entry_create (log_level, message);

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -2735,7 +2735,7 @@ test_detect_nongenuine_hosts (void)
       ASSERT_CAPTURED_LOG (
          "nongenuine host should log",
          MONGOC_LOG_LEVEL_INFO,
-         "You appear to be connected to a DoumentDB cluster. For more "
+         "You appear to be connected to a DocumentDB cluster. For more "
          "information regarding feature compatibility and support please visit "
          "https://www.mongodb.com/supportability/documentdb");
       mongoc_topology_destroy (topology);

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -2682,7 +2682,7 @@ test_detect_nongenuine_hosts (void)
       "mongodb://a.mongo.cosmos.azure.com:19555/",
       /* Test case-insensitive matching */
       "mongodb://a.MONGO.COSMOS.AZURE.COM:19555/",
-      /* Mixing genuine and non-genuine hosts (unlikely in practice) */
+      /* Mixing genuine and nongenuine hosts (unlikely in practice) */
       "mongodb://a.example.com:27017,b.mongo.cosmos.azure.com:19555/",
       /* Note: SRV connection strings are intentionally untested, since initial
        * lookup responses cannot be easily mocked. */

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -2738,7 +2738,8 @@ test_detect_nongenuine_hosts (void)
       mongoc_uri_destroy (uri);
    }
 
-   for (size_t i = 0u; i < sizeof (genuine_uris) / sizeof (*genuine_uris); ++i) {
+   for (size_t i = 0u; i < sizeof (genuine_uris) / sizeof (*genuine_uris);
+        ++i) {
       capture_logs (true);
       mongoc_uri_t *const uri = mongoc_uri_new (genuine_uris[i]);
       ASSERT (uri);

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -2678,10 +2678,6 @@ test_failure_to_setup_after_retry (void)
 static void
 test_detect_nongenuine_hosts (void)
 {
-   mongoc_uri_t *uri;
-   mongoc_topology_t *topology;
-   int i;
-
    const char *cosmos_uris[] = {
       "mongodb://a.mongo.cosmos.azure.com:19555/",
       /* Test case-insensitive matching */
@@ -2710,11 +2706,11 @@ test_detect_nongenuine_hosts (void)
       "mongodb://a.docdb-elastic.amazonaws.com.tld:27017/",
    };
 
-   for (i = 0; i < sizeof (cosmos_uris) / sizeof (const char *); i++) {
+   for (size_t i = 0u; i < sizeof (cosmos_uris) / sizeof (*cosmos_uris); ++i) {
       capture_logs (true);
-      uri = mongoc_uri_new (cosmos_uris[i]);
+      mongoc_uri_t *const uri = mongoc_uri_new (cosmos_uris[i]);
       ASSERT (uri);
-      topology = mongoc_topology_new (uri, true);
+      mongoc_topology_t *const topology = mongoc_topology_new (uri, true);
       ASSERT (topology);
       ASSERT_CAPTURED_LOG (
          "nongenuine host should log",
@@ -2726,11 +2722,11 @@ test_detect_nongenuine_hosts (void)
       mongoc_uri_destroy (uri);
    }
 
-   for (i = 0; i < sizeof (docdb_uris) / sizeof (const char *); i++) {
+   for (size_t i = 0u; i < sizeof (docdb_uris) / sizeof (*docdb_uris); ++i) {
       capture_logs (true);
-      uri = mongoc_uri_new (docdb_uris[i]);
+      mongoc_uri_t *const uri = mongoc_uri_new (docdb_uris[i]);
       ASSERT (uri);
-      topology = mongoc_topology_new (uri, true);
+      mongoc_topology_t *const topology = mongoc_topology_new (uri, true);
       ASSERT (topology);
       ASSERT_CAPTURED_LOG (
          "nongenuine host should log",
@@ -2742,11 +2738,11 @@ test_detect_nongenuine_hosts (void)
       mongoc_uri_destroy (uri);
    }
 
-   for (i = 0; i < sizeof (genuine_uris) / sizeof (const char *); i++) {
+   for (size_t i = 0u; i < sizeof (genuine_uris) / sizeof (*genuine_uris); ++i) {
       capture_logs (true);
-      uri = mongoc_uri_new (genuine_uris[i]);
+      mongoc_uri_t *const uri = mongoc_uri_new (genuine_uris[i]);
       ASSERT (uri);
-      topology = mongoc_topology_new (uri, true);
+      mongoc_topology_t *const topology = mongoc_topology_new (uri, true);
       ASSERT (topology);
       ASSERT_NO_CAPTURED_LOGS ("genuine host should not log");
       mongoc_topology_destroy (topology);

--- a/src/libmongoc/tests/test-mongoc-uri.c
+++ b/src/libmongoc/tests/test-mongoc-uri.c
@@ -2740,72 +2740,6 @@ test_casing_options (void)
    mongoc_uri_destroy (uri);
 }
 
-
-static void
-test_check_for_genuine_hosts (void)
-{
-   mongoc_uri_t *uri;
-   int i;
-
-   const char *cosmos_hosts[] = {
-      "mongodb://x:y@compass-serverless.mongo.cosmos.azure.com:19555/"
-      "?ssl=true&retrywrites=false&maxIdleTimeMS=120000&appName=@compass-"
-      "serverless@",
-      "mongodb://x:y@compass.mongo.cosmos.azure.com:19555/"
-      "?ssl=true&retrywrites=false&maxIdleTimeMS=120000&appName=@compass@",
-      "mongodb+srv://x:y@compass-vcore.mongocluster.cosmos.azure.com/"
-      "?retrywrites=false&maxIdleTimeMS=120000",
-   };
-
-   const char *docdb_hosts[] = {
-      "mongodb://"
-      "x:y@docdb-2001-01-01-01-01-01.cluster-abc.eu-central-1.docdb.amazonaws."
-      "com:27017/"
-      "?replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false",
-      "mongodb://"
-      "x:y@elastic-docdb-123456789.eu-central-1.docdb-elastic.amazonaws.com:"
-      "27017",
-   };
-
-   const char *genuine_hosts[] = {
-      "mongodb://"
-      "mongodb0.example.com:27017,mongodb1.example.com:27017,mongodb2.example."
-      "com:27017/?replicaSet=myRepl",
-      "mongodb+srv://server.example.com/",
-      "mongodb://xyz456-shard-00-00.ab123.mongodb.net:27017",
-      "mongodb+srv://xyz456.ab123.mongodb.net",
-   };
-
-   for (i = 0; i < sizeof (cosmos_hosts) / sizeof (const char *); i++) {
-      capture_logs (true);
-      uri = mongoc_uri_new (cosmos_hosts[i]);
-      ASSERT (uri);
-      ASSERT_CAPTURED_LOG ("mongoc_uri_check_for_genuine_hosts",
-                           MONGOC_LOG_LEVEL_INFO,
-                           "Azure Cosmos DB is not genuine");
-      mongoc_uri_destroy (uri);
-   }
-
-   for (i = 0; i < sizeof (docdb_hosts) / sizeof (const char *); i++) {
-      capture_logs (true);
-      uri = mongoc_uri_new (docdb_hosts[i]);
-      ASSERT (uri);
-      ASSERT_CAPTURED_LOG ("mongoc_uri_check_for_genuine_hosts",
-                           MONGOC_LOG_LEVEL_INFO,
-                           "Amazon DocumentDB is not genuine");
-      mongoc_uri_destroy (uri);
-   }
-
-   for (i = 0; i < sizeof (genuine_hosts) / sizeof (const char *); i++) {
-      capture_logs (true);
-      uri = mongoc_uri_new (genuine_hosts[i]);
-      ASSERT (uri);
-      ASSERT_NO_CAPTURED_LOGS ("mongoc_uri_check_for_genuine_hosts");
-      mongoc_uri_destroy (uri);
-   }
-}
-
-
 void
 test_uri_install (TestSuite *suite)
 {
@@ -2840,6 +2774,4 @@ test_uri_install (TestSuite *suite)
                   "/Uri/one_tls_option_enables_tls",
                   test_one_tls_option_enables_tls);
    TestSuite_Add (suite, "/Uri/options_casing", test_casing_options);
-   TestSuite_Add (
-      suite, "/Uri/check_for_genuine_hosts", test_check_for_genuine_hosts);
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-4682

The log messages are specified in [DRIVERS-2583](https://jira.mongodb.org/browse/DRIVERS-2583).