### PR TITLE
CDRIVER-4754 pre-4.4 mongos writeConcernError does not determine retryability

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -1712,8 +1712,7 @@ retry:
    ret = mongoc_cluster_run_command_monitored (
       &client->cluster, &parts->assembled, reply, error);
 
-   _mongoc_write_error_handle_labels (
-      ret, error, reply, server_stream->sd->max_wire_version);
+   _mongoc_write_error_handle_labels (ret, error, reply, server_stream->sd);
 
    if (is_retryable) {
       _mongoc_write_error_update_if_unsupported_storage_engine (

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -530,7 +530,7 @@ _handle_txn_error_labels (bool cmd_ret,
    }
 
    _mongoc_write_error_handle_labels (
-      cmd_ret, cmd_err, reply, cmd->server_stream->sd->max_wire_version);
+      cmd_ret, cmd_err, reply, cmd->server_stream->sd);
 }
 
 /*

--- a/src/libmongoc/src/mongoc/mongoc-collection.c
+++ b/src/libmongoc/src/mongoc/mongoc-collection.c
@@ -3548,7 +3548,7 @@ retry:
 
    if (parts.is_retryable_write) {
       _mongoc_write_error_handle_labels (
-         ret, error, reply_ptr, server_stream->sd->max_wire_version);
+         ret, error, reply_ptr, server_stream->sd);
    }
 
    if (is_retryable) {

--- a/src/libmongoc/src/mongoc/mongoc-error-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-error-private.h
@@ -19,6 +19,8 @@
 #include <bson/bson.h>
 #include <stddef.h>
 
+#include "mongoc-server-description.h"
+
 BSON_BEGIN_DECLS
 
 typedef enum {
@@ -72,7 +74,7 @@ void
 _mongoc_write_error_handle_labels (bool cmd_ret,
                                    const bson_error_t *cmd_err,
                                    bson_t *reply,
-                                   int32_t server_max_wire_version);
+                                   mongoc_server_description_t *sd);
 
 bool
 _mongoc_error_is_shutdown (bson_error_t *error);

--- a/src/libmongoc/src/mongoc/mongoc-write-command.c
+++ b/src/libmongoc/src/mongoc/mongoc-write-command.c
@@ -750,7 +750,7 @@ _mongoc_write_opmsg (mongoc_write_command_t *command,
 
          if (parts.is_retryable_write) {
             _mongoc_write_error_handle_labels (
-               ret, error, &reply, server_stream->sd->max_wire_version);
+               ret, error, &reply, server_stream->sd);
          }
 
          /* Add this batch size so we skip these documents next time */

--- a/src/libmongoc/tests/json/retryable_writes/unified/insertOne-serverErrors.json
+++ b/src/libmongoc/tests/json/retryable_writes/unified/insertOne-serverErrors.json
@@ -165,6 +165,309 @@
           ]
         }
       ]
+    },
+    {
+      "description": "RetryableWriteError label is added based on top-level code in pre-4.4 server response",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2",
+          "maxServerVersion": "4.2.99",
+          "topologies": [
+            "replicaset",
+            "sharded"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 189
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 3,
+              "x": 33
+            }
+          },
+          "expectError": {
+            "errorLabelsContain": [
+              "RetryableWriteError"
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 3,
+                      "x": 33
+                    }
+                  ]
+                },
+                "commandName": "insert",
+                "databaseName": "retryable-writes-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 3,
+                      "x": 33
+                    }
+                  ]
+                },
+                "commandName": "insert",
+                "databaseName": "retryable-writes-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "RetryableWriteError label is added based on writeConcernError in pre-4.4 mongod response",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2",
+          "maxServerVersion": "4.2.99",
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "writeConcernError": {
+                  "code": 91,
+                  "errmsg": "Replication is being shut down"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 3,
+              "x": 33
+            }
+          },
+          "expectError": {
+            "errorLabelsContain": [
+              "RetryableWriteError"
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 3,
+                      "x": 33
+                    }
+                  ]
+                },
+                "commandName": "insert",
+                "databaseName": "retryable-writes-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 3,
+                      "x": 33
+                    }
+                  ]
+                },
+                "commandName": "insert",
+                "databaseName": "retryable-writes-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "RetryableWriteError label is not added based on writeConcernError in pre-4.4 mongos response",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2",
+          "maxServerVersion": "4.2.99",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "writeConcernError": {
+                  "code": 91,
+                  "errmsg": "Replication is being shut down"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 3,
+              "x": 33
+            }
+          },
+          "expectError": {
+            "errorLabelsOmit": [
+              "RetryableWriteError"
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 3,
+                      "x": 33
+                    }
+                  ]
+                },
+                "commandName": "insert",
+                "databaseName": "retryable-writes-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-4754

POC for https://github.com/mongodb/specifications/pull/1486