### PR TITLE
CDRIVER-4767 support Sphinx 1.7.6

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,15 @@
+libmongoc 1.25.3
+================
+
+Fixes:
+
+  * Disable shared libmongoc targets if `ENABLE_SHARED=OFF`
+  * Fix documentation build with Python 3.9.
+
+Thanks to everyone who contributed to the development of this release.
+
+  * Kevin Albertson
+
 libmongoc 1.25.2
 ================
 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+libmongoc 1.25.4 (Unreleased)
+=============================
+
+Fixes:
+
+  * Restore support for Sphinx 1.7.6 for man page build.
+
 libmongoc 1.25.3
 ================
 

--- a/build/cmake/SphinxBuild.cmake
+++ b/build/cmake/SphinxBuild.cmake
@@ -144,7 +144,6 @@ function (sphinx_build_man target_name)
          "PYTHONDONTWRITEBYTECODE=1"
       ${SPHINX_EXECUTABLE}
          -qW -b man
-         -j "${NPROCS}"
          -c "${CMAKE_CURRENT_SOURCE_DIR}"
          -d "${doctrees_dir}"
          "${CMAKE_CURRENT_SOURCE_DIR}"

--- a/build/sphinx/mongoc_common.py
+++ b/build/sphinx/mongoc_common.py
@@ -16,7 +16,6 @@ except ImportError:
     # Try importing from older Sphinx version path.
     from sphinx.builders.html import DirectoryHTMLBuilder
 from sphinx.config import Config
-from sphinx.project import Project
 from docutils.parsers.rst import Directive
 
 needs_sphinx = "5.0"
@@ -46,7 +45,6 @@ def _collect_man(app: Sphinx, config: Config) -> None:
     "Populate the man_pages value from the given source directory input"
     # Note: 'app' is partially-formed, as this is called from the Sphinx.__init__
     docdir = Path(app.srcdir)
-    proj = Project(app.srcdir, config.source_suffix)
     # Find everything:
     children = docdir.rglob("*")
     # Find only regular files:
@@ -59,7 +57,7 @@ def _collect_man(app: Sphinx, config: Config) -> None:
     pairs: Iterable[tuple[Path, str]] = ((f, m) for f, m in with_man_name if m)
     # Populate the man_pages:
     for filepath, man_name in pairs:
-        docname = proj.path2doc(str(filepath))
+        docname = app.env.path2doc(str(filepath))
         assert docname, filepath
         man_pages.append((docname, man_name, "", [author], 3))
 

--- a/build/sphinx/mongoc_common.py
+++ b/build/sphinx/mongoc_common.py
@@ -18,7 +18,7 @@ except ImportError:
 from sphinx.config import Config
 from docutils.parsers.rst import Directive
 
-needs_sphinx = "5.0"
+needs_sphinx = "1.7" # Do not require newer sphinx. EPEL packages build man pages with Sphinx 1.7.6. Refer: CDRIVER-4767
 author = "MongoDB, Inc"
 
 # -- Options for HTML output ----------------------------------------------

--- a/build/sphinx/mongoc_common.py
+++ b/build/sphinx/mongoc_common.py
@@ -10,7 +10,11 @@ from docutils.nodes import Node, document
 
 from sphinx.application import Sphinx
 from sphinx.application import logger as sphinx_log
-from sphinx.builders.dirhtml import DirectoryHTMLBuilder
+try:
+    from sphinx.builders.dirhtml import DirectoryHTMLBuilder
+except ImportError:
+    # Try importing from older Sphinx version path.
+    from sphinx.builders.html import DirectoryHTMLBuilder
 from sphinx.config import Config
 from sphinx.project import Project
 from sphinx.util.docutils import SphinxDirective

--- a/build/sphinx/mongoc_common.py
+++ b/build/sphinx/mongoc_common.py
@@ -17,7 +17,7 @@ except ImportError:
     from sphinx.builders.html import DirectoryHTMLBuilder
 from sphinx.config import Config
 from sphinx.project import Project
-from sphinx.util.docutils import SphinxDirective
+from docutils.parsers.rst import Directive
 
 needs_sphinx = "5.0"
 author = "MongoDB, Inc"
@@ -103,7 +103,7 @@ def add_ga_javascript(app: Sphinx, pagename: str, templatename: str, context: di
     )
 
 
-class VersionList(SphinxDirective):
+class VersionList(Directive):
     """Custom directive to generate the version list from an environment variable"""
 
     option_spec = {}

--- a/src/libbson/NEWS
+++ b/src/libbson/NEWS
@@ -1,3 +1,8 @@
+libbson 1.25.3
+==============
+
+No changes since 1.25.2. Version incremented to match the libmongoc version.
+
 libbson 1.25.2
 ==============
 

