### PR TITLE
CDRIVER-4767 use `typing.Union` to support Python 3.9

### DIFF
--- a/build/sphinx/mongoc_common.py
+++ b/build/sphinx/mongoc_common.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import re
 from pathlib import Path

--- a/build/sphinx/mongoc_common.py
+++ b/build/sphinx/mongoc_common.py
@@ -1,7 +1,7 @@
 import os
 import re
 from pathlib import Path
-from typing import Any, Iterable, Sequence, Union
+from typing import Any, Iterable, Sequence
 
 from docutils import nodes
 from docutils.nodes import Node, document
@@ -26,7 +26,7 @@ html_show_sourcelink = False
 html_copy_source = False
 
 
-def _file_man_page_name(fpath: Path) -> Union[str, None]:
+def _file_man_page_name(fpath: Path) -> str | None:
     "Given an rST file input, find the :man_page: frontmatter value, if present"
     lines = fpath.read_text().splitlines()
     for line in lines:

--- a/build/sphinx/mongoc_common.py
+++ b/build/sphinx/mongoc_common.py
@@ -1,7 +1,7 @@
 import os
 import re
 from pathlib import Path
-from typing import Any, Iterable, Sequence
+from typing import Any, Iterable, Sequence, Union
 
 from docutils import nodes
 from docutils.nodes import Node, document
@@ -26,7 +26,7 @@ html_show_sourcelink = False
 html_copy_source = False
 
 
-def _file_man_page_name(fpath: Path) -> str | None:
+def _file_man_page_name(fpath: Path) -> Union[str, None]:
     "Given an rST file input, find the :man_page: frontmatter value, if present"
     lines = fpath.read_text().splitlines()
     for line in lines:


### PR DESCRIPTION
# Summary

Use `typing.Union` instead of `X | Y` to fix documentation build with Python 3.9.

# Background & Motivation

CDRIVER-4767 reports builds for EPEL are failing to build documentation:

```
Traceback (most recent call last):
  File "/Users/kevin.albertson/code/tasks/mongo-c-driver-CDRIVER-4767/.venv/lib/python3.9/site-packages/sphinx/config.py", line 358, in eval_config_file
    exec(code, namespace)  # NoQA: S102
  File "/Users/kevin.albertson/code/tasks/mongo-c-driver-CDRIVER-4767/src/libmongoc/doc/conf.py", line 30, in <module>
    from mongoc_common import *
  File "/Users/kevin.albertson/code/tasks/mongo-c-driver-CDRIVER-4767/build/sphinx/mongoc_common.py", line 29, in <module>
    def _file_man_page_name(fpath: Path) -> str | None:
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

Writing union types as `X | Y` was [introduced in Python 3.10](https://docs.python.org/3/whatsnew/3.10.html). The error can be reproduced by installing Python 3.9 (using `pyenv`) and running:
```bash
cmake \
    -DENABLE_MAN_PAGES:BOOL=ON \
    -S . -B cmake-build
cmake --build cmake-build --target mongoc-man bson-man
```