### PR TITLE
Address potential leak in unified test runner on killAllAssertions error

### DIFF
--- a/src/libmongoc/tests/unified/runner.c
+++ b/src/libmongoc/tests/unified/runner.c
@@ -321,6 +321,7 @@ test_runner_terminate_open_transactions (test_runner_t *test_runner,
                "Unexpected error running killAllSessions on server (%d): %s",
                (int) server_id,
                cmd_error.message);
+            _mongoc_array_destroy (&server_ids);
             goto done;
          }
       }


### PR DESCRIPTION
Drive-by fix discovered during CDRIVER-4702 work.