### PR TITLE
Add `git` to `PATH` in `link-sample-program-mingw*` scripts

### DIFF
--- a/.evergreen/scripts/link-sample-program-mingw-bson.cmd
+++ b/.evergreen/scripts/link-sample-program-mingw-bson.cmd
@@ -1,6 +1,3 @@
-rem Ensure Cygwin executables like sh.exe are not in PATH
-rem set PATH=C:\Windows\system32;C:\Windows
-
 echo on
 echo
 

--- a/.evergreen/scripts/link-sample-program-mingw-bson.cmd
+++ b/.evergreen/scripts/link-sample-program-mingw-bson.cmd
@@ -8,7 +8,7 @@ set TAR=C:\cygwin\bin\tar
 set CMAKE_MAKE_PROGRAM=C:\mingw-w64\x86_64-4.9.1-posix-seh-rt_v3-rev1\mingw64\bin\mingw32-make.exe
 set CC=C:\mingw-w64\x86_64-4.9.1-posix-seh-rt_v3-rev1\mingw64\bin\gcc.exe
 rem Ensure Cygwin executables like sh.exe are not in PATH
-set PATH=C:\cygwin\bin;C:\Windows\system32;C:\Windows;C:\mingw-w64\x86_64-4.9.1-posix-seh-rt_v3-rev1\mingw64\bin;C:\mongoc;src\libbson;src\libmongoc
+set "PATH=C:\cygwin\bin;C:\Windows\system32;C:\Windows;C:\mingw-w64\x86_64-4.9.1-posix-seh-rt_v3-rev1\mingw64\bin;C:\mongoc;src\libbson;src\libmongoc;C:\Program Files\Git\cmd"
 set LINK_STATIC=1
 
 set SRCROOT=%CD%

--- a/.evergreen/scripts/link-sample-program-mingw.cmd
+++ b/.evergreen/scripts/link-sample-program-mingw.cmd
@@ -9,7 +9,7 @@ set TAR=C:\cygwin\bin\tar
 set CMAKE_MAKE_PROGRAM=C:\mingw-w64\x86_64-4.9.1-posix-seh-rt_v3-rev1\mingw64\bin\mingw32-make.exe
 set CC=C:\mingw-w64\x86_64-4.9.1-posix-seh-rt_v3-rev1\mingw64\bin\gcc.exe
 rem Ensure Cygwin executables like sh.exe are not in PATH
-set PATH=C:\cygwin\bin;C:\Windows\system32;C:\Windows;C:\mingw-w64\x86_64-4.9.1-posix-seh-rt_v3-rev1\mingw64\bin;C:\mongoc;src\libbson;src\libmongoc
+set "PATH=C:\cygwin\bin;C:\Windows\system32;C:\Windows;C:\mingw-w64\x86_64-4.9.1-posix-seh-rt_v3-rev1\mingw64\bin;C:\mongoc;src\libbson;src\libmongoc;C:\Program Files\Git\cmd"
 
 set SRCROOT=%CD%
 set BUILD_DIR=%CD%\build-dir

--- a/.evergreen/scripts/link-sample-program-mingw.cmd
+++ b/.evergreen/scripts/link-sample-program-mingw.cmd
@@ -1,6 +1,3 @@
-rem Ensure Cygwin executables like sh.exe are not in PATH
-rem set PATH=C:\Windows\system32;C:\Windows
-
 echo on
 echo
 


### PR DESCRIPTION
# Summary

Add `git` to `PATH` in `link-sample-program-mingw*` scripts.

Verified with this patch build: https://spruce.mongodb.com/version/65395baf1e2d1738a950cc24

# Background & Motivation

The `link-with-bson-mingw` and `link-with-cmake-mingw` tasks fail to build due to not finding `git`. Here is an [example task](https://spruce.mongodb.com/task/mongo_c_driver_smoke_link_with_bson_mingw_1b0a49ae1dd2a5fff380dd06873437444cb069af_23_10_24_17_28_23/logs?execution=0) logging:

```
RuntimeError: Failed to execute subprocess ['git', 'rev-parse', '--revs-only', '--short=10', 'HEAD^{commit}']: [WinError 2] The system cannot find the file specified [Does the executable ôgitö not exist?]
```
