### PR TITLE
Update NEWS for upcoming 1.25.0 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,7 @@ libmongoc 1.25.0 (Unreleased)
 Improvements:
 
   * Remove optional dependency of libicu.
+  * Use OP_MSG exhaust for mongod >= 4.2. Enable exhaust cursors for mongos >= 7.1.
 Build Configuration:
 
   * Remove `ENABLE_SRV=AUTO`. Only support boolean values for `ENABLE_SRV`.

--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,7 @@ Improvements:
 
   * Remove optional dependency of libicu.
   * Use OP_MSG exhaust for mongod >= 4.2. Enable exhaust cursors for mongos >= 7.1.
+  * Share cached credentials for SCRAM authentication among all clients to improve performance.
 Build Configuration:
 
   * Remove `ENABLE_SRV=AUTO`. Only support boolean values for `ENABLE_SRV`.

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,9 @@ libmongoc 1.25.0 (Unreleased)
 Improvements:
 
   * Remove optional dependency of libicu.
+Build Configuration:
+
+  * Remove `ENABLE_SRV=AUTO`. Only support boolean values for `ENABLE_SRV`.
 
 Platform Support:
 

--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,8 @@ Improvements:
   * Remove optional dependency of libicu.
   * Use OP_MSG exhaust for mongod >= 4.2. Enable exhaust cursors for mongos >= 7.1.
   * Share cached credentials for SCRAM authentication among all clients to improve performance.
+  * Use polling monitoring in FaaS environments.
+
 Build Configuration:
 
   * Remove `ENABLE_SRV=AUTO`. Only support boolean values for `ENABLE_SRV`.

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,10 @@
 libmongoc 1.25.0 (Unreleased)
 =============================
 
+Fixes:
+
+  * Send `recoveryToken` in transactions when connected to a load balancer.
+
 Improvements:
 
   * Remove optional dependency of libicu.

--- a/src/libbson/NEWS
+++ b/src/libbson/NEWS
@@ -1,14 +1,18 @@
-libbson 1.24.4
-==============
-
-Fixes:
-  * Fix libmongoc build failure caused by missing install of `bson-dsl.h`.
+libbson 1.25.0 (Unreleased)
+===========================
 
 Platform Support:
 
   * Support for macOS 10.14 is dropped.
   * Support for Ubuntu 14.04 is dropped.
   * Support for Debian 8.1 is dropped.
+
+
+libbson 1.24.4
+==============
+
+Fixes:
+  * Fix libmongoc build failure caused by missing install of `bson-dsl.h`.
 
 Thanks to everyone who contributed to the development of this release.
 

--- a/src/libbson/NEWS
+++ b/src/libbson/NEWS
@@ -1,6 +1,10 @@
 libbson 1.25.0 (Unreleased)
 ===========================
 
+New Features:
+
+  * Add `bson_array_builder_t`.
+
 Platform Support:
 
   * Support for macOS 10.14 is dropped.


### PR DESCRIPTION
# Summary
Update NEWS for upcoming 1.25.0 release

# Background & Motivation

Commits planned for the 1.25.0 release were inspected by viewing the following commits:
```
MERGE_BASE=$(git merge-base origin/r1.24 master)
git log $MERGE_BASE..master
```

This PR includes NEWS entries for the following commits:

0dc1a4e833a9339096009ec26e7197e87842f6f7 CDRIVER-4637 Remove ENABLE_SRV=AUTO, clean up SRV URI support (#1301)
9affd70760c66ed9bb85652d014802841ed3378e CDRIVER-504 add `bson_array_builder_t` (#1344)
1c8da0ee199661a4276c87fb9ec2fbb375a2a4ad CDRIVER-4244 use OP_MSG for exhaust cursors (#1399)
84d9d8f5da9ded04d8d2ef9836373679bf8119fb Share SCRAM cache via a global lookup table (#1406)
c7fa88c0bb54bdce42ed9880bcb14ee0580d02af CDRIVER-4615 use polling monitoring in FaaS environments (#1362)
b39e2ebedc65fac7c28f935e12a83df32ac30adf CDRIVER-4718 store `recoveryToken` for Load Balanced topology (#1417)