### PR TITLE
CDRIVER-4739 Migrate MongoDB 7.0+ Evergreen tasks from Ubuntu 18.04 to 20.04

### DIFF
--- a/.evergreen/config_generator/components/cse/openssl.py
+++ b/.evergreen/config_generator/components/cse/openssl.py
@@ -25,6 +25,7 @@ COMPILE_MATRIX = [
     ('ubuntu1804-arm64',  'gcc',       None, ['cyrus']),
     ('ubuntu1804',        'gcc',       None, ['cyrus']),
     ('ubuntu2004',        'gcc',       None, ['cyrus']),
+    ('ubuntu2004-arm64',  'gcc',       None, ['cyrus']),
     ('windows-vsCurrent', 'vs2017x64', None, ['cyrus']),
 ]
 
@@ -38,9 +39,10 @@ TEST_MATRIX = [
     ('windows-vsCurrent', 'vs2017x64', None, 'cyrus', ['auth'], ['server'], ['4.2', '4.4', '5.0', '6.0' ]),
 
     # Test 7.0+ with a replica set since Queryable Encryption does not support the 'server' topology. Queryable Encryption tests require 7.0+.
-    ('ubuntu1804',        'gcc',       None, 'cyrus', ['auth'], ['server', 'replica'], [ '7.0', 'latest']),
+    # Test 7.0+ with Ubuntu 20.04+ since MongoDB 7.0 no longer ships binaries for Ubuntu 18.04.
+    ('ubuntu2004',        'gcc',       None, 'cyrus', ['auth'], ['server', 'replica'], [ '7.0', 'latest']),
     ('rhel83-zseries',    'gcc',       None, 'cyrus', ['auth'], ['server', 'replica'], [ '7.0', 'latest']),
-    ('ubuntu1804-arm64',  'gcc',       None, 'cyrus', ['auth'], ['server', 'replica'], [ '7.0', 'latest']),
+    ('ubuntu2004-arm64',  'gcc',       None, 'cyrus', ['auth'], ['server', 'replica'], [ '7.0', 'latest']),
     ('windows-vsCurrent', 'vs2017x64', None, 'cyrus', ['auth'], ['server', 'replica'], [ '7.0', 'latest']),
 ]
 # fmt: on

--- a/.evergreen/config_generator/components/sanitizers/asan_cse.py
+++ b/.evergreen/config_generator/components/sanitizers/asan_cse.py
@@ -11,13 +11,15 @@ from config_generator.components.sanitizers.asan import TAG
 # fmt: off
 COMPILE_MATRIX = [
     ('ubuntu1804', 'clang', None, ['cyrus']),
+    ('ubuntu2004', 'clang', None, ['cyrus']),
 ]
 
 TEST_MATRIX = [
     ('ubuntu1804', 'clang', None, 'cyrus', ['auth'], ['server',          ], ['4.2', '4.4', '5.0', '6.0'                ]),
 
     # Test 7.0+ with a replica set since Queryable Encryption does not support the 'server' topology. Queryable Encryption tests require 7.0+.
-    ('ubuntu1804', 'clang', None, 'cyrus', ['auth'], ['server', 'replica'], [                           '7.0', 'latest']),
+    # Test 7.0+ with Ubuntu 20.04+ since MongoDB 7.0 no longer ships binaries for Ubuntu 18.04.
+    ('ubuntu2004', 'clang', None, 'cyrus', ['auth'], ['server', 'replica'], [                           '7.0', 'latest']),
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/sanitizers/asan_cse.py
+++ b/.evergreen/config_generator/components/sanitizers/asan_cse.py
@@ -15,11 +15,11 @@ COMPILE_MATRIX = [
 ]
 
 TEST_MATRIX = [
-    ('ubuntu1804', 'clang', None, 'cyrus', ['auth'], ['server',          ], ['4.2', '4.4', '5.0', '6.0'                ]),
+    ('ubuntu1804', 'clang', None, 'cyrus', ['auth'], ['server'], ['4.2', '4.4', '5.0', '6.0']),
 
     # Test 7.0+ with a replica set since Queryable Encryption does not support the 'server' topology. Queryable Encryption tests require 7.0+.
     # Test 7.0+ with Ubuntu 20.04+ since MongoDB 7.0 no longer ships binaries for Ubuntu 18.04.
-    ('ubuntu2004', 'clang', None, 'cyrus', ['auth'], ['server', 'replica'], [                           '7.0', 'latest']),
+    ('ubuntu2004', 'clang', None, 'cyrus', ['auth'], ['server', 'replica'], ['7.0', 'latest']),
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/sanitizers/asan_sasl.py
+++ b/.evergreen/config_generator/components/sanitizers/asan_sasl.py
@@ -16,10 +16,11 @@ COMPILE_MATRIX = [
 ]
 
 TEST_MATRIX = [
-    ('ubuntu1604', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], ['3.6',                                                   ]),
-    ('ubuntu1804', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], [       '4.0', '4.2', '4.4', '5.0', '6.0'                 ]),
+    ('ubuntu1604', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], ['3.6',                                  ]),
+    ('ubuntu1804', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], [       '4.0', '4.2', '4.4', '5.0', '6.0']),
+
     # Test 7.0+ with Ubuntu 20.04+ since MongoDB 7.0 no longer ships binaries for Ubuntu 18.04.
-    ('ubuntu2004', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], [                                          '7.0', 'latest']),
+    ('ubuntu2004', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], ['7.0', 'latest']),
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/sanitizers/asan_sasl.py
+++ b/.evergreen/config_generator/components/sanitizers/asan_sasl.py
@@ -12,11 +12,14 @@ from config_generator.components.sanitizers.asan import TAG
 COMPILE_MATRIX = [
     ('ubuntu1604', 'clang', None, ['cyrus']),
     ('ubuntu1804', 'clang', None, ['cyrus']),
+    ('ubuntu2004', 'clang', None, ['cyrus']),
 ]
 
 TEST_MATRIX = [
     ('ubuntu1604', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], ['3.6',                                                   ]),
-    ('ubuntu1804', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], [       '4.0', '4.2', '4.4', '5.0', '6.0', '7.0', 'latest']),
+    ('ubuntu1804', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], [       '4.0', '4.2', '4.4', '5.0', '6.0'                 ]),
+    # Test 7.0+ with Ubuntu 20.04+ since MongoDB 7.0 no longer ships binaries for Ubuntu 18.04.
+    ('ubuntu2004', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], [                                          '7.0', 'latest']),
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/sanitizers/tsan_sasl.py
+++ b/.evergreen/config_generator/components/sanitizers/tsan_sasl.py
@@ -11,10 +11,13 @@ from config_generator.components.sanitizers.tsan import TAG
 # fmt: off
 COMPILE_MATRIX = [
     ('ubuntu1804', 'clang', None, ['cyrus']),
+    ('ubuntu2004', 'clang', None, ['cyrus']),
 ]
 
 TEST_OPENSSL_MATRIX = [
-    ('ubuntu1804', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], ['4.0', '4.2', '4.4', '5.0', '6.0', '7.0', 'latest']),
+    ('ubuntu1804', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], ['4.0', '4.2', '4.4', '5.0', '6.0',                ]),
+    # Test 7.0+ with Ubuntu 20.04+ since MongoDB 7.0 no longer ships binaries for Ubuntu 18.04.
+    ('ubuntu2004', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], [                                   '7.0', 'latest']),
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/sanitizers/tsan_sasl.py
+++ b/.evergreen/config_generator/components/sanitizers/tsan_sasl.py
@@ -15,9 +15,10 @@ COMPILE_MATRIX = [
 ]
 
 TEST_OPENSSL_MATRIX = [
-    ('ubuntu1804', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], ['4.0', '4.2', '4.4', '5.0', '6.0',                ]),
+    ('ubuntu1804', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], ['4.0', '4.2', '4.4', '5.0', '6.0']),
+
     # Test 7.0+ with Ubuntu 20.04+ since MongoDB 7.0 no longer ships binaries for Ubuntu 18.04.
