### PR TITLE
Replace custom null check with strlen

### DIFF
--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -1559,13 +1559,7 @@ bson_append_regex_w_len (bson_t *bson,
       regex_length = (int) strlen (regex);
    } else {
       /* Necessary to validate embedded NULL is not present in key. */
-<<<<<<< HEAD
       HANDLE_KEY_LENGTH (regex, regex_length);
-=======
-      if (strlen (regex) < regex_length) {
-         return false;
-      }
->>>>>>> f345bf55bb (Replace custom null check with strlen)
    }
 
    if (!regex) {

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -422,7 +422,7 @@ _bson_append (bson_t *bson,              /* IN */
          key_length = (int) strlen (key);                                 \
       } else {                                                            \
          /* Necessary to validate embedded NULL is not present in key. */ \
-         if (strnlen (key, key_length) < key_length) {                                 \
+         if (strnlen (key, key_length) < key_length) {                    \
             return false;                                                 \
          }                                                                \
       }                                                                   \
@@ -1559,7 +1559,13 @@ bson_append_regex_w_len (bson_t *bson,
       regex_length = (int) strlen (regex);
    } else {
       /* Necessary to validate embedded NULL is not present in key. */
-      HANDLE_KEY_LENGTH(regex, regex_length);
+<<<<<<< HEAD
+      HANDLE_KEY_LENGTH (regex, regex_length);
+=======
+      if (strlen (regex) < regex_length) {
+         return false;
+      }
+>>>>>>> f345bf55bb (Replace custom null check with strlen)
    }
 
    if (!regex) {

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -422,7 +422,7 @@ _bson_append (bson_t *bson,              /* IN */
          key_length = (int) strlen (key);                                 \
       } else {                                                            \
          /* Necessary to validate embedded NULL is not present in key. */ \
-         if (strlen (key) < key_length) {                                 \
+         if (strnlen (key, key_length) < key_length) {                                 \
             return false;                                                 \
          }                                                                \
       }                                                                   \
@@ -1559,9 +1559,7 @@ bson_append_regex_w_len (bson_t *bson,
       regex_length = (int) strlen (regex);
    } else {
       /* Necessary to validate embedded NULL is not present in key. */
-      if (_string_contains_null (regex, regex_length)) {
-         return false;
-      }
+      HANDLE_KEY_LENGTH(regex, regex_length);
    }
 
    if (!regex) {

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -416,24 +416,13 @@ _bson_append (bson_t *bson,              /* IN */
    return ok;
 }
 
-static BSON_INLINE bool
-_string_contains_null (const char *str, size_t len)
-{
-   for (; len; ++str, --len) {
-      if (*str == 0) {
-         return true;
-      }
-   }
-   return false;
-}
-
 #define HANDLE_KEY_LENGTH(key, key_length)                                \
    do {                                                                   \
       if (key_length < 0) {                                               \
          key_length = (int) strlen (key);                                 \
       } else {                                                            \
          /* Necessary to validate embedded NULL is not present in key. */ \
-         if (_string_contains_null (key, key_length)) {                   \
+         if (strlen (key) < key_length) {                                 \
             return false;                                                 \
          }                                                                \
       }                                                                   \

--- a/src/libbson/tests/test-bson.c
+++ b/src/libbson/tests/test-bson.c
@@ -171,6 +171,7 @@ test_bson_append_utf8 (void)
    BSON_ASSERT_BSON_EQUAL (b3, b2);
    bson_destroy (b);
    bson_destroy (b2);
+   bson_destroy (b3);
 }
 
 

--- a/src/libbson/tests/test-bson.c
+++ b/src/libbson/tests/test-bson.c
@@ -161,13 +161,14 @@ BSON_ASSERT_BSON_EQUAL_FILE (const bson_t *b, const char *filename)
 static void
 test_bson_append_utf8 (void)
 {
-   bson_t *b;
-   bson_t *b2;
+   bson_t *b = bson_new ();
+   bson_t *b2 = get_bson ("test11.bson");
+   bson_t *b3 = bson_new ();
 
-   b = bson_new ();
-   b2 = get_bson ("test11.bson");
    BSON_ASSERT (bson_append_utf8 (b, "hello", -1, "world", -1));
    BSON_ASSERT_BSON_EQUAL (b, b2);
+   BSON_ASSERT (bson_append_utf8 (b3, "hello123", 5, "world", -1));
+   BSON_ASSERT_BSON_EQUAL (b3, b2);
    bson_destroy (b);
    bson_destroy (b2);
 }


### PR DESCRIPTION
strlen is faster than a manual loop and will be optimized away for compile-time strings.

Use less-than rather than equality to preserve the behavior where the user can get the first x characters of a string by setting a shorter length.