### PR TITLE
CDRIVER-4536 replace calls to malloc/calloc/free with bson wrapper equivalents

### DIFF
--- a/src/libbson/examples/bson-streaming-reader.c
+++ b/src/libbson/examples/bson-streaming-reader.c
@@ -142,17 +142,17 @@ main (int argc, char *argv[])
       case 'h':
          fprintf (
             stdout, "Usage: %s [-s SERVER_NAME] [-p PORT_NUM]\n", argv[0]);
-         free (hostname);
-         free (port);
+         bson_free (hostname);
+         bson_free (port);
          return EXIT_SUCCESS;
       case 'p':
-         free (port);
-         port = (char *) malloc (strlen (optarg) + 1);
+         bson_free (port);
+         port = (char *) bson_malloc (strlen (optarg) + 1);
          strcpy (port, optarg);
          break;
       case 's':
-         free (hostname);
-         hostname = (char *) malloc (strlen (optarg) + 1);
+         bson_free (hostname);
+         hostname = (char *) bson_malloc (strlen (optarg) + 1);
          strcpy (hostname, optarg);
          break;
       default:
@@ -167,8 +167,8 @@ main (int argc, char *argv[])
     */
    fd = bson_streaming_remote_open (hostname, port);
    if (fd == -1) {
-      free (hostname);
-      free (port);
+      bson_free (hostname);
+      bson_free (port);
       return EXIT_FAILURE;
    }
 
@@ -185,7 +185,7 @@ main (int argc, char *argv[])
     * destruction.
     */
    bson_reader_destroy (reader);
-   free (hostname);
-   free (port);
+   bson_free (hostname);
+   bson_free (port);
    return EXIT_SUCCESS;
 }

--- a/src/libbson/src/bson/bson-dsl.md
+++ b/src/libbson/src/bson/bson-dsl.md
@@ -804,7 +804,7 @@ user_info get_user(const bson_t* data) {
                       else(do(ret.age = bsonAs(int32))))),
             else(error("The 'age' property is missing")));
   if (bsonParseError) {
-    free(ret.name);
+    bson_free(ret.name);
     fprintf(stderr, "Error while reading user_info from bson: %s\n", bsonParseError);
     return {0};
   }

--- a/src/libbson/src/bson/bson-memory.c
+++ b/src/libbson/src/bson/bson-memory.c
@@ -152,7 +152,7 @@ bson_malloc0 (size_t num_bytes) /* IN */
 /*
  *--------------------------------------------------------------------------
  *
- * bson_aligned_malloc --
+ * bson_aligned_alloc --
  *
  *       Allocates @num_bytes of memory with an alignment of @alignment and
  *       returns a pointer to it.  If malloc failed to allocate the memory,

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -2185,7 +2185,7 @@ bson_copy_to (const bson_t *src, bson_t *dst)
    if ((src->flags & BSON_FLAG_INLINE)) {
 #ifdef BSON_MEMCHECK
       dst->len = src->len;
-      dst->canary = malloc (1);
+      dst->canary = bson_malloc (1);
       memcpy (dst->padding, src->padding, sizeof dst->padding);
 #else
       memcpy (dst, src, sizeof *dst);

--- a/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
@@ -1302,7 +1302,7 @@ fail:
    bson_destroy (&client_command);
    bson_destroy (&server_reply);
    kms_request_destroy (request);
-   free (signature);
+   bson_free (signature);
    bson_free (server_nonce_str);
    return ret;
 }

--- a/src/libmongoc/src/mongoc/mongoc-cluster-sspi.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-sspi.c
@@ -71,7 +71,7 @@ _mongoc_cluster_sspi_new (mongoc_uri_t *uri,
    service_ascii_len = strlen (service_ascii);
 
    /* this is donated to the sspi */
