### PR TITLE
CDRIVER-4791 AIX doesn't have aligned_alloc

### DIFF
--- a/src/libbson/src/bson/bson-memory.c
+++ b/src/libbson/src/bson/bson-memory.c
@@ -34,7 +34,7 @@ BSON_STATIC_ASSERT2 (bson_mem_vtable_t,
 static void *
 _aligned_alloc_impl (size_t alignment, size_t num_bytes)
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && \
-   !defined(_WIN32) && !defined(__ANDROID__)
+   !defined(_WIN32) && !defined(__ANDROID__) && !defined(_AIX)
 {
    return aligned_alloc (alignment, num_bytes);
 }


### PR DESCRIPTION
...so add it to the list of platforms.

This should probably be checked in CMake/autotools instead.