### PR TITLE
CDRIVER-4512 remove legacy shell from AWS test scripts

### DIFF
--- a/.evergreen/config_generator/components/funcs/fetch_det.py
+++ b/.evergreen/config_generator/components/funcs/fetch_det.py
@@ -21,11 +21,7 @@ class FetchDET(Function):
         bash_exec(
             command_type=EvgCommandType.SETUP,
             working_dir="drivers-evergreen-tools",
-            script='''\
-                for file in $(find .evergreen -type f -name "*.sh"); do
-                    chmod +rx "$file" || exit
-                done
-            ''',
+            script='find .evergreen -type f -name "*.sh" -execdir chmod +rx "{}" \;',
         ),
 
         # python is used frequently enough by many tasks that it is worth

--- a/.evergreen/config_generator/components/funcs/fetch_det.py
+++ b/.evergreen/config_generator/components/funcs/fetch_det.py
@@ -17,6 +17,17 @@ class FetchDET(Function):
             ''',
         ),
 
+        # Make shell scripts executable.
+        bash_exec(
+            command_type=EvgCommandType.SETUP,
+            working_dir="drivers-evergreen-tools",
+            script='''\
+                for file in $(find .evergreen -type f -name \*.sh); do
+                    chmod +x "$file" || exit
+                done
+            ''',
+        ),
+
         # python is used frequently enough by many tasks that it is worth
         # running find_python3 once here and reusing the result.
         bash_exec(

--- a/.evergreen/config_generator/components/funcs/fetch_det.py
+++ b/.evergreen/config_generator/components/funcs/fetch_det.py
@@ -22,8 +22,8 @@ class FetchDET(Function):
             command_type=EvgCommandType.SETUP,
             working_dir="drivers-evergreen-tools",
             script='''\
