### PR TITLE
Reorder start point for doc examples for consistency

### DIFF
--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -92,8 +92,8 @@ test_example_1 (mongoc_database_t *db)
    }
    /* End Example 1 */
    ASSERT_COUNT (1, collection);
-   /* Start Example 1 Post */
 done:
+   /* Start Example 1 Post */
    mongoc_collection_destroy (collection);
    /* End Example 1 Post */
 }
@@ -579,7 +579,7 @@ test_example_14 (mongoc_database_t *db)
    }
    /* End Example 14 */
 
-   done:
+done:
    /* Start Example 14 Post */
    bson_destroy (&reply);
    mongoc_bulk_operation_destroy (bulk);

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -579,7 +579,7 @@ test_example_14 (mongoc_database_t *db)
    }
    /* End Example 14 */
 
-done:
+   done:
    /* Start Example 14 Post */
    bson_destroy (&reply);
    mongoc_bulk_operation_destroy (bulk);


### PR DESCRIPTION
The first of the insert code examples we import into the documentation have the `done:` line in the example, while others don't. This cleans up that discrepancy and makes the code examples consistent.