### PR TITLE
CDRIVER-4353 unskip `/server_discovery_and_monitoring/monitoring/heartbeat/pooled/dns`

### DIFF
--- a/.evergreen/etc/skip-tests.txt
+++ b/.evergreen/etc/skip-tests.txt
@@ -39,7 +39,6 @@
 /transactions/legacy/mongos-recovery-token/"commitTransaction retry fails on new mongos" # fails with server selection timeout (CDRIVER-4268)
 /transactions/legacy/pin-mongos/"unpin after transient error within a transaction and commit" # (CDRIVER-4351) server selection timeout (on ASAN Tests Ubuntu 18.04 build variant)
 /Samples # (CDRIVER-4352) strange "heartbeat failed" error
-/server_discovery_and_monitoring/monitoring/heartbeat/pooled/dns # (CDRIVER-4353) this initially seemed like a zSeries w/ RHEL8 issue, but it also appeared on arm64 w/ Ubuntu 18.04
 /crud/unified/bulkWrite-deleteOne-let/"BulkWrite deleteOne with let option unsupported (server-side error)" # (CDRIVER-4354) error: expected error, but no error
 /crud/unified/bulkWrite-replaceOne-let/"BulkWrite replaceOne with let option unsupported (server-side error)" # (CDRIVER-4354) error: expected error, but no error
 /crud/unified/bulkWrite-updateMany-let/"BulkWrite updateMany with let option unsupported (server-side error)" # (CDRIVER-4354) error: expected error, but no error

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -1998,31 +1998,6 @@ test_framework_skip_if_offline (void)
 
 
 int
-test_framework_skip_if_rhel8_zseries (void)
-{
-   /* CDRIVER-3923: It appears that when running on RHEL8 on zSeries the
-    * /server_discovery_and_monitoring/monitoring/heartbeat/pooled/dns test
-    * fails.  The best guess is that calling getaddrinfo() on that platform
-    * blocks for 5 seconds, while the test expects a server selection error
-    * after 3000 ms, or 3 seconds.  Skip the test when executing on RHEL8 on
-    * zSeries. */
-#ifdef __s390x__
-   char *name;
-   char *version;
-   _mongoc_linux_distro_scanner_get_distro (&name, &version);
-   bool rhel = strcmp (name, "Red Hat Enterprise Linux") == 0;
-   bool vers8 = version[0] == '8';
-   int skip = (rhel && vers8) ? 0 : 1;
-   bson_free (name);
-   bson_free (version);
-   return skip;
-#else
-   return 1;
-#endif
-}
-
-
-int
 test_framework_skip_if_slow (void)
 {
    return test_framework_getenv_bool ("MONGOC_TEST_SKIP_SLOW") ? 0 : 1;

--- a/src/libmongoc/tests/test-libmongoc.h
+++ b/src/libmongoc/tests/test-libmongoc.h
@@ -189,8 +189,6 @@ test_framework_skip_if_not_single (void);
 int
 test_framework_skip_if_offline (void);
 int
-test_framework_skip_if_rhel8_zseries (void);
-int
 test_framework_skip_if_slow (void);
 int
 test_framework_skip_if_slow_or_live (void);

--- a/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
@@ -848,7 +848,7 @@ _test_heartbeat_fails_dns (bool pooled)
     * client for a client pool). */
    start = bson_get_monotonic_time ();
    uri = mongoc_uri_new (
-      "mongodb://doesntexist.invalid/?serverSelectionTimeoutMS=3000");
+      "mongodb://doesntexist.invalid/?serverSelectionTimeoutMS=100");
    if (pooled) {
       pool = test_framework_client_pool_new_from_uri (uri, NULL);
       pool_set_heartbeat_event_callbacks (pool, &context);

--- a/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
@@ -848,7 +848,7 @@ _test_heartbeat_fails_dns (bool pooled)
     * client for a client pool). */
    start = bson_get_monotonic_time ();
    uri = mongoc_uri_new (
-      "mongodb://doesntexist.foobar/?serverSelectionTimeoutMS=3000");
+      "mongodb://doesntexist.invalid/?serverSelectionTimeoutMS=3000");
    if (pooled) {
       pool = test_framework_client_pool_new_from_uri (uri, NULL);
       pool_set_heartbeat_event_callbacks (pool, &context);

--- a/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
@@ -893,18 +893,14 @@ _test_heartbeat_fails_dns (bool pooled)
 }
 
 static void
