### PR TITLE
CDRIVER-4333 unskip `mongohouse` tests

### DIFF
--- a/.evergreen/etc/skip-tests.txt
+++ b/.evergreen/etc/skip-tests.txt
@@ -17,14 +17,6 @@
 # /skip/entire/test # this will be output by the runner as the skip reason
 # /skip/part/of/spec/test/"sub-test description" # this will also be output
 
-/mongohouse/aggregate # CDRIVER-4333
-/mongohouse/estimatedDocumentCount # CDRIVER-4333
-/mongohouse/find # CDRIVER-4333
-/mongohouse/getMore # CDRIVER-4333
-/mongohouse/listCollections # CDRIVER-4333
-/mongohouse/listDatabases # CDRIVER-4333
-/mongohouse/runCommand # CDRIVER-4333
-
 /change_stream/live/track_resume_token # (CDRIVER-4344) Condition 'bson_compare (resume_token, &doc2_rt) == 0' failed
 /ClientPool/pop_timeout # (CDRIVER-4348) precondition failed: duration_usec / 1000 >= 1990
 

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -258,9 +258,8 @@ functions:
         wait_for_mongohouse 27017 || exit
         echo "Waiting for mongohouse to start... done."
         pgrep -a "mongohouse"
-        export RUN_MONGOHOUSE_TESTS=true
+        export RUN_MONGOHOUSE_TESTS=ON
         ./src/libmongoc/test-libmongoc --no-fork -l /mongohouse/* -d --skip-tests .evergreen/etc/skip-tests.txt
-        unset RUN_MONGOHOUSE_TESTS
   run aws tests:
   - command: ec2.assume_role
     params:

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/functions.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/functions.py
@@ -190,9 +190,8 @@ all_functions = OD([
         wait_for_mongohouse 27017 || exit
         echo "Waiting for mongohouse to start... done."
         pgrep -a "mongohouse"
-        export RUN_MONGOHOUSE_TESTS=true
+        export RUN_MONGOHOUSE_TESTS=ON
         ./src/libmongoc/test-libmongoc --no-fork -l /mongohouse/* -d --skip-tests .evergreen/etc/skip-tests.txt
-        unset RUN_MONGOHOUSE_TESTS
         '''),
     )),
     ('run aws tests', Function(

--- a/src/libmongoc/tests/json-test.c
+++ b/src/libmongoc/tests/json-test.c
@@ -1338,6 +1338,11 @@ deactivate_fail_points (mongoc_client_t *client, uint32_t server_id)
 
    ASSERT (client);
 
+   if (test_framework_getenv_bool ("RUN_MONGOHOUSE_TESTS")) {
+      // mongohouse does not support failpoints.
+      return;
+   }
+
    if (server_id) {
       sd = mongoc_client_get_server_description (client, server_id);
       BSON_ASSERT (sd);

--- a/src/libmongoc/tests/json-test.c
+++ b/src/libmongoc/tests/json-test.c
@@ -1922,8 +1922,11 @@ run_json_general_test (const json_test_config_t *config)
 
       set_auto_encryption_opts (client, &test);
       /* Drop and recreate test database/collection if necessary. */
-      _recreate (db_name, collection_name, scenario);
-      _recreate (db2_name, collection2_name, scenario);
+      if (!test_framework_getenv_bool ("RUN_MONGOHOUSE_TESTS")) {
+         // mongohouse test user is not authorized to run `drop`.
+         _recreate (db_name, collection_name, scenario);
+         _recreate (db2_name, collection2_name, scenario);
+      }
       insert_data (db_name, collection_name, scenario);
 
       db = mongoc_client_get_database (client, db_name);

--- a/src/libmongoc/tests/json-test.c
+++ b/src/libmongoc/tests/json-test.c
@@ -1338,7 +1338,7 @@ deactivate_fail_points (mongoc_client_t *client, uint32_t server_id)
 
    ASSERT (client);
 
