### PR TITLE
Update EVG config with ccache updates

### DIFF
--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -1784,6 +1784,10 @@ tasks:
         export distro_id='${distro_id}' # Required by find_cmake_latest.
         . .evergreen/scripts/find-cmake-latest.sh
         cmake_binary="$(find_cmake_latest)"
+        # Allow reuse of ccache compilation results between different build directories.
+        export CCACHE_BASEDIR CCACHE_NOHASHDIR
+        CCACHE_BASEDIR="$(pwd)"
+        CCACHE_NOHASHDIR=1
         # Compile test-awsauth. Disable unnecessary dependencies since test-awsauth is copied to a remote Ubuntu 20.04 ECS cluster for testing, which may not have all dependent libraries.
         export CC='${CC}'
         "$cmake_binary" -DENABLE_TRACING=ON -DENABLE_SASL=OFF -DENABLE_SNAPPY=OFF -DENABLE_ZSTD=OFF -DENABLE_CLIENT_SIDE_ENCRYPTION=OFF .


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1522. Missed config generation step.