### PR TITLE
CDRIVER-4797 Restore documentation describing dev packages

### DIFF
--- a/src/libmongoc/doc/learn/get/installing.rst
+++ b/src/libmongoc/doc/learn/get/installing.rst
@@ -194,7 +194,7 @@ Yum/DNF.
     # yum install epel-release
 
   `epel-release` must be installed before attempting to install the C driver
-  libraries (i.e. one cannot install them both in a single `yum intsall`
+  libraries (i.e. one cannot install them both in a single `yum install`
   command).
 
 To install |libbson| only, install the `libbson-devel` package::

--- a/src/libmongoc/doc/learn/get/installing.rst
+++ b/src/libmongoc/doc/learn/get/installing.rst
@@ -207,6 +207,8 @@ To install the full C database driver (|libmongoc|), install
   ## (This package will transitively install libbson-devel)
   # yum install mongo-c-driver-devel
 
+The development packages (ending in `-devel`) include files required to build applications using |libbson| and |libmongoc|.
+To only install the libraries without development files, install the `libbson` or `mongo-c-driver-libs` packages.
 
 .. index::
     !pair: installation; Debian
@@ -232,6 +234,8 @@ To install |libmongoc| (which will also install |libbson|)::
 
   # apt install libmongoc-dev
 
+The development packages (ending in `-dev`) include files required to build applications using |libbson| and |libmongoc|.
+To only install the libraries without development files, install the `libbson-1.0-0` or `libmongoc-1.0-0` packages.
 
 .. index::
   !pair: installation; macOS

--- a/src/libmongoc/doc/learn/get/installing.rst
+++ b/src/libmongoc/doc/learn/get/installing.rst
@@ -207,6 +207,8 @@ To install the full C database driver (|libmongoc|), install
   ## (This package will transitively install libbson-devel)
   # yum install mongo-c-driver-devel
 
+To check which version is available, see https://packages.fedoraproject.org/pkgs/mongo-c-driver/mongo-c-driver-devel.
+
 The development packages (ending in `-devel`) include files required to build applications using |libbson| and |libmongoc|.
 To only install the libraries without development files, install the `libbson` or `mongo-c-driver-libs` packages.
 
@@ -233,6 +235,8 @@ To install only |libbson|::
 To install |libmongoc| (which will also install |libbson|)::
 
   # apt install libmongoc-dev
+
+To check which version is available, run `apt-cache policy libmongoc-dev`.
 
 The development packages (ending in `-dev`) include files required to build applications using |libbson| and |libmongoc|.
 To only install the libraries without development files, install the `libbson-1.0-0` or `libmongoc-1.0-0` packages.

--- a/src/libmongoc/doc/ref/packages.rst
+++ b/src/libmongoc/doc/ref/packages.rst
@@ -21,6 +21,10 @@ Package Names and Availability
 
 This table details the names and usage notes of such packages.
 
+.. note::
+  
+  The development packages (ending in ``-dev`` or ``-devel``) include files required to build applications using |libbson| and |libmongoc|.
+
 .. seealso::
 
   For a step-by-step tutorial on installing packages, refer to


### PR DESCRIPTION
# Summary

- Restore documentation describing dev packages.
- Document steps to check version of Fedora / Debian packages.

# Background & Motivation

Documentation was previously added in https://github.com/mongodb/mongo-c-driver/pull/1270 but removed after a documentation rewrite.
Documentation is intended to help users choose the type of package to install.

Rendered HTML can be viewed from the `make-docs` task here: https://mciuploads.s3.amazonaws.com/mongo-c-driver/docs/libmongoc/-65831b3e2a60ed7f998135b9/index.html


