### PR TITLE
CDRIVER-4677 conditionally restore AWS instance profile

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -42,6 +42,7 @@ post:
   - func: upload-test-results
   - func: stop-mongo-orchestration
   - func: stop-load-balancer
+  - func: restore-instance-profile
 
 include:
   - filename: .evergreen/generated_configs/legacy-config.yml

--- a/.evergreen/config_generator/components/funcs/restore_instance_profile.py
+++ b/.evergreen/config_generator/components/funcs/restore_instance_profile.py
@@ -24,7 +24,7 @@ class RestoreInstanceProfile(Function):
             
             echo "restoring instance profile ... "
             # Capture and hide logs on success. Logs may included expected `HTTP Error 404: Not Found` messages when checking for instance profile.
-            if ! ( python ./lib/aws_assign_instance_profile.py 2>&1 >| output.txt ); then
+            if ! { python ./lib/aws_assign_instance_profile.py 2>&1 >|output.txt }; then
                 echo "reassigning instance profile ... failed"
                 cat output.txt 1>&2
                 exit 1

--- a/.evergreen/config_generator/components/funcs/restore_instance_profile.py
+++ b/.evergreen/config_generator/components/funcs/restore_instance_profile.py
@@ -21,7 +21,15 @@ class RestoreInstanceProfile(Function):
             fi
 
             . ./activate-authawsvenv.sh
-            python ./lib/aws_assign_instance_profile.py
+            
+            echo "restoring instance profile ... "
+            # Capture and hide logs on success. Logs may included expected `HTTP Error 404: Not Found` messages when checking for instance profile.
+            if ! ( python ./lib/aws_assign_instance_profile.py 2>&1 >| output.txt ); then
+                echo "reassigning instance profile ... failed"
+                cat output.txt 1>&2
+                exit 1
+            fi
+            echo "restoring instance profile ... succeeded"
             '''
         ),
     ]

--- a/.evergreen/config_generator/components/funcs/restore_instance_profile.py
+++ b/.evergreen/config_generator/components/funcs/restore_instance_profile.py
@@ -1,0 +1,32 @@
+from config_generator.etc.function import Function
+from config_generator.etc.utils import bash_exec
+
+
+class RestoreInstanceProfile(Function):
+    name = 'restore-instance-profile'
+    commands = [
+        bash_exec(
+            script='''\
+            # Restore the AWS Instance Profile that may have been removed in AWS tasks.
+
+            if [[ ! -d drivers-evergreen-tools ]]; then
+                echo "drivers-evergreen-tools not present ... skipping"
+                exit 0
+            fi
+
+            cd "drivers-evergreen-tools/.evergreen/auth_aws"
+            if [ -f "./aws_e2e_setup.json" ]; then
+                . ./activate-authawsvenv.sh
+                python ./lib/aws_assign_instance_profile.py
+            fi
+            '''
+        ),
+    ]
+
+    @classmethod
+    def call(cls, **kwargs):
+        return cls.default_call(**kwargs)
+
+
+def functions():
+    return RestoreInstanceProfile.defn()

--- a/.evergreen/config_generator/components/funcs/restore_instance_profile.py
+++ b/.evergreen/config_generator/components/funcs/restore_instance_profile.py
@@ -14,11 +14,14 @@ class RestoreInstanceProfile(Function):
                 exit 0
             fi
 
-            cd "drivers-evergreen-tools/.evergreen/auth_aws"
-            if [ -f "./aws_e2e_setup.json" ]; then
-                . ./activate-authawsvenv.sh
-                python ./lib/aws_assign_instance_profile.py
+            cd drivers-evergreen-tools/.evergreen/auth_aws
+            if [[ ! -f aws_e2e_setup.json ]]; then
+                echo "aws_e2e_setup.json not present ... skipping"
+                exit 0
             fi
+
+            . ./activate-authawsvenv.sh
+            python ./lib/aws_assign_instance_profile.py
             '''
         ),
     ]

--- a/.evergreen/config_generator/components/funcs/restore_instance_profile.py
+++ b/.evergreen/config_generator/components/funcs/restore_instance_profile.py
@@ -25,7 +25,7 @@ class RestoreInstanceProfile(Function):
             echo "restoring instance profile ... "
             # Capture and hide logs on success. Logs may included expected `HTTP Error 404: Not Found` messages when checking for instance profile.
             if ! { python ./lib/aws_assign_instance_profile.py 2>&1 >|output.txt }; then
-                echo "reassigning instance profile ... failed"
+                echo "restoring instance profile ... failed"
                 cat output.txt 1>&2
                 exit 1
             fi

--- a/.evergreen/config_generator/components/funcs/restore_instance_profile.py
+++ b/.evergreen/config_generator/components/funcs/restore_instance_profile.py
@@ -24,7 +24,7 @@ class RestoreInstanceProfile(Function):
             
             echo "restoring instance profile ... "
             # Capture and hide logs on success. Logs may included expected `HTTP Error 404: Not Found` messages when checking for instance profile.
-            if ! { python ./lib/aws_assign_instance_profile.py 2>&1 >|output.txt }; then
+            if ! { python ./lib/aws_assign_instance_profile.py 2>&1 >|output.txt; }; then
                 echo "restoring instance profile ... failed"
                 cat output.txt 1>&2
                 exit 1

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -309,8 +309,8 @@ functions:
 
             echo "restoring instance profile ... "
             # Capture and hide logs on success. Logs may included expected `HTTP Error 404: Not Found` messages when checking for instance profile.
-            if ! ( python ./lib/aws_assign_instance_profile.py 2>&1 >| output.txt ); then
-                echo "reassigning instance profile ... failed"
+            if ! { python ./lib/aws_assign_instance_profile.py 2>&1 >|output.txt; }; then
+                echo "restoring instance profile ... failed"
                 cat output.txt 1>&2
                 exit 1
             fi

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -285,6 +285,36 @@ functions:
                     echo "Cannot append kerberos.realm to /etc/krb5.conf; skipping." 1>&2
                 fi
             fi
+  restore-instance-profile:
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - -c
+          - |
+            # Restore the AWS Instance Profile that may have been removed in AWS tasks.
+
+            if [[ ! -d drivers-evergreen-tools ]]; then
+                echo "drivers-evergreen-tools not present ... skipping"
+                exit 0
+            fi
+
+            cd drivers-evergreen-tools/.evergreen/auth_aws
+            if [[ ! -f aws_e2e_setup.json ]]; then
+                echo "aws_e2e_setup.json not present ... skipping"
+                exit 0
+            fi
+
+            . ./activate-authawsvenv.sh
+
+            echo "restoring instance profile ... "
+            # Capture and hide logs on success. Logs may included expected `HTTP Error 404: Not Found` messages when checking for instance profile.
+            if ! ( python ./lib/aws_assign_instance_profile.py 2>&1 >| output.txt ); then
+                echo "reassigning instance profile ... failed"
+                cat output.txt 1>&2
+                exit 1
+            fi
+            echo "restoring instance profile ... succeeded"
   run-mock-kms-servers:
     - command: subprocess.exec
       type: setup


### PR DESCRIPTION
# Summary

- Conditionally restore the AWS instance profile after task

Changes verified with [this patch build](https://spruce.mongodb.com/version/650b42742a60ed69ab93574e). 

# Background & Motivation

The description of DRIVERS-2639 describes the motivation.

Changes were copied and modified from https://github.com/mongodb/mongo-python-driver/pull/1218/files
