### PR TITLE
CDRIVER-4718 store `recoveryToken` for Load Balanced topology

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -493,7 +493,7 @@ done:
    RETURN (ret);
 }
 
-bool
+static bool
 _in_sharded_txn (const mongoc_client_session_t *session)
 {
    return session && _mongoc_client_session_in_txn_or_ending (session) &&

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -504,11 +504,19 @@ _in_sharded_txn (const mongoc_client_session_t *session)
 static bool
 _in_sharded_or_loadbalanced_txn (const mongoc_client_session_t *session)
 {
-   return session && _mongoc_client_session_in_txn_or_ending (session) &&
-          (_mongoc_topology_get_type (session->client->topology) ==
-              MONGOC_TOPOLOGY_SHARDED ||
-           _mongoc_topology_get_type (session->client->topology) ==
-              MONGOC_TOPOLOGY_LOAD_BALANCED);
+   if (!session) {
+      return false;
+   }
+
+   if (!_mongoc_client_session_in_txn_or_ending (session)) {
+      return false;
+   }
+
+   mongoc_topology_description_type_t type =
+      _mongoc_topology_get_type (session->client->topology);
+
+   return (type == MONGOC_TOPOLOGY_SHARDED) ||
+          (type == MONGOC_TOPOLOGY_LOAD_BALANCED);
 }
 
 static void

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -894,7 +894,7 @@ _stream_run_hello (mongoc_cluster_t *cluster,
       if (negotiate_sasl_supported_mechs) {
          bsonParse (reply,
                     find (allOf (key ("ok"), isFalse), //
-                          do({
+                          do ({
                              /* hello response returned ok: 0. According to
                               * auth spec: "If the hello of the MongoDB
                               * Handshake fails with an error, drivers MUST

--- a/src/libmongoc/tests/test-mongoc-loadbalanced.c
+++ b/src/libmongoc/tests/test-mongoc-loadbalanced.c
@@ -824,6 +824,98 @@ skip_if_not_loadbalanced (void)
 }
 
 void
+store_last_command_started_callback (const mongoc_apm_command_started_t *event)
+{
+   bson_t **last_command = mongoc_apm_command_started_get_context (event);
+   const bson_t *cmd = mongoc_apm_command_started_get_command (event);
+   bson_destroy (*last_command);
+   *last_command = bson_copy (cmd);
+}
+
+// `test_loadbalanced_sends_recoveryToken` is a regression test for
+// CDRIVER-4718. Ensure that a `recoveryToken` is included in the outgoing
+// `commitTransaction` and `abortTransaction` commands when connected to a load
+// balanced cluster.
+static void
+test_loadbalanced_sends_recoveryToken (void *unused)
+{
+   mongoc_client_t *client;
+   bson_error_t error;
+   bson_t *last_command = NULL;
+
+   BSON_UNUSED (unused);
+
+   client = test_framework_new_default_client ();
+   // Set a callback to store the most recent command started.
+   {
+      mongoc_apm_callbacks_t *cbs = mongoc_apm_callbacks_new ();
+      mongoc_apm_set_command_started_cb (cbs,
+                                         store_last_command_started_callback);
+      mongoc_client_set_apm_callbacks (client, cbs, &last_command);
+      mongoc_apm_callbacks_destroy (cbs);
+   }
+
+   mongoc_client_session_t *session =
+      mongoc_client_start_session (client, NULL /* opts */, &error);
+   ASSERT_OR_PRINT (session, error);
+
+   mongoc_collection_t *coll =
+      mongoc_client_get_collection (client, "db", "coll");
+
+   // Commit a transaction. Expect `commitTransaction` to include
+   // `recoveryToken`.
+   {
+      bool ok = mongoc_client_session_start_transaction (
+         session, NULL /* opts */, &error);
+      ASSERT_OR_PRINT (ok, error);
+
+      bson_t *insert_opts = tmp_bson ("{}");
+      ok = mongoc_client_session_append (session, insert_opts, &error);
+      ASSERT_OR_PRINT (ok, error);
+
+      ok = mongoc_collection_insert_one (
+         coll, tmp_bson ("{}"), insert_opts, NULL, &error);
+      ASSERT_OR_PRINT (ok, error);
+
+      ok = mongoc_client_session_commit_transaction (
+         session, NULL /* reply */, &error);
+      ASSERT_OR_PRINT (ok, error);
+
+      ASSERT_MATCH (
+         last_command,
+         "{'commitTransaction': 1, 'recoveryToken': { '$exists': true } }");
+   }
+
+   // Abort a transaction. Expect `abortTransaction` to include
+   // `recoveryToken`.
+   {
+      bool ok = mongoc_client_session_start_transaction (
+         session, NULL /* opts */, &error);
+      ASSERT_OR_PRINT (ok, error);
+
+      bson_t *insert_opts = tmp_bson ("{}");
+      ok = mongoc_client_session_append (session, insert_opts, &error);
+      ASSERT_OR_PRINT (ok, error);
+
+      ok = mongoc_collection_insert_one (
+         coll, tmp_bson ("{}"), insert_opts, NULL, &error);
+      ASSERT_OR_PRINT (ok, error);
+
+      ok = mongoc_client_session_abort_transaction (session, &error);
+      ASSERT_OR_PRINT (ok, error);
+
+      ASSERT_MATCH (
+         last_command,
+         "{'abortTransaction': 1, 'recoveryToken': { '$exists': true } }");
+   }
+
+   mongoc_collection_destroy (coll);
+   mongoc_client_session_destroy (session);
+   mongoc_client_destroy (client);
+   bson_destroy (last_command);
+}
+
+void
 test_loadbalanced_install (TestSuite *suite)
 {
    TestSuite_AddFull (suite,
@@ -893,4 +985,11 @@ test_loadbalanced_install (TestSuite *suite)
       suite,
       "/loadbalanced/post_handshake_error_clears_pool",
       test_post_handshake_error_clears_pool);
+
+   TestSuite_AddFull (suite,
+                      "/loadbalanced/sends_recoveryToken",
+                      test_loadbalanced_sends_recoveryToken,
+                      NULL /* ctx */,
+                      NULL /* dtor */,
+                      skip_if_not_loadbalanced);
 }

--- a/src/libmongoc/tests/test-mongoc-loadbalanced.c
+++ b/src/libmongoc/tests/test-mongoc-loadbalanced.c
@@ -823,7 +823,7 @@ skip_if_not_loadbalanced (void)
    return test_framework_is_loadbalanced () ? 1 : 0;
 }
 
-void
+static void
 store_last_command_started_callback (const mongoc_apm_command_started_t *event)
 {
    bson_t **last_command = mongoc_apm_command_started_get_context (event);


### PR DESCRIPTION
# Summary

- Store `recoveryToken` for Load Balanced topology

# Background & Motivation

Bug was discovered running proposed specification test changes with the PHP driver: https://github.com/mongodb/specifications/pull/1459#discussion_r1313559280

> Additionally, several other pinning tests fail due to [`recoveryToken` fields](https://github.com/mongodb/specifications/blob/master/source/transactions/transactions.rst#recoverytoken-field) not being found in outgoing `commitTransaction` and `abortTransaction` commands

The [Load Balancer specification](https://github.com/mongodb/specifications/blob/master/source/load-balancers/load-balancers.rst#behaviour-with-transactions) notes:

> When executing a transaction in load balancing mode, drivers MUST follow the rules outlined in [Sharded Transactions](https://github.com/mongodb/specifications/blob/master/source/transactions/transactions.rst#sharded-transactions)

[Sharded Transactions](https://github.com/mongodb/specifications/blob/master/source/transactions/transactions.rst#sharded-transactions) describes expected behavior for `recoveryToken`:

> Drivers MUST track the most recently received `recoveryToken` field and MUST append this field to any subsequent commitTransaction or abortTransaction commands.

## Aside: Connection pinning

The [Load Balancer specification](https://github.com/mongodb/specifications/blob/master/source/load-balancers/load-balancers.rst#behaviour-with-transactions) describes required behavior for pinning all transaction operations to one connection:

> The rules for pinning to a connection and releasing a pinned connection are the same as those for server pinning in non-load balanced sharded transactions

This is intentionally not implemented in libmongoc due to not being needed. CDRIVER-4056 notes:
> **Not in scope**
> Connection pinning to cursors or transactions. Rationale: The C driver does not implement a CMAP compliant connection pool (see [CDRIVER-2871](https://jira.mongodb.org/browse/CDRIVER-2871)). Only one connection is available to a server for all operations within a client.

This motivated keeping a separate `_in_sharded_txn` (to check for mongos pinning) from `_in_sharded_or_loadbalanced_txn` (to check for `recoveryToken`)
