### PR TITLE
CDRIVER-4710 move data compression doc to top-level

### DIFF
--- a/src/libmongoc/doc/advanced-connections.rst
+++ b/src/libmongoc/doc/advanced-connections.rst
@@ -5,7 +5,7 @@ Advanced Connections
 
 The following guide contains information specific to certain types of MongoDB configurations.
 
-For an example of connecting to a simple standalone server, see the :ref:`Tutorial <tutorial_connecting>`. To establish a connection with authentication options enabled, see the :doc:`Authentication <authentication>` page.
+For an example of connecting to a simple standalone server, see the :ref:`Tutorial <tutorial_connecting>`. To establish a connection with authentication options enabled, see the :doc:`Authentication <authentication>` page. To see an example of a connection with data compression, see the :doc:`Data Compression <data-compression>` page.
 
 Connecting to a Replica Set
 ---------------------------
@@ -145,26 +145,7 @@ See :doc:`configuring_tls` for more information on the various TLS related optio
 Compressing data to and from MongoDB
 ------------------------------------
 
-MongoDB 3.4 added Snappy compression support, zlib compression in 3.6, and zstd compression in 4.2.
-To enable compression support the client must be configured with which compressors to use:
-
-.. code-block:: none
-
-  mongoc_client_t *client = NULL;
-  client = mongoc_client_new ("mongodb://localhost:27017/?compressors=snappy,zlib,zstd");
-
-The ``compressors`` option specifies the priority order of compressors the
-client wants to use. Messages are compressed if the client and server share any
-compressors in common.
-
-Note that the compressor used by the server might not be the same compressor as
-the client used.  For example, if the client uses the connection string
-``compressors=zlib,snappy`` the client will use ``zlib`` compression to send
-data (if possible), but the server might still reply using ``snappy``,
-depending on how the server was configured.
-
-The driver must be built with zlib and/or snappy and/or zstd support to enable compression
-support, any unknown (or not compiled in) compressor value will be ignored.
+This content has been relocated to the :doc:`Data Compression <data-compression>` page.
 
 Additional Connection Options
 -----------------------------

--- a/src/libmongoc/doc/data-compression.rst
+++ b/src/libmongoc/doc/data-compression.rst
@@ -1,0 +1,31 @@
+:man_page: mongoc_data_compression
+
+Data Compression
+================
+
+The following guide explains how data compression support works between the MongoDB server and client. It also shows an example of how to connect to a server with data compression.
+
+Compressing data to and from MongoDB
+------------------------------------
+
+MongoDB 3.4 added Snappy compression support, while zlib compression was added in 3.6, and zstd compression in 4.2.
+To enable compression support the client must be configured with which compressors to use:
+
+.. code-block:: none
+
+  mongoc_client_t *client = NULL;
+  client = mongoc_client_new ("mongodb://localhost:27017/?compressors=snappy,zlib,zstd");
+
+The ``compressors`` option specifies the priority order of compressors the
+client wants to use. Messages are compressed if the client and server share any
+compressors in common.
+
+Note that the compressor used by the server might not be the same compressor as
+the client used.  For example, if the client uses the connection string
+``compressors=zlib,snappy`` the client will use ``zlib`` compression to send
+data (if possible), but the server might still reply using ``snappy``,
+depending on how the server was configured.
+
+The driver must be built with zlib and/or snappy and/or zstd support to enable compression
+support, any unknown (or not compiled in) compressor value will be ignored.
+

--- a/src/libmongoc/doc/guides.rst
+++ b/src/libmongoc/doc/guides.rst
@@ -11,6 +11,7 @@ Guides
    mongoc-common-task-examples
    advanced-connections
    connection-pooling
+   data-compression
    cursors
    bulk
    aggregate

--- a/src/libmongoc/doc/tutorial.rst
+++ b/src/libmongoc/doc/tutorial.rst
@@ -109,7 +109,7 @@ At the start of an application, call :symbol:`mongoc_init` before any other libm
 
 The example below establishes a connection to a standalone server on ``localhost``, registers the client application as "connect-example," and performs a simple command.
 
-More information about database operations can be found in the :ref:`CRUD Operations <tutorial_crud_operations>` and :ref:`Executing Commands <tutorial_executing_commands>` sections. Examples of connecting to replica sets and sharded clusters can be found on the :doc:`Advanced Connections <advanced-connections>` page.
+More information about database operations can be found in the :ref:`CRUD Operations <tutorial_crud_operations>` and :ref:`Executing Commands <tutorial_executing_commands>` sections. Examples of connecting to replica sets and sharded clusters can be found in the :doc:`Advanced Connections <advanced-connections>` page, while examples of data compression can be found in the :doc:`Data Compression <data-compression>` page.
 
 .. literalinclude:: ../examples/hello_mongoc.c
   :caption: hello_mongoc.c


### PR DESCRIPTION
It looks to me like we already have sufficient documentation of how to use data compression. In this PR I relocated it to a top-level document (as indicated in the ticket) and added appropriate additional links.