-test_heartbeat_fails_dns_single (void *ctx)
+test_heartbeat_fails_dns_single (void)
 {
-   BSON_UNUSED (ctx);
-
    _test_heartbeat_fails_dns (false);
 }
 
 static void
-test_heartbeat_fails_dns_pooled (void *ctx)
+test_heartbeat_fails_dns_pooled (void)
 {
-   BSON_UNUSED (ctx);
-
    _test_heartbeat_fails_dns (true);
 }
 
@@ -1054,21 +1050,14 @@ test_sdam_monitoring_install (TestSuite *suite)
       suite,
       "/server_discovery_and_monitoring/monitoring/heartbeat/pooled/failed",
       test_heartbeat_events_pooled_failed);
-   TestSuite_AddFull (
+   TestSuite_Add (
       suite,
       "/server_discovery_and_monitoring/monitoring/heartbeat/single/dns",
-      test_heartbeat_fails_dns_single,
-      NULL,
-      NULL,
-      test_framework_skip_if_offline);
-   TestSuite_AddFull (
+      test_heartbeat_fails_dns_single);
+   TestSuite_Add (
       suite,
       "/server_discovery_and_monitoring/monitoring/heartbeat/pooled/dns",
-      test_heartbeat_fails_dns_pooled,
-      NULL,
-      NULL,
-      test_framework_skip_if_offline,
-      test_framework_skip_if_rhel8_zseries);
+      test_heartbeat_fails_dns_pooled);
    TestSuite_AddMockServerTest (
       suite,
       "/server_discovery_and_monitoring/monitoring/no_duplicates",

--- a/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
@@ -869,7 +869,6 @@ _test_heartbeat_fails_dns (bool pooled)
                           MONGOC_ERROR_SERVER_SELECTION_FAILURE,
                           "No suitable servers found");
 
-   duration = bson_get_monotonic_time () - start;
 
    if (pooled) {
       mongoc_client_pool_push (pool, client);
@@ -877,6 +876,8 @@ _test_heartbeat_fails_dns (bool pooled)
    } else {
       mongoc_client_destroy (client);
    }
+
+   duration = bson_get_monotonic_time () - start;
 
    durations = &context.heartbeat_failed_durations;
 

--- a/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
@@ -862,13 +862,12 @@ _test_heartbeat_fails_dns (bool pooled)
    r = mongoc_client_command_simple (
       client, "admin", tmp_bson ("{'foo': 1}"), NULL, NULL, &error);
 
-   /* This should result in either a DNS failure or connection failure depending
-    * on the network. We assert the domain/code but not the message string. */
+   /* Expect a server selection error. */
    ASSERT (!r);
    ASSERT_ERROR_CONTAINS (error,
                           MONGOC_ERROR_SERVER_SELECTION,
                           MONGOC_ERROR_SERVER_SELECTION_FAILURE,
-                          "");
+                          "No suitable servers found");
 
    duration = bson_get_monotonic_time () - start;
 


### PR DESCRIPTION
# Summary

Unskip `/server_discovery_and_monitoring/monitoring/heartbeat/pooled/dns`.

Additional related changes are described in commits.

Changes were tested on [this patch](https://spruce.mongodb.com/version/6525acdee3c331ec7fe7e9f5) with all tasks with names matching `".*test.*`. Three repeated runs passed excluding unrelated task failures.

# Background & Motivation

Similar to changes in https://github.com/mongodb/mongo-c-driver/pull/1426, this PR proposes use of the TLD `.invalid` intended to reliably return a DNS error. [RFC 2606](https://www.rfc-editor.org/rfc/rfc2606.html#section-2) notes:

> ".invalid" is intended for use in online construction of domain names that are sure to be invalid and which it is obvious at a glance are invalid.