### PR TITLE
CDRIVER-4740 Improve performance of bson_utf8_escape_for_json

### DIFF
--- a/src/libbson/CMakeLists.txt
+++ b/src/libbson/CMakeLists.txt
@@ -291,6 +291,11 @@ if (ENABLE_EXAMPLES)
    add_example (creating examples/creating.c)
 endif () # ENABLE_EXAMPLES
 
+add_executable(fuzz_test_bson_utf8_escape_for_json ${PROJECT_SOURCE_DIR}/fuzz/fuzz_test_bson_utf8_escape_for_json.c)
+target_link_libraries(fuzz_test_bson_utf8_escape_for_json bson_static)
+target_compile_options (fuzz_test_bson_utf8_escape_for_json PRIVATE "-fsanitize=fuzzer")
+target_link_options (fuzz_test_bson_utf8_escape_for_json PRIVATE "-fsanitize=fuzzer")
+
 
 # 8888888                   888             888 888
 #   888                     888             888 888

--- a/src/libbson/doc/bson_string_alloc.rst
+++ b/src/libbson/doc/bson_string_alloc.rst
@@ -1,0 +1,28 @@
+:man_page: bson_string_alloc
+
+bson_string_alloc()
+===================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  bson_string_t *
+  bson_string_alloc (uint8_t len);
+
+Parameters
+----------
+
+* ``len``: The length of the string to be allocated.
+
+Description
+-----------
+
+Creates a new string builder, which uses power-of-two growth of buffers. The buffer is initialized to the given length and the required memory is allocated. Use the various bson_string_append*() functions to append to the string.
+
+Returns
+-------
+
+A newly allocated bson_string_t that should be freed with bson_string_free() when no longer in use.
+

--- a/src/libbson/doc/bson_string_append_ex.rst
+++ b/src/libbson/doc/bson_string_append_ex.rst
@@ -1,0 +1,25 @@
+:man_page: bson_string_append_ex
+
+bson_string_append_ex()
+=======================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  void
+  bson_string_append_ex (bson_string_t *string, const char *str, uint32_t len);
+
+Parameters
+----------
+
+* ``string``: A :symbol:`bson_string_t`.
+* ``str``: A string.
+* ``len``: The length of ``str`` in bytes.
+
+Description
+-----------
+
+Copies ``len`` bytes from ``str`` to ``string``. This allows appending strings containing NULLs.
+

--- a/src/libbson/doc/bson_string_t.rst
+++ b/src/libbson/doc/bson_string_t.rst
@@ -34,6 +34,7 @@ This API is useful if you need to build UTF-8 encoded strings.
     :titlesonly:
     :maxdepth: 1
 
+    bson_string_alloc
     bson_string_append
     bson_string_append_c
     bson_string_append_printf

--- a/src/libbson/doc/bson_string_t.rst
+++ b/src/libbson/doc/bson_string_t.rst
@@ -37,6 +37,7 @@ This API is useful if you need to build UTF-8 encoded strings.
     bson_string_alloc
     bson_string_append
     bson_string_append_c
+    bson_string_append_ex
     bson_string_append_printf
     bson_string_append_unichar
     bson_string_free

--- a/src/libbson/doc/bson_utf8_escape_for_json.rst
+++ b/src/libbson/doc/bson_utf8_escape_for_json.rst
@@ -32,3 +32,7 @@ Returns
 -------
 
 A newly allocated string that should be freed with :symbol:`bson_free()`.
+
+.. warning::
+  If ``utf8`` represents invalid UTF-8 data the behavior of :symbol:`bson_utf8_escape_for_json` is undefined.
+  UTF-8 may be validated with :symbol:`bson_utf8_validate`.

--- a/src/libbson/fuzz/fuzz_test_bson_utf8_escape_for_json.c
+++ b/src/libbson/fuzz/fuzz_test_bson_utf8_escape_for_json.c
@@ -1,0 +1,39 @@
+/*
+Fuzz test `bson_utf8_escape_for_json`.
+
+Configure using `-DMONGO_SANITIZE="address"` to enable the Address Sanitizer:
+
+```sh
+cmake \
+    -DCMAKE_BUILD_TYPE="Debug" \
+    -DCMAKE_C_COMPILER="/opt/homebrew/opt/llvm/bin/clang" \
+    -DMONGO_SANITIZE="address" \
+    -S$(pwd) -B$(pwd)/cmake-build
+```
+
+Build with:
+```sh
+cmake --build cmake-build --target fuzz_test_bson_utf8_escape_for_json
+```
+
+Run with:
+```sh
+./cmake-build/src/libbson/fuzz_test_bson_utf8_escape_for_json
+```
+
+*/
+
+#include <bson/bson.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    bool ok = bson_utf8_validate ((const char*) data, size, true /* allow null */);
+    if (!ok) {
+        // Ignore invalid UTF-8. Assume this is unexpected input.
+        return 0;
+    }
+
+    char* got = bson_utf8_escape_for_json ((const char*) data, (ssize_t) size);
+    BSON_ASSERT (got);
+    bson_free (got);
+    return 0;
+}

