### PR TITLE
do not link to OpenSSL in MinGW task

### DIFF
--- a/.evergreen/scripts/link-sample-program-mingw.cmd
+++ b/.evergreen/scripts/link-sample-program-mingw.cmd
@@ -1,8 +1,8 @@
 echo on
 echo
 
-rem Use ENABLE_SSL=WINDOWS to link to Secure Channel. CMake is unable to locate OpenSSL installed on Windows hosts due to https://gitlab.kitware.com/cmake/cmake/-/issues/25859
-set CMAKE_FLAGS=-DENABLE_SSL=WINDOWS -DENABLE_SASL=CYRUS
+rem Use DENABLE_SSL=OFF. Windows hosts do not have a MinGW ABI compatible OpenSSL install.
+set CMAKE_FLAGS=-DENABLE_SSL=OFF -DENABLE_SASL=CYRUS
 set TAR=C:\cygwin\bin\tar
 set CMAKE_MAKE_PROGRAM=C:\mingw-w64\x86_64-4.9.1-posix-seh-rt_v3-rev1\mingw64\bin\mingw32-make.exe
 set CC=C:\mingw-w64\x86_64-4.9.1-posix-seh-rt_v3-rev1\mingw64\bin\gcc.exe

--- a/.evergreen/scripts/link-sample-program-mingw.cmd
+++ b/.evergreen/scripts/link-sample-program-mingw.cmd
@@ -1,7 +1,8 @@
 echo on
 echo
 
-set CMAKE_FLAGS=-DENABLE_SSL=OPENSSL -DENABLE_SASL=CYRUS
+rem Use ENABLE_SSL=WINDOWS to link to Secure Channel. CMake is unable to locate OpenSSL installed on Windows hosts due to https://gitlab.kitware.com/cmake/cmake/-/issues/25859
+set CMAKE_FLAGS=-DENABLE_SSL=WINDOWS -DENABLE_SASL=CYRUS
 set TAR=C:\cygwin\bin\tar
 set CMAKE_MAKE_PROGRAM=C:\mingw-w64\x86_64-4.9.1-posix-seh-rt_v3-rev1\mingw64\bin\mingw32-make.exe
 set CC=C:\mingw-w64\x86_64-4.9.1-posix-seh-rt_v3-rev1\mingw64\bin\gcc.exe


### PR DESCRIPTION
This PR intends to fix the failing `link-with-cmake-mingw` task ([example](https://spruce.mongodb.com/task/mongo_c_driver_smoke_link_with_cmake_mingw_378eebdc545caedeb4e6df4f43dadd47a29dd588_24_04_02_19_09_02/logs?execution=0)):

```
[2024/04/02 15:34:08.441] CMake Error at C:/Users/mci-exec/AppData/Local/mongo-c-driver/tmp.qA7z0pyqSC/cmake-3.29.0-windows-x86_64/share/cmake-3.29/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
[2024/04/02 15:34:08.441]   Could NOT find OpenSSL, try to set the path to OpenSSL root folder in the
[2024/04/02 15:34:08.441]   system variable OPENSSL_ROOT_DIR (missing: OPENSSL_CRYPTO_LIBRARY
[2024/04/02 15:34:08.441]   OPENSSL_INCLUDE_DIR)
[2024/04/02 15:34:08.441] Call Stack (most recent call first):
[2024/04/02 15:34:08.441]   C:/Users/mci-exec/AppData/Local/mongo-c-driver/tmp.qA7z0pyqSC/cmake-3.29.0-windows-x86_64/share/cmake-3.29/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
[2024/04/02 15:34:08.441]   C:/Users/mci-exec/AppData/Local/mongo-c-driver/tmp.qA7z0pyqSC/cmake-3.29.0-windows-x86_64/share/cmake-3.29/Modules/FindOpenSSL.cmake:682 (find_package_handle_standard_args)
[2024/04/02 15:34:08.441]   src/libmongoc/CMakeLists.txt:204 (find_package)
[2024/04/02 15:34:08.441]   src/libmongoc/CMakeLists.txt:160 (_use_named_tls_lib)
[2024/04/02 15:34:08.441]   src/libmongoc/CMakeLists.txt:231 (_pick_which_tls_lib)
```

Here is a patch build with these changes applied and the task `link-with-cmake-mingw` task passing: https://spruce.mongodb.com/version/660da4c4b9585300076ee2e0

This is a follow-up to https://github.com/mongodb/mongo-c-driver/pull/1566. Upgrading to CMake 3.29.0 fixed OpenSSL tasks with Visual Studio, but not the MinGW task. The error locating OpenSSL with the MinGW generator was reported to CMake here: https://gitlab.kitware.com/cmake/cmake/-/issues/25859. The response noted:

> IIUC, that installation is the Shining Light Productions distribution which is only for the MSVC ABI, not the GNU ABI (MinGW). You need to use an OpenSSL package that's meant for MinGW.

I am not sure how valuable it is to test linking to OpenSSL when building with MinGW. This PR changes to use ENABLE_SSL=WINDOWS to use Windows Secure Channel to keep test coverage of building with MinGW.
