### PR TITLE
Address nounset errors in find-cmake-version.sh

### DIFF
--- a/.evergreen/scripts/find-cmake-version.sh
+++ b/.evergreen/scripts/find-cmake-version.sh
@@ -168,16 +168,6 @@ find_cmake_version() {
   *) ;; # Build from source.
   esac
 
-  declare -a download_args=(--out="cmake.${extension}")
-
-  # TODO: remove once BUILD-16817 is resolved.
-  # Workaround SSL certificate validation failures on certain distros.
-  case "$OS_SHORTNAME-$ARCHNAME" in
-    ubuntu14-*|ubuntu16-ppc|RedHat7-ppc)
-      download_args+=(--no-tls-verify)
-      ;;
-  esac
-
   {
     # Doesn't matter who creates the cache directory so long as it exists.
     mkdir -p "${cache_dir}" || return
@@ -190,7 +180,20 @@ find_cmake_version() {
   if [[ -n "${platform:-}" ]]; then
     cmake_download_binary() (
       declare -r cmake_url="https://cmake.org/files/v${major}.${minor}/cmake-${version}-${platform}.${extension}"
-      download_args+=(--uri="${cmake_url}")
+
+      declare -a download_args
+      download_args=(
+        --out="cmake.${extension}"
+        --uri="${cmake_url}"
+      )
+
+      # TODO: remove once BUILD-16817 is resolved.
+      # Workaround SSL certificate validation failures on certain distros.
+      case "$OS_SHORTNAME-$ARCHNAME" in
+      ubuntu14-* | ubuntu16-ppc | RedHat7-ppc)
+        download_args+=(--no-tls-verify)
+        ;;
+      esac
 
       echo "Downloading cmake-${version}-${platform}..."
 


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1403. Addresses the following error observed in CXX Driver patch builds (see https://github.com/mongodb/mongo-cxx-driver/pull/1023):

```
find-cmake-version.sh: line 171: extension: unbound variable
```

`download_args` is only required in `cmake_download_binary()`, which is only invoked when `$platform` variables (including `$extension`) are set.