### PR TITLE
CDRIVER-5487 use aligned alloc for bson_array_builder_t

### DIFF
--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -3657,7 +3657,7 @@ struct _bson_array_builder_t {
 bson_array_builder_t *
 bson_array_builder_new (void)
 {
-   bson_array_builder_t *bab = bson_malloc0 (sizeof (bson_array_builder_t));
+   bson_array_builder_t *bab = bson_aligned_alloc0 (128, sizeof (bson_array_builder_t));
    bson_init (&bab->bson);
    return bab;
 }

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -3657,7 +3657,7 @@ struct _bson_array_builder_t {
 bson_array_builder_t *
 bson_array_builder_new (void)
 {
-   bson_array_builder_t *bab = bson_aligned_alloc0 (128, sizeof (bson_array_builder_t));
+   bson_array_builder_t *bab = BSON_ALIGNED_ALLOC0 (bson_array_builder_t);
    bson_init (&bab->bson);
    return bab;
 }


### PR DESCRIPTION
Catched with UBSAN:

    runtime error: member access within misaligned address 0x51100000a040 for type 'bson_array_builder_t' (aka 'struct _bson_array_builder_t'), which requires 128 byte alignment
    0x51100000a040: note: pointer points here
    01 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00
                 ^

    #0 0x5bb2a5c5b759 in bson_array_builder_new [...]/mongo-c-driver/src/src/libbson/src/bson/bson.c:3662:21
    #1 0x5bb2a5c65a43 in bson_append_array_builder_begin [...]/mongo-c-driver/src/src/libbson/src/bson/bson.c:3983:13