### PR TITLE
CDRIVER-4512 add `INSTALL_LEGACY_SHELL=1` workaround

### DIFF
--- a/.evergreen/scripts/integration-tests.sh
+++ b/.evergreen/scripts/integration-tests.sh
@@ -30,7 +30,9 @@ DIR=$(dirname $0)
 
 get_distro
 get_mongodb_download_url_for "$DISTRO" "$MONGODB_VERSION"
-DRIVERS_TOOLS=./ download_and_extract "$MONGODB_DOWNLOAD_URL" "$EXTRACT" "$MONGOSH_DOWNLOAD_URL" "$EXTRACT_MONGOSH"
+# TODO (CDRIVER-4512): remove `INSTALL_LEGACY_SHELL=1` to verify legacy `mongo` shell is no longer needed.
+# Currently, the legacy `mongo` shell is used in AWS test setup scripts.
+INSTALL_LEGACY_SHELL=1 DRIVERS_TOOLS=./ download_and_extract "$MONGODB_DOWNLOAD_URL" "$EXTRACT" "$MONGOSH_DOWNLOAD_URL" "$EXTRACT_MONGOSH"
 
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 


### PR DESCRIPTION
# Summary

Define `INSTALL_LEGACY_SHELL` to fix some AWS tasks.

See patch build: https://spruce.mongodb.com/version/658c81f3c9ec447a9082690f/

# Background & Motivation

https://github.com/mongodb-labs/drivers-evergreen-tools/pull/366 changes the default behavior of the `download-mongodb.sh` script in drivers-evergreen-tools:

> This PR removes the current `SKIP_LEGACY_SHELL` environment variable and introduces a new `INSTALL_LEGACY_SHELL` variable to essentially flip the default behaviour.

The C driver script `run-aws-tests.sh` [uses](https://github.com/mongodb/mongo-c-driver/blob/0da4704d32f80a9eac7d264f1fda2bd70ebe399d/.evergreen/scripts/run-aws-tests.sh#L77) the legacy `mongo` shell.

This PR is intended to be a short-term fix to get more AWS tasks passing in the C driver Evergreen. I expect resolving CDRIVER-4512 requires removing references to the legacy `mongo` shell in the C driver evergreen scripts.
