### PR TITLE
CDRIVER-4355 unskip `/sessions/unified/snapshot-sessions`

### DIFF
--- a/.evergreen/etc/skip-tests.txt
+++ b/.evergreen/etc/skip-tests.txt
@@ -38,7 +38,6 @@
 /transactions/legacy/pin-mongos/"unpin after transient error within a transaction and commit" # (CDRIVER-4351) server selection timeout (on ASAN Tests Ubuntu 18.04 build variant)
 /Samples # (CDRIVER-4352) strange "heartbeat failed" error
 /server_discovery_and_monitoring/monitoring/heartbeat/pooled/dns # (CDRIVER-4353) this initially seemed like a zSeries w/ RHEL8 issue, but it also appeared on arm64 w/ Ubuntu 18.04
-/sessions/unified/snapshot-sessions/"countDocuments operation with snapshot" # (CDRIVER-4355) error: checking expectResult:  { "$numberInt" : "2" }
 /load_balancers/non-lb-connection-establishment/"operations against non-load balanced clusters fail if URI contains loadBalanced=true" # (CDRIVER-4356) error: expected error to contain "Driver attempted to initialize in load balancing mode, but the server does not support this mode", but got: "BSON field 'hello.loadBalanced' is an unknown field."
 
 /client_side_encryption/bypass_spawning_mongocryptd/mongocryptdBypassSpawn  # Fails if crypt_shared is visible


### PR DESCRIPTION
# Summary

Unskip `/sessions/unified/snapshot-sessions`

# Background & Motivation

Test was unskipped and run in a patch build with all variants and tasks with names matching `".*test.*`: https://spruce.mongodb.com/version/65269a2657e85a612dd2f043
Results of three runs were successful with unrelated task failures.

I am unsure what caused the original reported error `error: checking expectResult:  { "$numberInt" : "2" }`. https://github.com/mongodb/mongo-c-driver/commit/904db5300d7c90349ef96c2dcfb203bf6609ab6c#diff-1f83e54d27ecd8d43c2fd4d5835485a87bc4882cf6d3d9602d4abf7208cfedffR366 improves the error message to include the actual value. If a later test failure is observed, this may help to diagnose the cause if a future error is observed.