### PR TITLE
CDRIVER-5510 Remove redundant redefinition of BSON_COMPILATION

### DIFF
--- a/src/libbson/libbson.rc.in
+++ b/src/libbson/libbson.rc.in
@@ -1,9 +1,8 @@
 // Defines Version Information to include in DLL on Windows.
 // Refer: https://learn.microsoft.com/en-us/windows/win32/menurc/versioninfo-resource
 #include <winver.h> // Defines VS_VERSION_INFO
-#define BSON_COMPILATION // Tell bson-version.h it is part of compilation.
+
 #include <bson/bson-version.h> // Defines BSON_MAJOR_VERSION and other version macros.
-#undef BSON_COMPILATION
 
 #define BSON_OUTPUT_BASENAME "@BSON_OUTPUT_BASENAME@"
 #define BSON_API_VERSION "@BSON_API_VERSION@"

--- a/src/libmongoc/libmongoc.rc.in
+++ b/src/libmongoc/libmongoc.rc.in
@@ -1,6 +1,7 @@
 // Defines Version Information to include in DLL on Windows.
 // Refer: https://learn.microsoft.com/en-us/windows/win32/menurc/versioninfo-resource
 #include <winver.h> // Defines VS_VERSION_INFO
+
 #include <mongoc/mongoc-version.h> // Defines MONGOC_MAJOR_VERSION and other version macros.
 
 #define MONGOC_OUTPUT_BASENAME "@MONGOC_OUTPUT_BASENAME@"


### PR DESCRIPTION
Resolves CDRIVER-5510. Followup to https://github.com/mongodb/mongo-c-driver/pull/1457.

Addresses the preprocessor macro redefinition warning when compiling `libbson.rc`:

```
warning RC4005: 'BSON_COMPILATION' : redefinition
```