### PR TITLE
An Even-More-Basic Earthly Project

### DIFF
--- a/.evergreen/config_generator/components/earthly.py
+++ b/.evergreen/config_generator/components/earthly.py
@@ -1,0 +1,66 @@
+from shrub.v3.evg_build_variant import BuildVariant
+from shrub.v3.evg_task import EvgTaskRef
+from ..etc.utils import Task
+from shrub.v3.evg_command import subprocess_exec, EvgCommandType
+
+_ENV_PARAM_NAME = "MONGOC_EARTHLY_ENV"
+
+
+class EarthlyTask(Task):
+    def __init__(self, *, suffix: str, target: str) -> None:
+        super().__init__(
+            name=f"earthly-{suffix}",
+            commands=[
+                subprocess_exec(
+                    "bash",
+                    args=[
+                        "tools/earthly.sh",
+                        f"+{target}",
+                        f"--env=${{{_ENV_PARAM_NAME}}}",
+                    ],
+                    working_dir="mongoc",
+                    command_type=EvgCommandType.TEST,
+                )
+            ],
+            tags=[f"earthly", "pr-merge-gate"],
+            run_on=CONTAINER_RUN_DISTROS,
+        )
+
+
+#: A mapping from environment keys to the environment name.
+#: These correspond to special "*-env" targets in the Earthfile.
+ENVS = {
+    "u22": "Ubuntu 22.04",
+    "alpine3.18": "Alpine 3.18",
+    "archlinux": "Arch Linux",
+}
+
+CONTAINER_RUN_DISTROS = [
+    "ubuntu2204-small",
+    "ubuntu2204-large",
+    "ubuntu2004-small",
+    "ubuntu2004",
+    "ubuntu1804",
+    "ubuntu1804-medium",
+    "debian10",
+    "debian11",
+    "amazon2",
+]
+
+
+def tasks() -> list[Task]:
+    return [EarthlyTask(suffix="build-and-test", target="test-example")]
+
+
+def variants() -> list[BuildVariant]:
+    return [
+        BuildVariant(
+            name=f"earthly-{env_key}",
+            tasks=[EvgTaskRef(name=".earthly")],
+            display_name=env_name,
+            expansions={
+                _ENV_PARAM_NAME: env_key,
+            },
+        )
+        for env_key, env_name in ENVS.items()
+    ]

