### PR TITLE
CDRIVER-4385 Add .git-blame-ignore-revs entry for ColumnLimit: 80 -> 120

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Format source files with ColumnLimit: 120
+482ea4e8d20a6af4be9c01d4fd220dd63b231332


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1545.