### PR TITLE
Cleanup and relocate BUILD_VERSION calculation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,23 @@
 cmake_minimum_required (VERSION 3.15)
 
-project (mongo-c-driver C)
+list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/build/cmake")
+# Defines BUILD_VERSION, which we use throughout:
+include (BuildVersion)
 
-list (APPEND CMAKE_MODULE_PATH
-      "${PROJECT_SOURCE_DIR}/build/cmake"
-      )
+project (
+   mongo-c-driver
+   LANGUAGES C
+   # BUILD_VERSION_SIMPLE is a CMake-compatible version number that omits suffixes
+   VERSION "${BUILD_VERSION_SIMPLE}"
+)
+
+# Set MONGOC_MAJOR_VERSION, MONGOC_MINOR_VERSION, etc.
+include (ParseVersion)
+ParseVersion ("${BUILD_VERSION}" MONGOC)
+# Defines additional similar variables:
+include (LoadVersion)
+file (WRITE VERSION_CURRENT "${BUILD_VERSION}")
+LoadVersion (VERSION_CURRENT MONGOC)
 
 include (MongoSettings)
 include (MongoPlatform)
@@ -263,52 +276,6 @@ include (CCache)
 if (NOT MSVC)
    include (LLDLinker)
 endif ()
-
-set (BUILD_VERSION "0.0.0" CACHE STRING "Library version (for both libbson and libmongoc)")
-
-include (ParseVersion)
-
-# Set MONGOC_MAJOR_VERSION, MONGOC_MINOR_VERSION, etc.
-if (BUILD_VERSION STREQUAL "0.0.0")
-   if (EXISTS ${PROJECT_SOURCE_DIR}/VERSION_CURRENT)
-      file (STRINGS ${PROJECT_SOURCE_DIR}/VERSION_CURRENT BUILD_VERSION)
-      message (STATUS "file VERSION_CURRENT contained BUILD_VERSION ${BUILD_VERSION}")
-   else ()
-      find_package (PythonInterp)
-      if (PYTHONINTERP_FOUND)
-         execute_process (
-            COMMAND ${PYTHON_EXECUTABLE} build/calc_release_version.py
-            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-            OUTPUT_VARIABLE CALC_RELEASE_VERSION
-            RESULT_VARIABLE CALC_RELEASE_VERSION_RESULT
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-         )
-         if (NOT CALC_RELEASE_VERSION_RESULT STREQUAL 0)
-            # If python failed above, stderr would tell the user about it
-            message (FATAL_ERROR
-               "BUILD_VERSION not specified and could not be calculated\
- (script invocation failed); specify in CMake command, -DBUILD_VERSION=<version>"
-            )
-         else ()
-            set (BUILD_VERSION ${CALC_RELEASE_VERSION})
-            message (STATUS "calculated BUILD_VERSION ${BUILD_VERSION}")
-         endif ()
-      else ()
-         message (FATAL_ERROR
-            "BUILD_VERSION not specified and could not be calculated\
- (Python was not found on the system); specify in CMake command, -DBUILD_VERSION=<version>"
-         )
-      endif ()
-      message (STATUS "storing BUILD_VERSION ${BUILD_VERSION} in file VERSION_CURRENT for later use")
-      file (WRITE ${PROJECT_SOURCE_DIR}/VERSION_CURRENT ${BUILD_VERSION})
-   endif ()
-else ()
-   message (STATUS "storing BUILD_VERSION ${BUILD_VERSION} in file VERSION_CURRENT for later use")
-   file (WRITE ${PROJECT_SOURCE_DIR}/VERSION_CURRENT ${BUILD_VERSION})
-endif ()
-
-include (LoadVersion)
-LoadVersion (${PROJECT_SOURCE_DIR}/VERSION_CURRENT MONGOC)
 
 if ( (ENABLE_BUILD_DEPENDECIES STREQUAL OFF) AND (NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR) )
    set (ENABLE_BUILD_DEPENDECIES ON)

--- a/build/cmake/BuildVersion.cmake
+++ b/build/cmake/BuildVersion.cmake
@@ -46,13 +46,8 @@ function(compute_build_version outvar)
     set("${outvar}" "${output}" PARENT_SCOPE)
 endfunction()
 
-# Define the BUILD_VERSION setting:
-mongo_setting(
-   BUILD_VERSION "Library version (for both libbson and libmongoc)"
-   DEFAULT EVAL [[
-      compute_build_version(DEFAULT)
-   ]]
-)
+# Define the BUILD_VERSION:
+compute_build_version(BUILD_VERSION)
 
 # Set a BUILD_VERSION_SIMPLE, which is just a three-number-triple that CMake understands
 string (REGEX REPLACE "([0-9]+\\.[0-9]+\\.[0-9]+).*$" "\\1" BUILD_VERSION_SIMPLE "${BUILD_VERSION}")

