### PR TITLE
CDRIVER-4816 Error parsing large IPv6 literal

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-host-list.c
+++ b/src/libmongoc/src/mongoc/mongoc-host-list.c
@@ -1,7 +1,7 @@
 /*
  * Copyright 2015 MongoDB Inc.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
+ *
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include <inttypes.h> // PRIu16
 
 #include "mongoc-host-list-private.h"
 /* strcasecmp on windows */

--- a/src/libmongoc/src/mongoc/mongoc-host-list.c
+++ b/src/libmongoc/src/mongoc/mongoc-host-list.c
@@ -358,7 +358,7 @@ _mongoc_host_list_from_hostport_with_err (mongoc_host_list_t *link_,
       mongoc_lowercase (link_->host, link_->host);
       int req = bson_snprintf (link_->host_and_port,
                                sizeof link_->host_and_port,
-                               "[%s]:%hu",
+                               "[%s]:%" PRIu16,
                                link_->host,
                                link_->port);
       BSON_ASSERT (bson_in_range_size_t_signed (req));
@@ -374,7 +374,7 @@ _mongoc_host_list_from_hostport_with_err (mongoc_host_list_t *link_,
       mongoc_lowercase (link_->host, link_->host);
       int req = bson_snprintf (link_->host_and_port,
                                sizeof link_->host_and_port,
-                               "%s:%hu",
+                               "%s:%" PRIu16,
                                link_->host,
                                link_->port);
       BSON_ASSERT (bson_in_range_size_t_signed (req));

--- a/src/libmongoc/src/mongoc/mongoc-host-list.c
+++ b/src/libmongoc/src/mongoc/mongoc-host-list.c
@@ -343,6 +343,18 @@ _mongoc_host_list_from_hostport_with_err (mongoc_host_list_t *link_,
    if (strchr (host, ':')) {
       link_->family = AF_INET6;
 
+      // Check that IPv6 literal is two less than the max to account for `[` and
+      // `]` added below.
+      if (host_len > BSON_HOST_NAME_MAX - 2) {
+         bson_set_error (
+            error,
+            MONGOC_ERROR_STREAM,
+            MONGOC_ERROR_STREAM_NAME_RESOLUTION,
+            "IPv6 literal provided in URI is too long, max is %d chars",
+            BSON_HOST_NAME_MAX - 2);
+         return false;
+      }
+
       mongoc_lowercase (link_->host, link_->host);
       bson_snprintf (link_->host_and_port,
                      sizeof link_->host_and_port,

--- a/src/libmongoc/src/mongoc/mongoc-host-list.c
+++ b/src/libmongoc/src/mongoc/mongoc-host-list.c
@@ -356,12 +356,14 @@ _mongoc_host_list_from_hostport_with_err (mongoc_host_list_t *link_,
       }
 
       mongoc_lowercase (link_->host, link_->host);
-      bson_snprintf (link_->host_and_port,
-                     sizeof link_->host_and_port,
-                     "[%s]:%hu",
-                     link_->host,
-                     link_->port);
-
+      int req = bson_snprintf (link_->host_and_port,
+                               sizeof link_->host_and_port,
+                               "[%s]:%hu",
+                               link_->host,
+                               link_->port);
+      BSON_ASSERT (bson_in_range_size_t_signed (req));
+      // Use `<`, not `<=` to account for NULL byte.
+      BSON_ASSERT ((size_t) req < sizeof link_->host_and_port);
    } else if (strchr (host, '/') && strstr (host, ".sock")) {
       link_->family = AF_UNIX;
       bson_strncpy (link_->host_and_port, link_->host, host_len + 1);
@@ -370,11 +372,14 @@ _mongoc_host_list_from_hostport_with_err (mongoc_host_list_t *link_,
       link_->family = AF_UNSPEC;
 
       mongoc_lowercase (link_->host, link_->host);
-      bson_snprintf (link_->host_and_port,
-                     sizeof link_->host_and_port,
-                     "%s:%hu",
-                     link_->host,
-                     link_->port);
+      int req = bson_snprintf (link_->host_and_port,
+                               sizeof link_->host_and_port,
+                               "%s:%hu",
+                               link_->host,
+                               link_->port);
+      BSON_ASSERT (bson_in_range_size_t_signed (req));
+      // Use `<`, not `<=` to account for NULL byte.
+      BSON_ASSERT ((size_t) req < sizeof link_->host_and_port);
    }
 
    link_->next = NULL;

--- a/src/libmongoc/tests/test-mongoc-uri.c
+++ b/src/libmongoc/tests/test-mongoc-uri.c
@@ -2740,6 +2740,60 @@ test_casing_options (void)
    mongoc_uri_destroy (uri);
 }
 
+static void
+test_parses_long_ipv6 (void)
+{
+   // Test parsing long malformed IPv6 literals. This is a regression test for
+   // CDRIVER-4816.
+   bson_error_t error;
+
+   // Test the largest permitted IPv6 literal.
+   {
+      // Construct a string of repeating `:`.
+      bson_string_t *host = bson_string_new (NULL);
+      for (int i = 0; i < BSON_HOST_NAME_MAX - 2; i++) {
+         // Max IPv6 literal is two less due to including `[` and `]`.
+         bson_string_append (host, ":");
+      }
+
+      char *host_and_port = bson_strdup_printf ("[%s]:27017", host->str);
+      char *uri_string = bson_strdup_printf ("mongodb://%s", host_and_port);
+      mongoc_uri_t *uri = mongoc_uri_new_with_error (uri_string, &error);
+      ASSERT_OR_PRINT (uri, error);
+      const mongoc_host_list_t *hosts = mongoc_uri_get_hosts (uri);
+      ASSERT_CMPSTR (hosts->host, host->str);
+      ASSERT_CMPSTR (hosts->host_and_port, host_and_port);
+      ASSERT_CMPUINT16 (hosts->port, ==, 27017);
+      ASSERT (!hosts->next);
+
+      mongoc_uri_destroy (uri);
+      bson_free (uri_string);
+      bson_free (host_and_port);
+      bson_string_free (host, true /* free_segment */);
+   }
+
+   // Test one character more than the largest IPv6 literal.
+   {
+      // Construct a string of repeating `:`.
+      bson_string_t *host = bson_string_new (NULL);
+      for (int i = 0; i < BSON_HOST_NAME_MAX - 2 + 1; i++) {
+         bson_string_append (host, ":");
+      }
+
+      char *host_and_port = bson_strdup_printf ("[%s]:27017", host->str);
+      char *uri_string = bson_strdup_printf ("mongodb://%s", host_and_port);
+      mongoc_uri_t *uri = mongoc_uri_new_with_error (uri_string, &error);
+
+      // Expect an error.
+      ASSERT (!uri); // Bug: No error occurs.
+
+      mongoc_uri_destroy (uri);
+      bson_free (uri_string);
+      bson_free (host_and_port);
+      bson_string_free (host, true /* free_segment */);
+   }
+}
+
 void
 test_uri_install (TestSuite *suite)
 {
@@ -2774,4 +2828,5 @@ test_uri_install (TestSuite *suite)
                   "/Uri/one_tls_option_enables_tls",
                   test_one_tls_option_enables_tls);
    TestSuite_Add (suite, "/Uri/options_casing", test_casing_options);
+   TestSuite_Add (suite, "/Uri/parses_long_ipv6", test_parses_long_ipv6);
 }


### PR DESCRIPTION
# Summary

Error parsing IPv6 literals exceeding `BSON_HOST_NAME_MAX - 2` bytes.

Tested with this patch build: https://spruce.mongodb.com/version/65b91a525623434922184fa6. Test failures appear to be unrelated.

# Background & Motivation

See CDRIVER-4816.

Assertions are added to the return values of `bson_snprintf` in `_mongoc_host_list_from_hostport_with_err` to ensure the destination has enough capacity. CDRIVER-4820 was filed to check other calls to `bson_snprintf` in the codebase.

# Rejected alternatives

Increasing the size of `mongoc_host_list_t::host_and_port` was briefly considered, but decided against due to `mongoc_host_list_t` being included in the [public API](https://mongoc.org/libmongoc/current/mongoc_host_list_t.html). Changing the size is an ABI breaking change.