### PR TITLE
CDRIVER-4512 do not use `execdir`

### DIFF
--- a/.evergreen/config_generator/components/funcs/fetch_det.py
+++ b/.evergreen/config_generator/components/funcs/fetch_det.py
@@ -21,7 +21,7 @@ class FetchDET(Function):
         bash_exec(
             command_type=EvgCommandType.SETUP,
             working_dir="drivers-evergreen-tools",
-            script='find .evergreen -type f -name "*.sh" -execdir chmod +rx "{}" \;',
+            script='find .evergreen -type f -name "*.sh" -exec chmod +rx "{}" \;',
         ),
 
         # python is used frequently enough by many tasks that it is worth

--- a/.evergreen/config_generator/components/funcs/fetch_det.py
+++ b/.evergreen/config_generator/components/funcs/fetch_det.py
@@ -21,11 +21,7 @@ class FetchDET(Function):
         bash_exec(
             command_type=EvgCommandType.SETUP,
             working_dir="drivers-evergreen-tools",
-            script='''\
-                for file in $(find .evergreen -type f -name "*.sh"); do
-                    chmod +rx "$file" || exit
-                done
-            '''
+            script='find .evergreen -type f -name "*.sh" -execdir chmod +rx "{}" \;',
         ),
 
         # python is used frequently enough by many tasks that it is worth

--- a/.evergreen/config_generator/components/funcs/fetch_det.py
+++ b/.evergreen/config_generator/components/funcs/fetch_det.py
@@ -21,7 +21,11 @@ class FetchDET(Function):
         bash_exec(
             command_type=EvgCommandType.SETUP,
             working_dir="drivers-evergreen-tools",
-            script='find .evergreen -type f -name "*.sh" -execdir chmod +rx "{}" \;',
+            script='''\
+                for file in $(find .evergreen -type f -name "*.sh"); do
+                    chmod +rx "$file" || exit
+                done
+            '''
         ),
 
         # python is used frequently enough by many tasks that it is worth

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -180,10 +180,7 @@ functions:
         working_dir: drivers-evergreen-tools
         args:
           - -c
-          - |
-            for file in $(find .evergreen -type f -name "*.sh"); do
-                chmod +rx "$file" || exit
-            done
+          - find .evergreen -type f -name "*.sh" -execdir chmod +rx "{}" \;
     - command: subprocess.exec
       type: setup
       params:

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -180,7 +180,10 @@ functions:
         working_dir: drivers-evergreen-tools
         args:
           - -c
-          - find .evergreen -type f -name "*.sh" -execdir chmod +rx "{}" \;
+          - |
+            for file in $(find .evergreen -type f -name "*.sh"); do
+                chmod +rx "$file" || exit
+            done
     - command: subprocess.exec
       type: setup
       params:

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -180,7 +180,7 @@ functions:
         working_dir: drivers-evergreen-tools
         args:
           - -c
-          - find .evergreen -type f -name "*.sh" -execdir chmod +rx "{}" \;
+          - find .evergreen -type f -name "*.sh" -exec chmod +rx "{}" \;
     - command: subprocess.exec
       type: setup
       params:


### PR DESCRIPTION
This is a follow-up to https://github.com/mongodb/mongo-c-driver/pull/1514 intended to resolve errors on some tasks running `find` with `-execdir`. [Example](https://spruce.mongodb.com/task/mongo_c_driver_cse_matrix_openssl_cse_sasl_cyrus_openssl_ubuntu2004_arm64_gcc_test_latest_server_auth_7f1a88b42a311e6db8edd4adafcce55aa3b8a094_24_01_17_13_28_12/logs?execution=0):

> [2024/01/17 08:36:31.247] find: The relative path '.local/bin' is included in the PATH environment variable, which is insecure in combination with the -execdir action of find.  Please remove that entry from $PATH

Verified with this patch build: https://spruce.mongodb.com/version/65a80624a4cf47738e04ec81