-    ('ubuntu2004', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], [                                   '7.0', 'latest']),
+    ('ubuntu2004', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], ['7.0', 'latest']),
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/sasl/nossl.py
+++ b/.evergreen/config_generator/components/sasl/nossl.py
@@ -18,12 +18,14 @@ COMPILE_MATRIX = [
     ('macos-1014',        'clang',       None,   ['off']),
     ('ubuntu1604',        'gcc',         None,   ['off']),
     ('ubuntu1804',        'gcc',         None,   ['off']),
+    ('ubuntu2004',        'gcc',         None,   ['off']),
     ('windows-vsCurrent', 'vs2017x64',   None,   ['off']),
 ]
 
 TEST_MATRIX = [
     ('ubuntu1604', 'gcc', None, 'off', ['noauth'], ['server', 'replica', 'sharded'], ['3.6',                                                   ]),
-    ('ubuntu1804', 'gcc', None, 'off', ['noauth'], ['server', 'replica', 'sharded'], [       '4.0', '4.2', '4.4', '5.0', '6.0', '7.0', 'latest']),
+    ('ubuntu1804', 'gcc', None, 'off', ['noauth'], ['server', 'replica', 'sharded'], [       '4.0', '4.2', '4.4', '5.0', '6.0',                ]),
+    ('ubuntu2004', 'gcc', None, 'off', ['noauth'], ['server', 'replica', 'sharded'], [                                          '7.0', 'latest']),
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/sasl/openssl.py
+++ b/.evergreen/config_generator/components/sasl/openssl.py
@@ -43,10 +43,11 @@ TEST_MATRIX = [
     ('rhel83-zseries',    'gcc',       None, 'cyrus', ['auth'], ['server',          ], [                     '5.0', '6.0', '7.0', 'latest']),
     ('ubuntu1804-arm64',  'gcc',       None, 'cyrus', ['auth'], ['server',          ], [       '4.2', '4.4', '5.0', '6.0',                ]),
     ('ubuntu1804',        'gcc',       None, 'cyrus', ['auth'], ['server', 'replica'], ['4.0', '4.2', '4.4', '5.0', '6.0',                ]),
+
     # Test 7.0+ with Ubuntu 20.04+ since MongoDB 7.0 no longer ships binaries for Ubuntu 18.04.
-    ('ubuntu2004-arm64',  'gcc',       None, 'cyrus', ['auth'], ['server',          ], [                                   '7.0', 'latest']),
-    ('ubuntu2004',        'gcc',       None, 'cyrus', ['auth'], ['server',          ], [                                   '7.0', 'latest']),
-    ('windows-vsCurrent', 'vs2017x64', None, 'cyrus', ['auth'], ['server',          ], [                                          'latest']),
+    ('ubuntu2004-arm64',  'gcc',       None, 'cyrus', ['auth'], ['server'], ['7.0', 'latest']),
+    ('ubuntu2004',        'gcc',       None, 'cyrus', ['auth'], ['server'], ['7.0', 'latest']),
+    ('windows-vsCurrent', 'vs2017x64', None, 'cyrus', ['auth'], ['server'], [       'latest']),
 
     # Test ARM64 + 4.0 on Ubuntu 16.04, as MongoDB server does not produce
     # downloads for Ubuntu 18.04 arm64.

--- a/.evergreen/config_generator/components/sasl/openssl.py
+++ b/.evergreen/config_generator/components/sasl/openssl.py
@@ -33,6 +33,7 @@ COMPILE_MATRIX = [
     ('ubuntu1604',        'clang',      None, ['cyrus']),
     ('ubuntu1804-arm64',  'gcc',        None, ['cyrus']),
     ('ubuntu1804',        'gcc',        None, ['cyrus']),
+    ('ubuntu2004-arm64',  'gcc',        None, ['cyrus']),
     ('ubuntu2004',        'gcc',        None, ['cyrus']),
     ('windows-vsCurrent', 'vs2017x64',  None, ['cyrus']),
 ]
@@ -40,8 +41,11 @@ COMPILE_MATRIX = [
 TEST_MATRIX = [
     ('rhel81-power8',     'gcc',       None, 'cyrus', ['auth'], ['server',          ], [       '4.2', '4.4', '5.0', '6.0', '7.0', 'latest']),
     ('rhel83-zseries',    'gcc',       None, 'cyrus', ['auth'], ['server',          ], [                     '5.0', '6.0', '7.0', 'latest']),
-    ('ubuntu1804-arm64',  'gcc',       None, 'cyrus', ['auth'], ['server',          ], [       '4.2', '4.4', '5.0', '6.0', '7.0', 'latest']),
-    ('ubuntu1804',        'gcc',       None, 'cyrus', ['auth'], ['server', 'replica'], ['4.0', '4.2', '4.4', '5.0', '6.0', '7.0', 'latest']),
+    ('ubuntu1804-arm64',  'gcc',       None, 'cyrus', ['auth'], ['server',          ], [       '4.2', '4.4', '5.0', '6.0',                ]),
+    ('ubuntu1804',        'gcc',       None, 'cyrus', ['auth'], ['server', 'replica'], ['4.0', '4.2', '4.4', '5.0', '6.0',                ]),
+    # Test 7.0+ with Ubuntu 20.04+ since MongoDB 7.0 no longer ships binaries for Ubuntu 18.04.
+    ('ubuntu2004-arm64',  'gcc',       None, 'cyrus', ['auth'], ['server',          ], [                                   '7.0', 'latest']),
+    ('ubuntu2004',        'gcc',       None, 'cyrus', ['auth'], ['server',          ], [                                   '7.0', 'latest']),
     ('windows-vsCurrent', 'vs2017x64', None, 'cyrus', ['auth'], ['server',          ], [                                          'latest']),
 
     # Test ARM64 + 4.0 on Ubuntu 16.04, as MongoDB server does not produce

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -1458,8 +1458,8 @@ tasks:
       SSL: ssl
 - name: test-versioned-api-accept-version-two-7.0
   tags:
+  - '7.0'
   - versioned-api
-  - versioned-api-7.0
   depends_on:
     name: debug-compile-nosasl-nossl
   commands:
@@ -1506,8 +1506,8 @@ tasks:
       SSL: ssl
 - name: test-versioned-api-accept-version-two-6.0
   tags:
+  - '6.0'
   - versioned-api
-  - versioned-api-6.0
   depends_on:
     name: debug-compile-nosasl-nossl
   commands:
@@ -1554,8 +1554,8 @@ tasks:
       SSL: ssl
 - name: test-versioned-api-accept-version-two-5.0
   tags:
+  - '5.0'
   - versioned-api
-  - versioned-api-5.0
   depends_on:
     name: debug-compile-nosasl-nossl
   commands:
@@ -1801,8 +1801,8 @@ tasks:
   - func: upload-build
 - name: test-aws-openssl-regular-latest
   tags:
+  - latest
   - test-aws
-  - test-aws-latest
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1821,8 +1821,8 @@ tasks:
       TESTCASE: REGULAR
 - name: test-aws-openssl-regular-7.0
   tags:
+  - '7.0'
   - test-aws
-  - test-aws-7.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1841,8 +1841,8 @@ tasks:
       TESTCASE: REGULAR
 - name: test-aws-openssl-regular-6.0
   tags:
+  - '6.0'
   - test-aws
-  - test-aws-6.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1861,8 +1861,8 @@ tasks:
       TESTCASE: REGULAR
 - name: test-aws-openssl-regular-5.0
   tags:
+  - '5.0'
   - test-aws
-  - test-aws-5.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1881,8 +1881,8 @@ tasks:
       TESTCASE: REGULAR
 - name: test-aws-openssl-regular-4.4
   tags:
+  - '4.4'
   - test-aws
-  - test-aws-4.4
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1901,8 +1901,8 @@ tasks:
       TESTCASE: REGULAR
 - name: test-aws-openssl-ec2-latest
   tags:
+  - latest
   - test-aws
-  - test-aws-latest
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1921,8 +1921,8 @@ tasks:
       TESTCASE: EC2
 - name: test-aws-openssl-ec2-7.0
   tags:
+  - '7.0'
   - test-aws
-  - test-aws-7.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1941,8 +1941,8 @@ tasks:
       TESTCASE: EC2
 - name: test-aws-openssl-ec2-6.0
   tags:
+  - '6.0'
   - test-aws
-  - test-aws-6.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1961,8 +1961,8 @@ tasks:
       TESTCASE: EC2
 - name: test-aws-openssl-ec2-5.0
   tags:
+  - '5.0'
   - test-aws
-  - test-aws-5.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1981,8 +1981,8 @@ tasks:
       TESTCASE: EC2
 - name: test-aws-openssl-ec2-4.4
   tags:
+  - '4.4'
   - test-aws
-  - test-aws-4.4
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2001,8 +2001,8 @@ tasks:
       TESTCASE: EC2
 - name: test-aws-openssl-ecs-latest
   tags:
+  - latest
   - test-aws
-  - test-aws-latest
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2021,8 +2021,8 @@ tasks:
       TESTCASE: ECS
 - name: test-aws-openssl-ecs-7.0
   tags:
+  - '7.0'
   - test-aws
-  - test-aws-7.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2041,8 +2041,8 @@ tasks:
       TESTCASE: ECS
 - name: test-aws-openssl-ecs-6.0
   tags:
+  - '6.0'
   - test-aws
-  - test-aws-6.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2061,8 +2061,8 @@ tasks:
       TESTCASE: ECS
 - name: test-aws-openssl-ecs-5.0
   tags:
+  - '5.0'
   - test-aws
-  - test-aws-5.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2081,8 +2081,8 @@ tasks:
       TESTCASE: ECS
 - name: test-aws-openssl-ecs-4.4
   tags:
+  - '4.4'
   - test-aws
-  - test-aws-4.4
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2101,8 +2101,8 @@ tasks:
       TESTCASE: ECS
 - name: test-aws-openssl-lambda-latest
   tags:
+  - latest
   - test-aws
-  - test-aws-latest
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2121,8 +2121,8 @@ tasks:
       TESTCASE: LAMBDA
 - name: test-aws-openssl-lambda-7.0
   tags:
+  - '7.0'
   - test-aws
-  - test-aws-7.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2141,8 +2141,8 @@ tasks:
       TESTCASE: LAMBDA
 - name: test-aws-openssl-lambda-6.0
   tags:
+  - '6.0'
   - test-aws
-  - test-aws-6.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2161,8 +2161,8 @@ tasks:
       TESTCASE: LAMBDA
 - name: test-aws-openssl-lambda-5.0
   tags:
+  - '5.0'
   - test-aws
-  - test-aws-5.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2181,8 +2181,8 @@ tasks:
       TESTCASE: LAMBDA
 - name: test-aws-openssl-lambda-4.4
   tags:
+  - '4.4'
   - test-aws
-  - test-aws-4.4
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2201,8 +2201,8 @@ tasks:
       TESTCASE: LAMBDA
 - name: test-aws-openssl-assume_role-latest
   tags:
+  - latest
   - test-aws
-  - test-aws-latest
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2221,8 +2221,8 @@ tasks:
       TESTCASE: ASSUME_ROLE
 - name: test-aws-openssl-assume_role-7.0
   tags:
+  - '7.0'
   - test-aws
-  - test-aws-7.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2241,8 +2241,8 @@ tasks:
       TESTCASE: ASSUME_ROLE
 - name: test-aws-openssl-assume_role-6.0
   tags:
+  - '6.0'
   - test-aws
-  - test-aws-6.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2261,8 +2261,8 @@ tasks:
       TESTCASE: ASSUME_ROLE
 - name: test-aws-openssl-assume_role-5.0
   tags:
+  - '5.0'
   - test-aws
-  - test-aws-5.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2281,8 +2281,8 @@ tasks:
       TESTCASE: ASSUME_ROLE
 - name: test-aws-openssl-assume_role-4.4
   tags:
+  - '4.4'
   - test-aws
-  - test-aws-4.4
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2301,8 +2301,8 @@ tasks:
       TESTCASE: ASSUME_ROLE
 - name: test-aws-openssl-assume_role_with_web_identity-latest
   tags:
+  - latest
   - test-aws
-  - test-aws-latest
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2321,8 +2321,8 @@ tasks:
       TESTCASE: ASSUME_ROLE_WITH_WEB_IDENTITY
 - name: test-aws-openssl-assume_role_with_web_identity-7.0
   tags:
+  - '7.0'
   - test-aws
-  - test-aws-7.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2341,8 +2341,8 @@ tasks:
       TESTCASE: ASSUME_ROLE_WITH_WEB_IDENTITY
 - name: test-aws-openssl-assume_role_with_web_identity-6.0
   tags:
+  - '6.0'
   - test-aws
-  - test-aws-6.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2361,8 +2361,8 @@ tasks:
       TESTCASE: ASSUME_ROLE_WITH_WEB_IDENTITY
 - name: test-aws-openssl-assume_role_with_web_identity-5.0
   tags:
+  - '5.0'
   - test-aws
-  - test-aws-5.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2381,8 +2381,8 @@ tasks:
       TESTCASE: ASSUME_ROLE_WITH_WEB_IDENTITY
 - name: test-aws-openssl-assume_role_with_web_identity-4.4
   tags:
+  - '4.4'
   - test-aws
-  - test-aws-4.4
   depends_on:
     name: debug-compile-aws
   commands:
@@ -14672,9 +14672,9 @@ buildvariants:
   run_on: ubuntu1804-small
   tasks:
   - debug-compile-aws
-  - .test-aws-4.4
-  - .test-aws-5.0
-  - .test-aws-6.0
+  - .test-aws .4.4
+  - .test-aws .5.0
+  - .test-aws .6.0
 - name: aws-ubuntu2004
   display_name: AWS Tests (Ubuntu 20.04)
   expansions:
@@ -14682,8 +14682,8 @@ buildvariants:
   run_on: ubuntu2004-small
   tasks:
   - debug-compile-aws
-  - .test-aws-7.0
-  - .test-aws-latest
+  - .test-aws .7.0
+  - .test-aws .latest
 - name: mongohouse
   display_name: Mongohouse Test
   run_on: ubuntu1804-test
@@ -14728,15 +14728,15 @@ buildvariants:
   tasks:
   - debug-compile-nosasl-openssl
   - debug-compile-nosasl-nossl
-  - .versioned-api-5.0
-  - .versioned-api-6.0
+  - .versioned-api .5.0
+  - .versioned-api .6.0
 - name: versioned-api-ubuntu2004
   display_name: Versioned API Tests (Ubuntu 20.04)
   run_on: ubuntu2004-test
   tasks:
   - debug-compile-nosasl-openssl
   - debug-compile-nosasl-nossl
-  - .versioned-api-7.0
+  - .versioned-api .7.0
 - name: testazurekms-variant
   display_name: Azure KMS
   run_on: debian10-small

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -1435,6 +1435,7 @@ tasks:
 - name: test-versioned-api-7.0
   tags:
   - versioned-api
+  - versioned-api-7.0
   depends_on:
     name: debug-compile-nosasl-openssl
   commands:
@@ -1458,6 +1459,7 @@ tasks:
 - name: test-versioned-api-accept-version-two-7.0
   tags:
   - versioned-api
+  - versioned-api-7.0
   depends_on:
     name: debug-compile-nosasl-nossl
   commands:
@@ -1481,6 +1483,7 @@ tasks:
 - name: test-versioned-api-6.0
   tags:
   - versioned-api
+  - versioned-api-6.0
   depends_on:
     name: debug-compile-nosasl-openssl
   commands:
@@ -1504,6 +1507,7 @@ tasks:
 - name: test-versioned-api-accept-version-two-6.0
   tags:
   - versioned-api
+  - versioned-api-6.0
   depends_on:
     name: debug-compile-nosasl-nossl
   commands:
@@ -1527,6 +1531,7 @@ tasks:
 - name: test-versioned-api-5.0
   tags:
   - versioned-api
+  - versioned-api-5.0
   depends_on:
     name: debug-compile-nosasl-openssl
   commands:
@@ -1550,6 +1555,7 @@ tasks:
 - name: test-versioned-api-accept-version-two-5.0
   tags:
   - versioned-api
+  - versioned-api-5.0
   depends_on:
     name: debug-compile-nosasl-nossl
   commands:
@@ -1796,6 +1802,7 @@ tasks:
 - name: test-aws-openssl-regular-latest
   tags:
   - test-aws
+  - test-aws-latest
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1815,6 +1822,7 @@ tasks:
 - name: test-aws-openssl-regular-7.0
   tags:
   - test-aws
+  - test-aws-7.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1834,6 +1842,7 @@ tasks:
 - name: test-aws-openssl-regular-6.0
   tags:
   - test-aws
+  - test-aws-6.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1853,6 +1862,7 @@ tasks:
 - name: test-aws-openssl-regular-5.0
   tags:
   - test-aws
+  - test-aws-5.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1872,6 +1882,7 @@ tasks:
 - name: test-aws-openssl-regular-4.4
   tags:
   - test-aws
+  - test-aws-4.4
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1891,6 +1902,7 @@ tasks:
 - name: test-aws-openssl-ec2-latest
   tags:
   - test-aws
+  - test-aws-latest
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1910,6 +1922,7 @@ tasks:
 - name: test-aws-openssl-ec2-7.0
   tags:
   - test-aws
+  - test-aws-7.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1929,6 +1942,7 @@ tasks:
 - name: test-aws-openssl-ec2-6.0
   tags:
   - test-aws
+  - test-aws-6.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1948,6 +1962,7 @@ tasks:
 - name: test-aws-openssl-ec2-5.0
   tags:
   - test-aws
+  - test-aws-5.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1967,6 +1982,7 @@ tasks:
 - name: test-aws-openssl-ec2-4.4
   tags:
   - test-aws
+  - test-aws-4.4
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1986,6 +2002,7 @@ tasks:
 - name: test-aws-openssl-ecs-latest
   tags:
   - test-aws
+  - test-aws-latest
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2005,6 +2022,7 @@ tasks:
 - name: test-aws-openssl-ecs-7.0
   tags:
   - test-aws
+  - test-aws-7.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2024,6 +2042,7 @@ tasks:
 - name: test-aws-openssl-ecs-6.0
   tags:
   - test-aws
+  - test-aws-6.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2043,6 +2062,7 @@ tasks:
 - name: test-aws-openssl-ecs-5.0
   tags:
   - test-aws
+  - test-aws-5.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2062,6 +2082,7 @@ tasks:
 - name: test-aws-openssl-ecs-4.4
   tags:
   - test-aws
+  - test-aws-4.4
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2081,6 +2102,7 @@ tasks:
 - name: test-aws-openssl-lambda-latest
   tags:
   - test-aws
+  - test-aws-latest
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2100,6 +2122,7 @@ tasks:
 - name: test-aws-openssl-lambda-7.0
   tags:
   - test-aws
+  - test-aws-7.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2119,6 +2142,7 @@ tasks:
 - name: test-aws-openssl-lambda-6.0
   tags:
   - test-aws
+  - test-aws-6.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2138,6 +2162,7 @@ tasks:
 - name: test-aws-openssl-lambda-5.0
   tags:
   - test-aws
+  - test-aws-5.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2157,6 +2182,7 @@ tasks:
 - name: test-aws-openssl-lambda-4.4
   tags:
   - test-aws
+  - test-aws-4.4
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2176,6 +2202,7 @@ tasks:
 - name: test-aws-openssl-assume_role-latest
   tags:
   - test-aws
+  - test-aws-latest
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2195,6 +2222,7 @@ tasks:
 - name: test-aws-openssl-assume_role-7.0
   tags:
   - test-aws
+  - test-aws-7.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2214,6 +2242,7 @@ tasks:
 - name: test-aws-openssl-assume_role-6.0
   tags:
   - test-aws
+  - test-aws-6.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2233,6 +2262,7 @@ tasks:
 - name: test-aws-openssl-assume_role-5.0
   tags:
   - test-aws
+  - test-aws-5.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2252,6 +2282,7 @@ tasks:
 - name: test-aws-openssl-assume_role-4.4
   tags:
   - test-aws
+  - test-aws-4.4
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2271,6 +2302,7 @@ tasks:
 - name: test-aws-openssl-assume_role_with_web_identity-latest
   tags:
   - test-aws
+  - test-aws-latest
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2290,6 +2322,7 @@ tasks:
 - name: test-aws-openssl-assume_role_with_web_identity-7.0
   tags:
   - test-aws
+  - test-aws-7.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2309,6 +2342,7 @@ tasks:
 - name: test-aws-openssl-assume_role_with_web_identity-6.0
   tags:
   - test-aws
+  - test-aws-6.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2328,6 +2362,7 @@ tasks:
 - name: test-aws-openssl-assume_role_with_web_identity-5.0
   tags:
   - test-aws
+  - test-aws-5.0
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2347,6 +2382,7 @@ tasks:
 - name: test-aws-openssl-assume_role_with_web_identity-4.4
   tags:
   - test-aws
+  - test-aws-4.4
   depends_on:
     name: debug-compile-aws
   commands:
@@ -14627,10 +14663,27 @@ buildvariants:
     CC: clang
   run_on: ubuntu1804-test
   tasks:
-  - debug-compile-aws
   - debug-compile-sasl-openssl-static
   - .authentication-tests .asan
-  - .test-aws
+- name: aws-ubuntu1804
+  display_name: AWS Tests (Ubuntu 18.04)
+  expansions:
+    CC: clang
+  run_on: ubuntu1804-small
+  tasks:
+  - debug-compile-aws
+  - .test-aws-4.4
+  - .test-aws-5.0
+  - .test-aws-6.0
+- name: aws-ubuntu2004
+  display_name: AWS Tests (Ubuntu 20.04)
+  expansions:
+    CC: clang
+  run_on: ubuntu2004-small
+  tasks:
+  - debug-compile-aws
+  - .test-aws-7.0
+  - .test-aws-latest
 - name: mongohouse
   display_name: Mongohouse Test
   run_on: ubuntu1804-test
@@ -14669,13 +14722,21 @@ buildvariants:
     - rhel90-arm64-small
   tags:
   - pr-merge-gate
-- name: versioned-api
-  display_name: Versioned API Tests
+- name: versioned-api-ubuntu1804
+  display_name: Versioned API Tests (Ubuntu 18.04)
   run_on: ubuntu1804-test
   tasks:
   - debug-compile-nosasl-openssl
   - debug-compile-nosasl-nossl
-  - .versioned-api
+  - .versioned-api-5.0
+  - .versioned-api-6.0
+- name: versioned-api-ubuntu2004
+  display_name: Versioned API Tests (Ubuntu 20.04)
+  run_on: ubuntu2004-test
+  tasks:
+  - debug-compile-nosasl-openssl
+  - debug-compile-nosasl-nossl
+  - .versioned-api-7.0
 - name: testazurekms-variant
   display_name: Azure KMS
   run_on: debian10-small

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -190,14 +190,22 @@ tasks:
       - func: run-simple-http-server
       - func: run-mock-kms-servers
       - func: run-tests
-  - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-7.0-replica-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, cse, asan, auth, replica, "7.0"]
-    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
+  - name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile
+    run_on: ubuntu2004-large
+    tags: [sanitizers-matrix-asan, compile, ubuntu2004, clang, cse, asan, sasl-cyrus]
+    commands:
+      - func: cse-sasl-cyrus-openssl-compile
+        vars:
+          CC: clang
+      - func: upload-build
+  - name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-test-7.0-replica-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, cse, asan, auth, replica, "7.0"]
+    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile
+          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile
       - command: expansions.update
         params:
           updates:
@@ -212,14 +220,14 @@ tasks:
       - func: run-simple-http-server
       - func: run-mock-kms-servers
       - func: run-tests
-  - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-7.0-replica-auth-with-mongocrypt
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, cse, asan, auth, replica, "7.0", with-mongocrypt]
-    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
+  - name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-test-7.0-replica-auth-with-mongocrypt
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, cse, asan, auth, replica, "7.0", with-mongocrypt]
+    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile
+          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile
       - command: expansions.update
         params:
           updates:
@@ -235,14 +243,14 @@ tasks:
       - func: run-simple-http-server
       - func: run-mock-kms-servers
       - func: run-tests
-  - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-7.0-server-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, cse, asan, auth, server, "7.0"]
-    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
+  - name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-test-7.0-server-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, cse, asan, auth, server, "7.0"]
+    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile
+          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile
       - command: expansions.update
         params:
           updates:
@@ -257,14 +265,14 @@ tasks:
       - func: run-simple-http-server
       - func: run-mock-kms-servers
       - func: run-tests
-  - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-7.0-server-auth-with-mongocrypt
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, cse, asan, auth, server, "7.0", with-mongocrypt]
-    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
+  - name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-test-7.0-server-auth-with-mongocrypt
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, cse, asan, auth, server, "7.0", with-mongocrypt]
+    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile
+          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile
       - command: expansions.update
         params:
           updates:
@@ -280,14 +288,14 @@ tasks:
       - func: run-simple-http-server
       - func: run-mock-kms-servers
       - func: run-tests
-  - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-latest-replica-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, cse, asan, auth, replica, latest]
-    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
+  - name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-test-latest-replica-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, cse, asan, auth, replica, latest]
+    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile
+          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile
       - command: expansions.update
         params:
           updates:
@@ -302,14 +310,14 @@ tasks:
       - func: run-simple-http-server
       - func: run-mock-kms-servers
       - func: run-tests
