### PR TITLE
Fix merge of FunctionCall vars argument in FetchBuild

### DIFF
--- a/.evergreen/config_generator/components/funcs/fetch_build.py
+++ b/.evergreen/config_generator/components/funcs/fetch_build.py
@@ -33,8 +33,11 @@ class FetchBuild(Function):
     ]
 
     @classmethod
-    def call(cls, build_name, **kwargs):
-        return cls.default_call(vars={'BUILD_NAME': build_name}, **kwargs)
+    def call(cls, build_name, vars=None, **kwargs):
+        if vars is None:
+            vars = {}
+        vars.update({'BUILD_NAME': build_name})
+        return cls.default_call(vars=vars, **kwargs)
 
 
 def functions():


### PR DESCRIPTION
A fix to a bug that has not yet been encountered in the C Driver.

If a custom `vars={...}` argument is given to `FetchBuild.call(build_name="abc", vars={...})`, e.g. to define additional environment variables, the config generator will fail due to the `vars` argument being specified multiple times:

```
TypeError: config_generator.etc.function.Function.default_call() got multiple values for keyword argument 'vars'
```

This PR uses `.update()` to ensure if `vars` is given, that the `build_name` will correctly be merged into `vars` instead of triggering a conflict.