### PR TITLE
Fix debian build 1050439

### DIFF
--- a/.evergreen/scripts/debian_package_build.sh
+++ b/.evergreen/scripts/debian_package_build.sh
@@ -40,8 +40,7 @@ cd ..
 
 git clone https://salsa.debian.org/installer-team/debootstrap.git debootstrap.git
 export DEBOOTSTRAP_DIR=`pwd`/debootstrap.git
-# revert trixie -> unstable once Debian bug #1050439 is fixed
-sudo -E ./debootstrap.git/debootstrap trixie ./unstable-chroot/ http://cdn-aws.deb.debian.org/debian
+sudo -E ./debootstrap.git/debootstrap unstable ./unstable-chroot/ http://cdn-aws.deb.debian.org/debian
 cp -a mongoc ./unstable-chroot/tmp/
 sudo chroot ./unstable-chroot /bin/bash -c "(\
   apt-get install -y build-essential git-buildpackage fakeroot debhelper cmake libssl-dev pkg-config python3-sphinx python3-sphinx-design zlib1g-dev libsasl2-dev libsnappy-dev libzstd-dev libmongocrypt-dev libjs-mathjax libutf8proc-dev furo && \

--- a/debian/rules
+++ b/debian/rules
@@ -35,6 +35,7 @@ override_dh_auto_configure:
 	[ "$(DOCS)" = "ON" ] || echo "Found 'nodoc' in 'DEB_BUILD_OPTIONS'; not building documentation"
 	dh_auto_configure -- \
 	-DBUILD_VERSION=$(DEB_VERSION_UPSTREAM) \
+	-DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF \
 	-DENABLE_MONGOC=ON \
 	-DENABLE_MAN_PAGES=$(DOCS) \
 	-DENABLE_HTML_DOCS=$(DOCS) \


### PR DESCRIPTION
Evergreen patch build of only the debian-package-build task: https://spruce.mongodb.com/task/mongo_c_driver_packaging_debian_package_build_patch_f54103278dcfc9c0b509f31e9fcadadf32d41b1b_64ef63e957e85a2ed3272848_23_08_30_15_44_43/logs?execution=0