-                for file in $(find .evergreen -type f -name \*.sh); do
-                    chmod +x "$file" || exit
+                for file in $(find .evergreen -type f -name "*.sh"); do
+                    chmod +rx "$file" || exit
                 done
             ''',
         ),

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -177,6 +177,17 @@ functions:
       type: setup
       params:
         binary: bash
+        working_dir: drivers-evergreen-tools
+        args:
+          - -c
+          - |
+            for file in $(find .evergreen -type f -name \*.sh); do
+                chmod +x "$file" || exit
+            done
+    - command: subprocess.exec
+      type: setup
+      params:
+        binary: bash
         args:
           - -c
           - |

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -181,8 +181,8 @@ functions:
         args:
           - -c
           - |
-            for file in $(find .evergreen -type f -name \*.sh); do
-                chmod +x "$file" || exit
+            for file in $(find .evergreen -type f -name "*.sh"); do
+                chmod +rx "$file" || exit
             done
     - command: subprocess.exec
       type: setup

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -180,7 +180,7 @@ functions:
         working_dir: drivers-evergreen-tools
         args:
           - -c
-          - find .evergreen -type f -name "*.sh" -execdir chmod +x "{}" \;
+          - find .evergreen -type f -name "*.sh" -execdir chmod +rx "{}" \;
     - command: subprocess.exec
       type: setup
       params:

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -180,10 +180,7 @@ functions:
         working_dir: drivers-evergreen-tools
         args:
           - -c
-          - |
-            for file in $(find .evergreen -type f -name "*.sh"); do
-                chmod +rx "$file" || exit
-            done
+          - find .evergreen -type f -name "*.sh" -execdir chmod +x "{}" \;
     - command: subprocess.exec
       type: setup
       params:

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -14407,6 +14407,13 @@ buildvariants:
   - debug-compile-aws
   - .test-aws .4.4
   - .test-aws .5.0
+- name: aws-ubuntu2204
+  display_name: AWS Tests (Ubuntu 22.04)
+  expansions:
+    CC: clang
+  run_on: ubuntu2004-small
+  tasks:
+  - debug-compile-aws
   - .test-aws .6.0
   - .test-aws .7.0
   - .test-aws .latest

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -1788,7 +1788,7 @@ tasks:
         cmake_binary="$(find_cmake_latest)"
         # Compile test-awsauth. Disable unnecessary dependencies since test-awsauth is copied to a remote Ubuntu 20.04 ECS cluster for testing, which may not have all dependent libraries.
         export CC='${CC}'
-        "$cmake_binary" -DENABLE_SASL=OFF -DENABLE_SNAPPY=OFF -DENABLE_ZSTD=OFF -DENABLE_CLIENT_SIDE_ENCRYPTION=OFF .
+        "$cmake_binary" -DENABLE_TRACING=ON -DENABLE_SASL=OFF -DENABLE_SNAPPY=OFF -DENABLE_ZSTD=OFF -DENABLE_CLIENT_SIDE_ENCRYPTION=OFF .
         "$cmake_binary" --build . --target test-awsauth
   - func: upload-build
 - name: test-aws-openssl-regular-latest

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -1786,7 +1786,7 @@ tasks:
         export distro_id='${distro_id}' # Required by find_cmake_latest.
         . .evergreen/scripts/find-cmake-latest.sh
         cmake_binary="$(find_cmake_latest)"
-        # Compile test-awsauth. Disable unnecessary dependencies since test-awsauth is copied to a remote Ubuntu 18.04 ECS cluster for testing, which may not have all dependent libraries.
+        # Compile test-awsauth. Disable unnecessary dependencies since test-awsauth is copied to a remote Ubuntu 20.04 ECS cluster for testing, which may not have all dependent libraries.
         export CC='${CC}'
         "$cmake_binary" -DENABLE_SASL=OFF -DENABLE_SNAPPY=OFF -DENABLE_ZSTD=OFF -DENABLE_CLIENT_SIDE_ENCRYPTION=OFF .
         "$cmake_binary" --build . --target test-awsauth
@@ -14398,16 +14398,6 @@ buildvariants:
   tasks:
   - debug-compile-sasl-openssl-static
   - .authentication-tests .asan
-- name: aws-ubuntu1804
-  display_name: AWS Tests (Ubuntu 18.04)
-  expansions:
-    CC: clang
-  run_on: ubuntu1804-small
-  tasks:
-  - debug-compile-aws
-  - .test-aws .4.4
-  - .test-aws .5.0
-  - .test-aws .6.0
 - name: aws-ubuntu2004
   display_name: AWS Tests (Ubuntu 20.04)
   expansions:
@@ -14415,6 +14405,9 @@ buildvariants:
   run_on: ubuntu2004-small
   tasks:
   - debug-compile-aws
+  - .test-aws .4.4
+  - .test-aws .5.0
+  - .test-aws .6.0
   - .test-aws .7.0
   - .test-aws .latest
 - name: mongohouse

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -263,43 +263,29 @@ functions:
         ./src/libmongoc/test-libmongoc --no-fork -l /mongohouse/* -d --skip-tests .evergreen/etc/skip-tests.txt
         unset RUN_MONGOHOUSE_TESTS
   run aws tests:
+  - command: ec2.assume_role
+    params:
+      role_arn: ${aws_test_secrets_role}
   - command: shell.exec
     type: test
     params:
-      silent: true
       working_dir: mongoc
+      include_expansions_in_env:
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
       shell: bash
       script: |-
         set -o errexit
-        # Add AWS variables to a file.
-        cat <<EOF > ../drivers-evergreen-tools/.evergreen/auth_aws/aws_e2e_setup.json
-        {
-            "iam_auth_ecs_account" : "${iam_auth_ecs_account}",
-            "iam_auth_ecs_secret_access_key" : "${iam_auth_ecs_secret_access_key}",
-            "iam_auth_ecs_account_arn": "arn:aws:iam::557821124784:user/authtest_fargate_user",
-            "iam_auth_ecs_cluster": "${iam_auth_ecs_cluster}",
-            "iam_auth_ecs_task_definition": "${iam_auth_ecs_task_definition}",
-            "iam_auth_ecs_subnet_a": "${iam_auth_ecs_subnet_a}",
-            "iam_auth_ecs_subnet_b": "${iam_auth_ecs_subnet_b}",
-            "iam_auth_ecs_security_group": "${iam_auth_ecs_security_group}",
-            "iam_auth_assume_aws_account" : "${iam_auth_assume_aws_account}",
-            "iam_auth_assume_aws_secret_access_key" : "${iam_auth_assume_aws_secret_access_key}",
-            "iam_auth_assume_role_name" : "${iam_auth_assume_role_name}",
-            "iam_auth_ec2_instance_account" : "${iam_auth_ec2_instance_account}",
-            "iam_auth_ec2_instance_secret_access_key" : "${iam_auth_ec2_instance_secret_access_key}",
-            "iam_auth_ec2_instance_profile" : "${iam_auth_ec2_instance_profile}",
-            "iam_auth_assume_web_role_name": "${iam_auth_assume_web_role_name}",
-            "iam_web_identity_issuer": "${iam_web_identity_issuer}",
-            "iam_web_identity_rsa_key": "${iam_web_identity_rsa_key}",
-            "iam_web_identity_jwks_uri": "${iam_web_identity_jwks_uri}",
-            "iam_web_identity_token_file": "${iam_web_identity_token_file}"
-        }
-        EOF
+        pushd ../drivers-evergreen-tools/.evergreen/auth_aws
+        ./setup_secrets.sh drivers/aws_auth
+        popd # ../drivers-evergreen-tools/.evergreen/auth_aws
   - command: shell.exec
     type: test
     params:
       working_dir: mongoc
-      add_expansions_to_env: true
+      include_expansions_in_env:
+      - TESTCASE
       shell: bash
       script: |-
         set -o errexit

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -928,7 +928,7 @@ aws_compile_task = NamedTask(
             cmake_binary="$(find_cmake_latest)"
             # Compile test-awsauth. Disable unnecessary dependencies since test-awsauth is copied to a remote Ubuntu 20.04 ECS cluster for testing, which may not have all dependent libraries.
             export CC='${CC}'
-            "$cmake_binary" -DENABLE_SASL=OFF -DENABLE_SNAPPY=OFF -DENABLE_ZSTD=OFF -DENABLE_CLIENT_SIDE_ENCRYPTION=OFF .
+            "$cmake_binary" -DENABLE_TRACING=ON -DENABLE_SASL=OFF -DENABLE_SNAPPY=OFF -DENABLE_ZSTD=OFF -DENABLE_CLIENT_SIDE_ENCRYPTION=OFF .
             "$cmake_binary" --build . --target test-awsauth
             """
         ),

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -926,7 +926,7 @@ aws_compile_task = NamedTask(
             export distro_id='${distro_id}' # Required by find_cmake_latest.
             . .evergreen/scripts/find-cmake-latest.sh
             cmake_binary="$(find_cmake_latest)"
-            # Compile test-awsauth. Disable unnecessary dependencies since test-awsauth is copied to a remote Ubuntu 18.04 ECS cluster for testing, which may not have all dependent libraries.
+            # Compile test-awsauth. Disable unnecessary dependencies since test-awsauth is copied to a remote Ubuntu 20.04 ECS cluster for testing, which may not have all dependent libraries.
             export CC='${CC}'
             "$cmake_binary" -DENABLE_SASL=OFF -DENABLE_SNAPPY=OFF -DENABLE_ZSTD=OFF -DENABLE_CLIENT_SIDE_ENCRYPTION=OFF .
             "$cmake_binary" --build . --target test-awsauth

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -422,7 +422,7 @@ all_variants = [
         ],
         {"CC": "clang"},
     ),
-    # Test with Ubuntu 20.04+. MongoDB 7.0 no longer ships binaries for Ubuntu 18.04. AWS setup scripts expect Ubuntu 20.04+.
+    # Test with Ubuntu 20.04. MongoDB 7.0 no longer ships binaries for Ubuntu 18.04. AWS setup scripts expect Ubuntu 20.04+. MongoDB 4.4 and 5.0 are not available on Ubuntu 20.04.
     Variant(
         "aws-ubuntu2004",
         "AWS Tests (Ubuntu 20.04)",
@@ -431,6 +431,15 @@ all_variants = [
             "debug-compile-aws",
             ".test-aws .4.4",
             ".test-aws .5.0",
+        ],
+        {"CC": "clang"},
+    ),
+    Variant(
+        "aws-ubuntu2204",
+        "AWS Tests (Ubuntu 22.04)",
+        "ubuntu2004-small",
+        [
+            "debug-compile-aws",
             ".test-aws .6.0",
             ".test-aws .7.0",
             ".test-aws .latest",

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -422,7 +422,7 @@ all_variants = [
         ],
         {"CC": "clang"},
     ),
-    # Test with Ubuntu 20.04. MongoDB 7.0 no longer ships binaries for Ubuntu 18.04. AWS setup scripts expect Ubuntu 20.04+. MongoDB 4.4 and 5.0 are not available on Ubuntu 20.04.
+    # Run AWS tests for MongoDB 4.4 and 5.0 on Ubuntu 20.04. AWS setup scripts expect Ubuntu 20.04+. MongoDB 4.4 and 5.0 are not available on 22.04.
     Variant(
         "aws-ubuntu2004",
         "AWS Tests (Ubuntu 20.04)",

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -422,25 +422,16 @@ all_variants = [
         ],
         {"CC": "clang"},
     ),
-    Variant(
-        "aws-ubuntu1804",
-        "AWS Tests (Ubuntu 18.04)",
-        "ubuntu1804-small",
-        [
-            "debug-compile-aws",
-            ".test-aws .4.4",
-            ".test-aws .5.0",
-            ".test-aws .6.0",
-        ],
-        {"CC": "clang"},
-    ),
-    # Test 7.0+ with Ubuntu 20.04+ since MongoDB 7.0 no longer ships binaries for Ubuntu 18.04.
+    # Test with Ubuntu 20.04+. MongoDB 7.0 no longer ships binaries for Ubuntu 18.04. AWS setup scripts expect Ubuntu 20.04+.
     Variant(
         "aws-ubuntu2004",
         "AWS Tests (Ubuntu 20.04)",
         "ubuntu2004-small",
         [
             "debug-compile-aws",
+            ".test-aws .4.4",
+            ".test-aws .5.0",
+            ".test-aws .6.0",
             ".test-aws .7.0",
             ".test-aws .latest",
         ],

--- a/.evergreen/scripts/run-aws-tests.sh
+++ b/.evergreen/scripts/run-aws-tests.sh
@@ -55,6 +55,7 @@ if [[ "${TESTCASE}" == "REGULAR" ]]; then
   pushd "${drivers_tools_dir}/.evergreen/auth_aws"
   # shellcheck source=/dev/null
   . aws_setup.sh regular # Sets USER and PASS
+  : "${USER:?}" "${PASS:?}"
   popd # "${drivers_tools_dir}/.evergreen/auth_aws"
 
   expect_success "mongodb://${USER:?}:${PASS:?}@localhost/?authMechanism=MONGODB-AWS"
@@ -68,6 +69,7 @@ if [[ "${TESTCASE}" == "ASSUME_ROLE" ]]; then
   pushd "${drivers_tools_dir}/.evergreen/auth_aws"
   # shellcheck source=/dev/null
   . aws_setup.sh assume-role # Sets USER, PASS, and SESSION_TOKEN
+  : "${USER:?}" "${PASS:?}" "${SESSION_TOKEN:?}"
   popd # "${drivers_tools_dir}/.evergreen/auth_aws"
 
   expect_success "mongodb://${USER}:${PASS}@localhost/aws?authMechanism=MONGODB-AWS&authSource=\$external&authMechanismProperties=AWS_SESSION_TOKEN:${SESSION_TOKEN}"
@@ -81,6 +83,7 @@ if [[ "LAMBDA" = "$TESTCASE" ]]; then
     pushd "${drivers_tools_dir}/.evergreen/auth_aws"
     # shellcheck source=/dev/null
     . aws_setup.sh env-creds # Sets AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+    : "${AWS_ACCESS_KEY_ID:?}" "${AWS_SECRET_ACCESS_KEY:?}"
     popd # "${drivers_tools_dir}/.evergreen/auth_aws"
     expect_success "mongodb://localhost/?authMechanism=MONGODB-AWS"
   )
@@ -89,6 +92,7 @@ if [[ "LAMBDA" = "$TESTCASE" ]]; then
     pushd "${drivers_tools_dir}/.evergreen/auth_aws"
     # shellcheck source=/dev/null
     . aws_setup.sh session-creds # Sets AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and SESSION_TOKEN
+    : "${AWS_ACCESS_KEY_ID:?}" "${AWS_SECRET_ACCESS_KEY:?}" "${SESSION_TOKEN:?}"
     popd # "${drivers_tools_dir}/.evergreen/auth_aws"
     expect_success "mongodb://localhost/?authMechanism=MONGODB-AWS"
   )
@@ -135,6 +139,7 @@ if [[ "${TESTCASE}" == "ASSUME_ROLE_WITH_WEB_IDENTITY" ]]; then
   pushd "${drivers_tools_dir}/.evergreen/auth_aws"
   # shellcheck source=/dev/null
   . aws_setup.sh web-identity # Sets AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE
+  : "${AWS_ROLE_ARN:?}" "${AWS_WEB_IDENTITY_TOKEN_FILE:?}"
   popd # "${drivers_tools_dir}/.evergreen/auth_aws"
 
   echo "Valid credentials via Web Identity - should succeed"

--- a/.evergreen/scripts/run-aws-tests.sh
+++ b/.evergreen/scripts/run-aws-tests.sh
@@ -17,6 +17,7 @@ set +o xtrace
 
 # shellcheck source=.evergreen/scripts/env-var-utils.sh
 . "$(dirname "${BASH_SOURCE[0]}")/env-var-utils.sh"
+# shellcheck source=.evergreen/scripts/use-tools.sh
 . "$(dirname "${BASH_SOURCE[0]}")/use-tools.sh" paths
 
 check_var_req TESTCASE
@@ -52,6 +53,7 @@ if [[ "${TESTCASE}" == "REGULAR" ]]; then
 
   # Create user on $external db.
   pushd "${drivers_tools_dir}/.evergreen/auth_aws"
+  # shellcheck source=/dev/null
   . aws_setup.sh regular # Sets USER and PASS
   popd # "${drivers_tools_dir}/.evergreen/auth_aws"
 
@@ -64,6 +66,7 @@ fi
 if [[ "${TESTCASE}" == "ASSUME_ROLE" ]]; then
   echo "===== Testing auth with session token via URI with AssumeRole ====="
   pushd "${drivers_tools_dir}/.evergreen/auth_aws"
+  # shellcheck source=/dev/null
   . aws_setup.sh assume-role # Sets USER, PASS, and SESSION_TOKEN
   popd # "${drivers_tools_dir}/.evergreen/auth_aws"
 
@@ -76,6 +79,7 @@ if [[ "LAMBDA" = "$TESTCASE" ]]; then
   echo "===== Testing auth via environment variables ====="
 
   pushd "${drivers_tools_dir}/.evergreen/auth_aws"
+  # shellcheck source=/dev/null
   . aws_setup.sh session-creds # Sets AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and SESSION_TOKEN
   popd # "${drivers_tools_dir}/.evergreen/auth_aws"
   expect_success "mongodb://localhost/?authMechanism=MONGODB-AWS"
@@ -87,6 +91,7 @@ if [[ "${TESTCASE}" == "EC2" ]]; then
   # Do necessary setup for EC2
   # Create user on $external db.
   pushd "${drivers_tools_dir}/.evergreen/auth_aws"
+  # shellcheck source=/dev/null
   . aws_setup.sh ec2
   popd # "${drivers_tools_dir}/.evergreen/auth_aws"
 
@@ -119,6 +124,7 @@ if [[ "${TESTCASE}" == "ASSUME_ROLE_WITH_WEB_IDENTITY" ]]; then
   # Do necessary setup.
   # Create user on $external db.
   pushd "${drivers_tools_dir}/.evergreen/auth_aws"
+  # shellcheck source=/dev/null
   . aws_setup.sh web-identity # Sets AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE
   popd # "${drivers_tools_dir}/.evergreen/auth_aws"
 

--- a/.evergreen/scripts/run-aws-tests.sh
+++ b/.evergreen/scripts/run-aws-tests.sh
@@ -140,37 +140,33 @@ if [[ "${TESTCASE}" == "ASSUME_ROLE_WITH_WEB_IDENTITY" ]]; then
   # Do necessary setup.
   # Create user on $external db.
   pushd "${drivers_tools_dir}/.evergreen/auth_aws"
-  mongo --verbose aws_e2e_web_identity.js
+  . aws_setup.sh web-identity # Sets AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE
   popd # "${drivers_tools_dir}/.evergreen/auth_aws"
 
-  declare iam_auth_assume_web_role_name iam_web_identity_token_file
-  iam_auth_assume_web_role_name="$(jq -r '.iam_auth_assume_web_role_name' "${drivers_tools_dir}/.evergreen/auth_aws/aws_e2e_setup.json")"
-  iam_web_identity_token_file="$(jq -r '.iam_web_identity_token_file' "${drivers_tools_dir}/.evergreen/auth_aws/aws_e2e_setup.json")"
-
   echo "Valid credentials via Web Identity - should succeed"
-  AWS_ROLE_ARN="${iam_auth_assume_web_role_name}" \
-  AWS_WEB_IDENTITY_TOKEN_FILE="${iam_web_identity_token_file}" \
+  AWS_ROLE_ARN="${AWS_ROLE_ARN}" \
+  AWS_WEB_IDENTITY_TOKEN_FILE="${AWS_WEB_IDENTITY_TOKEN_FILE}" \
     expect_success "mongodb://localhost/?authMechanism=MONGODB-AWS"
 
   echo "Valid credentials via Web Identity with session name - should succeed"
-  AWS_ROLE_ARN="${iam_auth_assume_web_role_name}" \
-  AWS_WEB_IDENTITY_TOKEN_FILE="${iam_web_identity_token_file}" \
+  AWS_ROLE_ARN="${AWS_ROLE_ARN}" \
+  AWS_WEB_IDENTITY_TOKEN_FILE="${AWS_WEB_IDENTITY_TOKEN_FILE}" \
   AWS_ROLE_SESSION_NAME=test \
     expect_success "mongodb://localhost/?authMechanism=MONGODB-AWS"
 
   echo "Invalid AWS_ROLE_ARN via Web Identity with session name - should fail"
   AWS_ROLE_ARN="invalid_role_arn" \
-  AWS_WEB_IDENTITY_TOKEN_FILE="${iam_web_identity_token_file}" \
+  AWS_WEB_IDENTITY_TOKEN_FILE="${AWS_WEB_IDENTITY_TOKEN_FILE}" \
     expect_failure "mongodb://localhost/?authMechanism=MONGODB-AWS"
 
   echo "Invalid AWS_WEB_IDENTITY_TOKEN_FILE via Web Identity with session name - should fail"
-  AWS_ROLE_ARN="${iam_auth_assume_web_role_name}" \
+  AWS_ROLE_ARN="${AWS_ROLE_ARN}" \
   AWS_WEB_IDENTITY_TOKEN_FILE="/invalid/path" \
     expect_failure "mongodb://localhost/?authMechanism=MONGODB-AWS"
 
   echo "Invalid AWS_ROLE_SESSION_NAME via Web Identity with session name - should fail"
-  AWS_ROLE_ARN="${iam_auth_assume_web_role_name}" \
-  AWS_WEB_IDENTITY_TOKEN_FILE="${iam_web_identity_token_file}" \
+  AWS_ROLE_ARN="${AWS_ROLE_ARN}" \
+  AWS_WEB_IDENTITY_TOKEN_FILE="${AWS_WEB_IDENTITY_TOKEN_FILE}" \
   AWS_ROLE_SESSION_NAME="contains_invalid_character_^" \
     expect_failure "mongodb://localhost/?authMechanism=MONGODB-AWS"
   exit

--- a/.evergreen/scripts/run-aws-tests.sh
+++ b/.evergreen/scripts/run-aws-tests.sh
@@ -50,20 +50,6 @@ expect_failure() {
   "${test_awsauth}" "${1:?}" "EXPECT_FAILURE" || exit
 }
 
-url_encode() {
-  declare encoded=""
-  for c in $(echo ${1:?} | grep -o .); do
-    case "${c}" in
-    [a-zA-Z0-9.~_-])
-      encoded="${encoded}${c}"
-      ;;
-    *)
-      encoded="${encoded}$(printf '%%%02X' "'${c}")"
-      ;;
-    esac
-  done
-  echo "${encoded}"
-}
 
 # Some of the setup scripts expect mongo to be on path.
 export PATH

--- a/.evergreen/scripts/run-aws-tests.sh
+++ b/.evergreen/scripts/run-aws-tests.sh
@@ -48,10 +48,6 @@ expect_failure() {
 }
 
 
-# Some of the setup scripts expect mongo to be on path.
-export PATH
-PATH+=":${mongodb_bin_dir}"
-
 if [[ "${TESTCASE}" == "REGULAR" ]]; then
   echo "===== Testing regular auth via URI ====="
 

--- a/.evergreen/scripts/run-aws-tests.sh
+++ b/.evergreen/scripts/run-aws-tests.sh
@@ -76,13 +76,22 @@ if [[ "${TESTCASE}" == "ASSUME_ROLE" ]]; then
 fi
 
 if [[ "LAMBDA" = "$TESTCASE" ]]; then
-  echo "===== Testing auth via environment variables ====="
-
-  pushd "${drivers_tools_dir}/.evergreen/auth_aws"
-  # shellcheck source=/dev/null
-  . aws_setup.sh session-creds # Sets AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and SESSION_TOKEN
-  popd # "${drivers_tools_dir}/.evergreen/auth_aws"
-  expect_success "mongodb://localhost/?authMechanism=MONGODB-AWS"
+  (
+    echo "===== Testing auth via environment variables without session token ====="
+    pushd "${drivers_tools_dir}/.evergreen/auth_aws"
+    # shellcheck source=/dev/null
+    . aws_setup.sh env-creds # Sets AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+    popd # "${drivers_tools_dir}/.evergreen/auth_aws"
+    expect_success "mongodb://localhost/?authMechanism=MONGODB-AWS"
+  )
+  (
+    echo "===== Testing auth via environment variables with session token ====="
+    pushd "${drivers_tools_dir}/.evergreen/auth_aws"
+    # shellcheck source=/dev/null
+    . aws_setup.sh session-creds # Sets AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and SESSION_TOKEN
+    popd # "${drivers_tools_dir}/.evergreen/auth_aws"
+    expect_success "mongodb://localhost/?authMechanism=MONGODB-AWS"
+  )
   exit
 fi
 

--- a/.evergreen/scripts/run-aws-tests.sh
+++ b/.evergreen/scripts/run-aws-tests.sh
@@ -74,15 +74,11 @@ if [[ "${TESTCASE}" == "REGULAR" ]]; then
 
   # Create user on $external db.
   pushd "${drivers_tools_dir}/.evergreen/auth_aws"
-  mongo --verbose aws_e2e_regular_aws.js
+  . aws_setup.sh regular # Sets USER and PASS
   popd # "${drivers_tools_dir}/.evergreen/auth_aws"
 
-  declare user_encoded pass_encoded
-  user_encoded="$(url_encode "${iam_auth_ecs_account:?}")"
-  pass_encoded="$(url_encode "${iam_auth_ecs_secret_access_key:?}")"
-
-  expect_success "mongodb://${user_encoded:?}:${pass_encoded:?}@localhost/?authMechanism=MONGODB-AWS"
-  expect_failure "mongodb://${user_encoded:?}:bad_password@localhost/?authMechanism=MONGODB-AWS"
+  expect_success "mongodb://${USER:?}:${PASS:?}@localhost/?authMechanism=MONGODB-AWS"
+  expect_failure "mongodb://${USER:?}:bad_password@localhost/?authMechanism=MONGODB-AWS"
 
   exit
 fi

--- a/.evergreen/scripts/run-aws-tests.sh
+++ b/.evergreen/scripts/run-aws-tests.sh
@@ -98,18 +98,8 @@ if [[ "LAMBDA" = "$TESTCASE" ]]; then
   echo "===== Testing auth via environment variables ====="
 
   pushd "${drivers_tools_dir}/.evergreen/auth_aws"
-  mongo --verbose aws_e2e_assume_role.js
+  . aws_setup.sh session-creds # Sets AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and SESSION_TOKEN
   popd # "${drivers_tools_dir}/.evergreen/auth_aws"
-
-  declare user pass token
-  user="$(jq -r '.AccessKeyId' "${drivers_tools_dir}/.evergreen/auth_aws/creds.json")"
-  pass="$(jq -r '.SecretAccessKey' "${drivers_tools_dir}/.evergreen/auth_aws/creds.json")"
-  token="$(jq -r '.SessionToken' "${drivers_tools_dir}/.evergreen/auth_aws/creds.json")"
-
-  echo "Valid credentials - should succeed:"
-  export AWS_ACCESS_KEY_ID="${user:?}"
-  export AWS_SECRET_ACCESS_KEY="${pass:?}"
-  export AWS_SESSION_TOKEN="${token:?}"
   expect_success "mongodb://localhost/?authMechanism=MONGODB-AWS"
   exit
 fi

--- a/.evergreen/scripts/run-aws-tests.sh
+++ b/.evergreen/scripts/run-aws-tests.sh
@@ -86,21 +86,11 @@ fi
 if [[ "${TESTCASE}" == "ASSUME_ROLE" ]]; then
   echo "===== Testing auth with session token via URI with AssumeRole ====="
   pushd "${drivers_tools_dir}/.evergreen/auth_aws"
-  mongo --verbose aws_e2e_assume_role.js
+  . aws_setup.sh assume-role # Sets USER, PASS, and SESSION_TOKEN
   popd # "${drivers_tools_dir}/.evergreen/auth_aws"
 
-  declare user pass token
-  user="$(jq -r '.AccessKeyId' "${drivers_tools_dir}/.evergreen/auth_aws/creds.json")"
-  pass="$(jq -r '.SecretAccessKey' "${drivers_tools_dir}/.evergreen/auth_aws/creds.json")"
-  token="$(jq -r '.SessionToken' "${drivers_tools_dir}/.evergreen/auth_aws/creds.json")"
-
-  declare user_encoded pass_encoded token_encoded
-  user_encoded="$(url_encode "${user:?}")"
-  pass_encoded="$(url_encode "${pass:?}")"
-  token_encoded="$(url_encode "${token:?}")"
-
-  expect_success "mongodb://${user_encoded}:${pass_encoded}@localhost/aws?authMechanism=MONGODB-AWS&authSource=\$external&authMechanismProperties=AWS_SESSION_TOKEN:${token_encoded}"
-  expect_failure "mongodb://${user_encoded}:${pass_encoded}@localhost/aws?authMechanism=MONGODB-AWS&authSource=\$external&authMechanismProperties=AWS_SESSION_TOKEN:bad_token"
+  expect_success "mongodb://${USER}:${PASS}@localhost/aws?authMechanism=MONGODB-AWS&authSource=\$external&authMechanismProperties=AWS_SESSION_TOKEN:${SESSION_TOKEN}"
+  expect_failure "mongodb://${USER}:${PASS}@localhost/aws?authMechanism=MONGODB-AWS&authSource=\$external&authMechanismProperties=AWS_SESSION_TOKEN:bad_token"
   exit
 fi
 

--- a/.evergreen/scripts/run-aws-tests.sh
+++ b/.evergreen/scripts/run-aws-tests.sh
@@ -7,10 +7,7 @@
 #
 # Example:
 # TESTCASE=EC2 run-aws-tests.sh
-#
-# Optional environment variables:
-# iam_auth_ecs_account and iam_auth_ecs_secret_access_key
-#   Set to access key id/secret access key. Required for some tests.
+
 
 set -o errexit
 set -o pipefail

--- a/.evergreen/scripts/run-aws-tests.sh
+++ b/.evergreen/scripts/run-aws-tests.sh
@@ -111,14 +111,12 @@ if [[ "${TESTCASE}" == "ECS" ]]; then
   ECS_SRC_DIR=${drivers_tools_dir}/.evergreen/auth_aws/src
   mkdir -p "${ECS_SRC_DIR}/.evergreen"
   # Move the test script to the correct location.
-  chmod 777 "${script_dir}/run-mongodb-aws-ecs-test.sh"
   cp "${script_dir}/run-mongodb-aws-ecs-test.sh" "${ECS_SRC_DIR}/.evergreen"
   # Move artifacts needed for test to $ECS_SRC_DIR
   cp "${mongoc_dir}/src/libmongoc/test-awsauth" "${ECS_SRC_DIR}/"
 
   # Run the test
   pushd "${drivers_tools_dir}/.evergreen/auth_aws"
-  chmod u+x ./aws_setup.sh
   PROJECT_DIRECTORY="$ECS_SRC_DIR" MONGODB_BINARIES=${mongoc_dir}/mongodb/bin ./aws_setup.sh ecs
   popd # "${drivers_tools_dir}/.evergreen/auth_aws"
   exit

--- a/.evergreen/scripts/run-aws-tests.sh
+++ b/.evergreen/scripts/run-aws-tests.sh
@@ -109,7 +109,7 @@ if [[ "${TESTCASE}" == "EC2" ]]; then
   # Do necessary setup for EC2
   # Create user on $external db.
   pushd "${drivers_tools_dir}/.evergreen/auth_aws"
-  mongo --verbose aws_e2e_ec2.js
+  . aws_setup.sh ec2
   popd # "${drivers_tools_dir}/.evergreen/auth_aws"
 
   echo "Valid credentials via EC2 - should succeed"

--- a/.evergreen/scripts/run-aws-tests.sh
+++ b/.evergreen/scripts/run-aws-tests.sh
@@ -91,8 +91,8 @@ if [[ "LAMBDA" = "$TESTCASE" ]]; then
     echo "===== Testing auth via environment variables with session token ====="
     pushd "${drivers_tools_dir}/.evergreen/auth_aws"
     # shellcheck source=/dev/null
-    . aws_setup.sh session-creds # Sets AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and SESSION_TOKEN
-    : "${AWS_ACCESS_KEY_ID:?}" "${AWS_SECRET_ACCESS_KEY:?}" "${SESSION_TOKEN:?}"
+    . aws_setup.sh session-creds # Sets AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_SESSION_TOKEN
+    : "${AWS_ACCESS_KEY_ID:?}" "${AWS_SECRET_ACCESS_KEY:?}" "${AWS_SESSION_TOKEN:?}"
     popd # "${drivers_tools_dir}/.evergreen/auth_aws"
     expect_success "mongodb://localhost/?authMechanism=MONGODB-AWS"
   )

--- a/.evergreen/scripts/run-aws-tests.sh
+++ b/.evergreen/scripts/run-aws-tests.sh
@@ -30,7 +30,6 @@ mongoc_dir="$(to_absolute "${script_dir}/../..")"
 declare drivers_tools_dir
 drivers_tools_dir="$(to_absolute "${mongoc_dir}/../drivers-evergreen-tools")"
 
-declare mongodb_bin_dir="${mongoc_dir}/mongodb/bin"
 declare test_awsauth="${mongoc_dir}/src/libmongoc/test-awsauth"
 
 if [[ "${OSTYPE}" == "cygwin" ]]; then

--- a/.evergreen/scripts/run-mongodb-aws-ecs-test.sh
+++ b/.evergreen/scripts/run-mongodb-aws-ecs-test.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 
-# ECS tests have paths /root/mongoc/
+# run-mongodb-aws-ecs-test.sh is intended to run on a remote ECS host.
+# For a description of ECS tests, see: https://github.com/mongodb-labs/drivers-evergreen-tools/tree/b01493d57e6716cb6385afaa4dc06330e4f33e01/.evergreen/auth_aws#ecs-test-process
+
+# ECS tests have paths /root/src
 
 echo "run-mongodb-aws-ecs-test.sh"
 
-
 expect_success() {
   echo "Should succeed:"
-  /root/mongoc/src/libmongoc/test-awsauth "${1:?}" "EXPECT_SUCCESS"
+  /root/src/test-awsauth "${1:?}" "EXPECT_SUCCESS"
 }
 
 expect_success "${1:?}"

--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,5 @@ x64
 dist
 
 # `secrets-export.sh` is created by the drivers-evergreen-tools `setup_secrets.sh` script.
+# Ignore this file to reduce risk of committing credentials during local development.
 secrets-export.sh

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ x64
 
 # "dist" is produced during the release process
 dist
+
+# `secrets-export.sh` is created by the drivers-evergreen-tools `setup_secrets.sh` script.
+secrets-export.sh

--- a/src/libmongoc/doc/tutorial.rst
+++ b/src/libmongoc/doc/tutorial.rst
@@ -20,9 +20,9 @@ To run the examples in this tutorial, MongoDB must be installed and running on `
 
 .. code-block:: none
 
-  $ mongo --host localhost --port 27017
-  MongoDB shell version: 3.0.6
-  connecting to: localhost:27017/test
+  $ mongosh --host localhost --port 27017 --quiet
+  Enterprise rs0 [direct: primary] test> db.version()
+  7.0.0
   >
 
 Include and link libmongoc in your C program


### PR DESCRIPTION
# Summary

This PR migrates AWS tests to use scripts from drivers-evergreen-tools added in DRIVERS-2328.

This removes use of the legacy `mongo` shell and resulted in passing the `.*aws.*` tasks. Verified by this patch build: https://spruce.mongodb.com/version/65a6e2ad0ae60677917cf830

I suggest reviewing individual commits.

## Additional changes

https://github.com/mongodb/mongo-c-driver/pull/1514/commits/072eace3a1d00a69d3c61158fbd38bd04125e114 migrates AWS tests using MongoDB 6.0+ to Ubuntu 22.04. This is intended to better follow [Guidelines around Evergreen distros](https://wiki.corp.mongodb.com/display/DBDEVPROD/Guidelines+around+Evergreen+distros):

> Prefer 22.04 when possible

https://github.com/mongodb/mongo-c-driver/pull/1514/commits/6840e85fae72a884cfbbd720ca8d0834765b172b enables tracing in `test-awsauth` intended to help diagnose future test failures. A spurious [test failure](https://spruce.mongodb.com/task/mongo_c_driver_aws_ubuntu2004_test_aws_openssl_lambda_6.0_patch_0da4704d32f80a9eac7d264f1fda2bd70ebe399d_65a167d0850e61bbdb91b2d6_24_01_12_16_24_51/logs?execution=0) was observed on the LAMBDA test case. I was unable to determine the cause.

ec6a689071f1c68717723ec3d0f9db58087120d9 adds a test case for `LAMBDA` to test without a session token. [The AWS test README](https://github.com/mongodb/specifications/blob/2176bbac035263d9397b585c5e70ac1a97359757/source/auth/tests/mongodb-aws.rst) describes two test cases in AWS Lambda:

> Sample URIs both with and without optional session tokens set are shown below. Drivers MUST test both cases.

# Additional background

The `aws_test_secrets_role` variable is now defined on https://spruce.mongodb.com/project/mongo-c-driver/settings/variables. [Using AWS Secrets Manager to Store Testing Secrets](https://wiki.corp.mongodb.com/display/DRIVERS/Using+AWS+Secrets+Manager+to+Store+Testing+Secrets) provides instructions for obtaining secrets.

[Configuration Scripts for End-to-end Testing](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/8e2f560511bbd0a532a84eef6528a12f01890143/.evergreen/auth_aws/README.md) describes the flow for running drivers AWS tests in Evergreen.

