### PR TITLE
CDRIVER-5511 disable loading Cyrus plugins on Windows by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,11 @@ mongo_setting(
    ]]
 )
 
+mongo_setting(CYRUS_PLUGIN_PATH_PREFIX "A path prefix to enable loading Cyrus-SASL plug-ins on Windows"
+   TYPE STRING
+   VISIBLE_IF [["ENABLE_SASL = CYRUS AND WIN32"]]
+)
+
 mongo_setting(ENABLE_CLIENT_SIDE_ENCRYPTION "Enable In-Use Encryption support. Requires additional support libraries."
               OPTIONS ON OFF AUTO
               DEFAULT VALUE AUTO)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ mongo_setting(
 
 mongo_setting(CYRUS_PLUGIN_PATH_PREFIX "A path prefix to enable loading Cyrus-SASL plug-ins on Windows"
    TYPE STRING
-   VISIBLE_IF [["ENABLE_SASL = CYRUS AND WIN32"]]
+   VISIBLE_IF [[ENABLE_SASL STREQUAL "CYRUS" AND WIN32]]
 )
 
 mongo_setting(ENABLE_CLIENT_SIDE_ENCRYPTION "Enable In-Use Encryption support. Requires additional support libraries."

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ mongo_setting(
    ]]
 )
 
-mongo_setting(CYRUS_PLUGIN_PATH_PREFIX "An absolute path prefix to enable loading Cyrus-SASL plug-ins on Windows"
+mongo_setting(CYRUS_PLUGIN_PATH_PREFIX "An absolute path prefix to enable loading Cyrus SASL plug-ins on Windows"
    TYPE STRING
    VISIBLE_IF [[ENABLE_SASL STREQUAL "CYRUS" AND WIN32]]
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ mongo_setting(
    ]]
 )
 
-mongo_setting(CYRUS_PLUGIN_PATH_PREFIX "A path prefix to enable loading Cyrus-SASL plug-ins on Windows"
+mongo_setting(CYRUS_PLUGIN_PATH_PREFIX "An absolute path prefix to enable loading Cyrus-SASL plug-ins on Windows"
    TYPE STRING
    VISIBLE_IF [[ENABLE_SASL STREQUAL "CYRUS" AND WIN32]]
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ mongo_setting(
    ]]
 )
 
