### PR TITLE
use `furo` theme in homepage

### DIFF
--- a/build/sphinx/homepage-config/conf.py
+++ b/build/sphinx/homepage-config/conf.py
@@ -58,8 +58,7 @@ def setup(app):
 
 # -- Options for HTML output ----------------------------------------------
 
-html_theme_path = ["../"]
-html_theme = 'readable'
+html_theme = 'furo'
 html_title = html_shorttitle = 'MongoDB C Driver %s' % version
 # html_favicon = None
 html_use_smartypants = False


### PR DESCRIPTION
# Summary

Use `furo` theme for homepage.

# Background & Motivation

https://github.com/mongodb/mongo-c-driver/pull/1354 switched the libmongoc and libbson to the `furo` theme. This PR also switches the homepage to the `furo` theme.

Using [release.py](https://github.com/10gen/mongo-c-driver-tools/blob/1bbff82ce822f9e6384a35edacf0e0b5546b8e33/release.py#L960) to build docs locally resulted in an error locating the `readable` theme:

```sh
$ poetry run $HOME/code/mongo-c-driver-tools/release.py docs_build \
    $(pwd)/KEVINALBS/mongo-c-driver_master \
    $(pwd)/KEVINALBS/mongo-c-driver_ghpages \
    1.25.0
```

Resulted in the following error:
```sh
Building home page

Theme error:
no theme named 'readable' found (missing theme.conf?)
Traceback (most recent call last):
  File "/Users/kevin.albertson/code/mongo-c-driver-tools/release.py", line 1023, in <module>
    cli()
  File "/Users/kevin.albertson/.venv/lib/python3.11/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kevin.albertson/.venv/lib/python3.11/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/kevin.albertson/.venv/lib/python3.11/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kevin.albertson/.venv/lib/python3.11/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kevin.albertson/.venv/lib/python3.11/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kevin.albertson/.venv/lib/python3.11/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kevin.albertson/code/mongo-c-driver-tools/release.py", line 978, in localdocs
    builddocs (ctx, lib_dir, docs_dir, new)
  File "/Users/kevin.albertson/code/mongo-c-driver-tools/release.py", line 913, in builddocs
    print(check_output(['sphinx-build', '-D', 'analytics=1', '-a', '.', docs_dir], cwd=homepage_dir))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.4_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.4_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['sphinx-build', '-D', 'analytics=1', '-a', '.', '/Users/kevin.albertson/code/mongo-c-driver-release/KEVINALBS/mongo-c-driver_ghpages']' returned non-zero exit status 2.
```
