### PR TITLE
CDRIVER-4341 unskip `/Stepdown/not_primary_keep`

### DIFF
--- a/.evergreen/etc/skip-tests.txt
+++ b/.evergreen/etc/skip-tests.txt
@@ -30,7 +30,6 @@
 /versioned_api/transaction-handling/"All commands in a transaction declare an API version" # (CDRIVER-4335) API parameters are only allowed in the first command of a multi-document transaction
 /Topology/request_scan_on_error # (CDRIVER-4338) precondition failed: checks_cmp (&checks, "n_succeeded", '=', 2), and other times fails with a socket timeout
 /streamable/topology_version/update # (CDRIVER-4339) _force_scan(): precondition failed: sd
-/Stepdown/not_primary_keep # (CDRIVER-4341) Assert Failure: 673 == 674
 /Topology/multiple_selection_errors # (CDRIVER-4342) [No suitable servers found (`serverSelectionTryOnce` set): [Failed to resolve 'doesntexist'] [Failed to resolve 'example.com']] does not contain [calling hello on 'example.com:2']
 /Topology/server_removed/single # (CDRIVER-4343) error domain 1 doesn't match expected 2
 /change_stream/live/track_resume_token # (CDRIVER-4344) Condition 'bson_compare (resume_token, &doc2_rt) == 0' failed

--- a/src/libmongoc/tests/test-mongoc-primary-stepdown.c
+++ b/src/libmongoc/tests/test-mongoc-primary-stepdown.c
@@ -1,3 +1,7 @@
+// test-mongoc-primary-stepdown.c contains tests specified in:
+// `Connections Survive Primary Step Down Tests`. See:
+// https://github.com/mongodb/specifications/tree/db3114e957f7c0976a1af09882dbb46cb4a70049/source/connections-survive-step-down/tests
+
 #include "mongoc/mongoc.h"
 #include "mongoc/mongoc-read-concern-private.h"
 #include "mongoc/mongoc-util-private.h"

--- a/src/libmongoc/tests/test-mongoc-primary-stepdown.c
+++ b/src/libmongoc/tests/test-mongoc-primary-stepdown.c
@@ -521,83 +521,29 @@ test_primary_stepdown_install (TestSuite *suite)
    test_ctx_t single_ctx = {.use_pooled = false};
    test_ctx_t pooled_ctx = {.use_pooled = true};
 
