### PR TITLE
fix crash if password is NULL

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-scram.c
+++ b/src/libmongoc/src/mongoc/mongoc-scram.c
@@ -995,7 +995,7 @@ bool
 _mongoc_sasl_prep_required (const char *str)
 {
    unsigned char c;
-   while (*str) {
+   while (str != NULL && *str) {
       c = (unsigned char) *str;
       /* characters below 32 contain all of the control characters.
        * characters above 127 are multibyte UTF-8 characters.


### PR DESCRIPTION
If I have a custom connection string without password - 'mongodb://superuser@127.0.0.1:27030/admin', then mongo cursor crashes