### PR TITLE
CDRIVER-4799 sync Index Management tests

### DIFF
--- a/src/libmongoc/tests/json/index-management/createSearchIndex.json
+++ b/src/libmongoc/tests/json/index-management/createSearchIndex.json
@@ -55,7 +55,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],
@@ -102,7 +102,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],

--- a/src/libmongoc/tests/json/index-management/createSearchIndexes.json
+++ b/src/libmongoc/tests/json/index-management/createSearchIndexes.json
@@ -49,7 +49,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],
@@ -89,7 +89,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],
@@ -138,7 +138,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],

--- a/src/libmongoc/tests/json/index-management/dropSearchIndex.json
+++ b/src/libmongoc/tests/json/index-management/dropSearchIndex.json
@@ -49,7 +49,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],

--- a/src/libmongoc/tests/json/index-management/listSearchIndexes.json
+++ b/src/libmongoc/tests/json/index-management/listSearchIndexes.json
@@ -46,7 +46,7 @@
           "object": "collection0",
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],
@@ -81,7 +81,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],
@@ -122,7 +122,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],

--- a/src/libmongoc/tests/json/index-management/updateSearchIndex.json
+++ b/src/libmongoc/tests/json/index-management/updateSearchIndex.json
@@ -50,7 +50,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],


### PR DESCRIPTION
# Summary

Sync tests from https://github.com/mongodb/specifications/pull/1485

# Background & Motivation

SERVER-83290 changed an error message causing test assertions to fail latest server builds. For example [asan-sasl-cyrus-openssl-ubuntu2004-clang-test-latest-replica-auth](https://spruce.mongodb.com/task/mongo_c_driver_sanitizers_matrix_asan_asan_sasl_cyrus_openssl_ubuntu2004_clang_test_latest_replica_auth_patch_3a624d53dfed8820019a8fb0e436f6151588f0f5_658071a13627e050878a2577_23_12_18_16_21_55/logs?execution=0) failed with:

> error: expected error to contain "Search index commands are only supported with Atlas", but got: "Using Atlas Search Database Commands and the $listSearchIndexes aggregation stage requires additional configuration. Please connect to Atlas or an AtlasCLI local deployment to enable. For more information on how to connect, see https://dochub.mongodb.org/core/atlas-cli-deploy-local-reqs."

The message assertions were updated in https://github.com/mongodb/specifications/pull/1485

Tests were run in C driver to verify they are now passing: https://spruce.mongodb.com/version/6581c5d12a60ed6df70bbe25