--- a/src/libbson/src/bson/bson-string.c
+++ b/src/libbson/src/bson/bson-string.c
@@ -77,10 +77,8 @@ bson_string_new (const char *str) /* IN */
    if (str) {
       memcpy (ret->str, str, ret->len);
    }
-   ret->str[ret->len] = '\0';
 
    ret->str[ret->len] = '\0';
-
    return ret;
 }
 
@@ -127,11 +125,7 @@ bson_string_alloc (uint8_t len)
    BSON_ASSERT (ret->alloc >= 1);
 
    ret->str = bson_malloc (ret->alloc);
-
    ret->str[ret->len] = '\0';
-
-   ret->str[ret->len] = '\0';
-
    return ret;
 }
 
@@ -302,7 +296,7 @@ bson_string_append_codepoint (bson_string_t *string,  /* IN */
 
    BSON_ASSERT (string);
 
-   if (unichar > 0xFFFF) {
+   if (unichar > 0xffff) {
       bson_string_append_printf (string, "\\u%04x", unichar);
       return;
    }

--- a/src/libbson/src/bson/bson-string.c
+++ b/src/libbson/src/bson/bson-string.c
@@ -160,6 +160,45 @@ bson_string_free (bson_string_t *string, /* IN */
 /*
  *--------------------------------------------------------------------------
  *
+ * bson_string_append_ex --
+ *
+ *       Append the UTF-8 string @str of given length @len to @string.
+ *
+ * Returns:
+ *       None.
+ *
+ * Side effects:
+ *       None.
+ *
+ *--------------------------------------------------------------------------
+ */
+
+void
+bson_string_append_ex (bson_string_t *string, /* IN */
+                       const char *str,       /* IN */
+                       uint32_t len)          /* IN */
+{
+   BSON_ASSERT (string);
+   BSON_ASSERT (str);
+
+   if ((string->alloc - string->len - 1) < len) {
+      string->alloc += len;
+      if (!bson_is_power_of_two (string->alloc)) {
+         string->alloc =
+            (uint32_t) bson_next_power_of_two ((size_t) string->alloc);
+      }
+      string->str = bson_realloc (string->str, string->alloc);
+   }
+
+   memcpy (string->str + string->len, str, len);
+   string->len += len;
+   string->str[string->len] = '\0';
+}
+
+
+/*
+ *--------------------------------------------------------------------------
+ *
  * bson_string_append --
  *
  *       Append the UTF-8 string @str to @string.
@@ -177,25 +216,7 @@ void
 bson_string_append (bson_string_t *string, /* IN */
                     const char *str)       /* IN */
 {
-   uint32_t len;
-
-   BSON_ASSERT (string);
-   BSON_ASSERT (str);
-
-   len = (uint32_t) strlen (str);
-
-   if ((string->alloc - string->len - 1) < len) {
-      string->alloc += len;
-      if (!bson_is_power_of_two (string->alloc)) {
-         string->alloc =
-            (uint32_t) bson_next_power_of_two ((size_t) string->alloc);
-      }
-      string->str = bson_realloc (string->str, string->alloc);
-   }
-
-   memcpy (string->str + string->len, str, len);
-   string->len += len;
-   string->str[string->len] = '\0';
+   bson_string_append_ex (string, str, (uint32_t) strlen (str));
 }
 
 

--- a/src/libbson/src/bson/bson-string.c
+++ b/src/libbson/src/bson/bson-string.c
@@ -84,6 +84,57 @@ bson_string_new (const char *str) /* IN */
    return ret;
 }
 
+/*
+ *--------------------------------------------------------------------------
+ *
+ * bson_string_alloc --
+ *
+ *       Create a new bson_string_t and allocate memory for it.
+ *
+ *       bson_string_t is a power-of-2 allocation growing string. Every
+ *       time data is appended the next power of two size is chosen for
+ *       the allocation. Pretty standard stuff.
+ *
+ *       It is UTF-8 aware through the use of bson_string_append_unichar().
+ *       The proper UTF-8 character sequence will be used.
+ *
+ * Parameters:
+ *       @len: Length of the string to allocate
+ *
+ * Returns:
+ *       A newly allocated bson_string_t that should be freed with
+ *       bson_string_free().
+ *
+ * Side effects:
+ *       None.
+ *
+ *--------------------------------------------------------------------------
+ */
+
+bson_string_t *
+bson_string_alloc (uint8_t len)
+{
+   bson_string_t *ret;
+
+   ret = bson_malloc0 (sizeof *ret);
+   ret->len = 0;
+   ret->alloc = len + 1;
+
+   if (!bson_is_power_of_two (ret->alloc)) {
+      ret->alloc = (uint32_t) bson_next_power_of_two ((size_t) ret->alloc);
+   }
+
+   BSON_ASSERT (ret->alloc >= 1);
+
+   ret->str = bson_malloc (ret->alloc);
+
+   ret->str[ret->len] = '\0';
+
+   ret->str[ret->len] = '\0';
+
+   return ret;
+}
+
 char *
 bson_string_free (bson_string_t *string, /* IN */
                   bool free_segment)     /* IN */

--- a/src/libbson/src/bson/bson-string.c
+++ b/src/libbson/src/bson/bson-string.c
@@ -293,6 +293,28 @@ bson_string_append_unichar (bson_string_t *string,  /* IN */
    }
 }
 
