### PR TITLE
Group OCSP tasks into display tasks by SSL library

### DIFF
--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -14447,6 +14447,19 @@ buildvariants:
   - name: debug-compile-nosasl-openssl-1.0.1
   - name: .ocsp-openssl-1.0.1
   batchtime: 10080
+  display_tasks:
+  - execution_tasks:
+    - .ocsp-openssl
+    name: ocsp-openssl
+  - execution_tasks:
+    - .ocsp-darwinssl
+    name: ocsp-darwinssl
+  - execution_tasks:
+    - .ocsp-winssl
+    name: ocsp-winssl
+  - execution_tasks:
+    - .ocsp-openssl-1.0.1
+    name: ocsp-openssl-1.0.1
 - name: packaging
   display_name: Linux Distro Packaging
   run_on: ubuntu1804-test

--- a/.evergreen/legacy_config_generator/evergreen_config_generator/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_generator/variants.py
@@ -28,6 +28,7 @@ class Variant(ConfigObject):
         expansions: Mapping[str, str] | None = None,
         tags: Iterable[str] = (),
         batchtime: int | None = None,
+        display_tasks: Iterable[ValueMapping] = None,
     ):
         super(Variant, self).__init__()
         self._variant_name = name
@@ -37,6 +38,7 @@ class Variant(ConfigObject):
         self.expansions = expansions
         self.tags = list(tags)
         self.batchtime = batchtime
+        self.display_tasks = display_tasks
 
     @property
     def name(self):
@@ -44,7 +46,7 @@ class Variant(ConfigObject):
 
     def to_dict(self):
         v = super(Variant, self).to_dict()
-        for i in "display_name", "expansions", "run_on", "tasks", "batchtime", "tags":
+        for i in "display_name", "expansions", "run_on", "tasks", "batchtime", "tags", "display_tasks":
             if getattr(self, i):
                 v[i] = getattr(self, i)
         return v

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -464,6 +464,24 @@ all_variants = [
         ],
         {},
         batchtime=days(7),
+        display_tasks=[
+            {
+                "name": "ocsp-openssl",
+                "execution_tasks": [".ocsp-openssl"],
+            },
+            {
+                "name": "ocsp-darwinssl",
+                "execution_tasks": [".ocsp-darwinssl"],
+            },
+            {
+                "name": "ocsp-winssl",
+                "execution_tasks": [".ocsp-winssl"],
+            },
+            {
+                "name": "ocsp-openssl-1.0.1",
+                "execution_tasks": [".ocsp-openssl-1.0.1"],
+            },
+        ]
     ),
     Variant(
         "packaging",


### PR DESCRIPTION
Applies [display_task](https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Project-Configuration-Files/#display-tasks) to OCSP tasks, grouped by SSL library, to significantly simplify the task list of C Driver EVG builds.

See [this patch](https://spruce.mongodb.com/version/65d5237e0305b9759fba61cb) for example of results.

Proper migration of the OCSP task matrix to the modern config generator is deferred in favor of immediate benefits. Other task matrices may be given display tasks on a case-by-case basis going forward to further simplify the EVG task list.