--- a/src/libbson/NEWS
+++ b/src/libbson/NEWS
@@ -1,3 +1,11 @@
+libbson 1.25.4 (Unreleased)
+===========================
+
+Fixes:
+
+  * Restore support for Sphinx 1.7.6 for man page build.
+
+
 libbson 1.25.3
 ==============
 

--- a/src/libmongoc/doc/conf.py
+++ b/src/libmongoc/doc/conf.py
@@ -25,7 +25,7 @@ try:
     from sphinx_design.dropdown import DropdownDirective
     has_sphinx_design = True
 except ImportError:
-    print ("Unable to import sphinx_design. Documentation cannot be built as HTML.")
+    pass
 
 # Ensure we can import "mongoc" extension module.
 this_path = os.path.dirname(__file__)

--- a/src/libmongoc/doc/conf.py
+++ b/src/libmongoc/doc/conf.py
@@ -174,16 +174,16 @@ rst_prolog = rf"""
    Offer these substitutions for simpler variable references:
 
 .. |cmvar:CMAKE_BUILD_TYPE| replace::
-    :external+cmake:cmake:variable:`CMAKE_BUILD_TYPE <variable:CMAKE_BUILD_TYPE>`
+    :cmake:variable:`CMAKE_BUILD_TYPE <variable:CMAKE_BUILD_TYPE>`
 
 .. |cmvar:CMAKE_INSTALL_PREFIX| replace::
-    :external+cmake:cmake:variable:`CMAKE_INSTALL_PREFIX <variable:CMAKE_INSTALL_PREFIX>`
+    :cmake:variable:`CMAKE_INSTALL_PREFIX <variable:CMAKE_INSTALL_PREFIX>`
 
 .. |cmvar:CMAKE_PREFIX_PATH| replace::
-    :external+cmake:cmake:variable:`CMAKE_PREFIX_PATH <variable:CMAKE_PREFIX_PATH>`
+    :cmake:variable:`CMAKE_PREFIX_PATH <variable:CMAKE_PREFIX_PATH>`
 
 .. |cmcmd:find_package| replace::
-    :external+cmake:cmake:command:`find_package() <command:find_package>`
+    :cmake:command:`find_package() <command:find_package>`
 
 """
 

--- a/src/libmongoc/doc/conf.py
+++ b/src/libmongoc/doc/conf.py
@@ -211,9 +211,14 @@ else:
         def run(self):
             return []
         
+has_add_css_file = True
+        
 def check_html_builder_requirements (app):
-    if isinstance(app.builder, DirectoryHTMLBuilder) and not has_sphinx_design:
-        raise RuntimeError("The sphinx-design package is required to build HTML documentation but was not detected. Install sphinx-design.")
+    if isinstance(app.builder, DirectoryHTMLBuilder):
+        if not has_sphinx_design:
+            raise RuntimeError("The sphinx-design package is required to build HTML documentation but was not detected. Install sphinx-design.")
+        if not has_add_css_file:
+            raise RuntimeError("A newer version of Sphinx is required to build HTML documentation with CSS files. Upgrade Sphinx to v3.5.0 or newer")
 
 def setup(app: Sphinx):
     mongoc_common_setup(app)
@@ -224,6 +229,11 @@ def setup(app: Sphinx):
         app.add_directive("ad-dropdown", EmptyDirective)
         app.add_directive("tab-set", EmptyDirective)
     app.connect("html-page-context", add_canonical_link)
-    app.add_css_file("styles.css")
+    if hasattr(app, "add_css_file"):
+        app.add_css_file("styles.css")
+    else:
+        global has_add_css_file
+        has_add_css_file = False
+        
     app.connect("config-inited", _maybe_update_inventories)
     app.add_config_value(_UPDATE_KEY, default=False, rebuild=True, types=[bool])

--- a/src/libmongoc/doc/conf.py
+++ b/src/libmongoc/doc/conf.py
@@ -6,7 +6,12 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
-from sphinx.builders.dirhtml import DirectoryHTMLBuilder
+try:
+    from sphinx.builders.dirhtml import DirectoryHTMLBuilder
+except ImportError:
+    # Try importing from older Sphinx version path.
+    from sphinx.builders.html import DirectoryHTMLBuilder
+
 from docutils.parsers.rst import directives, Directive
 from sphinx.application import Sphinx
 from sphinx.application import logger as sphinx_log

