### PR TITLE
CDRIVER-4808 do not check writeConcernError in mongoc_error_has_label()

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-error.c
+++ b/src/libmongoc/src/mongoc/mongoc-error.c
@@ -40,22 +40,6 @@ mongoc_error_has_label (const bson_t *reply, const char *label)
       }
    }
 
-   if (!bson_iter_init_find (&iter, reply, "writeConcernError")) {
-      return false;
-   }
-
-   BSON_ASSERT (bson_iter_recurse (&iter, &iter));
-
-   if (bson_iter_find (&iter, "errorLabels") &&
-       bson_iter_recurse (&iter, &error_labels)) {
-      while (bson_iter_next (&error_labels)) {
-         if (BSON_ITER_HOLDS_UTF8 (&error_labels) &&
-             !strcmp (bson_iter_utf8 (&error_labels, NULL), label)) {
-            return true;
-         }
-      }
-   }
-
    return false;
 }
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-4808

Server responses do not return errorLabels within writeConcernError. It is only a top-level field.