### PR TITLE
Unskip passing mock server tests

### DIFF
--- a/.evergreen/etc/skip-tests.txt
+++ b/.evergreen/etc/skip-tests.txt
@@ -28,7 +28,6 @@
 /mongohouse/runCommand # CDRIVER-4333
 
 /versioned_api/transaction-handling/"All commands in a transaction declare an API version" # (CDRIVER-4335) API parameters are only allowed in the first command of a multi-document transaction
-/Topology/request_scan_on_error # (CDRIVER-4338) precondition failed: checks_cmp (&checks, "n_succeeded", '=', 2), and other times fails with a socket timeout
 /streamable/topology_version/update # (CDRIVER-4339) _force_scan(): precondition failed: sd
 /Stepdown/not_primary_keep # (CDRIVER-4341) Assert Failure: 673 == 674
 /Topology/multiple_selection_errors # (CDRIVER-4342) [No suitable servers found (`serverSelectionTryOnce` set): [Failed to resolve 'doesntexist'] [Failed to resolve 'example.com']] does not contain [calling hello on 'example.com:2']

--- a/.evergreen/etc/skip-tests.txt
+++ b/.evergreen/etc/skip-tests.txt
@@ -28,7 +28,6 @@
 /mongohouse/runCommand # CDRIVER-4333
 
 /versioned_api/transaction-handling/"All commands in a transaction declare an API version" # (CDRIVER-4335) API parameters are only allowed in the first command of a multi-document transaction
-/streamable/topology_version/update # (CDRIVER-4339) _force_scan(): precondition failed: sd
 /Stepdown/not_primary_keep # (CDRIVER-4341) Assert Failure: 673 == 674
 /Topology/multiple_selection_errors # (CDRIVER-4342) [No suitable servers found (`serverSelectionTryOnce` set): [Failed to resolve 'doesntexist'] [Failed to resolve 'example.com']] does not contain [calling hello on 'example.com:2']
 /Topology/server_removed/single # (CDRIVER-4343) error domain 1 doesn't match expected 2

--- a/.evergreen/etc/skip-tests.txt
+++ b/.evergreen/etc/skip-tests.txt
@@ -37,13 +37,6 @@
 /ClientPool/pop_timeout # (CDRIVER-4348) precondition failed: duration_usec / 1000 >= 1990
 /Client/get_handshake_hello_response/pooled # (CDRIVER-4349) Assert Failure: "Unknown" != "PossiblePrimary"
 
-# These all look like they could be related to CDRIVER-4111
-/Client/fetch_stream/retry/fail # (CDRIVER-4340) looks like the mock server hangs up prematurely
-/Client/command/read_prefs/pooled # (CDRIVER-4340) request_matches_msg(): precondition failed: request
-/Client/mongos_seeds_reconnect/single # (CDRIVER-4340) looks like the mock server hangs up prematurely
-/Client/mongos_seeds_connect/pooled # (CDRIVER-4340) looks like the mock server hangs up prematurely
-/Client/exhaust_cursor/err/server/2nd_batch/pooled # (CDRIVER-4340) looks like the mock server hangs up prematurely
-/Client/rs_seeds_connect/pooled # (CDRIVER-4340) hang up! monitor: [127.0.0.1:59723] command or network error occurred: Failed to read 4 bytes: socket error or timeout
 /inheritance/find/readPrefs # (CDRIVER-4350) request_matches_msg(): precondition failed: request
 /BulkOperation/error/unordered # (CDRIVER-4350) request_matches_msg(): precondition failed: request
 /command_monitoring/get_error # (CDRIVER-4350) request_matches_msg(): precondition failed: request


### PR DESCRIPTION
# Summary

- CDRIVER-4340 unskip `/Client` tests
- CDRIVER-4339 unskip `/streamable/topology_version/update`
- CDRIVER-4338 unskip `/Topology/request_scan_on_error`

# Background & Motivation

- `/Client` tests were unskipped and run in a patch build: https://spruce.mongodb.com/version/651b1f640305b92a0664d607
- `/streamable/topology_version/update` test was unskipped and run in a patch build: https://spruce.mongodb.com/version/651b1d733e8e86d0cea86480
- `/Topology/request_scan_on_error` test was unskipped and run in a patch build: https://spruce.mongodb.com/version/651b136a850e61b816afadd9

Restarting tasks three times resulted in success each time.

As of https://github.com/mongodb/mongo-c-driver/pull/1277, mock server tests are only run on ubuntu2204-small distro. The flaky test failures may no longer be applicable.