### PR TITLE
WIP: CDRIVER-3514 Sharing SCRAM cache among all clients in pool

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-client-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-private.h
@@ -241,19 +241,6 @@ mongoc_client_uses_server_api (const mongoc_client_t *client);
 bool
 mongoc_client_uses_loadbalanced (const mongoc_client_t *client);
 
-// The workflow is designed to be as follows:
-// 1. Client has it's own copy of the scram cache. It wants to get the "main"
-// copy from topology.
-// 2. The client calls get_cache_v2
-// 3. If the cache isn't set on the topology, the client will set the cache on
-// its topology and then copy it over to its own copy of the scram cache.
-// Ideally this will only happen once, although with multithreading we cannot be
-// certain of this. This can be changes with more locking in get_cache_v2, but
-// we opted to try to do as minimal of locking as possible. As long as it's not
-// generating the cache everytime, we should theoretically save time.
-// 4. If the cache is set on the topology, simply copy it over to the client's
-// copy of the scram cache.
-
 void
 _mongoc_scram_cache_destroy_v2 (mongoc_scram_cache_v2_t *cache);
 

--- a/src/libmongoc/src/mongoc/mongoc-client-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-private.h
@@ -118,6 +118,8 @@ struct _mongoc_client_t {
    unsigned int csid_rand_seed;
 
    uint32_t generation;
+
+   mongoc_scram_cache_v2_t *scram_cache;
 };
 
 /* Defines whether _mongoc_client_command_with_opts() is acting as a read
@@ -238,6 +240,22 @@ mongoc_client_uses_server_api (const mongoc_client_t *client);
  * false. */
 bool
 mongoc_client_uses_loadbalanced (const mongoc_client_t *client);
+
+// The workflow is designed to be as follows:
+// 1. Client has it's own copy of the scram cache. It wants to get the "main"
+// copy from topology.
+// 2. The client calls get_cache_v2
+// 3. If the cache isn't set on the topology, the client will set the cache and
+// then copy it over to its own copy of the scram cache. Ideally this will only
+// happen once.
+// 4. If the cache is set on the topology, simply copy it over to the client's
+// copy of the scram cache.
+
+void
+_mongoc_scram_cache_destroy_v2 (mongoc_scram_cache_v2_t *cache);
+
+void
+_mongoc_scram_get_cache_v2 (mongoc_client_t *client);
 
 BSON_END_DECLS
 

--- a/src/libmongoc/src/mongoc/mongoc-client-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-private.h
@@ -245,9 +245,12 @@ mongoc_client_uses_loadbalanced (const mongoc_client_t *client);
 // 1. Client has it's own copy of the scram cache. It wants to get the "main"
 // copy from topology.
 // 2. The client calls get_cache_v2
-// 3. If the cache isn't set on the topology, the client will set the cache and
-// then copy it over to its own copy of the scram cache. Ideally this will only
-// happen once.
+// 3. If the cache isn't set on the topology, the client will set the cache on
+// its topology and then copy it over to its own copy of the scram cache.
+// Ideally this will only happen once, although with multithreading we cannot be
+// certain of this. This can be changes with more locking in get_cache_v2, but
+// we opted to try to do as minimal of locking as possible. As long as it's not
+// generating the cache everytime, we should theoretically save time.
 // 4. If the cache is set on the topology, simply copy it over to the client's
 // copy of the scram cache.
 

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -1212,7 +1212,9 @@ mongoc_client_destroy (mongoc_client_t *client)
 #ifdef MONGOC_ENABLE_SSL
       _mongoc_ssl_opts_cleanup (&client->ssl_opts, true);
 #endif
-
+      if (client->scram_cache) {
+         _mongoc_scram_cache_destroy_v2 (client->scram_cache);
+      }
       bson_free (client);
 
       mongoc_counter_clients_active_dec ();

