### PR TITLE
Bump patch version of latest CMake version to 3.25.3

### DIFF
--- a/.evergreen/scripts/find-cmake-latest.sh
+++ b/.evergreen/scripts/find-cmake-latest.sh
@@ -9,5 +9,5 @@ find_cmake_latest() {
   # shellcheck source=.evergreen/scripts/find-cmake-version.sh
   . "${script_dir}/find-cmake-version.sh" || return
 
-  find_cmake_version 3 25 2
+  find_cmake_version 3 25 3
 }


### PR DESCRIPTION
This _might_ address [flaky task failures](https://parsley.mongodb.com/evergreen/cxx_driver_auth__os~windows_2k8_mongodb_version~latest_compile_and_test_auth_with_shared_libs_60a3e7c4bf04079116c37a7eb9de5d30f67c02cb_23_09_13_19_02_31/0/task?bookmarks=0,366&shareLine=289) observed in the CXX Driver EVG waterfall due to the following error (cached CMake binary no longer binary/script-compatible with Git?):

```
      0 [main] sh (1044) C:\Program Files\Git\usr\bin\sh.exe: *** fatal error - cygheap base mismatch detected - 0xFB6410/0xE56410.
This problem is probably due to using incompatible versions of the cygwin DLL.
Search for cygwin1.dll using the Windows Start->Find/Search facility
and delete all but the most recent version.  The most recent version *should*
reside in x:\cygwin\bin, where 'x' is the drive on which you have
installed the cygwin distribution.  Rebooting is also suggested if you
are unable to find another cygwin DLL.
3078162 [main] sh 2884 fork: child -1 - forked process 1044 died unexpectedly, retry 0, exit code 0xC0000142, errno 11
C:\Program Files\Git\mingw32/libexec/git-core\git-submodule: fork: retry: Resource temporarily unavailable
```

Otherwise, this is just a simple patch version bump. Considered bumping to the latest minor version 3.27.4 but decided to postpone it for now.