### PR TITLE
CDRIVER-5550 fix crash when password is empty

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-scram.c
+++ b/src/libmongoc/src/mongoc/mongoc-scram.c
@@ -341,6 +341,11 @@ _mongoc_scram_start (
       goto FAIL;
    }
 
+   if (!scram->pass) {
+      // Apply an empty string as a default.
+      scram->pass = bson_strdup ("");
+   }
+
    /* auth message is as big as the outbuf just because */
    scram->auth_message = (uint8_t *) bson_malloc (outbufmax);
    scram->auth_messagemax = outbufmax;
@@ -994,6 +999,7 @@ _mongoc_scram_step (mongoc_scram_t *scram,
 bool
 _mongoc_sasl_prep_required (const char *str)
 {
+   BSON_ASSERT_PARAM (str);
    unsigned char c;
    while (*str) {
       c = (unsigned char) *str;


### PR DESCRIPTION
# Summary

Fix crash when a URI includes an empty password string.

# Background & Motivation

Issue was originally reported in: https://github.com/mongodb/mongo-c-driver/pull/1585

The failing Earthly tasks attached to this PR appear to be failing from unrelated reasons (environment change?). Here is a [patch build](https://spruce.mongodb.com/version/662fd37bd5216d0007283216) verifying these changes with the `*auth*` tasks.
