### PR TITLE
fix `authentication-tests-darwinssl`

### DIFF
--- a/.evergreen/config_generator/components/funcs/prepare_kerberos.py
+++ b/.evergreen/config_generator/components/funcs/prepare_kerberos.py
@@ -12,7 +12,7 @@ class PrepareKerberos(Function):
             working_dir='mongoc',
             silent=True,
             script='''\
-            if test "${keytab|}" && [[ -f /etc/krb5.conf ]]; then
+            if test "${keytab|}" && command -v kinit >/dev/null; then
                 echo "${keytab}" > /tmp/drivers.keytab.base64
                 base64 --decode /tmp/drivers.keytab.base64 > /tmp/drivers.keytab
                 if touch /etc/krb5.conf 2>/dev/null; then

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -274,7 +274,7 @@ functions:
         args:
           - -c
           - |
-            if test "${keytab|}" && [[ -f /etc/krb5.conf ]]; then
+            if test "${keytab|}" && command -v kinit >/dev/null; then
                 echo "${keytab}" > /tmp/drivers.keytab.base64
                 base64 --decode /tmp/drivers.keytab.base64 > /tmp/drivers.keytab
                 if touch /etc/krb5.conf 2>/dev/null; then

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -1961,7 +1961,7 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-mock-kms-servers
       - func: run-tests
-  - name: earthly-build-and-test
+  - name: earthly-build-check
     run_on:
       - ubuntu2204-small
       - ubuntu2204-large

--- a/.evergreen/scripts/run-auth-tests.sh
+++ b/.evergreen/scripts/run-auth-tests.sh
@@ -62,7 +62,7 @@ esac
 : "${test_gssapi:?}"
 : "${ip_addr:?}"
 
-if command -v kinit && [[ -f /tmp/drivers.keytab ]]; then
+if command -v kinit >/dev/null && [[ -f /tmp/drivers.keytab ]]; then
   kinit -k -t /tmp/drivers.keytab -p drivers@LDAPTEST.10GEN.CC || true
 fi
 


### PR DESCRIPTION
# Summary

Replace check of existence of `/etc/krb5.conf` with presence of `kinit` command.
Fixes failing `authentication-tests-darwinssl` task.

Changes verified with this patch build: https://spruce.mongodb.com/version/64ff5b602fbabe466a2b35d1/

# Background & Summary

The condition in `prepare-kerberos` checked for existence of `/etc/krb5.conf`:
```sh
if test "${keytab|}" && [[ -f /etc/krb5.conf ]]; then
```

[A patch build](https://spruce.mongodb.com/task/mongo_c_driver_darwin_authentication_tests_darwinssl_patch_5c101ce5a565ffa9d160b6e44fb276b502b57157_64fbcaf11e2d17299e8c0ead_23_09_09_01_31_32/logs?execution=0) with more logging showed the `/etc/krb5.conf` file does not exist on the macOS host:

```
/etc/krb5.conf does not exist
```

`man kinit` on macOS notes the expected default path to be `/etc/krb5.conf`:

```
     KRB5_CONFIG
             The file name of krb5.conf, the default being /etc/krb5.conf.
```

It appears not to be necessary to check for the existence of `/etc/krb5.conf`.