### PR TITLE
don't clobber 64-bit .debs with 32-bit .debs

### DIFF
--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -875,6 +875,24 @@ tasks:
       permissions: public-read
       local_file: deb.tar.gz
       content_type: ${content_type|application/x-gzip}
+  - command: s3.put
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/${branch_name}/mongo-c-driver-debian-packages-i386-${CURRENT_VERSION}.tar.gz
+      bucket: mciuploads
+      permissions: public-read
+      local_file: deb-i386.tar.gz
+      content_type: ${content_type|application/x-gzip}
+  - command: s3.put
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      remote_file: ${project}/${branch_name}/${revision}/${version_id}/${build_id}/${execution}/mongo-c-driver-debian-packages-i386.tar.gz
+      bucket: mciuploads
+      permissions: public-read
+      local_file: deb-i386.tar.gz
+      content_type: ${content_type|application/x-gzip}
 - name: rpm-package-build
   commands:
   - command: shell.exec

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -313,6 +313,16 @@ all_tasks = [
                 remote_file="${branch_name}/${revision}/${version_id}/${build_id}/${execution}/mongo-c-driver-debian-packages.tar.gz",
                 content_type="${content_type|application/x-gzip}",
             ),
+            s3_put(
+                local_file="deb-i386.tar.gz",
+                remote_file="${branch_name}/mongo-c-driver-debian-packages-i386-${CURRENT_VERSION}.tar.gz",
+                content_type="${content_type|application/x-gzip}",
+            ),
+            s3_put(
+                local_file="deb-i386.tar.gz",
+                remote_file="${branch_name}/${revision}/${version_id}/${build_id}/${execution}/mongo-c-driver-debian-packages-i386.tar.gz",
+                content_type="${content_type|application/x-gzip}",
+            ),
         ],
     ),
     NamedTask(

--- a/.evergreen/scripts/debian_package_build.sh
+++ b/.evergreen/scripts/debian_package_build.sh
@@ -90,7 +90,7 @@ sudo chroot ./unstable-i386-chroot /bin/bash -c "(\
   gcc -I/usr/include/libmongoc-1.0 -I/usr/include/libbson-1.0 -o example-client src/libmongoc/examples/example-client.c -lmongoc-1.0 -lbson-1.0 )"
 
 [ -e ./unstable-i386-chroot/tmp/mongoc/example-client ] || (echo "Example was not built!" ; exit 1)
-(cd ./unstable-i386-chroot/tmp/ ; tar zcvf ../../deb.tar.gz *.dsc *.orig.tar.gz *.debian.tar.xz *.build *.deb)
+(cd ./unstable-i386-chroot/tmp/ ; tar zcvf ../../deb-i386.tar.gz *.dsc *.orig.tar.gz *.debian.tar.xz *.build *.deb)
 
 # Build a second time, to ensure a "double build" works
 sudo chroot ./unstable-i386-chroot /bin/bash -c "(\


### PR DESCRIPTION
Once this is merged, the `debian-package-build` task in the C++ driver should start working again.