+void
+bson_string_append_codepoint (bson_string_t *string,  /* IN */
+                              bson_unichar_t unichar) /* IN */
+{
+   const char digits[] = "0123456789abcdef";
+   char str[6] = "\\u0000";
+
+   BSON_ASSERT (string);
+
+   if (unichar > 0xFFFF) {
+      bson_string_append_printf (string, "\\u%04x", unichar);
+      return;
+   }
+
+   str[2] = digits[(unichar >> 12) & 0xf];
+   str[3] = digits[(unichar >> 8) & 0xf];
+   str[4] = digits[(unichar >> 4) & 0xf];
+   str[5] = digits[unichar & 0xf];
+
+   bson_string_append_ex (string, str, 6);
+}
+
 
 /*
  *--------------------------------------------------------------------------

--- a/src/libbson/src/bson/bson-string.h
+++ b/src/libbson/src/bson/bson-string.h
@@ -44,6 +44,8 @@ bson_string_alloc (uint8_t len);
 BSON_EXPORT (char *)
 bson_string_free (bson_string_t *string, bool free_segment);
 BSON_EXPORT (void)
+bson_string_append_ex (bson_string_t *string, const char *str, uint32_t len);
+BSON_EXPORT (void)
 bson_string_append (bson_string_t *string, const char *str);
 BSON_EXPORT (void)
 bson_string_append_c (bson_string_t *string, char str);

--- a/src/libbson/src/bson/bson-string.h
+++ b/src/libbson/src/bson/bson-string.h
@@ -39,6 +39,8 @@ typedef struct {
 
 BSON_EXPORT (bson_string_t *)
 bson_string_new (const char *str);
+BSON_EXPORT (bson_string_t *)
+bson_string_alloc (uint8_t len);
 BSON_EXPORT (char *)
 bson_string_free (bson_string_t *string, bool free_segment);
 BSON_EXPORT (void)

--- a/src/libbson/src/bson/bson-string.h
+++ b/src/libbson/src/bson/bson-string.h
@@ -52,6 +52,8 @@ bson_string_append_c (bson_string_t *string, char str);
 BSON_EXPORT (void)
 bson_string_append_unichar (bson_string_t *string, bson_unichar_t unichar);
 BSON_EXPORT (void)
+bson_string_append_codepoint (bson_string_t *string, bson_unichar_t unichar);
+BSON_EXPORT (void)
 bson_string_append_printf (bson_string_t *string, const char *format, ...)
    BSON_GNUC_PRINTF (2, 3);
 BSON_EXPORT (void)

--- a/src/libbson/src/bson/bson-utf8.c
+++ b/src/libbson/src/bson/bson-utf8.c
@@ -270,12 +270,12 @@ bson_utf8_escape_for_json (const char *utf8, /* IN */
 
    BSON_ASSERT (utf8);
 
-   str = bson_string_new (NULL);
-
    if (utf8_len < 0) {
       length_provided = false;
       utf8_len = strlen (utf8);
    }
+
+   str = bson_string_alloc (utf8_len);
 
    end = utf8 + utf8_len;
 

