### PR TITLE
CDRIVER-4781 Avoid intermediate uint32_t for socketTimeoutMS

### DIFF
--- a/src/libmongoc/doc/mongoc_stream_read.rst
+++ b/src/libmongoc/doc/mongoc_stream_read.rst
@@ -26,6 +26,13 @@ Parameters
 
 The :symbol:`mongoc_stream_read()` function shall perform a read from a :symbol:`mongoc_stream_t`. It's modeled on the API and semantics of ``read()``, though the parameters map only loosely.
 
+.. warning::
+
+  The "default timeout" indicated by a negative value is both unspecified and
+  unrelated to the documented default values for ``*TimeoutMS`` URI options.
+  To specify a default timeout value for a ``*TimeoutMS`` URI option, use the
+  ``MONGOC_DEFAULT_*`` constants defined in ``mongoc-client.h``.
+
 Returns
 -------
 
@@ -38,4 +45,3 @@ The :symbol:`mongoc_stream_read` function returns the number of bytes read on su
   | :symbol:`mongoc_stream_write()`
 
   | :symbol:`mongoc_stream_writev()`
-

--- a/src/libmongoc/doc/mongoc_stream_readv.rst
+++ b/src/libmongoc/doc/mongoc_stream_readv.rst
@@ -26,6 +26,13 @@ Parameters
 
 This function is identical to :symbol:`mongoc_stream_read()` except that it takes a :symbol:`mongoc_iovec_t` to perform gathered I/O.
 
+.. warning::
+
+  The "default timeout" indicated by a negative value is both unspecified and
+  unrelated to the documented default values for ``*TimeoutMS`` URI options.
+  To specify a default timeout value for a ``*TimeoutMS`` URI option, use the
+  ``MONGOC_DEFAULT_*`` constants defined in ``mongoc-client.h``.
+
 Returns
 -------
 
@@ -38,4 +45,3 @@ Returns
   | :symbol:`mongoc_stream_write()`
 
   | :symbol:`mongoc_stream_writev()`
-

--- a/src/libmongoc/doc/mongoc_stream_write.rst
+++ b/src/libmongoc/doc/mongoc_stream_write.rst
@@ -24,6 +24,13 @@ Parameters
 
 The :symbol:`mongoc_stream_write()` function shall perform a write to a :symbol:`mongoc_stream_t`. It's modeled on the API and semantics of ``write()``, though the parameters map only loosely.
 
+.. warning::
+
+  The "default timeout" indicated by a negative value is both unspecified and
+  unrelated to the documented default values for ``*TimeoutMS`` URI options.
+  To specify a default timeout value for a ``*TimeoutMS`` URI option, use the
+  ``MONGOC_DEFAULT_*`` constants defined in ``mongoc-client.h``.
+
 Returns
 -------
 
@@ -36,4 +43,3 @@ The :symbol:`mongoc_stream_write` function returns the number of bytes written o
   | :symbol:`mongoc_stream_readv()`
 
   | :symbol:`mongoc_stream_writev()`
-

--- a/src/libmongoc/doc/mongoc_stream_writev.rst
+++ b/src/libmongoc/doc/mongoc_stream_writev.rst
@@ -27,8 +27,14 @@ to a :symbol:`mongoc_stream_t`. It's modeled on the
 API and semantics of ``writev()``, though the parameters map only
 loosely.
 
+.. warning::
+
+  The "default timeout" indicated by a negative value is both unspecified and
+  unrelated to the documented default values for ``*TimeoutMS`` URI options.
+  To specify a default timeout value for a ``*TimeoutMS`` URI option, use the
+  ``MONGOC_DEFAULT_*`` constants defined in ``mongoc-client.h``.
+
 Returns
 -------
 
 The number of bytes written on success, or ``-1`` upon failure and ``errno`` is set.
-

--- a/src/libmongoc/doc/mongoc_uri_t.rst
+++ b/src/libmongoc/doc/mongoc_uri_t.rst
@@ -104,8 +104,6 @@ MONGOC_URI_LOADBALANCED                    loadbalanced                      fal
 MONGOC_URI_SRVMAXHOSTS                     srvmaxhosts                       0                                 If zero, the number of hosts in DNS results is unlimited. If greater than zero, the number of hosts in DNS results is limited to being less than or equal to the given value.
 ========================================== ================================= ================================= ============================================================================================================================================================================================================================================
 
