### PR TITLE
CDRIVER-4257 unskip `/Topology/slow_server/pooled`

### DIFF
--- a/.evergreen/etc/skip-tests.txt
+++ b/.evergreen/etc/skip-tests.txt
@@ -17,8 +17,6 @@
 # /skip/entire/test # this will be output by the runner as the skip reason
 # /skip/part/of/spec/test/"sub-test description" # this will also be output
 
-/Topology/slow_server/pooled # CDRIVER-4257
-
 /mongohouse/aggregate # CDRIVER-4333
 /mongohouse/estimatedDocumentCount # CDRIVER-4333
 /mongohouse/find # CDRIVER-4333


### PR DESCRIPTION
# Summary

Unskip `/Topology/slow_server/pooled`

# Background & Motivation

Unskipping test and running five times in Evergreen resulted in success: https://spruce.mongodb.com/version/6515985ea4cf4765a33fb138

As of https://github.com/mongodb/mongo-c-driver/pull/1277, mock server tests are only run on ubuntu2204-small distro. The flaky test failure may no longer be applicable (ran on Windows 2015).