### PR TITLE
Fix testing instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,13 +135,14 @@ To run the entire test suite, including authentication and support for the
 enabled:
 
 ```
-$ mongod --auth --setParameter enableTestCommands=1
+$ mkdir db
+$ mongod --auth --setParameter enableTestCommands=1 --dbpath db/
 ```
 
 In another terminal, use the `mongo` shell to create a user:
 
 ```
-$ mongo --eval "db.createUser({user: 'admin', pwd: 'pass', roles: ['root']})" admin
+$ mongosh --eval "db.createUser({user: 'admin', pwd: 'pass', roles: ['root']})" admin
 ```
 
 Authentication in MongoDB 3.0 and later uses SCRAM-SHA-1, which in turn

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,7 +139,7 @@ $ mkdir db
 $ mongod --auth --setParameter enableTestCommands=1 --dbpath db/
 ```
 
-In another terminal, use the `mongo` shell to create a user:
+In another terminal, use the `mongosh` shell to create a user:
 
 ```
 $ mongosh --eval "db.createUser({user: 'admin', pwd: 'pass', roles: ['root']})" admin


### PR DESCRIPTION
Previously, following the testing instructions in CONTRIBUTING.md results in the following error:
```
"error":"NonExistentPath: Data directory /data/db not found. Create the missing directory or specify another path using (1) the --dbpath command line option, or (2) by adding the 'storage.dbPath' option in the configuration file."
```
This adds the dbpath to the command line so that way one can copy and paste the instructions in order to run tests.

Also, prefer to use the newer mongosh over mongo.