### PR TITLE
CDRIVER-4342 unskip `/Topology/multiple_selection_errors`

### DIFF
--- a/.evergreen/etc/skip-tests.txt
+++ b/.evergreen/etc/skip-tests.txt
@@ -31,7 +31,6 @@
 /Topology/request_scan_on_error # (CDRIVER-4338) precondition failed: checks_cmp (&checks, "n_succeeded", '=', 2), and other times fails with a socket timeout
 /streamable/topology_version/update # (CDRIVER-4339) _force_scan(): precondition failed: sd
 /Stepdown/not_primary_keep # (CDRIVER-4341) Assert Failure: 673 == 674
-/Topology/multiple_selection_errors # (CDRIVER-4342) [No suitable servers found (`serverSelectionTryOnce` set): [Failed to resolve 'doesntexist'] [Failed to resolve 'example.com']] does not contain [calling hello on 'example.com:2']
 /Topology/server_removed/single # (CDRIVER-4343) error domain 1 doesn't match expected 2
 /change_stream/live/track_resume_token # (CDRIVER-4344) Condition 'bson_compare (resume_token, &doc2_rt) == 0' failed
 /change_stream/resumable_error # (CDRIVER-4345) getMore: not found

--- a/src/libmongoc/tests/test-mongoc-server-selection-errors.c
+++ b/src/libmongoc/tests/test-mongoc-server-selection-errors.c
@@ -144,9 +144,9 @@ _test_server_selection_error_dns_multi_success (bool pooled)
    char *uri_str;
 
    host = test_framework_get_host ();
-   uri_str = bson_strdup_printf ("mongodb://example-localhost:27017,"
+   uri_str = bson_strdup_printf ("mongodb://example-localhost.invalid:27017,"
                                  "%s:%d,"
-                                 "other-example-localhost:27017/",
+                                 "other-example-localhost.invalid:27017/",
                                  host,
                                  test_framework_get_port ());
 

--- a/src/libmongoc/tests/test-mongoc-server-selection-errors.c
+++ b/src/libmongoc/tests/test-mongoc-server-selection-errors.c
@@ -91,9 +91,9 @@ static void
 test_server_selection_error_dns_direct_single (void)
 {
    server_selection_error_dns (
-      "mongodb://example-localhost:27017/",
+      "mongodb://example-localhost.invalid:27017/",
       "No suitable servers found (`serverSelectionTryOnce` set): "
-      "[Fake error for 'example-localhost']",
+      "[Fake error for 'example-localhost.invalid']",
       false,
       false);
 }
@@ -104,9 +104,9 @@ test_server_selection_error_dns_direct_pooled (void *ctx)
    BSON_UNUSED (ctx);
 
    server_selection_error_dns (
-      "mongodb://example-localhost:27017/",
+      "mongodb://example-localhost.invalid:27017/",
       "No suitable servers found: `serverSelectionTimeoutMS` expired: "
-      "[Fake error for 'example-localhost']",
+      "[Fake error for 'example-localhost.invalid']",
       false,
       true);
 }
@@ -115,10 +115,11 @@ static void
 test_server_selection_error_dns_multi_fail_single (void)
 {
    server_selection_error_dns (
-      "mongodb://example-localhost:27017,other-example-localhost:27017/",
+      "mongodb://"
+      "example-localhost.invalid:27017,other-example-localhost.invalid:27017/",
       "No suitable servers found (`serverSelectionTryOnce` set):"
-      " [Fake error for 'example-localhost']"
-      " [Fake error for 'other-example-localhost']",
+      " [Fake error for 'example-localhost.invalid']"
+      " [Fake error for 'other-example-localhost.invalid']",
       false,
       false);
 }
