### PR TITLE
sync RPM spec file from downstream

### DIFF
--- a/.evergreen/etc/mongo-c-driver.spec
+++ b/.evergreen/etc/mongo-c-driver.spec
@@ -10,7 +10,7 @@
 %global gh_project   mongo-c-driver
 %global libname      libmongoc
 %global libver       1.0
-%global up_version   1.26.1
+%global up_version   1.26.2
 #global up_prever    rc0
 # disabled as require a MongoDB server
 %bcond_with          tests
@@ -243,6 +243,9 @@ exit $ret
 
 
 %changelog
+* Wed Apr  3 2024 Remi Collet <remi@remirepo.net> - 1.26.2-1
+- update to 1.26.2
+
 * Wed Mar  6 2024 Remi Collet <remi@remirepo.net> - 1.26.1-1
 - update to 1.26.1
 

--- a/.evergreen/etc/spec.patch
+++ b/.evergreen/etc/spec.patch
@@ -4,7 +4,7 @@
  %global gh_project   mongo-c-driver
  %global libname      libmongoc
  %global libver       1.0
--%global up_version   1.26.1
+-%global up_version   1.26.2
 +%global up_version   1.27.0
  #global up_prever    rc0
  # disabled as require a MongoDB server


### PR DESCRIPTION
Patch build: https://evergreen.mongodb.com/version/660eecab6af00800079e0321?redirect_spruce_users=true

Note that the task is till failing because C driver `master` needs a newer libmongocrypt than what is in the distro repos.