--- a/src/libmongoc/src/mongoc/mongoc-topology-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-private.h
@@ -104,6 +104,19 @@ typedef union mc_shared_tpld {
 /** A null-pointer initializer for an `mc_shared_tpld` */
 #define MC_SHARED_TPLD_NULL ((mc_shared_tpld){._sptr_ = MONGOC_SHARED_PTR_NULL})
 
+typedef struct _mongoc_scram_cache_v2_t {
+   /* pre-secrets */
+   char *hashed_password;
+   uint8_t decoded_salt[MONGOC_SCRAM_B64_HASH_MAX_SIZE];
+   uint32_t iterations;
+   /* secrets */
+   uint8_t client_key[MONGOC_SCRAM_HASH_MAX_SIZE];
+   uint8_t server_key[MONGOC_SCRAM_HASH_MAX_SIZE];
+   uint8_t salted_password[MONGOC_SCRAM_HASH_MAX_SIZE];
+
+
+} mongoc_scram_cache_v2_t;
+
 typedef struct _mongoc_topology_t {
    /**
     * @brief The topology description. Do not access directly. Instead, use
@@ -212,6 +225,9 @@ typedef struct _mongoc_topology_t {
     * topology. This could occur if the URI is invalid.
     * An invalid topology does not monitor servers. */
    bool valid;
+
+   mongoc_scram_cache_v2_t *scram_cache;
+   bson_shared_mutex_t scram_cache_rw_lock;
 } mongoc_topology_t;
 
 mongoc_topology_t *

--- a/src/libmongoc/src/mongoc/mongoc-topology-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-private.h
@@ -113,8 +113,6 @@ typedef struct _mongoc_scram_cache_v2_t {
    uint8_t client_key[MONGOC_SCRAM_HASH_MAX_SIZE];
    uint8_t server_key[MONGOC_SCRAM_HASH_MAX_SIZE];
    uint8_t salted_password[MONGOC_SCRAM_HASH_MAX_SIZE];
-
-
 } mongoc_scram_cache_v2_t;
 
 typedef struct _mongoc_topology_t {

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -689,6 +689,12 @@ mongoc_topology_destroy (mongoc_topology_t *topology)
          mc_tpld_unsafe_get_const (topology));
    }
 
+   bson_shared_mutex_lock (&topology->scram_cache_rw_lock);
+   if (topology->scram_cache) {
+      _mongoc_scram_cache_destroy_v2 (topology->scram_cache);
+   }
+   bson_shared_mutex_unlock (&topology->scram_cache_rw_lock);
+
    mongoc_uri_destroy (topology->uri);
    mongoc_shared_ptr_reset_null (&topology->_shared_descr_._sptr_);
    mongoc_topology_scanner_destroy (topology->scanner);

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -426,6 +426,7 @@ mongoc_topology_new (const mongoc_uri_t *uri, bool single_threaded)
                                    topology->connect_timeout_msec);
 
    bson_mutex_init (&topology->tpld_modification_mtx);
