### PR TITLE
CDRIVER-4335 unskip `/versioned_api/transaction-handling`

### DIFF
--- a/.evergreen/etc/skip-tests.txt
+++ b/.evergreen/etc/skip-tests.txt
@@ -27,7 +27,6 @@
 /mongohouse/listDatabases # CDRIVER-4333
 /mongohouse/runCommand # CDRIVER-4333
 
-/versioned_api/transaction-handling/"All commands in a transaction declare an API version" # (CDRIVER-4335) API parameters are only allowed in the first command of a multi-document transaction
 /versioned_api/test-commands-deprecation-errors # (CDRIVER-4336) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
 /versioned_api/test-commands-strict-mode # (CDRIVER-4336) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
 /versioned_api/runcommand-helper-no-api-version-declared # (CDRIVER-4336) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']


### PR DESCRIPTION
# Summary

- unskip `/versioned_api/transaction-handling`

# Background & Motivation

Tests were unskipped and run in a patch build: https://spruce.mongodb.com/version/651ac07c2fbabec06e975fa7/ on the "Versioned API Tests" variant. The result of three repeated runs was success.