### PR TITLE
CDRIVER-5497 implement downstream RPM spec check

### DIFF
--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -886,6 +886,15 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
+        export IS_PATCH="${is_patch}"
+        sh .evergreen/scripts/check_rpm_spec.sh
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
         sh .evergreen/scripts/build_snapshot_rpm.sh
   - command: s3.put
     params:

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -328,6 +328,7 @@ all_tasks = [
     NamedTask(
         "rpm-package-build",
         commands=[
+            shell_mongoc('export IS_PATCH="${is_patch}"\n' "sh .evergreen/scripts/check_rpm_spec.sh"),
             shell_mongoc("sh .evergreen/scripts/build_snapshot_rpm.sh"),
             s3_put(
                 local_file="rpm.tar.gz",

--- a/.evergreen/scripts/check_rpm_spec.sh
+++ b/.evergreen/scripts/check_rpm_spec.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2024 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -o errexit
+
+#
+# check_rpm_spec.sh - Check if our RPM spec matches downstream's
+#
+# Supported/used environment variables:
+#   IS_PATCH    If "true", this is an Evergreen patch build.
+
+
+on_exit () {
+  if [ -n "${SPEC_FILE}" ]; then
+    rm -f "${SPEC_FILE}"
+  fi
+}
+trap on_exit EXIT
+
+if [ "${IS_PATCH}" = "true" ]; then
+   echo "This is a patch build...skipping RPM spec check"
+   exit
+fi
+
+SPEC_FILE=$(mktemp --tmpdir -u mongo-c-driver.XXXXXXXX.spec)
+curl --retry 5 https://src.fedoraproject.org/rpms/mongo-c-driver/raw/rawhide/f/mongo-c-driver.spec -sS --max-time 120 --fail --output "${SPEC_FILE}"
+
+diff -q .evergreen/etc/mongo-c-driver.spec "${SPEC_FILE}" || (echo "Synchronize RPM spec from downstream to fix this failure."; exit 1)

--- a/.evergreen/scripts/check_rpm_spec.sh
+++ b/.evergreen/scripts/check_rpm_spec.sh
@@ -40,4 +40,4 @@ fi
 SPEC_FILE=$(mktemp --tmpdir -u mongo-c-driver.XXXXXXXX.spec)
 curl --retry 5 https://src.fedoraproject.org/rpms/mongo-c-driver/raw/rawhide/f/mongo-c-driver.spec -sS --max-time 120 --fail --output "${SPEC_FILE}"
 
-diff -q .evergreen/etc/mongo-c-driver.spec "${SPEC_FILE}" || (echo "Synchronize RPM spec from downstream to fix this failure."; exit 1)
+diff -q .evergreen/etc/mongo-c-driver.spec "${SPEC_FILE}" || (echo "Synchronize RPM spec from downstream to fix this failure. See instructions here: https://docs.google.com/document/d/1ItyBC7VN383zNXu3oUOQJYR7adfYI8ECjLMJ5kqA9X8/edit#heading=h.ahdrr3b5xv3"; exit 1)


### PR DESCRIPTION
This change implements a check whereby if the RPM spec file we are shipping in the C driver repository differs from the downstream RPM spec file (e.g., because downstream has updated and we have not yet synced it to obtain that update), then the `rpm-package-build` task will fail. This is implemented so that it will only run on waterfall builds (so that patch builds are not unnecessarily cluttered by a most likely unrelated failure of this task).

Patch build: https://spruce.mongodb.com/task/mongo_c_driver_packaging_rpm_package_build_patch_bef6e2d37436fd465f165d7062af9fe2262d6738_65e76bd77742aeab743dd2c9_24_03_05_19_00_42/logs?execution=0
```
[2024/03/05 14:02:04.386] Running command 'shell.exec' (step 1 of 4).
[2024/03/05 14:02:04.391] This is a patch build...skipping RPM spec check
[2024/03/05 14:02:04.391] Finished command 'shell.exec' (step 1 of 4) in 4.205077ms.
```

Simulated waterfall build (failure): https://spruce.mongodb.com/task/mongo_c_driver_packaging_rpm_package_build_patch_bef6e2d37436fd465f165d7062af9fe2262d6738_65e76a571e2d17ab5ad0ee45_24_03_05_18_54_19/logs?execution=0

```
[2024/03/05 13:58:53.494] Running command 'shell.exec' (step 1 of 4).
[2024/03/05 13:58:53.688] Files .evergreen/etc/mongo-c-driver.spec and /data/mci/770212188af98933ef70bdd5e63e2642/tmp/mongo-c-driver.sQAlkiZ7.spec differ
[2024/03/05 13:58:53.690] Synchronize RPM spec from downstream to fix this failure.
[2024/03/05 13:58:53.690] Command 'shell.exec' (step 1 of 4) failed: shell script encountered problem: exit code 1.
```

Simulated waterfall build (success, produces no output): https://spruce.mongodb.com/task/mongo_c_driver_packaging_rpm_package_build_patch_bef6e2d37436fd465f165d7062af9fe2262d6738_65e76a2ae3c331b0aa3b7297_24_03_05_18_53_34/logs?execution=0

```
[2024/03/05 13:57:01.710] Running command 'shell.exec' (step 1 of 4).
[2024/03/05 13:57:01.900] Finished command 'shell.exec' (step 1 of 4) in 189.687348ms.
```

I will also cherry-pick this to r1.26 after merging.