### PR TITLE
CDRIVER-4356 unskip `/load_balancers/non-lb-connection-establishment`

### DIFF
--- a/.evergreen/etc/skip-tests.txt
+++ b/.evergreen/etc/skip-tests.txt
@@ -39,6 +39,5 @@
 /Samples # (CDRIVER-4352) strange "heartbeat failed" error
 /server_discovery_and_monitoring/monitoring/heartbeat/pooled/dns # (CDRIVER-4353) this initially seemed like a zSeries w/ RHEL8 issue, but it also appeared on arm64 w/ Ubuntu 18.04
 /sessions/unified/snapshot-sessions/"countDocuments operation with snapshot" # (CDRIVER-4355) error: checking expectResult:  { "$numberInt" : "2" }
-/load_balancers/non-lb-connection-establishment/"operations against non-load balanced clusters fail if URI contains loadBalanced=true" # (CDRIVER-4356) error: expected error to contain "Driver attempted to initialize in load balancing mode, but the server does not support this mode", but got: "BSON field 'hello.loadBalanced' is an unknown field."
 
 /client_side_encryption/bypass_spawning_mongocryptd/mongocryptdBypassSpawn  # Fails if crypt_shared is visible


### PR DESCRIPTION
# Summary

Unskip `/load_balancers/non-lb-connection-establishment`

# Background & Motivation

Test was unskipped and run in a patch build with all variants and tasks with names matching `".*test.*`: https://spruce.mongodb.com/version/65269c41e3c331ec7fe9e579
Results of three runs were successful with unrelated task failures.