### PR TITLE
CDRIVER-4823 Avoid use of redundant EVG project variables

### DIFF
--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -1002,8 +1002,8 @@ tasks:
   commands:
   - command: s3.get
     params:
-      aws_key: ${toolchain_aws_key}
-      aws_secret: ${toolchain_aws_secret}
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
       remote_file: mongo-c-toolchain/${distro_id}/2023/06/07/mongo-c-toolchain.tar.gz
       bucket: mongo-c-toolchain
       local_file: mongo-c-toolchain.tar.gz

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -407,8 +407,8 @@ all_tasks = [
                         "params",
                         OD(
                             [
-                                ("aws_key", "${toolchain_aws_key}"),
-                                ("aws_secret", "${toolchain_aws_secret}"),
+                                ("aws_key", "${aws_key}"),
+                                ("aws_secret", "${aws_secret}"),
                                 ("remote_file", "mongo-c-toolchain/${distro_id}/2023/06/07/mongo-c-toolchain.tar.gz"),
                                 ("bucket", "mongo-c-toolchain"),
                                 ("local_file", "mongo-c-toolchain.tar.gz"),


### PR DESCRIPTION
Part of CDRIVER-4823. Changes in this PR will be cherry-picked onto the r1.26 branch.

The `toolchain_aws_*` EVG project variables are redundant, fulfilling the same function as the plain `aws_*` EVG project variables. This PR removes their use in the EVG config so the variables can be deleted in EVG project settings.