### PR TITLE
Unskip tests failing to connect to port 8000

### DIFF
--- a/.evergreen/etc/skip-tests.txt
+++ b/.evergreen/etc/skip-tests.txt
@@ -28,9 +28,6 @@
 /mongohouse/runCommand # CDRIVER-4333
 
 /versioned_api/transaction-handling/"All commands in a transaction declare an API version" # (CDRIVER-4335) API parameters are only allowed in the first command of a multi-document transaction
-/versioned_api/test-commands-deprecation-errors # (CDRIVER-4336) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
-/versioned_api/test-commands-strict-mode # (CDRIVER-4336) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
-/versioned_api/runcommand-helper-no-api-version-declared # (CDRIVER-4336) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
 /Topology/request_scan_on_error # (CDRIVER-4338) precondition failed: checks_cmp (&checks, "n_succeeded", '=', 2), and other times fails with a socket timeout
 /streamable/topology_version/update # (CDRIVER-4339) _force_scan(): precondition failed: sd
 /Stepdown/not_primary_keep # (CDRIVER-4341) Assert Failure: 673 == 674

--- a/.evergreen/etc/skip-tests.txt
+++ b/.evergreen/etc/skip-tests.txt
@@ -31,7 +31,6 @@
 /versioned_api/test-commands-deprecation-errors # (CDRIVER-4336) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
 /versioned_api/test-commands-strict-mode # (CDRIVER-4336) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
 /versioned_api/runcommand-helper-no-api-version-declared # (CDRIVER-4336) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
-/command_monitoring/unified/redacted-commands # (CDRIVER-4337) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
 /Topology/request_scan_on_error # (CDRIVER-4338) precondition failed: checks_cmp (&checks, "n_succeeded", '=', 2), and other times fails with a socket timeout
 /streamable/topology_version/update # (CDRIVER-4339) _force_scan(): precondition failed: sd
 /Stepdown/not_primary_keep # (CDRIVER-4341) Assert Failure: 673 == 674


### PR DESCRIPTION
# Summary

- CDRIVER-4337 unskip `/command_monitoring/unified/redacted-commands`
- CDRIVER-4336 unskip `/versioned_api` tests

# Background & Motivation

The reported error references `127.0.0.1:8000`. Port 8000 is used by the load balanced tests. Load balanced tests were removed during Evergreen config migration. New load balancer tasks proposed in https://github.com/mongodb/mongo-c-driver/pull/1414 were used to run patch builds to test.

Tests with the loadbalanced variant for the `/versioned_api` tests were run in a patch build three times and succeeded each time: https://spruce.mongodb.com/version/651ac700d1fe0718dd9615a0

Tests with the loadbalanced variant for the `/command_monitoring/unified/redacted-commands`
 tests were run in a patch build three times and succeeded each time: https://spruce.mongodb.com/version/651ac8619ccd4e0a512e877d