### PR TITLE
CDRIVER-4790 AIX has a glibc-compatible strerror_r w/ diff name

### DIFF
--- a/src/libbson/src/bson/bson-error.c
+++ b/src/libbson/src/bson/bson-error.c
@@ -116,6 +116,10 @@ bson_strerror_r (int err_code,                    /* IN */
    if (strerror_s (buf, buflen, err_code) != 0) {
       ret = buf;
    }
+#elif defined(_AIX)
+   // AIX does not provide strerror_l, and its strerror_r isn't glibc's.
+   // But it does provide a glibc compatible one called __linux_strerror_r
+   ret = __linux_strerror_r (err_code, buf, buflen);
 #elif defined(__APPLE__)
    // Apple does not provide `strerror_l`, but it does unconditionally provide
    // the XSI-compliant `strerror_r`, but only when compiling with Apple Clang.


### PR DESCRIPTION
The AIX strerror_r doesn't have the same semantics as glibc's (diff type signature), but it does provide one under a different name. This name is used if you use -D_LINUX_SOURCE_COMPAT, but it's a big hammer. We can just use it directly.