@@ -129,10 +130,11 @@ test_server_selection_error_dns_multi_fail_pooled (void *ctx)
    BSON_UNUSED (ctx);
 
    server_selection_error_dns (
-      "mongodb://example-localhost:27017,other-example-localhost:27017/",
+      "mongodb://"
+      "example-localhost.invalid:27017,other-example-localhost.invalid:27017/",
       "No suitable servers found: `serverSelectionTimeoutMS` expired:"
-      " [Fake error for 'example-localhost']"
-      " [Fake error for 'other-example-localhost']",
+      " [Fake error for 'example-localhost.invalid']"
+      " [Fake error for 'other-example-localhost.invalid']",
       false,
       true);
 }

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -1071,9 +1071,8 @@ test_select_after_try_once (void)
 static void
 test_multiple_selection_errors (void)
 {
-   const char *uri =
-      "mongodb://doesntexist.invalid,example.invalid/?replicaSet=rs"
-      "&connectTimeoutMS=100";
+   const char *const uri = "mongodb://doesntexist.invalid,example.invalid/"
+                           "?replicaSet=rs&connectTimeoutMS=100";
    mongoc_client_t *client;
    bson_t reply;
    bson_error_t error;

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -1069,7 +1069,7 @@ test_select_after_try_once (void)
 
 
 static void
-test_multiple_selection_errors (void *context)
+test_multiple_selection_errors (void)
 {
    const char *uri =
       "mongodb://doesntexist.invalid,example.invalid/?replicaSet=rs"
@@ -1077,8 +1077,6 @@ test_multiple_selection_errors (void *context)
    mongoc_client_t *client;
    bson_t reply;
    bson_error_t error;
-
-   BSON_UNUSED (context);
 
    client = test_framework_client_new (uri, NULL);
    mongoc_client_command_simple (
@@ -2833,12 +2831,9 @@ test_topology_install (TestSuite *suite)
                                 NULL,
                                 NULL,
                                 test_framework_skip_if_slow);
-   TestSuite_AddFull (suite,
-                      "/Topology/multiple_selection_errors",
-                      test_multiple_selection_errors,
-                      NULL,
-                      NULL,
-                      test_framework_skip_if_offline);
+   TestSuite_Add (suite,
+                  "/Topology/multiple_selection_errors",
+                  test_multiple_selection_errors);
    TestSuite_AddMockServerTest (
       suite, "/Topology/connect_timeout/succeed", test_select_after_timeout);
    TestSuite_AddMockServerTest (

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -1071,8 +1071,9 @@ test_select_after_try_once (void)
 static void
 test_multiple_selection_errors (void *context)
 {
-   const char *uri = "mongodb://doesntexist,example.com:2/?replicaSet=rs"
-                     "&connectTimeoutMS=100";
+   const char *uri =
+      "mongodb://doesntexist.invalid,example.invalid/?replicaSet=rs"
+      "&connectTimeoutMS=100";
    mongoc_client_t *client;
    bson_t reply;
    bson_error_t error;
@@ -1088,13 +1089,13 @@ test_multiple_selection_errors (void *context)
 
    /* Like:
     * "No suitable servers found (`serverselectiontryonce` set):
-    *  [Failed to resolve 'doesntexist']
-    *  [connection error calling hello on 'example.com:2']"
+    *  [Failed to resolve 'doesntexist.invalid']
+    *  [Failed to resolve 'example.invalid']
     */
    ASSERT_CONTAINS (error.message, "No suitable servers found");
    /* either "connection error" or "connection timeout" calling hello */
-   ASSERT_CONTAINS (error.message, "calling hello on 'example.com:2'");
-   ASSERT_CONTAINS (error.message, "[Failed to resolve 'doesntexist']");
+   ASSERT_CONTAINS (error.message, "[Failed to resolve 'doesntexist.invalid']");
+   ASSERT_CONTAINS (error.message, "[Failed to resolve 'example.invalid']");
 
    bson_destroy (&reply);
    mongoc_client_destroy (client);


### PR DESCRIPTION
# Summary

- unskip `/Topology/multiple_selection_errors`
- use `.invalid` domain in test to get reliable error

# Background & Motivation

This PR proposes use of the TLD `.invalid` intended to reliably return a DNS error. [RFC 2606](https://www.rfc-editor.org/rfc/rfc2606.html#section-2) notes:

> ".invalid" is intended for use in online construction of domain names that are sure to be invalid and which it is obvious at a glance are invalid.

Similar use of the `.invalid` TLD was similarly done in https://github.com/mongodb/specifications/pull/1136