### PR TITLE
Share SCRAM cache via a global lookup table

### DIFF
--- a/.tsan-suppressions
+++ b/.tsan-suppressions
@@ -1,1 +1,2 @@
 race:mongoc_counter*
+race:_mongoc_handshake_freeze

--- a/src/libmongoc/src/mongoc/mongoc-cluster-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-private.h
@@ -62,8 +62,6 @@ typedef struct _mongoc_cluster_t {
 
    mongoc_set_t *nodes;
    mongoc_array_t iov;
-
-   mongoc_scram_cache_t *scram_cache;
 } mongoc_cluster_t;
 
 

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -812,7 +812,6 @@ _stream_run_hello (mongoc_cluster_t *cluster,
                    const char *address,
                    uint32_t server_id,
                    bool negotiate_sasl_supported_mechs,
-                   mongoc_scram_cache_t *scram_cache,
                    mongoc_scram_t *scram,
                    bson_t *speculative_auth_response /* OUT */,
                    bson_error_t *error)
@@ -843,7 +842,7 @@ _stream_run_hello (mongoc_cluster_t *cluster,
 #endif
 
       _mongoc_topology_scanner_add_speculative_authentication (
-         &handshake_command, cluster->uri, ssl_opts, scram_cache, scram);
+         &handshake_command, cluster->uri, ssl_opts, scram);
    }
 
    if (negotiate_sasl_supported_mechs) {
@@ -966,7 +965,6 @@ static mongoc_server_description_t *
 _cluster_run_hello (mongoc_cluster_t *cluster,
                     mongoc_cluster_node_t *node,
                     uint32_t server_id,
-                    mongoc_scram_cache_t *scram_cache,
                     mongoc_scram_t *scram /* OUT */,
                     bson_t *speculative_auth_response /* OUT */,
                     bson_error_t *error /* OUT */)
@@ -984,7 +982,6 @@ _cluster_run_hello (mongoc_cluster_t *cluster,
                            node->connection_address,
                            server_id,
                            _mongoc_uri_requires_auth_negotiation (cluster->uri),
-                           scram_cache,
                            scram,
                            speculative_auth_response,
                            error);
@@ -1415,11 +1412,6 @@ _mongoc_cluster_init_scram (const mongoc_cluster_t *cluster,
                             mongoc_crypto_hash_algorithm_t algo)
 {
    _mongoc_uri_init_scram (cluster->uri, scram, algo);
-
-   /* Apply previously cached SCRAM secrets if available */
-   if (cluster->scram_cache) {
-      _mongoc_scram_set_cache (scram, cluster->scram_cache);
-   }
 }
 
 /*
@@ -1780,13 +1772,6 @@ _mongoc_cluster_auth_scram_continue (
    }
 
    TRACE ("%s", "SCRAM: authenticated");
-
-   /* Save cached SCRAM secrets for future use */
-   if (cluster->scram_cache) {
-      _mongoc_scram_cache_destroy (cluster->scram_cache);
-   }
-
-   cluster->scram_cache = _mongoc_scram_get_cache (scram);
 
    return true;
 }
@@ -2175,7 +2160,6 @@ _cluster_add_node (mongoc_cluster_t *cluster,
    handshake_sd = _cluster_run_hello (cluster,
                                       cluster_node,
                                       server_id,
-                                      cluster->scram_cache,
                                       &scram,
                                       &speculative_auth_response,
                                       error);
@@ -2781,12 +2765,6 @@ mongoc_cluster_destroy (mongoc_cluster_t *cluster) /* INOUT */
    mongoc_set_destroy (cluster->nodes);
 
    _mongoc_array_destroy (&cluster->iov);
-
-#ifdef MONGOC_ENABLE_CRYPTO
-   if (cluster->scram_cache) {
-      _mongoc_scram_cache_destroy (cluster->scram_cache);
-   }
-#endif
 
    EXIT;
 }

--- a/src/libmongoc/src/mongoc/mongoc-scram-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-scram-private.h
@@ -44,19 +44,6 @@ enum {
    MONGOC_SCRAM_CACHE_SIZE = 64,
 };
 
