### PR TITLE
CDRIVER-3549 remove unused `test_framework_skip_if_time_sensitive`

### DIFF
--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -2534,17 +2534,6 @@ test_framework_skip_if_serverless (void)
 }
 
 int
-test_framework_skip_if_time_sensitive (void)
-{
-/* Skip time sensitive tests on macOS per CDRIVER-3549. */
-#ifdef __APPLE__
-   return 0;
-#else
-   return 1;
-#endif
-}
-
-int
 test_framework_skip_due_to_cdriver3708 (void)
 {
    if (0 == test_framework_skip_if_auth () &&

--- a/src/libmongoc/tests/test-libmongoc.h
+++ b/src/libmongoc/tests/test-libmongoc.h
@@ -260,9 +260,6 @@ int
 test_framework_skip_if_no_client_side_encryption (void);
 
 int
-test_framework_skip_if_time_sensitive (void);
-
-int
 test_framework_skip_if_no_aws (void);
 
 int

--- a/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
@@ -1050,12 +1050,10 @@ test_sdam_monitoring_install (TestSuite *suite)
       suite,
       "/server_discovery_and_monitoring/monitoring/heartbeat/pooled/succeeded",
       test_heartbeat_events_pooled_succeeded);
-   _TestSuite_AddMockServerTest (
+   TestSuite_AddMockServerTest (
       suite,
       "/server_discovery_and_monitoring/monitoring/heartbeat/pooled/failed",
-      test_heartbeat_events_pooled_failed,
-      test_framework_skip_if_time_sensitive,
-      NULL);
+      test_heartbeat_events_pooled_failed);
    TestSuite_AddFull (
       suite,
       "/server_discovery_and_monitoring/monitoring/heartbeat/single/dns",

--- a/src/libmongoc/tests/test-mongoc-thread.c
+++ b/src/libmongoc/tests/test-mongoc-thread.c
@@ -5,13 +5,11 @@
 
 
 static void
-test_cond_wait (void *unused)
+test_cond_wait (void)
 {
    int64_t start, duration_usec;
    bson_mutex_t mutex;
    mongoc_cond_t cond;
-
-   BSON_UNUSED (unused);
 
    bson_mutex_init (&mutex);
    mongoc_cond_init (&cond);
@@ -35,10 +33,5 @@ test_cond_wait (void *unused)
 void
 test_thread_install (TestSuite *suite)
 {
-   TestSuite_AddFull (suite,
-                      "/Thread/cond_wait",
-                      test_cond_wait,
-                      NULL /* dtor */,
-                      NULL /* ctx */,
-                      test_framework_skip_if_time_sensitive);
+   TestSuite_Add (suite, "/Thread/cond_wait", test_cond_wait);
 }

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -2838,16 +2838,10 @@ test_topology_install (TestSuite *suite)
                       NULL,
                       NULL,
                       test_framework_skip_if_offline);
-   _TestSuite_AddMockServerTest (suite,
-                                 "/Topology/connect_timeout/succeed",
-                                 test_select_after_timeout,
-                                 test_framework_skip_if_time_sensitive,
-                                 NULL);
-   _TestSuite_AddMockServerTest (suite,
-                                 "/Topology/try_once/succeed",
-                                 test_select_after_try_once,
-                                 test_framework_skip_if_time_sensitive,
-                                 NULL);
+   TestSuite_AddMockServerTest (
+      suite, "/Topology/connect_timeout/succeed", test_select_after_timeout);
+   TestSuite_AddMockServerTest (
+      suite, "/Topology/try_once/succeed", test_select_after_try_once);
    TestSuite_AddLive (
       suite, "/Topology/invalid_server_id", test_invalid_server_id);
    TestSuite_AddMockServerTest (suite,

--- a/src/libmongoc/tests/test-mongoc-usleep.c
+++ b/src/libmongoc/tests/test-mongoc-usleep.c
@@ -4,12 +4,10 @@
 
 
 static void
-test_mongoc_usleep_basic (void *unused)
+test_mongoc_usleep_basic (void)
 {
    int64_t start;
    int64_t duration;
-
-   BSON_UNUSED (unused);
 
    start = bson_get_monotonic_time ();
    _mongoc_usleep (50 * 1000); /* 50 ms */
@@ -21,10 +19,5 @@ test_mongoc_usleep_basic (void *unused)
 void
 test_usleep_install (TestSuite *suite)
 {
-   TestSuite_AddFull (suite,
-                      "/Sleep/basic",
-                      test_mongoc_usleep_basic,
-                      NULL /* dtor */,
-                      NULL /* dtor */,
-                      test_framework_skip_if_time_sensitive);
+   TestSuite_Add (suite, "/Sleep/basic", test_mongoc_usleep_basic);
 }


### PR DESCRIPTION
# Summary
Remove unused `test_framework_skip_if_time_sensitive` skip.

# Background & Motivation

`test_framework_skip_if_time_sensitive` was introduced in CDRIVER-3549 to skip mock server tests observed to fail on macOS hosts. As of https://github.com/mongodb/mongo-c-driver/pull/1277, mock server tests are only run on ubuntu2204-small distro. Removing the skip to enable running tests locally on macOS. Running locally repeatedly did not result in failure.