### PR TITLE
Fix ValueError error during config generation

### DIFF
--- a/.evergreen/config_generator/components/kms_divergence_check.py
+++ b/.evergreen/config_generator/components/kms_divergence_check.py
@@ -22,7 +22,7 @@ class KmsDivergenceCheck(Function):
 
 
 def functions():
-    return KmsDivergenceCheck.defn(),
+    return KmsDivergenceCheck.defn()
 
 
 def tasks():


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1381. Addresses this very unhelpful error during EVG config generation:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File ".evergreen/config_generator/generate.py", line 34, in main
    m.generate()
  File ".evergreen/config_generator/generators/functions.py", line 13, in generate
    functions.update(component.functions())
ValueError: dictionary update sequence element #0 has length 1; 2 is required
```