-   TestSuite_AddFull (suite,
-                      "/Stepdown/getmore/single",
-                      test_getmore_iteration_runner,
-                      NULL,
-                      &single_ctx,
-                      test_framework_skip_if_auth,
+#define TestPooledAndSingle(name, fn)                      \
+   TestSuite_AddFull (suite,                               \
+                      name "/single",                      \
+                      fn,                                  \
+                      NULL,                                \
+                      &single_ctx,                         \
+                      test_framework_skip_if_auth,         \
+                      test_framework_skip_if_not_replset); \
+   TestSuite_AddFull (suite,                               \
+                      name "/pooled",                      \
+                      fn,                                  \
+                      NULL,                                \
+                      &pooled_ctx,                         \
+                      test_framework_skip_if_auth,         \
                       test_framework_skip_if_not_replset);
 
-   TestSuite_AddFull (suite,
-                      "/Stepdown/getmore/pooled",
-                      test_getmore_iteration_runner,
-                      NULL,
-                      &pooled_ctx,
-                      test_framework_skip_if_auth,
-                      test_framework_skip_if_not_replset);
-
-   TestSuite_AddFull (suite,
-                      "/Stepdown/not_primary_keep/single",
-                      test_not_primary_keep_pool_runner,
-                      NULL,
-                      &single_ctx,
-                      test_framework_skip_if_auth,
-                      test_framework_skip_if_not_replset);
-
-   TestSuite_AddFull (suite,
-                      "/Stepdown/not_primary_keep/pooled",
-                      test_not_primary_keep_pool_runner,
-                      NULL,
-                      &pooled_ctx,
-                      test_framework_skip_if_auth,
-                      test_framework_skip_if_not_replset);
-
-   TestSuite_AddFull (suite,
-                      "/Stepdown/not_primary_reset/single",
-                      test_not_primary_reset_pool_runner,
-                      NULL,
-                      &single_ctx,
-                      test_framework_skip_if_auth,
-                      test_framework_skip_if_not_replset);
-
-   TestSuite_AddFull (suite,
-                      "/Stepdown/not_primary_reset/pooled",
-                      test_not_primary_reset_pool_runner,
-                      NULL,
-                      &pooled_ctx,
-                      test_framework_skip_if_auth,
-                      test_framework_skip_if_not_replset);
-
-   TestSuite_AddFull (suite,
-                      "/Stepdown/shutdown_reset_pool/single",
-                      test_shutdown_reset_pool_runner,
-                      NULL,
-                      &single_ctx,
-                      test_framework_skip_if_auth,
-                      test_framework_skip_if_not_replset);
-
-   TestSuite_AddFull (suite,
-                      "/Stepdown/shutdown_reset_pool/pooled",
-                      test_shutdown_reset_pool_runner,
-                      NULL,
-                      &pooled_ctx,
-                      test_framework_skip_if_auth,
-                      test_framework_skip_if_not_replset);
-
-   TestSuite_AddFull (suite,
-                      "/Stepdown/interrupt_shutdown/single",
-                      test_interrupted_shutdown_reset_pool_runner,
-                      NULL,
-                      &single_ctx,
-                      test_framework_skip_if_auth,
-                      test_framework_skip_if_not_replset);
-
-   TestSuite_AddFull (suite,
-                      "/Stepdown/interrupt_shutdown/pooled",
-                      test_interrupted_shutdown_reset_pool_runner,
-                      NULL,
-                      &pooled_ctx,
-                      test_framework_skip_if_auth,
-                      test_framework_skip_if_not_replset);
+   TestPooledAndSingle ("/Stepdown/getmore", test_getmore_iteration_runner);
+   TestPooledAndSingle ("/Stepdown/not_primary_keep",
+                        test_not_primary_keep_pool_runner);
+   TestPooledAndSingle ("/Stepdown/not_primary_reset",
+                        test_not_primary_reset_pool_runner);
+   TestPooledAndSingle ("/Stepdown/shutdown_reset_pool",
+                        test_shutdown_reset_pool_runner);
+   TestPooledAndSingle ("/Stepdown/interrupt_shutdown",
+                        test_interrupted_shutdown_reset_pool_runner);
 }


### PR DESCRIPTION
# Summary

- unskip `/Stepdown/not_primary_keep`
- separate `/Stepdown` tests into `/pooled` and `/single`

# Background & Motivation

`/Stepdown/not_primary_keep` was unskipped and run in a patch build with all variants and tasks with names matching `".*replica-noauth.*`: https://spruce.mongodb.com/version/651c0c8957e85a9882f5109e. Restarting the tasks five times resulted in success (excluding a [System Failure downloading 7.0 server](https://spruce.mongodb.com/task/mongo_c_driver_sasl_matrix_nossl_sasl_off_nossl_ubuntu1804_gcc_test_7.0_replica_noauth_patch_f710a87f9405badfbc652d22ed083ac051820ab3_651c0c8957e85a9882f5109e_23_10_03_12_43_56/logs?execution=3)).

I am not sure what caused the reported failure and if anything has changed to resolve. To help diagnose possible future failures, the `/Stepdown` tests are split into separate `/pooled` and `/single` tests. At present, both a pooled client and single-threaded client are tested in the scope of one test:
```
Begin /Stepdown/not_primary_keep, seed 1761489099
    { "status": "pass", "test_file": "/Stepdown/not_primary_keep", "seed": "1761489099", "start": 331.882479, "end": 333.485490, "elapsed": 1.603011  }
```

With this PR, the test is split into:
```
Begin /Stepdown/not_primary_keep/single, seed 959976514
    { "status": "pass", "test_file": "/Stepdown/not_primary_keep/single", "seed": "959976514", "start": 1205.916470, "end": 1205.998609, "elapsed": 0.082139  },
Begin /Stepdown/not_primary_keep/pooled, seed 1738711717
    { "status": "pass", "test_file": "/Stepdown/not_primary_keep/pooled", "seed": "1738711717", "start": 1206.012584, "end": 1206.098426, "elapsed": 0.085842  }
```

This may help to narrow down a test failure. The failing assert does not identify whether a pooled client was used.