### PR TITLE
Ensure Python binary used by Poetry is consistent post-install

### DIFF
--- a/tools/poetry.ps1
+++ b/tools/poetry.ps1
@@ -72,10 +72,11 @@ $stamp_file = Join-Path $PoetryHome ".installed.done"
 # Poetry respects the POETRY_HOME environment variable.
 $env:POETRY_HOME = $PoetryHome
 
+$py = Find-Python
+
 # Create the Poetry installation if it is not already present
 if (!(Test-Path $stamp_file)) {
     Write-Debug "Installing Poetry $PoetryVersion into [$PoetryHome]"
-    $py = Find-Python
     # Lock to prevent concurrent installations
     $mtx = New-Object System.Threading.Mutex($false, "Global\MongoCPoetryInstall")
     [void]$mtx.WaitOne()
@@ -96,5 +97,6 @@ if (!(Test-Path $stamp_file)) {
 
 # Execute the Poetry command
 $poetry_exe = Join-Path $PoetryHome "bin/poetry.exe"
+& $poetry_exe env use $py
 & $poetry_exe @Command
 exit $LASTEXITCODE

--- a/tools/poetry.ps1
+++ b/tools/poetry.ps1
@@ -97,6 +97,6 @@ if (!(Test-Path $stamp_file)) {
 
 # Execute the Poetry command
 $poetry_exe = Join-Path $PoetryHome "bin/poetry.exe"
-& $poetry_exe env use $py
+& $poetry_exe env use --quiet $py
 & $poetry_exe @Command
 exit $LASTEXITCODE

--- a/tools/poetry.sh
+++ b/tools/poetry.sh
@@ -70,7 +70,7 @@ ensure-poetry() {
     # See: https://github.com/python-poetry/poetry/issues/522
     with-lock "$POETRY_HOME/.install.lock" \
         env POETRY_HOME="$POETRY_HOME" \
-        "$POETRY_EXE" env use "$POETRY_PYTHON_BINARY" \
+        "$POETRY_EXE" env use --quiet -- "$POETRY_PYTHON_BINARY" \
     || (
         fail "Poetry failed to set Python binary to $POETRY_PYTHON_BINARY"
     )

--- a/tools/poetry.sh
+++ b/tools/poetry.sh
@@ -28,11 +28,14 @@
 #       executed).
 # * WANT_POETRY_VERSION (overridable) (default 1.5.1)
 #     • The version of Poetry that will be installed by run-poetry when executed.
+# * POETRY_PYTHON_VERSION (overridable) (default to result of find-python)
+#     • The Python binary to use by the Poetry installer and virtual environment(s).
 
 # Load vars and utils:
 . "$(dirname "${BASH_SOURCE[0]}")/use.sh" python paths base with_lock download
 
 : "${WANT_POETRY_VERSION:=1.5.1}"
+: "${POETRY_PYTHON_BINARY:="$(find-python)"}"
 declare -r -x POETRY_HOME=${FORCE_POETRY_HOME:-"$BUILD_CACHE_DIR/poetry-$WANT_POETRY_VERSION"}
 declare -r POETRY_EXE=$POETRY_HOME/bin/poetry$EXE_SUFFIX
 
@@ -45,21 +48,12 @@ install-poetry() {
     # Download the automated installer:
     installer=$poetry_home/install-poetry.py
     download-file --uri=https://install.python-poetry.org --out="$installer"
-    python_binary="$(find-python)"
     # Run the install:
     with-lock "$POETRY_HOME/.install.lock" \
         env POETRY_HOME="$poetry_home" \
-        "$python_binary" -u "$installer" --yes --version "$poetry_version" \
+        "$POETRY_PYTHON_BINARY" -u "$installer" --yes --version "$poetry_version" \
     || (
         cat -- poetry-installer*.log && fail "Poetry installation failed"
-    )
-    # Extra step must be taken to ensure Poetry's virtual environment continues to use the correct Python binary.
-    # See: https://github.com/python-poetry/poetry/issues/522#issuecomment-492369712
-    with-lock "$POETRY_HOME/.install.lock" \
-        env POETRY_HOME="$poetry_home" \
-        "$POETRY_EXE" env use "$python_binary" \
-    || (
-        fail "Poetry installation failed (env use <path/to/python>)"
     )
     printf %s "$poetry_version" > "$POETRY_HOME/installed.txt"
 }
@@ -72,6 +66,14 @@ ensure-poetry() {
     if ! is-file "$home/installed.txt" || [[ "$(cat "$home/installed.txt")" != "$version" ]]; then
         install-poetry "$version" "$home"
     fi
+    # Extra step must be taken to ensure Poetry's virtual environment uses the correct Python binary.
+    # See: https://github.com/python-poetry/poetry/issues/522
+    with-lock "$POETRY_HOME/.install.lock" \
+        env POETRY_HOME="$POETRY_HOME" \
+        "$POETRY_EXE" env use "$POETRY_PYTHON_BINARY" \
+    || (
+        fail "Poetry failed to set Python binary to $POETRY_PYTHON_BINARY"
+    )
 }
 
 run-poetry() {


### PR DESCRIPTION
A minor improvement to the `poetry.sh` script that works around unintuitive Poetry Python binary selection behavior post-install. The venv created by Poetry doesn't always use the correct Python binary post-install, even if a specific Python binary was used to run the install script. See the linked PR in the comment for further details.

The separate call to `with-lock` makes me frown, but I could not find a straightforward solution to combine both the Poetry `install` and `run` commands, as `with-lock` [does not support](https://github.com/mongodb/mongo-c-driver/blob/23e375f44249907a44ab043957b722f5d997fd23/tools/with_lock.sh#L6) using shell functions as the executed command, and Poetry itself doesn't support specifying the Python binary in the install command (user requests for `--python <path/to/python>` seem to have been rejected; see linked PR). I don't think this will cause issues in practice (it's not _that_ likely that we run into a race condition here), so proposed as-is, but if there's a more elegant solution here that I missed, I'd be happy to apply it.