-typedef struct _mongoc_scram_cache_t {
-   /* book keeping */
-   bool taken;
-   /* pre-secrets */
-   char hashed_password[MONGOC_SCRAM_HASH_MAX_SIZE];
-   uint8_t decoded_salt[MONGOC_SCRAM_B64_HASH_MAX_SIZE];
-   uint32_t iterations;
-   /* secrets */
-   uint8_t client_key[MONGOC_SCRAM_HASH_MAX_SIZE];
-   uint8_t server_key[MONGOC_SCRAM_HASH_MAX_SIZE];
-   uint8_t salted_password[MONGOC_SCRAM_HASH_MAX_SIZE];
-} mongoc_scram_cache_t;
-
 typedef struct _mongoc_scram_t {
    int step;
    char *user;
@@ -75,19 +62,12 @@ typedef struct _mongoc_scram_t {
 #ifdef MONGOC_ENABLE_CRYPTO
    mongoc_crypto_t crypto;
 #endif
-   mongoc_scram_cache_t *cache;
 } mongoc_scram_t;
 
 #ifdef MONGOC_ENABLE_CRYPTO
 void
 _mongoc_scram_init (mongoc_scram_t *scram, mongoc_crypto_hash_algorithm_t algo);
 #endif
-
-mongoc_scram_cache_t *
-_mongoc_scram_get_cache (mongoc_scram_t *scram);
-
-void
-_mongoc_scram_set_cache (mongoc_scram_t *scram, mongoc_scram_cache_t *cache);
 
 void
 _mongoc_scram_set_pass (mongoc_scram_t *scram, const char *pass);
@@ -116,9 +96,6 @@ _mongoc_scram_step (mongoc_scram_t *scram,
                     uint32_t outbufmax,
                     uint32_t *outbuflen,
                     bson_error_t *error);
-
-void
-_mongoc_scram_cache_destroy (mongoc_scram_cache_t *cache);
 
 /* returns false if this string does not need SASLPrep. It returns true
  * conservatively, if str might need to be SASLPrep'ed. */

--- a/src/libmongoc/src/mongoc/mongoc-scram-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-scram-private.h
@@ -38,9 +38,17 @@ BSON_BEGIN_DECLS
 #define MONGOC_SCRAM_B64_HASH_MAX_SIZE \
    MONGOC_SCRAM_B64_ENCODED_SIZE (MONGOC_SCRAM_HASH_MAX_SIZE)
 
+enum {
+   /* It is unlikely that there will be more than 64 different user accounts
+    * used in a single process */
+   MONGOC_SCRAM_CACHE_SIZE = 64,
+};
+
 typedef struct _mongoc_scram_cache_t {
+   /* book keeping */
+   bool taken;
    /* pre-secrets */
-   char *hashed_password;
+   char hashed_password[MONGOC_SCRAM_HASH_MAX_SIZE];
    uint8_t decoded_salt[MONGOC_SCRAM_B64_HASH_MAX_SIZE];
    uint32_t iterations;
    /* secrets */
@@ -53,7 +61,7 @@ typedef struct _mongoc_scram_t {
    int step;
    char *user;
    char *pass;
-   char *hashed_password;
+   char hashed_password[MONGOC_SCRAM_HASH_MAX_SIZE];
    uint8_t decoded_salt[MONGOC_SCRAM_B64_HASH_MAX_SIZE];
    uint32_t iterations;
    uint8_t client_key[MONGOC_SCRAM_HASH_MAX_SIZE];

--- a/src/libmongoc/src/mongoc/mongoc-scram.c
+++ b/src/libmongoc/src/mongoc/mongoc-scram.c
@@ -375,9 +375,7 @@ again:
          !memcmp (cache_entry->salted_password,
                   scram->salted_password,
                   sizeof (cache_entry->salted_password)) &&
-         !memcmp (cache_entry->decoded_salt,
-                  scram->decoded_salt,
-                  sizeof (cache_entry->salted_password));
+         );
 
       if (already_exists) {
          /* cache entry already populated between read and write lock

--- a/src/libmongoc/src/mongoc/mongoc-scram.c
+++ b/src/libmongoc/src/mongoc/mongoc-scram.c
@@ -104,6 +104,7 @@ _mongoc_scram_cache_clear (void)
 static BSON_ONCE_FUN (_mongoc_scram_cache_init)
 {
    bson_shared_mutex_init (&g_scram_cache_rwlock);
+   bson_mutex_init (&clear_cache_lock);
    _mongoc_scram_cache_clear ();
 
    BSON_ONCE_RETURN;

--- a/src/libmongoc/src/mongoc/mongoc-scram.c
+++ b/src/libmongoc/src/mongoc/mongoc-scram.c
@@ -86,7 +86,7 @@ static BSON_ONCE_FUN (_block_until_first_cache_entry_populated)
    BSON_ONCE_RETURN;
 }
 
-static BSON_ONCE_FUN (_unblock_when_first_cache_entry_populated)
+static BSON_ONCE_FUN (_unblock_after_first_cache_entry_populated)
 {
    bson_mutex_unlock (&first_cache_entry_lock);
 
@@ -1222,7 +1222,7 @@ CLEANUP:
    bson_free (val_v);
 
    bson_once (&unblock_after_first_entry_once_control,
-              _unblock_when_first_cache_entry_populated);
+              _unblock_after_first_cache_entry_populated);
    return rval;
 }
 

--- a/src/libmongoc/src/mongoc/mongoc-scram.c
+++ b/src/libmongoc/src/mongoc/mongoc-scram.c
@@ -218,7 +218,7 @@ _mongoc_scram_cache_has_presecrets (mongoc_scram_cache_t *cache /* out */,
 
    /*
     * - Take a read lock
-    * - Search through g_scram_cache if the hashed_password, decoded_salt, etc
+    * - Search through g_scram_cache if the hashed_password, decoded_salt, and iterations
     *   match an entry.
     * - If so, then return true
     * - Otherwise return false

--- a/src/libmongoc/src/mongoc/mongoc-scram.c
+++ b/src/libmongoc/src/mongoc/mongoc-scram.c
@@ -874,11 +874,6 @@ _mongoc_scram_step2 (mongoc_scram_t *scram,
    mongoc_scram_cache_entry_t cache;
    if (_mongoc_scram_cache_has_presecrets (&cache, scram)) {
       _mongoc_scram_cache_apply_secrets (&cache, scram);
-   } else {
-      /*
-       * Block other threads here to until SCRAM step 3 finishes so that the
-       * cache will get populated for the others threads.
-       */
    }
 
    if (!*scram->salted_password) {

--- a/src/libmongoc/src/mongoc/mongoc-scram.c
+++ b/src/libmongoc/src/mongoc/mongoc-scram.c
@@ -107,23 +107,7 @@ static void
 _mongoc_scram_cache_clear (void)
 {
    bson_mutex_lock (&clear_cache_lock);
-   for (size_t i = 0; i < MONGOC_SCRAM_CACHE_SIZE; i++) {
-      g_scram_cache[i].taken = false;
-      g_scram_cache[i].iterations = 0;
-      memset (g_scram_cache[i].hashed_password,
-              0,
-              sizeof (g_scram_cache[i].hashed_password));
-      memset (g_scram_cache[i].decoded_salt,
-              0,
-              sizeof (g_scram_cache[i].decoded_salt));
-      memset (
-         g_scram_cache[i].client_key, 0, sizeof (g_scram_cache[i].client_key));
-      memset (
-         g_scram_cache[i].server_key, 0, sizeof (g_scram_cache[i].server_key));
-      memset (g_scram_cache[i].salted_password,
-              0,
-              sizeof (g_scram_cache[i].salted_password));
-   }
+   memset (g_scram_cache, 0, sizeof (g_scram_cache));
    bson_mutex_unlock (&clear_cache_lock);
 }
 

--- a/src/libmongoc/src/mongoc/mongoc-scram.c
+++ b/src/libmongoc/src/mongoc/mongoc-scram.c
@@ -374,8 +374,7 @@ again:
                   sizeof (cache_entry->server_key)) &&
          !memcmp (cache_entry->salted_password,
                   scram->salted_password,
-                  sizeof (cache_entry->salted_password)) &&
-         );
+                  sizeof (cache_entry->salted_password));
 
       if (already_exists) {
          /* cache entry already populated between read and write lock

--- a/src/libmongoc/src/mongoc/mongoc-scram.c
+++ b/src/libmongoc/src/mongoc/mongoc-scram.c
@@ -29,6 +29,7 @@
 #include "common-b64-private.h"
 
 #include "mongoc-memcmp-private.h"
+#include "common-thread-private.h"
 #include <utf8proc.h>
 
 #define MONGOC_SCRAM_SERVER_KEY "Server Key"
@@ -64,6 +65,84 @@ _mongoc_utf8_code_point_length (uint32_t c);
 ssize_t
 _mongoc_utf8_code_point_to_str (uint32_t c, char *out);
 
+static bson_shared_mutex_t g_scram_cache_rwlock;
+
+/*
+ * On the first cache miss, let one thread fill the first cache entry before
+ * letting other threads proceed. This stops the inrush of many threads trying
+ * to get scram credentials on an empty scram cache.
+ */
+static bson_once_t block_until_first_entry_once_control = BSON_ONCE_INIT;
+static bson_once_t unblock_after_first_entry_once_control = BSON_ONCE_INIT;
+static bson_mutex_t first_cache_entry_lock;
+
+static bson_once_t init_cache_once_control = BSON_ONCE_INIT;
+static bson_mutex_t clear_cache_lock;
+
+static BSON_ONCE_FUN (_block_until_first_cache_entry_populated)
+{
+   bson_mutex_lock (&first_cache_entry_lock);
+
+   BSON_ONCE_RETURN;
+}
+
+static BSON_ONCE_FUN (_unblock_when_first_cache_entry_populated)
+{
+   bson_mutex_unlock (&first_cache_entry_lock);
+
+   BSON_ONCE_RETURN;
+}
+
+/*
+ * Cache lookups are a linear search through this table. This table is a
+ * constant size, which is small enough that lookup cost is insignificant.
+ *
+ * This can be refactored into a hashmap if the cache size needs to grow larger
+ * in the future, but a linear lookup is currently fast enough and is much
+ * simpler logic to reason about.
+ */
+static mongoc_scram_cache_t g_scram_cache[MONGOC_SCRAM_CACHE_SIZE];
+
+static void
+_mongoc_scram_cache_clear (void)
+{
+   bson_mutex_lock (&clear_cache_lock);
+   for (size_t i = 0; i < MONGOC_SCRAM_CACHE_SIZE; i++) {
+      g_scram_cache[i].taken = false;
+      g_scram_cache[i].iterations = 0;
+      memset (g_scram_cache[i].hashed_password,
+              0,
+              sizeof (g_scram_cache[i].hashed_password));
+      memset (g_scram_cache[i].decoded_salt,
+              0,
+              sizeof (g_scram_cache[i].decoded_salt));
+      memset (
+         g_scram_cache[i].client_key, 0, sizeof (g_scram_cache[i].client_key));
+      memset (
+         g_scram_cache[i].server_key, 0, sizeof (g_scram_cache[i].server_key));
+      memset (g_scram_cache[i].salted_password,
+              0,
+              sizeof (g_scram_cache[i].salted_password));
+   }
+   bson_mutex_unlock (&clear_cache_lock);
+}
+
+static BSON_ONCE_FUN (_mongoc_scram_cache_init)
+{
+   bson_shared_mutex_init (&g_scram_cache_rwlock);
+   bson_mutex_init (&first_cache_entry_lock);
+   bson_mutex_init (&clear_cache_lock);
+   _mongoc_scram_cache_clear ();
+
+   BSON_ONCE_RETURN;
+}
+
+static void
+_mongoc_scram_cache_init_once (void)
+{
+   bson_once (&init_cache_once_control, _mongoc_scram_cache_init);
+}
+
 static int
 _scram_hash_size (mongoc_scram_t *scram)
 {
@@ -98,7 +177,9 @@ _mongoc_scram_cache_copy (const mongoc_scram_cache_t *cache)
 
    if (cache) {
       ret = (mongoc_scram_cache_t *) bson_malloc0 (sizeof (*ret));
-      ret->hashed_password = bson_strdup (cache->hashed_password);
+      memcpy (ret->hashed_password,
+              cache->hashed_password,
+              sizeof (ret->hashed_password));
       memcpy (
          ret->decoded_salt, cache->decoded_salt, sizeof (ret->decoded_salt));
       ret->iterations = cache->iterations;
@@ -116,29 +197,62 @@ void
 _mongoc_scram_cache_destroy (mongoc_scram_cache_t *cache)
 {
    BSON_ASSERT (cache);
-
-   if (cache->hashed_password) {
-      bson_zero_free (cache->hashed_password, strlen (cache->hashed_password));
-   }
-
    bson_free (cache);
 }
 
 
-/* Checks whether the cache contains scram's pre-secrets */
+/*
+ * Checks whether the cache contains scram's pre-secrets.
+ * Populate `cache` with the values found in the global cache if found.
+ */
 static bool
-_mongoc_scram_cache_has_presecrets (mongoc_scram_cache_t *cache,
-                                    mongoc_scram_t *scram)
+_mongoc_scram_cache_has_presecrets (mongoc_scram_cache_t *cache /* out */,
+                                    const mongoc_scram_t *scram)
 {
+   bool cache_hit = false;
+
    BSON_ASSERT (cache);
    BSON_ASSERT (scram);
 
-   return cache->hashed_password && scram->hashed_password &&
-          !strcmp (cache->hashed_password, scram->hashed_password) &&
-          cache->iterations == scram->iterations &&
-          !memcmp (cache->decoded_salt,
-                   scram->decoded_salt,
-                   sizeof (cache->decoded_salt));
+   _mongoc_scram_cache_init_once ();
+
+   /*
+    * - Take a read lock
+    * - Search through g_scram_cache if the hashed_password, decoded_salt, etc
+    *   match an entry.
+    * - If so, then return true
+    * - Otherwise return false
+    */
+   bson_shared_mutex_lock_shared (&g_scram_cache_rwlock);
+
+   for (size_t i = 0; i < MONGOC_SCRAM_CACHE_SIZE; i++) {
+      if (g_scram_cache[i].taken) {
+         mongoc_scram_cache_t *cache_entry = &g_scram_cache[i];
+         cache_hit =
+            !strcmp (cache_entry->hashed_password, scram->hashed_password) &&
+            cache_entry->iterations == scram->iterations &&
+            !memcmp (cache_entry->decoded_salt,
+                     scram->decoded_salt,
+                     sizeof (cache_entry->decoded_salt));
+         if (cache_hit) {
+            /* copy the found cache items into the 'cache' output parameter */
+            memcpy (cache->client_key,
+                    cache_entry->client_key,
+                    sizeof (cache->client_key));
+            memcpy (cache->server_key,
+                    cache_entry->server_key,
+                    sizeof (cache->server_key));
+            memcpy (cache->salted_password,
+                    cache_entry->salted_password,
+                    sizeof (cache->salted_password));
+            goto done;
+         }
+      }
+   }
+
+done:
+   bson_shared_mutex_unlock (&g_scram_cache_rwlock);
+   return cache_hit;
 }
 
 
@@ -146,8 +260,14 @@ mongoc_scram_cache_t *
 _mongoc_scram_get_cache (mongoc_scram_t *scram)
 {
    BSON_ASSERT (scram);
+   mongoc_scram_cache_t *cache_copy = NULL;
+   mongoc_scram_cache_t cache;
+   bool cache_hit = _mongoc_scram_cache_has_presecrets (&cache, scram);
+   if (cache_hit) {
+      cache_copy = _mongoc_scram_cache_copy (&cache);
+   }
 
-   return _mongoc_scram_cache_copy (scram->cache);
+   return cache_copy;
 }
 
 
@@ -155,11 +275,6 @@ void
 _mongoc_scram_set_cache (mongoc_scram_t *scram, mongoc_scram_cache_t *cache)
 {
    BSON_ASSERT (scram);
-
-   if (scram->cache) {
-      _mongoc_scram_cache_destroy (scram->cache);
-   }
-
    scram->cache = _mongoc_scram_cache_copy (cache);
 }
 
@@ -209,9 +324,7 @@ _mongoc_scram_destroy (mongoc_scram_t *scram)
       bson_zero_free (scram->pass, strlen (scram->pass));
    }
 
-   if (scram->hashed_password) {
-      bson_zero_free (scram->hashed_password, strlen (scram->hashed_password));
-   }
+   memset (scram->hashed_password, 0, sizeof (scram->hashed_password));
 
    bson_free (scram->auth_message);
 
@@ -222,31 +335,130 @@ _mongoc_scram_destroy (mongoc_scram_t *scram)
    memset (scram, 0, sizeof *scram);
 }
 
+static void
+_mongoc_scram_cache_update_values (const mongoc_scram_t *scram)
+{
+   bson_shared_mutex_lock (&g_scram_cache_rwlock);
+
+   for (size_t i = 0; i < MONGOC_SCRAM_CACHE_SIZE; i++) {
+      mongoc_scram_cache_t *cache_entry = &g_scram_cache[i];
+      bool cache_hit =
+         !strcmp (cache_entry->hashed_password, scram->hashed_password) &&
+         cache_entry->iterations == scram->iterations &&
+         !memcmp (cache_entry->decoded_salt,
+                  scram->decoded_salt,
+                  sizeof (cache_entry->decoded_salt));
+      if (cache_hit) {
+         memcpy (cache_entry->client_key,
+                 scram->client_key,
+                 sizeof (cache_entry->client_key));
+         memcpy (cache_entry->server_key,
+                 scram->server_key,
+                 sizeof (cache_entry->server_key));
+         memcpy (cache_entry->salted_password,
+                 scram->salted_password,
+                 sizeof (cache_entry->salted_password));
+         memcpy (cache_entry->decoded_salt,
+                 scram->decoded_salt,
+                 sizeof (cache_entry->salted_password));
+         break;
+      }
+   }
+
+   bson_shared_mutex_unlock (&g_scram_cache_rwlock);
+}
+
+static void
+_mongoc_scram_cache_insert (const mongoc_scram_t *scram)
+{
+   bson_shared_mutex_lock (&g_scram_cache_rwlock);
+
+again:
+   for (size_t i = 0; i < MONGOC_SCRAM_CACHE_SIZE; i++) {
+      mongoc_scram_cache_t *cache_entry = &g_scram_cache[i];
+      bool already_exists =
+         !strcmp (cache_entry->hashed_password, scram->hashed_password) &&
+         cache_entry->iterations == scram->iterations &&
+         !memcmp (cache_entry->decoded_salt,
+                  scram->decoded_salt,
+                  sizeof (cache_entry->decoded_salt)) &&
+         !memcmp (cache_entry->client_key,
+                  scram->client_key,
+                  sizeof (cache_entry->client_key)) &&
+         !memcmp (cache_entry->server_key,
+                  scram->server_key,
+                  sizeof (cache_entry->server_key)) &&
+         !memcmp (cache_entry->salted_password,
+                  scram->salted_password,
+                  sizeof (cache_entry->salted_password)) &&
+         !memcmp (cache_entry->decoded_salt,
+                  scram->decoded_salt,
+                  sizeof (cache_entry->salted_password));
+
+      if (already_exists) {
+         /* cache entry already populated between read and write lock
+          * acquisition, skipping */
+         break;
+      }
+
+      if (!cache_entry->taken) {
+         /* found an empty slot */
+         memcpy (cache_entry->client_key,
+                 scram->client_key,
+                 sizeof (cache_entry->client_key));
+         memcpy (cache_entry->server_key,
+                 scram->server_key,
+                 sizeof (cache_entry->server_key));
+         memcpy (cache_entry->salted_password,
+                 scram->salted_password,
+                 sizeof (cache_entry->salted_password));
+         memcpy (cache_entry->decoded_salt,
+                 scram->decoded_salt,
+                 sizeof (cache_entry->decoded_salt));
+         memcpy (cache_entry->hashed_password,
+                 scram->hashed_password,
+                 sizeof (cache_entry->hashed_password));
+         cache_entry->iterations = scram->iterations;
+         cache_entry->taken = true;
+         break;
+      }
+
+      /* if cache is full, then invalidate the cache and insert again */
+      if (i == (MONGOC_SCRAM_CACHE_SIZE - 1)) {
+         _mongoc_scram_cache_clear ();
+         goto again;
+      }
+   }
+
+   bson_shared_mutex_unlock (&g_scram_cache_rwlock);
+}
 
 /* Updates the cache with scram's last-used pre-secrets and secrets */
 static void
-_mongoc_scram_update_cache (mongoc_scram_t *scram)
+_mongoc_scram_update_cache (const mongoc_scram_t *scram)
 {
-   mongoc_scram_cache_t *cache;
-
-   BSON_ASSERT (scram);
-
-   if (scram->cache) {
-      _mongoc_scram_cache_destroy (scram->cache);
+   mongoc_scram_cache_t cache;
+   bool found = _mongoc_scram_cache_has_presecrets (&cache, scram);
+   if (found) {
+      bool values_match =
+         !memcmp (
+            cache.server_key, scram->server_key, sizeof (cache.server_key)) &&
+         !memcmp (
+            cache.client_key, scram->client_key, sizeof (cache.client_key)) &&
+         !memcmp (cache.decoded_salt,
+                  scram->decoded_salt,
+                  sizeof (cache.decoded_salt)) &&
+         !memcmp (cache.salted_password,
+                  scram->salted_password,
+                  sizeof (cache.salted_password));
+      if (!values_match) {
+         /* cache hit, but values are out of date */
+         _mongoc_scram_cache_update_values (scram);
+      }
+   } else {
+      /* cache miss, insert this as a new cache entry */
+      _mongoc_scram_cache_insert (scram);
    }
-
-   cache = (mongoc_scram_cache_t *) bson_malloc0 (sizeof (*cache));
-   cache->hashed_password = bson_strdup (scram->hashed_password);
-   memcpy (
-      cache->decoded_salt, scram->decoded_salt, sizeof (cache->decoded_salt));
-   cache->iterations = scram->iterations;
-   memcpy (cache->client_key, scram->client_key, sizeof (cache->client_key));
-   memcpy (cache->server_key, scram->server_key, sizeof (cache->server_key));
-   memcpy (cache->salted_password,
-           scram->salted_password,
-           sizeof (cache->salted_password));
-
-   scram->cache = cache;
 }
 
 
@@ -557,7 +769,7 @@ _mongoc_scram_step2 (mongoc_scram_t *scram,
    const uint8_t *next_comma;
 
    char *tmp;
-   char *hashed_password;
+   char *hashed_password = NULL;
 
    uint8_t decoded_salt[MONGOC_SCRAM_B64_HASH_MAX_SIZE] = {0};
    int32_t decoded_salt_len;
@@ -779,13 +991,25 @@ _mongoc_scram_step2 (mongoc_scram_t *scram,
    }
 
    /* Save the presecrets for caching */
-   scram->hashed_password = bson_strdup (hashed_password);
+   if (hashed_password) {
+      bson_strncpy (scram->hashed_password,
+                    hashed_password,
+                    sizeof (scram->hashed_password));
+   }
+
    scram->iterations = iterations;
    memcpy (scram->decoded_salt, decoded_salt, sizeof (scram->decoded_salt));
 
-   if (scram->cache &&
-       _mongoc_scram_cache_has_presecrets (scram->cache, scram)) {
-      _mongoc_scram_cache_apply_secrets (scram->cache, scram);
+   mongoc_scram_cache_t cache;
+   if (_mongoc_scram_cache_has_presecrets (&cache, scram)) {
+      _mongoc_scram_cache_apply_secrets (&cache, scram);
+   } else {
+      /*
+       * Block other threads here to until SCRAM step 3 finishes so that the
+       * cache will get populated for the others threads.
+       */
+      bson_once (&block_until_first_entry_once_control,
+                 _block_until_first_cache_entry_populated);
    }
 
    if (!*scram->salted_password) {
@@ -997,6 +1221,8 @@ CLEANUP:
    bson_free (val_e);
    bson_free (val_v);
 
+   bson_once (&unblock_after_first_entry_once_control,
+              _unblock_when_first_cache_entry_populated);
    return rval;
 }
 

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner-private.h
@@ -214,7 +214,6 @@ _mongoc_topology_scanner_add_speculative_authentication (
    bson_t *cmd,
    const mongoc_uri_t *uri,
    const mongoc_ssl_opt_t *ssl_opts,
-   mongoc_scram_cache_t *scram_cache,
    mongoc_scram_t *scram /* OUT */);
 
 void

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
@@ -170,7 +170,6 @@ _mongoc_topology_scanner_add_speculative_authentication (
    bson_t *cmd,
    const mongoc_uri_t *uri,
    const mongoc_ssl_opt_t *ssl_opts,
-   mongoc_scram_cache_t *scram_cache,
    mongoc_scram_t *scram /* OUT */)
 {
    bson_t auth_cmd;
@@ -203,10 +202,6 @@ _mongoc_topology_scanner_add_speculative_authentication (
             : MONGOC_CRYPTO_ALGORITHM_SHA_256;
 
       _mongoc_uri_init_scram (uri, scram, algo);
-
-      if (scram_cache) {
-         _mongoc_scram_set_cache (scram, scram_cache);
-      }
 
       if (_mongoc_cluster_get_auth_cmd_scram (algo, scram, &auth_cmd, &error)) {
          const char *auth_source;
@@ -411,12 +406,8 @@ _begin_hello_cmd (mongoc_topology_scanner_node_t *node,
       ssl_opts = ts->ssl_opts;
 #endif
 
-      // _mongoc_topology_scanner_add_speculative_authentication is called with
-      // NULL for the scram_cache argument. The scram cache is not used for
-      // speculative authentication in the topology scanner. This is planned to
-      // be improved in CDRIVER-3642.
       _mongoc_topology_scanner_add_speculative_authentication (
-         &cmd, ts->uri, ssl_opts, NULL, &node->scram);
+         &cmd, ts->uri, ssl_opts, &node->scram);
    }
 
    if (!bson_empty (&ts->cluster_time)) {

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -1295,16 +1295,17 @@ test_framework_replset_name (void)
 {
    bson_t reply;
    bson_iter_t iter;
-   char *replset_name;
+   char *replset_name = NULL;
 
    call_hello (&reply);
    if (!bson_iter_init_find (&iter, &reply, "setName")) {
-      return NULL;
+      goto cleanup;
    }
 
    replset_name = bson_strdup (bson_iter_utf8 (&iter, NULL));
-   bson_destroy (&reply);
 
+cleanup:
+   bson_destroy (&reply);
    return replset_name;
 }
 

--- a/src/libmongoc/tests/test-mongoc-client.c
+++ b/src/libmongoc/tests/test-mongoc-client.c
@@ -675,24 +675,6 @@ test_mongoc_client_authenticate_cached (bool pooled)
       }
    }
 
-   /* screw up the cache */
-   memcpy (client->cluster.scram_cache->client_key, "foo", 3);
-   cursor = mongoc_collection_find_with_opts (collection, &insert, NULL, NULL);
-   capture_logs (true);
-   r = mongoc_cursor_next (cursor, &doc);
-
-   if (pooled) {
-      ASSERT_CAPTURED_LOG ("The cachekey broke",
-                           MONGOC_LOG_LEVEL_WARNING,
-                           "Failed authentication");
-   }
-   capture_logs (false);
-   ASSERT (mongoc_cursor_error (cursor, &error));
-   ASSERT_ERROR_CONTAINS (
-      error, MONGOC_ERROR_CLIENT, MONGOC_ERROR_CLIENT_AUTHENTICATE, "");
-   ASSERT (!r);
-   mongoc_cursor_destroy (cursor);
-
    mongoc_collection_destroy (collection);
    if (pooled) {
       capture_logs (true);

--- a/src/libmongoc/tests/test-mongoc-scram.c
+++ b/src/libmongoc/tests/test-mongoc-scram.c
@@ -201,13 +201,16 @@ static BSON_THREAD_FUN (_scram_cache_invalidation_thread, username_number_ptr)
    mongoc_uri_t *cache_test_uri = mongoc_uri_new (cache_test_user_uri);
    BSON_ASSERT (cache_test_uri);
 
-   mongoc_client_pool_t *pool =
-      test_framework_client_pool_new_from_uri (cache_test_uri, NULL);
-   BSON_ASSERT (pool);
+   // Set serverSelectionTryOnce=false so a single failed connection attempt
+   // does not result in an error.
+   mongoc_uri_set_option_as_bool (
+      cache_test_uri, MONGOC_URI_SERVERSELECTIONTRYONCE, false);
 
-   test_framework_set_pool_ssl_opts (pool);
+   mongoc_client_t *client =
+      test_framework_client_new_from_uri (cache_test_uri, NULL /* api */);
+   BSON_ASSERT (client);
 
-   mongoc_client_t *client = mongoc_client_pool_pop (pool);
+   test_framework_set_ssl_opts (client);
    BSON_ASSERT (client);
 
    mongoc_collection_t *collection =

--- a/src/libmongoc/tests/test-mongoc-scram.c
+++ b/src/libmongoc/tests/test-mongoc-scram.c
@@ -193,7 +193,7 @@ static BSON_THREAD_FUN (_scram_cache_invalidation_thread, username_number_ptr)
    const char *password = "mypass";
    char *username = bson_strdup_printf ("cachetestuser%dX", i);
 
-   const char *uri_str = "mongodb://localhost:27017/";
+   char *uri_str = test_framework_get_uri_str_no_auth ("admin");
    char *cache_test_user_uri =
       test_framework_add_user_password (uri_str, username, password);
    BSON_ASSERT (cache_test_user_uri);

--- a/src/libmongoc/tests/test-mongoc-scram.c
+++ b/src/libmongoc/tests/test-mongoc-scram.c
@@ -193,7 +193,7 @@ static BSON_THREAD_FUN (_scram_cache_invalidation_thread, username_number_ptr)
    const char *password = "mypass";
    char *username = bson_strdup_printf ("cachetestuser%dX", i);
 
-   char *uri_str = test_framework_get_uri_str_no_auth ("admin");
+   const char *uri_str = "mongodb://localhost:27017/";
    char *cache_test_user_uri =
       test_framework_add_user_password (uri_str, username, password);
    BSON_ASSERT (cache_test_user_uri);
@@ -222,10 +222,11 @@ static BSON_THREAD_FUN (_scram_cache_invalidation_thread, username_number_ptr)
       mongoc_collection_insert_one (collection, &insert, NULL, NULL, &error);
    ASSERT_OR_PRINT (ok, error);
 
-   bson_free (username);
-   bson_free (cache_test_user_uri);
    mongoc_collection_destroy (collection);
+   mongoc_client_destroy (client);
    mongoc_uri_destroy (cache_test_uri);
+   bson_free (cache_test_user_uri);
+   bson_free (username);
 
    BSON_THREAD_RETURN;
 }
@@ -273,6 +274,7 @@ test_mongoc_scram_cache_invalidation (void *ctx)
    }
 
    mongoc_database_destroy (db);
+   mongoc_client_destroy (client);
    mongoc_uri_destroy (uri);
 }
 

--- a/src/libmongoc/tests/test-mongoc-scram.c
+++ b/src/libmongoc/tests/test-mongoc-scram.c
@@ -276,10 +276,10 @@ test_mongoc_scram_cache_invalidation (void *ctx)
       BSON_ASSERT (rc == 0);
    }
 
-   mongoc_uri_destroy (uri);
+   mongoc_database_destroy (db);
    mongoc_client_pool_push (pool, client);
    mongoc_client_pool_destroy (pool);
-   mongoc_database_destroy (db);
+   mongoc_uri_destroy (uri);
 }
 
 static void

--- a/src/libmongoc/tests/test-mongoc-scram.c
+++ b/src/libmongoc/tests/test-mongoc-scram.c
@@ -233,16 +233,11 @@ static BSON_THREAD_FUN (_scram_cache_invalidation_thread, username_number_ptr)
 static void
 test_mongoc_scram_cache_invalidation (void *ctx)
 {
-   mongoc_client_pool_t *pool = NULL;
-   mongoc_client_t *client = NULL;
    bson_error_t error;
    mongoc_uri_t *const uri = test_framework_get_uri ();
    BSON_ASSERT (uri);
 
-   pool = test_framework_client_pool_new_from_uri (uri, NULL);
-   BSON_ASSERT (pool);
-   test_framework_set_pool_ssl_opts (pool);
-   client = mongoc_client_pool_pop (pool);
+   mongoc_client_t *client = test_framework_new_default_client ();
    BSON_ASSERT (client);
 
    mongoc_database_t *const db = mongoc_client_get_database (client, "admin");
@@ -278,8 +273,6 @@ test_mongoc_scram_cache_invalidation (void *ctx)
    }
 
    mongoc_database_destroy (db);
-   mongoc_client_pool_push (pool, client);
-   mongoc_client_pool_destroy (pool);
    mongoc_uri_destroy (uri);
 }
 

