### PR TITLE
Allow ccache to reuse results across build directories

### DIFF
--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -926,6 +926,12 @@ aws_compile_task = NamedTask(
             export distro_id='${distro_id}' # Required by find_cmake_latest.
             . .evergreen/scripts/find-cmake-latest.sh
             cmake_binary="$(find_cmake_latest)"
+
+            # Allow reuse of ccache compilation results between different build directories.
+            export CCACHE_BASEDIR CCACHE_NOHASHDIR
+            CCACHE_BASEDIR="$(pwd)"
+            CCACHE_NOHASHDIR=1
+
             # Compile test-awsauth. Disable unnecessary dependencies since test-awsauth is copied to a remote Ubuntu 20.04 ECS cluster for testing, which may not have all dependent libraries.
             export CC='${CC}'
             "$cmake_binary" -DENABLE_TRACING=ON -DENABLE_SASL=OFF -DENABLE_SNAPPY=OFF -DENABLE_ZSTD=OFF -DENABLE_CLIENT_SIDE_ENCRYPTION=OFF .

--- a/.evergreen/scripts/compile-openssl-static.sh
+++ b/.evergreen/scripts/compile-openssl-static.sh
@@ -109,5 +109,10 @@ if [[ "${OSTYPE}" == darwin* ]]; then
   }
 fi
 
+# Allow reuse of ccache compilation results between different build directories.
+export CCACHE_BASEDIR CCACHE_NOHASHDIR
+CCACHE_BASEDIR="$(pwd)"
+CCACHE_NOHASHDIR=1
+
 "${CMAKE}" "${configure_flags[@]}" .
 "${CMAKE}" --build . -- -j "$(nproc)"

--- a/.evergreen/scripts/compile-scan-build.sh
+++ b/.evergreen/scripts/compile-scan-build.sh
@@ -148,6 +148,11 @@ for dir in "${scan_build_directories[@]}"; do
 done
 : "${scan_build_binary:?"could not find a scan-build binary!"}"
 
+# Allow reuse of ccache compilation results between different build directories.
+export CCACHE_BASEDIR CCACHE_NOHASHDIR
+CCACHE_BASEDIR="$(pwd)"
+CCACHE_NOHASHDIR=1
+
 "${scan_build_binary}" --use-cc="${CC}" --use-c++="${CXX}" "${cmake_binary}" "${configure_flags[@]}" .
 
 if [[ "${OSTYPE}" == darwin* ]]; then

--- a/.evergreen/scripts/compile-std.sh
+++ b/.evergreen/scripts/compile-std.sh
@@ -134,5 +134,10 @@ echo "Installing libmongocrypt... done."
 echo "CFLAGS: ${CFLAGS}"
 echo "configure_flags: ${configure_flags[*]}"
 
+# Allow reuse of ccache compilation results between different build directories.
+export CCACHE_BASEDIR CCACHE_NOHASHDIR
+CCACHE_BASEDIR="$(pwd)"
+CCACHE_NOHASHDIR=1
+
 "${cmake_binary}" "${configure_flags[@]}" .
 "${cmake_binary}" --build .

--- a/.evergreen/scripts/compile-test-azurekms.sh
+++ b/.evergreen/scripts/compile-test-azurekms.sh
@@ -16,6 +16,11 @@ echo "Installing libmongocrypt ... begin"
 }
 echo "Installing libmongocrypt ... end"
 
+# Allow reuse of ccache compilation results between different build directories.
+export CCACHE_BASEDIR CCACHE_NOHASHDIR
+CCACHE_BASEDIR="$(pwd)"
+CCACHE_NOHASHDIR=1
+
 echo "Compile test-azurekms ... begin"
 # Disable unnecessary dependencies. test-azurekms is copied to a remote host for testing, which may not have all dependent libraries.
 "${cmake_binary}" \

--- a/.evergreen/scripts/compile-test-gcpkms.sh
+++ b/.evergreen/scripts/compile-test-gcpkms.sh
@@ -16,6 +16,11 @@ echo "Installing libmongocrypt ... begin"
 }
 echo "Installing libmongocrypt ... end"
 
