### PR TITLE
CDRIVER-4350 unskip mock tests and remove unnecessary skips

### DIFF
--- a/.evergreen/etc/skip-tests.txt
+++ b/.evergreen/etc/skip-tests.txt
@@ -37,7 +37,6 @@
 /change_streams/legacy/change-streams-resume-allowlist # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
 /change_streams/legacy/change-streams-resume-errorLabels # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
 /unified/assertNumberConnectionsCheckedOut # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
-/unified/entity-client-cmap-events # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
 /unified/entity-client-storeEventsAsEntities # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
 /unified/entity-find-cursor # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
 /change_streams/legacy/change-streams-errors # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000'] (on ASAN Tests Ubuntu 18.04 build variant)

--- a/.evergreen/etc/skip-tests.txt
+++ b/.evergreen/etc/skip-tests.txt
@@ -37,7 +37,6 @@
 /change_streams/legacy/change-streams-resume-allowlist # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
 /change_streams/legacy/change-streams-resume-errorLabels # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
 /unified/assertNumberConnectionsCheckedOut # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
-/unified/entity-client-storeEventsAsEntities # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
 /unified/entity-find-cursor # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
 /change_streams/legacy/change-streams-errors # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000'] (on ASAN Tests Ubuntu 18.04 build variant)
 

--- a/.evergreen/etc/skip-tests.txt
+++ b/.evergreen/etc/skip-tests.txt
@@ -36,7 +36,6 @@
 /change_streams/legacy/change-streams # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
 /change_streams/legacy/change-streams-resume-allowlist # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
 /change_streams/legacy/change-streams-resume-errorLabels # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
-/unified/assertNumberConnectionsCheckedOut # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
 /unified/entity-find-cursor # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
 /change_streams/legacy/change-streams-errors # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000'] (on ASAN Tests Ubuntu 18.04 build variant)
 

--- a/.evergreen/etc/skip-tests.txt
+++ b/.evergreen/etc/skip-tests.txt
@@ -33,15 +33,9 @@
 /ClientPool/pop_timeout # (CDRIVER-4348) precondition failed: duration_usec / 1000 >= 1990
 /Client/get_handshake_hello_response/pooled # (CDRIVER-4349) Assert Failure: "Unknown" != "PossiblePrimary"
 
-/inheritance/find/readPrefs # (CDRIVER-4350) request_matches_msg(): precondition failed: request
-/BulkOperation/error/unordered # (CDRIVER-4350) request_matches_msg(): precondition failed: request
-/command_monitoring/get_error # (CDRIVER-4350) request_matches_msg(): precondition failed: request
 /change_streams/legacy/change-streams # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
 /change_streams/legacy/change-streams-resume-allowlist # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
 /change_streams/legacy/change-streams-resume-errorLabels # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
-/Collection/find_with_opts/newoption # (CDRIVER-4350) request_matches_msg(): precondition failed: request
-/inheritance/replace_one/writeConcern # (CDRIVER-4350) request_matches_msg(): precondition failed: request
-/Collection/find_with_opts/newoption # (CDRIVER-4350) request_matches_msg(): precondition failed: request
 /unified/assertNumberConnectionsCheckedOut # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
 /unified/entity-client-cmap-events # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']
 /unified/entity-client-storeEventsAsEntities # (CDRIVER-4350) Could not establish stream for node 127.0.0.1:8000: [TLS handshake failed: Connection timed out calling hello on '127.0.0.1:8000']

--- a/src/libmongoc/tests/unified/runner.c
+++ b/src/libmongoc/tests/unified/runner.c
@@ -37,8 +37,6 @@ typedef struct {
 skipped_unified_test_t SKIPPED_TESTS[] = {
    // CDRIVER-4001, DRIVERS-1781, and DRIVERS-1448: 5.0 cursor behavior
    {"poc-command-monitoring", "A successful find event with a getmore and the server kills the cursor"},
-   // CDRIVER-3867: drivers atlas testing (schema version 1.2)
-   {"entity-client-storeEventsAsEntities", SKIP_ALL_TESTS},
    // libmongoc does not have a distinct helper, so skip snapshot tests testing particular distinct functionality
    {"snapshot-sessions", "Distinct operation with snapshot"},
    {"snapshot-sessions", "Mixed operation with snapshot"},


### PR DESCRIPTION
# Summary

This PR partially resolves CDRIVER-4350.

Unskip the following mock server tests:

- `/inheritance/find/readPrefs`
- `/BulkOperation/error/unordered`
- `/command_monitoring/get_error`
- `/Collection/find_with_opts/newoption`
- `/inheritance/replace_one/writeConcern`
- `/Collection/find_with_opts/newoption`

Unskip the following live test:
- `/unified/entity-client-storeEventsAsEntities`

Remove unnecessary skips for the following tests:
- `/unified/assertNumberConnectionsCheckedOut`
- `/unified/entity-client-cmap-events`

# Background and Motivation

CDRIVER-4350 references both live and mock tests. The following are mock tests:
- `/inheritance/find/readPrefs`
- `/BulkOperation/error/unordered`
- `/command_monitoring/get_error`
- `/Collection/find_with_opts/newoption`
- `/inheritance/replace_one/writeConcern`
- `/Collection/find_with_opts/newoption`

As of https://github.com/mongodb/mongo-c-driver/pull/1277, mock server tests are only run on ubuntu2204-small distro. The flaky test failures may no longer be applicable. Mock tests were unskipped and run in a patch build: https://spruce.mongodb.com/version/6523f7c20305b90bc8cf1bee The result of three runs was success.

The following live tests were already [skipped in runner.c](https://github.com/mongodb/mongo-c-driver/blob/843fd5f56a231e446bdb8cd62e51763c8c0198c6/src/libmongoc/tests/unified/runner.c#L51):
- `/unified/assertNumberConnectionsCheckedOut`
- `/unified/entity-client-cmap-events`
- `/unified/entity-client-storeEventsAsEntities`

Entries in skip-tests.txt were removed due to unnecessary duplicate skips.

`/unified/entity-client-storeEventsAsEntities` was initially skipped in https://github.com/mongodb/mongo-c-driver/pull/820 due to not implementing the `storeEventsAsEntities` used in the test:
> For schema version 1.2, I've skipped implementing the `loop` operation and the `storeEventsAsEntities` option, as they are only required once we resume work on drivers atlas testing. 

https://github.com/mongodb/mongo-c-driver/pull/1220 implements the `storeEventsAsEntities` operation. `/unified/entity-client-storeEventsAsEntities` is unskipped in `runner.c`.

Unskipping other live referenced tests resulted in an observed test failure in `/change_streams/legacy/change-streams-resume-allowlist` on [this patch](https://spruce.mongodb.com/version/652400193e8e86b0d6da9796/tasks) and is not addressed in this PR.