### PR TITLE
Replace SSH git clone commands with HTTPS equivalents

### DIFF
--- a/.evergreen/benchmark.yml
+++ b/.evergreen/benchmark.yml
@@ -36,7 +36,7 @@ variables:
           set -o verbose
 
           cmake -DENABLE_TESTS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=mongoc -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF . && make -j8 && make install
-          git clone git@github.com:mongodb/mongo-c-driver-performance.git
+          git clone https://github.com/mongodb/mongo-c-driver-performance.git
           cd mongo-c-driver-performance
           cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=../mongoc . && make -j8
 

--- a/.evergreen/config_generator/components/funcs/fetch_det.py
+++ b/.evergreen/config_generator/components/funcs/fetch_det.py
@@ -12,7 +12,7 @@ class FetchDET(Function):
             command_type=EvgCommandType.SETUP,
             script='''\
                 if [[ ! -d drivers-evergreen-tools ]]; then
-                    git clone --depth=1 git@github.com:mongodb-labs/drivers-evergreen-tools.git
+                    git clone --depth=1 https://github.com/mongodb-labs/drivers-evergreen-tools.git
                 fi
             ''',
         ),

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -181,7 +181,7 @@ functions:
           - -c
           - |
             if [[ ! -d drivers-evergreen-tools ]]; then
-                git clone --depth=1 git@github.com:mongodb-labs/drivers-evergreen-tools.git
+                git clone --depth=1 https://github.com/mongodb-labs/drivers-evergreen-tools.git
             fi
     - command: subprocess.exec
       type: setup

--- a/.evergreen/scripts/integration-tests.sh
+++ b/.evergreen/scripts/integration-tests.sh
@@ -110,7 +110,7 @@ case "$OS" in
       venvcreate "${PYTHON3_BINARY}" venv
       cd venv
       rm -rf mongo-orchestration
-      git clone --depth 1 git@github.com:10gen/mongo-orchestration.git
+      git clone --depth 1 https://github.com/10gen/mongo-orchestration.git
       cd mongo-orchestration
       python -m pip install .
       cd ../..
@@ -123,7 +123,7 @@ case "$OS" in
       cd venv
       rm -rf mongo-orchestration
       # Make sure MO is running latest version
-      git clone --depth 1 git@github.com:10gen/mongo-orchestration.git
+      git clone --depth 1 https://github.com/10gen/mongo-orchestration.git
       cd mongo-orchestration
       # Our zSeries machines are static-provisioned, cache corruptions persist.
       if [ $(uname -m) = "s390x" ]; then


### PR DESCRIPTION
Consistently replaces all instances of SSH git clone commands in scripts (not in documentation) with HTTPS equivalents as a proactive measure concerning upcoming updates to EVG. Verified by [this patch](https://spruce.mongodb.com/version/66296fc56a1f920007224b85).