### PR TITLE
CDRIVER-4828 skip `rangePreview` tests on server 8.0+

### DIFF
--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Date-Aggregate.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Date-Aggregate.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Date-Correctness.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Date-Correctness.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Date-Delete.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Date-Delete.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Date-FindOneAndUpdate.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Date-FindOneAndUpdate.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Date-InsertFind.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Date-InsertFind.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Date-Update.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Date-Update.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Decimal-Aggregate.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Decimal-Aggregate.json
@@ -2,10 +2,10 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Decimal-Correctness.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Decimal-Correctness.json
@@ -2,10 +2,10 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Decimal-Delete.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Decimal-Delete.json
@@ -2,10 +2,10 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.json
@@ -2,10 +2,10 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Decimal-InsertFind.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Decimal-InsertFind.json
@@ -2,10 +2,10 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Decimal-Update.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Decimal-Update.json
@@ -2,10 +2,10 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-DecimalPrecision-Aggregate.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-DecimalPrecision-Aggregate.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-DecimalPrecision-Correctness.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-DecimalPrecision-Correctness.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-DecimalPrecision-Delete.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-DecimalPrecision-Delete.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-DecimalPrecision-InsertFind.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-DecimalPrecision-InsertFind.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-DecimalPrecision-Update.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-DecimalPrecision-Update.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Double-Aggregate.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Double-Aggregate.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Double-Correctness.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Double-Correctness.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Double-Delete.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Double-Delete.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Double-FindOneAndUpdate.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Double-FindOneAndUpdate.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Double-InsertFind.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Double-InsertFind.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Double-Update.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Double-Update.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-DoublePrecision-Aggregate.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-DoublePrecision-Aggregate.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-DoublePrecision-Correctness.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-DoublePrecision-Correctness.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-DoublePrecision-Delete.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-DoublePrecision-Delete.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-DoublePrecision-InsertFind.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-DoublePrecision-InsertFind.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-DoublePrecision-Update.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-DoublePrecision-Update.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Int-Aggregate.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Int-Aggregate.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Int-Correctness.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Int-Correctness.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Int-Delete.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Int-Delete.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Int-FindOneAndUpdate.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Int-FindOneAndUpdate.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Int-InsertFind.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Int-InsertFind.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Int-Update.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Int-Update.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Long-Aggregate.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Long-Aggregate.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Long-Correctness.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Long-Correctness.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Long-Delete.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Long-Delete.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Long-FindOneAndUpdate.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Long-FindOneAndUpdate.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Long-InsertFind.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Long-InsertFind.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Long-Update.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-Long-Update.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-WrongType.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/fle2v2-Range-WrongType.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -2261,6 +2261,12 @@ WIRE_VERSION_CHECKS (19)
 WIRE_VERSION_CHECKS (21)
 /* wire version 22 begins with the 7.1 release. */
 WIRE_VERSION_CHECKS (22)
+/* wire version 23 begins with the 7.2 release. */
+WIRE_VERSION_CHECKS (23)
+/* wire version 24 begins with the 7.3 release. */
+WIRE_VERSION_CHECKS (24)
+/* wire version 25 begins with the 8.0 release. */
+WIRE_VERSION_CHECKS (25)
 
 int
 test_framework_skip_if_no_dual_ip_hostname (void)

--- a/src/libmongoc/tests/test-libmongoc.h
+++ b/src/libmongoc/tests/test-libmongoc.h
@@ -209,6 +209,12 @@ WIRE_VERSION_CHECK_DECLS (19)
 WIRE_VERSION_CHECK_DECLS (21)
 /* wire version 22 begins with the 7.1 release. */
 WIRE_VERSION_CHECK_DECLS (22)
+/* wire version 23 begins with the 7.2 release. */
+WIRE_VERSION_CHECK_DECLS (23)
+/* wire version 24 begins with the 7.3 release. */
+WIRE_VERSION_CHECK_DECLS (24)
+/* wire version 25 begins with the 8.0 release. */
+WIRE_VERSION_CHECK_DECLS (25)
 
 #undef WIRE_VERSION_CHECK_DECLS
 

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -6515,6 +6515,7 @@ test_client_side_encryption_install (TestSuite *suite)
                                   (void *) rangeTypes[i] /* ctx */,
                                   test_framework_skip_if_no_client_side_encryption,
                                   test_framework_skip_if_max_wire_version_less_than_21,
+                                  test_framework_skip_if_max_wire_version_more_than_24 /* skip on MongoDB 8.0+ */,
                                   // Remove skip_if_serverless once DRIVERS-2589 is resolved.
                                   test_framework_skip_if_serverless,
                                   test_framework_skip_if_not_replset);
@@ -6526,6 +6527,7 @@ test_client_side_encryption_install (TestSuite *suite)
                                   (void *) rangeTypes[i] /* ctx */,
                                   test_framework_skip_if_no_client_side_encryption,
                                   test_framework_skip_if_max_wire_version_less_than_21,
+                                  test_framework_skip_if_max_wire_version_more_than_24 /* skip on MongoDB 8.0+ */,
                                   // Remove skip_if_serverless once DRIVERS-2589 is resolved.
                                   test_framework_skip_if_serverless,
                                   test_framework_skip_if_single);


### PR DESCRIPTION
This PR does not resolve CDRIVER-4828, but adds skips for `rangePreview` tests on MongoDB Server 8.0+ to avoid expected test failures on latest server builds.

See https://github.com/mongodb/specifications/pull/1548 for motivation.

Verified with this patch build: https://spruce.mongodb.com/version/65f06c270ae60677761ed38f. Though server changes expected to fail are not-yet-available.