--- a/src/libbson/src/bson/bson-utf8.c
+++ b/src/libbson/src/bson/bson-utf8.c
@@ -368,7 +368,7 @@ bson_utf8_escape_for_json (const char *utf8, /* IN */
 
       default:
          BSON_ASSERT (c < ' ');
-         bson_string_append_printf (str, "\\u%04x", (unsigned) c);
+         bson_string_append_codepoint (str, c);
          break;
       }
 

--- a/src/libbson/src/bson/bson-utf8.c
+++ b/src/libbson/src/bson/bson-utf8.c
@@ -234,7 +234,7 @@ bson_utf8_validate (const char *utf8, /* IN */
 
 
 static bool
-is_special_char (bson_unichar_t c)
+is_special_char (unsigned char c)
 {
    /*
    C++ equivalent:

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -1583,7 +1583,7 @@ bson_append_regex_w_len (bson_t *bson,
       options = "";
    }
 
-   options_sorted = bson_string_new (NULL);
+   options_sorted = bson_string_alloc (strlen (options));
 
    _bson_append_regex_options_sorted (options_sorted, options);
 

--- a/src/libbson/tests/test-string.c
+++ b/src/libbson/tests/test-string.c
@@ -305,6 +305,37 @@ test_bson_strcasecmp (void)
 }
 
 
+static void
+_append_hello_world_string (bson_string_t *str)
+{
+   for (const char *c = "hello world"; *c; c++) {
+      bson_string_append_c (str, *c);
+   }
+}
+
+
+static void
+test_bson_string_new_performance (void)
+{
+   for (int i = 0; i < 1000000; i++) {
+      bson_string_t *str = bson_string_new (NULL);
+      _append_hello_world_string (str);
+      bson_string_free (str, true);
+   }
+}
+
+
+static void
+test_bson_string_alloc_performance (void)
+{
+   for (int i = 0; i < 1000000; i++) {
+      bson_string_t *str = bson_string_alloc (11);
+      _append_hello_world_string (str);
+      bson_string_free (str, true);
+   }
+}
+
+
 void
 test_string_install (TestSuite *suite)
 {
@@ -323,4 +354,8 @@ test_string_install (TestSuite *suite)
    TestSuite_Add (suite, "/bson/string/snprintf", test_bson_snprintf);
    TestSuite_Add (suite, "/bson/string/strnlen", test_bson_strnlen);
    TestSuite_Add (suite, "/bson/string/strcasecmp", test_bson_strcasecmp);
+   TestSuite_Add (
+      suite, "/bson/string/new_performance", test_bson_string_new_performance);
+   TestSuite_Add (
+      suite, "/bson/string/alloc_performance", test_bson_string_alloc_performance);
 }

--- a/src/libbson/tests/test-utf8.c
+++ b/src/libbson/tests/test-utf8.c
@@ -87,6 +87,18 @@ test_bson_utf8_escape_for_json (void)
 
 
 static void
+test_bson_utf8_escape_for_json_performance (void)
+{
+   char *str;
+
+   for (int i = 0; i < 1000000; i++) {
+      str = bson_utf8_escape_for_json ("my\0key", 6);
+      bson_free (str);
+   }
+}
+
+
+static void
 test_bson_utf8_invalid (void)
 {
    /* no UTF-8 sequence can start with 0x80 */
@@ -259,6 +271,8 @@ test_utf8_install (TestSuite *suite)
    TestSuite_Add (suite, "/bson/utf8/nil", test_bson_utf8_nil);
    TestSuite_Add (
       suite, "/bson/utf8/escape_for_json", test_bson_utf8_escape_for_json);
+   TestSuite_Add (
+      suite, "/bson/utf8/escape_for_json_performance", test_bson_utf8_escape_for_json_performance);
    TestSuite_Add (
       suite, "/bson/utf8/get_char_next_char", test_bson_utf8_get_char);
    TestSuite_Add (

--- a/src/libbson/tests/test-utf8.c
+++ b/src/libbson/tests/test-utf8.c
@@ -65,23 +65,23 @@ test_bson_utf8_escape_for_json (void)
    char *unescaped = "\x0e";
 
    str = bson_utf8_escape_for_json ("my\0key", 6);
-   BSON_ASSERT (0 == memcmp (str, "my\\u0000key", 7));
+   ASSERT_MEMCMP (str, "my\\u0000key", 7);
    bson_free (str);
 
    str = bson_utf8_escape_for_json ("my\"key", 6);
-   BSON_ASSERT (0 == memcmp (str, "my\\\"key", 8));
+   ASSERT_MEMCMP (str, "my\\\"key", 8);
    bson_free (str);
 
    str = bson_utf8_escape_for_json ("my\\key", 6);
-   BSON_ASSERT (0 == memcmp (str, "my\\\\key", 8));
+   ASSERT_MEMCMP (str, "my\\\\key", 8);
    bson_free (str);
 
    str = bson_utf8_escape_for_json ("\\\"\\\"", -1);
-   BSON_ASSERT (0 == memcmp (str, "\\\\\\\"\\\\\\\"", 9));
+   ASSERT_MEMCMP (str, "\\\\\\\"\\\\\\\"", 9);
    bson_free (str);
 
    str = bson_utf8_escape_for_json (unescaped, -1);
-   BSON_ASSERT (0 == memcmp (str, "\\u000e", 7));
+   ASSERT_MEMCMP (str, "\\u000e", 7);
    bson_free (str);
 }
 


### PR DESCRIPTION
While implementing the BSON performance benchmarks in the PHP driver, we noticed a performance problem when converting BSON to JSON. In our tests, we found that encoding a `bson_t*` to JSON using `bson_as_json` was significantly slower than converting the BSON to PHP objects using a `bson_visitor_t`, then running PHP's own JSON encoder on it. Using `bson_as_json` was slower by about a factor of 5. A bit of trial and error brought me to `bson_utf8_escape_for_json`: since the performance payload didn't need it, I removed the calls for testing purposes and the performance of `bson_as_json` improved dramatically to the point where it was not significantly slower than JSON encoding using PHP's logic.

This pull request is the result of the analysis @jmikola and I did, comparing libbson's escape logic with PHP's.

The first commit introduces a performance test for `bson_utf8_escape_for_json`. This test escapes the string `"my\0key"` 1 million times. The baseline time for this was 0.359726 according to test output.

Comparing libbson's implementation with PHP's [`php_json_escape_string`](https://github.com/php/php-src/blob/7200bc23a097d6f55b2810c81a76928ae723eee5/ext/json/json_encoder.c#L318), I found several fixes which I applied commit by commit:

The first fix regards allocation of a new `bson_string_t` for the escaped value. Previously, an empty `bson_string_t` was created, which then grows by factors of 2 as we append escaped characters. Since we know that escaping a string of length `n` produces a string with a length greater or equal than `n`, I added a `bson_string_alloc` similar to `bson_string_new`, but allocating a number of bytes while setting the length to 0. This reduces the number of reallocations while encoding and resulted in a benchmark time of 0.327364 seconds, yielding a ~9% improvement.

The second commit was heavily inspired by PHP's logic in `php_json_escape_string` and changes the way many "straightforward" characters are handled. To determine whether characters need escaping, it leverages a bit mask. Note that our bit mask looks slightly different from PHP's, as PHP offers to escape significantly more characters depending on options.
Characters that don't need escaping are no longer copied to the escaped string one by one, but rather in a single chunk once the first special character is encountered. This reduces the number of calls to `memcpy`. To help with this, I extracted `bson_string_append_ex` which appends a given number of characters from the source string to the destination. This is necessary as we don't want to append the entire unescaped string, but only a certain number of characters.
Any non-ASCII characters (`c >= 0x80`) are appended using the previous logic of using `bson_string_append_unichar`.
At this point in the loop, the only characters left to handle are those that need escaping (`"`, `\`, `\b`, `\f`, `\n`, `\r`, `\t`) and all non-printable ASCII characters, which are added either escaped, or as code points (`\uxxxx`).

This change resulted in a significant performance improvement, bringing the benchmark time down to 0.207105 seconds, a 42% improvement compared to the baseline.

The last optimisation is around adding code points: I noticed that `bson_string_append_printf` was rather slow, especially when the format is rather predictable. A new `bson_string_append_codepoint` method optimises for this path, bypassing `printf` for small enough values.

This last optimisation further reduces the benchmark time to 0.122769 seconds, a whopping 65% faster than the original.

Here's a summary of the benchmark results:


Test | Time | Improvement
-- | -- | --
Baseline | 0,359726 |  
`bson_string_alloc` | 0,327364 | 8,996 %
Bit mask optimisation | 0,207105 | 42,427 %
Code point optimisation | 0,122769 | 65,872 %

For now, I created this PR as a draft as I'm sure there are a number of potential improvements. For one, all of the new methods are part of the public API, which might not be desired. I'm also sure there are a number of tests that can be added to cover all potential "unhappy paths".