### PR TITLE
Fix Evergreen task failure

### DIFF
--- a/.evergreen/scripts/debian_package_build.sh
+++ b/.evergreen/scripts/debian_package_build.sh
@@ -26,6 +26,12 @@ if [ "${IS_PATCH}" = "true" ]; then
   git clean -fdx
   git reset --hard HEAD
   if [ -s ../upstream.patch ]; then
+    git remote add upstream https://github.com/mongodb/mongo-c-driver
+    git fetch upstream
+    CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    git checkout upstream/debian/unstable
+    git checkout ${CURRENT_BRANCH}
+    git checkout upstream/debian/unstable -- ./debian/
     [ -d debian/patches ] || mkdir debian/patches
     mv ../upstream.patch debian/patches/
     echo upstream.patch >> debian/patches/series
@@ -44,9 +50,9 @@ cd ..
 
 git clone https://salsa.debian.org/installer-team/debootstrap.git debootstrap.git
 export DEBOOTSTRAP_DIR=`pwd`/debootstrap.git
-sudo -E ./debootstrap.git/debootstrap unstable ./unstable-chroot/ http://cdn-aws.deb.debian.org/debian
+sudo -E ./debootstrap.git/debootstrap --variant=buildd unstable ./unstable-chroot/ http://cdn-aws.deb.debian.org/debian
 cp -a mongoc ./unstable-chroot/tmp/
