### PR TITLE
CDRIVER-5536 zero-init `bson_iter_t::value`

### DIFF
--- a/src/libbson/src/bson/bson-iter.c
+++ b/src/libbson/src/bson/bson-iter.c
@@ -62,6 +62,7 @@ bson_iter_init (bson_iter_t *iter,  /* OUT */
    iter->d4 = 0;
    iter->next_off = 4;
    iter->err_off = 0;
+   iter->value = (bson_value_t){0};
 
    return true;
 }


### PR DESCRIPTION
# Summary

Zero-initialize `bson_iter_t::value`.

This PR is related to, but does not resolve CDRIVER-5536.

# Background & Motivation
There are many Coverity issues in the libmongocrypt project referencing uninitialized access of the `bson_iter_t::value` field:

```c
bson_iter_t iter1;
BSON_ASSERT (bson_iter_init (&iter1, &bson)); // Does not initialize `iter1.value`
bson_iter_t iter2 = iter1; // Assigns uninitialized `value`.
```

I expect this is OK in practice. I do not expect `bson_iter_t::value` is meant to be directly accessed. The `bson_iter_t::value` is initialized and returned in `bson_iter_value`. Regardless, this PR errs towards safety. A caller may reasonably expect `bson_iter_init` to initialize all struct fields.