+# Allow reuse of ccache compilation results between different build directories.
+export CCACHE_BASEDIR CCACHE_NOHASHDIR
+CCACHE_BASEDIR="$(pwd)"
+CCACHE_NOHASHDIR=1
+
 echo "Compile test-gcpkms ... begin"
 # Disable unnecessary dependencies. test-gcpkms is copied to a remote host for testing, which may not have all dependent libraries.
 "${cmake_binary}" \

--- a/.evergreen/scripts/compile-unix.sh
+++ b/.evergreen/scripts/compile-unix.sh
@@ -202,6 +202,11 @@ else
   configure_flags_append "-DENABLE_CLIENT_SIDE_ENCRYPTION=OFF"
 fi
 
+# Allow reuse of ccache compilation results between different build directories.
+export CCACHE_BASEDIR CCACHE_NOHASHDIR
+CCACHE_BASEDIR="$(pwd)"
+CCACHE_NOHASHDIR=1
+
 "${cmake_binary}" "${configure_flags[@]}" ${extra_configure_flags[@]+"${extra_configure_flags[@]}"} .
 "${cmake_binary}" --build . -- -j "$(nproc)"
 "${cmake_binary}" --build . --target install

--- a/.evergreen/scripts/install-uninstall-check.sh
+++ b/.evergreen/scripts/install-uninstall-check.sh
@@ -47,6 +47,10 @@ else
   BSON_ONLY_OPTION="-DENABLE_MONGOC=ON"
 fi
 
+# Allow reuse of ccache compilation results between different build directories.
+export CCACHE_BASEDIR CCACHE_NOHASHDIR
+CCACHE_BASEDIR="$SCRATCH_DIR"
+CCACHE_NOHASHDIR=1
 
 $CMAKE -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX -DCMAKE_PREFIX_PATH=$INSTALL_DIR/lib/cmake $BSON_ONLY_OPTION "$SCRATCH_DIR"
 $CMAKE --build .
@@ -201,4 +205,3 @@ if test -d $INSTALL_DIR/share/mongo-c-driver; then
 else
   echo "$INSTALL_DIR/share/mongo-c-driver check ok"
 fi
-

--- a/.evergreen/scripts/link-sample-program-bson.sh
+++ b/.evergreen/scripts/link-sample-program-bson.sh
@@ -44,6 +44,11 @@ mkdir -p $INSTALL_DIR
 
 cd $BUILD_DIR
 
+# Allow reuse of ccache compilation results between different build directories.
+export CCACHE_BASEDIR CCACHE_NOHASHDIR
+CCACHE_BASEDIR="$SCRATCH_DIR"
+CCACHE_NOHASHDIR=1
+
 if [ "$LINK_STATIC" ]; then
   # Our CMake system builds shared and static by default.
   $CMAKE -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DENABLE_TESTS=OFF "$SCRATCH_DIR"
@@ -70,6 +75,9 @@ else
   fi
 
 fi
+
+# Revert ccache options, they no longer apply.
+unset CCACHE_BASEDIR CCACHE_NOHASHDIR
 
 ls -l $INSTALL_DIR/lib
 

--- a/.evergreen/scripts/link-sample-program.sh
+++ b/.evergreen/scripts/link-sample-program.sh
@@ -72,9 +72,17 @@ fi
 
 ZSTD="AUTO"
 
+# Allow reuse of ccache compilation results between different build directories.
+export CCACHE_BASEDIR CCACHE_NOHASHDIR
+CCACHE_BASEDIR="$SCRATCH_DIR"
+CCACHE_NOHASHDIR=1
+
 $CMAKE -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DCMAKE_PREFIX_PATH=$INSTALL_DIR/lib/cmake $SSL_CMAKE_OPTION $SNAPPY_CMAKE_OPTION $STATIC_CMAKE_OPTION -DENABLE_ZSTD=$ZSTD "$SCRATCH_DIR"
 $CMAKE --build . --parallel
 $CMAKE --build . --parallel --target install
