### PR TITLE
CDRIVER-4798 sync tests for revised runOnRequirements

### DIFF
--- a/src/libmongoc/tests/json/retryable_writes/unified/bulkWrite-serverErrors.json
+++ b/src/libmongoc/tests/json/retryable_writes/unified/bulkWrite-serverErrors.json
@@ -3,9 +3,15 @@
   "schemaVersion": "1.0",
   "runOnRequirements": [
     {
-      "minServerVersion": "3.6",
+      "minServerVersion": "4.0",
       "topologies": [
         "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topologies": [
+        "sharded"
       ]
     }
   ],
@@ -53,20 +59,6 @@
   "tests": [
     {
       "description": "BulkWrite succeeds after retryable writeConcernError in first batch",
-      "runOnRequirements": [
-        {
-          "minServerVersion": "4.0",
-          "topologies": [
-            "replicaset"
-          ]
-        },
-        {
-          "minServerVersion": "4.1.7",
-          "topologies": [
-            "sharded-replicaset"
-          ]
-        }
-      ],
       "operations": [
         {
           "name": "failPoint",

--- a/src/libmongoc/tests/json/retryable_writes/unified/insertOne-serverErrors.json
+++ b/src/libmongoc/tests/json/retryable_writes/unified/insertOne-serverErrors.json
@@ -3,9 +3,15 @@
   "schemaVersion": "1.0",
   "runOnRequirements": [
     {
-      "minServerVersion": "3.6",
+      "minServerVersion": "4.0",
       "topologies": [
         "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topologies": [
+        "sharded"
       ]
     }
   ],
@@ -53,20 +59,6 @@
   "tests": [
     {
       "description": "InsertOne succeeds after retryable writeConcernError",
-      "runOnRequirements": [
-        {
-          "minServerVersion": "4.0",
-          "topologies": [
-            "replicaset"
-          ]
-        },
-        {
-          "minServerVersion": "4.1.7",
-          "topologies": [
-            "sharded-replicaset"
-          ]
-        }
-      ],
       "operations": [
         {
           "name": "failPoint",

--- a/src/libmongoc/tests/json/unified/poc-retryable-writes.json
+++ b/src/libmongoc/tests/json/unified/poc-retryable-writes.json
@@ -1,14 +1,6 @@
 {
   "description": "poc-retryable-writes",
   "schemaVersion": "1.0",
-  "runOnRequirements": [
-    {
-      "minServerVersion": "3.6",
-      "topologies": [
-        "replicaset"
-      ]
-    }
-  ],
   "createEntities": [
     {
       "client": {
@@ -79,6 +71,14 @@
   "tests": [
     {
       "description": "FindOneAndUpdate is committed on first attempt",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6",
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -132,6 +132,14 @@
     },
     {
       "description": "FindOneAndUpdate is not committed on first attempt",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6",
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -188,6 +196,14 @@
     },
     {
       "description": "FindOneAndUpdate is never committed",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6",
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -253,7 +269,7 @@
         {
           "minServerVersion": "4.1.7",
           "topologies": [
-            "sharded-replicaset"
+            "sharded"
           ]
         }
       ],
@@ -345,7 +361,7 @@
         {
           "minServerVersion": "4.1.7",
           "topologies": [
-            "sharded-replicaset"
+            "sharded"
           ]
         }
       ],
@@ -414,7 +430,7 @@
         {
           "minServerVersion": "4.1.7",
           "topologies": [
-            "sharded-replicaset"
+            "sharded"
           ]
         }
       ],
@@ -432,6 +448,9 @@
               "data": {
                 "failCommands": [
                   "insert"
+                ],
+                "errorLabels": [
+                  "RetryableWriteError"
                 ],
                 "writeConcernError": {
                   "code": 91,


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-4798

Synced with https://github.com/mongodb/specifications/commit/4c73bb13daa0241a3956a30b451edda10f79dde6

This pulls in some changes for [CDRIVER-4639](https://jira.mongodb.org/browse/CDRIVER-4639) for poc-retryable-writes.json, but other files pertinent to [CDRIVER-4639](https://jira.mongodb.org/browse/CDRIVER-4639) have not been synced.

----

This is based on https://github.com/mongodb/mongo-c-driver/pull/1499
