### PR TITLE
CDRIVER-4343 unskip `/Topology/server_removed/single`

### DIFF
--- a/.evergreen/etc/skip-tests.txt
+++ b/.evergreen/etc/skip-tests.txt
@@ -32,7 +32,6 @@
 /streamable/topology_version/update # (CDRIVER-4339) _force_scan(): precondition failed: sd
 /Stepdown/not_primary_keep # (CDRIVER-4341) Assert Failure: 673 == 674
 /Topology/multiple_selection_errors # (CDRIVER-4342) [No suitable servers found (`serverSelectionTryOnce` set): [Failed to resolve 'doesntexist'] [Failed to resolve 'example.com']] does not contain [calling hello on 'example.com:2']
-/Topology/server_removed/single # (CDRIVER-4343) error domain 1 doesn't match expected 2
 /change_stream/live/track_resume_token # (CDRIVER-4344) Condition 'bson_compare (resume_token, &doc2_rt) == 0' failed
 /change_stream/resumable_error # (CDRIVER-4345) getMore: not found
 /BulkOperation/split # (CDRIVER-4346) Assert Failure: count of split_1512376901_50824 is 97759, not 100010


### PR DESCRIPTION
# Summary

- unskip `/Topology/server_removed/single`

# Background & Motivation

As of https://github.com/mongodb/mongo-c-driver/pull/1277, mock server tests are only run on ubuntu2204-small distro. The flaky test failure may no longer be applicable.

Test was unskipped and run in a patch build: https://spruce.mongodb.com/version/651d5efe9ccd4ecaf0fd37a8
Result of three runs was success.