-mongo_setting(CYRUS_PLUGIN_PATH_PREFIX "An absolute path prefix to enable loading Cyrus SASL plug-ins on Windows"
+mongo_setting(CYRUS_PLUGIN_PATH_PREFIX "An absolute path prefix to enable loading Cyrus SASL plugins on Windows"
    TYPE STRING
    VISIBLE_IF [[ENABLE_SASL STREQUAL "CYRUS" AND WIN32]]
 )

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,7 @@
 libmongoc 1.26.2 (unreleased)
 =============================
 
-Fixes:
+Cyrus SASL:
 
   * Disable plug-in loading with Cyrus-SASL on Windows by default. To re-enable, set the CMake option `CYRUS_PLUGIN_PATH_PREFIX` to the path prefix of the Cyrus-SASL plug-ins.
 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+libmongoc 1.26.2 (unreleased)
+=============================
+
+Fixes:
+
+  * Disable plug-in loading with Cyrus-SASL on Windows by default. To re-enable, set the CMake option `CYRUS_PLUGIN_PATH_PREFIX` to the path prefix of the Cyrus-SASL plug-ins.
+
 libmongoc 1.26.1
 ================
 

--- a/NEWS
+++ b/NEWS
@@ -3,7 +3,7 @@ libmongoc 1.26.2 (unreleased)
 
 Cyrus SASL:
 
-  * Disable plug-in loading with Cyrus-SASL on Windows by default. To re-enable, set the CMake option `CYRUS_PLUGIN_PATH_PREFIX` to the path prefix of the Cyrus-SASL plug-ins.
+  * Disable plug-in loading with Cyrus SASL on Windows by default. To re-enable, set the CMake option `CYRUS_PLUGIN_PATH_PREFIX` to the path prefix of the Cyrus SASL plug-ins.
 
 libmongoc 1.26.1
 ================

--- a/NEWS
+++ b/NEWS
@@ -3,7 +3,7 @@ libmongoc 1.26.2 (unreleased)
 
 Cyrus SASL:
 
-  * Disable plug-in loading with Cyrus SASL on Windows by default. To re-enable, set the CMake option `CYRUS_PLUGIN_PATH_PREFIX` to the path prefix of the Cyrus SASL plug-ins.
+  * Disable plugin loading with Cyrus SASL on Windows by default. To re-enable, set the CMake option `CYRUS_PLUGIN_PATH_PREFIX` to the absolute path prefix of the Cyrus SASL plugins.
 
 libmongoc 1.26.1
 ================

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -814,7 +814,11 @@ if (MONGOC_ENABLE_STATIC_BUILD)
    set_target_properties (mcd_rpc PROPERTIES OUTPUT_NAME "mcd-rpc")
 endif ()
 
-set_source_files_properties (src/mongoc/mongoc-cyrus.c PROPERTIES COMPILE_DEFINITIONS MONGOC_CYRUS_PLUGIN_PATH_PREFIX="${CYRUS_PLUGIN_PATH_PREFIX}")
+set_property(
+   SOURCE ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-cyrus.c
+   APPEND PROPERTY COMPILE_DEFINITIONS
+   "MONGOC_CYRUS_PLUGIN_PATH_PREFIX=$<IF:$<STREQUAL:${CYRUS_PLUGIN_PATH_PREFIX},>,NULL,\"${CYRUS_PLUGIN_PATH_PREFIX}\">"
+)
 
 if (ENABLE_SHARED)
    add_library (mongoc_shared SHARED ${SOURCES} ${HEADERS} ${HEADERS_FORWARDING})

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -814,6 +814,8 @@ if (MONGOC_ENABLE_STATIC_BUILD)
    set_target_properties (mcd_rpc PROPERTIES OUTPUT_NAME "mcd-rpc")
 endif ()
 
+set_source_files_properties (src/mongoc/mongoc-cyrus.c PROPERTIES COMPILE_DEFINITIONS MONGOC_CYRUS_PLUGIN_PATH_PREFIX="${CYRUS_PLUGIN_PATH_PREFIX}")
+
 if (ENABLE_SHARED)
    add_library (mongoc_shared SHARED ${SOURCES} ${HEADERS} ${HEADERS_FORWARDING})
    if(WIN32)

--- a/src/libmongoc/doc/authentication.rst
+++ b/src/libmongoc/doc/authentication.rst
@@ -82,6 +82,7 @@ GSSAPI (Kerberos) Authentication
   On UNIX-like environments, Kerberos support requires compiling the driver against `Cyrus SASL <https://www.cyrusimap.org/sasl/>`_.
 
   On Windows, Kerberos support requires compiling the driver against Windows Native SSPI or Cyrus SASL. The default configuration of the driver will use Windows Native SSPI.
+  If using Cyrus SASL on Windows, setting the CMake option ``CYRUS_PLUGIN_PATH_PREFIX`` to the absolute path prefix is required to enable loading plugins.
 
   To modify the default configuration, use the cmake option ``ENABLE_SASL``.
 

--- a/src/libmongoc/doc/authentication.rst
+++ b/src/libmongoc/doc/authentication.rst
@@ -82,7 +82,7 @@ GSSAPI (Kerberos) Authentication
   On UNIX-like environments, Kerberos support requires compiling the driver against `Cyrus SASL <https://www.cyrusimap.org/sasl/>`_.
 
   On Windows, Kerberos support requires compiling the driver against Windows Native SSPI or Cyrus SASL. The default configuration of the driver will use Windows Native SSPI.
-  If using Cyrus SASL on Windows, setting the CMake option ``CYRUS_PLUGIN_PATH_PREFIX`` to the absolute path prefix is required to enable loading plugins.
+  Using Cyrus SASL on Windows requires configuring the CMake option ``CYRUS_PLUGIN_PATH_PREFIX`` to the absolute path prefix of the ``GSSAPI`` plugin to enable loading the plugin.
 
   To modify the default configuration, use the cmake option ``ENABLE_SASL``.
 

--- a/src/libmongoc/doc/authentication.rst
+++ b/src/libmongoc/doc/authentication.rst
@@ -79,9 +79,9 @@ GSSAPI (Kerberos) Authentication
 
 .. note::
 
-  On UNIX-like environments, Kerberos support requires compiling the driver against ``cyrus-sasl``.
+  On UNIX-like environments, Kerberos support requires compiling the driver against `Cyrus SASL <https://www.cyrusimap.org/sasl/>`_.
 
-  On Windows, Kerberos support requires compiling the driver against Windows Native SSPI or ``cyrus-sasl``. The default configuration of the driver will use Windows Native SSPI.
+  On Windows, Kerberos support requires compiling the driver against Windows Native SSPI or Cyrus SASL. The default configuration of the driver will use Windows Native SSPI.
 
   To modify the default configuration, use the cmake option ``ENABLE_SASL``.
 

--- a/src/libmongoc/src/mongoc/mongoc-cyrus-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-cyrus-private.h
@@ -46,6 +46,8 @@ struct _mongoc_cyrus_t {
 #define SASL_CALLBACK_FN(_f) ((int (*) (void)) ((void (*) (void)) (_f)))
 #endif
 
+int
+_mongoc_cyrus_verifyfile_cb (void *context, const char *file, sasl_verify_type_t type);
 void
 _mongoc_cyrus_init (mongoc_cyrus_t *sasl);
 bool

--- a/src/libmongoc/src/mongoc/mongoc-cyrus.c
+++ b/src/libmongoc/src/mongoc/mongoc-cyrus.c
@@ -149,7 +149,7 @@ _mongoc_cyrus_verifyfile_cb (void *context, const char *file, sasl_verify_type_t
    TRACE ("Attempting to load file: `%s`. Type is %s\n", file, sasl_verify_type_to_str (type));
 
 #ifdef _WIN32
-   // On Windows, Cyrus-SASL hard-codes the plugin path.
+   // On Windows, Cyrus SASL hard-codes the plugin path.
    // Only permit loading plug-in from user configured path to prevent unintentional library loading.
    if (type == SASL_VRFY_PLUGIN) {
       const char *path_prefix = MONGOC_CYRUS_PLUGIN_PATH_PREFIX;
@@ -158,7 +158,7 @@ _mongoc_cyrus_verifyfile_cb (void *context, const char *file, sasl_verify_type_t
       if (has_valid_prefix) {
          return SASL_OK;
       }
-      MONGOC_WARNING ("Not loading Cyrus-SASL plugin: %s. If plugin is needed, set CMake option "
+      MONGOC_WARNING ("Not loading Cyrus SASL plugin: %s. If plugin is needed, set CMake option "
                       "`CYRUS_PLUGIN_PATH_PREFIX (currently '%s')` to a non-empty string contain the path prefix.",
                       file,
                       path_prefix);

--- a/src/libmongoc/src/mongoc/mongoc-cyrus.c
+++ b/src/libmongoc/src/mongoc/mongoc-cyrus.c
@@ -126,6 +126,49 @@ _mongoc_cyrus_get_user (mongoc_cyrus_t *sasl, int param_id, const char **result,
    return (sasl->credentials.user != NULL) ? SASL_OK : SASL_FAIL;
 }
 
+static const char *
+sasl_verify_type_to_str (sasl_verify_type_t type)
+{
+   switch (type) {
+   case SASL_VRFY_PLUGIN:
+      return "SASL_VRFY_PLUGIN";
+   case SASL_VRFY_CONF:
+      return "SASL_VRFY_CONF";
+   case SASL_VRFY_PASSWD:
+      return "SASL_VRFY_PASSWD";
+   case SASL_VRFY_OTHER:
+      return "SASL_VRFY_OTHER";
+   default:
+      return "Unknown";
+   }
+}
+
+int
+_mongoc_cyrus_verifyfile_cb (void *context, const char *file, sasl_verify_type_t type)
+{
+   TRACE ("Attempting to load file: `%s`. Type is %s\n", file, sasl_verify_type_to_str (type));
+
+#ifdef _WIN32
+   // On Windows, Cyrus-SASL hard-codes the plugin path.
+   // Only permit loading plug-in from user configured path to prevent unintentional library loading.
+   if (type == SASL_VRFY_PLUGIN) {
+      const char *path_prefix = MONGOC_CYRUS_PLUGIN_PATH_PREFIX;
+      bool has_valid_prefix = (0 != strlen (path_prefix) && file == strstr (file, path_prefix));
+      // Check if `file` has necessary prefix.
+      if (has_valid_prefix) {
+         return SASL_OK;
+      }
+      MONGOC_WARNING ("Not loading Cyrus-SASL plugin: %s. If plugin is needed, set CMake option "
+                      "`CYRUS_PLUGIN_PATH_PREFIX (currently '%s')` to a non-empty string contain the path prefix.",
+                      file,
+                      path_prefix);
+      return SASL_CONTINUE;
+   }
+#endif
+
+   return SASL_OK;
+}
+
 
 void
 _mongoc_cyrus_init (mongoc_cyrus_t *sasl)
@@ -134,6 +177,7 @@ _mongoc_cyrus_init (mongoc_cyrus_t *sasl)
                                   {SASL_CB_USER, SASL_CALLBACK_FN (_mongoc_cyrus_get_user), sasl},
                                   {SASL_CB_PASS, SASL_CALLBACK_FN (_mongoc_cyrus_get_pass), sasl},
                                   {SASL_CB_CANON_USER, SASL_CALLBACK_FN (_mongoc_cyrus_canon_user), sasl},
+                                  {SASL_CB_VERIFYFILE, SASL_CALLBACK_FN (_mongoc_cyrus_verifyfile_cb), NULL},
                                   {SASL_CB_LIST_END}};
 
    BSON_ASSERT (sasl);

--- a/src/libmongoc/src/mongoc/mongoc-cyrus.c
+++ b/src/libmongoc/src/mongoc/mongoc-cyrus.c
@@ -159,7 +159,7 @@ _mongoc_cyrus_verifyfile_cb (void *context, const char *file, sasl_verify_type_t
          return SASL_OK;
       }
       MONGOC_WARNING ("Refusing to load Cyrus SASL plugin at: '%s'. If needed, set CYRUS_PLUGIN_PATH_PREFIX (currently "
-                      "'%s') to the absolute path prefix during build configuration.",
+                      "'%s') to the absolute path prefix of the plugin during build configuration of the C Driver.",
                       file,
                       path_prefix ? path_prefix : "(unset)");
       return SASL_CONTINUE;

--- a/src/libmongoc/src/mongoc/mongoc-cyrus.c
+++ b/src/libmongoc/src/mongoc/mongoc-cyrus.c
@@ -153,7 +153,7 @@ _mongoc_cyrus_verifyfile_cb (void *context, const char *file, sasl_verify_type_t
    // Only permit loading plug-in from user configured path to prevent unintentional library loading.
    if (type == SASL_VRFY_PLUGIN) {
       const char *path_prefix = MONGOC_CYRUS_PLUGIN_PATH_PREFIX;
-      bool has_valid_prefix = (0 != strlen (path_prefix) && file == strstr (file, path_prefix));
+      bool has_valid_prefix = (path_prefix && file == strstr (file, path_prefix));
       // Check if `file` has necessary prefix.
       if (has_valid_prefix) {
          return SASL_OK;
@@ -161,7 +161,7 @@ _mongoc_cyrus_verifyfile_cb (void *context, const char *file, sasl_verify_type_t
       MONGOC_WARNING ("Refusing to load Cyrus SASL plugin at: '%s'. If needed, set CYRUS_PLUGIN_PATH_PREFIX (currently "
                       "'%s') to the absolute path prefix during build configuration.",
                       file,
-                      path_prefix);
+                      path_prefix ? path_prefix : "(unset)");
       return SASL_CONTINUE;
    }
 #endif

--- a/src/libmongoc/src/mongoc/mongoc-cyrus.c
+++ b/src/libmongoc/src/mongoc/mongoc-cyrus.c
@@ -150,7 +150,7 @@ _mongoc_cyrus_verifyfile_cb (void *context, const char *file, sasl_verify_type_t
 
 #ifdef _WIN32
    // On Windows, Cyrus SASL hard-codes the plugin path.
-   // Only permit loading plug-in from user configured path to prevent unintentional library loading.
+   // Only permit loading plugin from user configured path to prevent unintentional library loading.
    if (type == SASL_VRFY_PLUGIN) {
       const char *path_prefix = MONGOC_CYRUS_PLUGIN_PATH_PREFIX;
       bool has_valid_prefix = (path_prefix && file == strstr (file, path_prefix));

--- a/src/libmongoc/src/mongoc/mongoc-cyrus.c
+++ b/src/libmongoc/src/mongoc/mongoc-cyrus.c
@@ -158,8 +158,8 @@ _mongoc_cyrus_verifyfile_cb (void *context, const char *file, sasl_verify_type_t
       if (has_valid_prefix) {
          return SASL_OK;
       }
-      MONGOC_WARNING ("Not loading Cyrus SASL plugin: %s. If plugin is needed, set CMake option "
-                      "`CYRUS_PLUGIN_PATH_PREFIX (currently '%s')` to a non-empty string contain the path prefix.",
+      MONGOC_WARNING ("Refusing to load Cyrus SASL plugin at: '%s'. If needed, set CYRUS_PLUGIN_PATH_PREFIX (currently "
+                      "'%s') to the absolute path prefix during build configuration.",
                       file,
                       path_prefix);
       return SASL_CONTINUE;

--- a/src/libmongoc/src/mongoc/mongoc-init.c
+++ b/src/libmongoc/src/mongoc/mongoc-init.c
@@ -52,6 +52,7 @@
 
 #ifdef MONGOC_ENABLE_SASL_CYRUS
 #include <sasl/sasl.h>
+#include <mongoc-cyrus-private.h> // _mongoc_cyrus_verifyfile_cb
 
 static void *
 mongoc_cyrus_mutex_alloc (void)
@@ -110,7 +111,11 @@ static BSON_ONCE_FUN (_mongoc_do_init)
    sasl_set_mutex (
       mongoc_cyrus_mutex_alloc, mongoc_cyrus_mutex_lock, mongoc_cyrus_mutex_unlock, mongoc_cyrus_mutex_free);
 
-   status = sasl_client_init (NULL);
+   sasl_callback_t callbacks[] = {// Include callback to disable loading plugins.
+                                  {SASL_CB_VERIFYFILE, SASL_CALLBACK_FN (_mongoc_cyrus_verifyfile_cb), NULL},
+                                  {SASL_CB_LIST_END}};
+
+   status = sasl_client_init (callbacks);
    BSON_ASSERT (status == SASL_OK);
 #endif
 


### PR DESCRIPTION
# Summary

This PR proposes disabling loading Cyrus-SASL plug-ins by default on Windows.

Users of Cyrus-SASL on Windows can set the new CMake option `CYRUS_PLUGIN_PATH_PREFIX` to enable Cyrus plug-in loading on Windows.

# Background

This is intended to address concerns described in CDRIVER-5511.

I expect this PR is backwards breaking behavior. Loading the GSSAPI plug-in is needed for GSSAPI auth on Windows. GSSAPI is not a [default static plug-in](https://github.com/cyrusimap/cyrus-sasl/blob/master/win32/README.md#msbuild):

> Some of them will be statically linked into sasl2.dll [...] gssapi builds gssapi dynamic plugin

# Dropping Cyrus-SASL on Windows?

By default, SSPI is used for GSSAPI auth on Windows. I expect there are few users using the C driver with Cyrus-SASL instead of the default SSPI. CDRIVER-5514 was filed to propose dropping Cyrus-SASL on Windows in a future release of the C driver.

# Testing

As noted in CDRIVER-5514, GSSAPI auth on Windows with Cyrus-SASL appears untested in Evergreen. GSSAPI auth is the only feature that uses Cyrus-SASL.

Manual tests of GSSAPI auth on Windows with Cyrus-SASL were run on a spawn host. Instructions to test are [documented here](https://github.com/kevinAlbs/c-bootstrap/tree/223ffbde68d9b54372ede953d5677d7d431c75fe/investigations/testing-cyrus-on-windows). This may be of use in the future. If dropping Cyrus-SASL on Windows is not acceptable, I would want to test to CI.

A [patch build](https://spruce.mongodb.com/version/65fb42d0965c6d000731aeff) was run for `authentication-tests*` tasks to test GSSAPI with other configurations.