### PR TITLE
fix symbol ref in mongoc_client_session_t doc

### DIFF
--- a/src/libmongoc/doc/mongoc_client_session_t.rst
+++ b/src/libmongoc/doc/mongoc_client_session_t.rst
@@ -13,7 +13,7 @@ Synopsis
 
 Fork Safety
 -----------
-A :symbol:`mongoc_client_session_t` is only usable in the parent process after a fork. The child process must call :symbol:`mongo_client_reset` on the ``client`` field.
+A :symbol:`mongoc_client_session_t` is only usable in the parent process after a fork. The child process must call :symbol:`mongoc_client_reset` on the ``client`` field.
 
 Example
 -------


### PR DESCRIPTION
Follow-up for 6fee88bbd68c31ff0741cc1941ea6ba0e1b71823

Patch build on the affected task: https://spruce.mongodb.com/version/652f06eed1fe071ba70d8dc2/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC