### PR TITLE
CDRIVER-4682 Detect non-MongoDB host names before SRV lookup.

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -387,6 +387,8 @@ mongoc_topology_new (const mongoc_uri_t *uri, bool single_threaded)
 
    BSON_ASSERT (uri);
 
+   _detect_nongenuine_hosts (uri);
+
 #ifndef MONGOC_ENABLE_CRYPTO
    if (mongoc_uri_get_option_as_bool (
           uri, MONGOC_URI_RETRYWRITES, MONGOC_DEFAULT_RETRYWRITES)) {
@@ -649,8 +651,6 @@ mongoc_topology_new (const mongoc_uri_t *uri, bool single_threaded)
       mongoc_topology_description_add_server (td, elem->host_and_port, &id);
       mongoc_topology_scanner_add (topology->scanner, elem, id, false);
    }
-
-   _detect_nongenuine_hosts (uri);
 
    bson_free ((void *) hl_array);
 

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -346,11 +346,11 @@ _detect_nongenuine_host (const char *host)
 }
 
 static void
-_detect_nongenuine_hosts (const mongoc_host_list_t *hosts)
+_detect_nongenuine_hosts (const mongoc_uri_t *uri)
 {
    const mongoc_host_list_t *iter;
 
-   LL_FOREACH (hosts, iter)
+   LL_FOREACH (mongoc_uri_get_hosts (uri), iter)
    {
       if (_detect_nongenuine_host (iter->host)) {
          return;
@@ -650,7 +650,7 @@ mongoc_topology_new (const mongoc_uri_t *uri, bool single_threaded)
       mongoc_topology_scanner_add (topology->scanner, elem, id, false);
    }
 
-   _detect_nongenuine_hosts (*hl_array);
+   _detect_nongenuine_hosts (uri);
 
    bson_free ((void *) hl_array);
 

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -318,7 +318,7 @@ _mongoc_apply_srv_max_hosts (const mongoc_host_list_t *hl,
 static bool
 _detect_nongenuine_host (const char *host)
 {
-   char *host_lowercase = bson_strdup (host);
+   char *const host_lowercase = bson_strdup (host);
 
    mongoc_lowercase (host, host_lowercase);
 

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -348,6 +348,12 @@ _detect_nongenuine_host (const char *host)
 static void
 _detect_nongenuine_hosts (const mongoc_uri_t *uri)
 {
+   const char *srv_hostname = mongoc_uri_get_srv_hostname (uri);
+   if (srv_hostname) {
+      _detect_nongenuine_host (srv_hostname);
+      return;
+   }
+
    const mongoc_host_list_t *iter;
 
    LL_FOREACH (mongoc_uri_get_hosts (uri), iter)

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -2711,7 +2711,7 @@ test_detect_nongenuine_hosts (void)
       /* Test genuine SRV URIs */
       "mongodb+srv://a.example.com/",
       "mongodb+srv://a.mongodb.net/",
-      /* Host names do not end with expected suffix */
+      /* SRV host names do not end with expected suffix */
       "mongodb+srv://a.mongo.cosmos.azure.com.tld/",
       "mongodb+srv://a.docdb.amazonaws.com.tld/",
       "mongodb+srv://a.docdb-elastic.amazonaws.com.tld/",

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -2713,7 +2713,7 @@ test_detect_nongenuine_hosts (void)
       mongoc_topology_t *const topology = mongoc_topology_new (uri, true);
       ASSERT (topology);
       ASSERT_CAPTURED_LOG (
-         "nongenuine host should log",
+         cosmos_uris[i],
          MONGOC_LOG_LEVEL_INFO,
          "You appear to be connected to a CosmosDB cluster. For more "
          "information regarding feature compatibility and support please visit "
@@ -2729,7 +2729,7 @@ test_detect_nongenuine_hosts (void)
       mongoc_topology_t *const topology = mongoc_topology_new (uri, true);
       ASSERT (topology);
       ASSERT_CAPTURED_LOG (
-         "nongenuine host should log",
+         docdb_uris[i],
          MONGOC_LOG_LEVEL_INFO,
          "You appear to be connected to a DocumentDB cluster. For more "
          "information regarding feature compatibility and support please visit "
@@ -2745,7 +2745,7 @@ test_detect_nongenuine_hosts (void)
       ASSERT (uri);
       mongoc_topology_t *const topology = mongoc_topology_new (uri, true);
       ASSERT (topology);
-      ASSERT_NO_CAPTURED_LOGS ("genuine host should not log");
+      ASSERT_NO_CAPTURED_LOGS (genuine_uris[i]);
       mongoc_topology_destroy (topology);
       mongoc_uri_destroy (uri);
    }

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -2684,8 +2684,10 @@ test_detect_nongenuine_hosts (void)
       "mongodb://a.MONGO.COSMOS.AZURE.COM:19555/",
       /* Mixing genuine and nongenuine hosts (unlikely in practice) */
       "mongodb://a.example.com:27017,b.mongo.cosmos.azure.com:19555/",
-      /* Note: SRV connection strings are intentionally untested, since initial
-       * lookup responses cannot be easily mocked. */
+      /* Test SRV matching */
+      "mongodb+srv://a.mongo.cosmos.azure.com/",
+      /* Test SRV case-insensitive matching */
+      "mongodb+srv://A.MONGO.COSMOS.AZURE.COM/",
    };
 
    const char *docdb_uris[] = {
@@ -2695,6 +2697,8 @@ test_detect_nongenuine_hosts (void)
       "mongodb://a.DOCDB-ELASTIC.AMAZONAWS.COM:27017/",
       "mongodb://a.example.com:27017,b.docdb.amazonaws.com:27017/",
       "mongodb://a.example.com:27017,b.docdb-elastic.amazonaws.com:27017/",
+      "mongodb+srv://a.DOCDB.AMAZONAWS.COM/",
+      "mongodb+srv://a.DOCDB-ELASTIC.AMAZONAWS.COM/",
    };
 
    const char *genuine_uris[] = {
@@ -2704,6 +2708,13 @@ test_detect_nongenuine_hosts (void)
       "mongodb://a.mongo.cosmos.azure.com.tld:19555/",
       "mongodb://a.docdb.amazonaws.com.tld:27017/",
       "mongodb://a.docdb-elastic.amazonaws.com.tld:27017/",
+      /* Test genuine SRV URIs */
+      "mongodb+srv://a.example.com/",
+      "mongodb+srv://a.mongodb.net/",
+      /* Host names do not end with expected suffix */
+      "mongodb+srv://a.mongo.cosmos.azure.com.tld/",
+      "mongodb+srv://a.docdb.amazonaws.com.tld/",
+      "mongodb+srv://a.docdb-elastic.amazonaws.com.tld/",
    };
 
    for (size_t i = 0u; i < sizeof (cosmos_uris) / sizeof (*cosmos_uris); ++i) {


### PR DESCRIPTION
# Summary

- Detect non-MongoDB host names before SRV lookup.

# Background & Motivation

CDRIVER-4682 requires the driver to detect connection to a non-MongoDB server and log a message.

CDRIVER-4682 was initially implemented to detect after SRV lookup. Requirements were later changed to detect before SRV lookup:

> If SRV is used, this check should be done on the SRV's `{hostname}.{domainname}` prior to SRV lookup (ex: xyz.mongodb.net).

As a drive-by improvement, `test_detect_nongenuine_hosts` is updated to print the input URI string on test failure.