### PR TITLE
Fix test suite log handler UB due to incorrect argument

### DIFF
--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -2679,7 +2679,7 @@ test_libmongoc_init (TestSuite *suite,
 
    bson_mutex_init (&captured_logs_mutex);
    _mongoc_array_init (&captured_logs, sizeof (log_entry_t *));
-   mongoc_log_set_handler (log_handler, (void *) &suite);
+   mongoc_log_set_handler (log_handler, (void *) suite);
 
 #ifdef MONGOC_ENABLE_SSL
    test_framework_global_ssl_opts_init ();


### PR DESCRIPTION
Addresses a test suite regression introduced in https://github.com/mongodb/mongo-c-driver/pull/1220 (CDRIVER-2964). The UB is triggered when accessing the `suite` variable on this line: https://github.com/mongodb/mongo-c-driver/blob/b06a0018f377889a7e18928795f7e60bac3b4d7c/src/libmongoc/tests/test-libmongoc.c#L219

The `suite` variable is accessed as "a pointer to `TestSuite`", when its value is in fact "a pointer to _a pointer to_ `TestSuite`" as (incorrectly) set on this line: https://github.com/mongodb/mongo-c-driver/blob/b06a0018f377889a7e18928795f7e60bac3b4d7c/src/libmongoc/tests/test-libmongoc.c#L2682

When detected, ASAN reports the resulting UB in the form of a difficult-to-diagnose stack-use-after-free error. The actual cause is access of the `suite` _parameter_ in `test_libmongoc_init` long after the function had completed execution.