### PR TITLE
CDRIVER-4099 Support mongos redirection during retryable operations

### DIFF
--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -1039,6 +1039,7 @@ set (test-libmongoc-sources
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-read-concern.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-read-prefs.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-read-write-concern.c
+   ${PROJECT_SOURCE_DIR}/tests/test-mongoc-retryability-helpers.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-retryable-reads.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-retryable-writes.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-sample-commands.c

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -566,6 +566,7 @@ set (SOURCES ${SOURCES}
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-cursor-array.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-database.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-error.c
+   ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-deprioritized-servers.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-flags.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-find-and-modify.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-generation-map.c

--- a/src/libmongoc/src/mongoc/mongoc-bulk-operation.c
+++ b/src/libmongoc/src/mongoc/mongoc-bulk-operation.c
@@ -816,7 +816,7 @@ mongoc_bulk_operation_execute (mongoc_bulk_operation_t *bulk, /* IN */
                                               error);
       } else {
          server_stream = mongoc_cluster_stream_for_writes (
-            cluster, bulk->session, reply, error);
+            cluster, bulk->session, NULL, reply, error);
       }
 
       if (!server_stream) {

--- a/src/libmongoc/src/mongoc/mongoc-change-stream.c
+++ b/src/libmongoc/src/mongoc/mongoc-change-stream.c
@@ -288,8 +288,12 @@ _make_cursor (mongoc_change_stream_t *stream)
       goto cleanup;
    }
 