--- a/src/libmongoc/tests/test-mongoc-scram.c
+++ b/src/libmongoc/tests/test-mongoc-scram.c
@@ -226,8 +226,6 @@ static BSON_THREAD_FUN (_scram_cache_invalidation_thread, username_number_ptr)
    bson_free (cache_test_user_uri);
    mongoc_collection_destroy (collection);
    mongoc_uri_destroy (cache_test_uri);
-   mongoc_client_pool_push (pool, client);
-   mongoc_client_pool_destroy (pool);
 
    BSON_THREAD_RETURN;
 }

--- a/src/libmongoc/tests/test-mongoc-scram.c
+++ b/src/libmongoc/tests/test-mongoc-scram.c
@@ -188,12 +188,10 @@ static BSON_THREAD_FUN (_scram_cache_invalidation_thread, username_number_ptr)
 {
    bson_error_t error;
 
-   int *pun_i_ptr = username_number_ptr;
-   int i = *pun_i_ptr;
-   bson_free (username_number_ptr);
-
    const char *password = "mypass";
-   char *username = bson_strdup_printf ("cachetestuser%dX", i);
+   char *username =
+      bson_strdup_printf ("cachetestuser%dX", *(int *) username_number_ptr);
+   bson_free (username_number_ptr);
 
    const char *uri_str = _scram_cache_invalidation_uri_str;
    char *cache_test_user_uri =


### PR DESCRIPTION
CDRIVER-3514

# Overview

This fixes an issue that Genny encountered where performance was degraded due to clients not sharing a SCRAM cache within a pool.

This change makes the scram cache global so that way all clients share the SCRAM cache.

# Measurements

I measured the time it took to execute the program below and recorded the runtime in milliseconds. I first did a "warmup" run of 100 iterations to literally warm up my CPU so that there would be less variability in boost clock speed, thus ensuring the system would be at a steady state by the time I start collecting data points. The data from these first 100 iterations was thrown away. I then immediately ran 1000 iterations of this program and collected the timing measurements to produce the median results below.

On master (8a0e9c28b), the median runtime is 1299.5 ms.
On this branch (aa0133e9d), the median runtime is 186 ms.

This represents a 7 times speedup by using the new global scram cache.

The following source code was used for collecting measurements. The program below is a slight modification to the test program that Josh wrote when he initially started this project.

```C
#include <stdio.h>
#include <mongoc/mongoc.h>
#include <pthread.h>

#define NUM_THREADS 5000

static void *threadScramAuth(void *data) {
   mongoc_client_pool_t *pool = data;
   mongoc_client_t *client;
   bson_t ping = BSON_INITIALIZER;
   bson_error_t error;
   bool r;
   int rc;

   BSON_APPEND_INT32 (&ping, "ping", 1);

   client = mongoc_client_pool_pop (pool);
   r = mongoc_client_command_simple (
         client, "admin", &ping, NULL, NULL, &error);
   if (!r) {
      fprintf(stderr, "FAILED TO PING SERVER!\n");
      abort();
   }
   mongoc_client_pool_push(pool, client);

   bson_destroy (&ping);

   return NULL;
}

int main() {
   mongoc_client_t *client = NULL;
   mongoc_database_t *database = NULL;
   mongoc_client_pool_t *pool = NULL;
   bson_error_t error;
   const char *uri_string = "mongodb://127.0.0.1/";
   char * scram_uri;
   mongoc_uri_t *uri = NULL;
   bson_t roles;
   void *ret;
   pthread_t threads[NUM_THREADS];
   int rc = 0;
   bool success;
   mongoc_init ();

   bson_init (&roles);

   uri = mongoc_uri_new_with_error (uri_string, &error);
   if (!uri) {
      fprintf (stderr,
               "failed to parse URI: %s\n"
               "error message:       %s\n",
               uri_string,
               error.message);
      return EXIT_FAILURE;
   }

   client = mongoc_client_new_from_uri (uri);
   if (!client) {
      return EXIT_FAILURE;
   }

   mongoc_uri_destroy(uri);

   success = mongoc_client_set_error_api (client, 2);
   if (!success) {
      perror("mongoc_client_set_error_api");
      exit(EXIT_FAILURE);
   }

   database = mongoc_client_get_database (client, "test");
   if (!database) {
      perror("mongoc_client_get_database");
      exit(EXIT_FAILURE);
   }

   BCON_APPEND (&roles, "0", "{", "role", "root", "db", "admin", "}");
   mongoc_database_add_user (database, "user,=", "pass", &roles, NULL, &error);
   mongoc_database_destroy (database);
   mongoc_client_destroy (client);

   scram_uri = bson_strdup_printf("mongodb://user,=:pass@127.0.0.1/test?appname=scram-example&maxPoolSize=%d&authMechanism=SCRAM-SHA-1", NUM_THREADS);
   if (!scram_uri) {
      perror("bson_strdup_printf");
      exit(EXIT_FAILURE);
   }

   uri = mongoc_uri_new_with_error (scram_uri, &error);

   bson_free(scram_uri);
   if (!uri) {
      fprintf (stderr,
               "failed to parse URI\n"
               "error message: %s\n",
               error.message);
      return EXIT_FAILURE;
   }

   pool = mongoc_client_pool_new (uri);
   if (!pool) {
      printf("pool failure\n");
   }
   mongoc_client_pool_set_error_api (pool, 2);

   printf("starting with %d threads \n", NUM_THREADS);

   int64_t before = bson_get_monotonic_time();
   for (int i = 0; i < NUM_THREADS; ++i) {
      rc = pthread_create(&threads[i], NULL, threadScramAuth, pool);
      if (rc) {
         perror("pthread_create");
         exit(1);
      }
   }

   for (int i = 0; i < NUM_THREADS; ++i) {
      rc = pthread_join (threads[i], &ret);
      if (rc) {
         perror("pthread_join");
         exit(1);
      }
   }

   int64_t after = bson_get_monotonic_time();

   printf("total time taken: %"PRId64 " ms\n", (after - before)/1000);

   bson_destroy (&roles);
   mongoc_uri_destroy(uri);
   mongoc_client_pool_destroy(pool);
   mongoc_cleanup ();
   return 0;
}
```

I used the following script to run the above program 1000 times per branch

```sh
#!/bin/bash

set -e

for i in {1..100}
do
    ./cmake-build/main.out &> /dev/null
done

for i in {1..1000}
do
    ./cmake-build/main.out | grep 'total time taken' | awk '{ print $4 }'
done
```