### PR TITLE
libbson: prevent -Werror=conversion with GCC 12

### DIFF
--- a/src/libbson/src/bson/bson-iter.h
+++ b/src/libbson/src/bson/bson-iter.h
@@ -440,10 +440,11 @@ bson_iter_timeval_unsafe (const bson_iter_t *iter, struct timeval *tv)
    int64_t value = bson_iter_int64_unsafe (iter);
 #ifdef BSON_OS_WIN32
    tv->tv_sec = (long) (value / 1000);
+   tv->tv_usec = (long) (value % 1000) * 1000;
 #else
    tv->tv_sec = (suseconds_t) (value / 1000);
+   tv->tv_usec = (suseconds_t) (value % 1000) * 1000;
 #endif
-   tv->tv_usec = (value % 1000) * 1000;
 }
 
 


### PR DESCRIPTION
Building on ARM32 fails with GCC 12.3:


    bson-iter.h:434:33: error: conversion from 'int64_t' {aka 'long long int'} to '__suseconds_t' {aka 'long int'} may change value [-Werror=conversion]
    434 | tv->tv_usec = (value % 1000) * 1000;
    | ~~~~~~~~~~~~~~~^~~~~~
    cc1plus: all warnings being treated as errors

Do the same as with tv->tv_sec, and explicitely cast it to suseconds_t on non-Win32 systems and to long on Win32.