-  - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-latest-replica-auth-with-mongocrypt
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, cse, asan, auth, replica, latest, with-mongocrypt]
-    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
+  - name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-test-latest-replica-auth-with-mongocrypt
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, cse, asan, auth, replica, latest, with-mongocrypt]
+    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile
+          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile
       - command: expansions.update
         params:
           updates:
@@ -325,14 +333,14 @@ tasks:
       - func: run-simple-http-server
       - func: run-mock-kms-servers
       - func: run-tests
-  - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-latest-server-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, cse, asan, auth, server, latest]
-    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
+  - name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-test-latest-server-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, cse, asan, auth, server, latest]
+    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile
+          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile
       - command: expansions.update
         params:
           updates:
@@ -347,14 +355,14 @@ tasks:
       - func: run-simple-http-server
       - func: run-mock-kms-servers
       - func: run-tests
-  - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-latest-server-auth-with-mongocrypt
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, cse, asan, auth, server, latest, with-mongocrypt]
-    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
+  - name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-test-latest-server-auth-with-mongocrypt
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, cse, asan, auth, server, latest, with-mongocrypt]
+    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile
+          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile
       - command: expansions.update
         params:
           updates:
@@ -746,14 +754,22 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-7.0-replica-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, asan, auth, replica, "7.0"]
-    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
+  - name: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile
+    run_on: ubuntu2004-large
+    tags: [sanitizers-matrix-asan, compile, ubuntu2004, clang, asan, sasl-cyrus]
+    commands:
+      - func: sasl-cyrus-openssl-compile
+        vars:
+          CC: clang
+      - func: upload-build
+  - name: asan-sasl-cyrus-openssl-ubuntu2004-clang-test-7.0-replica-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, asan, auth, replica, "7.0"]
+    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile
+          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile
       - command: expansions.update
         params:
           updates:
@@ -766,14 +782,14 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-7.0-server-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, asan, auth, server, "7.0"]
-    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
+  - name: asan-sasl-cyrus-openssl-ubuntu2004-clang-test-7.0-server-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, asan, auth, server, "7.0"]
+    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile
+          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile
       - command: expansions.update
         params:
           updates:
@@ -786,14 +802,14 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-7.0-sharded-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, asan, auth, sharded, "7.0"]
-    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
+  - name: asan-sasl-cyrus-openssl-ubuntu2004-clang-test-7.0-sharded-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, asan, auth, sharded, "7.0"]
+    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile
+          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile
       - command: expansions.update
         params:
           updates:
@@ -806,14 +822,14 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-latest-replica-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, asan, auth, replica, latest]
-    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
+  - name: asan-sasl-cyrus-openssl-ubuntu2004-clang-test-latest-replica-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, asan, auth, replica, latest]
+    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile
+          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile
       - command: expansions.update
         params:
           updates:
@@ -826,14 +842,14 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-latest-server-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, asan, auth, server, latest]
-    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
+  - name: asan-sasl-cyrus-openssl-ubuntu2004-clang-test-latest-server-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, asan, auth, server, latest]
+    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile
+          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile
       - command: expansions.update
         params:
           updates:
@@ -846,14 +862,14 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-latest-sharded-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, asan, auth, sharded, latest]
-    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
+  - name: asan-sasl-cyrus-openssl-ubuntu2004-clang-test-latest-sharded-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, asan, auth, sharded, latest]
+    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile
+          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile
       - command: expansions.update
         params:
           updates:
@@ -1627,86 +1643,6 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-mock-kms-servers
       - func: run-tests
-  - name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-7.0-replica-auth
-    run_on: ubuntu1804-arm64-small
-    tags: [cse-matrix-openssl, test, ubuntu1804-arm64, gcc, sasl-cyrus, cse, auth, replica, "7.0"]
-    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "7.0" }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-mock-kms-servers
-      - func: run-tests
-  - name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-7.0-server-auth
-    run_on: ubuntu1804-arm64-small
-    tags: [cse-matrix-openssl, test, ubuntu1804-arm64, gcc, sasl-cyrus, cse, auth, server, "7.0"]
-    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "7.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-mock-kms-servers
-      - func: run-tests
-  - name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-latest-replica-auth
-    run_on: ubuntu1804-arm64-small
-    tags: [cse-matrix-openssl, test, ubuntu1804-arm64, gcc, sasl-cyrus, cse, auth, replica, latest]
-    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: latest }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-mock-kms-servers
-      - func: run-tests
-  - name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-latest-server-auth
-    run_on: ubuntu1804-arm64-small
-    tags: [cse-matrix-openssl, test, ubuntu1804-arm64, gcc, sasl-cyrus, cse, auth, server, latest]
-    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: latest }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-mock-kms-servers
-      - func: run-tests
   - name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-compile
     run_on: ubuntu1804-large
     tags: [cse-matrix-openssl, compile, ubuntu1804, gcc, cse, sasl-cyrus]