-   server_stream = mongoc_cluster_stream_for_reads (
-      &stream->client->cluster, stream->read_prefs, cs, &reply, &stream->err);
+   server_stream = mongoc_cluster_stream_for_reads (&stream->client->cluster,
+                                                    stream->read_prefs,
+                                                    cs,
+                                                    NULL,
+                                                    &reply,
+                                                    &stream->err);
    if (!server_stream) {
       bson_destroy (&stream->err_doc);
       bson_copy_to (&reply, &stream->err_doc);

--- a/src/libmongoc/src/mongoc/mongoc-client-session.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-session.c
@@ -1104,8 +1104,12 @@ mongoc_client_session_start_transaction (mongoc_client_session_t *session,
    BSON_ASSERT (session);
 
    ret = true;
-   server_stream = mongoc_cluster_stream_for_writes (
-      &session->client->cluster, session, NULL /* reply */, error);
+   server_stream =
+      mongoc_cluster_stream_for_writes (&session->client->cluster,
+                                        session,
+                                        NULL /* deprioritized servers */,
+                                        NULL /* reply */,
+                                        error);
    if (!server_stream) {
       ret = false;
       GOTO (done);

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -1730,12 +1730,29 @@ retry:
       /* each write command may be retried at most once */
       is_retryable = false;
 
-      if (retry_server_stream) {
-         mongoc_server_stream_cleanup (retry_server_stream);
-      }
+      {
+         mongoc_deprioritized_servers_t *const ds =
+            mongoc_deprioritized_servers_new ();
 
-      retry_server_stream = mongoc_cluster_stream_for_writes (
-         &client->cluster, parts->assembled.session, NULL, &ignored_error);
+         if (retry_server_stream) {
+            mongoc_deprioritized_servers_add_if_sharded (
+               ds, retry_server_stream->topology_type, server_stream->sd);
+
+            mongoc_server_stream_cleanup (retry_server_stream);
+         } else {
+            mongoc_deprioritized_servers_add_if_sharded (
+               ds, server_stream->topology_type, server_stream->sd);
+         }
+
+         retry_server_stream =
+            mongoc_cluster_stream_for_writes (&client->cluster,
+                                              parts->assembled.session,
+                                              ds,
+                                              NULL,
+                                              &ignored_error);
+
+         mongoc_deprioritized_servers_destroy (ds);
+      }
 
       if (retry_server_stream) {
          parts->assembled.server_stream = retry_server_stream;
@@ -1820,16 +1837,29 @@ retry:
       /* each read command may be retried at most once */
       is_retryable = false;
 
-      if (retry_server_stream) {
-         mongoc_server_stream_cleanup (retry_server_stream);
-      }
+      {
+         mongoc_deprioritized_servers_t *const ds =
+            mongoc_deprioritized_servers_new ();
 
-      retry_server_stream =
-         mongoc_cluster_stream_for_reads (&client->cluster,
-                                          parts->read_prefs,
-                                          parts->assembled.session,
-                                          NULL,
-                                          &ignored_error);
+         if (retry_server_stream) {
+            mongoc_deprioritized_servers_add_if_sharded (
+               ds, retry_server_stream->topology_type, retry_server_stream->sd);
+            mongoc_server_stream_cleanup (retry_server_stream);
+         } else {
+            mongoc_deprioritized_servers_add_if_sharded (
+               ds, server_stream->topology_type, server_stream->sd);
+         }
+
+         retry_server_stream =
+            mongoc_cluster_stream_for_reads (&client->cluster,
+                                             parts->read_prefs,
+                                             parts->assembled.session,
+                                             ds,
+                                             NULL,
+                                             &ignored_error);
+
+         mongoc_deprioritized_servers_destroy (ds);
+      }
 
       if (retry_server_stream) {
          parts->assembled.server_stream = retry_server_stream;
@@ -1918,8 +1948,8 @@ mongoc_client_command_simple (mongoc_client_t *client,
     * configuration. The generic command method SHOULD allow an optional read
     * preference argument."
     */
-   server_stream =
-      mongoc_cluster_stream_for_reads (cluster, read_prefs, NULL, reply, error);
+   server_stream = mongoc_cluster_stream_for_reads (
+      cluster, read_prefs, NULL, NULL, reply, error);
 
    if (server_stream) {
       ret = _mongoc_client_command_with_stream (
@@ -2074,10 +2104,10 @@ _mongoc_client_command_with_opts (mongoc_client_t *client,
       }
    } else if (parts.is_write_command) {
       server_stream =
-         mongoc_cluster_stream_for_writes (cluster, cs, reply_ptr, error);
+         mongoc_cluster_stream_for_writes (cluster, cs, NULL, reply_ptr, error);
    } else {
-      server_stream =
-         mongoc_cluster_stream_for_reads (cluster, prefs, cs, reply_ptr, error);
+      server_stream = mongoc_cluster_stream_for_reads (
+         cluster, prefs, cs, NULL, reply_ptr, error);
    }
 
    if (!server_stream) {
@@ -2622,6 +2652,7 @@ mongoc_client_kill_cursor (mongoc_client_t *client, int64_t cursor_id)
                                           MONGOC_SS_WRITE,
                                           read_prefs,
                                           NULL /* chosen read mode */,
+                                          NULL /* deprioritized servers */,
                                           topology->local_threshold_msec);
 
    if (selected_server) {
@@ -3060,8 +3091,13 @@ _mongoc_client_end_sessions (mongoc_client_t *client)
 
    while (!mongoc_server_session_pool_is_empty (t->session_pool)) {
       prefs = mongoc_read_prefs_new (MONGOC_READ_PRIMARY_PREFERRED);
-      server_id = mongoc_topology_select_server_id (
-         t, MONGOC_SS_READ, prefs, NULL /* chosen read mode */, &error);
+      server_id =
+         mongoc_topology_select_server_id (t,
+                                           MONGOC_SS_READ,
+                                           prefs,
+                                           NULL /* chosen read mode */,
+                                           NULL /* deprioritized servers */,
+                                           &error);
 
       mongoc_read_prefs_destroy (prefs);
       if (!server_id) {

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -1727,23 +1727,17 @@ retry:
        _mongoc_write_error_get_type (reply) == MONGOC_WRITE_ERR_RETRY) {
       bson_error_t ignored_error;
 
-      /* each write command may be retried at most once */
+      // The write command may be retried at most once.
       is_retryable = false;
 
       {
          mongoc_deprioritized_servers_t *const ds =
             mongoc_deprioritized_servers_new ();
 
-         if (retry_server_stream) {
-            mongoc_deprioritized_servers_add_if_sharded (
-               ds, retry_server_stream->topology_type, server_stream->sd);
+         mongoc_deprioritized_servers_add_if_sharded (
+            ds, server_stream->topology_type, server_stream->sd);
 
-            mongoc_server_stream_cleanup (retry_server_stream);
-         } else {
-            mongoc_deprioritized_servers_add_if_sharded (
-               ds, server_stream->topology_type, server_stream->sd);
-         }
-
+         BSON_ASSERT (!retry_server_stream);
          retry_server_stream =
             mongoc_cluster_stream_for_writes (&client->cluster,
                                               parts->assembled.session,

--- a/src/libmongoc/src/mongoc/mongoc-cluster-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-private.h
@@ -38,6 +38,7 @@
 #include "mongoc-scram-private.h"
 #include "mongoc-cmd-private.h"
 #include "mongoc-crypto-private.h"
+#include "mongoc-deprioritized-servers-private.h"
 
 BSON_BEGIN_DECLS
 
@@ -121,6 +122,7 @@ mongoc_server_stream_t *
 mongoc_cluster_stream_for_reads (mongoc_cluster_t *cluster,
                                  const mongoc_read_prefs_t *read_prefs,
                                  mongoc_client_session_t *cs,
+                                 const mongoc_deprioritized_servers_t *ds,
                                  bson_t *reply,
                                  bson_error_t *error);
 
@@ -138,6 +140,7 @@ mongoc_cluster_stream_for_reads (mongoc_cluster_t *cluster,
 mongoc_server_stream_t *
 mongoc_cluster_stream_for_writes (mongoc_cluster_t *cluster,
                                   mongoc_client_session_t *cs,
+                                  const mongoc_deprioritized_servers_t *ds,
                                   bson_t *reply,
                                   bson_error_t *error);
 

--- a/src/libmongoc/src/mongoc/mongoc-database.c
+++ b/src/libmongoc/src/mongoc/mongoc-database.c
@@ -1101,6 +1101,7 @@ create_collection_with_encryptedFields (mongoc_database_t *database,
       mongoc_server_stream_t *stream =
          mongoc_cluster_stream_for_writes (&database->client->cluster,
                                            NULL /* client session */,
+                                           NULL /* deprioritized servers */,
                                            NULL /* reply */,
                                            error);
       if (!stream) {

--- a/src/libmongoc/src/mongoc/mongoc-deprioritized-servers-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-deprioritized-servers-private.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mongoc-prelude.h"
+
+#ifndef MONGOC_DEPRIORITIZED_SERVERS_PRIVATE_H
+#define MONGOC_DEPRIORITIZED_SERVERS_PRIVATE_H
+
+#include <bson/bson.h>
+
+#include "mongoc-server-description.h"
+
+#include <stdbool.h>
+
+BSON_BEGIN_DECLS
+
+typedef struct _mongoc_deprioritized_servers_t mongoc_deprioritized_servers_t;
+
+mongoc_deprioritized_servers_t *
+mongoc_deprioritized_servers_new (void);
+
+void
+mongoc_deprioritized_servers_destroy (
+   mongoc_deprioritized_servers_t *ds);
+
+void
+mongoc_deprioritized_servers_add (
+   mongoc_deprioritized_servers_t *ds,
+   const mongoc_server_description_t *sd);
+
+bool
+mongoc_deprioritized_servers_contains (
+   const mongoc_deprioritized_servers_t *ds,
+   const mongoc_server_description_t *sd);
+
+BSON_END_DECLS
+
+#endif // MONGOC_DEPRIORITIZED_SERVERS_PRIVATE_H

--- a/src/libmongoc/src/mongoc/mongoc-deprioritized-servers.c
+++ b/src/libmongoc/src/mongoc/mongoc-deprioritized-servers.c
@@ -1,0 +1,58 @@
+#include "mongoc-deprioritized-servers-private.h"
+
+#include "mongoc-set-private.h"
+
+// Dedicated non-zero value to avoid confusing "key is present with a NULL item"
+// from "key is not present" (also NULL).
+#define MONGOC_DEPRIORITIZED_SERVERS_ITEM_VALUE ((void *) 1)
+
+struct _mongoc_deprioritized_servers_t {
+   // Use server ID (uint32_t) as keys to identify deprioritized servers.
+   mongoc_set_t *ids;
+};
+
+mongoc_deprioritized_servers_t *
+mongoc_deprioritized_servers_new (void)
+{
+   mongoc_deprioritized_servers_t *const ret = bson_malloc (sizeof (*ret));
+
+   *ret = (mongoc_deprioritized_servers_t){
+      .ids = mongoc_set_new (1u, NULL, NULL),
+   };
+
+   return ret;
+}
+
+void
+mongoc_deprioritized_servers_destroy (mongoc_deprioritized_servers_t *ds)
+{
+   if (!ds) {
+      return;
+   }
+
+   mongoc_set_destroy (ds->ids);
+   bson_free (ds);
+}
+
+void
+mongoc_deprioritized_servers_add (mongoc_deprioritized_servers_t *ds,
+                                  const mongoc_server_description_t *sd)
+{
+   BSON_ASSERT_PARAM (ds);
+   BSON_ASSERT_PARAM (sd);
+
+   mongoc_set_add (ds->ids,
+                   mongoc_server_description_id (sd),
+                   MONGOC_DEPRIORITIZED_SERVERS_ITEM_VALUE);
+}
+
+bool
+mongoc_deprioritized_servers_contains (const mongoc_deprioritized_servers_t *ds,
+                                       const mongoc_server_description_t *sd)
+{
+   BSON_ASSERT_PARAM (ds);
+   BSON_ASSERT_PARAM (sd);
+
+   return mongoc_set_get_const (ds->ids, mongoc_server_description_id (sd)) ==
+          MONGOC_DEPRIORITIZED_SERVERS_ITEM_VALUE;
+}

--- a/src/libmongoc/src/mongoc/mongoc-topology-description-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description-private.h
@@ -24,6 +24,7 @@
 #include "mongoc-array-private.h"
 #include "mongoc-topology-description.h"
 #include "mongoc-apm-private.h"
+#include "mongoc-deprioritized-servers-private.h"
 
 
 typedef enum {
@@ -114,6 +115,7 @@ mongoc_topology_description_select (
    mongoc_ss_optype_t optype,
    const mongoc_read_prefs_t *read_pref,
    bool *must_use_primary,
+   const mongoc_deprioritized_servers_t *ds,
    int64_t local_threshold_ms);
 
 mongoc_server_description_t *
@@ -149,6 +151,7 @@ mongoc_topology_description_suitable_servers (
    const mongoc_topology_description_t *topology,
    const mongoc_read_prefs_t *read_pref,
    bool *must_use_primary,
+   const mongoc_deprioritized_servers_t *ds,
    int64_t local_threshold_ms);
 
 bool
@@ -193,5 +196,11 @@ _mongoc_topology_description_clear_connection_pool (
    mongoc_topology_description_t *td,
    uint32_t server_id,
    const bson_oid_t *service_id);
+
+void
+mongoc_deprioritized_servers_add_if_sharded (
+   mongoc_deprioritized_servers_t *ds,
+   mongoc_topology_description_type_t topology_type,
+   const mongoc_server_description_t *sd);
 
 #endif /* MONGOC_TOPOLOGY_DESCRIPTION_PRIVATE_H */

--- a/src/libmongoc/src/mongoc/mongoc-topology-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-private.h
@@ -284,6 +284,8 @@ mongoc_topology_select (mongoc_topology_t *topology,
  * @param must_use_primary An optional output parameter. Server selection might
  * need to override the caller's read preferences' read mode to 'primary'.
  * Whether or not that takes place will be set through this pointer.
+ * @param ds A list of server that should be selected only if there are no other
+ * suitable servers.
  * @param error An output parameter for any error information.
  * @return uint32_t A non-zero integer ID of the server description. In case of
  * error, sets `error` and returns zero.
@@ -295,6 +297,7 @@ mongoc_topology_select_server_id (mongoc_topology_t *topology,
                                   mongoc_ss_optype_t optype,
                                   const mongoc_read_prefs_t *read_prefs,
                                   bool *must_use_primary,
+                                  const mongoc_deprioritized_servers_t *ds,
                                   bson_error_t *error);
 
 /**

--- a/src/libmongoc/src/mongoc/mongoc-topology-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-private.h
@@ -284,8 +284,8 @@ mongoc_topology_select (mongoc_topology_t *topology,
  * @param must_use_primary An optional output parameter. Server selection might
  * need to override the caller's read preferences' read mode to 'primary'.
  * Whether or not that takes place will be set through this pointer.
- * @param ds A list of server that should be selected only if there are no other
- * suitable servers.
+ * @param ds A list of servers that should be selected only if there are no
+ * other suitable servers.
  * @param error An output parameter for any error information.
  * @return uint32_t A non-zero integer ID of the server description. In case of
  * error, sets `error` and returns zero.

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -1053,7 +1053,7 @@ mongoc_topology_select (mongoc_topology_t *topology,
                         bson_error_t *error)
 {
    uint32_t server_id = mongoc_topology_select_server_id (
-      topology, optype, read_prefs, must_use_primary, error);
+      topology, optype, read_prefs, must_use_primary, NULL, error);
 
    if (server_id) {
       /* new copy of the server description */
@@ -1098,6 +1098,7 @@ _mongoc_topology_select_server_id_loadbalanced (mongoc_topology_t *topology,
                                           MONGOC_SS_WRITE,
                                           NULL /* read prefs */,
                                           NULL /* chosen read mode */,
+                                          NULL /* deprioritized servers */,
                                           0 /* local threshold */);
 
    if (!selected_server) {
@@ -1166,6 +1167,7 @@ mongoc_topology_select_server_id (mongoc_topology_t *topology,
                                   mongoc_ss_optype_t optype,
                                   const mongoc_read_prefs_t *read_prefs,
                                   bool *must_use_primary,
+                                  const mongoc_deprioritized_servers_t *ds,
                                   bson_error_t *error)
 {
    static const char *timeout_msg =
@@ -1281,8 +1283,13 @@ mongoc_topology_select_server_id (mongoc_topology_t *topology,
             goto done;
          }
 
-         selected_server = mongoc_topology_description_select (
-            td.ptr, optype, read_prefs, must_use_primary, local_threshold_ms);
+         selected_server =
+            mongoc_topology_description_select (td.ptr,
+                                                optype,
+                                                read_prefs,
+                                                must_use_primary,
+                                                ds,
+                                                local_threshold_ms);
 
          if (selected_server) {
             server_id = selected_server->id;
@@ -1328,7 +1335,7 @@ mongoc_topology_select_server_id (mongoc_topology_t *topology,
       }
 
       selected_server = mongoc_topology_description_select (
-         td.ptr, optype, read_prefs, must_use_primary, local_threshold_ms);
+         td.ptr, optype, read_prefs, must_use_primary, ds, local_threshold_ms);
 
       if (selected_server) {
          server_id = selected_server->id;
@@ -1344,7 +1351,7 @@ mongoc_topology_select_server_id (mongoc_topology_t *topology,
        * occurred while we were waiting on the lock. */
       mc_tpld_renew_ref (&td, topology);
       selected_server = mongoc_topology_description_select (
-         td.ptr, optype, read_prefs, must_use_primary, local_threshold_ms);
+         td.ptr, optype, read_prefs, must_use_primary, ds, local_threshold_ms);
       if (selected_server) {
          server_id = selected_server->id;
          bson_mutex_unlock (&topology->tpld_modification_mtx);
@@ -1613,11 +1620,13 @@ _mongoc_topology_pop_server_session (mongoc_topology_t *topology,
    if (!loadbalanced && timeout == MONGOC_NO_SESSIONS) {
       /* if needed, connect and check for session timeout again */
       if (!mongoc_topology_description_has_data_node (td.ptr)) {
-         if (!mongoc_topology_select_server_id (topology,
-                                                MONGOC_SS_READ,
-                                                NULL /* read prefs */,
-                                                NULL /* chosen read mode */,
-                                                error)) {
+         if (!mongoc_topology_select_server_id (
+                topology,
+                MONGOC_SS_READ,
+                NULL /* read prefs */,
+                NULL /* chosen read mode */,
+                NULL /* deprioritized servers */,
+                error)) {
             ss = NULL;
             goto done;
          }

--- a/src/libmongoc/src/mongoc/mongoc-write-command.c
+++ b/src/libmongoc/src/mongoc/mongoc-write-command.c
@@ -772,12 +772,26 @@ _mongoc_write_opmsg (mongoc_write_command_t *command,
             /* each write command may be retried at most once */
             is_retryable = false;
 
-            if (retry_server_stream) {
-               mongoc_server_stream_cleanup (retry_server_stream);
-            }
+            {
+               mongoc_deprioritized_servers_t *const ds =
+                  mongoc_deprioritized_servers_new ();
 
-            retry_server_stream = mongoc_cluster_stream_for_writes (
-               &client->cluster, cs, NULL, &ignored_error);
+               if (retry_server_stream) {
+                  mongoc_deprioritized_servers_add_if_sharded (
+                     ds,
+                     retry_server_stream->topology_type,
+                     retry_server_stream->sd);
+                  mongoc_server_stream_cleanup (retry_server_stream);
+               } else {
+                  mongoc_deprioritized_servers_add_if_sharded (
+                     ds, server_stream->topology_type, server_stream->sd);
+               }
+
+               retry_server_stream = mongoc_cluster_stream_for_writes (
+                  &client->cluster, cs, ds, NULL, &ignored_error);
+
+               mongoc_deprioritized_servers_destroy (ds);
+            }
 
             if (retry_server_stream) {
                parts.assembled.server_stream = retry_server_stream;

--- a/src/libmongoc/tests/json-test.c
+++ b/src/libmongoc/tests/json-test.c
@@ -501,6 +501,7 @@ test_server_selection_logic_cb (bson_t *test)
       &topology,
       read_prefs,
       NULL,
+      NULL,
       MONGOC_TOPOLOGY_LOCAL_THRESHOLD_MS);
 
    /* check each server in expected_servers is in selected_servers */
@@ -1213,7 +1214,7 @@ execute_test (const json_test_config_t *config,
 
    /* Select a primary for testing */
    server_id = mongoc_topology_select_server_id (
-      client->topology, MONGOC_SS_WRITE, NULL, NULL, &error);
+      client->topology, MONGOC_SS_WRITE, NULL, NULL, NULL, &error);
    ASSERT_OR_PRINT (server_id, error);
 
    json_test_ctx_init (&ctx, test, client, db, collection, config);
@@ -1905,7 +1906,7 @@ run_json_general_test (const json_test_config_t *config)
 
       /* clean up in case a previous test aborted */
       server_id = mongoc_topology_select_server_id (
-         client->topology, MONGOC_SS_WRITE, NULL, NULL, &error);
+         client->topology, MONGOC_SS_WRITE, NULL, NULL, NULL, &error);
       ASSERT_OR_PRINT (server_id, error);
       deactivate_fail_points (client, server_id);
       r = mongoc_client_command_with_opts (client,

--- a/src/libmongoc/tests/mock_server/mock-server.c
+++ b/src/libmongoc/tests/mock_server/mock-server.c
@@ -329,7 +329,6 @@ mock_server_run (mock_server_t *server)
    size_t bind_addr_len = 0;
    int r;
 
-   MONGOC_INFO ("Starting mock server on port %d.", server->port);
    ssock = mongoc_socket_new (
       server->bind_opts.family ? server->bind_opts.family : AF_INET,
       SOCK_STREAM,
@@ -385,6 +384,8 @@ mock_server_run (mock_server_t *server)
       perror ("Failed to get bound port number");
       return 0;
    }
+
+   MONGOC_INFO ("Starting mock server on port %d.", bound_port);
 
    bson_mutex_lock (&server->mutex);
 

--- a/src/libmongoc/tests/test-mongoc-client-session.c
+++ b/src/libmongoc/tests/test-mongoc-client-session.c
@@ -196,7 +196,7 @@ _test_session_pool_timeout (bool pooled)
     * trigger discovery
     */
    server_id = mongoc_topology_select_server_id (
-      client->topology, MONGOC_SS_READ, NULL, NULL, &error);
+      client->topology, MONGOC_SS_READ, NULL, NULL, NULL, &error);
    ASSERT_OR_PRINT (server_id, error);
 
    /*

--- a/src/libmongoc/tests/test-mongoc-cluster.c
+++ b/src/libmongoc/tests/test-mongoc-cluster.c
@@ -26,7 +26,7 @@ server_id_for_reads (mongoc_cluster_t *cluster)
    uint32_t id;
 
    server_stream =
-      mongoc_cluster_stream_for_reads (cluster, NULL, NULL, NULL, &error);
+      mongoc_cluster_stream_for_reads (cluster, NULL, NULL, NULL, NULL, &error);
    ASSERT_OR_PRINT (server_stream, error);
    id = server_stream->sd->id;
 
@@ -1140,8 +1140,8 @@ future_command_private (mongoc_client_t *client)
 
    ASSERT (client);
 
-   server_stream =
-      mongoc_cluster_stream_for_writes (&client->cluster, NULL, NULL, &error);
+   server_stream = mongoc_cluster_stream_for_writes (
+      &client->cluster, NULL, NULL, NULL, &error);
    ASSERT_OR_PRINT (server_stream, error);
 
    mongoc_cmd_parts_init (
@@ -1785,8 +1785,11 @@ test_cluster_stream_invalidation_single (void)
 
    /* Test "clearing the pool". This should invalidate existing server streams.
     */
-   stream = mongoc_cluster_stream_for_writes (
-      &client->cluster, NULL /* session */, NULL /* reply */, &error);
+   stream = mongoc_cluster_stream_for_writes (&client->cluster,
+                                              NULL /* session */,
+                                              NULL /* deprioritized servers */,
+                                              NULL /* reply */,
+                                              &error);
    ASSERT_OR_PRINT (stream, error);
    BSON_ASSERT (mongoc_cluster_stream_valid (&client->cluster, stream));
    tdmod = mc_tpld_modify_begin (client->topology);
@@ -1798,8 +1801,11 @@ test_cluster_stream_invalidation_single (void)
 
    /* Test closing the connection. This should invalidate existing server
     * streams. */
-   stream = mongoc_cluster_stream_for_writes (
-      &client->cluster, NULL /* session */, NULL /* reply */, &error);
+   stream = mongoc_cluster_stream_for_writes (&client->cluster,
+                                              NULL /* session */,
+                                              NULL /* deprioritized servers */,
+                                              NULL /* reply */,
+                                              &error);
    ASSERT_OR_PRINT (stream, error);
    BSON_ASSERT (mongoc_cluster_stream_valid (&client->cluster, stream));
    mongoc_cluster_disconnect_node (&client->cluster, sd->id);
@@ -1807,8 +1813,11 @@ test_cluster_stream_invalidation_single (void)
    mongoc_server_stream_cleanup (stream);
 
    /* Test that a new stream is considered valid. */
-   stream = mongoc_cluster_stream_for_writes (
-      &client->cluster, NULL /* session */, NULL /* reply */, &error);
+   stream = mongoc_cluster_stream_for_writes (&client->cluster,
+                                              NULL /* session */,
+                                              NULL /* deprioritized servers */,
+                                              NULL /* reply */,
+                                              &error);
    ASSERT_OR_PRINT (stream, error);
    BSON_ASSERT (mongoc_cluster_stream_valid (&client->cluster, stream));
    mongoc_server_stream_cleanup (stream);
@@ -1837,8 +1846,11 @@ test_cluster_stream_invalidation_pooled (void)
 
    /* Test "clearing the pool". This should invalidate existing server streams.
     */
-   stream = mongoc_cluster_stream_for_writes (
-      &client->cluster, NULL /* session */, NULL /* reply */, &error);
+   stream = mongoc_cluster_stream_for_writes (&client->cluster,
+                                              NULL /* session */,
+                                              NULL /* deprioritized servers */,
+                                              NULL /* reply */,
+                                              &error);
    ASSERT_OR_PRINT (stream, error);
    BSON_ASSERT (mongoc_cluster_stream_valid (&client->cluster, stream));
    tdmod = mc_tpld_modify_begin (client->topology);
@@ -1850,8 +1862,11 @@ test_cluster_stream_invalidation_pooled (void)
 
    /* Test closing the connection. This should invalidate existing server
     * streams. */
-   stream = mongoc_cluster_stream_for_writes (
-      &client->cluster, NULL /* session */, NULL /* reply */, &error);
+   stream = mongoc_cluster_stream_for_writes (&client->cluster,
+                                              NULL /* session */,
+                                              NULL /* deprioritized servers */,
+                                              NULL /* reply */,
+                                              &error);
    ASSERT_OR_PRINT (stream, error);
    BSON_ASSERT (mongoc_cluster_stream_valid (&client->cluster, stream));
    mongoc_cluster_disconnect_node (&client->cluster, sd->id);
@@ -1859,8 +1874,11 @@ test_cluster_stream_invalidation_pooled (void)
    mongoc_server_stream_cleanup (stream);
 
    /* Test that a new stream is considered valid. */
-   stream = mongoc_cluster_stream_for_writes (
-      &client->cluster, NULL /* session */, NULL /* reply */, &error);
+   stream = mongoc_cluster_stream_for_writes (&client->cluster,
+                                              NULL /* session */,
+                                              NULL /* deprioritized servers */,
+                                              NULL /* reply */,
+                                              &error);
    ASSERT_OR_PRINT (stream, error);
    BSON_ASSERT (mongoc_cluster_stream_valid (&client->cluster, stream));
    mongoc_server_stream_cleanup (stream);

--- a/src/libmongoc/tests/test-mongoc-cyrus.c
+++ b/src/libmongoc/tests/test-mongoc-cyrus.c
@@ -77,7 +77,7 @@ test_sasl_canonicalize_hostname (void *ctx)
 
    client = test_framework_new_default_client ();
    ss = mongoc_cluster_stream_for_reads (
-      &client->cluster, NULL, NULL, NULL, &error);
+      &client->cluster, NULL, NULL, NULL, NULL, &error);
    ASSERT_OR_PRINT (ss, error);
 
    BSON_ASSERT (_mongoc_sasl_get_canonicalized_name (

--- a/src/libmongoc/tests/test-mongoc-primary-stepdown.c
+++ b/src/libmongoc/tests/test-mongoc-primary-stepdown.c
@@ -160,11 +160,13 @@ test_getmore_iteration (mongoc_client_t *client)
    /* Store the primary ID. After step down, the primary may be a different
     * server. We must execute serverStatus against the same server to check
     * connection counts. */
-   primary_id = mongoc_topology_select_server_id (client->topology,
-                                                  MONGOC_SS_WRITE,
-                                                  NULL /* read prefs */,
-                                                  NULL /* chosen read mode */,
-                                                  &error);
+   primary_id =
+      mongoc_topology_select_server_id (client->topology,
+                                        MONGOC_SS_WRITE,
+                                        NULL /* read prefs */,
+                                        NULL /* chosen read mode */,
+                                        NULL /* deprioritized servers */,
+                                        &error);
    ASSERT_OR_PRINT (primary_id, error);
    conn_count = _connection_count (client, primary_id);
 
@@ -241,11 +243,13 @@ test_not_primary_keep_pool (mongoc_client_t *client)
    /* Store the primary ID. After step down, the primary may be a different
     * server. We must execute serverStatus against the same server to check
     * connection counts. */
-   primary_id = mongoc_topology_select_server_id (client->topology,
-                                                  MONGOC_SS_WRITE,
-                                                  NULL /* read prefs */,
-                                                  NULL /* chosen read mode */,
-                                                  &error);
+   primary_id =
+      mongoc_topology_select_server_id (client->topology,
+                                        MONGOC_SS_WRITE,
+                                        NULL /* read prefs */,
+                                        NULL /* chosen read mode */,
+                                        NULL /* deprioritized servers */,
+                                        &error);
    ASSERT_OR_PRINT (primary_id, error);
    conn_count = _connection_count (client, primary_id);
    res = mongoc_database_command_simple (
@@ -314,11 +318,13 @@ test_not_primary_reset_pool (mongoc_client_t *client)
    /* Store the primary ID. After step down, the primary may be a different
     * server. We must execute serverStatus against the same server to check
     * connection counts. */
-   primary_id = mongoc_topology_select_server_id (client->topology,
-                                                  MONGOC_SS_WRITE,
-                                                  NULL /* read prefs */,
-                                                  NULL /* chosen read mode */,
-                                                  &error);
+   primary_id =
+      mongoc_topology_select_server_id (client->topology,
+                                        MONGOC_SS_WRITE,
+                                        NULL /* read prefs */,
+                                        NULL /* chosen read mode */,
+                                        NULL /* deprioritized servers */,
+                                        &error);
    ASSERT_OR_PRINT (primary_id, error);
    conn_count = _connection_count (client, primary_id);
    res = mongoc_database_command_simple (
@@ -391,11 +397,13 @@ test_shutdown_reset_pool (mongoc_client_t *client)
    /* Store the primary ID. After step down, the primary may be a different
     * server. We must execute serverStatus against the same server to check
     * connection counts. */
-   primary_id = mongoc_topology_select_server_id (client->topology,
-                                                  MONGOC_SS_WRITE,
-                                                  NULL /* read prefs */,
-                                                  NULL /* chosen read mode */,
-                                                  &error);
+   primary_id =
+      mongoc_topology_select_server_id (client->topology,
+                                        MONGOC_SS_WRITE,
+                                        NULL /* read prefs */,
+                                        NULL /* chosen read mode */,
+                                        NULL /* deprioritized servers */,
+                                        &error);
    ASSERT_OR_PRINT (primary_id, error);
    conn_count = _connection_count (client, primary_id);
    res = mongoc_database_command_simple (
@@ -462,11 +470,13 @@ test_interrupted_shutdown_reset_pool (mongoc_client_t *client)
    /* Store the primary ID. After step down, the primary may be a different
     * server. We must execute serverStatus against the same server to check
     * connection counts. */
-   primary_id = mongoc_topology_select_server_id (client->topology,
-                                                  MONGOC_SS_WRITE,
-                                                  NULL /* read prefs */,
-                                                  NULL /* chosen read mode */,
-                                                  &error);
+   primary_id =
+      mongoc_topology_select_server_id (client->topology,
+                                        MONGOC_SS_WRITE,
+                                        NULL /* read prefs */,
+                                        NULL /* chosen read mode */,
+                                        NULL /* deprioritized servers */,
+                                        &error);
    ASSERT_OR_PRINT (primary_id, error);
    conn_count = _connection_count (client, primary_id);
    res = mongoc_database_command_simple (

--- a/src/libmongoc/tests/test-mongoc-retryability-helpers.c
+++ b/src/libmongoc/tests/test-mongoc-retryability-helpers.c
@@ -1,0 +1,67 @@
+#include "test-mongoc-retryability-helpers.h"
+
+#include <bson/bson-error.h>
+
+#include "mongoc-array-private.h"
+
+#include "test-conveniences.h"
+#include "test-libmongoc.h"
+#include "TestSuite.h"
+
+#include <stddef.h>
+
+mongoc_array_t
+_test_get_mongos_clients (const char **ports, size_t num_ports)
+{
+   bson_error_t error = {0};
+
+   mongoc_array_t clients;
+   _mongoc_array_init (&clients, sizeof (mongoc_client_t *));
+
+   for (size_t i = 0u; i < num_ports; ++i) {
+      const char *const port = ports[i];
+
+      char *const host_and_port =
+         bson_strdup_printf ("mongodb://localhost:%s", port);
+      char *const uri_str =
+         test_framework_add_user_password_from_env (host_and_port);
+
+      mongoc_uri_t *const uri = mongoc_uri_new_with_error (uri_str, &error);
+      ASSERT_OR_PRINT (uri, error);
+
+      mongoc_client_t *const client =
+         mongoc_client_new_from_uri_with_error (uri, &error);
+      ASSERT_OR_PRINT (client, error);
+      test_framework_set_ssl_opts (client);
+
+      {
+         bson_t reply = BSON_INITIALIZER;
+
+         ASSERT_OR_PRINT (
+            mongoc_client_command_simple (client,
+                                          "admin",
+                                          tmp_bson ("{'hello': 1}"),
+                                          NULL,
+                                          &reply,
+                                          &error),
+            error);
+
+         ASSERT_WITH_MSG (
+            bson_has_field (&reply, "msg") &&
+               strcmp (bson_lookup_utf8 (&reply, "msg"), "isdbgrid") == 0,
+            "expected a mongos on port %s",
+            port);
+
+         bson_destroy (&reply);
+      }
+
+      _mongoc_array_append_val (&clients, client); // Ownership transfer.
+
+      mongoc_uri_destroy (uri);
+
+      bson_free (host_and_port);
+      bson_free (uri_str);
+   }
+
+   return clients;
+}

--- a/src/libmongoc/tests/test-mongoc-retryability-helpers.h
+++ b/src/libmongoc/tests/test-mongoc-retryability-helpers.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TEST_MONGOC_RETRYABILITY_HELPERS_H
+#define TEST_MONGOC_RETRYABILITY_HELPERS_H
+
+#include <mongoc/mongoc-array-private.h>
+
+mongoc_array_t
+_test_get_mongos_clients (const char **ports, size_t num_ports);
+
+#endif

--- a/src/libmongoc/tests/test-mongoc-retryable-reads.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-reads.c
@@ -8,6 +8,7 @@
 #include "mock_server/future.h"
 #include "mock_server/future-functions.h"
 #include "json-test-operations.h"
+#include "test-mongoc-retryability-helpers.h"
 
 static bool
 retryable_reads_test_run_operation (json_test_ctx_t *ctx,
@@ -278,6 +279,367 @@ test_retry_reads_off (void *ctx)
    mongoc_client_destroy (client);
 }
 
+typedef struct _test_retry_reads_sharded_on_other_mongos_ctx {
+   int count;
+   uint16_t ports[2];
+} test_retry_reads_sharded_on_other_mongos_ctx;
+
+static void
+_test_retry_reads_sharded_on_other_mongos_cb (
+   const mongoc_apm_command_failed_t *event)
+{
+   BSON_ASSERT_PARAM (event);
+
+   test_retry_reads_sharded_on_other_mongos_ctx *const ctx =
+      (test_retry_reads_sharded_on_other_mongos_ctx *)
+         mongoc_apm_command_failed_get_context (event);
+   BSON_ASSERT (ctx);
+
+   ASSERT_WITH_MSG (ctx->count < 2,
+                    "expected at most two failpoints to trigger");
+
+   const mongoc_host_list_t *const host =
+      mongoc_apm_command_failed_get_host (event);
+   BSON_ASSERT (host);
+   BSON_ASSERT (!host->next);
+   ctx->ports[ctx->count++] = host->port;
+}
+
+// Retryable Reads Are Retried on a Different mongos if One is Available
+static void
+test_retry_reads_sharded_on_other_mongos (void *_ctx)
+{
+   BSON_UNUSED (_ctx);
+
+   bson_error_t error = {0};
+
+   // Create two clients `s0` and `s1` that each connect to a single mongos from
+   // the sharded cluster. They must not connect to the same mongos.
+   const char *ports[] = {"27017", "27018"};
+   const size_t num_ports = sizeof (ports) / sizeof (*ports);
+   mongoc_array_t clients = _test_get_mongos_clients (ports, num_ports);
+   BSON_ASSERT (clients.len == 2u);
+   mongoc_client_t *const s0 =
+      _mongoc_array_index (&clients, mongoc_client_t *, 0u);
+   mongoc_client_t *const s1 =
+      _mongoc_array_index (&clients, mongoc_client_t *, 1u);
+   BSON_ASSERT (s0 && s1);
+
+   // Deprioritization cannot be deterministically asserted by this test due to
+   // randomized selection from suitable servers. Repeat the test a few times to
+   // increase the likelihood of detecting incorrect deprioritization behavior.
+   for (int i = 0; i < 10; ++i) {
+      // Configure the following fail point for both s0 and s1:
+      {
+         bson_t *const command =
+            tmp_bson ("{"
+                      "  'configureFailPoint': 'failCommand',"
+                      "  'mode': { 'times': 1 },"
+                      "  'data': {"
+                      "    'failCommands': ['find'],"
+                      "    'errorCode': 6"
+                      "  }"
+                      "}");
+
+         ASSERT_OR_PRINT (mongoc_client_command_simple (
+                             s0, "admin", command, NULL, NULL, &error),
+                          error);
+         ASSERT_OR_PRINT (mongoc_client_command_simple (
+                             s1, "admin", command, NULL, NULL, &error),
+                          error);
+      }
+
+      // Create a client client with `retryReads=true` that connects to the
+      // cluster with both mongoses used by `s0` and `s1` in the initial seed
+      // list.
+      mongoc_client_t *client = NULL;
+      {
+         const char *const host_and_port =
+            "mongodb://localhost:27017,localhost:27018/?retryReads=true";
+         char *const uri_str =
+            test_framework_add_user_password_from_env (host_and_port);
+         mongoc_uri_t *const uri = mongoc_uri_new (uri_str);
+
+         client = mongoc_client_new_from_uri_with_error (uri, &error);
+         ASSERT_OR_PRINT (client, error);
+         test_framework_set_ssl_opts (client);
+
+         mongoc_uri_destroy (uri);
+         bson_free (uri_str);
+      }
+      BSON_ASSERT (client);
+
+      {
+         test_retry_reads_sharded_on_other_mongos_ctx ctx = {0};
+
+         // Enable failed command event monitoring for client.
+         {
+            mongoc_apm_callbacks_t *const callbacks =
+               mongoc_apm_callbacks_new ();
+            mongoc_apm_set_command_failed_cb (
+               callbacks, _test_retry_reads_sharded_on_other_mongos_cb);
+            mongoc_client_set_apm_callbacks (client, callbacks, &ctx);
+            mongoc_apm_callbacks_destroy (callbacks);
+         }
+
+         // Execute a `find` command with `client`. Assert that the command
+         // failed.
+         {
+            mongoc_database_t *const db =
+               mongoc_client_get_database (client, "db");
+            mongoc_collection_t *const coll =
+               mongoc_database_get_collection (db, "test");
+            mongoc_cursor_t *const cursor = mongoc_collection_find_with_opts (
+               coll, tmp_bson ("{}"), NULL, NULL);
+            const bson_t *reply = NULL;
+            ASSERT_WITH_MSG (!mongoc_cursor_next (cursor, &reply),
+                             "expected find command to fail");
+            ASSERT_WITH_MSG (mongoc_cursor_error (cursor, &error),
+                             "expected find command to fail");
+            mongoc_cursor_destroy (cursor);
+            mongoc_collection_destroy (coll);
+            mongoc_database_destroy (db);
+         }
+
+         // Assert that two failed command events occurred.
+         ASSERT_WITH_MSG (ctx.count == 2,
+                          "expected exactly 2 failpoints to trigger, but "
+                          "observed %d with error: %s",
+                          ctx.count,
+                          error.message);
+
+         // Assert that both events occurred on different mongoses.
+         ASSERT_WITH_MSG ((ctx.ports[0] == 27017 || ctx.ports[0] == 27018) &&
+                             (ctx.ports[1] == 27017 || ctx.ports[1] == 27018) &&
+                             (ctx.ports[0] != ctx.ports[1]),
+                          "expected failpoints to trigger once on each mongos, "
+                          "but observed failures on %d and %d",
+                          ctx.ports[0],
+                          ctx.ports[1]);
+
+         mongoc_client_destroy (client);
+      }
+
+      // Disable the fail point on both s0 and s1.
+      {
+         bson_t *const command =
+            tmp_bson ("{"
+                      "  'configureFailPoint': 'failCommand',"
+                      "  'mode': 'off'"
+                      "}");
+
+         ASSERT_OR_PRINT (mongoc_client_command_simple (
+                             s0, "admin", command, NULL, NULL, &error),
+                          error);
+         ASSERT_OR_PRINT (mongoc_client_command_simple (
+                             s1, "admin", command, NULL, NULL, &error),
+                          error);
+      }
+   }
+
+   mongoc_client_destroy (s0);
+   mongoc_client_destroy (s1);
+   _mongoc_array_destroy (&clients);
+}
+
+typedef struct _test_retry_reads_sharded_on_same_mongos_ctx {
+   int failed_count;
+   int succeeded_count;
+   uint16_t failed_port;
+   uint16_t succeeded_port;
+} test_retry_reads_sharded_on_same_mongos_ctx;
+
+static void
+_test_retry_reads_sharded_on_same_mongos_cb (
+   test_retry_reads_sharded_on_same_mongos_ctx *ctx,
+   const mongoc_apm_command_failed_t *failed,
+   const mongoc_apm_command_succeeded_t *succeeded)
+{
+   BSON_ASSERT_PARAM (ctx);
+   BSON_ASSERT (failed || true);
+   BSON_ASSERT (succeeded || true);
+
+   ASSERT_WITH_MSG (
+      ctx->failed_count < 2 && ctx->succeeded_count < 2,
+      "expected at most two events, but observed %d failed and %d succeeded",
+      ctx->failed_count,
+      ctx->succeeded_count);
+
+   if (failed) {
+      ctx->failed_count += 1;
+
+      const mongoc_host_list_t *const host =
+         mongoc_apm_command_failed_get_host (failed);
+      BSON_ASSERT (host);
+      BSON_ASSERT (!host->next);
+      ctx->failed_port = host->port;
+   }
+
+   if (succeeded) {
+      ctx->succeeded_count += 1;
+
+      const mongoc_host_list_t *const host =
+         mongoc_apm_command_succeeded_get_host (succeeded);
+      BSON_ASSERT (host);
+      BSON_ASSERT (!host->next);
+      ctx->succeeded_port = host->port;
+   }
+}
+
+static void
+_test_retry_reads_sharded_on_same_mongos_failed_cb (
+   const mongoc_apm_command_failed_t *event)
+{
+   _test_retry_reads_sharded_on_same_mongos_cb (
+      mongoc_apm_command_failed_get_context (event), event, NULL);
+}
+
+static void
+_test_retry_reads_sharded_on_same_mongos_succeeded_cb (
+   const mongoc_apm_command_succeeded_t *event)
+{
+   _test_retry_reads_sharded_on_same_mongos_cb (
+      mongoc_apm_command_succeeded_get_context (event), NULL, event);
+}
+
+// Retryable Reads Are Retried on the Same mongos if No Others are Available
+static void
+test_retry_reads_sharded_on_same_mongos (void *_ctx)
+{
+   BSON_UNUSED (_ctx);
+
+   bson_error_t error = {0};
+
+   // Create a client `s0` that connects to a single mongos from the cluster.
+   const char *ports[] = {"27017"};
+   const size_t num_ports = sizeof (ports) / sizeof (*ports);
+   mongoc_array_t clients = _test_get_mongos_clients (ports, num_ports);
+   BSON_ASSERT (clients.len == 1u);
+   mongoc_client_t *const s0 =
+      _mongoc_array_index (&clients, mongoc_client_t *, 0u);
+   BSON_ASSERT (s0);
+
+   // Configure the following fail point for `s0`:
+   ASSERT_OR_PRINT (mongoc_client_command_simple (
+                       s0,
+                       "admin",
+                       tmp_bson ("{"
+                                 "  'configureFailPoint': 'failCommand',"
+                                 "  'mode': { 'times': 1 },"
+                                 "  'data': {"
+                                 "    'failCommands': ['find'],"
+                                 "    'errorCode': 6"
+                                 "  }"
+                                 "}"),
+                       NULL,
+                       NULL,
+                       &error),
+                    error);
+
+   // Create a client client with `directConnection=false` (when not set by
+   // default) and `retryReads=true` that connects to the cluster using the same
+   // single mongos as `s0`.
+   mongoc_client_t *client = NULL;
+   {
+      const char *const host_and_port =
+         "mongodb://localhost:27017/?retryReads=true&directConnection=false";
+      char *const uri_str =
+         test_framework_add_user_password_from_env (host_and_port);
+      mongoc_uri_t *const uri = mongoc_uri_new (uri_str);
+
+      client = mongoc_client_new_from_uri_with_error (uri, &error);
+      ASSERT_OR_PRINT (client, error);
+      test_framework_set_ssl_opts (client);
+
+      mongoc_uri_destroy (uri);
+      bson_free (uri_str);
+   }
+   BSON_ASSERT (client);
+
+   {
+      test_retry_reads_sharded_on_same_mongos_ctx ctx = {
+         .failed_count = 0,
+         .succeeded_count = 0,
+      };
+
+      // Enable succeeded and failed command event monitoring for `client`.
+      {
+         mongoc_apm_callbacks_t *const callbacks = mongoc_apm_callbacks_new ();
+         mongoc_apm_set_command_failed_cb (
+            callbacks, _test_retry_reads_sharded_on_same_mongos_failed_cb);
+         mongoc_apm_set_command_succeeded_cb (
+            callbacks, _test_retry_reads_sharded_on_same_mongos_succeeded_cb);
+         mongoc_client_set_apm_callbacks (client, callbacks, &ctx);
+         mongoc_apm_callbacks_destroy (callbacks);
+      }
+
+      // Execute a `find` command with `client`. Assert that the command
+      // succeeded.
+      {
+         mongoc_database_t *const db =
+            mongoc_client_get_database (client, "db");
+         mongoc_collection_t *const coll =
+            mongoc_database_get_collection (db, "test");
+         bson_t opts = BSON_INITIALIZER;
+         {
+            // Ensure drop from earlier is observed.
+            mongoc_read_concern_t *const rc = mongoc_read_concern_new ();
+            mongoc_read_concern_set_level (rc,
+                                           MONGOC_READ_CONCERN_LEVEL_MAJORITY);
+            mongoc_read_concern_append (rc, &opts);
+            mongoc_read_concern_destroy (rc);
+         }
+         mongoc_cursor_t *const cursor =
+            mongoc_collection_find_with_opts (coll, &opts, NULL, NULL);
+         const bson_t *reply = NULL;
+         ASSERT_WITH_MSG (mongoc_cursor_next (cursor, &reply) ||
+                             !mongoc_cursor_error (cursor, &error),
+                          "expecting find to succeed, but observed error: %s",
+                          error.message);
+         mongoc_cursor_destroy (cursor);
+         bson_destroy (&opts);
+         mongoc_collection_destroy (coll);
+         mongoc_database_destroy (db);
+      }
+
+      // Assert that exactly one failed command event and one succeeded command
+      // event occurred.
+      ASSERT_WITH_MSG (
+         ctx.failed_count == 1 && ctx.succeeded_count == 1,
+         "expected exactly one failed event and one succeeded "
+         "event, but observed %d failures and %d successes with error: %s",
+         ctx.failed_count,
+         ctx.succeeded_count,
+         ctx.succeeded_count > 1 ? "none" : error.message);
+
+      //  Assert that both events occurred on the same mongos.
+      ASSERT_WITH_MSG (
+         ctx.failed_port == ctx.succeeded_port,
+         "expected failed and succeeded events on the same mongos, but "
+         "instead observed port %d (failed) and port %d (succeeded)",
+         ctx.failed_port,
+         ctx.succeeded_port);
+
+      mongoc_client_destroy (client);
+   }
+
+   // Disable the fail point on s0.
+   ASSERT_OR_PRINT (mongoc_client_command_simple (
+                       s0,
+                       "admin",
+                       tmp_bson ("{"
+                                 "  'configureFailPoint': 'failCommand',"
+                                 "  'mode': 'off'"
+                                 "}"),
+                       NULL,
+                       NULL,
+                       &error),
+                    error);
+
+   mongoc_client_destroy (s0);
+   _mongoc_array_destroy (&clients);
+}
+
 /*
  *-----------------------------------------------------------------------
  *
@@ -318,4 +680,22 @@ test_retryable_reads_install (TestSuite *suite)
                       test_framework_skip_if_max_wire_version_less_than_7,
                       test_framework_skip_if_mongos,
                       test_framework_skip_if_no_failpoint);
+   TestSuite_AddFull (suite,
+                      "/retryable_reads/sharded/on_other_mongos",
+                      test_retry_reads_sharded_on_other_mongos,
+                      NULL,
+                      NULL,
+                      test_framework_skip_if_not_mongos,
+                      test_framework_skip_if_no_failpoint,
+                      // `retryReads=true` is a 4.2+ feature.
+                      test_framework_skip_if_max_wire_version_less_than_8);
+   TestSuite_AddFull (suite,
+                      "/retryable_reads/sharded/on_same_mongos",
+                      test_retry_reads_sharded_on_same_mongos,
+                      NULL,
+                      NULL,
+                      test_framework_skip_if_not_mongos,
+                      test_framework_skip_if_no_failpoint,
+                      // `retryReads=true` is a 4.2+ feature.
+                      test_framework_skip_if_max_wire_version_less_than_8);
 }

--- a/src/libmongoc/tests/test-mongoc-retryable-reads.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-reads.c
@@ -105,7 +105,7 @@ test_cmd_helpers (void *ctx)
 
    /* clean up in case a previous test aborted */
    server_id = mongoc_topology_select_server_id (
-      client->topology, MONGOC_SS_WRITE, NULL, NULL, &error);
+      client->topology, MONGOC_SS_WRITE, NULL, NULL, NULL, &error);
    ASSERT_OR_PRINT (server_id, error);
    deactivate_fail_points (client, server_id);
 
@@ -190,7 +190,7 @@ test_cmd_helpers (void *ctx)
    /* read/write agnostic command_simple_with_server_id helper must not retry.
     */
    server_id = mongoc_topology_select_server_id (
-      client->topology, MONGOC_SS_WRITE, NULL, NULL, &error);
+      client->topology, MONGOC_SS_WRITE, NULL, NULL, NULL, &error);
    ASSERT_OR_PRINT (server_id, error);
    _set_failpoint (client);
    ASSERT (!mongoc_client_command_simple_with_server_id (
@@ -252,7 +252,7 @@ test_retry_reads_off (void *ctx)
 
    /* clean up in case a previous test aborted */
    server_id = mongoc_topology_select_server_id (
-      client->topology, MONGOC_SS_WRITE, NULL, NULL, &error);
+      client->topology, MONGOC_SS_WRITE, NULL, NULL, NULL, &error);
    ASSERT_OR_PRINT (server_id, error);
    deactivate_fail_points (client, server_id);
 

--- a/src/libmongoc/tests/test-mongoc-retryable-reads.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-reads.c
@@ -460,7 +460,7 @@ _test_retry_reads_sharded_on_same_mongos_cb (
    BSON_ASSERT (succeeded || true);
 
    ASSERT_WITH_MSG (
-      ctx->failed_count < 2 && ctx->succeeded_count < 2,
+      ctx->failed_count + ctx->succeeded_count < 2,
       "expected at most two events, but observed %d failed and %d succeeded",
       ctx->failed_count,
       ctx->succeeded_count);

--- a/src/libmongoc/tests/test-mongoc-retryable-reads.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-reads.c
@@ -592,8 +592,8 @@ test_retry_reads_sharded_on_same_mongos (void *_ctx)
          mongoc_cursor_t *const cursor =
             mongoc_collection_find_with_opts (coll, &opts, NULL, NULL);
          const bson_t *reply = NULL;
-         ASSERT_WITH_MSG (mongoc_cursor_next (cursor, &reply) ||
-                             !mongoc_cursor_error (cursor, &error),
+         (void) mongoc_cursor_next (cursor, &reply);
+         ASSERT_WITH_MSG (!mongoc_cursor_error (cursor, &error),
                           "expecting find to succeed, but observed error: %s",
                           error.message);
          mongoc_cursor_destroy (cursor);

--- a/src/libmongoc/tests/test-mongoc-retryable-reads.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-reads.c
@@ -602,6 +602,9 @@ test_retry_reads_sharded_on_same_mongos (void *_ctx)
          mongoc_database_destroy (db);
       }
 
+      // Avoid capturing additional events.
+      mongoc_client_set_apm_callbacks (client, NULL, NULL);
+
       // Assert that exactly one failed command event and one succeeded command
       // event occurred.
       ASSERT_WITH_MSG (

--- a/src/libmongoc/tests/test-mongoc-retryable-writes.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-writes.c
@@ -1106,7 +1106,7 @@ _test_retry_writes_sharded_on_same_mongos_cb (
    BSON_ASSERT (succeeded || true);
 
    ASSERT_WITH_MSG (
-      ctx->failed_count < 2 && ctx->succeeded_count < 2,
+      ctx->failed_count + ctx->succeeded_count < 2,
       "expected at most two events, but observed %d failed and %d succeeded",
       ctx->failed_count,
       ctx->succeeded_count);

--- a/src/libmongoc/tests/test-mongoc-retryable-writes.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-writes.c
@@ -951,8 +951,8 @@ _test_retry_writes_sharded_on_other_mongos_cb (
    ctx->ports[ctx->count++] = host->port;
 }
 
-// Test that in a sharded cluster writes are retried on a different mongos if
-// one available.
+// Test that in a sharded cluster writes are retried on a different mongos when
+// one is available.
 static void
 retryable_writes_sharded_on_other_mongos (void *_ctx)
 {
@@ -1148,7 +1148,8 @@ _test_retry_writes_sharded_on_same_mongos_succeeded_cb (
       mongoc_apm_command_succeeded_get_context (event), NULL, event);
 }
 
-// Test that in a sharded cluster on the same mongos if no other is available.
+// Test that in a sharded cluster writes are retried on the same mongos when no
+// others are available.
 static void
 retryable_writes_sharded_on_same_mongos (void *_ctx)
 {

--- a/src/libmongoc/tests/test-mongoc-retryable-writes.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-writes.c
@@ -158,7 +158,7 @@ test_command_with_opts (void *ctx)
 
    /* clean up in case a previous test aborted */
    server_id = mongoc_topology_select_server_id (
-      client->topology, MONGOC_SS_WRITE, NULL, NULL, &error);
+      client->topology, MONGOC_SS_WRITE, NULL, NULL, NULL, &error);
    ASSERT_OR_PRINT (server_id, error);
    deactivate_fail_points (client, server_id);
 
@@ -638,7 +638,7 @@ set_up_original_error_test (mongoc_apm_callbacks_t *callbacks,
 
    // clean up in case a previous test aborted
    server_id = mongoc_topology_select_server_id (
-      client->topology, MONGOC_SS_WRITE, NULL, NULL, &error);
+      client->topology, MONGOC_SS_WRITE, NULL, NULL, NULL, &error);
    ASSERT_OR_PRINT (server_id, error);
    deactivate_fail_points (client, server_id);
 

--- a/src/libmongoc/tests/test-mongoc-retryable-writes.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-writes.c
@@ -1237,6 +1237,9 @@ retryable_writes_sharded_on_same_mongos (void *_ctx)
          mongoc_database_destroy (db);
       }
 
+      // Avoid capturing additional events.
+      mongoc_client_set_apm_callbacks (client, NULL, NULL);
+
       // Assert that exactly one failed command event and one succeeded
       // command event occurred.
       ASSERT_WITH_MSG (

--- a/src/libmongoc/tests/test-mongoc-retryable-writes.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-writes.c
@@ -8,6 +8,7 @@
 #include "mock_server/future.h"
 #include "mock_server/future-functions.h"
 #include "json-test-operations.h"
+#include "test-mongoc-retryability-helpers.h"
 
 
 static bool
@@ -924,6 +925,366 @@ test_bulk_retry_tracks_new_server (void *unused)
    mongoc_client_destroy (client);
 }
 
+typedef struct _test_retry_writes_sharded_on_other_mongos_ctx {
+   int count;
+   uint16_t ports[2];
+} test_retry_writes_sharded_on_other_mongos_ctx;
+
+static void
+_test_retry_writes_sharded_on_other_mongos_cb (
+   const mongoc_apm_command_failed_t *event)
+{
+   BSON_ASSERT_PARAM (event);
+
+   test_retry_writes_sharded_on_other_mongos_ctx *const ctx =
+      (test_retry_writes_sharded_on_other_mongos_ctx *)
+         mongoc_apm_command_failed_get_context (event);
+   BSON_ASSERT (ctx);
+
+   ASSERT_WITH_MSG (ctx->count < 2,
+                    "expected at most two failpoints to trigger");
+
+   const mongoc_host_list_t *const host =
+      mongoc_apm_command_failed_get_host (event);
+   BSON_ASSERT (host);
+   BSON_ASSERT (!host->next);
+   ctx->ports[ctx->count++] = host->port;
+}
+
+// Test that in a sharded cluster writes are retried on a different mongos if
+// one available.
+static void
+retryable_writes_sharded_on_other_mongos (void *_ctx)
+{
+   BSON_UNUSED (_ctx);
+
+   bson_error_t error = {0};
+
+   // Create two clients `s0` and `s1` that each connect to a single mongos from
+   // the sharded cluster. They must not connect to the same mongos.
+   const char *ports[] = {"27017", "27018"};
+   const size_t num_ports = sizeof (ports) / sizeof (*ports);
+   mongoc_array_t clients = _test_get_mongos_clients (ports, num_ports);
+   BSON_ASSERT (clients.len == 2u);
+   mongoc_client_t *const s0 =
+      _mongoc_array_index (&clients, mongoc_client_t *, 0u);
+   mongoc_client_t *const s1 =
+      _mongoc_array_index (&clients, mongoc_client_t *, 1u);
+   BSON_ASSERT (s0 && s1);
+
+   // Deprioritization cannot be deterministically asserted by this test due to
+   // randomized selection from suitable servers. Repeat the test a few times to
+   // increase the likelihood of detecting incorrect deprioritization behavior.
+   for (int i = 0; i < 10; ++i) {
+      // Configure the following fail point for both `s0` and `s1`:
+      {
+         bson_t *const command =
+            tmp_bson ("{"
+                      "  'configureFailPoint': 'failCommand',"
+                      "  'mode': { 'times': 1 },"
+                      "  'data': {"
+                      "    'failCommands': ['insert'],"
+                      "    'errorCode': 6,"
+                      "    'errorLabels': ['RetryableWriteError']"
+                      "  }"
+                      "}");
+
+         ASSERT_OR_PRINT (mongoc_client_command_simple (
+                             s0, "admin", command, NULL, NULL, &error),
+                          error);
+         ASSERT_OR_PRINT (mongoc_client_command_simple (
+                             s1, "admin", command, NULL, NULL, &error),
+                          error);
+      }
+
+      // Create a client `client` with `retryWrites=true` that connects to the
+      // cluster with both mongoses used by `s0` and `s1` in the initial seed
+      // list.
+      mongoc_client_t *client = NULL;
+      {
+         const char *const host_and_port =
+            "mongodb://localhost:27017,localhost:27018/?retryWrites=true";
+         char *const uri_str =
+            test_framework_add_user_password_from_env (host_and_port);
+         mongoc_uri_t *const uri = mongoc_uri_new (uri_str);
+
+         client = mongoc_client_new_from_uri_with_error (uri, &error);
+         ASSERT_OR_PRINT (client, error);
+         test_framework_set_ssl_opts (client);
+
+         mongoc_uri_destroy (uri);
+         bson_free (uri_str);
+      }
+      BSON_ASSERT (client);
+
+      {
+         test_retry_writes_sharded_on_other_mongos_ctx ctx = {0};
+
+         // Enable failed command event monitoring for `client`.
+         {
+            mongoc_apm_callbacks_t *const callbacks =
+               mongoc_apm_callbacks_new ();
+            mongoc_apm_set_command_failed_cb (
+               callbacks, _test_retry_writes_sharded_on_other_mongos_cb);
+            mongoc_client_set_apm_callbacks (client, callbacks, &ctx);
+            mongoc_apm_callbacks_destroy (callbacks);
+         }
+
+         // Execute an `insert` command with `client`. Assert that the command
+         // failed.
+         {
+            mongoc_database_t *const db =
+               mongoc_client_get_database (client, "db");
+            mongoc_collection_t *const coll =
+               mongoc_database_get_collection (db, "test");
+            ASSERT_WITH_MSG (
+               !mongoc_collection_insert_one (
+                  coll, tmp_bson ("{'x': 1}"), NULL, NULL, &error),
+               "expected insert command to fail");
+            MONGOC_DEBUG ("insert error: %s", error.message);
+            mongoc_collection_destroy (coll);
+            mongoc_database_destroy (db);
+         }
+
+         // Assert that two failed command events occurred.
+         ASSERT_WITH_MSG (ctx.count == 2,
+                          "expected exactly 2 failpoints to trigger, but "
+                          "observed %d with error: %s",
+                          ctx.count,
+                          error.message);
+
+         // Assert that the failed command events occurred on different
+         // mongoses.
+         ASSERT_WITH_MSG ((ctx.ports[0] == 27017 || ctx.ports[0] == 27018) &&
+                             (ctx.ports[1] == 27017 || ctx.ports[1] == 27018) &&
+                             (ctx.ports[0] != ctx.ports[1]),
+                          "expected failpoints to trigger once on each mongos, "
+                          "but observed failures on %d and %d",
+                          ctx.ports[0],
+                          ctx.ports[1]);
+
+         mongoc_client_destroy (client);
+      }
+
+      // Disable the fail points.
+      {
+         bson_t *const command =
+            tmp_bson ("{"
+                      "  'configureFailPoint': 'failCommand',"
+                      "  'mode': 'off'"
+                      "}");
+
+         ASSERT_OR_PRINT (mongoc_client_command_simple (
+                             s0, "admin", command, NULL, NULL, &error),
+                          error);
+         ASSERT_OR_PRINT (mongoc_client_command_simple (
+                             s1, "admin", command, NULL, NULL, &error),
+                          error);
+      }
+   }
+
+   mongoc_client_destroy (s0);
+   mongoc_client_destroy (s1);
+   _mongoc_array_destroy (&clients);
+}
+
+typedef struct _test_retry_writes_sharded_on_same_mongos_ctx {
+   int failed_count;
+   int succeeded_count;
+   uint16_t failed_port;
+   uint16_t succeeded_port;
+} test_retry_writes_sharded_on_same_mongos_ctx;
+
+static void
+_test_retry_writes_sharded_on_same_mongos_cb (
+   test_retry_writes_sharded_on_same_mongos_ctx *ctx,
+   const mongoc_apm_command_failed_t *failed,
+   const mongoc_apm_command_succeeded_t *succeeded)
+{
+   BSON_ASSERT_PARAM (ctx);
+   BSON_ASSERT (failed || true);
+   BSON_ASSERT (succeeded || true);
+
+   ASSERT_WITH_MSG (
+      ctx->failed_count < 2 && ctx->succeeded_count < 2,
+      "expected at most two events, but observed %d failed and %d succeeded",
+      ctx->failed_count,
+      ctx->succeeded_count);
+
+   if (failed) {
+      ctx->failed_count += 1;
+
+      const mongoc_host_list_t *const host =
+         mongoc_apm_command_failed_get_host (failed);
+      BSON_ASSERT (host);
+      BSON_ASSERT (!host->next);
+      ctx->failed_port = host->port;
+   }
+
+   if (succeeded) {
+      ctx->succeeded_count += 1;
+
+      const mongoc_host_list_t *const host =
+         mongoc_apm_command_succeeded_get_host (succeeded);
+      BSON_ASSERT (host);
+      BSON_ASSERT (!host->next);
+      ctx->succeeded_port = host->port;
+   }
+}
+
+static void
+_test_retry_writes_sharded_on_same_mongos_failed_cb (
+   const mongoc_apm_command_failed_t *event)
+{
+   _test_retry_writes_sharded_on_same_mongos_cb (
+      mongoc_apm_command_failed_get_context (event), event, NULL);
+}
+
+static void
+_test_retry_writes_sharded_on_same_mongos_succeeded_cb (
+   const mongoc_apm_command_succeeded_t *event)
+{
+   _test_retry_writes_sharded_on_same_mongos_cb (
+      mongoc_apm_command_succeeded_get_context (event), NULL, event);
+}
+
+// Test that in a sharded cluster on the same mongos if no other is available.
+static void
+retryable_writes_sharded_on_same_mongos (void *_ctx)
+{
+   BSON_UNUSED (_ctx);
+
+   bson_error_t error = {0};
+
+   // Create a client `s0` that connects to a single mongos from the cluster.
+   const char *ports[] = {"27017"};
+   const size_t num_ports = sizeof (ports) / sizeof (*ports);
+   mongoc_array_t clients = _test_get_mongos_clients (ports, num_ports);
+   BSON_ASSERT (clients.len == 1u);
+   mongoc_client_t *const s0 =
+      _mongoc_array_index (&clients, mongoc_client_t *, 0u);
+   BSON_ASSERT (s0);
+
+   // Deprioritization cannot be deterministically asserted by this test due to
+   // randomized selection from suitable servers. Repeat the test a few times to
+   // increase the likelihood of detecting incorrect deprioritization behavior.
+   for (int i = 0; i < 10; ++i) {
+      // Configure the following fail point for `s0`:
+      ASSERT_OR_PRINT (mongoc_client_command_simple (
+                          s0,
+                          "admin",
+                          tmp_bson ("{"
+                                    "  'configureFailPoint': 'failCommand',"
+                                    "  'mode': { 'times': 1 },"
+                                    "  'data': {"
+                                    "    'failCommands': ['insert'],"
+                                    "    'errorCode': 6,"
+                                    "    'errorLabels': ['RetryableWriteError']"
+                                    "  }"
+                                    "}"),
+                          NULL,
+                          NULL,
+                          &error),
+                       error);
+
+      // Create a client client with `directConnection=false` (when not set by
+      // default) and `retryWrites=true` that connects to the cluster using the
+      // same single mongos as `s0`.
+      mongoc_client_t *client = NULL;
+      {
+         const char *const host_and_port =
+            "mongodb://localhost:27017/"
+            "?retryWrites=true&directConnection=false";
+         char *const uri_str =
+            test_framework_add_user_password_from_env (host_and_port);
+         mongoc_uri_t *const uri = mongoc_uri_new (uri_str);
+
+         client = mongoc_client_new_from_uri_with_error (uri, &error);
+         ASSERT_OR_PRINT (client, error);
+         test_framework_set_ssl_opts (client);
+
+         mongoc_uri_destroy (uri);
+         bson_free (uri_str);
+      }
+      BSON_ASSERT (client);
+
+      {
+         test_retry_writes_sharded_on_same_mongos_ctx ctx = {
+            .failed_count = 0,
+            .succeeded_count = 0,
+         };
+
+         // Enable succeeded and failed command event monitoring for `client`.
+         {
+            mongoc_apm_callbacks_t *const callbacks =
+               mongoc_apm_callbacks_new ();
+            mongoc_apm_set_command_failed_cb (
+               callbacks, _test_retry_writes_sharded_on_same_mongos_failed_cb);
+            mongoc_apm_set_command_succeeded_cb (
+               callbacks,
+               _test_retry_writes_sharded_on_same_mongos_succeeded_cb);
+            mongoc_client_set_apm_callbacks (client, callbacks, &ctx);
+            mongoc_apm_callbacks_destroy (callbacks);
+         }
+
+         // Execute an `insert` command with `client`. Assert that the command
+         // succeeded.
+         {
+            mongoc_database_t *const db =
+               mongoc_client_get_database (client, "db");
+            mongoc_collection_t *const coll =
+               mongoc_database_get_collection (db, "test");
+            ASSERT_WITH_MSG (
+               mongoc_collection_insert_one (
+                  coll, tmp_bson ("{'x': 1}"), NULL, NULL, &error),
+               "expecting insert to succeed, but observed error: %s",
+               error.message);
+            mongoc_collection_destroy (coll);
+            mongoc_database_destroy (db);
+         }
+
+         // Assert that exactly one failed command event and one succeeded
+         // command event occurred.
+         ASSERT_WITH_MSG (
+            ctx.failed_count == 1 && ctx.succeeded_count == 1,
+            "expected exactly one failed event and one succeeded "
+            "event, but observed %d failures and %d successes with error: %s",
+            ctx.failed_count,
+            ctx.succeeded_count,
+            ctx.succeeded_count > 1 ? "none" : error.message);
+
+         // Assert that both events occurred on the same mongos.
+         ASSERT_WITH_MSG (
+            ctx.failed_port == ctx.succeeded_port,
+            "expected failed and succeeded events on the same mongos, but "
+            "instead observed port %d (failed) and port %d (succeeded)",
+            ctx.failed_port,
+            ctx.succeeded_port);
+
+         mongoc_client_set_apm_callbacks (client, NULL, NULL);
+      }
+
+      mongoc_client_destroy (client);
+   }
+
+   // Disable the fail point.
+   ASSERT_OR_PRINT (mongoc_client_command_simple (
+                       s0,
+                       "admin",
+                       tmp_bson ("{"
+                                 "  'configureFailPoint': 'failCommand',"
+                                 "  'mode': 'off'"
+                                 "}"),
+                       NULL,
+                       NULL,
+                       &error),
+                    error);
+
+   mongoc_client_destroy (s0);
+   _mongoc_array_destroy (&clients);
+}
+
+
 void
 test_retryable_writes_install (TestSuite *suite)
 {
@@ -1000,5 +1361,25 @@ test_retryable_writes_install (TestSuite *suite)
                       NULL,
                       test_framework_skip_if_not_replset,
                       test_framework_skip_if_max_wire_version_less_than_17,
+                      test_framework_skip_if_no_crypto);
+   TestSuite_AddFull (suite,
+                      "/retryable_writes/prose_test_4",
+                      retryable_writes_sharded_on_other_mongos,
+                      NULL,
+                      NULL,
+                      test_framework_skip_if_not_mongos,
+                      test_framework_skip_if_no_failpoint,
+                      // `errorLabels` is a 4.3.1+ feature.
+                      test_framework_skip_if_max_wire_version_less_than_9,
+                      test_framework_skip_if_no_crypto);
+   TestSuite_AddFull (suite,
+                      "/retryable_writes/prose_test_5",
+                      retryable_writes_sharded_on_same_mongos,
+                      NULL,
+                      NULL,
+                      test_framework_skip_if_not_mongos,
+                      test_framework_skip_if_no_failpoint,
+                      // `errorLabels` is a 4.3.1+ feature.
+                      test_framework_skip_if_max_wire_version_less_than_9,
                       test_framework_skip_if_no_crypto);
 }

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -181,7 +181,7 @@ test_topology_client_creation (void)
 
    /* ensure that we are sharing streams with the client */
    server_stream = mongoc_cluster_stream_for_reads (
-      &client_a->cluster, NULL, NULL, NULL, &error);
+      &client_a->cluster, NULL, NULL, NULL, NULL, &error);
 
    ASSERT_OR_PRINT (server_stream, error);
    node = mongoc_topology_scanner_get_node (client_a->topology->scanner,
@@ -495,7 +495,7 @@ _test_topology_invalidate_server (bool pooled)
 
    /* call explicitly */
    server_stream = mongoc_cluster_stream_for_reads (
-      &client->cluster, NULL, NULL, NULL, &error);
+      &client->cluster, NULL, NULL, NULL, NULL, &error);
    ASSERT_OR_PRINT (server_stream, error);
    sd = server_stream->sd;
    id = server_stream->sd->id;
@@ -602,7 +602,7 @@ test_invalid_cluster_node (void *ctx)
 
    /* load stream into cluster */
    server_stream = mongoc_cluster_stream_for_reads (
-      &client->cluster, NULL, NULL, NULL, &error);
+      &client->cluster, NULL, NULL, NULL, NULL, &error);
    ASSERT_OR_PRINT (server_stream, error);
    id = server_stream->sd->id;
    mongoc_server_stream_cleanup (server_stream);
@@ -675,7 +675,7 @@ test_max_wire_version_race_condition (void *ctx)
 
    /* load stream into cluster */
    server_stream = mongoc_cluster_stream_for_reads (
-      &client->cluster, NULL, NULL, NULL, &error);
+      &client->cluster, NULL, NULL, NULL, NULL, &error);
    ASSERT_OR_PRINT (server_stream, error);
    id = server_stream->sd->id;
    mongoc_server_stream_cleanup (server_stream);

--- a/src/libmongoc/tests/test-mongoc-transactions.c
+++ b/src/libmongoc/tests/test-mongoc-transactions.c
@@ -983,7 +983,7 @@ test_selected_server_is_pinned_to_mongos (void *ctx)
    BSON_ASSERT (0 == mongoc_client_session_get_server_id (session));
 
    expected_id = mongoc_topology_select_server_id (
-      client->topology, MONGOC_SS_WRITE, NULL, NULL, &error);
+      client->topology, MONGOC_SS_WRITE, NULL, NULL, NULL, &error);
    ASSERT_OR_PRINT (expected_id, error);
 
    /* session should still be unpinned */

--- a/src/libmongoc/tests/test-mongoc-write-commands.c
+++ b/src/libmongoc/tests/test-mongoc-write-commands.c
@@ -54,8 +54,8 @@ test_split_insert (void)
       _mongoc_write_command_insert_append (&command, docs[i]);
    }
 
-   server_stream =
-      mongoc_cluster_stream_for_writes (&client->cluster, NULL, NULL, &error);
+   server_stream = mongoc_cluster_stream_for_writes (
+      &client->cluster, NULL, NULL, NULL, &error);
    ASSERT_OR_PRINT (server_stream, error);
    _mongoc_write_command_execute (&command,
                                   client,
@@ -125,8 +125,8 @@ test_invalid_write_concern (void)
    _mongoc_write_command_init_insert (
       &command, doc, NULL, write_flags, ++client->cluster.operation_id);
    _mongoc_write_result_init (&result);
-   server_stream =
-      mongoc_cluster_stream_for_writes (&client->cluster, NULL, NULL, &error);
+   server_stream = mongoc_cluster_stream_for_writes (
+      &client->cluster, NULL, NULL, NULL, &error);
    ASSERT_OR_PRINT (server_stream, error);
    _mongoc_write_command_execute (&command,
                                   client,


### PR DESCRIPTION
Resolves CDRIVER-4099. Verified by [this patch](https://spruce.mongodb.com/version/65c2a91d32f41714fea620ce/tasks?taskName=-cyrus-.%2A-sharded-) (filtered to relevant tasks; CSE tasks are failing atm due to an unrelated issue).

This PR also implements the proposed prose test spec changes in https://github.com/mongodb/specifications/pull/1504.

## Description

There are five internal functions in libmongoc that each individually (re)implement retryable reads/writes:

- `_mongoc_client_retryable_write_command_with_stream`
- `_mongoc_client_retryable_read_command_with_stream`
- `mongoc_collection_find_and_modify_with_opts`
- `_mongoc_cursor_run_command`
- `_mongoc_write_opmsg`

This PR refrains from refactoring these instances to use a comment implementation due to the complexity required. Instead, the new `mongoc_deprioritized_servers_add_if_sharded` function serves to document the instances of retry-op code paths for future reference and make a first step towards unifying the behavior of these disparate implementations in the future.

The `mongoc_deprioritized_servers_add_if_sharded` is a convenient function that only adds the provided server to the set of deprioritized servers when the topology is Sharded, [per spec](https://github.com/mongodb/specifications/commit/86d961fee4c5e92fbcff76a62abe1aea3fafd451#diff-a47a9f399433d1fd1666e605c2a402955eb48cc75bbe1ab75682382767231a11R271):

> In a sharded cluster, the server on which the operation failed MUST be provided to the server selection mechanism as a deprioritized server.

The `mongoc_deprioritized_servers_t` interface deliberately operates on `mongoc_server_description_t` objects, rather than the underlying server IDs currently used as keys in the set, to leave the path open for changing the method used to identify servers (i.e. to `host_and_port`) or using an array instead of a set (can't use strings as keys in `mongoc_set_t`) if needed without requiring a significant refactor.

The bulk of changes in this PR are to accomodate the addition of a new parameter to all intermediate internal functions that must forward the deprioritized servers list _aaaaall_ the way down to `mongoc_topology_description_suitable_servers` where it is ultimately used, [per spec](https://github.com/mongodb/specifications/commit/86d961fee4c5e92fbcff76a62abe1aea3fafd451#diff-894b3661e1f3249c636d8de2da83bca4341783fe4ec6c90d39338b4d6d4c5dedR846):

> Find suitable servers by topology type and operation type. If a list of deprioritized servers is provided, and the topology is a sharded cluster, these servers should be selected only if there are no other suitable servers. The server selection algorithm MUST ignore the deprioritized servers if the topology is not a sharded cluster.

This was interpreted as being most appropriately implemented in `mongoc_topology_description_suitable_servers` in the "Sharded clusters" block immediately before filtering for suitable mongoses.

Trace log messages are used to verify that deprioritization code paths are being executed as intended by the prose tests. All relevant trace logs use the `deprioritization:` prefix for easy filtering in the verbose trace logs, e.g. `./test-libmongoc -t | grep "deprioritization"` (simplified):

```
mongoc_deprioritized_servers_add_if_sharded():2710 deprioritization: add to list: localhost:27018 (id: 2)
_mongoc_filter_deprioritized_servers():562 deprioritization: filtering list of candidates
_mongoc_filter_deprioritized_servers():574 deprioritization: - kept: localhost:27017 (id: 1)
_mongoc_filter_deprioritized_servers():579 deprioritization: - removed: localhost:27018 (id: 2)
_mongoc_filter_deprioritized_servers():591 deprioritization: using filtered list of candidates
```

```
mongoc_deprioritized_servers_add_if_sharded():2710 deprioritization: add to list: localhost:27017 (id: 1)
_mongoc_filter_deprioritized_servers():562 deprioritization: filtering list of candidates
_mongoc_filter_deprioritized_servers():579 deprioritization: - removed: localhost:27017 (id: 1)
_mongoc_filter_deprioritized_servers():585 deprioritization: reverted due to no other suitable servers
```

The `on_other_mongos` prose tests for both retryable read and retryable write are repeated several times in an effort to reduce the possibility of (incorrectly using) normal SDAM behavior _happening to_ produce the same result as server deprioritization due to randomized server selection. Otherwise the test may occasionally succeed (false-positive) even without the implementation of server deprioritization. The loops can be removed if considered excessive/slow.

A drive-by fix moves the `MONGOC_INFO` message for mock server startup to a position where the printed port number is accurate to the actual port of the running server.