-   service = calloc (service_ascii_len + 1, sizeof (WCHAR));
+   service = bson_malloc0 ((service_ascii_len + 1) * sizeof (WCHAR));
    service_len = MultiByteToWideChar (CP_UTF8,
                                       0,
                                       service_ascii,
@@ -85,7 +85,7 @@ _mongoc_cluster_sspi_new (mongoc_uri_t *uri,
       tmp_creds_len = strlen (state->sasl.pass);
 
       /* this is donated to the sspi */
-      pass = calloc (tmp_creds_len + 1, sizeof (WCHAR));
+      pass = bson_malloc0 ((tmp_creds_len + 1) * sizeof (WCHAR));
       pass_len = MultiByteToWideChar (CP_UTF8,
                                       0,
                                       state->sasl.pass,
@@ -99,7 +99,7 @@ _mongoc_cluster_sspi_new (mongoc_uri_t *uri,
       tmp_creds_len = strlen (state->sasl.user);
 
       /* this is donated to the sspi */
-      user = calloc (tmp_creds_len + 1, sizeof (WCHAR));
+      user = bson_malloc0 ((tmp_creds_len + 1) * sizeof (WCHAR));
       user_len = MultiByteToWideChar (CP_UTF8,
                                       0,
                                       state->sasl.user,

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -756,7 +756,7 @@ mongoc_secure_channel_handshake_step_2 (mongoc_stream_tls_t *tls,
       _mongoc_secure_channel_init_sec_buffer (
          &inbuf[0],
          SECBUFFER_TOKEN,
-         malloc (secure_channel->encdata_offset),
+         bson_malloc (secure_channel->encdata_offset),
          (unsigned long) (secure_channel->encdata_offset &
                           (size_t) 0xFFFFFFFFUL));
       _mongoc_secure_channel_init_sec_buffer (
@@ -802,7 +802,7 @@ mongoc_secure_channel_handshake_step_2 (mongoc_stream_tls_t *tls,
                                     &secure_channel->ctxt->time_stamp);
 
       /* free buffer for received handshake data */
-      free (inbuf[0].pvBuffer);
+      bson_free (inbuf[0].pvBuffer);
 
       /* check if the handshake was incomplete */
       if (sspi_status == SEC_E_INCOMPLETE_MESSAGE) {

--- a/src/libmongoc/tests/TestSuite.c
+++ b/src/libmongoc/tests/TestSuite.c
@@ -315,7 +315,7 @@ _V_TestSuite_AddFull (TestSuite *suite,
       return NULL;
    }
 
-   test = (Test *) calloc (1, sizeof *test);
+   test = (Test *) bson_malloc0 (sizeof *test);
    test->name = bson_strdup (name);
    test->func = func;
    test->num_checks = 0;
@@ -395,7 +395,7 @@ _TestSuite_TestFnCtxDtor (void *ctx)
    if (dtor) {
       dtor (ctx);
    }
-   free (ctx);
+   bson_free (ctx);
 }
 
 
@@ -1003,7 +1003,7 @@ _process_skip_file (const char *filename, mongoc_array_t *skips)
          continue; /* Comment line or blank line */
       }
 
-      skip = (TestSkip *) calloc (1, sizeof *skip);
+      skip = (TestSkip *) bson_malloc0 (sizeof *skip);
       if (buffer[buflen - 1] == '\n')
          buflen--;
       test_name_end = buffer + buflen;
@@ -1166,8 +1166,8 @@ TestSuite_Destroy (TestSuite *suite)
       if (test->dtor) {
          test->dtor (test->ctx);
       }
-      free (test->name);
-      free (test);
+      bson_free (test->name);
+      bson_free (test);
    }
 
    if (suite->outfile) {
@@ -1178,9 +1178,9 @@ TestSuite_Destroy (TestSuite *suite)
       bson_string_free (suite->mock_server_log_buf, true);
    }
 
-   free (suite->name);
-   free (suite->prgname);
-   free (suite->ctest_run);
+   bson_free (suite->name);
+   bson_free (suite->prgname);
+   bson_free (suite->ctest_run);
    for (size_t i = 0u; i < suite->match_patterns.len; i++) {
       char *val = _mongoc_array_index (&suite->match_patterns, char *, i);
       bson_free (val);

--- a/src/libmongoc/tests/TestSuite.h
+++ b/src/libmongoc/tests/TestSuite.h
@@ -757,19 +757,19 @@ void
 _TestSuite_TestFnCtxDtor (void *ctx);
 #define TestSuite_AddFull(_suite, _name, _func, _dtor, _ctx, ...) \
    _TestSuite_AddFull (_suite, _name, _func, _dtor, _ctx, __VA_ARGS__, NULL)
-#define TestSuite_AddFullWithTestFn(                \
-   _suite, _name, _func, _dtor, _test_fn, ...)      \
-   do {                                             \
-      TestFnCtx *ctx = malloc (sizeof (TestFnCtx)); \
-      ctx->test_fn = (TestFunc) (_test_fn);         \
-      ctx->dtor = _dtor;                            \
-      _TestSuite_AddFull (_suite,                   \
-                          _name,                    \
-                          _func,                    \
-                          _TestSuite_TestFnCtxDtor, \
-                          ctx,                      \
-                          __VA_ARGS__,              \
-                          NULL);                    \
+#define TestSuite_AddFullWithTestFn(                     \
+   _suite, _name, _func, _dtor, _test_fn, ...)           \
+   do {                                                  \
+      TestFnCtx *ctx = bson_malloc (sizeof (TestFnCtx)); \
+      ctx->test_fn = (TestFunc) (_test_fn);              \
+      ctx->dtor = _dtor;                                 \
+      _TestSuite_AddFull (_suite,                        \
+                          _name,                         \
+                          _func,                         \
+                          _TestSuite_TestFnCtxDtor,      \
+                          ctx,                           \
+                          __VA_ARGS__,                   \
+                          NULL);                         \
    } while (0)
 int
 TestSuite_Run (TestSuite *suite);

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -2612,7 +2612,7 @@ windows_exception_handler (EXCEPTION_POINTERS *pExceptionInfo)
    stack_frame.AddrStack.Mode = AddrModeFlat;
 
    SYMBOL_INFO *symbol;
-   symbol = calloc (sizeof (SYMBOL_INFO) + 256, 1);
+   symbol = bson_malloc0 (sizeof (SYMBOL_INFO) + 256);
    symbol->MaxNameLen = 255;
    symbol->SizeOfStruct = sizeof (SYMBOL_INFO);
 

--- a/src/libmongoc/tests/test-mongoc-matcher.c
+++ b/src/libmongoc/tests/test-mongoc-matcher.c
@@ -61,7 +61,7 @@ test_mongoc_matcher_basic (void)
    {
       char *out = bson_as_canonical_extended_json(&matcher_query, NULL);
       fprintf(stderr, "bson: %s\n", out);
-      free(out);
+      bson_free(out);
    }
 #endif
 


### PR DESCRIPTION
Patch build: https://spruce.mongodb.com/version/64e928f59ccd4e4f7ecb296e/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Note: The failure of authentication-tests-openssl on zSeries is spurious. I checked and it is also failing on master.