@@ -1795,14 +1731,22 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-mock-kms-servers
       - func: run-tests
-  - name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-test-7.0-replica-auth
-    run_on: ubuntu1804-small
-    tags: [cse-matrix-openssl, test, ubuntu1804, gcc, sasl-cyrus, cse, auth, replica, "7.0"]
-    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-compile }]
+  - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
+    run_on: ubuntu2004-arm64-large
+    tags: [cse-matrix-openssl, compile, ubuntu2004-arm64, gcc, cse, sasl-cyrus]
+    commands:
+      - func: cse-sasl-cyrus-openssl-compile
+        vars:
+          CC: gcc
+      - func: upload-build
+  - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-7.0-replica-auth
+    run_on: ubuntu2004-arm64-small
+    tags: [cse-matrix-openssl, test, ubuntu2004-arm64, gcc, sasl-cyrus, cse, auth, replica, "7.0"]
+    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu1804-gcc-compile
+          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
       - command: expansions.update
         params:
           updates:
@@ -1815,14 +1759,14 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-mock-kms-servers
       - func: run-tests
-  - name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-test-7.0-server-auth
-    run_on: ubuntu1804-small
-    tags: [cse-matrix-openssl, test, ubuntu1804, gcc, sasl-cyrus, cse, auth, server, "7.0"]
-    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-compile }]
+  - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-7.0-server-auth
+    run_on: ubuntu2004-arm64-small
+    tags: [cse-matrix-openssl, test, ubuntu2004-arm64, gcc, sasl-cyrus, cse, auth, server, "7.0"]
+    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu1804-gcc-compile
+          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
       - command: expansions.update
         params:
           updates:
@@ -1835,14 +1779,14 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-mock-kms-servers
       - func: run-tests
-  - name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-test-latest-replica-auth
-    run_on: ubuntu1804-small
-    tags: [cse-matrix-openssl, test, ubuntu1804, gcc, sasl-cyrus, cse, auth, replica, latest]
-    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-compile }]
+  - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-latest-replica-auth
+    run_on: ubuntu2004-arm64-small
+    tags: [cse-matrix-openssl, test, ubuntu2004-arm64, gcc, sasl-cyrus, cse, auth, replica, latest]
+    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu1804-gcc-compile
+          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
       - command: expansions.update
         params:
           updates:
@@ -1855,14 +1799,14 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-mock-kms-servers
       - func: run-tests
-  - name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-test-latest-server-auth
-    run_on: ubuntu1804-small
-    tags: [cse-matrix-openssl, test, ubuntu1804, gcc, sasl-cyrus, cse, auth, server, latest]
-    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-compile }]
+  - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-latest-server-auth
+    run_on: ubuntu2004-arm64-small
+    tags: [cse-matrix-openssl, test, ubuntu2004-arm64, gcc, sasl-cyrus, cse, auth, server, latest]
+    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu1804-gcc-compile
+          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
       - command: expansions.update
         params:
           updates:
@@ -1883,6 +1827,86 @@ tasks:
         vars:
           CC: gcc
       - func: upload-build
+  - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-7.0-replica-auth
+    run_on: ubuntu2004-small
+    tags: [cse-matrix-openssl, test, ubuntu2004, gcc, sasl-cyrus, cse, auth, replica, "7.0"]
+    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu2004-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "7.0" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-7.0-server-auth
+    run_on: ubuntu2004-small
+    tags: [cse-matrix-openssl, test, ubuntu2004, gcc, sasl-cyrus, cse, auth, server, "7.0"]
+    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu2004-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "7.0" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-latest-replica-auth
+    run_on: ubuntu2004-small
+    tags: [cse-matrix-openssl, test, ubuntu2004, gcc, sasl-cyrus, cse, auth, replica, latest]
+    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu2004-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: latest }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-latest-server-auth
+    run_on: ubuntu2004-small
+    tags: [cse-matrix-openssl, test, ubuntu2004, gcc, sasl-cyrus, cse, auth, server, latest]
+    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu2004-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: latest }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-mock-kms-servers
+      - func: run-tests
   - name: cse-sasl-cyrus-openssl-windows-2019-vs2017-x64-compile
     run_on: windows-vsCurrent-large
     tags: [cse-matrix-openssl, compile, windows-vsCurrent, vs2017x64, cse, sasl-cyrus]
