### PR TITLE
CDRIVER-4771 use Docker image to run `mongohouse`

### DIFF
--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -14418,7 +14418,7 @@ buildvariants:
   - .test-aws .latest
 - name: mongohouse
   display_name: Mongohouse Test
-  run_on: ubuntu1804-test
+  run_on: ubuntu2204-small
   tasks:
   - debug-compile-sasl-openssl
   - test-mongohouse

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -223,18 +223,17 @@ functions:
         set -o errexit
         cd drivers-evergreen-tools
         export DRIVERS_TOOLS=$(pwd)
-        bash .evergreen/atlas_data_lake/build-mongohouse-local.sh
+        bash .evergreen/atlas_data_lake/pull-mongohouse-image.sh
   run mongohouse:
   - command: shell.exec
     type: test
     params:
-      background: true
       shell: bash
       script: |-
         set -o errexit
         cd drivers-evergreen-tools
         export DRIVERS_TOOLS=$(pwd)
-        bash .evergreen/atlas_data_lake/run-mongohouse-local.sh
+        bash .evergreen/atlas_data_lake/run-mongohouse-image.sh
   test mongohouse:
   - command: shell.exec
     type: test

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/functions.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/functions.py
@@ -162,15 +162,15 @@ all_functions = OD([
         shell_exec(r'''
         cd drivers-evergreen-tools
         export DRIVERS_TOOLS=$(pwd)
-        bash .evergreen/atlas_data_lake/build-mongohouse-local.sh
+        bash .evergreen/atlas_data_lake/pull-mongohouse-image.sh
         '''),
     )),
     ('run mongohouse', Function(
         shell_exec(r'''
         cd drivers-evergreen-tools
         export DRIVERS_TOOLS=$(pwd)
-        bash .evergreen/atlas_data_lake/run-mongohouse-local.sh
-        ''', background=True),
+        bash .evergreen/atlas_data_lake/run-mongohouse-image.sh
+        '''),
     )),
     ('test mongohouse', Function(
         shell_mongoc(r'''

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -446,7 +446,7 @@ all_variants = [
         ],
         {"CC": "clang"},
     ),
-    Variant("mongohouse", "Mongohouse Test", "ubuntu1804-test", ["debug-compile-sasl-openssl", "test-mongohouse"], {}),
+    Variant("mongohouse", "Mongohouse Test", "ubuntu2204-small", ["debug-compile-sasl-openssl", "test-mongohouse"], {}),
     Variant(
         "ocsp",
         "OCSP tests",


### PR DESCRIPTION
# Summary

Use mongohouse Docker image added in DRIVERS-2543 to fix `test-mongohouse` task.

Verified with this patch build: https://spruce.mongodb.com/version/65aa7f650ae6066158bd3dc1

# Background & Motivation

DRIVERS-2543 adds scripts to use the Docker image maintained by the Atlas Data Lake team.

The `run-mongohouse-local.sh` script currently fails to run. https://github.com/mongodb-labs/drivers-evergreen-tools/pull/392 proposes removing `run-mongohouse-local.sh` from drivers-evergreen-tools.