+   bson_shared_mutex_init (&topology->scram_cache_rw_lock);
    mongoc_cond_init (&topology->cond_client);
 
    if (single_threaded) {
@@ -697,7 +698,7 @@ mongoc_topology_destroy (mongoc_topology_t *topology)
 
    mongoc_cond_destroy (&topology->cond_client);
    bson_mutex_destroy (&topology->tpld_modification_mtx);
-
+   bson_shared_mutex_destroy (&topology->scram_cache_rw_lock);
    bson_destroy (topology->encrypted_fields_map);
 
    bson_free (topology);

--- a/src/libmongoc/tests/test-mongoc-client.c
+++ b/src/libmongoc/tests/test-mongoc-client.c
@@ -4291,10 +4291,6 @@ test_scram_cache (void)
    ASSERT (client_a->scram_cache->iterations ==
            client_b->scram_cache->iterations);
 
-   _mongoc_scram_cache_destroy_v2 (client_a->scram_cache);
-   _mongoc_scram_cache_destroy_v2 (client_b->scram_cache);
-   _mongoc_scram_cache_destroy_v2 (topology_a->scram_cache);
-
    mongoc_client_pool_push (pool, client_a);
    mongoc_client_pool_push (pool, client_b);
    mongoc_client_pool_destroy (pool);
@@ -4318,22 +4314,19 @@ static void
 test_scram_cache_check_iterations (void)
 {
    mongoc_client_pool_t *pool;
-   pthread_t threads[100];
+   pthread_t threads[99];
    void *ret;
 
    pool = test_framework_new_default_client_pool ();
 
-   for (int i = 0; i < 100; ++i) {
+   for (int i = 0; i < 99; ++i) {
       pthread_create (&threads[i], NULL, thread_get_cache, pool);
    }
 
-   for (int i = 0; i < 100; ++i) {
+   for (int i = 0; i < 99; ++i) {
       pthread_join (threads[i], &ret);
    }
 
-   mongoc_client_t *client = mongoc_client_pool_pop (pool);
-   _mongoc_scram_cache_destroy_v2 (client->topology->scram_cache);
-   mongoc_client_pool_push (pool, client);
    mongoc_client_pool_destroy (pool);
 }
 


### PR DESCRIPTION
# Summary
This PR will modify `mongoc_client_t` architecture so that the SCRAM cache will be shared among all of the clients in the pool. Unfortunately, my internship ended before I was able to finish this ticket, so the details below are designed to get the next assignee up to speed.

# Background
The PERF team pointed out a potential bottleneck with SCRAM authentication among clients in the C driver: https://jira.mongodb.org/browse/PERF-4166. We verified this by creating a simple program and generating our own FlameGraph: https://jira.mongodb.org/browse/CDRIVER-3514. 

# Proposed Solution
Currently, the SCRAM cache is created and managed by `mongoc_cluster_t` and every `mongoc_client_t` has a `mongoc_cluster_t`. We believe the best way to improve SCRAM authentication time is to share this SCRAM cache among all `mongoc_client_t`s through `mongoc_topology_t`. All `mongoc_client_t`s have a `mongoc_topology_t` attached to them, and if the client is in a `mongoc_pool_t`, then all of the clients in the pool have the same topology. Moving the SCRAM cache to `mongoc_topology_t` will provide all clients in the pool access. Here are the steps of the new proposed architecture:
1. A `mongoc_client_t` exists or gets popped from a pool. It wants initialize its SCRAM cache.
2. The client will check the `mongoc_topology_t` attached to it to see if it already has a copy of the SCRAM cache.
3. If it does not, it will generate a SCRAM cache on the topology. If it does, do nothing.
4. The client will copy the topology's "main" copy of the SCRAM cache so that it can have a local copy to read from without worrying about thread safety.

# Current Changes
I added a new SCRAM cache `mongoc_scram_cache_v2_t` for a quick POC. As mentioned above, this struct will be used in two places, `mongoc_client_t` and `mongoc_topology_t`. Due to multiple threads potentially accessing the topology SCRAM cache at once, I also added a `bson_shared_mutex_t` (RW lock) on `mongoc_topology_t`. 

There are two new functions in `mongoc_client_t`, `_mongoc_scram_cache_destroy_v2` and `_mongoc_scram_get_cache_v2`. The latter is thread-safe as it will potentially modify the SCRAM cache in topology. Please note that at the moment we are generating a fake cache.

I added two tests as a POC that the cache will be shared correctly. The first will setup 2 clients on the same pool, assert that they have the same topology, and assert that they have the same "iteration" of cache (should be iteration 0 because it's only generated once). The second test will setup a pool and threads to pop from the pool, get the cache, and then push back onto the pool. Based on print statements I added, it's evident that the cache is only getting generated once.

# What's Next
-  Start generating a real cache in `_mongoc_scram_get_cache_v2`. Admittedly, I did not have time to do research on how I think this can be done. Right now, all of the SCRAM authentication is done in `mongoc_cluster_t` so I would suggest starting there and most likely moving things over to the topology file. There is also some SCRAM cache activity happening in `mongoc-scram` and I think there's the potential for consolidation. I would think this is going to be the most time consuming part of this ticket.
- Test the changes to see if SCRAM authentication is any faster. The information on how to generate a FlameGraph is in the JIRA ticket.
- If this solution proves to work, phase out the old SCRAM cache architecture.