### PR TITLE
CDRIVER-4767 Support Python 3.6 in man page build

### DIFF
--- a/build/sphinx/mongoc_common.py
+++ b/build/sphinx/mongoc_common.py
@@ -1,7 +1,7 @@
 import os
 import re
 from pathlib import Path
-from typing import Any, Iterable, Sequence, Union
+from typing import Any, Iterable, Sequence, Union, List, Tuple, Dict
 
 from docutils import nodes
 from docutils.nodes import Node, document
@@ -64,7 +64,7 @@ def _collect_man (app: Sphinx):
 # -- Options for manual page output ---------------------------------------
 
 # NOTE: This starts empty, but we populate it in `setup` in _collect_man() (see above)
-man_pages: list[tuple[str, str, str, list[str], int]] = []
+man_pages: List[Tuple[str, str, str, List[str], int]] = []
 
 # If true, show URL addresses after external links.
 #
@@ -73,7 +73,7 @@ man_pages: list[tuple[str, str, str, list[str], int]] = []
 # -- Sphinx customization ---------------------------------------
 
 
-def add_ga_javascript(app: Sphinx, pagename: str, templatename: str, context: dict[str, Any], doctree: document):
+def add_ga_javascript(app: Sphinx, pagename: str, templatename: str, context: Dict[str, Any], doctree: document):
     if not app.env.config.analytics:
         return
 
@@ -140,7 +140,7 @@ class VersionList(Directive):
         return [header, blist]
 
 
-def generate_html_redirs(app: Sphinx, page: str, templatename: str, context: dict[str, Any], doctree: Any) -> None:
+def generate_html_redirs(app: Sphinx, page: str, templatename: str, context: Dict[str, Any], doctree: Any) -> None:
     builder = app.builder
     if not isinstance(builder, DirectoryHTMLBuilder) or "writing-redirect" in context:
         return

--- a/build/sphinx/mongoc_common.py
+++ b/build/sphinx/mongoc_common.py
@@ -1,9 +1,7 @@
-from __future__ import annotations
-
 import os
 import re
 from pathlib import Path
-from typing import Any, Iterable, Sequence
+from typing import Any, Iterable, Sequence, Union
 
 from docutils import nodes
 from docutils.nodes import Node, document
@@ -31,7 +29,7 @@ html_show_sourcelink = False
 html_copy_source = False
 
 
-def _file_man_page_name(fpath: Path) -> str | None:
+def _file_man_page_name(fpath: Path) -> Union[str, None]:
     "Given an rST file input, find the :man_page: frontmatter value, if present"
     lines = fpath.read_text().splitlines()
     for line in lines:

--- a/src/libmongoc/doc/cmakerefdomain.py
+++ b/src/libmongoc/doc/cmakerefdomain.py
@@ -8,7 +8,7 @@ domain plugin. If that is the case, this extention can likely be disabled and
 replaced by a more full-featured extension.
 
 """
-from typing import Any
+from typing import Any, List
 from sphinx.application import Sphinx
 from sphinx.roles import XRefRole
 from sphinx.domains import Domain, ObjType
@@ -43,7 +43,7 @@ class CMakeRefDomain(Domain):
     directives = {}
     initial_data: Any = {}
 
-    def merge_domaindata(self, docnames: list[str], otherdata: Any) -> None:
+    def merge_domaindata(self, docnames: List[str], otherdata: Any) -> None:
         # We have nothing to do, but this is required for parallel execution
         return
 

--- a/src/libmongoc/doc/cmakerefdomain.py
+++ b/src/libmongoc/doc/cmakerefdomain.py
@@ -38,7 +38,8 @@ class CMakeRefDomain(Domain):
     name = "cmake"
     label = "CMake (Minimal)"
     object_types = {k: ObjType(k, k) for k in kinds}
-    roles = {k: XRefRole() for k in kinds} | {"command": XRefRole(fix_parens=True)}
+    roles = {k: XRefRole() for k in kinds}
+    roles["command"] = XRefRole(fix_parens=True)
     directives = {}
     initial_data: Any = {}
 

--- a/src/libmongoc/doc/conf.py
+++ b/src/libmongoc/doc/conf.py
@@ -4,7 +4,7 @@ import os.path
 import sys
 import urllib.request
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict
 
 try:
     from sphinx.builders.dirhtml import DirectoryHTMLBuilder
@@ -190,7 +190,7 @@ rst_prolog = rf"""
 """
 
 
-def add_canonical_link(app: Sphinx, pagename: str, templatename: str, context: dict[str, Any], doctree: Any):
+def add_canonical_link(app: Sphinx, pagename: str, templatename: str, context: Dict[str, Any], doctree: Any):
     link = f'<link rel="canonical" href="https://www.mongoc.org/libmongoc/current/{pagename}/"/>'
 
     context["metatags"] = context.get("metatags", "") + link

--- a/src/libmongoc/doc/conf.py
+++ b/src/libmongoc/doc/conf.py
@@ -109,8 +109,10 @@ def _maybe_update_inventories(app: Sphinx):
             dest = Path(app.srcdir) / filename
             sphinx_log.info("%s Saving inventory [%s] to file [%s]", prefix, url, dest)
             with dest.open("wb") as out:
-                while buf := req.read(1024 * 4):
+                buf = req.read(1024 * 4)
+                while buf:
                     out.write(buf)
+                    buf = req.read(1024 * 4)
         sphinx_log.info(
             "%s Inventory file [%s] was updated. Commit the result to save it for subsequent builds.",
             prefix,


### PR DESCRIPTION
# Summary

This PR is intended to support building man pages with Python 3.6.
Commit messages describe the change, and the version of Python that introduced a feature.

# Background & Motivation

CDRIVER-4767 reports builds for EPEL 8 are failing to build man pages:

```
Configuration error:
There is a syntax error in your configuration file: future feature annotations is not defined (mongoc_common.py, line 1)
Did you change the syntax from 2.x to 3.x?
gmake[2]: *** [src/libbson/doc/CMakeFiles/bson-man.dir/build.make:566: src/libbson/doc/man/bson_aligned_alloc.3] Error 2
gmake[2]: Leaving directory '/builddir/build/BUILD/mongo-c-driver-1.25.4'
gmake[1]: *** [CMakeFiles/Makefile2:1034: src/libbson/doc/CMakeFiles/bson-man.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....Configuration error:
There is a syntax error in your configuration file: bad input (conf.py, line 112)
```

https://rpms.remirepo.net/rpmphp/zoom.php?rpm=python3 reports Python 3.6.8 for EL 8.

Documentation was tested locally with a Rocky Linux 8 Docker image using Sphinx 1.7.6 and Python 3.6.8. Tests in CI are planned in CDRIVER-4794.