### PR TITLE
CDRIVER-4346 unskip `/BulkOperation/split`

### DIFF
--- a/.evergreen/etc/skip-tests.txt
+++ b/.evergreen/etc/skip-tests.txt
@@ -26,7 +26,6 @@
 /mongohouse/runCommand # CDRIVER-4333
 
 /change_stream/live/track_resume_token # (CDRIVER-4344) Condition 'bson_compare (resume_token, &doc2_rt) == 0' failed
-/BulkOperation/split # (CDRIVER-4346) Assert Failure: count of split_1512376901_50824 is 97759, not 100010
 /ClientPool/pop_timeout # (CDRIVER-4348) precondition failed: duration_usec / 1000 >= 1990
 /Client/get_handshake_hello_response/pooled # (CDRIVER-4349) Assert Failure: "Unknown" != "PossiblePrimary"
 

--- a/src/libmongoc/tests/test-mongoc-bulk.c
+++ b/src/libmongoc/tests/test-mongoc-bulk.c
@@ -3485,8 +3485,10 @@ test_numerous_unordered (void *ctx)
 
 
 static void
-test_bulk_split (void)
+test_bulk_split (void *ctx)
 {
+   BSON_UNUSED (ctx);
+
    mongoc_client_t *client;
    mongoc_collection_t *collection;
    bson_t opts = BSON_INITIALIZER;
@@ -5330,7 +5332,12 @@ test_bulk_install (TestSuite *suite)
       suite, "/BulkOperation/OP_MSG/max_batch_size", test_bulk_max_batch_size);
    TestSuite_AddLive (
       suite, "/BulkOperation/OP_MSG/max_msg_size", test_bulk_max_msg_size);
-   TestSuite_AddLive (suite, "/BulkOperation/split", test_bulk_split);
+   TestSuite_AddFull (suite,
+                      "/BulkOperation/split",
+                      test_bulk_split,
+                      NULL /* dtor */,
+                      NULL /* ctx */,
+                      test_framework_skip_if_no_sessions);
    TestSuite_AddFull (suite,
                       "/BulkOperation/write_concern/split",
                       test_bulk_write_concern_split,


### PR DESCRIPTION
# Summary

- Unskip `/BulkOperation/split`.
- Use "read-your-own-writes" semantics in test to prevent undercounting.

# Background & Motivation

Three repeated runs of the `/BulkOperation/split` test on all variants and tasks with names matching `".*test.*` did not result in the test failing: https://spruce.mongodb.com/version/651eaee656234357657a0c22

Changes in this PR intend to address a possible cause of the original reported error. The original error reported an undercount after inserting: `Assert Failure: count of split_1512376901_50824 is 97759, not 100010`.

This PR proposes using "read-your-own-writes" semantics to read the count. This is done by using a session with causal consistency, and performing operations with majority read and write concerns described in [Client Sessions and Causal Consistency Guarantees](https://www.mongodb.com/docs/manual/core/read-isolation-consistency-recency/#client-sessions-and-causal-consistency-guarantees).

Updated test was tested in this patch build: https://spruce.mongodb.com/version/65255627850e61e7577a509b