--- a/build/cmake/BuildVersion.cmake
+++ b/build/cmake/BuildVersion.cmake
@@ -1,0 +1,58 @@
+include_guard(GLOBAL)
+
+include(MongoSettings)
+
+# We use Python to calculate the BUILD_VERSION value
+find_package(Python3 COMPONENTS Interpreter)
+
+set(_CALC_VERSION_PY "${CMAKE_CURRENT_LIST_DIR}/../calc_release_version.py")
+
+#[[
+    Attempts to find the current build version string. If VERSION_CURRENT exists
+    in the current source directory, uses that. Otherwise, runs calc_release_version.py
+    to compute the version from the Git history.
+
+    The computed build version is set in the parent scope according to `outvar`.
+]]
+function(compute_build_version outvar)
+    list(APPEND CMAKE_MESSAGE_CONTEXT ${CMAKE_CURRENT_FUNCTION})
+    # If it is present, defer to the VERSION_CURRENT file:
+    set(ver_cur_file "${CMAKE_CURRENT_SOURCE_DIR}/VERSION_CURRENT")
+    if(EXISTS "${ver_cur_file}")
+        message(DEBUG "Using existing VERSION_CURRENT file as BUILD_VERSION [${ver_cur_file}]")
+        file(READ "${ver_cur_file}" version)
+        set("${outvar}" "${version}" PARENT_SCOPE)
+        return()
+    endif()
+    # Otherwise, we require Python:
+    if(NOT TARGET Python3::Interpreter)
+        message(WARNING "No default build version could be calculated (Python was not found)")
+        set("${outvar}" "0.0.0-unknown+no-python-found")
+        return()
+    endif()
+    get_target_property(py Python3::Interpreter IMPORTED_LOCATION)
+    message(STATUS "Computing the current release version...")
+    execute_process(
+        COMMAND "${py}" "${_CALC_VERSION_PY}"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        OUTPUT_VARIABLE output
+        RESULT_VARIABLE retc
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if(retc)
+        message(FATAL_ERROR "Computing the build version failed! [${retc}]:\n${out}")
+    endif()
+    message(DEBUG "calc_release_version.py returned output: “${output}”")
+    set("${outvar}" "${output}" PARENT_SCOPE)
+endfunction()
+
+# Define the BUILD_VERSION setting:
+mongo_setting(
+   BUILD_VERSION "Library version (for both libbson and libmongoc)"
+   DEFAULT EVAL [[
+      compute_build_version(DEFAULT)
+   ]]
+)
+
+# Set a BUILD_VERSION_SIMPLE, which is just a three-number-triple that CMake understands
+string (REGEX REPLACE "([0-9]+\\.[0-9]+\\.[0-9]+).*$" "\\1" BUILD_VERSION_SIMPLE "${BUILD_VERSION}")

--- a/build/cmake/BuildVersion.cmake
+++ b/build/cmake/BuildVersion.cmake
@@ -3,7 +3,7 @@ include_guard(GLOBAL)
 include(MongoSettings)
 
 # We use Python to calculate the BUILD_VERSION value
-find_package(Python3 COMPONENTS Interpreter)
+find_package(Python COMPONENTS Interpreter)
 
 set(_CALC_VERSION_PY "${CMAKE_CURRENT_LIST_DIR}/../calc_release_version.py")
 
@@ -25,12 +25,12 @@ function(compute_build_version outvar)
         return()
     endif()
     # Otherwise, we require Python:
-    if(NOT TARGET Python3::Interpreter)
+    if(NOT TARGET Python::Interpreter)
         message(WARNING "No default build version could be calculated (Python was not found)")
         set("${outvar}" "0.0.0-unknown+no-python-found")
         return()
     endif()
-    get_target_property(py Python3::Interpreter IMPORTED_LOCATION)
+    get_target_property(py Python::Interpreter IMPORTED_LOCATION)
     message(STATUS "Computing the current release version...")
     execute_process(
         COMMAND "${py}" "${_CALC_VERSION_PY}"


### PR DESCRIPTION
- The computation of BUILD_VERSION is now lifted above project(), which allows us to use that value in the project() call itself, giving us correct PROJECT_VERSION values throughout.
- Define BUILD_VERSION using mongo_setting(), and use the calc_release_version.py to compute its default value.

---

Possible concerns:

- The `LoadVersion` and `ParseVersion` are extremely similar, but both are required to get the project to work. Some locations refer to the `_VERSION_PATCH` suffix, while others use `_MICRO_VERSION` suffix. These could/should probably be consolidated to a single variable set.
- It isn't clear what the purpose of `BUILD_VERSION` (as a cache variable) serves when `VERSION_CURRENT` (the text file) will usually take precedence.