### PR TITLE
CDRIVER-4766 cast size_t/ssize_t to long

### DIFF
--- a/.evergreen/scripts/debian_package_build.sh
+++ b/.evergreen/scripts/debian_package_build.sh
@@ -10,8 +10,12 @@ set -o errexit
 
 on_exit () {
   if [ -e ./unstable-chroot/debootstrap/debootstrap.log ]; then
-    echo "Dumping debootstrap.log"
+    echo "Dumping debootstrap.log (64-bit)"
     cat ./unstable-chroot/debootstrap/debootstrap.log
+  fi
+  if [ -e ./unstable-i386-chroot/debootstrap/debootstrap.log ]; then
+    echo "Dumping debootstrap.log (32-bit)"
+    cat ./unstable-i386-chroot/debootstrap/debootstrap.log
   fi
 }
 trap on_exit EXIT
@@ -62,6 +66,34 @@ sudo chroot ./unstable-chroot /bin/bash -c "(\
 
 # Build a second time, to ensure a "double build" works
 sudo chroot ./unstable-chroot /bin/bash -c "(\
+  cd /tmp/mongoc && \
+  rm -f example-client && \
+  git status --ignored && \
+  dpkg-buildpackage -b && dpkg-buildpackage -S )"
+
+# And now do it all again for 32-bit
+sudo -E ./debootstrap.git/debootstrap --arch i386 unstable ./unstable-i386-chroot/ http://cdn-aws.deb.debian.org/debian
+cp -a mongoc ./unstable-i386-chroot/tmp/
+sudo chroot ./unstable-i386-chroot /bin/bash -c "(\
+  apt-get install -y build-essential git-buildpackage fakeroot debhelper cmake libssl-dev pkg-config python3-sphinx python3-sphinx-design zlib1g-dev libsasl2-dev libsnappy-dev libzstd-dev libmongocrypt-dev libjs-mathjax libutf8proc-dev furo && \
+  chown -R root:root /tmp/mongoc && \
+  cd /tmp/mongoc && \
+  git clean -fdx && \
+  git reset --hard HEAD && \
+  python3 build/calc_release_version.py > VERSION_CURRENT && \
+  python3 build/calc_release_version.py -p > VERSION_RELEASED && \
+  git add --force VERSION_CURRENT VERSION_RELEASED && \
+  git commit VERSION_CURRENT VERSION_RELEASED -m 'Set current/released versions' && \
+  LANG=C /bin/bash ./debian/build_snapshot.sh && \
+  debc ../*.changes && \
+  dpkg -i ../*.deb && \
+  gcc -I/usr/include/libmongoc-1.0 -I/usr/include/libbson-1.0 -o example-client src/libmongoc/examples/example-client.c -lmongoc-1.0 -lbson-1.0 )"
+
+[ -e ./unstable-i386-chroot/tmp/mongoc/example-client ] || (echo "Example was not built!" ; exit 1)
+(cd ./unstable-i386-chroot/tmp/ ; tar zcvf ../../deb.tar.gz *.dsc *.orig.tar.gz *.debian.tar.xz *.build *.deb)
+
+# Build a second time, to ensure a "double build" works
+sudo chroot ./unstable-i386-chroot /bin/bash -c "(\
   cd /tmp/mongoc && \
   rm -f example-client && \
   git status --ignored && \

--- a/src/libmongoc/src/mongoc/mongoc-linux-distro-scanner.c
+++ b/src/libmongoc/src/mongoc/mongoc-linux-distro-scanner.c
@@ -67,7 +67,7 @@ _fgets_wrapper (char *buffer, size_t buffer_size, FILE *f)
        * This protects us from files like:
        * aaaaa...DISTRIB_ID=nasal demons
        */
-      TRACE ("Found line of length %ld, bailing out", len);
+      TRACE ("Found line of length %ld, bailing out", (long)len);
       return 0;
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-socket.c
+++ b/src/libmongoc/src/mongoc/mongoc-socket.c
@@ -1313,7 +1313,7 @@ _mongoc_socket_try_sendv (mongoc_socket_t *sock, /* IN */
 #else
                   0);
 #endif
-   TRACE ("Send %ld out of %ld bytes", ret, iov->iov_len);
+   TRACE ("Send %ld out of %ld bytes", (long)ret, (long)iov->iov_len);
 #endif
 
 

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl.c
@@ -343,15 +343,15 @@ _mongoc_stream_tls_openssl_writev (mongoc_stream_t *stream,
                _mongoc_stream_tls_openssl_write (tls, to_write, to_write_len);
             if (bson_cmp_not_equal_su (child_ret, to_write_len)) {
                TRACE ("Got child_ret: %ld while to_write_len is: %ld",
-                      child_ret,
-                      to_write_len);
+                      (long)child_ret,
+                      (long)to_write_len);
             }
 
             if (child_ret < 0) {
                TRACE ("Returning what I had (%ld) as apposed to the error "
                       "(%ld, errno:%d)",
-                      ret,
-                      child_ret,
+                      (long)ret,
+                      (long)child_ret,
                       errno);
                RETURN (ret);
             }


### PR DESCRIPTION
This fixes compilation failure when %ld format specifier is used on 32-bit platforms.
    
Ref: https://bugs.debian.org/1055264

This PR also adds a Debian packaging build for 32-bit (i386) architecture.

Patch build that adds the 32-bit Debian packaging build and shows the compilation failure: https://spruce.mongodb.com/version/6544461e32f417938789cb2b/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Patch build with the fix in this PR: https://spruce.mongodb.com/version/65444681c9ec44cc612a0da4/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC