### PR TITLE
CDRIVER-3727 unskip `/TOPOLOGY/happy_eyeballs*` tests

### DIFF
--- a/.evergreen/scripts/run-mock-server-tests.sh
+++ b/.evergreen/scripts/run-mock-server-tests.sh
@@ -32,6 +32,7 @@ export MONGOC_TEST_SERVER_LOG="json"
 export MONGOC_TEST_SKIP_MOCK="off"
 export MONGOC_TEST_SKIP_LIVE="on"
 export MONGOC_TEST_SKIP_SLOW="on"
+export MONGOC_TEST_IPV4_AND_IPV6_HOST="ipv4_and_ipv6.test.build.10gen.cc"
 
 # shellcheck source=.evergreen/scripts/add-build-dirs-to-paths.sh
 . "${script_dir}/add-build-dirs-to-paths.sh"

--- a/src/libmongoc/tests/test-happy-eyeballs.c
+++ b/src/libmongoc/tests/test-happy-eyeballs.c
@@ -360,22 +360,22 @@ _testcase_run (he_testcase_t *testcase)
 
 #define CLIENT(client) \
    {                   \
-#client          \
+      #client          \
    }
 
 #define CLIENT_WITH_DNS_CACHE_TIMEOUT(type, timeout) \
    {                                                 \
-#type, timeout                                 \
+      #type, timeout                                 \
    }
 #define HANGUP true
 #define LISTEN false
 #define SERVER(type, hangup) \
    {                         \
-#type, hangup          \
+      #type, hangup          \
    }
 #define DELAYED_SERVER(type, hangup, delay) \
    {                                        \
-#type, hangup, delay                  \
+      #type, hangup, delay                  \
    }
 #define SERVERS(...) \
    {                 \
@@ -385,7 +385,7 @@ _testcase_run (he_testcase_t *testcase)
 #define DURATION_MS(min, max) (min), (max)
 #define EXPECT(type, num_acmds, duration) \
    {                                      \
-#type, num_acmds, duration          \
+      #type, num_acmds, duration          \
    }
 #define NCMDS(n) (n)
 

--- a/src/libmongoc/tests/test-happy-eyeballs.c
+++ b/src/libmongoc/tests/test-happy-eyeballs.c
@@ -437,12 +437,6 @@ test_happy_eyeballs_dns_cache (void)
 }
 
 void
-test_happy_eyeballs_retirement (void)
-{
-   /* test connecting to a retired node that fails to initiate a connection. */
-}
-
-void
 test_happy_eyeballs_install (TestSuite *suite)
 {
 #define E 1000 /* epsilon. wiggle room for time constraints. */


### PR DESCRIPTION
# Summary

set `MONGOC_TEST_IPV4_AND_IPV6_HOST` in mock server tests to unskip `/TOPOLOGY/happy_eyeballs*` tests

# Background & Motivation

The `/TOPOLOGY/happy_eyeballs` tests are [currently skipped](https://parsley.mongodb.com/evergreen/mongo_c_driver_mock_server_test_mock_server_test_8a0e9c28b32724c5eb1493bc100fddb505433671_23_09_26_15_17_45/0/task?bookmarks=0,7275&shareLine=6428) due to missing environment requirements (`test_framework_skip_if_no_dual_ip_hostname`).

`export MONGOC_TEST_IPV4_AND_IPV6_HOST="ipv4_and_ipv6.test.build.10gen.cc"` is added to `run-mock-server-tests.sh` to unskip the test.

The mock-server-test task was [run repeatedly 5 times](https://spruce.mongodb.com/task/mongo_c_driver_mock_server_test_mock_server_test_patch_015c4497c2e98469d31eedf0213e0e7500105f31_65142d739ccd4ec58892d9cd_23_09_27_13_26_14/logs?execution=4&sortBy=STATUS&sortDir=ASC) to check for a previously reported flaky failure in CDRIVER-3727. As of https://github.com/mongodb/mongo-c-driver/pull/1277, mock server tests are only run on ubuntu2204-small distro. The flaky test failure may no longer be applicable.