### PR TITLE
CDRIVER-3514 Fix Windows shared mutex unlocking

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-scram.c
+++ b/src/libmongoc/src/mongoc/mongoc-scram.c
@@ -201,7 +201,7 @@ _mongoc_scram_cache_has_presecrets (mongoc_scram_cache_entry_t *cache /* out */,
    }
 
 done:
-   bson_shared_mutex_unlock (&g_scram_cache_rwlock);
+   bson_shared_mutex_unlock_shared (&g_scram_cache_rwlock);
    return cache_hit;
 }
 


### PR DESCRIPTION
Unlike a POSIX read/write lock, in which both a read lock and a write lock are unlocked by the same function, Windows requires that a read lock is unlocked by a different function than a write lock.