### PR TITLE
CDRIVER-4781 add `void*` cast in test

### DIFF
--- a/src/libmongoc/tests/test-mongoc-stream.c
+++ b/src/libmongoc/tests/test-mongoc-stream.c
@@ -219,7 +219,7 @@ test_stream_writev_timeout (void)
 {
    bson_error_t error;
 
-   char data[1] = {0};
+   uint8_t data[1] = {0};
    mongoc_iovec_t iov = {.iov_base = data, .iov_len = 1u};
 
    // A positive timeout value should be forwarded as-is to the writev function.

--- a/src/libmongoc/tests/test-mongoc-stream.c
+++ b/src/libmongoc/tests/test-mongoc-stream.c
@@ -220,7 +220,7 @@ test_stream_writev_timeout (void)
    bson_error_t error;
 
    uint8_t data[1] = {0};
-   mongoc_iovec_t iov = {.iov_base = data, .iov_len = 1u};
+   mongoc_iovec_t iov = {.iov_base = (void *) data, .iov_len = 1u};
 
    // A positive timeout value should be forwarded as-is to the writev function.
    {

--- a/src/libmongoc/tests/test-mongoc-stream.c
+++ b/src/libmongoc/tests/test-mongoc-stream.c
@@ -219,7 +219,7 @@ test_stream_writev_timeout (void)
 {
    bson_error_t error;
 
-   uint8_t data[1] = {0};
+   char data[1] = {0};
    mongoc_iovec_t iov = {.iov_base = data, .iov_len = 1u};
 
    // A positive timeout value should be forwarded as-is to the writev function.


### PR DESCRIPTION
This PR is a follow-up to #1475 intended to fix MinGW builds expecting `char` for the `iov_base` field of `struct iovec`.

Verified changes fix MinGW tasks with this patch: https://spruce.mongodb.com/version/6553ec620ae6067d73912916