### PR TITLE
CDRIVER-5515 fix assert when legacy exhaust cursor receives no documents

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-cursor-legacy.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor-legacy.c
@@ -222,8 +222,14 @@ _mongoc_cursor_op_getmore (mongoc_cursor_t *cursor, mongoc_cursor_response_legac
 
    cursor->cursor_id = mcd_rpc_op_reply_get_cursor_id (response->rpc);
 
-   response->reader = bson_reader_new_from_data (mcd_rpc_op_reply_get_documents (response->rpc),
-                                                 mcd_rpc_op_reply_get_documents_len (response->rpc));
+   const void *documents = mcd_rpc_op_reply_get_documents (response->rpc);
+   if (documents == NULL) {
+      // Use a non-NULL pointer to satisfy precondition of
+      // `bson_reader_new_from_data`:
+      documents = "";
+   }
+
+   response->reader = bson_reader_new_from_data (documents, mcd_rpc_op_reply_get_documents_len (response->rpc));
 
    _mongoc_cursor_monitor_succeeded (cursor,
                                      response,
@@ -584,8 +590,14 @@ _mongoc_cursor_op_query_find (mongoc_cursor_t *cursor, bson_t *filter, mongoc_cu
 
    cursor->cursor_id = mcd_rpc_op_reply_get_cursor_id (response->rpc);
 
-   response->reader = bson_reader_new_from_data (mcd_rpc_op_reply_get_documents (response->rpc),
-                                                 mcd_rpc_op_reply_get_documents_len (response->rpc));
+   const void *documents = mcd_rpc_op_reply_get_documents (response->rpc);
+   if (documents == NULL) {
+      // Use a non-NULL pointer to satisfy precondition of
+      // `bson_reader_new_from_data`:
+      documents = "";
+   }
+
+   response->reader = bson_reader_new_from_data (documents, mcd_rpc_op_reply_get_documents_len (response->rpc));
 
    if (_mongoc_cursor_get_opt_bool (cursor, MONGOC_CURSOR_EXHAUST)) {
       cursor->in_exhaust = true;

--- a/src/libmongoc/tests/test-mongoc-exhaust.c
+++ b/src/libmongoc/tests/test-mongoc-exhaust.c
@@ -345,6 +345,45 @@ test_exhaust_cursor_works (void *context)
    mongoc_client_destroy (client);
 }
 
+// `test_exhaust_cursor_no_match` is a regression test for CDRIVER-5515
+static void
+test_exhaust_cursor_no_match (void *context)
+{
+   BSON_UNUSED (context);
+   bson_error_t error;
+   mongoc_client_t *client = test_framework_new_default_client ();
+   mongoc_collection_t *coll = mongoc_client_get_collection (client, "db", "coll");
+
+   // Drop collection to remove prior test data.
+   mongoc_collection_drop (coll, NULL /* ignore error */);
+
+   mongoc_cursor_t *cursor =
+      mongoc_collection_find_with_opts (coll, tmp_bson ("{}"), tmp_bson ("{'exhaust': true }"), NULL /* read_prefs */);
+   const bson_t *result;
+   size_t count = 0;
+   while (mongoc_cursor_next (cursor, &result)) {
+      count++;
+   }
+   // Expect an error if exhaust cursors are not supported.
+   const bool sharded = _mongoc_topology_get_type (cursor->client->topology) == MONGOC_TOPOLOGY_SHARDED;
+   int64_t wire_version;
+   test_framework_get_max_wire_version (&wire_version);
+   if (sharded && wire_version < WIRE_VERSION_MONGOS_EXHAUST) {
+      ASSERT (mongoc_cursor_error (cursor, &error));
+      ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_CURSOR, MONGOC_ERROR_CURSOR_INVALID_CURSOR, "exhaust cursors require");
+   } else {
+      // Expect no error.
+      ASSERT_OR_PRINT (!mongoc_cursor_error (cursor, &error), error);
+      // Expect no results.
+      ASSERT_CMPSIZE_T (count, ==, 0);
+   }
+
+   mongoc_cursor_destroy (cursor);
+   mongoc_collection_destroy (coll);
+   mongoc_client_destroy (client);
+}
+
+
 static void
 test_exhaust_cursor_single (void *context)
 {
@@ -709,6 +748,8 @@ void
 test_exhaust_install (TestSuite *suite)
 {
    TestSuite_AddFull (suite, "/Client/exhaust_cursor/works", test_exhaust_cursor_works, NULL, NULL, skip_if_no_exhaust);
+   TestSuite_AddFull (
+      suite, "/Client/exhaust_cursor/no_match", test_exhaust_cursor_no_match, NULL, NULL, skip_if_no_exhaust);
    TestSuite_AddFull (
       suite, "/Client/exhaust_cursor/single", test_exhaust_cursor_single, NULL, NULL, skip_if_no_exhaust);
    TestSuite_AddFull (suite, "/Client/exhaust_cursor/pool", test_exhaust_cursor_pool, NULL, NULL, skip_if_no_exhaust);


### PR DESCRIPTION
# Summary

Fixes a failed assert when an exhaust cursor receives no documents:

```
src/libbson/src/bson/bson-reader.c:534 bson_reader_new_from_data(): precondition failed: data
```

Changes verified with a [patch build](https://spruce.mongodb.com/version/66018d4b86edac00076b6b3d) testing all server 3.6 tasks. 3.6 uses legacy exhaust cursors.

# Analysis

Regression was introduced in 6f58b9d7f32d5ea83b32c162a59d1f97e958657b.

On the prior commit, the call to `bson_reader_new_from_data` was the following:
```c
   response->reader =
      bson_reader_new_from_data (response->rpc.reply.documents,
                                 (size_t) response->rpc.reply.documents_len);
```

`response->rpc.reply.documents` was always non-NULL. When no documents are received, the pointer [is assigned](https://github.com/mongodb/mongo-c-driver/blob/daf8cce548f316540bc6ce556f87ea62cb6befb5/src/libmongoc/src/mongoc/mongoc-rpc.c#L501-L503) the address of the end of the OP_REPLY.

6f58b9d7f32d5ea83b32c162a59d1f97e958657b changed to use `mcd_rpc_op_reply_get_documents`:

```c
   response->reader = bson_reader_new_from_data (
      mcd_rpc_op_reply_get_documents (response->rpc),
      mcd_rpc_op_reply_get_documents_len (response->rpc));
```

`mcd_rpc_op_reply_get_documents` returns NULL if there are no documents. This causes the assert failure in `bson_reader_new_from_data`.

This PR does not change behavior of `mcd_rpc_op_reply_get_documents`. Returning `NULL` is [documented behavior](https://github.com/mongodb/mongo-c-driver/blob/0e771ca6b16098a82cb05346622c712906253faf/src/libmongoc/src/mongoc/mcd-rpc.h#L422). Though `mcd_rpc_op_reply_get_documents` is not in a public header, it is expected to be used by the Serverless Proxy (as part of CDRIVER-4625).