### PR TITLE
CDRIVER-4794 build RPM in EPEL environments

### DIFF
--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -914,6 +914,26 @@ tasks:
       permissions: public-read
       local_file: rpm.tar.gz
       content_type: ${content_type|application/x-gzip}
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        sudo rm -rf ../build ../mock-result ../rpm.tar.gz
+        export MOCK_TARGET_CONFIG=rocky+epel-9-aarch64
+        sh -x .evergreen/scripts/build_snapshot_rpm.sh
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: mongoc
+      shell: bash
+      script: |-
+        set -o errexit
+        sudo rm -rf ../build ../mock-result ../rpm.tar.gz
+        export MOCK_TARGET_CONFIG=rocky+epel-8-aarch64
+        sh -x .evergreen/scripts/build_snapshot_rpm.sh
 - name: install-uninstall-check-mingw
   commands:
   - command: shell.exec

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -340,6 +340,8 @@ all_tasks = [
                 remote_file="${branch_name}/${revision}/${version_id}/${build_id}/${execution}/mongo-c-driver-rpm-packages.tar.gz",
                 content_type="${content_type|application/x-gzip}",
             ),
+            shell_mongoc("sudo rm -rf ../build ../mock-result ../rpm.tar.gz\n" "export MOCK_TARGET_CONFIG=rocky+epel-9-aarch64\n" "sh .evergreen/scripts/build_snapshot_rpm.sh"),
+            shell_mongoc("sudo rm -rf ../build ../mock-result ../rpm.tar.gz\n" "export MOCK_TARGET_CONFIG=rocky+epel-8-aarch64\n" "sh .evergreen/scripts/build_snapshot_rpm.sh"),
         ],
     ),
     NamedTask(

--- a/.evergreen/scripts/build_snapshot_rpm.sh
+++ b/.evergreen/scripts/build_snapshot_rpm.sh
@@ -76,11 +76,17 @@ build_dir=$(basename $(pwd))
 sudo mock -r ${config} --use-bootstrap-image --isolation=simple --clean
 sudo mock -r ${config} --use-bootstrap-image --isolation=simple --init
 mock_root=$(sudo mock -r ${config} --use-bootstrap-image --isolation=simple --print-root-path)
-sudo mock -r ${config} --use-bootstrap-image --isolation=simple --install rpmdevtools git rpm-build cmake python gcc openssl-devel
+sudo mock -r ${config} --use-bootstrap-image --isolation=simple --install rpmdevtools git rpm-build cmake python3.11 gcc openssl-devel
+
+# This step is needed to avoid the following error on rocky+epel8:
+# Problem: conflicting requests
+#  - package utf8proc-devel-2.6.1-3.module+el8.7.0+1065+42200b2e.aarch64 from powertools is filtered out by modular filtering
+sudo mock -r ${config} --use-bootstrap-image --isolation=simple --dnf-cmd --setopt=powertools.module_hotfixes=true install utf8proc-devel
+
 sudo mock -r ${config} --use-bootstrap-image --isolation=simple --copyin "$(pwd)" "$(pwd)/${spec_file}" /tmp
 sudo mock -r ${config} --use-bootstrap-image --isolation=simple --cwd "/tmp/${build_dir}" --chroot -- /bin/sh -c "(
-  python build/calc_release_version.py | sed -E 's/([^-]+).*/\1/' > VERSION_CURRENT ;
-  python build/calc_release_version.py -p > VERSION_RELEASED
+  python3.11 build/calc_release_version.py | sed -E 's/([^-]+).*/\1/' > VERSION_CURRENT ;
+  python3.11 build/calc_release_version.py -p > VERSION_RELEASED
   )"
 sudo mock -r ${config} --use-bootstrap-image --isolation=simple --copyout "/tmp/${build_dir}/VERSION_CURRENT" "/tmp/${build_dir}/VERSION_RELEASED" .
 


### PR DESCRIPTION
The patch build for this PR (specifically for the `rpm-package-build task`) is in a failed state. This is because the `master` branch of the C driver relies on newly introduced features in libmongocrypt which are not present in the libmongocrypt package which can be installed from the Fedora repo. The PR for `r1.26` (#1580) branch has a patch build demonstrating that this is a working change.