### PR TITLE
CDRIVER-4776 add thread library to pkg-config `Libs`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,6 +228,10 @@ set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 mongo_platform_use_target(Threads::Threads)
 
+if(CMAKE_THREAD_LIBS_INIT)
+   set_property(DIRECTORY APPEND PROPERTY pkg_config_LIBS ${CMAKE_THREAD_LIBS_INIT})
+endif()
+
 if(WIN32)
    # Required for gethostbyname on Windows:
    mongo_platform_link_libraries(ws2_32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,9 +228,7 @@ set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 mongo_platform_use_target(Threads::Threads)
 
-if(CMAKE_THREAD_LIBS_INIT)
-   set_property(DIRECTORY APPEND PROPERTY pkg_config_LIBS ${CMAKE_THREAD_LIBS_INIT})
-endif()
+set_property(DIRECTORY APPEND PROPERTY pkg_config_LIBS ${CMAKE_THREAD_LIBS_INIT})
 
 if(WIN32)
    # Required for gethostbyname on Windows:

--- a/build/cmake/GeneratePkgConfig.cmake
+++ b/build/cmake/GeneratePkgConfig.cmake
@@ -286,7 +286,7 @@ function(_generate_pkg_config_content out)
     # XXX: Could we define a genex that can transform the INTERFACE_LINK_LIBRARIES to a list of
     #      pkg-config-compatible "-l"-flags? That would remove the need to populate pkg_config_LIBS
     #      manually, and instead rely on target properties to handle transitive dependencies.
-    string(APPEND libs "$<JOIN:${gx_libs};${gx_linkopts}, >")
+    string(APPEND libs "$<JOIN:${gx_libs}, >")
 
     # Cflags:
     set(cflags)


### PR DESCRIPTION
# Summary

Add thread library to pkg-config `Libs`

# Background & Motivation

Attempting to compile and link in separate steps with static libbson results in a linker error related to pthread with gcc 7.5.0:

```bash
# Tell pkg-config where to find .pc files:
export PKG_CONFIG_PATH=$(pwd)/.install-baseline/lib/pkgconfig
# Compile:
gcc -c ./src/libbson/examples/hello_bson.c -o hello_bson.o $(pkg-config --cflags libbson-static-1.0)
# Link:
gcc -o hello_bson hello_bson.o $(pkg-config --libs libbson-static-1.0)
```

Results in an error at the Link step:
```bash
/usr/bin/ld: /home/ubuntu/code/tasks/mongo-c-driver-C4776/.install/lib/libbson-static-1.0.a(common-b64.c.o): undefined reference to symbol 'pthread_once@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```

`man gcc` notes for `-pthread`:

> should be used consistently for both compilation and linking.

After applying these changes, the `Libs` section of the installed `libbson-static-1.0.pc` includes `-pthread`. The reproducing steps pass.