@@ -2914,46 +2938,6 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-7.0-server-auth
-    run_on: ubuntu1804-arm64-small
-    tags: [sasl-matrix-openssl, test, ubuntu1804-arm64, gcc, sasl-cyrus, auth, server, "7.0"]
-    depends_on: [{ name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "7.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-latest-server-auth
-    run_on: ubuntu1804-arm64-small
-    tags: [sasl-matrix-openssl, test, ubuntu1804-arm64, gcc, sasl-cyrus, auth, server, latest]
-    depends_on: [{ name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: latest }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
   - name: sasl-cyrus-openssl-ubuntu1804-gcc-compile
     run_on: ubuntu1804-large
     tags: [sasl-matrix-openssl, compile, ubuntu1804, gcc, sasl-cyrus]
@@ -3162,34 +3146,22 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-7.0-replica-auth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-openssl, test, ubuntu1804, gcc, sasl-cyrus, auth, replica, "7.0"]
-    depends_on: [{ name: sasl-cyrus-openssl-ubuntu1804-gcc-compile }]
+  - name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
+    run_on: ubuntu2004-arm64-large
+    tags: [sasl-matrix-openssl, compile, ubuntu2004-arm64, gcc, sasl-cyrus]
+    commands:
+      - func: sasl-cyrus-openssl-compile
+        vars:
+          CC: gcc
+      - func: upload-build
+  - name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-7.0-server-auth
+    run_on: ubuntu2004-arm64-small
+    tags: [sasl-matrix-openssl, test, ubuntu2004-arm64, gcc, sasl-cyrus, auth, server, "7.0"]
+    depends_on: [{ name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: sasl-cyrus-openssl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "7.0" }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-7.0-server-auth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-openssl, test, ubuntu1804, gcc, sasl-cyrus, auth, server, "7.0"]
-    depends_on: [{ name: sasl-cyrus-openssl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-cyrus-openssl-ubuntu1804-gcc-compile
+          BUILD_NAME: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
       - command: expansions.update
         params:
           updates:
@@ -3202,34 +3174,14 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-latest-replica-auth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-openssl, test, ubuntu1804, gcc, sasl-cyrus, auth, replica, latest]
-    depends_on: [{ name: sasl-cyrus-openssl-ubuntu1804-gcc-compile }]
+  - name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-latest-server-auth
+    run_on: ubuntu2004-arm64-small
+    tags: [sasl-matrix-openssl, test, ubuntu2004-arm64, gcc, sasl-cyrus, auth, server, latest]
+    depends_on: [{ name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: sasl-cyrus-openssl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: latest }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-latest-server-auth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-openssl, test, ubuntu1804, gcc, sasl-cyrus, auth, server, latest]
-    depends_on: [{ name: sasl-cyrus-openssl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-cyrus-openssl-ubuntu1804-gcc-compile
+          BUILD_NAME: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
       - command: expansions.update
         params:
           updates:
@@ -3250,6 +3202,46 @@ tasks:
         vars:
           CC: gcc
       - func: upload-build
+  - name: sasl-cyrus-openssl-ubuntu2004-gcc-test-7.0-server-auth
+    run_on: ubuntu2004-small
+    tags: [sasl-matrix-openssl, test, ubuntu2004, gcc, sasl-cyrus, auth, server, "7.0"]
+    depends_on: [{ name: sasl-cyrus-openssl-ubuntu2004-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: sasl-cyrus-openssl-ubuntu2004-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "7.0" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: sasl-cyrus-openssl-ubuntu2004-gcc-test-latest-server-auth
+    run_on: ubuntu2004-small
+    tags: [sasl-matrix-openssl, test, ubuntu2004, gcc, sasl-cyrus, auth, server, latest]
+    depends_on: [{ name: sasl-cyrus-openssl-ubuntu2004-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: sasl-cyrus-openssl-ubuntu2004-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: latest }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
   - name: sasl-cyrus-openssl-windows-2019-vs2017-x64-compile
     run_on: windows-vsCurrent-large
     tags: [sasl-matrix-openssl, compile, windows-vsCurrent, vs2017x64, sasl-cyrus]
@@ -3846,14 +3838,22 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: sasl-off-nossl-ubuntu1804-gcc-test-7.0-replica-noauth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-nossl, test, ubuntu1804, gcc, sasl-off, noauth, replica, "7.0"]
-    depends_on: [{ name: sasl-off-nossl-ubuntu1804-gcc-compile }]
+  - name: sasl-off-nossl-ubuntu2004-gcc-compile
+    run_on: ubuntu2004-large
+    tags: [sasl-matrix-nossl, compile, ubuntu2004, gcc, sasl-off]
+    commands:
+      - func: sasl-off-nossl-compile
+        vars:
+          CC: gcc
+      - func: upload-build
+  - name: sasl-off-nossl-ubuntu2004-gcc-test-7.0-replica-noauth
+    run_on: ubuntu2004-small
+    tags: [sasl-matrix-nossl, test, ubuntu2004, gcc, sasl-off, noauth, replica, "7.0"]
+    depends_on: [{ name: sasl-off-nossl-ubuntu2004-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: sasl-off-nossl-ubuntu1804-gcc-compile
+          BUILD_NAME: sasl-off-nossl-ubuntu2004-gcc-compile
       - command: expansions.update
         params:
           updates:
@@ -3866,14 +3866,14 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: sasl-off-nossl-ubuntu1804-gcc-test-7.0-server-noauth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-nossl, test, ubuntu1804, gcc, sasl-off, noauth, server, "7.0"]
-    depends_on: [{ name: sasl-off-nossl-ubuntu1804-gcc-compile }]
+  - name: sasl-off-nossl-ubuntu2004-gcc-test-7.0-server-noauth
+    run_on: ubuntu2004-small
+    tags: [sasl-matrix-nossl, test, ubuntu2004, gcc, sasl-off, noauth, server, "7.0"]
+    depends_on: [{ name: sasl-off-nossl-ubuntu2004-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: sasl-off-nossl-ubuntu1804-gcc-compile
+          BUILD_NAME: sasl-off-nossl-ubuntu2004-gcc-compile
       - command: expansions.update
         params:
           updates:
@@ -3886,14 +3886,14 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: sasl-off-nossl-ubuntu1804-gcc-test-7.0-sharded-noauth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-nossl, test, ubuntu1804, gcc, sasl-off, noauth, sharded, "7.0"]
-    depends_on: [{ name: sasl-off-nossl-ubuntu1804-gcc-compile }]
+  - name: sasl-off-nossl-ubuntu2004-gcc-test-7.0-sharded-noauth
+    run_on: ubuntu2004-small
+    tags: [sasl-matrix-nossl, test, ubuntu2004, gcc, sasl-off, noauth, sharded, "7.0"]
+    depends_on: [{ name: sasl-off-nossl-ubuntu2004-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: sasl-off-nossl-ubuntu1804-gcc-compile
+          BUILD_NAME: sasl-off-nossl-ubuntu2004-gcc-compile
       - command: expansions.update
         params:
           updates:
@@ -3906,14 +3906,14 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: sasl-off-nossl-ubuntu1804-gcc-test-latest-replica-noauth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-nossl, test, ubuntu1804, gcc, sasl-off, noauth, replica, latest]
-    depends_on: [{ name: sasl-off-nossl-ubuntu1804-gcc-compile }]
+  - name: sasl-off-nossl-ubuntu2004-gcc-test-latest-replica-noauth
+    run_on: ubuntu2004-small
+    tags: [sasl-matrix-nossl, test, ubuntu2004, gcc, sasl-off, noauth, replica, latest]
+    depends_on: [{ name: sasl-off-nossl-ubuntu2004-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: sasl-off-nossl-ubuntu1804-gcc-compile
+          BUILD_NAME: sasl-off-nossl-ubuntu2004-gcc-compile
       - command: expansions.update
         params:
           updates:
@@ -3926,14 +3926,14 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: sasl-off-nossl-ubuntu1804-gcc-test-latest-server-noauth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-nossl, test, ubuntu1804, gcc, sasl-off, noauth, server, latest]
-    depends_on: [{ name: sasl-off-nossl-ubuntu1804-gcc-compile }]
+  - name: sasl-off-nossl-ubuntu2004-gcc-test-latest-server-noauth
+    run_on: ubuntu2004-small
+    tags: [sasl-matrix-nossl, test, ubuntu2004, gcc, sasl-off, noauth, server, latest]
+    depends_on: [{ name: sasl-off-nossl-ubuntu2004-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: sasl-off-nossl-ubuntu1804-gcc-compile
+          BUILD_NAME: sasl-off-nossl-ubuntu2004-gcc-compile
       - command: expansions.update
         params:
           updates:
@@ -3946,14 +3946,14 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: sasl-off-nossl-ubuntu1804-gcc-test-latest-sharded-noauth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-nossl, test, ubuntu1804, gcc, sasl-off, noauth, sharded, latest]
-    depends_on: [{ name: sasl-off-nossl-ubuntu1804-gcc-compile }]
+  - name: sasl-off-nossl-ubuntu2004-gcc-test-latest-sharded-noauth
+    run_on: ubuntu2004-small
+    tags: [sasl-matrix-nossl, test, ubuntu2004, gcc, sasl-off, noauth, sharded, latest]
+    depends_on: [{ name: sasl-off-nossl-ubuntu2004-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: sasl-off-nossl-ubuntu1804-gcc-compile
+          BUILD_NAME: sasl-off-nossl-ubuntu2004-gcc-compile
       - command: expansions.update
         params:
           updates:
@@ -4586,14 +4586,22 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-7.0-replica-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-tsan, test, ubuntu1804, clang, sasl-cyrus, tsan, auth, replica, "7.0"]
-    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
+  - name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile
+    run_on: ubuntu2004-large
+    tags: [sanitizers-matrix-tsan, compile, ubuntu2004, clang, tsan, sasl-cyrus]
+    commands:
+      - func: sasl-cyrus-openssl-compile
+        vars:
+          CC: clang
+      - func: upload-build
+  - name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-test-7.0-replica-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-tsan, test, ubuntu2004, clang, sasl-cyrus, tsan, auth, replica, "7.0"]
+    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile
+          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile
       - command: expansions.update
         params:
           updates:
@@ -4606,14 +4614,14 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-7.0-server-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-tsan, test, ubuntu1804, clang, sasl-cyrus, tsan, auth, server, "7.0"]
-    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
+  - name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-test-7.0-server-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-tsan, test, ubuntu2004, clang, sasl-cyrus, tsan, auth, server, "7.0"]
+    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile
+          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile
       - command: expansions.update
         params:
           updates:
@@ -4626,14 +4634,14 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-7.0-sharded-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-tsan, test, ubuntu1804, clang, sasl-cyrus, tsan, auth, sharded, "7.0"]
-    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
+  - name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-test-7.0-sharded-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-tsan, test, ubuntu2004, clang, sasl-cyrus, tsan, auth, sharded, "7.0"]
+    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile
+          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile
       - command: expansions.update
         params:
           updates:
@@ -4646,14 +4654,14 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-latest-replica-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-tsan, test, ubuntu1804, clang, sasl-cyrus, tsan, auth, replica, latest]
-    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
+  - name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-test-latest-replica-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-tsan, test, ubuntu2004, clang, sasl-cyrus, tsan, auth, replica, latest]
+    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile
+          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile
       - command: expansions.update
         params:
           updates:
@@ -4666,14 +4674,14 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-latest-server-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-tsan, test, ubuntu1804, clang, sasl-cyrus, tsan, auth, server, latest]
-    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
+  - name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-test-latest-server-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-tsan, test, ubuntu2004, clang, sasl-cyrus, tsan, auth, server, latest]
+    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile
+          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile
       - command: expansions.update
         params:
           updates:
@@ -4686,14 +4694,14 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-latest-sharded-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-tsan, test, ubuntu1804, clang, sasl-cyrus, tsan, auth, sharded, latest]
-    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
+  - name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-test-latest-sharded-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-tsan, test, ubuntu2004, clang, sasl-cyrus, tsan, auth, sharded, latest]
+    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile
+          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile
       - command: expansions.update
         params:
           updates:

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -741,7 +741,7 @@ for server_version in [ "7.0", "6.0", "5.0"]:
         [
             PostCompileTask(
                 "test-versioned-api-" + server_version,
-                tags=["versioned-api"],
+                tags=["versioned-api", f"versioned-api-{server_version}"],
                 get_build="debug-compile-nosasl-openssl",
                 commands=[
                     func("fetch-det"),
@@ -759,7 +759,7 @@ for server_version in [ "7.0", "6.0", "5.0"]:
             ),
             PostCompileTask(
                 "test-versioned-api-accept-version-two-" + server_version,
-                tags=["versioned-api"],
+                tags=["versioned-api", f"versioned-api-{server_version}"],
                 get_build="debug-compile-nosasl-nossl",
                 commands=[
                     func("fetch-det"),

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -759,7 +759,7 @@ for server_version in [ "7.0", "6.0", "5.0"]:
             ),
             PostCompileTask(
                 "test-versioned-api-accept-version-two-" + server_version,
-                tags=["versioned-api", f"versioned-api-{server_version}"],
+                tags=["versioned-api", f"{server_version}"],
                 get_build="debug-compile-nosasl-nossl",
                 commands=[
                     func("fetch-det"),

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -741,7 +741,7 @@ for server_version in [ "7.0", "6.0", "5.0"]:
         [
             PostCompileTask(
                 "test-versioned-api-" + server_version,
-                tags=["versioned-api", f"versioned-api-{server_version}"],
+                tags=["versioned-api", f"{server_version}"],
                 get_build="debug-compile-nosasl-openssl",
                 commands=[
                     func("fetch-det"),

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -944,6 +944,7 @@ class AWSTestTask(MatrixTask):
 
     def additional_tags(self) -> Iterable[str]:
         yield from super().additional_tags()
+        yield f'test-aws-{self.settings.version}'
         yield f'test-aws'
 
     def post_commands(self) -> Iterable[Value]:

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -944,7 +944,7 @@ class AWSTestTask(MatrixTask):
 
     def additional_tags(self) -> Iterable[str]:
         yield from super().additional_tags()
-        yield f'test-aws-{self.settings.version}'
+        yield f'{self.settings.version}'
         yield f'test-aws'
 
     def post_commands(self) -> Iterable[Value]:

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -449,10 +449,32 @@ all_variants = [
         "clang 6.0 (Ubuntu 18.04)",
         "ubuntu1804-test",
         [
-            "debug-compile-aws",
             "debug-compile-sasl-openssl-static",
             ".authentication-tests .asan",
-            ".test-aws",
+        ],
+        {"CC": "clang"},
+    ),
+    Variant(
+        "aws-ubuntu1804",
+        "AWS Tests (Ubuntu 18.04)",
+        "ubuntu1804-small",
+        [
+            "debug-compile-aws",
+            ".test-aws-4.4",
+            ".test-aws-5.0",
+            ".test-aws-6.0",
+        ],
+        {"CC": "clang"},
+    ),
+    # Test 7.0+ with Ubuntu 20.04+ since MongoDB 7.0 no longer ships binaries for Ubuntu 18.04.
+    Variant(
+        "aws-ubuntu2004",
+        "AWS Tests (Ubuntu 20.04)",
+        "ubuntu2004-small",
+        [
+            "debug-compile-aws",
+            ".test-aws-7.0",
+            ".test-aws-latest",
         ],
         {"CC": "clang"},
     ),

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -509,10 +509,27 @@ all_variants = [
         tags=["pr-merge-gate"],
     ),
     Variant(
-        "versioned-api",
-        "Versioned API Tests",
+        "versioned-api-ubuntu1804",
+        "Versioned API Tests (Ubuntu 18.04)",
         "ubuntu1804-test",
-        ["debug-compile-nosasl-openssl", "debug-compile-nosasl-nossl", ".versioned-api"],
+        [
+            "debug-compile-nosasl-openssl",
+            "debug-compile-nosasl-nossl",
+            ".versioned-api-5.0",
+            ".versioned-api-6.0",
+        ],
+        {},
+    ),
+    # Test 7.0+ with Ubuntu 20.04+ since MongoDB 7.0 no longer ships binaries for Ubuntu 18.04.
+    Variant(
+        "versioned-api-ubuntu2004",
+        "Versioned API Tests (Ubuntu 20.04)",
+        "ubuntu2004-test",
+        [
+            "debug-compile-nosasl-openssl",
+            "debug-compile-nosasl-nossl",
+            ".versioned-api-7.0",
+        ],
         {},
     ),
 ]

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -460,9 +460,9 @@ all_variants = [
         "ubuntu1804-small",
         [
             "debug-compile-aws",
-            ".test-aws-4.4",
-            ".test-aws-5.0",
-            ".test-aws-6.0",
+            ".test-aws .4.4",
+            ".test-aws .5.0",
+            ".test-aws .6.0",
         ],
         {"CC": "clang"},
     ),
@@ -473,8 +473,8 @@ all_variants = [
         "ubuntu2004-small",
         [
             "debug-compile-aws",
-            ".test-aws-7.0",
-            ".test-aws-latest",
+            ".test-aws .7.0",
+            ".test-aws .latest",
         ],
         {"CC": "clang"},
     ),

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -515,8 +515,8 @@ all_variants = [
         [
             "debug-compile-nosasl-openssl",
             "debug-compile-nosasl-nossl",
-            ".versioned-api-5.0",
-            ".versioned-api-6.0",
+            ".versioned-api .5.0",
+            ".versioned-api .6.0",
         ],
         {},
     ),
@@ -528,7 +528,7 @@ all_variants = [
         [
             "debug-compile-nosasl-openssl",
             "debug-compile-nosasl-nossl",
-            ".versioned-api-7.0",
+            ".versioned-api .7.0",
         ],
         {},
     ),


### PR DESCRIPTION
# Summary

Migrate MongoDB 7.0+ Evergreen tasks from Ubuntu 18.04 to 20.04

Tasks matching `.*7.0.*` were run in this patch build to verify: https://spruce.mongodb.com/version/651d7291c9ec44a912961b62. The failing tasks are expected and fail on the master branch.

# Background & Motivation

MongoDB 7.0 does not officially support Ubuntu 18.04. Ubuntu 18.04 binaries were removed in 7.0.2 in SERVER-77233. This has resulted [task failures](https://spruce.mongodb.com/version/mongo_c_driver_eec9249e392082be8aacbe4f96275d948018f065/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&taskName=7.0) for server 7.0 tasks on Ubuntu 18.04.

This PR intends to make the minimal change to reduce test failures by upgrading selected variants to Ubuntu 20.04.