+
+# Revert ccache options, they no longer apply.
+unset CCACHE_BASEDIR CCACHE_NOHASHDIR
 
 ls -l $INSTALL_DIR/lib
 


### PR DESCRIPTION
This PR proposes adding environment variables instructing ccache to allow reuse of compilation results across different build directories. Verified by [this patch](https://spruce.mongodb.com/version/65b15576850e6198196c6533) (the unexpected task failures seem unrelated to this PR).

This is motivated by the realization that Evergreen tasks are typically executed under a working directory of the form `/data/mci/<hash>`, where `<hash>` is used to avoid conflicts between tasks running on the given host. Unfortunately this is also preventing ccache from reusing compilation results as intended.

Per [ccache documentation](https://ccache.dev/manual/4.9.html) under "Compiling in different directories":

> ... if you compile the same code in different locations, you can’t share compilation results between the different build directories since you get cache misses because of the absolute build directory paths that are part of the hash.

The presence of `<hash>` in the absolute paths means every execution of a task will fail to reuse cached compilation results on the given host... or even re-execution of the same task on the same host, as `<hash>` is apparently computed using a combination of task ID, execution number, and PID. A proper solution would probably also involve a [remote storage backend](https://ccache.dev/manual/4.9.html#_remote_storage_backends) (so that cached results can be reused across _hosts_ as well), but I have not explored how to go about supporting such a setup yet. Instead, this PR applies the instructions given "to enable cache hits between different build directories":

> - If you build with `-g` (or similar) to add debug information to the object file, you must [...] set `hash_dir = false`.
> - If you use absolute paths anywhere on the command line [...] you must set `base_dir` to an absolute path to a “base directory”. Ccache will then rewrite absolute paths under that directory to relative before computing the hash.

This PR applies both suggestions using the environment variables `CCACHE_BASEDIR` and `CCACHE_NOHASHDIR`. These are only added to scripts that are expected to be executed on non-Windows-like distros (our Windows tasks don't appear to be using ccache anyways). The scope of the env vars are deliberately such that they (generally) only apply to _our_ builds (positioned immediately before CMake configure commands run on the C Driver, which also identifies the directory to use as `base_dir`, and unset as necessary to avoid impacting unrelated builds).

I've elected to use the path to the _CMake source directory_ (as identified by the CMake configure command) as `base_dir`, since (I believe) paths to _source files_ (including header files and include directories) are primarily what impact the ccache hash, and these should be consistent regardless of the location of the source directory to maximize cache hits. Incidentally, for many tasks in the C Driver, this is equivalent to the binary directory (meaning they are in-source builds, which we should probably change to be out-of-source builds at some point...).

I do not expect these changes to lead to problems with cache reuse on Evergreen hosts. The hash still includes many toolchain and configuration details which in aggregate are unlikely to lead to undesirable conflicts. Concerning `base_dir`, ccache warns:

> It works OK in many cases, but there might be cases where things break. One known issue is that absolute paths are not reproduced in dependency files, which can mess up dependency detection in tools like Make and Ninja.

This is probably not a concern for our EVG tasks, which are always(?) doing a clean build, thus even if dependency detection is flawed, so long as the required artifacts are still built, it should not be an issue. Similarly, concerning `hash_dir`:

> The reason for including the CWD in the hash by default is to prevent a problem with the storage of the current working directory in the debug info of an object file, which can lead ccache to return a cached object file that has the working directory in the debug info set incorrectly. You can disable this option to get cache hits when compiling the same source code in different directories if you don’t mind that CWD in the debug info might be incorrect.

I do not think we will mind the `<hash>` in `/data/mci/<hash>` being different in debug info so long as the relative paths to actual source and binary files remains consistent and understandable, which should be the case given the other information that are still included in the ccache hash (preprocessor output, preprocessor and compiler options, input source file, etc.).