### PR TITLE
CDRIVER-4161 unskip `/crud/unified/aggregate-out-readConcern`

### DIFF
--- a/.evergreen/etc/skip-tests.txt
+++ b/.evergreen/etc/skip-tests.txt
@@ -66,7 +66,6 @@
 /change_streams/legacy/change-streams-errors # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000'] (on ASAN Tests Ubuntu 18.04 build variant)
 
 /transactions/legacy/mongos-recovery-token/"commitTransaction retry fails on new mongos" # fails with server selection timeout (CDRIVER-4268)
-/crud/unified/aggregate-out-readConcern/"readConcern available with out stage" # server error on sharded: "PlanExecutor error" (CDRIVER-4161)
 /transactions/legacy/pin-mongos/"unpin after transient error within a transaction and commit" # (CDRIVER-4351) server selection timeout (on ASAN Tests Ubuntu 18.04 build variant)
 /Samples # (CDRIVER-4352) strange "heartbeat failed" error
 /server_discovery_and_monitoring/monitoring/heartbeat/pooled/dns # (CDRIVER-4353) this initially seemed like a zSeries w/ RHEL8 issue, but it also appeared on arm64 w/ Ubuntu 18.04


### PR DESCRIPTION
# Summary

Unskip `/crud/unified/aggregate-out-readConcern`

# Background & Motivation

The referenced error appears resolved by SERVER-59924:

```
PlanExecutor error during aggregation :: caused by :: failed while running command { internalRenameIfOptionsAndIndexesMatch: 1, from: "crud-v2.tmp.agg_out.ac0577cb-2c92-4503-9543-6b14faa3c944", to: "crud-v2.other_test_collection", collectionOptions: {}, indexes: [ { v: 2, key: { _id: 1 }, name: "_id_" } ], writeConcern: { w: "majority", wtimeout: 0, provenance: "implicitDefault" } } :: caused by :: Request sent without attaching database version
```

Unskipping running `*sharded*` tasks on `sanitizers-matrix-asan` variant three times [resulted in success](https://spruce.mongodb.com/version/6515854a2a60ed1234d9c76f).