--- a/.evergreen/config_generator/components/earthly.py
+++ b/.evergreen/config_generator/components/earthly.py
@@ -49,7 +49,7 @@ CONTAINER_RUN_DISTROS = [
 
 
 def tasks() -> list[Task]:
-    return [EarthlyTask(suffix="build-and-test", target="test-example")]
+    return [EarthlyTask(suffix="build-check", target="test-example")]
 
 
 def variants() -> list[BuildVariant]:

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -1961,6 +1961,28 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-mock-kms-servers
       - func: run-tests
+  - name: earthly-build-and-test
+    run_on:
+      - ubuntu2204-small
+      - ubuntu2204-large
+      - ubuntu2004-small
+      - ubuntu2004
+      - ubuntu1804
+      - ubuntu1804-medium
+      - debian10
+      - debian11
+      - amazon2
+    tags: [earthly, pr-merge-gate]
+    commands:
+      - command: subprocess.exec
+        type: test
+        params:
+          binary: bash
+          working_dir: mongoc
+          args:
+            - tools/earthly.sh
+            - +test-example
+            - --env=${MONGOC_EARTHLY_ENV}
   - name: kms-divergence-check
     commands:
       - func: kms-divergence-check

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -20,6 +20,24 @@ buildvariants:
       DEBUG: "ON"
     tasks:
       - name: .cse-matrix-winssl
+  - name: earthly-alpine3.18
+    display_name: Alpine 3.18
+    expansions:
+      MONGOC_EARTHLY_ENV: alpine3.18
+    tasks:
+      - name: .earthly
+  - name: earthly-archlinux
+    display_name: Arch Linux
+    expansions:
+      MONGOC_EARTHLY_ENV: archlinux
+    tasks:
+      - name: .earthly
+  - name: earthly-u22
+    display_name: Ubuntu 22.04
+    expansions:
+      MONGOC_EARTHLY_ENV: u22
+    tasks:
+      - name: .earthly
   - name: mock-server-test
     display_name: Mock Server Test
     expansions:

--- a/.evergreen/scripts/cmake.sh
+++ b/.evergreen/scripts/cmake.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -eu
+. "$(dirname "${BASH_SOURCE[0]}")/find-cmake-latest.sh"
+
+cmake=$(find_cmake_latest)
+
+$cmake "$@"

--- a/.evergreen/scripts/find-cmake-latest.sh
+++ b/.evergreen/scripts/find-cmake-latest.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
 find_cmake_latest() {
-  # shellcheck source=.evergreen/scripts/env-var-utils.sh
-  . "$(dirname "${BASH_SOURCE[0]}")/env-var-utils.sh"
-  . "$(dirname "${BASH_SOURCE[0]}")/use-tools.sh" paths
+  . "$(dirname "${BASH_SOURCE[0]}")/use-tools.sh" paths || return
 
   declare script_dir
   script_dir="$(to_absolute "$(dirname "${BASH_SOURCE[0]}")")" || return

--- a/.evergreen/scripts/find-cmake-version.sh
+++ b/.evergreen/scripts/find-cmake-version.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Used to workaround curl certificate validation failures on certain distros.
-. "$(dirname "${BASH_SOURCE[0]}")/use-tools.sh" platform
+. "$(dirname "${BASH_SOURCE[0]}")/use-tools.sh" platform download
 
 # Create a temporary directory in the existing directory $1.
 make_tmpdir_in() {
@@ -168,19 +168,13 @@ find_cmake_version() {
   *) ;; # Build from source.
   esac
 
-  declare -a curl_args
-  curl_args=(
-    "--retry" "5"
-    "-sS"
-    "--max-time" "120"
-    "--fail"
-  )
+  declare -a download_args=(--out="cmake.${extension}")
 
   # TODO: remove once BUILD-16817 is resolved.
   # Workaround SSL certificate validation failures on certain distros.
   case "$OS_SHORTNAME-$ARCHNAME" in
     ubuntu14-*|ubuntu16-ppc|RedHat7-ppc)
-      curl_args+=("-k")
+      download_args+=(--no-tls-verify)
       ;;
   esac
 
@@ -196,13 +190,14 @@ find_cmake_version() {
   if [[ -n "${platform:-}" ]]; then
     cmake_download_binary() (
       declare -r cmake_url="https://cmake.org/files/v${major}.${minor}/cmake-${version}-${platform}.${extension}"
+      download_args+=(--uri="${cmake_url}")
 
       echo "Downloading cmake-${version}-${platform}..."
 
       cd "${tmp_cmake_dir}" || return
 
       # Allow download to fail and fallback to building from source.
-      if curl "${curl_args[@]}" "${cmake_url}" --output "cmake.${extension}"; then
+      if download-file "${download_args[@]}"; then
         "${decompressor}" "${decompressor_args[@]}" "cmake.${extension}" || return
 
         cmake_replace_version "${cache_dir}" "$(pwd)/${root_dir}" "${version}" || return

--- a/Earthfile
+++ b/Earthfile
@@ -53,7 +53,6 @@ BUILD_AND_INSTALL:
     RUN cmake -S "$source_dir" -B "$build_dir" -G "Ninja Multi-Config" \
         -D ENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF \
         -D ENABLE_MAINTAINER_FLAGS=ON \
-        -D ENABLE_RDTSCP=ON \
         -D ENABLE_SHM_COUNTERS=ON \
         -D ENABLE_EXTRA_ALIGNMENT=OFF \
         -D ENABLE_SASL=CYRUS \

--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,150 @@
+VERSION --arg-scope-and-set 0.7
+LOCALLY
+
+# PREP_CMAKE "warms up" the CMake installation cache for the current environment
+PREP_CMAKE:
+    COMMAND
+    LET scratch=/opt/mongoc-cmake
+    # Copy the minimal amount that we need, as to avoid cache invalidation
+    COPY tools/use.sh tools/platform.sh tools/paths.sh tools/base.sh tools/download.sh \
+        $scratch/tools/
+    COPY .evergreen/scripts/find-cmake-version.sh \
+        .evergreen/scripts/use-tools.sh \
+        .evergreen/scripts/find-cmake-latest.sh \
+        .evergreen/scripts/cmake.sh \
+        $scratch/.evergreen/scripts/
+    # "Install" a shim that runs our managed CMake executable:
+    RUN printf '#!/bin/sh\n /opt/mongoc-cmake/.evergreen/scripts/cmake.sh "$@"\n' \
+            > /usr/local/bin/cmake && \
+        chmod +x /usr/local/bin/cmake
+    # Executing any CMake command will warm the cache:
+    RUN cmake --version
+
+# version-current creates the VERSION_CURRENT file using Git. This file is exported as an artifact at /
+version-current:
+    # Run on Alpine, which does this work the fastest
+    FROM alpine:3.18
+    # Install Python and Git, the only things required for this job:
+    RUN apk add git python3
+    COPY --dir .git/ build/calc_release_version.py /s/
+    # Calculate it:
+    RUN cd /s/ && \
+        python calc_release_version.py > VERSION_CURRENT
+    SAVE ARTIFACT /s/VERSION_CURRENT
+
+# BUILD_AND_INSTALL executes the mongo-c-driver build and installs it to a prefix
+BUILD_AND_INSTALL:
+    COMMAND
+    ARG config=RelWithDebInfo
+    ARG install_prefix=/opt/mongo-c-driver
+    LET source_dir=/opt/mongoc/source
+    LET build_dir=/opt/mongoc/build
+    COPY --dir \
+        src/ \
+        build/ \
+        COPYING \
+        CMakeLists.txt \
+        README.rst \
+        THIRD_PARTY_NOTICES \
+        NEWS \
+        "$source_dir"
+    COPY +version-current/ $source_dir
+    ENV CCACHE_HOME=/root/.cache/ccache
+    RUN cmake -S "$source_dir" -B "$build_dir" -G "Ninja Multi-Config" \
+        -D ENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF \
+        -D ENABLE_MAINTAINER_FLAGS=ON \
+        -D ENABLE_RDTSCP=ON \
+        -D ENABLE_SHM_COUNTERS=ON \
+        -D ENABLE_EXTRA_ALIGNMENT=OFF \
+        -D ENABLE_SASL=CYRUS \
+        -D ENABLE_SNAPPY=ON \
+        -D ENABLE_SRV=ON \
+        -D ENABLE_ZLIB=BUNDLED \
+        -D ENABLE_SSL=OPENSSL \
+        -D ENABLE_COVERAGE=ON \
+        -D ENABLE_DEBUG_ASSERTIONS=ON \
+        -Werror
+    RUN --mount=type=cache,target=$CCACHE_HOME \
+        env CCACHE_BASE="$source_dir" \
+            cmake --build $build_dir --config $config
+    RUN cmake --install $build_dir --prefix="$install_prefix" --config $config
+
+alpine-base:
+    ARG --required version
+    FROM alpine:$version
+    RUN apk add cmake ninja-is-really-ninja gcc musl-dev
+
+alpine3.18-build-env:
+    FROM +alpine-base --version=3.18
+    RUN apk add openssl-dev cyrus-sasl-dev snappy-dev
+
+alpine3.18-test-env:
+    FROM +alpine-base --version=3.18
+    RUN apk add libsasl snappy
+
+archlinux-base:
+    FROM archlinux
+    RUN pacman --sync --refresh --sysupgrade --noconfirm --quiet ninja gcc snappy
+
+archlinux-build-env:
+    FROM +archlinux-base
+    DO +PREP_CMAKE
+
+archlinux-test-env:
+    FROM +archlinux-base
+    DO +PREP_CMAKE
+
+ubuntu-base:
+    ARG --required version
+    FROM ubuntu:$version
+    RUN apt-get update && apt-get -y install curl build-essential
+
+u22-build-env:
+    FROM +ubuntu-base --version=22.04
+    # Build dependencies:
+    RUN apt-get update && apt-get -y install \
+            ninja-build gcc ccache libssl-dev libsnappy-dev zlib1g-dev \
+            libsasl2-dev
+    DO +PREP_CMAKE
+
+u22-test-env:
+    FROM +ubuntu-base --version=22.04
+    RUN apt-get update && apt-get -y install libsnappy1v5 libsasl2-2 ninja-build
+    DO +PREP_CMAKE
+
+# build will build libmongoc and libbson using the specified environment.
+#
+# The --env argument specifies the build environment, which must be one of:
+#   • u22 (Ubuntu 22.04)
+#   • archlinux
+#   • alpine3.18
+build:
+    # env is an argument
+    ARG --required env
+    FROM +$env-build-env
+    DO +BUILD_AND_INSTALL --config=RelWithDebInfo
+    SAVE ARTIFACT /opt/mongoc/build/* /build-tree/
+    SAVE ARTIFACT /opt/mongo-c-driver/* /root/
+
+# test-example will build one of the libmongoc example projects using the build
+# that comes from the +build target.
+test-example:
+    ARG --required env
+    FROM +$env-test-env
+    # Grab the built
+    COPY (+build/root --env=$env) /opt/mongo-c-driver
+    COPY --dir \
+        src/libmongoc/examples/cmake \
+        src/libmongoc/examples/cmake-deprecated \
+        src/libmongoc/examples/hello_mongoc.c \
+        /opt/mongoc-test/
+    RUN cmake \
+            -S /opt/mongoc-test/cmake/find_package \
+            -B /bld \
+            -G Ninja \
+            -D CMAKE_PREFIX_PATH=/opt/mongo-c-driver
+    RUN cmake --build /bld
+
+# Simultaneously builds and tests multiple different platforms
+multibuild:
+    BUILD +test-example --env=u22 --env=archlinux --env=alpine3.18

--- a/build/cmake/ResSearch.cmake
+++ b/build/cmake/ResSearch.cmake
@@ -20,8 +20,11 @@ else()
     check_symbol_exists(res_search "${resolve_headers}" _MONGOC_HAVE_RES_SEARCH_RESOLV)
     check_symbol_exists(res_ndestroy "${resolve_headers}" _MONGOC_HAVE_RES_NDESTROY_RESOLV)
     check_symbol_exists(res_nclose "${resolve_headers}" _MONGOC_HAVE_RES_NCLOSE_RESOLV)
-    if((_MONGOC_HAVE_RES_NSEARCH_RESOLV OR _MONGOC_HAVE_RES_SEARCH_RESOLV)
-        AND (_MONGOC_HAVE_RES_NDESTROY_RESOLV OR _MONGOC_HAVE_RES_NCLOSE_RESOLV))
+    if(
+        (_MONGOC_HAVE_RES_NSEARCH_RESOLV
+            AND (_MONGOC_HAVE_RES_NDESTROY_RESOLV OR _MONGOC_HAVE_RES_NCLOSE_RESOLV))
+        OR _MONGOC_HAVE_RES_SEARCH_RESOLV
+    )
         set(RESOLVE_LIB_NAME resolv)
     else()
         # Can we use name resolution with just libc?
@@ -30,8 +33,11 @@ else()
         check_symbol_exists(res_search "${resolve_headers}" _MONGOC_HAVE_RES_SEARCH_NOLINK)
         check_symbol_exists(res_ndestroy "${resolve_headers}" _MONGOC_HAVE_RES_NDESTROY_NOLINK)
         check_symbol_exists(res_nclose "${resolve_headers}" _MONGOC_HAVE_RES_NCLOSE_NOLINK)
-        if((_MONGOC_HAVE_RES_NSEARCH_NOLINK OR _MONGOC_HAVE_RES_SEARCH_NOLINK)
-            AND (_MONGOC_HAVE_RES_NDESTROY_NOLINK OR _MONGOC_HAVE_RES_NCLOSE_NOLINK))
+        if(
+            (_MONGOC_HAVE_RES_NSEARCH_NOLINK
+                AND (_MONGOC_HAVE_RES_NDESTROY_NOLINK OR _MONGOC_HAVE_RES_NCLOSE_NOLINK))
+            OR _MONGOC_HAVE_RES_SEARCH_NOLINK
+        )
             set(resolve_is_libc TRUE)
             message(VERBOSE "Name resolution is provided by the C runtime")
         endif()

--- a/tools/download.sh
+++ b/tools/download.sh
@@ -42,6 +42,7 @@ download-file() {
     done
     if ! is-set uri || ! is-set out; then
         fail "download-file requires --uri=<uri> and --out=<filepath> arguments"
+        return
     fi
     debug "Download [$uri] to [$out]"
 
@@ -60,7 +61,7 @@ download-file() {
         fi
         curl_argv+=(-- "$uri")
         debug "Execute curl command: [curl ${curl_argv[*]}]"
-        output=$(curl "${curl_argv[@]}") || fail "$output"
+        output=$(curl "${curl_argv[@]}") || fail "$output" || return
         debug "$output"
     elif have-command wget; then
         wget_argv=(
@@ -73,10 +74,10 @@ download-file() {
         fi
         wget_argv+=(-- "$uri")
         debug "Execute wget command: [wget ${wget_argv[*]}]"
-        output=$(wget "${wget_argv[@]}" 2>&1) || fail "wget failed: $output"
+        output=$(wget "${wget_argv[@]}" 2>&1) || fail "wget failed: $output" || return
         debug "$output"
     else
-        fail "This script requires wither curl or wget to be available"
+        fail "This script requires either curl or wget to be available" || return
     fi
     debug "Download [$uri] to [$out] - Done"
 }

--- a/tools/earthly.sh
+++ b/tools/earthly.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/bash
+
+. "$(dirname "${BASH_SOURCE[0]}")/use.sh" paths platform
+
+set -euo pipefail
+
+: "${EARTHLY_VERSION:=0.7.16}"
+
+# Calc the arch of the executable we want
+case "$ARCHNAME" in
+    x64)
+        arch=amd64
+        ;;
+    arm64)
+        arch=arm64
+        ;;
+    *)
+        echo "Unsupported architecture for automatic Earthly download: $HOSTTYPE" 1>&1
+        exit 99
+        ;;
+esac
+
+# The location where the Earthly executable will live
+cache_dir="$USER_CACHES_DIR/earthly-sh/$EARTHLY_VERSION"
+mkdir -p "$cache_dir"
+
+exe_filename="earthly-$OS_FAMILY-$arch$EXE_SUFFIX"
+EARTHLY_EXE="$cache_dir/$exe_filename"
+
+# Download if it isn't already present
+if ! is-file "$EARTHLY_EXE"; then
+    echo "Downloading $exe_filename $EARTHLY_VERSION"
+    url="https://github.com/earthly/earthly/releases/download/v$EARTHLY_VERSION/$exe_filename"
+    curl --retry 5 -LsS --max-time 120 --fail "$url" --output "$EARTHLY_EXE"
+    chmod a+x "$EARTHLY_EXE"
+fi
+
+run-earthly() {
+    "$EARTHLY_EXE" "$@"
+}
+
+if is-main; then
+    run-earthly "$@"
+fi

--- a/tools/earthly.sh
+++ b/tools/earthly.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 . "$(dirname "${BASH_SOURCE[0]}")/use.sh" paths platform
 


### PR DESCRIPTION
The prior attempt to use Earthly (PR #987) used a very loose meaning of the word "basic", and is too much to review in a single pass. This time around, that build process and needs are much better understood since the opening of that changeset, so I am confident that this is more tractable and can be incrementally improved in the future.

---

# These Changes

This PR adds an `Earthfile`, an earthly shim alike `poetry.sh`, and makes a few supporting modifications other scripts.

In this changeset, the Earthfile only defines targets for a very simple build and a "Can we link a user application against this?" test. Currently, it defines platforms for Ubuntu 22.04, Alpine, and Arch Linux. We do not yet have existing CI for neither Ubuntu 22.04 nor Alpine, which have both been "TODO" for a long time. There is an existing ticket to remove our usage of Arch Linux as a build host, so this is a good opportunity to migrate it in a way that allows the EVG to retire the hosts while we can continue targeting the platform.

The Earthfile makes minimal use of existing CI scripting and prefers a more "clean slate" approach. There are plans to do more CI script refactoring, and having this tool to quickly reproduce issues and test changes locally will be a valuable tool.

## Trying it Out

If you have Docker or Podman installed and are able to launch Linux container images as your user, you can use this tool now:

```sh
$ ./tools/earthly.sh +build --env=u22
```

The `--env` parameter is not part of Earthly, but is defined as a build parameter of the `build` target. Refer to the Earthfile for more details. You can get more information using the `earthly docs` subcommand to print the doc comments for the targets in the Earthfile.

## The CI Story

This changeset adds three build variants for the three supported platforms, with one task that is used between them. The `--env` parameter is set using an expansion inherited from the variant in which the task runs.

Importantly, the Earthfile makes no assumptions about running on an EVG host, and should remain this way to facilitate local iteration.

# Drive-by Changes

The following additional changes were made is part of this changeset:

- A `.evergreen/scripts/cmake.sh` CMake shim was added. It launches the CMake executable that is managed by `find-cmake-latest.sh`. This is used as the `cmake` command within the container environments.
- It was discovered that `ResSearch.cmake` is incorrect in some situations (e.g. libmuslc). The conditions for finding name-resolution APIs have been modified for compat with libmuslc.
- The script which downloaded CMake has been modified to use a shim around either `wget` or `curl`, depending on what is available. Some platforms ship with one, the other, or neither.