-   if (test_framework_getenv_bool ("RUN_MONGOHOUSE_TESTS")) {
+   if (test_framework_is_mongohouse ()) {
       // mongohouse does not support failpoints.
       return;
    }
@@ -1927,7 +1927,7 @@ run_json_general_test (const json_test_config_t *config)
 
       set_auto_encryption_opts (client, &test);
       /* Drop and recreate test database/collection if necessary. */
-      if (!test_framework_getenv_bool ("RUN_MONGOHOUSE_TESTS")) {
+      if (!test_framework_is_mongohouse ()) {
          // mongohouse test user is not authorized to run `drop`.
          _recreate (db_name, collection_name, scenario);
          _recreate (db2_name, collection2_name, scenario);

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -2240,10 +2240,16 @@ test_framework_skip_if_single (void)
    return (test_framework_is_mongos () || test_framework_is_replset ());
 }
 
+bool
+test_framework_is_mongohouse (void)
+{
+   return test_framework_getenv_bool ("RUN_MONGOHOUSE_TESTS");
+}
+
 int
 test_framework_skip_if_no_mongohouse (void)
 {
-   if (!getenv ("RUN_MONGOHOUSE_TESTS")) {
+   if (!test_framework_is_mongohouse ()) {
       return 0;
    }
    return 1;

--- a/src/libmongoc/tests/test-libmongoc.h
+++ b/src/libmongoc/tests/test-libmongoc.h
@@ -138,6 +138,11 @@ bool
 test_framework_is_mongos (void);
 bool
 test_framework_is_replset (void);
+// `test_framework_is_mongohouse` returns true if configured to test
+// mongohoused (used for Atlas Data Lake).
+// See: "Atlas Data Lake Tests" in the MongoDB Specifications.
+bool
+test_framework_is_mongohouse (void);
 bool
 test_framework_server_is_secondary (mongoc_client_t *client,
                                     uint32_t server_id);

--- a/src/libmongoc/tests/test-mongoc-mongohouse.c
+++ b/src/libmongoc/tests/test-mongoc-mongohouse.c
@@ -221,6 +221,7 @@ test_mongohouse_kill_cursors (void *ctx_unused)
    mongoc_apm_set_command_started_cb (callbacks, cmd_started_cb);
    mongoc_apm_set_command_succeeded_cb (callbacks, cmd_succeeded_cb);
    mongoc_client_set_apm_callbacks (client, callbacks, (void *) &test);
+   mongoc_apm_callbacks_destroy (callbacks);
 
    coll = mongoc_client_get_collection (client, "test", "driverdata");
 


### PR DESCRIPTION
# Summary

This PR adds test runner behavior changes specific to `mongohoused` to unskip the the tests described in CDRIVER-4333.

- Skip running `configureFailPoint` if testing with `mongohoused`
- Skip running `drop` if testing with `mongohoused`

Verified with this patch build: https://spruce.mongodb.com/version/65ae70cb850e61cdd0af2591

# Background & Motivation

Tests were run with a local instance of `mongohoused`. Instructions to run `mongohoused` are described in the drivers-evergreen-tools [Atlas Data Lake Testing README](https://github.com/mongodb-labs/drivers-evergreen-tools/tree/95ad5f3708b2ecb8cfcbc9005743ea92e9f81027/.evergreen/atlas_data_lake).


Running `configureFailPoint` command results in this error:
```
Begin /mongohouse/aggregate, seed 976155304
FAIL:/Users/kevin.albertson/code/tasks/mongo-c-driver-CDRIVER-4333/src/libmongoc/tests/json-test.c:1376  deactivate_fail_points()
  r
  command configureFailPoint not found, correlationID = 17abdb65525cb53817152df6
```
The `configureFailPoint` is run by the test runner as a precaution to deactivate previously set fail points. The mongohouse tests do not activate fail points.


Running `drop` results in this error:
```
FAIL:/Users/kevin.albertson/code/tasks/mongo-c-driver-CDRIVER-4333/src/libmongoc/tests/json-test.c:1014  _recreate()
  error.code == 26
  not authorized: missing privilege for action storageSetConfig on resource __cluster__, correlationID = 17abdc13f48c92a717152e4f
```
The [Atlas Data Lake Testing specification](https://github.com/mongodb/specifications/tree/c5771dce88eed54386690039f76142e1d741d83f/source/atlas-data-lake-testing/tests) notes:
> the test runner for Atlas Data Lake Testing MUST NOT drop the collection and/or database under test.