### PR TITLE
use CMake 3.29.0 in tests

### DIFF
--- a/.evergreen/scripts/find-cmake-latest.sh
+++ b/.evergreen/scripts/find-cmake-latest.sh
@@ -9,5 +9,5 @@ find_cmake_latest() {
   # shellcheck source=.evergreen/scripts/find-cmake-version.sh
   . "${script_dir}/find-cmake-version.sh" || return
 
-  find_cmake_version 3 25 3
+  find_cmake_version 3 29 0
 }


### PR DESCRIPTION
# Summary

Build tests with CMake 3.29.0 to resolve Windows OpenSSL task failures.

# Background & Motivation

This PR is intended to address Windows OpenSSL tasks failing to locate OpenSSL. For example, [sasl-cyrus-openssl-windows-2019-vs2017-x64-compile](https://spruce.mongodb.com/task/mongo_c_driver_sasl_matrix_openssl_sasl_cyrus_openssl_windows_2019_vs2017_x64_compile_a2dedb3ff2875a5ac75e3e0a8ded72bf838be1ec_24_03_25_18_00_50/logs?execution=0) fails with:

```
[2024/03/25 15:11:45.958] CMake Error at C:/Users/mci-exec/AppData/Local/mongo-c-driver/tmp.mwlWImHNJh/cmake-3.25.3-windows-x86_64/share/cmake-3.25/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
[2024/03/25 15:11:45.958]   Could NOT find OpenSSL, try to set the path to OpenSSL root folder in the
[2024/03/25 15:11:45.958]   system variable OPENSSL_ROOT_DIR (missing: OPENSSL_CRYPTO_LIBRARY) (found
[2024/03/25 15:11:45.958]   version "3.2.1")
```

This appears to have been caused by a change in the OpenSSL install on Windows hosts to use `choco install` as part of [DEVPROD-5184](https://jira.mongodb.org/browse/DEVPROD-5184). Notably, this change results in Windows tasks testing with OpenSSL 3.

I expect the issue is addressed by https://gitlab.kitware.com/cmake/cmake/-/issues/25702. Upgrading CMake to 3.29.0 resolves the issue. Using the previous release, CMake 3.28.4, results in the same error.

Here is a [patch build](https://spruce.mongodb.com/version/6604b6d0f289e400079996b7/tasks?baseStatuses=failed&page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&taskName=openssl-windows) with the `sasl-cyrus-openssl-windows-2019-vs2017-x64-compile` task passing. There are several other task failures that this PR does not address.