--- a/src/libmongoc/doc/conf.py
+++ b/src/libmongoc/doc/conf.py
@@ -82,7 +82,7 @@ intersphinx_mapping = {
 _UPDATE_KEY = "update_external_inventories"
 
 
-def _maybe_update_inventories(app: Sphinx, config: Config):
+def _maybe_update_inventories(app: Sphinx):
     """
     We save Sphinx inventories for external projects saved within our own project
     so that we can support fully-offline builds. This is a convenience function
@@ -92,6 +92,7 @@ def _maybe_update_inventories(app: Sphinx, config: Config):
     value is defined.
     """
     prefix = "[libmongoc/doc/conf.py]"
+    config = app.config
     if not config[_UPDATE_KEY]:
         sphinx_log.info(
             "%s Using existing intersphinx inventories. Refresh by running with ‘-D %s=1’",
@@ -235,5 +236,5 @@ def setup(app: Sphinx):
         global has_add_css_file
         has_add_css_file = False
         
-    app.connect("config-inited", _maybe_update_inventories)
+    app.connect("builder-inited", _maybe_update_inventories)
     app.add_config_value(_UPDATE_KEY, default=False, rebuild=True, types=[bool])

--- a/src/libmongoc/doc/learn/get/docs.rst
+++ b/src/libmongoc/doc/learn/get/docs.rst
@@ -36,7 +36,7 @@ to be run when the `pyproject.toml` file is changed.
 Running Sphinx
 **************
 
-Poetry can be used to execute the :external:doc:`man/sphinx-build` command::
+Poetry can be used to execute the :std:doc:`man/sphinx-build` command::
 
   $ poetry run sphinx-build -b dirhtml "./src/libmongoc/doc" "./_build/docs/html"
 
@@ -47,8 +47,8 @@ subdirectory.
 
   Because Sphinx builds many pages, the build may run quite slowly. For faster
   builds, it is recommended to use the
-  :external:option:`--jobs <sphinx-build.--jobs>` command-line option when
-  invoking :external:doc:`man/sphinx-build`.
+  :std:option:`--jobs <sphinx:sphinx-build.--jobs>` command-line option when
+  invoking :std:doc:`sphinx:man/sphinx-build`.
 
 
 Viewing the Documentation
@@ -56,7 +56,7 @@ Viewing the Documentation
 
 To quickly view the rendered HTML pages, a simple local HTTP server can be
 spawned on the command line by using Python's built-in
-:external:mod:`http.server` module:
+:py:mod:`http.server` module:
 
 .. code-block:: sh
 

--- a/src/libmongoc/doc/learn/get/installing.rst
+++ b/src/libmongoc/doc/learn/get/installing.rst
@@ -11,8 +11,8 @@ Installing Prebuilt MongoDB C Driver Libraries
 .. _Homebrew: https://brew.sh/
 
 The |libmongoc| and |libbson| libraries are often available in the package
-management repositories of `common Linux distributions <installing.linux_>`_ and
-`macOS via Homebrew <installing.macos_>`_.
+management repositories of :ref:`common Linux distributions <installing.linux>` and
+:ref:`macOS via Homebrew <installing.macos>`.
 
 .. note::
 
@@ -42,7 +42,8 @@ management repositories of `common Linux distributions <installing.linux_>`_ and
   package managers; Conan
   package managers; vcpkg
   pair: installation; package managers
-  :name: installing.pkgman
+
+.. _installing.pkgman:
 
 Cross Platform Installs Using Library Package Managers
 ******************************************************
@@ -135,7 +136,8 @@ CMake toolchain file at the initial configure command::
 
 .. index::
   ! pair: Linux; installation
-  :name: installing.linux
+
+.. _installing.linux:
 
 Installing in Linux
 *******************

--- a/src/libmongoc/doc/mongoc_client_encryption_opts_set_kms_credential_provider_callback.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_opts_set_kms_credential_provider_callback.rst
@@ -34,7 +34,6 @@ Parameters
 .. rubric:: Related:
 
 .. c:type:: mongoc_kms_credentials_provider_callback_fn
-  :noindexentry:
 
   .. -
     The :noindexentry: prevents a one-off index entry for this item.


### PR DESCRIPTION
# Summary
This PR includes several workarounds to support building the man page targets with Sphinx 1.7.6.
Commit messages describe the change, and (if applicable) the later version of Sphinx that introduced a feature.

# Background & Motivation

CDRIVER-4767 reports builds for EPEL are failing to build documentation due to use of older Sphinx versions:

```
This project needs at least Sphinx v5.0 and therefore cannot be built with this version.
```

CDRIVER-4767 reports Sphinx versions used are "1.7.6 on EL-8 and 3.4.3 on EL-9"

This PR was tested by building the `mongoc-man` and `bson-man` targets locally with Sphinx 1.7.6, 3.4.3, and 7.1.2. Testing in CI is planned in to CDRIVER-4794.