-sudo chroot ./unstable-chroot /bin/bash -c "(\
+sudo chroot ./unstable-chroot /bin/bash -c '(\
   apt-get install -y build-essential git-buildpackage fakeroot debhelper cmake libssl-dev pkg-config python3-sphinx python3-sphinx-design zlib1g-dev libsasl2-dev libsnappy-dev libzstd-dev libmongocrypt-dev libjs-mathjax libutf8proc-dev furo && \
   chown -R root:root /tmp/mongoc && \
   cd /tmp/mongoc && \
@@ -55,11 +61,18 @@ sudo chroot ./unstable-chroot /bin/bash -c "(\
   python3 build/calc_release_version.py > VERSION_CURRENT && \
   python3 build/calc_release_version.py -p > VERSION_RELEASED && \
   git add --force VERSION_CURRENT VERSION_RELEASED && \
-  git commit VERSION_CURRENT VERSION_RELEASED -m 'Set current/released versions' && \
+  git commit VERSION_CURRENT VERSION_RELEASED -m "Set current/released versions" && \
+  git remote remove upstream || true && \
+  git remote add upstream https://github.com/mongodb/mongo-c-driver && \
+  git fetch upstream && \
+  git checkout upstream/debian/unstable && \
+  git checkout ${CURRENT_BRANCH} && \
+  git checkout upstream/debian/unstable -- ./debian/ && \
+  git commit -m "fetch debian directory from the debian/unstable branch" && \
   LANG=C /bin/bash ./debian/build_snapshot.sh && \
   debc ../*.changes && \
   dpkg -i ../*.deb && \
-  gcc -I/usr/include/libmongoc-1.0 -I/usr/include/libbson-1.0 -o example-client src/libmongoc/examples/example-client.c -lmongoc-1.0 -lbson-1.0 )"
+  gcc -I/usr/include/libmongoc-1.0 -I/usr/include/libbson-1.0 -o example-client src/libmongoc/examples/example-client.c -lmongoc-1.0 -lbson-1.0 )'
 
 [ -e ./unstable-chroot/tmp/mongoc/example-client ] || (echo "Example was not built!" ; exit 1)
 (cd ./unstable-chroot/tmp/ ; tar zcvf ../../deb.tar.gz *.dsc *.orig.tar.gz *.debian.tar.xz *.build *.deb)
@@ -72,9 +85,9 @@ sudo chroot ./unstable-chroot /bin/bash -c "(\
   dpkg-buildpackage -b && dpkg-buildpackage -S )"
 
 # And now do it all again for 32-bit
-sudo -E ./debootstrap.git/debootstrap --arch i386 unstable ./unstable-i386-chroot/ http://cdn-aws.deb.debian.org/debian
+sudo -E ./debootstrap.git/debootstrap --variant=buildd --arch i386 unstable ./unstable-i386-chroot/ http://cdn-aws.deb.debian.org/debian
 cp -a mongoc ./unstable-i386-chroot/tmp/
-sudo chroot ./unstable-i386-chroot /bin/bash -c "(\
+sudo chroot ./unstable-i386-chroot /bin/bash -c '(\
   apt-get install -y build-essential git-buildpackage fakeroot debhelper cmake libssl-dev pkg-config python3-sphinx python3-sphinx-design zlib1g-dev libsasl2-dev libsnappy-dev libzstd-dev libmongocrypt-dev libjs-mathjax libutf8proc-dev furo && \
   chown -R root:root /tmp/mongoc && \
   cd /tmp/mongoc && \
@@ -83,11 +96,19 @@ sudo chroot ./unstable-i386-chroot /bin/bash -c "(\
   python3 build/calc_release_version.py > VERSION_CURRENT && \
   python3 build/calc_release_version.py -p > VERSION_RELEASED && \
   git add --force VERSION_CURRENT VERSION_RELEASED && \
-  git commit VERSION_CURRENT VERSION_RELEASED -m 'Set current/released versions' && \
+  git commit VERSION_CURRENT VERSION_RELEASED -m "Set current/released versions" && \
+  git remote remove upstream || true && \
+  git remote add upstream https://github.com/mongodb/mongo-c-driver && \
+  git fetch upstream && \
+  export CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)" && \
+  git checkout upstream/debian/unstable && \
+  git checkout ${CURRENT_BRANCH} && \
+  git checkout upstream/debian/unstable -- ./debian/ && \
+  git commit -m "fetch debian directory from the debian/unstable branch" && \
   LANG=C /bin/bash ./debian/build_snapshot.sh && \
   debc ../*.changes && \
   dpkg -i ../*.deb && \
-  gcc -I/usr/include/libmongoc-1.0 -I/usr/include/libbson-1.0 -o example-client src/libmongoc/examples/example-client.c -lmongoc-1.0 -lbson-1.0 )"
+  gcc -I/usr/include/libmongoc-1.0 -I/usr/include/libbson-1.0 -o example-client src/libmongoc/examples/example-client.c -lmongoc-1.0 -lbson-1.0 )'
 
 [ -e ./unstable-i386-chroot/tmp/mongoc/example-client ] || (echo "Example was not built!" ; exit 1)
 (cd ./unstable-i386-chroot/tmp/ ; tar zcvf ../../deb-i386.tar.gz *.dsc *.orig.tar.gz *.debian.tar.xz *.build *.deb)

--- a/.evergreen/scripts/debian_package_build.sh
+++ b/.evergreen/scripts/debian_package_build.sh
@@ -21,29 +21,21 @@ on_exit () {
 trap on_exit EXIT
 
 if [ "${IS_PATCH}" = "true" ]; then
-  git diff HEAD -- . ':!debian' > ../upstream.patch
-  git diff HEAD -- debian > ../debian.patch
+  git diff HEAD > ../upstream.patch
   git clean -fdx
   git reset --hard HEAD
-  if [ -s ../upstream.patch ]; then
-    git remote add upstream https://github.com/mongodb/mongo-c-driver
-    git fetch upstream
-    CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-    git checkout upstream/debian/unstable
-    git checkout ${CURRENT_BRANCH}
-    git checkout upstream/debian/unstable -- ./debian/
-    [ -d debian/patches ] || mkdir debian/patches
-    mv ../upstream.patch debian/patches/
-    echo upstream.patch >> debian/patches/series
-    git add debian/patches/*
-    git commit -m 'Evergreen patch build - upstream changes'
-    git log -n1 -p
-  fi
-  if [ -s ../debian.patch ]; then
-    git apply --index ../debian.patch
-    git commit -m 'Evergreen patch build - Debian packaging changes'
-    git log -n1 -p
-  fi
+  git remote add upstream https://github.com/mongodb/mongo-c-driver
+  git fetch upstream
+  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  git checkout upstream/debian/unstable
+  git checkout ${CURRENT_BRANCH}
+  git checkout upstream/debian/unstable -- ./debian/
+  [ -d debian/patches ] || mkdir debian/patches
+  mv ../upstream.patch debian/patches/
+  echo upstream.patch >> debian/patches/series
+  git add debian/patches/*
+  git commit -m 'Evergreen patch build - upstream changes'
+  git log -n1 -p
 fi
 
 cd ..

--- a/.evergreen/scripts/debian_package_build.sh
+++ b/.evergreen/scripts/debian_package_build.sh
@@ -65,6 +65,7 @@ sudo chroot ./unstable-chroot /bin/bash -c '(\
   git remote remove upstream || true && \
   git remote add upstream https://github.com/mongodb/mongo-c-driver && \
   git fetch upstream && \
+  export CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)" && \
   git checkout upstream/debian/unstable && \
   git checkout ${CURRENT_BRANCH} && \
   git checkout upstream/debian/unstable -- ./debian/ && \

--- a/.evergreen/scripts/debian_package_build.sh
+++ b/.evergreen/scripts/debian_package_build.sh
@@ -30,12 +30,14 @@ if [ "${IS_PATCH}" = "true" ]; then
   git checkout upstream/debian/unstable
   git checkout ${CURRENT_BRANCH}
   git checkout upstream/debian/unstable -- ./debian/
-  [ -d debian/patches ] || mkdir debian/patches
-  mv ../upstream.patch debian/patches/
-  echo upstream.patch >> debian/patches/series
-  git add debian/patches/*
-  git commit -m 'Evergreen patch build - upstream changes'
-  git log -n1 -p
+  if [ -s ../upstream.patch ]; then
+    [ -d debian/patches ] || mkdir debian/patches
+    mv ../upstream.patch debian/patches/
+    echo upstream.patch >> debian/patches/series
+    git add debian/patches/*
+    git commit -m 'Evergreen patch build - upstream changes'
+    git log -n1 -p
+  fi
 fi
 
 cd ..


### PR DESCRIPTION
The Debian build process has been updated such that the `debian/` directory is now only in the `debian/unstable` branch. This change fetches that directory for Evergreen builds to enable building Debian packages in CI.