### PR TITLE
CDRIVER-4349 unskip `/Client/get_handshake_hello_response/pooled` and relax assertion.

### DIFF
--- a/.evergreen/etc/skip-tests.txt
+++ b/.evergreen/etc/skip-tests.txt
@@ -31,7 +31,6 @@
 /change_stream/live/track_resume_token # (CDRIVER-4344) Condition 'bson_compare (resume_token, &doc2_rt) == 0' failed
 /BulkOperation/split # (CDRIVER-4346) Assert Failure: count of split_1512376901_50824 is 97759, not 100010
 /ClientPool/pop_timeout # (CDRIVER-4348) precondition failed: duration_usec / 1000 >= 1990
-/Client/get_handshake_hello_response/pooled # (CDRIVER-4349) Assert Failure: "Unknown" != "PossiblePrimary"
 
 /inheritance/find/readPrefs # (CDRIVER-4350) request_matches_msg(): precondition failed: request
 /BulkOperation/error/unordered # (CDRIVER-4350) request_matches_msg(): precondition failed: request

--- a/src/libmongoc/tests/test-mongoc-client.c
+++ b/src/libmongoc/tests/test-mongoc-client.c
@@ -4089,7 +4089,18 @@ test_mongoc_client_get_handshake_hello_response_pooled (void)
    invalidated_sd =
       mongoc_client_get_server_description (client, monitor_sd->id);
    BSON_ASSERT (NULL != invalidated_sd);
-   ASSERT_CMPSTR ("Unknown", mongoc_server_description_type (invalidated_sd));
+
+   // Check the resulting server description.
+   // Invalidating sets the type to Unknown.
+   // A background monitor may have set the type to PossiblePrimary.
+   const char *got_description_type =
+      mongoc_server_description_type (invalidated_sd);
+   if (0 != strcmp ("Unknown", got_description_type) &&
+       0 != strcmp ("PossiblePrimary", got_description_type)) {
+      test_error ("Expected server to have type 'Unknown' or "
+                  "'PossiblePrimary', got: '%s'",
+                  got_description_type);
+   }
 
    /* The previously established connection should have a valid server
     * description. */


### PR DESCRIPTION
# Summary

Unskip `/Client/get_handshake_hello_response/pooled` and relax assertion.

Test was unskipped and run in a patch build with all variants and tasks with names matching `".*replica.*`: https://spruce.mongodb.com/version/651ebb7c2fbabe15fa1109fd

# Background & Motivation

The reported error is `Assert Failure: "Unknown" != "PossiblePrimary"`.

The test sets a server type to `Unknown` by calling `_mongoc_topology_invalidate_server`. The test then gets the type from the shared topology description with `mongoc_client_get_server_description` to check the type is `Unknown`.

In between setting and getting, I expect it is possible a background monitor for another server receives a response.

[SDAM](https://github.com/mongodb/specifications/blob/e3998f2c66f036ff6398aa1849b046314f019a9c/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#type) notes:

> PossiblePrimary	Not yet checked, but another member thinks it is the primary.

Following the SDAM behavior [updateRSWithoutPrimary](https://github.com/mongodb/specifications/blob/e3998f2c66f036ff6398aa1849b046314f019a9c/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#updaterswithoutprimary), a response may set the type of another server to `PossiblePrimary`.

The test has been updated to check the type is `Unknown` or `PossiblePrimary`.
