### PR TITLE
Update NEWS and docs for 1.25.0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,5 @@
-libmongoc 1.25.0 (Unreleased)
-=============================
+libmongoc 1.25.0
+================
 
 Fixes:
 
@@ -28,6 +28,17 @@ Other:
     release artifact. Please instead use the per-release repository archive
     attached to a GitHub release, or clone the repository at the desired release
     tag.
+
+Thanks to everyone who contributed to the development of this release.
+
+  * Kevin Albertson
+  * Colby Pike
+  * Adrian Dole
+  * Roberto C. Sánchez
+  * Ezra Chung
+  * Joshua Siegel
+  * Kyle Kloberdanz
+  * Jeremy Mikola
 
 libmongoc 1.24.4
 ================

--- a/build/sphinx/homepage-config/conf.py
+++ b/build/sphinx/homepage-config/conf.py
@@ -35,16 +35,12 @@ todo_include_todos = False
 def download_link(typ, rawtext, text, lineno, inliner, options={}, content=[]):
     if text == "mongoc":
         lib = "mongo-c-driver"
-    elif text == "bson":
-        lib = "libbson"
     else:
         raise ValueError(
-            "download link must be mongoc or libbson, not \"%s\"" % text)
+            "download link must be mongoc, not \"%s\"" % text)
 
-    title = "%s-%s.tar.gz" % (lib, version)
-    url = ("https://github.com/mongodb/%(lib)s/"
-           "releases/download/%(version)s/%(lib)s-%(version)s.tar.gz") % {
-              "lib": lib,
+    title = "%s-%s" % (lib, version)
+    url = ("https://github.com/mongodb/mongo-c-driver/releases/tag/%(version)s") % {
               "version": version
           }
 

--- a/src/libbson/NEWS
+++ b/src/libbson/NEWS
@@ -1,5 +1,5 @@
-libbson 1.25.0 (Unreleased)
-===========================
+libbson 1.25.0
+==============
 
 New Features:
 
@@ -10,6 +10,15 @@ Platform Support:
   * Support for macOS 10.14 is dropped.
   * Support for Ubuntu 14.04 is dropped.
   * Support for Debian 8.1 is dropped.
+
+Thanks to everyone who contributed to the development of this release.
+
+  * Kevin Albertson
+  * Colby Pike
+  * Adrian Dole
+  * Roberto C. Sánchez
+  * Ezra Chung
+  * Joshua Siegel
 
 
 libbson 1.24.4

--- a/src/libmongoc/doc/installing.rst
+++ b/src/libmongoc/doc/installing.rst
@@ -1,6 +1,5 @@
-:orphan:
-
 :man_page: mongoc_installing
+:orphan:
 
 Installing the MongoDB C Driver (libmongoc) and BSON library (libbson)
 ======================================================================


### PR DESCRIPTION
# Summary
- Update NEWS for 1.25.0.
- Link to GitHub release page, not tarball.
- Move `:man_page:` directive.

# Background & Motivation

The tarball link is broken for 1.25.0. The tarball is removed in 1.25.0 as part of CDRIVER-4640.

The `:man_page:` directive shows on the current https://mongoc.org/libmongoc/current/installing.html page:

![Screen Shot 2023-11-01 at 10 51 38 AM](https://github.com/mongodb/mongo-c-driver/assets/992997/5f463598-b1f0-476b-8c7c-436b93df3424)

Moving the `:man_page:` directive to the start appears to fix the rendering. I am not sure what the root cause is, but this was not investigated further.