### PR TITLE
CDRIVER-4763 reapply `BUILD_VERSION` CMake option

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,7 @@ Improvements:
 Build Configuration:
 
   * Remove `ENABLE_SRV=AUTO`. Only support boolean values for `ENABLE_SRV`.
+  * Remove `BUILD_VERSION` CMake option. To set a build version, create a file in the source root named `VERSION_CURRENT` containing the version.
 
 Platform Support:
 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+libmongoc 1.25.1 (Unreleased)
+=============================
+
+Fixes:
+
+  * Add back support for `BUILD_VERSION` CMake option. `BUILD_VERSION` was unintentionally removed in 1.25.0.
+
 libmongoc 1.25.0
 ================
 
@@ -15,7 +22,6 @@ Improvements:
 Build Configuration:
 
   * Remove `ENABLE_SRV=AUTO`. Only support boolean values for `ENABLE_SRV`.
-  * Remove `BUILD_VERSION` CMake option. To set a build version, create a file in the source root named `VERSION_CURRENT` containing the version.
 
 Platform Support:
 

--- a/build/cmake/BuildVersion.cmake
+++ b/build/cmake/BuildVersion.cmake
@@ -46,8 +46,10 @@ function(compute_build_version outvar)
     set("${outvar}" "${output}" PARENT_SCOPE)
 endfunction()
 
-# Define the BUILD_VERSION:
-compute_build_version(BUILD_VERSION)
+# Compute the BUILD_VERSION if it is not already defined:
+if(NOT DEFINED BUILD_VERSION)
+    compute_build_version(BUILD_VERSION)
+endif()
 
 # Set a BUILD_VERSION_SIMPLE, which is just a three-number-triple that CMake understands
 string (REGEX REPLACE "([0-9]+\\.[0-9]+\\.[0-9]+).*$" "\\1" BUILD_VERSION_SIMPLE "${BUILD_VERSION}")


### PR DESCRIPTION
# Summary

~~Document removal of `BUILD_VERSION` CMake option.~~

Apply `BUILD_VERSION` CMake option

# Background & Motivation

https://github.com/mongodb/mongo-c-driver/pull/1382 removes the ability to specify a custom `BUILD_VERSION`.

This may result in an error when if attempting to build a source archive with steps that previously worked on 1.24.4:

```bash
wget "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/1.25.0.tar.gz"
tar xf 1.25.0.tar.gz
cd mongo-c-driver-1.25.0
cmake -DBUILD_VERSION=1.25.0 -S. -Bcmake-build
```

Results in this error due to `BUILD_VERSION` being ignored:
```bash
Traceback (most recent call last):
  File "/Users/kevin.albertson/Desktop/mongo-c-driver-1.25.0/build/cmake/../calc_release_version.py", line 400, in <module>
    RELEASE_VER = previous(main()) if PREVIOUS else main()
                                                    ^^^^^^
  File "/Users/kevin.albertson/Desktop/mongo-c-driver-1.25.0/build/cmake/../calc_release_version.py", line 320, in main
    head_commit_short = check_output(['git', 'rev-parse', '--revs-only',
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kevin.albertson/Desktop/mongo-c-driver-1.25.0/build/cmake/../calc_release_version.py", line 136, in check_output
    raise subprocess.CalledProcessError(ret, args[0])
subprocess.CalledProcessError: Command 'git' returned non-zero exit status 128.
CMake Error at build/cmake/BuildVersion.cmake:43 (message):
  Computing the build version failed! [1]:

Call Stack (most recent call first):
  build/cmake/BuildVersion.cmake:50 (compute_build_version)
  CMakeLists.txt:5 (include)


-- Configuring incomplete, errors occurred!
```

Creating a `VERSION_CURRENT` file resolves the error. This was done in https://github.com/Homebrew/homebrew-core/pull/153065. 

---

If git history is available, the `BUILD_VERSION` is quietly ignored. The git history is used to compute the version:
```bash
git checkout a09129be6a3e1c875d4f923111e47b9a6ed4702c
if [ -f VERSION_CURRENT ]; then rm VERSION_CURRENT; fi
cmake -Bcmake-build -S. -DBUILD_VERSION=1.25.0-custom > /dev/null 2>&1
cat VERSION_CURRENT
```

Results in computing the version from the git history:
```
1.11.1-20231101+gita09129be6a
```

With changes in this PR:
```bash
git checkout document-removal-of-BUILD_VERSION
if [ -f VERSION_CURRENT ]; then rm VERSION_CURRENT; fi
cmake -Bcmake-build -S. -DBUILD_VERSION=1.25.0-custom > /dev/null 2>&1
cat VERSION_CURRENT
```

Results in applying the `BUILD_VERSION` from the CMake options:
```
1.25.0-custom
```

---

~~This PR proposes documenting this change in NEWS to inform use of the alternative.~~

Specifying `BUILD_VERSION` is documented: https://mongoc.org/libmongoc/1.25.0/learn/get/from-source.html#configuring-for-libbson

This PR proposes adding back support for the `BUILD_VERSION` option. This is intended to avoid quietly ignoring the applied `BUILD_VERSION` on existing builds specifying a custom `BUILD_VERSION` CMake option.