-Setting any of the \*timeoutMS options above to ``0`` will be interpreted as "use the default value".
-
 .. warning::
 
   Setting any of the \*timeoutMS options above to either ``0`` or a negative value is discouraged due to unspecified and inconsistent behavior.

--- a/src/libmongoc/doc/mongoc_uri_t.rst
+++ b/src/libmongoc/doc/mongoc_uri_t.rst
@@ -106,6 +106,13 @@ MONGOC_URI_SRVMAXHOSTS                     srvmaxhosts                       0  
 
 Setting any of the \*timeoutMS options above to ``0`` will be interpreted as "use the default value".
 
+.. warning::
+
+  Setting any of the \*timeoutMS options above to either ``0`` or a negative value is discouraged due to unspecified and inconsistent behavior.
+  The "default value" historically specified as a fallback for ``0`` or a negative value is NOT related to the default values for the \*timeoutMS options documented above.
+  The meaning of a timeout of ``0`` or a negative value may vary depending on the operation being executed, even when specified by the same URI option.
+  To specify the documented default value for a \*timeoutMS option, use the `MONGOC_DEFAULT_*` constants defined in ``mongoc-client.h`` instead.
+
 Authentication Options
 ----------------------
 
@@ -330,4 +337,3 @@ MONGOC_URI_SAFE                            safe                              {tr
     mongoc_uri_set_username
     mongoc_uri_set_write_concern
     mongoc_uri_unescape
-

--- a/src/libmongoc/doc/mongoc_write_concern_set_wtimeout.rst
+++ b/src/libmongoc/doc/mongoc_write_concern_set_wtimeout.rst
@@ -31,4 +31,3 @@ instead of altering the write concern.
 .. seealso::
 
   | :symbol:`mongoc_write_concern_get_wtimeout` and :symbol:`mongoc_write_concern_set_wtimeout_int64`.
-

--- a/src/libmongoc/src/mongoc/mongoc-buffer.c
+++ b/src/libmongoc/src/mongoc/mongoc-buffer.c
@@ -199,7 +199,7 @@ _mongoc_buffer_append_from_stream (mongoc_buffer_t *buffer,
       bson_set_error (error,
                       MONGOC_ERROR_STREAM,
                       MONGOC_ERROR_STREAM_SOCKET,
-                      "timeout_msec value %" PRIu64
+                      "timeout_msec value %" PRId64
                       " exceeds supported 32-bit range",
                       timeout_msec);
       RETURN (false);
@@ -266,7 +266,7 @@ _mongoc_buffer_fill (mongoc_buffer_t *buffer,
       bson_set_error (error,
                       MONGOC_ERROR_STREAM,
                       MONGOC_ERROR_STREAM_SOCKET,
-                      "timeout_msec value %" PRIu64
+                      "timeout_msec value %" PRId64
                       " exceeds supported 32-bit range",
                       timeout_msec);
       RETURN (false);
@@ -342,7 +342,7 @@ _mongoc_buffer_try_append_from_stream (mongoc_buffer_t *buffer,
 
    if (BSON_UNLIKELY (!bson_in_range_signed (int32_t, timeout_msec))) {
       // CDRIVER-4589
-      MONGOC_ERROR ("timeout_msec value %" PRIu64
+      MONGOC_ERROR ("timeout_msec value %" PRId64
                     " exceeds supported 32-bit range",
                     timeout_msec);
       RETURN (-1);

--- a/src/libmongoc/src/mongoc/mongoc-cluster-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-private.h
@@ -53,8 +53,8 @@ typedef struct _mongoc_cluster_node_t {
 typedef struct _mongoc_cluster_t {
    int64_t operation_id;
    int32_t request_id;
-   uint32_t sockettimeoutms;
-   uint32_t socketcheckintervalms;
+   int32_t sockettimeoutms;
+   int32_t socketcheckintervalms;
    mongoc_uri_t *uri;
    unsigned requires_auth : 1;
 

--- a/src/libmongoc/src/mongoc/mongoc-crypt.c
+++ b/src/libmongoc/src/mongoc/mongoc-crypt.c
@@ -491,9 +491,7 @@ _state_need_kms (_state_machine_t *state_machine, bson_error_t *error)
    mongocrypt_binary_t *http_req = NULL;
    mongocrypt_binary_t *http_reply = NULL;
    const char *endpoint;
-   uint32_t sockettimeout;
-
-   sockettimeout = MONGOC_DEFAULT_SOCKETTIMEOUTMS;
+   const int32_t sockettimeout = MONGOC_DEFAULT_SOCKETTIMEOUTMS;
    kms_ctx = mongocrypt_ctx_next_kms_ctx (state_machine->ctx);
    while (kms_ctx) {
       mongoc_iovec_t iov;

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -476,7 +476,7 @@ mongoc_secure_channel_read (mongoc_stream_tls_t *tls,
 
    if (BSON_UNLIKELY (!bson_in_range_signed (int32_t, tls->timeout_msec))) {
       // CDRIVER-4589
-      MONGOC_ERROR ("timeout_msec value %" PRIu64
+      MONGOC_ERROR ("timeout_msec value %" PRId64
                     " exceeds supported 32-bit range",
                     tls->timeout_msec);
       return -1;
@@ -511,7 +511,7 @@ mongoc_secure_channel_write (mongoc_stream_tls_t *tls,
 
    if (BSON_UNLIKELY (!bson_in_range_signed (int32_t, tls->timeout_msec))) {
       // CDRIVER-4589
-      MONGOC_ERROR ("timeout_msec value %" PRIu64
+      MONGOC_ERROR ("timeout_msec value %" PRId64
                     " exceeds supported 32-bit range",
                     tls->timeout_msec);
       return -1;

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl-bio.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl-bio.c
@@ -218,7 +218,7 @@ mongoc_stream_tls_openssl_bio_read (BIO *b, char *buf, int len)
 
    if (BSON_UNLIKELY (!bson_in_range_signed (int32_t, tls->timeout_msec))) {
       // CDRIVER-4589
-      MONGOC_ERROR ("timeout_msec value %" PRIu64
+      MONGOC_ERROR ("timeout_msec value %" PRId64
                     " exceeds supported 32-bit range",
                     tls->timeout_msec);
       return -1;
@@ -289,7 +289,7 @@ mongoc_stream_tls_openssl_bio_write (BIO *b, const char *buf, int len)
 
    if (BSON_UNLIKELY (!bson_in_range_signed (int32_t, tls->timeout_msec))) {
       // CDRIVER-4589
-      MONGOC_ERROR ("timeout_msec value %" PRIu64
+      MONGOC_ERROR ("timeout_msec value %" PRId64
                     " exceeds supported 32-bit range",
                     tls->timeout_msec);
       RETURN (-1);

--- a/src/libmongoc/src/mongoc/mongoc-stream.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream.c
@@ -157,6 +157,7 @@ mongoc_stream_writev (mongoc_stream_t *stream,
 
    BSON_ASSERT (stream->writev);
 
+   // CDRIVER-4781: for backward compatibility.
    if (timeout_msec < 0) {
       timeout_msec = MONGOC_DEFAULT_TIMEOUT_MSEC;
    }

--- a/src/libmongoc/src/mongoc/mongoc-stream.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream.c
@@ -441,7 +441,7 @@ _mongoc_stream_writev_full (mongoc_stream_t *stream,
       bson_set_error (error,
                       MONGOC_ERROR_STREAM,
                       MONGOC_ERROR_STREAM_SOCKET,
-                      "timeout_msec value %" PRIu64
+                      "timeout_msec value %" PRId64
                       " exceeds supported 32-bit range",
                       timeout_msec);
       RETURN (false);

--- a/src/libmongoc/tests/test-mongoc-stream.c
+++ b/src/libmongoc/tests/test-mongoc-stream.c
@@ -164,11 +164,126 @@ test_stream_writev_full (void)
    mongoc_stream_destroy (success_stream);
 }
 
+typedef struct {
+   mongoc_stream_t vtable;
+   int32_t timeout_msec;
+   bool is_set;
+} test_negative_timeout_stream_t;
+
+static void
+test_timeout_stream_destroy (mongoc_stream_t *stream)
+{
+   bson_free (stream);
+}
+
+static ssize_t
+test_timeout_stream_writev (mongoc_stream_t *stream_param,
+                            mongoc_iovec_t *iov,
+                            size_t iovcnt,
+                            int32_t timeout_msec)
+{
+   BSON_UNUSED (iov);
+   BSON_UNUSED (iovcnt);
+
+   test_negative_timeout_stream_t *const stream =
+      (test_negative_timeout_stream_t *) stream_param;
+
+   stream->is_set = true;
+   stream->timeout_msec = timeout_msec;
+
+   return 0;
+}
+
+static test_negative_timeout_stream_t *
+test_negative_timeout_stream_new (void)
+{
+   test_negative_timeout_stream_t *const stream =
+      bson_malloc (sizeof (test_negative_timeout_stream_t));
+
+   *stream = (test_negative_timeout_stream_t){
+      .vtable =
+         {
+            .type = 999, // For testing purposes.
+            .destroy = test_timeout_stream_destroy,
+            .writev = test_timeout_stream_writev,
+         },
+      .is_set = false,
+      .timeout_msec = 0,
+   };
+
+   return stream;
+}
+
+static void
+test_stream_writev_timeout (void)
+{
+   bson_error_t error;
+
+   uint8_t data[1] = {0};
+   mongoc_iovec_t iov = {.iov_base = data, .iov_len = 1u};
+
+   // A positive timeout value should be forwarded as-is to the writev function.
+   {
+      test_negative_timeout_stream_t *const stream =
+         test_negative_timeout_stream_new ();
+
+      ssize_t const res =
+         _mongoc_stream_writev_full ((mongoc_stream_t *) stream,
+                                     &iov,
+                                     1u,
+                                     MONGOC_DEFAULT_SOCKETTIMEOUTMS,
+                                     &error);
+      ASSERT_CMPSSIZE_T (res, ==, 0);
+      ASSERT_WITH_MSG (stream->is_set,
+                       "expected test_timeout_stream_writev() to be invoked");
+      ASSERT_CMPINT32 (
+         stream->timeout_msec, ==, MONGOC_DEFAULT_SOCKETTIMEOUTMS);
+
+      mongoc_stream_destroy ((mongoc_stream_t *) stream);
+   }
+
+   // A timeout value of 0 should be forwarded as-is to the writev function.
+   {
+      test_negative_timeout_stream_t *const stream =
+         test_negative_timeout_stream_new ();
+
+      ssize_t const res = _mongoc_stream_writev_full (
+         (mongoc_stream_t *) stream, &iov, 1u, 0, &error);
+      ASSERT_CMPSSIZE_T (res, ==, 0);
+      ASSERT_WITH_MSG (stream->is_set,
+                       "expected test_timeout_stream_writev() to be invoked");
+      ASSERT_CMPINT32 (stream->timeout_msec, ==, 0);
+
+      mongoc_stream_destroy ((mongoc_stream_t *) stream);
+   }
+
+   // CDRIVER-4781: a negative timeout value will fallback to an unspecified
+   // default value. The writev function should receive the unspecified default
+   // timeout value rather than the negative timeout value.
+   {
+      // See: MONGOC_DEFAULT_TIMEOUT_MSEC in mongoc-stream.c.
+      const int32_t default_timeout_msec = 60 * 60 * 1000;
+
+      test_negative_timeout_stream_t *const stream =
+         test_negative_timeout_stream_new ();
+
+      ssize_t const res = _mongoc_stream_writev_full (
+         (mongoc_stream_t *) stream, &iov, 1u, -1, &error);
+      ASSERT_CMPSSIZE_T (res, ==, 0);
+      ASSERT_WITH_MSG (stream->is_set,
+                       "expected test_timeout_stream_writev() to be invoked");
+      ASSERT_CMPINT32 (stream->timeout_msec, ==, default_timeout_msec);
+
+      mongoc_stream_destroy ((mongoc_stream_t *) stream);
+   }
+}
+
 
 void
 test_stream_install (TestSuite *suite)
 {
    TestSuite_Add (suite, "/Stream/buffered/basic", test_buffered_basic);
    TestSuite_Add (suite, "/Stream/buffered/oversized", test_buffered_oversized);
-   TestSuite_Add (suite, "/Stream/writev_full", test_stream_writev_full);
+   TestSuite_Add (suite, "/Stream/writev/full", test_stream_writev_full);
+   TestSuite_Add (suite, "/Stream/writev/timeout", test_stream_writev_timeout);
 }

--- a/src/libmongoc/tests/test-mongoc-stream.c
+++ b/src/libmongoc/tests/test-mongoc-stream.c
@@ -235,7 +235,7 @@ test_stream_writev_timeout (void)
       ASSERT_CMPSSIZE_T (res, ==, 0);
       ASSERT_WITH_MSG (
          stream->is_set,
-         "expected test_writev_timeout_stream_writev() to be invoked");
+         "expected _writev_timeout_stream_writev() to be invoked");
       ASSERT_CMPINT32 (
          stream->timeout_msec, ==, MONGOC_DEFAULT_SOCKETTIMEOUTMS);
 
@@ -251,7 +251,7 @@ test_stream_writev_timeout (void)
       ASSERT_CMPSSIZE_T (res, ==, 0);
       ASSERT_WITH_MSG (
          stream->is_set,
-         "expected test_writev_timeout_stream_writev() to be invoked");
+         "expected _writev_timeout_stream_writev() to be invoked");
       ASSERT_CMPINT32 (stream->timeout_msec, ==, 0);
 
       mongoc_stream_destroy ((mongoc_stream_t *) stream);
@@ -271,7 +271,7 @@ test_stream_writev_timeout (void)
       ASSERT_CMPSSIZE_T (res, ==, 0);
       ASSERT_WITH_MSG (
          stream->is_set,
-         "expected test_writev_timeout_stream_writev() to be invoked");
+         "expected _writev_timeout_stream_writev() to be invoked");
       ASSERT_CMPINT32 (stream->timeout_msec, ==, default_timeout_msec);
 
       mongoc_stream_destroy ((mongoc_stream_t *) stream);


### PR DESCRIPTION
Resolves CDRIVER-4781. Verified by [this patch](https://spruce.mongodb.com/version/65525bff0305b9e2e2b97975).

https://github.com/mongodb/mongo-c-driver/pull/1229 introduced range representability checks for conversion from `int64_t` -> `int32_t` timeout parameters in internal read/write utility functions, where due to historical reasons, `int64_t` timeout parameters for several read/write operations are forwarded to underlying `int32_t` timeout parameters (narrowing conversion). The new range checks are (correctly but unexpectedly) triggered by `mongoc_cluster_t::sockettimeoutms` when the URI option is set to `-1`, which has also been (implicitly) supported for historical reasons. The negative value was being implicitly converted to a large unsigned value before being passed as an `int64_t`, before being converted back to `-1` when cast back to `int32_t`:

```
-1         (int32_t: MONGOC_URI_SOCKETTIMEOUTMS)
4294967295 (uint32_t: mongoc_cluster_t::sockettimeoutms)
4294967295 (int64_t: _mongoc_stream_writev_full())
  >int32_t range check failure< (the breaking change)
-1         (int32_t: mongoc_stream_writev(), impl-defined narrowing signed conversion)
```

This PR restores support for negative values for the `socketTimeoutMS` URI option for backward compatibility by replacing the intermediate `uint32_t` data members of `mongoc_cluster_t` with `int32_t` for better consistency with how the values are both assigned and used internally. This avoids the implicit conversion into a large unsigned value that triggers the range check before conversion back to an `int32_t`. This change also addresses 5 GCC and 5 Clang warnings for implicit sign conversion. Other instances of internal representation of timeout values (that aren't ignored, i.e. gridfs functions) do not seem to be affected: there are no other instances of intermediately-representing the timeout as an unsigned integer.

A regression test is added that ensures the range check is not triggered by a negative socketTimeoutMS URI value. This regression test + git bisect verified that the breaking change was triggered by https://github.com/mongodb/mongo-c-driver/commit/abb0bb7da8230d342dac5061623c1e4936ed46d9 (https://github.com/mongodb/mongo-c-driver/pull/1229).

As a drive-by fix, this PR also fixes the incorrect format specifier for error messages concerning `timeout_ms` (`PRId64` for `int64_t`).

Additionally, an attempt is made to document the unspecified/inconsistent behavior of non-positive timeout values for the URI option documentation and for functions that have a timeout parameter (i.e. `mongoc_stream_*()`). Scanning through how the timeout values are both represented and interpreted within libmongoc, it does not seem desirable to continue to support non-positive URI timeout values (even `0`) despite historical (implicit) support.