### PR TITLE
CDRIVER-4363 refactor retryable writes into shared function

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-cluster-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-private.h
@@ -186,6 +186,16 @@ mongoc_cluster_stream_valid (mongoc_cluster_t *cluster, mongoc_server_stream_t *
 bool
 mongoc_cluster_run_command_monitored (mongoc_cluster_t *cluster, mongoc_cmd_t *cmd, bson_t *reply, bson_error_t *error);
 
+// `mongoc_cluster_run_retryable_write` executes a write command and may apply retryable writes behavior.
+// `*retry_server_stream` is set to a new stream on retry. The caller must call `mongoc_server_stream_cleanup`.
+bool
+mongoc_cluster_run_retryable_write (mongoc_cluster_t *cluster,
+                                    mongoc_cmd_t *cmd,
+                                    bool is_retryable_write,
+                                    mongoc_server_stream_t **retry_server_stream,
+                                    bson_t *reply,
+                                    bson_error_t *error);
+
 bool
 mongoc_cluster_run_command_parts (mongoc_cluster_t *cluster,
                                   mongoc_server_stream_t *server_stream,

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -3669,9 +3669,6 @@ retry:
 
    if (is_retryable_write) {
       _mongoc_write_error_handle_labels (ret, error, reply, cmd->server_stream->sd);
-   }
-
-   if (can_retry) {
       _mongoc_write_error_update_if_unsupported_storage_engine (ret, error, reply);
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -3636,3 +3636,94 @@ mcd_rpc_message_decompress_if_necessary (mcd_rpc_message *rpc, void **data, size
 
    return mcd_rpc_message_decompress (rpc, data, data_len);
 }
+
+bool
+mongoc_cluster_run_retryable_write (mongoc_cluster_t *cluster,
+                                    mongoc_cmd_t *cmd,
+                                    bool is_retryable_write,
+                                    mongoc_server_stream_t **retry_server_stream,
+                                    bson_t *reply,
+                                    bson_error_t *error)
+{
+   bool ret;
+   bool is_retryable = is_retryable_write;
+
+   /* increment the transaction number for the first attempt of each retryable
+    * write command */
+   if (is_retryable_write) {
+      bson_iter_t txn_number_iter;
+      BSON_ASSERT (bson_iter_init_find (&txn_number_iter, cmd->command, "txnNumber"));
+      bson_iter_overwrite_int64 (&txn_number_iter, ++cmd->session->server_session->txn_number);
+   }
+
+   // Store the original error and reply if needed.
+   struct {
+      bson_t reply;
+      bson_error_t error;
+      bool set;
+   } original_error = {.reply = {0}, .error = {0}, .set = false};
+
+retry:
+   ret = mongoc_cluster_run_command_monitored (cluster, cmd, reply, error);
+
+   if (is_retryable_write) {
+      _mongoc_write_error_handle_labels (ret, error, reply, cmd->server_stream->sd);
+   }
+
+   if (is_retryable) {
+      _mongoc_write_error_update_if_unsupported_storage_engine (ret, error, reply);
+   }
+
+   /* If a retryable error is encountered and the write is retryable, select
+    * a new writable stream and retry. If server selection fails or the selected
+    * server does not support retryable writes, fall through and allow the
+    * original error to be reported. */
+   if (is_retryable && _mongoc_write_error_get_type (reply) == MONGOC_WRITE_ERR_RETRY) {
+      bson_error_t ignored_error;
+
+      /* each write command may be retried at most once */
+      is_retryable = false;
+
+      {
+         mongoc_deprioritized_servers_t *const ds = mongoc_deprioritized_servers_new ();
+
+         mongoc_deprioritized_servers_add_if_sharded (ds, cmd->server_stream->topology_type, cmd->server_stream->sd);
+
+         *retry_server_stream =
+            mongoc_cluster_stream_for_writes (cluster, cmd->session, ds, NULL /* reply */, &ignored_error);
+
+         mongoc_deprioritized_servers_destroy (ds);
+      }
+
+      if (*retry_server_stream) {
+         cmd->server_stream = *retry_server_stream;
+         {
+            // Store the original error and reply before retry.
+            BSON_ASSERT (!original_error.set); // Retry only happens once.
+            original_error.set = true;
+            bson_copy_to (reply, &original_error.reply);
+            if (error) {
+               original_error.error = *error;
+            }
+         }
+         bson_destroy (reply);
+         GOTO (retry);
+      }
+   }
+
+   // If a retry attempt fails with an error labeled NoWritesPerformed,
+   // drivers MUST return the original error.
+   if (original_error.set && mongoc_error_has_label (reply, "NoWritesPerformed")) {
+      if (error) {
+         *error = original_error.error;
+      }
+      bson_destroy (reply);
+      bson_copy_to (&original_error.reply, reply);
+   }
+
+   if (original_error.set) {
+      bson_destroy (&original_error.reply);
+   }
+
+   RETURN (ret);
+}

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -3682,6 +3682,7 @@ retry:
       /* each write command may be retried at most once */
       can_retry = false;
 
+      // If talking to a sharded cluster, deprioritize the just-used mongos to prefer a new mongos for the retry.
       {
          mongoc_deprioritized_servers_t *const ds = mongoc_deprioritized_servers_new ();
 

--- a/src/libmongoc/src/mongoc/mongoc-collection.c
+++ b/src/libmongoc/src/mongoc/mongoc-collection.c
@@ -3296,6 +3296,7 @@ mongoc_collection_find_and_modify_with_opts (mongoc_collection_t *collection,
 
    mongoc_cmd_t *cmd = &parts.assembled;
    bool is_retryable_write = parts.is_retryable_write;
+   bson_destroy (reply);
 
    // Store the original error and reply if needed.
    struct {
@@ -3305,7 +3306,6 @@ mongoc_collection_find_and_modify_with_opts (mongoc_collection_t *collection,
    } original_error = {.reply = {0}, .error = {0}, .set = false};
 
 retry:
-   bson_destroy (reply);
    ret = mongoc_cluster_run_command_monitored (cluster, cmd, reply, error);
 
    if (is_retryable_write) {
@@ -3348,6 +3348,7 @@ retry:
                original_error.error = *error;
             }
          }
+         bson_destroy (reply);
          GOTO (retry);
       }
    }

--- a/src/libmongoc/src/mongoc/mongoc-collection.c
+++ b/src/libmongoc/src/mongoc/mongoc-collection.c
@@ -3309,7 +3309,7 @@ retry:
    ret = mongoc_cluster_run_command_monitored (cluster, cmd, reply, error);
 
    if (is_retryable_write) {
-      _mongoc_write_error_handle_labels (ret, error, reply, server_stream->sd);
+      _mongoc_write_error_handle_labels (ret, error, reply, cmd->server_stream->sd);
    }
 
    if (is_retryable) {
@@ -3329,7 +3329,7 @@ retry:
       {
          mongoc_deprioritized_servers_t *const ds = mongoc_deprioritized_servers_new ();
 
-         mongoc_deprioritized_servers_add_if_sharded (ds, server_stream->topology_type, server_stream->sd);
+         mongoc_deprioritized_servers_add_if_sharded (ds, cmd->server_stream->topology_type, cmd->server_stream->sd);
 
          retry_server_stream =
             mongoc_cluster_stream_for_writes (cluster, cmd->session, ds, NULL /* reply */, &ignored_error);


### PR DESCRIPTION
This PR relocates the retryable writes logic into a new function: `mongoc_cluster_run_retryable_write`.

This enables sharing the retryable writes logic among the current three uses. It is planned to be used in the new bulk write helper for CDRIVER-4363.

No functional changes are expected.