### PR TITLE
fix name of Alpine package

### DIFF
--- a/src/libmongoc/doc/ref/packages.rst
+++ b/src/libmongoc/doc/ref/packages.rst
@@ -63,7 +63,7 @@ This table details the names and usage notes of such packages.
   - - :index:`APK <!pair: APK; package names>`
     - :index:`Alpine Linux <!pair: Alpine Linux; package names>`
     - ``libbson``, ``libbson-dev``, ``libbson-static``
-    - ``libmongoc``, ``libmongoc-dev``, ``libmongoc-static``
+    - ``mongo-c-driver``, ``mongo-c-driver-dev``, ``mongo-c-driver-static``
     - .. empty cell
 
   - - :index:`pacman <!pair: package names; pacman>`


### PR DESCRIPTION
To match name and Sub Packages listed here: https://pkgs.alpinelinux.org/package/edge/community/armhf/mongo-c-driver

Can be tested with:
```bash
docker run --rm -it alpine:3.19 
/ # apk add mongo-c-driver
```

Discovered when auditing dependencies as part of CDRIVER-4818.