### PR TITLE
Reduce Warnings - Miscellaneous GCC and Clang Warnings (CDRIVER-5305)

### DIFF
--- a/src/common/common-md5.c
+++ b/src/common/common-md5.c
@@ -169,7 +169,7 @@ bson_md5_process (bson_md5_t *md5, const uint8_t *data)
           * On little-endian machines, we can process properly aligned
           * data without copying it.
           */
-         if (!((data - (const uint8_t *) 0) & 3)) {
+         if (!(((uintptr_t) data) & 3u)) {
 /* data are properly aligned */
 #ifdef __clang__
 #pragma clang diagnostic push

--- a/src/libbson/examples/bson-streaming-reader.c
+++ b/src/libbson/examples/bson-streaming-reader.c
@@ -52,7 +52,8 @@
 int
 bson_streaming_remote_open (const char *hostname, const char *port)
 {
-   int error, sock;
+   int error = 0;
+   int sock = 0;
    struct addrinfo hints, *ptr, *server_list;
 
    /*

--- a/src/libbson/examples/creating.c
+++ b/src/libbson/examples/creating.c
@@ -17,7 +17,7 @@
 #include <bson/bson.h>
 
 int
-main (int argc, const char **argv)
+main (void)
 {
    {
       // bson_append_document_begin example ... begin

--- a/src/libbson/src/bson/bson-decimal128.c
+++ b/src/libbson/src/bson/bson-decimal128.c
@@ -165,8 +165,10 @@ bson_decimal128_to_string (const bson_decimal128_t *dec, /* IN  */
       *(str_out++) = '-';
    }
 
-   low = (uint32_t) dec->low, midl = (uint32_t) (dec->low >> 32),
-   midh = (uint32_t) dec->high, high = (uint32_t) (dec->high >> 32);
+   low = (uint32_t) dec->low;
+   midl = (uint32_t) (dec->low >> 32);
+   midh = (uint32_t) dec->high;
+   high = (uint32_t) (dec->high >> 32);
 
    /* Decode combination field and exponent */
    combination = (high >> 26) & COMBINATION_MASK;

--- a/src/libbson/src/bson/bson-decimal128.c
+++ b/src/libbson/src/bson/bson-decimal128.c
@@ -32,15 +32,17 @@
 #define BSON_DECIMAL128_MAX_DIGITS 34
 
 #define BSON_DECIMAL128_SET_NAN(dec)      \
-   do {                                   \
+   if (1) {                               \
       (dec).high = 0x7c00000000000000ull; \
       (dec).low = 0;                      \
-   } while (0);
+   } else                                 \
+      (void) 0
 #define BSON_DECIMAL128_SET_INF(dec, isneg)                                 \
-   do {                                                                     \
+   if (1) {                                                                 \
       (dec).high = 0x7800000000000000ull + 0x8000000000000000ull * (isneg); \
       (dec).low = 0;                                                        \
-   } while (0);
+   } else                                                                   \
+      (void) 0
 
 /**
  * _bson_uint128_t:

--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -347,7 +347,7 @@ _noop (void)
    do {                                 \
       STACK_POP_DOC (_noop ());         \
       bson->code_data.in_scope = false; \
-   } while (0);
+   } while (0)
 #define STACK_POP_DBPOINTER STACK_POP_DOC (_noop ())
 #define BASIC_CB_PREAMBLE                         \
    const char *key;                               \
@@ -355,7 +355,8 @@ _noop (void)
    bson_json_reader_bson_t *bson = &reader->bson; \
    _bson_json_read_fixup_key (bson);              \
    key = bson->key;                               \
-   len = bson->key_buf.len;
+   len = bson->key_buf.len;                       \
+   (void) 0
 #define BASIC_CB_BAIL_IF_NOT_NORMAL(_type)                                     \
    if (bson->read_state != BSON_JSON_REGULAR) {                                \
       _bson_json_read_set_error (reader,                                       \
@@ -369,7 +370,8 @@ _noop (void)
                                  (_type),                                      \
                                  read_state_names[bson->read_state]);          \
       return;                                                                  \
-   }
+   } else                                                                      \
+      (void) 0
 #define HANDLE_OPTION(_selection_statement, _key, _type, _state)               \
    _selection_statement (len == strlen (_key) &&                               \
                          strncmp ((const char *) val, (_key), len) == 0)       \

--- a/src/libbson/tests/test-bson.c
+++ b/src/libbson/tests/test-bson.c
@@ -290,7 +290,7 @@ test_bson_append_array (void)
 static void
 test_bson_append_binary (void)
 {
-   const static uint8_t binary[] = {'1', '2', '3', '4'};
+   static const uint8_t binary[] = {'1', '2', '3', '4'};
    bson_t *b;
    bson_t *b2;
 
@@ -307,7 +307,7 @@ test_bson_append_binary (void)
 static void
 test_bson_append_binary_deprecated (void)
 {
-   const static uint8_t binary[] = {'1', '2', '3', '4'};
+   static const uint8_t binary[] = {'1', '2', '3', '4'};
    bson_t *b;
    bson_t *b2;
 

--- a/src/libbson/tests/test-decimal128.c
+++ b/src/libbson/tests/test-decimal128.c
@@ -37,7 +37,7 @@
    do {                                 \
       (dec).high = (h);                 \
       (dec).low = (l);                  \
-   } while (0);
+   } while (0)
 
 
 static void

--- a/src/libbson/tests/test-iso8601.c
+++ b/src/libbson/tests/test-iso8601.c
@@ -3,7 +3,7 @@
 #include "bson/bson-iso8601-private.h"
 #include "TestSuite.h"
 
-#define IS_TIME_T_SMALL (sizeof (time_t) == sizeof (int32_t))
+static const bool is_time_t_small = (sizeof (time_t) == sizeof (int32_t));
 
 static void
 test_date (const char *str, int64_t millis)
@@ -91,7 +91,7 @@ test_bson_iso8601_utc (void)
    test_date_rt ("1970-06-30T01:06:40.981Z", 15556000981ULL);
    test_date ("1970-01-01T00:00:00.000+0100", -3600LL * 1000);
 
-   if (!IS_TIME_T_SMALL) {
+   if (!is_time_t_small) {
       test_date_rt ("2058-02-20T18:29:11.100Z", 2781455351100ULL);
       test_date ("3001-01-01T08:00:00.000Z", 32535244800000ULL);
    }
@@ -134,7 +134,7 @@ test_bson_iso8601_local (void)
                  15556000981ULL);
    test_date_io ("1969-12-31T16:00:00.000-0800", "1970-01-01T00:00:00Z", 0ULL);
 
-   if (!IS_TIME_T_SMALL) {
+   if (!is_time_t_small) {
       test_date_io ("2058-02-20T13:29:11.100-0500",
                     "2058-02-20T18:29:11.100Z",
                     2781455351100ULL);
@@ -291,7 +291,7 @@ test_bson_iso8601_leap_year (void)
    test_date_rt ("2032-02-29T00:00:00Z", 1961625600000ULL);
    test_date_rt ("2036-02-29T00:00:00Z", 2087856000000ULL);
 
-   if (!IS_TIME_T_SMALL) {
+   if (!is_time_t_small) {
       test_date_rt ("2040-02-29T00:00:00Z", 2214086400000ULL);
       test_date_rt ("2044-02-29T00:00:00Z", 2340316800000ULL);
       test_date_rt ("2048-02-29T00:00:00Z", 2466547200000ULL);

--- a/src/libbson/tests/test-json.c
+++ b/src/libbson/tests/test-json.c
@@ -2951,7 +2951,7 @@ _test_json_produces_multiple (const char *json_in, int err_expected, ...)
 }
 
 #define TEST_JSON_PRODUCES_MULTIPLE(_json, _has_err, ...) \
-   _test_json_produces_multiple (_json, _has_err, __VA_ARGS__, NULL);
+   _test_json_produces_multiple (_json, _has_err, __VA_ARGS__, NULL)
 
 static void
 test_bson_as_json_multi_object (void)

--- a/src/libmongoc/examples/basic_aggregation/map-reduce-basic.c
+++ b/src/libmongoc/examples/basic_aggregation/map-reduce-basic.c
@@ -2,16 +2,14 @@ bool
 map_reduce_basic (mongoc_database_t *database)
 {
    bson_t reply;
-   bson_t *command;
-   bool res;
+   bool res = false;
    bson_error_t error;
-   mongoc_cursor_t *cursor;
-   const bson_t *doc;
+   mongoc_cursor_t *cursor = NULL;
 
    bool query_done = false;
 
    const char *out_collection_name = "outCollection";
-   mongoc_collection_t *out_collection;
+   mongoc_collection_t *out_collection = NULL;
 
    /* Empty find query */
    bson_t find_query = BSON_INITIALIZER;
@@ -20,14 +18,14 @@ map_reduce_basic (mongoc_database_t *database)
 
    /* Other arguments can also be specified here, like "query" or
       "limit" and so on */
-   command = BCON_NEW ("mapReduce",
-                       BCON_UTF8 (COLLECTION_NAME),
-                       "map",
-                       BCON_CODE (MAPPER),
-                       "reduce",
-                       BCON_CODE (REDUCER),
-                       "out",
-                       BCON_UTF8 (out_collection_name));
+   bson_t *const command = BCON_NEW ("mapReduce",
+                                     BCON_UTF8 (COLLECTION_NAME),
+                                     "map",
+                                     BCON_CODE (MAPPER),
+                                     "reduce",
+                                     BCON_CODE (REDUCER),
+                                     "out",
+                                     BCON_UTF8 (out_collection_name));
    res =
       mongoc_database_command_simple (database, command, NULL, &reply, &error);
 
@@ -47,6 +45,7 @@ map_reduce_basic (mongoc_database_t *database)
    query_done = true;
 
    /* Do something with the results */
+   const bson_t *doc = NULL;
    while (mongoc_cursor_next (cursor, &doc)) {
       print_res (doc);
    }

--- a/src/libmongoc/examples/example-session.c
+++ b/src/libmongoc/examples/example-session.c
@@ -83,7 +83,7 @@ main (int argc, char *argv[])
    if (!mongoc_client_session_append (client_session, find_opts, &error)) {
       fprintf (stderr, "Could not add session to opts: %s\n", error.message);
       goto done;
-   };
+   }
 
    /* read from secondary. since we're in a causally consistent session, the
     * data is guaranteed to reflect the update we did on the primary. the query

--- a/src/libmongoc/examples/tutorial/appending.c
+++ b/src/libmongoc/examples/tutorial/appending.c
@@ -1,7 +1,7 @@
 #include <bson/bson.h>
 
 int
-main (int argc, char *argv[])
+main (void)
 {
    struct tm born = {0};
    struct tm died = {0};

--- a/src/libmongoc/examples/tutorial/executing.c
+++ b/src/libmongoc/examples/tutorial/executing.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 
 int
-main (int argc, char *argv[])
+main (void)
 {
    mongoc_client_t *client;
    bson_error_t error;

--- a/src/libmongoc/src/mongoc/mongoc-aggregate.c
+++ b/src/libmongoc/src/mongoc/mongoc-aggregate.c
@@ -108,7 +108,8 @@ _make_agg_cmd (const char *ns,
               then (cstr (dot + 1)),
               // Otherwise just an integer 1:
               else (int32 (1)))));
-   if ((error_hint = "append-aggregate", error = bsonBuildError)) {
+   if ((error = bsonBuildError)) {
+      error_hint = "append-aggregate";
       goto fail;
    }
 
@@ -124,7 +125,8 @@ _make_agg_cmd (const char *ns,
       else ( // We did not find a "pipeline" array. copy the pipeline as
              // an array into the command
          append (*command, kv ("pipeline", array (insert (*pipeline, true))))));
-   if ((error_hint = "append-pipeline", error = bsonParseError)) {
+   if ((error = bsonParseError)) {
+      error_hint = "append-pipeline";
       goto fail;
    }
 
@@ -141,7 +143,9 @@ _make_agg_cmd (const char *ns,
                           // writing aggregate command.
                           parse (find (key ("$out", "$merge"),
                                        do (has_write_key = true)))))));
-   if ((error_hint = "parse-pipeline", error = bsonParseError)) {
+
+   if ((error = bsonParseError)) {
+      error_hint = "parse-pipeline";
       goto fail;
    }
 
@@ -154,7 +158,8 @@ _make_agg_cmd (const char *ns,
           doc (if (opts->batchSize_is_set &&
                       !(has_write_key && opts->batchSize == 0),
                    then (kv ("batchSize", int32 (opts->batchSize)))))));
-   if ((error_hint = "build-cursor", error = bsonBuildError)) {
+   if ((error = bsonBuildError)) {
+      error_hint = "build-cursor";
       goto fail;
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-change-stream.c
+++ b/src/libmongoc/src/mongoc/mongoc-change-stream.c
@@ -29,7 +29,7 @@
    bson_set_error (&stream->err,        \
                    MONGOC_ERROR_CURSOR, \
                    MONGOC_ERROR_BSON,   \
-                   "Could not set " _str);
+                   "Could not set " _str)
 
 /* the caller knows either a client or server error has occurred.
  * `reply` contains the server reply or an empty document. */

--- a/src/libmongoc/src/mongoc/mongoc-client-session.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-session.c
@@ -1241,7 +1241,6 @@ mongoc_client_session_get_transaction_state (
       MONGOC_ERROR ("invalid state %d when getting transaction state",
                     (int) session->txn.state);
       abort ();
-      break;
    }
 }
 

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -1892,7 +1892,7 @@ _mongoc_client_command_with_stream (mongoc_client_t *client,
    if (!mongoc_cmd_parts_assemble (parts, server_stream, error)) {
       _mongoc_bson_init_if_set (reply);
       return false;
-   };
+   }
 
    if (parts->is_retryable_write) {
       RETURN (_mongoc_client_retryable_write_command_with_stream (

--- a/src/libmongoc/src/mongoc/mongoc-compression.c
+++ b/src/libmongoc/src/mongoc/mongoc-compression.c
@@ -43,24 +43,20 @@ mongoc_compressor_max_compressed_length (int32_t compressor_id, size_t len)
 #ifdef MONGOC_ENABLE_COMPRESSION_SNAPPY
    case MONGOC_COMPRESSOR_SNAPPY_ID:
       return snappy_max_compressed_length (len);
-      break;
 #endif
 
 #ifdef MONGOC_ENABLE_COMPRESSION_ZLIB
    case MONGOC_COMPRESSOR_ZLIB_ID:
       BSON_ASSERT (bson_in_range_unsigned (unsigned_long, len));
       return compressBound ((unsigned long) len);
-      break;
 #endif
 
 #ifdef MONGOC_ENABLE_COMPRESSION_ZSTD
    case MONGOC_COMPRESSOR_ZSTD_ID:
       return ZSTD_compressBound (len);
-      break;
 #endif
    case MONGOC_COMPRESSOR_NOOP_ID:
       return len;
-      break;
    default:
       return 0;
    }
@@ -169,7 +165,6 @@ mongoc_uncompress (int32_t compressor_id,
                       "compression is not compiled in");
       return false;
 #endif
-      break;
    }
 
    case MONGOC_COMPRESSOR_ZLIB_ID: {
@@ -186,7 +181,6 @@ mongoc_uncompress (int32_t compressor_id,
                       "compression is not compiled in");
       return false;
 #endif
-      break;
    }
 
    case MONGOC_COMPRESSOR_ZSTD_ID: {
@@ -208,7 +202,6 @@ mongoc_uncompress (int32_t compressor_id,
                       "compression is not compiled in");
       return false;
 #endif
-      break;
    }
    case MONGOC_COMPRESSOR_NOOP_ID:
       memcpy (uncompressed, compressed, compressed_len);

--- a/src/libmongoc/src/mongoc/mongoc-crypt.c
+++ b/src/libmongoc/src/mongoc/mongoc-crypt.c
@@ -1142,7 +1142,6 @@ _state_machine_run (_state_machine_t *state_machine,
          break;
       case MONGOCRYPT_CTX_DONE:
          goto success;
-         break;
       }
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-crypt.c
+++ b/src/libmongoc/src/mongoc/mongoc-crypt.c
@@ -705,7 +705,7 @@ fail:
  * @retval false Otherwise or on error
  */
 static bool
-_needs_on_demand_aws_kms (bson_t const *kms_providers, bson_error_t *error)
+_needs_on_demand_aws_kms (bson_t const *kms_providers)
 {
    bson_iter_t iter;
    if (!bson_iter_init_find (&iter, kms_providers, "aws")) {
@@ -995,7 +995,7 @@ _state_need_kms_credentials (_state_machine_t *sm, bson_error_t *error)
       bson_iter_init_find (&iter, &creds, "aws");
 
    if (!callback_provided_aws &&
-       _needs_on_demand_aws_kms (&sm->crypt->kms_providers, error)) {
+       _needs_on_demand_aws_kms (&sm->crypt->kms_providers)) {
       // The original kmsProviders had an empty "aws" property, and the
       // user-provided callback did not fill in a new "aws" property for us.
       // Attempt instead to load the AWS credentials from the environment:

--- a/src/libmongoc/src/mongoc/mongoc-cursor.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor.c
@@ -870,7 +870,7 @@ _mongoc_cursor_monitor_failed (mongoc_cursor_t *cursor,
       if (bson_iter_as_bool (&iter)) {                             \
          *_flags |= _value;                                        \
       }                                                            \
-   } while (false);
+   } while (false)
 
 bool
 _mongoc_cursor_opts_to_flags (mongoc_cursor_t *cursor,

--- a/src/libmongoc/src/mongoc/mongoc-cyrus-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-cyrus-private.h
@@ -43,7 +43,7 @@ struct _mongoc_cyrus_t {
 
 
 #ifndef SASL_CALLBACK_FN
-#define SASL_CALLBACK_FN(_f) ((int (*) (void)) (_f))
+#define SASL_CALLBACK_FN(_f) ((int (*) (void)) ((void (*) (void)) (_f)))
 #endif
 
 void

--- a/src/libmongoc/src/mongoc/mongoc-gridfs-file.c
+++ b/src/libmongoc/src/mongoc/mongoc-gridfs-file.c
@@ -961,8 +961,6 @@ mongoc_gridfs_file_seek (mongoc_gridfs_file_t *file, int64_t delta, int whence)
    default:
       errno = EINVAL;
       return -1;
-
-      break;
    }
 
    if (offset < 0) {

--- a/src/libmongoc/src/mongoc/mongoc-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-openssl.c
@@ -1086,7 +1086,6 @@ _mongoc_openssl_extract_subject (const char *filename, const char *passphrase)
 
    certbio = BIO_new (BIO_s_file ());
    strbio = BIO_new (BIO_s_mem ());
-   ;
 
    BSON_ASSERT (certbio);
    BSON_ASSERT (strbio);

--- a/src/libmongoc/src/mongoc/mongoc-scram.c
+++ b/src/libmongoc/src/mongoc/mongoc-scram.c
@@ -627,28 +627,25 @@ _mongoc_scram_step2 (mongoc_scram_t *scram,
                      bson_error_t *error)
 {
    uint8_t *val_r = NULL;
-   uint32_t val_r_len;
+   uint32_t val_r_len = 0u;
    uint8_t *val_s = NULL;
-   uint32_t val_s_len;
+   uint32_t val_s_len = 0u;
    uint8_t *val_i = NULL;
-   uint32_t val_i_len;
+   uint32_t val_i_len = 0u;
 
-   uint8_t **current_val;
-   uint32_t *current_val_len;
+   uint8_t **current_val = NULL;
+   uint32_t *current_val_len = NULL;
 
-   const uint8_t *ptr;
-   const uint8_t *next_comma;
-
-   char *tmp;
+   char *tmp = NULL;
    char *hashed_password = NULL;
 
    uint8_t decoded_salt[MONGOC_SCRAM_B64_HASH_MAX_SIZE] = {0};
-   int32_t decoded_salt_len;
+   int32_t decoded_salt_len = 0;
    /* the decoded salt leaves four trailing bytes to add the int32 0x00000001 */
    const int32_t expected_salt_length = _scram_hash_size (scram) - 4;
    bool rval = true;
 
-   int iterations;
+   int iterations = 0;
 
 
    BSON_ASSERT (scram);
@@ -692,7 +689,7 @@ _mongoc_scram_step2 (mongoc_scram_t *scram,
       goto BUFFER_AUTH;
    }
 
-   for (ptr = inbuf; ptr < inbuf + inbuflen;) {
+   for (const uint8_t *ptr = inbuf; ptr < inbuf + inbuflen;) {
       switch (*ptr) {
       case 'r':
          current_val = &val_r;
@@ -728,7 +725,7 @@ _mongoc_scram_step2 (mongoc_scram_t *scram,
 
       ptr++;
 
-      next_comma =
+      const uint8_t *const next_comma =
          (const uint8_t *) memchr (ptr, ',', (inbuf + inbuflen) - ptr);
 
       if (next_comma) {
@@ -976,15 +973,12 @@ _mongoc_scram_step3 (mongoc_scram_t *scram,
                      bson_error_t *error)
 {
    uint8_t *val_e = NULL;
-   uint32_t val_e_len;
+   uint32_t val_e_len = 0;
    uint8_t *val_v = NULL;
-   uint32_t val_v_len;
+   uint32_t val_v_len = 0;
 
    uint8_t **current_val;
-   uint32_t *current_val_len;
-
-   const uint8_t *ptr;
-   const uint8_t *next_comma;
+   uint32_t *current_val_len = 0;
 
    bool rval = true;
 
@@ -993,7 +987,7 @@ _mongoc_scram_step3 (mongoc_scram_t *scram,
    BSON_ASSERT (outbufmax);
    BSON_ASSERT (outbuflen);
 
-   for (ptr = inbuf; ptr < inbuf + inbuflen;) {
+   for (const uint8_t *ptr = inbuf; ptr < inbuf + inbuflen;) {
       switch (*ptr) {
       case 'e':
          current_val = &val_e;
@@ -1024,7 +1018,7 @@ _mongoc_scram_step3 (mongoc_scram_t *scram,
 
       ptr++;
 
-      next_comma =
+      const uint8_t *const next_comma =
          (const uint8_t *) memchr (ptr, ',', (inbuf + inbuflen) - ptr);
 
       if (next_comma) {

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl.c
@@ -286,7 +286,7 @@ _mongoc_stream_tls_openssl_writev (mongoc_stream_t *stream,
    size_t bytes;
 
    char *to_write = NULL;
-   size_t to_write_len;
+   size_t to_write_len = 0u;
 
    BSON_ASSERT (tls);
    BSON_ASSERT (iov);

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -2055,7 +2055,7 @@ mc_tpld_modify_begin (mongoc_topology_t *tpl)
    mongoc_topology_description_t *new_td;
    bson_mutex_lock (&tpl->tpld_modification_mtx);
    prev_td = mc_tpld_take_ref (tpl);
-   new_td = mongoc_topology_description_new_copy (prev_td.ptr),
+   new_td = mongoc_topology_description_new_copy (prev_td.ptr);
    mc_tpld_drop_ref (&prev_td);
    return (mc_tpld_modification){
       .new_td = new_td,

--- a/src/libmongoc/src/mongoc/mongoc-uri.c
+++ b/src/libmongoc/src/mongoc/mongoc-uri.c
@@ -61,7 +61,7 @@ struct _mongoc_uri_t {
                    MONGOC_ERROR_COMMAND,             \
                    MONGOC_ERROR_COMMAND_INVALID_ARG, \
                    format,                           \
-                   __VA_ARGS__);
+                   __VA_ARGS__)
 
 
 static const char *escape_instructions = "Percent-encode username and password"
@@ -1061,9 +1061,10 @@ HANDLE_CONFLICT:
       MONGOC_WARNING ("Cannot override URI option \"%s\" from TXT record",    \
                       key);                                                   \
       continue;                                                               \
-   } else {                                                                   \
+   } else if (1) {                                                            \
       MONGOC_WARNING ("Overwriting previously provided value for '%s'", key); \
-   }
+   } else                                                                     \
+      (void) 0
 
 static bool
 mongoc_uri_apply_options (mongoc_uri_t *uri,

--- a/src/libmongoc/src/mongoc/mongoc-write-concern.c
+++ b/src/libmongoc/src/mongoc/mongoc-write-concern.c
@@ -558,10 +558,10 @@ _mongoc_write_concern_new_from_iter (const bson_iter_t *iter,
          if (!BSON_ITER_HOLDS_BOOL (&inner)) {
             goto fail;
          }
-         BEGIN_IGNORE_DEPRECATIONS;
+         BEGIN_IGNORE_DEPRECATIONS
          mongoc_write_concern_set_fsync (write_concern,
                                          bson_iter_bool (&inner));
-         END_IGNORE_DEPRECATIONS;
+         END_IGNORE_DEPRECATIONS
       } else if (BSON_ITER_IS_KEY (&inner, "j")) {
          if (!BSON_ITER_HOLDS_BOOL (&inner)) {
             goto fail;

--- a/src/libmongoc/src/mongoc/utlist.h
+++ b/src/libmongoc/src/mongoc/utlist.h
@@ -504,13 +504,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define LL_COUNT(head, el, counter) LL_COUNT2 (head, el, counter, next)
 
 #define LL_COUNT2(head, el, counter, next) \
-   {                                       \
+   if (1) {                                \
       counter = 0;                         \
       LL_FOREACH2 (head, el, next)         \
       {                                    \
          ++counter;                        \
       }                                    \
-   }
+   } else                                  \
+      (void) 0
 
 #define LL_FOREACH(head, el) LL_FOREACH2 (head, el, next)
 
@@ -658,13 +659,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define DL_COUNT(head, el, counter) DL_COUNT2 (head, el, counter, next)
 
 #define DL_COUNT2(head, el, counter, next) \
-   {                                       \
+   if (1) {                                \
       counter = 0;                         \
       DL_FOREACH2 (head, el, next)         \
       {                                    \
          ++counter;                        \
       }                                    \
-   }
+   } else                                  \
+      (void) 0
 
 #define DL_FOREACH(head, el) DL_FOREACH2 (head, el, next)
 
@@ -760,13 +762,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CDL_COUNT(head, el, counter) CDL_COUNT2 (head, el, counter, next)
 
 #define CDL_COUNT2(head, el, counter, next) \
-   {                                        \
+   if (1) {                                 \
       counter = 0;                          \
       CDL_FOREACH2 (head, el, next)         \
       {                                     \
          ++counter;                         \
       }                                     \
-   }
+   } else                                   \
+      (void) 0
 
 #define CDL_FOREACH(head, el) CDL_FOREACH2 (head, el, next)
 

--- a/src/libmongoc/tests/TestSuite.h
+++ b/src/libmongoc/tests/TestSuite.h
@@ -483,7 +483,7 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
          abort ();                                                    \
       };                                                              \
       ASSERT_CONTAINS (error.message, _message);                      \
-   } while (0);
+   } while (0)
 
 #define ASSERT_CAPTURED_LOG(_info, _level, _msg)                             \
    do {                                                                      \
@@ -497,7 +497,7 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
          print_captured_logs ("\t");                                         \
          abort ();                                                           \
       }                                                                      \
-   } while (0);
+   } while (0)
 
 #define ASSERT_NO_CAPTURED_LOGS(_info)                         \
    do {                                                        \
@@ -511,7 +511,7 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
          print_captured_logs ("\t");                           \
          abort ();                                             \
       }                                                        \
-   } while (0);
+   } while (0)
 
 #define ASSERT_HAS_FIELD(_bson, _field)                            \
    do {                                                            \

--- a/src/libmongoc/tests/bsonutil/bson-parser.c
+++ b/src/libmongoc/tests/bsonutil/bson-parser.c
@@ -76,7 +76,6 @@ parser_type_to_string (bson_parser_type_t ptype)
    default:
       return "INVALID";
    }
-   return "INVALID";
 }
 
 static mongoc_write_concern_t *

--- a/src/libmongoc/tests/json-test-operations.c
+++ b/src/libmongoc/tests/json-test-operations.c
@@ -887,7 +887,7 @@ bulk_write (mongoc_collection_t *collection,
 
 #define COPY_EXCEPT(...)           \
    bson_copy_to_excluding_noinit ( \
-      &args, &opts, "session", "readPreference", __VA_ARGS__, NULL);
+      &args, &opts, "session", "readPreference", __VA_ARGS__, NULL)
 
 
 static bool

--- a/src/libmongoc/tests/json-test-operations.c
+++ b/src/libmongoc/tests/json-test-operations.c
@@ -1994,8 +1994,7 @@ drop_collection (mongoc_database_t *db,
 
 
 static bool
-create_index (mongoc_database_t *db,
-              mongoc_collection_t *collection,
+create_index (mongoc_collection_t *collection,
               const bson_t *test,
               const bson_t *operation,
               mongoc_client_session_t *session,
@@ -2407,7 +2406,7 @@ json_test_operation (json_test_ctx_t *ctx,
       } else if (!strcmp (op_name, "mapReduce")) {
          test_error ("operation not implemented in libmongoc");
       } else if (!strcmp (op_name, "createIndex")) {
-         res = create_index (db, c, test, operation, session, reply);
+         res = create_index (c, test, operation, session, reply);
       } else {
          test_error ("unrecognized collection operation name %s", op_name);
       }

--- a/src/libmongoc/tests/test-atlas-executor.c
+++ b/src/libmongoc/tests/test-atlas-executor.c
@@ -38,7 +38,7 @@ void (*original_sigint_handler) (int) = NULL;
 static void
 sigint_handler (int sigint)
 {
-   assert (sigint == SIGINT);
+   BSON_ASSERT (sigint == SIGINT);
    operation_loop_terminated = true;
    signal (SIGINT, original_sigint_handler);
 }

--- a/src/libmongoc/tests/test-mcd-azure-imds.c
+++ b/src/libmongoc/tests/test-mcd-azure-imds.c
@@ -115,6 +115,7 @@ _test_with_mock_server (void *ctx)
 static int
 have_mock_server_env (TestSuite *ctx)
 {
+   BSON_UNUSED (ctx);
    return _get_test_imds_host () != NULL;
 }
 

--- a/src/libmongoc/tests/test-mongoc-background-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-background-monitoring.c
@@ -299,7 +299,7 @@ tf_destroy (test_fixture_t *tf)
             &_tf->cond, &_tf->mutex, _expires_ms - _start_ms);  \
       }                                                         \
       bson_mutex_unlock (&_tf->mutex);                          \
-   } while (0);
+   } while (0)
 
 /* Check that _predicate is true immediately. Upon failure,
  * dumps logs and observations. */
@@ -312,13 +312,13 @@ tf_destroy (test_fixture_t *tf)
          test_error ("Predicate failed: %s", #_predicate); \
       }                                                    \
       bson_mutex_unlock (&_tf->mutex);                     \
-   } while (0);
+   } while (0)
 
 /* Wait for two periods of the faster heartbeat.
  * Used to make observations that a scan doesn't occur when a test fixture is
  * configured with a faster heartbeat.
  */
-#define WAIT_TWO_MIN_HEARTBEAT_MS _mongoc_usleep (2 * FAST_HEARTBEAT_MS * 1000);
+#define WAIT_TWO_MIN_HEARTBEAT_MS _mongoc_usleep (2 * FAST_HEARTBEAT_MS * 1000)
 
 static void
 _signal_shutdown (test_fixture_t *tf)

--- a/src/libmongoc/tests/test-mongoc-change-stream.c
+++ b/src/libmongoc/tests/test-mongoc-change-stream.c
@@ -41,7 +41,7 @@
       future_wait (_future);                                               \
       future_destroy (_future);                                            \
       request_destroy (_request);                                          \
-   } while (0);
+   } while (0)
 
 
 typedef struct _data_change_stream_t {

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -3268,32 +3268,32 @@ _tls_test_make_client_encryption (mongoc_client_t *keyvault_client,
 
 #if defined(MONGOC_ENABLE_SSL_OPENSSL)
 #define ASSERT_EXPIRED(error) \
-   ASSERT_CONTAINS (error.message, "certificate has expired");
+   ASSERT_CONTAINS (error.message, "certificate has expired")
 #elif defined(MONGOC_ENABLE_SSL_SECURE_TRANSPORT)
 #define ASSERT_EXPIRED(error) \
-   ASSERT_CONTAINS (error.message, "CSSMERR_TP_CERT_EXPIRED");
+   ASSERT_CONTAINS (error.message, "CSSMERR_TP_CERT_EXPIRED")
 #elif defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
 #define ASSERT_EXPIRED(error) \
-   ASSERT_CONTAINS (error.message, "certificate has expired");
+   ASSERT_CONTAINS (error.message, "certificate has expired")
 #elif defined(MONGOC_ENABLE_SSL_LIBRESSL)
 #define ASSERT_EXPIRED(error) \
-   ASSERT_CONTAINS (error.message, "certificate has expired");
+   ASSERT_CONTAINS (error.message, "certificate has expired")
 #else
 #define ASSERT_EXPIRED(error)
 #endif
 
 #if defined(MONGOC_ENABLE_SSL_OPENSSL)
 #define ASSERT_INVALID_HOSTNAME(error) \
-   ASSERT_CONTAINS (error.message, "IP address mismatch");
+   ASSERT_CONTAINS (error.message, "IP address mismatch")
 #elif defined(MONGOC_ENABLE_SSL_SECURE_TRANSPORT)
 #define ASSERT_INVALID_HOSTNAME(error) \
-   ASSERT_CONTAINS (error.message, "Host name mismatch");
+   ASSERT_CONTAINS (error.message, "Host name mismatch")
 #elif defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
 #define ASSERT_INVALID_HOSTNAME(error) \
-   ASSERT_CONTAINS (error.message, "hostname doesn't match certificate");
+   ASSERT_CONTAINS (error.message, "hostname doesn't match certificate")
 #elif defined(MONGOC_ENABLE_SSL_LIBRESSL)
 #define ASSERT_INVALID_HOSTNAME(error) \
-   ASSERT_CONTAINS (error.message, "not present in server certificate");
+   ASSERT_CONTAINS (error.message, "not present in server certificate")
 #else
 #define ASSERT_INVALID_HOSTNAME(error)
 #endif

--- a/src/libmongoc/tests/test-mongoc-client.c
+++ b/src/libmongoc/tests/test-mongoc-client.c
@@ -3296,12 +3296,10 @@ test_mongoc_handshake_pool (void)
 static void
 _test_client_sends_handshake (bool pooled)
 {
-   mock_server_t *server;
-   request_t *request;
-   mongoc_uri_t *uri;
-   future_t *future;
-   mongoc_client_t *client;
-   mongoc_client_pool_t *pool;
+   request_t *request = NULL;
+   future_t *future = NULL;
+   mongoc_client_t *client = NULL;
+   mongoc_client_pool_t *pool = NULL;
    const char *const server_reply = tmp_str ("{'ok': 1,"
                                              " 'isWritablePrimary': true,"
                                              " 'minWireVersion': %d,"
@@ -3314,9 +3312,9 @@ _test_client_sends_handshake (bool pooled)
       return;
    }
 
-   server = mock_server_new ();
+   mock_server_t *const server = mock_server_new ();
    mock_server_run (server);
-   uri = mongoc_uri_copy (mock_server_get_uri (server));
+   mongoc_uri_t *const uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_int32 (uri, "heartbeatFrequencyMS", heartbeat_ms);
    mongoc_uri_set_option_as_int32 (uri, "connectTimeoutMS", 100);
 
@@ -3420,12 +3418,9 @@ test_client_sends_handshake_pooled (void)
 static void
 test_client_appname (bool pooled, bool use_uri)
 {
-   mock_server_t *server;
-   request_t *request;
-   mongoc_uri_t *uri;
-   future_t *future;
-   mongoc_client_t *client;
-   mongoc_client_pool_t *pool;
+   future_t *future = NULL;
+   mongoc_client_t *client = NULL;
+   mongoc_client_pool_t *pool = NULL;
    const char *const server_reply = tmp_str ("{'ok': 1,"
                                              " 'isWritablePrimary': true,"
                                              " 'minWireVersion': %d,"
@@ -3434,9 +3429,9 @@ test_client_appname (bool pooled, bool use_uri)
                                              WIRE_VERSION_MAX);
    const int heartbeat_ms = 500;
 
-   server = mock_server_new ();
+   mock_server_t *const server = mock_server_new ();
    mock_server_run (server);
-   uri = mongoc_uri_copy (mock_server_get_uri (server));
+   mongoc_uri_t *const uri = mongoc_uri_copy (mock_server_get_uri (server));
    mongoc_uri_set_option_as_int32 (uri, "heartbeatFrequencyMS", heartbeat_ms);
    mongoc_uri_set_option_as_int32 (uri, "connectTimeoutMS", 120 * 1000);
 
@@ -3458,7 +3453,7 @@ test_client_appname (bool pooled, bool use_uri)
       future = _force_hello_with_ping (client, heartbeat_ms);
    }
 
-   request =
+   request_t *const request =
       mock_server_receives_any_hello_with_match (server,
                                                  "{'client': {"
                                                  "    'application': {"

--- a/src/libmongoc/tests/test-mongoc-client.c
+++ b/src/libmongoc/tests/test-mongoc-client.c
@@ -563,7 +563,7 @@ test_mongoc_client_speculative_auth_failure (bool pooled)
           test_framework_max_wire_version_at_least (WIRE_VERSION_4_4)) {
          ASSERT_CAPTURED_LOG ("cluster",
                               MONGOC_LOG_LEVEL_WARNING,
-                              "Failed to send \"saslStart\" command")
+                              "Failed to send \"saslStart\" command");
          ASSERT_ERROR_CONTAINS (error,
                                 MONGOC_ERROR_CLIENT,
                                 MONGOC_ERROR_CLIENT_AUTHENTICATE,
@@ -3568,7 +3568,7 @@ _test_null_error_pointer (bool pooled)
    if (pooled) {
       ASSERT_CAPTURED_LOG ("cluster",
                            MONGOC_LOG_LEVEL_WARNING,
-                           "Failed to connect to target host")
+                           "Failed to connect to target host");
    }
    capture_logs (false);
 

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -836,14 +836,14 @@ test_insert_bulk_empty (void)
    database = get_test_database (client);
    collection = get_test_collection (client, "test_insert_bulk_empty");
 
-   BEGIN_IGNORE_DEPRECATIONS;
+   BEGIN_IGNORE_DEPRECATIONS
    ASSERT (!mongoc_collection_insert_bulk (collection,
                                            MONGOC_INSERT_NONE,
                                            (const bson_t **) &bptr,
                                            0,
                                            NULL,
                                            &error));
-   END_IGNORE_DEPRECATIONS;
+   END_IGNORE_DEPRECATIONS
 
    ASSERT_CMPINT (MONGOC_ERROR_COLLECTION, ==, error.domain);
    ASSERT_CMPINT (MONGOC_ERROR_COLLECTION_INSERT_FAILED, ==, error.code);
@@ -995,7 +995,7 @@ test_save (void)
    context = bson_context_new (BSON_CONTEXT_NONE);
    ASSERT (context);
 
-   BEGIN_IGNORE_DEPRECATIONS;
+   BEGIN_IGNORE_DEPRECATIONS
 
    for (i = 0; i < 10; i++) {
       bson_init (&b);
@@ -1009,7 +1009,7 @@ test_save (void)
 
    r = mongoc_collection_save (collection, tmp_bson ("{'': 1}"), NULL, &error);
 
-   END_IGNORE_DEPRECATIONS;
+   END_IGNORE_DEPRECATIONS
 
    ASSERT (!r);
    ASSERT_ERROR_CONTAINS (error,
@@ -3762,7 +3762,7 @@ test_many_return (void)
    ASSERT_ERROR_CONTAINS (error,
                           MONGOC_ERROR_CURSOR,
                           MONGOC_ERROR_CURSOR_INVALID_CURSOR,
-                          "Cannot advance a completed or failed cursor")
+                          "Cannot advance a completed or failed cursor");
 
    mongoc_cursor_destroy (cursor);
 

--- a/src/libmongoc/tests/test-mongoc-cursor.c
+++ b/src/libmongoc/tests/test-mongoc-cursor.c
@@ -441,17 +441,13 @@ _make_array_cursor (mongoc_collection_t *coll)
    return mongoc_client_find_databases_with_opts (coll->client, NULL);
 }
 
-#define TEST_CURSOR_FIND(prefix, fn)               \
-   TestSuite_AddFullWithTestFn (suite,             \
-                                prefix "/find",    \
-                                fn,                \
-                                NULL,              \
-                                _make_find_cursor, \
-                                TestSuite_CheckLive);
+#define TEST_CURSOR_FIND(prefix, fn) \
+   TestSuite_AddFullWithTestFn (     \
+      suite, prefix "/find", fn, NULL, _make_find_cursor, TestSuite_CheckLive)
 
 #define TEST_CURSOR_CMD(prefix, fn) \
    TestSuite_AddFullWithTestFn (    \
-      suite, prefix "/cmd", fn, NULL, _make_cmd_cursor, TestSuite_CheckLive);
+      suite, prefix "/cmd", fn, NULL, _make_cmd_cursor, TestSuite_CheckLive)
 
 #define TEST_CURSOR_CMD_DEPRECATED(prefix, fn)               \
    TestSuite_AddFullWithTestFn (suite,                       \
@@ -459,7 +455,7 @@ _make_array_cursor (mongoc_collection_t *coll)
                                 fn,                          \
                                 NULL,                        \
                                 _make_cmd_deprecated_cursor, \
-                                TestSuite_CheckLive);
+                                TestSuite_CheckLive)
 
 #define TEST_CURSOR_ARRAY(prefix, fn)               \
    TestSuite_AddFullWithTestFn (suite,              \
@@ -467,7 +463,7 @@ _make_array_cursor (mongoc_collection_t *coll)
                                 fn,                 \
                                 NULL,               \
                                 _make_array_cursor, \
-                                TestSuite_CheckLive);
+                                TestSuite_CheckLive)
 
 #define TEST_CURSOR_AGG(prefix, fn)                        \
    TestSuite_AddFullWithTestFn (suite,                     \
@@ -475,15 +471,18 @@ _make_array_cursor (mongoc_collection_t *coll)
                                 fn,                        \
                                 NULL,                      \
                                 _make_cmd_cursor_from_agg, \
-                                TestSuite_CheckLive);
+                                TestSuite_CheckLive)
 
 
-#define TEST_FOREACH_CURSOR(prefix, fn)     \
-   TEST_CURSOR_FIND (prefix, fn);           \
-   TEST_CURSOR_CMD (prefix, fn);            \
-   TEST_CURSOR_CMD_DEPRECATED (prefix, fn); \
-   TEST_CURSOR_ARRAY (prefix, fn);          \
-   TEST_CURSOR_AGG (prefix, fn);
+#define TEST_FOREACH_CURSOR(prefix, fn)        \
+   if (1) {                                    \
+      TEST_CURSOR_FIND (prefix, fn);           \
+      TEST_CURSOR_CMD (prefix, fn);            \
+      TEST_CURSOR_CMD_DEPRECATED (prefix, fn); \
+      TEST_CURSOR_ARRAY (prefix, fn);          \
+      TEST_CURSOR_AGG (prefix, fn);            \
+   } else                                      \
+      (void) 0
 
 
 static void
@@ -613,10 +612,13 @@ killcursors_succeeded (const mongoc_apm_command_succeeded_t *event)
 
    reply = mongoc_apm_command_succeeded_get_reply (event);
 
-#define ASSERT_EMPTY(_fieldname)                                   \
-   BSON_ASSERT (bson_iter_init_find (&iter, reply, (_fieldname))); \
-   BSON_ASSERT (bson_iter_recurse (&iter, &array));                \
-   BSON_ASSERT (!bson_iter_next (&array));
+#define ASSERT_EMPTY(_fieldname)                                      \
+   if (1) {                                                           \
+      BSON_ASSERT (bson_iter_init_find (&iter, reply, (_fieldname))); \
+      BSON_ASSERT (bson_iter_recurse (&iter, &array));                \
+      BSON_ASSERT (!bson_iter_next (&array));                         \
+   } else                                                             \
+      (void) 0
 
    ASSERT_EMPTY ("cursorsNotFound");
    ASSERT_EMPTY ("cursorsAlive");
@@ -784,7 +786,7 @@ _test_kill_cursors (bool pooled)
    if (!future_get_bool (future)) {
       mongoc_cursor_error (cursor, &error);
       test_error ("%s", error.message);
-   };
+   }
 
    ASSERT_MATCH (doc, "{'b': 1}");
    ASSERT_CMPINT (123, ==, (int) mongoc_cursor_get_id (cursor));

--- a/src/libmongoc/tests/test-mongoc-exhaust.c
+++ b/src/libmongoc/tests/test-mongoc-exhaust.c
@@ -239,7 +239,7 @@ test_exhaust_cursor (bool pooled)
          BSON_ASSERT (doc);
       }
 
-      while (!cursor->in_exhaust && (r = mongoc_cursor_next (cursor, &doc), r))
+      while (!cursor->in_exhaust && (r = mongoc_cursor_next (cursor, &doc)))
          ;
       BSON_ASSERT (client->in_exhaust);
       BSON_ASSERT (r);
@@ -288,7 +288,7 @@ test_exhaust_cursor (bool pooled)
       stream =
          (mongoc_stream_t *) mongoc_set_get (client->cluster.nodes, server_id);
 
-      while (cursor->in_exhaust && (r = mongoc_cursor_next (cursor, &doc), r))
+      while (cursor->in_exhaust && (r = mongoc_cursor_next (cursor, &doc)))
          ;
       BSON_ASSERT (!r);
       BSON_ASSERT (!doc);

--- a/src/libmongoc/tests/test-mongoc-exhaust.c
+++ b/src/libmongoc/tests/test-mongoc-exhaust.c
@@ -164,7 +164,7 @@ test_exhaust_cursor (bool pooled)
          bptr[i] = &b[i];
       }
 
-      BEGIN_IGNORE_DEPRECATIONS;
+      BEGIN_IGNORE_DEPRECATIONS
       ASSERT_OR_PRINT (mongoc_collection_insert_bulk (collection,
                                                       MONGOC_INSERT_NONE,
                                                       (const bson_t **) bptr,
@@ -172,7 +172,7 @@ test_exhaust_cursor (bool pooled)
                                                       wr,
                                                       &error),
                        error);
-      END_IGNORE_DEPRECATIONS;
+      END_IGNORE_DEPRECATIONS
    }
 
    /* create a couple of cursors */
@@ -259,14 +259,14 @@ test_exhaust_cursor (bool pooled)
 
    /* make sure writes fail as well */
    {
-      BEGIN_IGNORE_DEPRECATIONS;
+      BEGIN_IGNORE_DEPRECATIONS
       r = mongoc_collection_insert_bulk (collection,
                                          MONGOC_INSERT_NONE,
                                          (const bson_t **) bptr,
                                          10,
                                          wr,
                                          &error);
-      END_IGNORE_DEPRECATIONS;
+      END_IGNORE_DEPRECATIONS
 
       BSON_ASSERT (!r);
       ASSERT_CMPUINT32 (error.domain, ==, MONGOC_ERROR_CLIENT);

--- a/src/libmongoc/tests/test-mongoc-opts.c
+++ b/src/libmongoc/tests/test-mongoc-opts.c
@@ -130,12 +130,16 @@ func_ctx_cleanup (func_ctx_t *ctx)
                                                                                \
    mongoc_read_concern_set_level (rc, #_type);                                 \
    mongoc_write_concern_set_wtag (wc, #_type);                                 \
-   mongoc_read_prefs_set_tags (prefs, tmp_bson ("[{'%s': 'yes'}]", #_type))
+   mongoc_read_prefs_set_tags (prefs, tmp_bson ("[{'%s': 'yes'}]", #_type));   \
+   (void) 0
 
-#define SET_OPT_CLEANUP               \
-   mongoc_read_concern_destroy (rc);  \
-   mongoc_write_concern_destroy (wc); \
-   mongoc_read_prefs_destroy (prefs);
+#define SET_OPT_CLEANUP                  \
+   if (1) {                              \
+      mongoc_read_concern_destroy (rc);  \
+      mongoc_write_concern_destroy (wc); \
+      mongoc_read_prefs_destroy (prefs); \
+   } else                                \
+      (void) 0
 
 #define SET_OPT(_type)                                        \
    static void set_##_type##_opt (mongoc_##_type##_t *obj,    \

--- a/src/libmongoc/tests/test-mongoc-primary-stepdown.c
+++ b/src/libmongoc/tests/test-mongoc-primary-stepdown.c
@@ -531,21 +531,24 @@ test_primary_stepdown_install (TestSuite *suite)
    test_ctx_t single_ctx = {.use_pooled = false};
    test_ctx_t pooled_ctx = {.use_pooled = true};
 
-#define TestPooledAndSingle(name, fn)                      \
-   TestSuite_AddFull (suite,                               \
-                      name "/single",                      \
-                      fn,                                  \
-                      NULL,                                \
-                      &single_ctx,                         \
-                      test_framework_skip_if_auth,         \
-                      test_framework_skip_if_not_replset); \
-   TestSuite_AddFull (suite,                               \
-                      name "/pooled",                      \
-                      fn,                                  \
-                      NULL,                                \
-                      &pooled_ctx,                         \
-                      test_framework_skip_if_auth,         \
-                      test_framework_skip_if_not_replset);
+#define TestPooledAndSingle(name, fn)                         \
+   if (1) {                                                   \
+      TestSuite_AddFull (suite,                               \
+                         name "/single",                      \
+                         fn,                                  \
+                         NULL,                                \
+                         &single_ctx,                         \
+                         test_framework_skip_if_auth,         \
+                         test_framework_skip_if_not_replset); \
+      TestSuite_AddFull (suite,                               \
+                         name "/pooled",                      \
+                         fn,                                  \
+                         NULL,                                \
+                         &pooled_ctx,                         \
+                         test_framework_skip_if_auth,         \
+                         test_framework_skip_if_not_replset); \
+   } else                                                     \
+      (void) 0
 
    TestPooledAndSingle ("/Stepdown/getmore", test_getmore_iteration_runner);
    TestPooledAndSingle ("/Stepdown/not_primary_keep",

--- a/src/libmongoc/tests/test-mongoc-read-concern.c
+++ b/src/libmongoc/tests/test-mongoc-read-concern.c
@@ -39,7 +39,7 @@ test_read_concern_basic (void)
 
    read_concern = mongoc_read_concern_new ();
 
-   BEGIN_IGNORE_DEPRECATIONS;
+   BEGIN_IGNORE_DEPRECATIONS
 
    /*
     * Test defaults.

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -2862,8 +2862,6 @@ BSON_THREAD_FUN (insert_docs, p)
       bson_mutex_unlock (&ctx->lock);
       _mongoc_usleep (100 * 1000);  /* 100 ms */
    }
-   bson_destroy (&doc);
-   BSON_THREAD_RETURN;
 }
 
 

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -2600,6 +2600,8 @@ cleanup:
 static void
 test_example_59 (mongoc_database_t *db)
 {
+   BSON_UNUSED (db);
+
    if (!test_framework_skip_if_no_txns ()) {
       return;
    }
@@ -2717,6 +2719,8 @@ cleanup:
 static void
 test_example_60 (mongoc_database_t *db)
 {
+   BSON_UNUSED (db);
+
    if (!test_framework_skip_if_no_txns ()) {
       return;
    }

--- a/src/libmongoc/tests/test-mongoc-scram.c
+++ b/src/libmongoc/tests/test-mongoc-scram.c
@@ -234,6 +234,8 @@ static BSON_THREAD_FUN (_scram_cache_invalidation_thread, username_number_ptr)
 static void
 test_mongoc_scram_cache_invalidation (void *ctx)
 {
+   BSON_UNUSED (ctx);
+
    bson_error_t error;
    mongoc_uri_t *const uri = test_framework_get_uri ();
    BSON_ASSERT (uri);

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -2578,11 +2578,16 @@ initiator_fail (const mongoc_uri_t *uri,
                 void *user_data,
                 bson_error_t *error)
 {
+   BSON_UNUSED (uri);
+   BSON_UNUSED (host);
+   BSON_UNUSED (user_data);
+
    bson_set_error (error,
                    MONGOC_ERROR_STREAM,
                    MONGOC_ERROR_STREAM_CONNECT,
                    "failing in initiator");
    printf ("failing in initiator\n");
+
    return false;
 }
 

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -2333,23 +2333,19 @@ test_slow_server_pooled (void)
 static void
 _test_hello_versioned_api (bool pooled)
 {
-   mock_server_t *server;
-   mongoc_uri_t *uri;
-   mongoc_client_pool_t *pool;
-   mongoc_client_t *client;
-   char *hello_reply; /* the server's reply to the OP_MSG hello request */
-   future_t *future;
-   request_t *request;
+   mongoc_client_pool_t *pool = NULL;
+   mongoc_client_t *client = NULL;
+   future_t *future = NULL;
+   request_t *request = NULL;
    bson_error_t error;
    mongoc_server_api_version_t version;
-   mongoc_server_api_t *api;
 
-   server = mock_server_new ();
+   mock_server_t *const server = mock_server_new ();
    mock_server_run (server);
-   uri = mongoc_uri_copy (mock_server_get_uri (server));
+   mongoc_uri_t *const uri = mongoc_uri_copy (mock_server_get_uri (server));
 
    BSON_ASSERT (mongoc_server_api_version_from_string ("1", &version));
-   api = mongoc_server_api_new (version);
+   mongoc_server_api_t *const api = mongoc_server_api_new (version);
 
    if (pooled) {
       pool = test_framework_client_pool_new_from_uri (uri, api);
@@ -2359,15 +2355,16 @@ _test_hello_versioned_api (bool pooled)
       client = test_framework_client_new_from_uri (uri, api);
    }
 
-   hello_reply = bson_strdup_printf ("{'ok': 1,"
-                                     " 'isWritablePrimary': true,"
-                                     " 'setName': 'rs',"
-                                     " 'minWireVersion': %d,"
-                                     " 'maxWireVersion': %d,"
-                                     " 'hosts': ['%s']}",
-                                     WIRE_VERSION_MIN,
-                                     WIRE_VERSION_MAX,
-                                     mock_server_get_host_and_port (server));
+   char *const hello_reply =
+      bson_strdup_printf ("{'ok': 1,"
+                          " 'isWritablePrimary': true,"
+                          " 'setName': 'rs',"
+                          " 'minWireVersion': %d,"
+                          " 'maxWireVersion': %d,"
+                          " 'hosts': ['%s']}",
+                          WIRE_VERSION_MIN,
+                          WIRE_VERSION_MAX,
+                          mock_server_get_host_and_port (server));
 
    /* For client pools, the first handshake happens when the client is popped.
     * For non-pooled clients, we send a ping command to trigger a handshake. */

--- a/src/libmongoc/tests/test-mongoc-transactions.c
+++ b/src/libmongoc/tests/test-mongoc-transactions.c
@@ -566,7 +566,7 @@ _test_transient_txn_err (bool hangup)
    TEST_CMD_ERR (0 < mongoc_collection_count_documents (
                         collection, b, &opts, NULL, &reply, NULL));
 
-   BEGIN_IGNORE_DEPRECATIONS;
+   BEGIN_IGNORE_DEPRECATIONS
    TEST_CMD_ERR (mongoc_collection_create_index_with_opts (
       collection, b, NULL, &opts, &reply, NULL));
    END_IGNORE_DEPRECATIONS

--- a/src/libmongoc/tests/test-mongoc-uri.c
+++ b/src/libmongoc/tests/test-mongoc-uri.c
@@ -758,7 +758,7 @@ test_mongoc_uri_new_with_error (void)
    ASSERT_ERROR_CONTAINS (error,
                           MONGOC_ERROR_COMMAND,
                           MONGOC_ERROR_COMMAND_INVALID_ARG,
-                          "Invalid host string in URI")
+                          "Invalid host string in URI");
 
    memset (&error, 0, sizeof (bson_error_t));
    ASSERT (!mongoc_uri_new_with_error ("mongodb://localhost/db.na%me", &error));
@@ -2301,17 +2301,19 @@ test_mongoc_uri_duplicates (void)
    const mongoc_read_prefs_t *rp;
    bson_iter_t iter = {0};
 
-#define RECREATE_URI(opts)                                                     \
-   mongoc_uri_destroy (uri);                                                   \
-   uri = mongoc_uri_new_with_error ("mongodb://user:pwd@localhost/test?" opts, \
-                                    &err);                                     \
-   ASSERT_OR_PRINT (uri, err);
+#define RECREATE_URI(opts)                                 \
+   if (1) {                                                \
+      mongoc_uri_destroy (uri);                            \
+      uri = mongoc_uri_new_with_error (                    \
+         "mongodb://user:pwd@localhost/test?" opts, &err); \
+      ASSERT_OR_PRINT (uri, err);                          \
+   } else                                                  \
+      (void) 0
 
-#define ASSERT_LOG_DUPE(opt)                                              \
-   ASSERT_CAPTURED_LOG ("option: " opt,                                   \
-                        MONGOC_LOG_LEVEL_WARNING,                         \
-                        "Overwriting previously provided value for '" opt \
-                        "'");
+#define ASSERT_LOG_DUPE(opt)                      \
+   ASSERT_CAPTURED_LOG ("option: " opt,           \
+                        MONGOC_LOG_LEVEL_WARNING, \
+                        "Overwriting previously provided value for '" opt "'")
 
 /* iterate iter to key, and check that no other occurrences exist. */
 #define BSON_ITER_UNIQUE(key)                                             \
@@ -2324,7 +2326,7 @@ test_mongoc_uri_duplicates (void)
             ASSERT_WITH_MSG (false, "bson has duplicate keys for: " key); \
          }                                                                \
       }                                                                   \
-   } while (0);
+   } while (0)
 
    capture_logs (true);
 

--- a/src/libmongoc/tests/test-mongoc-write-concern.c
+++ b/src/libmongoc/tests/test-mongoc-write-concern.c
@@ -47,7 +47,7 @@ test_write_concern_basic (void)
 
    write_concern = mongoc_write_concern_new ();
 
-   BEGIN_IGNORE_DEPRECATIONS;
+   BEGIN_IGNORE_DEPRECATIONS
 
    /*
     * Test defaults.
@@ -108,7 +108,7 @@ test_write_concern_basic (void)
 
    mongoc_write_concern_destroy (write_concern);
 
-   END_IGNORE_DEPRECATIONS;
+   END_IGNORE_DEPRECATIONS
 }
 
 

--- a/src/libmongoc/tests/test-service-gcp.c
+++ b/src/libmongoc/tests/test-service-gcp.c
@@ -120,6 +120,7 @@ _test_with_mock_server (void *ctx)
 static int
 have_mock_server_env (TestSuite *ctx)
 {
+   BSON_UNUSED (ctx);
    return _get_test_host () != NULL;
 }
 


### PR DESCRIPTION
This PR addresses miscellanous GCC and Clang warnings. Verified by [this patch](https://spruce.mongodb.com/version/mongo_c_driver_08fdb599572a0459f01b0a5d172afebfe0f9f8fc/).

Many of these warnings are not normally enabled and have relatively low significance, but imo are worth addressing regardless to improve the quality of the codebase.

Each commit in this PR documents the number of warnings addressed according to GCC 11.4 and Clang 15.0 Of course, the numbers are specific to my machine, environment, and project configuration, but they help describe the scope of impact.

Warnings in bundled library source code (specifically jsonsl) are left as-is.

In total, this PR addresses 21 GCC warnings and 1058 Clang warnings on my machine.

Most changes are fairly straightforward and rather mundane.
However, a few changes deserve greater scrutiny from the rest, just in case:

- Removal of unreachable `BSON_THREAD_RETURN` in `BSON_THREAD_FUN (insert_docs, p)` in test-mongoc-sample-commands.c (double-check: continues to behave as expected?).
- Removal of UB null pointer arithmetic in `bson_md5_process` in common-md5.c (double-check: continues to behave as expected?).
- Removal of unused `error` parameter in `_needs_on_demand_aws_kms` in mongoc-crypt.c (double-check: no error handling required?).