### PR TITLE
Bson-string: Removed redundant assignement

### DIFF
--- a/src/libbson/src/bson/bson-string.c
+++ b/src/libbson/src/bson/bson-string.c
@@ -77,7 +77,6 @@ bson_string_new (const char *str) /* IN */
    if (str) {
       memcpy (ret->str, str, ret->len);
    }
-   ret->str[ret->len] = '\0';
 
    ret->str[ret->len] = '\0';
 


### PR DESCRIPTION
Hello,
Minor change, I just noticed a redundant assignment in bson-string.c.
Have a nice day.