### PR TITLE
CDRIVER-4743 Define `BSON_STATIC` for `bson_static` build

### DIFF
--- a/src/libbson/CMakeLists.txt
+++ b/src/libbson/CMakeLists.txt
@@ -198,8 +198,6 @@ if(ENABLE_SHARED)
       target_sources(bson_shared PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/libbson.rc)
    endif()
    list(APPEND bson_libs bson_shared)
-   # Always use PIC on shared libs.
-   set_property(TARGET bson_shared PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 endif()
 
 if(NOT bson_libs)

--- a/src/libbson/CMakeLists.txt
+++ b/src/libbson/CMakeLists.txt
@@ -171,34 +171,42 @@ file(GLOB_RECURSE all_sources CONFIGURE_DEPENDS
    "${mongo-c-driver_SOURCE_DIR}/src/common/*.c"
    )
 
-# The default object library for all libbson translation units:
-add_library(bson_obj OBJECT EXCLUDE_FROM_ALL ${all_sources})
+# List of the primary BSON library targets that we are building
+set(bson_libs)
 
-# The libbson object libraries that we will build
-set(bson_obj_libs bson_obj)
+if(ENABLE_STATIC)
+   add_library(bson_static STATIC ${all_sources})
+   list(APPEND bson_libs bson_static)
+   # When consumers link against bson_static, suppress the annotation __declspec(dllimport),
+   # since those symbols will be available immediately at the link step:
+   target_compile_definitions(bson_static INTERFACE BSON_STATIC)
 
-if(ENABLE_PIC OR WIN32)
-   # User wants (or platform requires) static libs to use PIC code. Since we
-   # already need PIC for the dynamic library, we can consolidate things and
-   # use a single object library for both the static and the shared library.
-   # No duplicate compilations necessary!
-   set_property(TARGET bson_obj PROPERTY POSITION_INDEPENDENT_CODE TRUE)
-   # The bson_obj_pic is just an alias of the base library:
-   add_library(bson_obj_pic ALIAS bson_obj)
-else()
-   # User does not want PIC in the static library. In that case, we just need a second object
-   # library that has PIC enabled so it can be used in creating the dynamic library.
-   add_library(bson_obj_pic OBJECT EXCLUDE_FROM_ALL ${all_sources})
-   set_property(TARGET bson_obj_pic PROPERTY POSITION_INDEPENDENT_CODE TRUE)
-   list(APPEND bson_obj_libs bson_obj_pic)
+   if(ENABLE_PIC OR WIN32)
+      # User wants (or platform requires) static libs to use PIC code.
+      set_property(TARGET bson_static PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+   endif()
 endif()
 
-# Set target properties for the object libraries.
+if(ENABLE_SHARED)
+   add_library(bson_shared SHARED  ${all_sources} $<$<PLATFORM_ID:Windows>:libbson.rc>)
+   list(APPEND bson_libs bson_shared)
+   # Always use PIC on shared libs.
+   set_property(TARGET bson_shared PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+endif()
+
+if(NOT bson_libs)
+   message(FATAL_ERROR "Neither bson_shared nor bson_static is going to be built. Did you mean to enable at least one of them?")
+endif()
+
+# Set target properties for the libraries.
 mongo_target_requirements(
-   ${bson_obj_libs}
+   ${bson_libs}
    LINK_LIBRARIES
       PUBLIC
-         _libbson_build_interface
+         # Build-local requirements:
+         $<BUILD_INTERFACE:_libbson_build_interface>
+         # Include in the install interface explicitly:
+         mongo::detail::c_platform
    COMPILE_DEFINITIONS
       PRIVATE
          # Tell headers that they are part of compilation:
@@ -215,35 +223,6 @@ mongo_target_requirements(
          $<$<AND:$<C_COMPILER_ID:MSVC>,$<VERSION_LESS:${MSVC_VERSION},1900>>:/wd4756>
 )
 
-# List of the primary BSON library targets that we are building
-set(bson_libs)
-
-if(ENABLE_STATIC)
-   add_library(bson_static STATIC)
-   target_link_libraries(bson_static PRIVATE $<BUILD_INTERFACE:bson_obj>)
-   list(APPEND bson_libs bson_static)
-   # When consumers link against bson_static, suppress the annotation __declspec(dllimport),
-   # since those symbols will be available immediately at the link step:
-   target_compile_definitions(bson_static INTERFACE BSON_STATIC)
-endif()
-
-if(ENABLE_SHARED)
-   add_library(bson_shared SHARED $<$<PLATFORM_ID:Windows>:libbson.rc>)
-   target_link_libraries(bson_shared PRIVATE $<BUILD_INTERFACE:bson_obj_pic>)
-   list(APPEND bson_libs bson_shared)
-endif()
-
-if(NOT bson_libs)
-   message(FATAL_ERROR "Neither bson_shared nor bson_static is going to be built. Did you mean to enable at least one of them?")
-endif()
-
-mongo_target_requirements(
-   ${bson_libs} LINK_LIBRARIES PUBLIC
-   # Build-local requirements:
-   $<BUILD_INTERFACE:_libbson_build_interface>
-   # Include in the install interface explicitly:
-   mongo::detail::c_platform
-)
 set_target_properties(${bson_libs} PROPERTIES
    VERSION "0.0.0"
    SOVERSION "0"

--- a/src/libbson/CMakeLists.txt
+++ b/src/libbson/CMakeLists.txt
@@ -184,8 +184,8 @@ if(ENABLE_STATIC)
    # since those symbols will be available immediately at the link step:
    target_compile_definitions(bson_static INTERFACE BSON_STATIC)
 
-   if(ENABLE_PIC OR WIN32)
-      # User wants (or platform requires) static libs to use PIC code.
+   if(ENABLE_PIC)
+      # User wants static libs to use PIC code.
       set_property(TARGET bson_static PROPERTY POSITION_INDEPENDENT_CODE TRUE)
    endif()
 endif()

--- a/src/libbson/CMakeLists.txt
+++ b/src/libbson/CMakeLists.txt
@@ -177,6 +177,9 @@ set(bson_libs)
 if(ENABLE_STATIC)
    add_library(bson_static STATIC ${all_sources})
    list(APPEND bson_libs bson_static)
+   # Define `BSON_STATIC` when building to suppress the annotation __declspec(dllexport).
+   # This prevents consumers of bson_static from exporting the symbols.
+   target_compile_definitions(bson_static PRIVATE BSON_STATIC)
    # When consumers link against bson_static, suppress the annotation __declspec(dllimport),
    # since those symbols will be available immediately at the link step:
    target_compile_definitions(bson_static INTERFACE BSON_STATIC)

--- a/src/libbson/src/bson/bson-macros.h
+++ b/src/libbson/src/bson/bson-macros.h
@@ -66,11 +66,10 @@
 
 
 /* Decorate public functions:
- * - if BSON_STATIC, we're compiling a program that uses libbson as a static
- *   library, don't decorate functions
- * - else if BSON_COMPILATION, we're compiling a static or shared libbson, mark
- *   public functions for export from the shared lib (which has no effect on
- *   the static lib)
+ * - if BSON_STATIC, we're compiling a static libbson or a program
+ *   that uses libbson as a static library. Don't decorate functions.
+ * - else if BSON_COMPILATION, we're compiling a shared libbson, mark
+ *   public functions for export from the shared lib
  * - else, we're compiling a program that uses libbson as a shared library,
  *   mark public functions as DLL imports for Microsoft Visual C
  */

--- a/src/libmongoc/src/mongoc/mongoc-macros.h
+++ b/src/libmongoc/src/mongoc/mongoc-macros.h
@@ -20,11 +20,10 @@
 #define MONGOC_MACROS_H
 
 /* Decorate public functions:
- * - if MONGOC_STATIC, we're compiling a program that uses libmongoc as
- *   a static library, don't decorate functions
- * - else if MONGOC_COMPILATION, we're compiling a static or shared libmongoc,
- *   mark public functions for export from the shared lib (which has no effect
- *   on the static lib)
+ * - if MONGOC_STATIC, we're compiling a static libmongoc or a program
+ *   that uses libmongoc as a static library. Don't decorate functions
+ * - else if MONGOC_COMPILATION, we're compiling a shared libmongoc,
+ *   mark public functions for export from the shared lib.
  * - else, we're compiling a program that uses libmongoc as a shared library,
  *   mark public functions as DLL imports for Microsoft Visual C.
  */


### PR DESCRIPTION
# Summary

 - Remove `bson_obj` library.
 - Define `BSON_STATIC` for `bson_static` build to suppress `__declspec (dllexport)`.

Verified with this patch: https://spruce.mongodb.com/version/65380a299ccd4ece69a2b84d

# Background & Motivation

This PR is intended to fix CI builds linking to libmongocrypt that began failing after https://github.com/mongodb/mongo-c-driver/commit/4592ca54f76019905b32995c8bcf032c54d34be7. Windows tasks linking to libmongocrypt fail to build with an "already defined" error. Here is an example from [cse-sasl-cyrus-winssl-windows-2019-vs2017-x64-compile](https://spruce.mongodb.com/task/mongo*c_driver_cse_matrix_winssl_cse_sasl_cyrus_winssl_windows_2019_vs2017_x64_compile_960760fcc19f48328c2cef1e9cf9cad3698e068d_23_10_12_20_02*57/logs?execution=0):
```
bson-static-1.0.lib(bson-error.obj) : error LNK2005: bson_set_error already defined in mongocrypt.lib(mongocrypt.dll) [C:\data\mci\a7f5819a07b0a787fb58c6c761152444\mongoc\src\libmongoc\test-libmongoc.vcxproj]
```

The error suggests libbson symbols are exported from libmongocrypt. libmongocrypt is installed [referencing the local mongo-c-driver directory](https://github.com/mongodb/mongo-c-driver/blob/2baa45ca752ffadd57ed8ea167fbe633db7e044a/.evergreen/scripts/compile-libmongocrypt.sh#L22).

Before https://github.com/mongodb/mongo-c-driver/commit/4592ca54f76019905b32995c8bcf032c54d34be7, running `dumpbin /EXPORTS mongocrypt.lib` does not show libbson symbols.

After https://github.com/mongodb/mongo-c-driver/commit/4592ca54f76019905b32995c8bcf032c54d34be7, running `dumpbin /EXPORTS mongocrypt.lib` shows libbson symbols:
```
> dumpbin /EXPORTS mongocrypt.lib
Microsoft (R) COFF/PE Dumper Version 14.16.27043.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file mongocrypt.lib

File Type: LIBRARY

     Exports

       ordinal    name

                  bcon_append
                  bcon_append_ctx
                  bcon_append_ctx_init
                  (... more libbson API ...)
```

4592ca54f76019905b32995c8bcf032c54d34be7 adds a `bson_obj` object library to sometimes combine building sources for the shared and static libbson build. `bson_obj` does not define the macro `BSON_STATIC`, causing `BSON_API` to be defined as [`__declspec (dllexport)`](https://github.com/mongodb/mongo-c-driver/blob/1b0a49ae1dd2a5fff380dd06873437444cb069af/src/libbson/src/bson/bson-macros.h#L85).

To conditionally define `__declspec (dllexport)`, this PR proposes splitting the static and shared libbson builds. `BSON_STATIC` is defined in the static build to suppress `__declspec (dllexport)`.

Future use of a module-definition (.def) file may enable a solution to combine building sources between the static and shared builds. This was not attempted in this PR. This PR is intended to be a minimal fix to fix failing CI builds.

