### PR TITLE
allow for 64-bit time_t on 32-bit architectures

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-log.c
+++ b/src/libmongoc/src/mongoc/mongoc-log.c
@@ -207,7 +207,7 @@ mongoc_log_default_handler (mongoc_log_level_t log_level, const char *log_domain
    fprintf (stream,
             "%s.%04" PRId64 ": [%5d]: %8s: %12s: %s\n",
             nowstr,
-            (int64_t)(tv.tv_usec / 1000L),
+            (int64_t) (tv.tv_usec / 1000),
             pid,
             mongoc_log_level_str (log_level),
             log_domain,

--- a/src/libmongoc/src/mongoc/mongoc-log.c
+++ b/src/libmongoc/src/mongoc/mongoc-log.c
@@ -205,9 +205,9 @@ mongoc_log_default_handler (mongoc_log_level_t log_level, const char *log_domain
 #endif
 
    fprintf (stream,
-            "%s.%04ld: [%5d]: %8s: %12s: %s\n",
+            "%s.%04" PRId64 ": [%5d]: %8s: %12s: %s\n",
             nowstr,
-            tv.tv_usec / 1000L,
+            (int64_t)(tv.tv_usec / 1000L),
             pid,
             mongoc_log_level_str (log_level),
             log_domain,


### PR DESCRIPTION
This was tested by executing a manual build on a Debian armhf porterbox (since the failure was revealed by a failed build on that architecture in Debian and we don't directly test 32-bit ARM architectures in our own CI).