### PR TITLE
[CDRIVER-5535] Add files and an Earthly target for an SBOM-lite

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -176,8 +176,6 @@ multibuild:
 #
 # This target will update the existing etc/cyclonedx.sbom.json file in-place based
 # on the content of etc/purls.txt.
-#
-# NOTE: Executing this target requires prior authentication with Artifactory!
 sbom-generate:
     FROM artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:1.0
     # Alias the silkbom executable to a simpler name:

--- a/Earthfile
+++ b/Earthfile
@@ -171,6 +171,28 @@ multibuild:
         --c_compiler=gcc --c_compiler=clang \
         --test_mongocxx_ref=master
 
+# sbom-generate :
+#   Generate/update the etc/cyclonedx.sbom.json file from the etc/purls.txt file.
+#
+# This target will update the existing etc/cyclonedx.sbom.json file in-place based
+# on the content of etc/purls.txt.
+#
+# NOTE: Executing this target requires prior authentication with Artifactory!
+sbom-generate:
+    FROM artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:1.0
+    # Alias the silkbom executable to a simpler name:
+    RUN ln -s /python/src/sbom/silkbomb/bin /usr/local/bin/silkbomb
+    # Copy in the relevant files:
+    WORKDIR /s
+    COPY etc/purls.txt etc/cyclonedx.sbom.json /s/
+    # Update the SBOM file:
+    RUN silkbomb update \
+        --purls purls.txt \
+        --sbom-in cyclonedx.sbom.json \
+        --sbom-out cyclonedx.sbom.json
+    # Save the result back to the host:
+    SAVE ARTIFACT /s/cyclonedx.sbom.json AS LOCAL etc/cyclonedx.sbom.json
+
 # test-vcpkg-classic :
 #   Builds src/libmongoc/examples/cmake/vcpkg by using vcpkg to download and
 #   install a mongo-c-driver build in "classic mode". *Does not* use the local

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -1,0 +1,134 @@
+{
+  "components": [
+    {
+      "bom-ref": "pkg:github/juliastrings/utf8proc@2.8.0",
+      "externalReferences": [
+        {
+          "type": "distribution",
+          "url": "https://github.com/juliastrings/utf8proc/archive/refs/tags/2.8.0.tar.gz"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/juliastrings/utf8proc/tree/2.8.0"
+        }
+      ],
+      "group": "juliastrings",
+      "name": "utf8proc",
+      "purl": "pkg:github/juliastrings/utf8proc@2.8.0",
+      "type": "library",
+      "version": "2.8.0"
+    },
+    {
+      "bom-ref": "pkg:github/madler/zlib@v1.2.13",
+      "externalReferences": [
+        {
+          "type": "distribution",
+          "url": "https://github.com/madler/zlib/archive/refs/tags/v1.2.13.tar.gz"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/madler/zlib/tree/v1.2.13"
+        }
+      ],
+      "group": "madler",
+      "name": "zlib",
+      "purl": "pkg:github/madler/zlib@v1.2.13",
+      "type": "library",
+      "version": "v1.2.13"
+    },
+    {
+      "bom-ref": "pkg:github/mnunberg/jsonsl",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/mnunberg/jsonsl"
+        }
+      ],
+      "group": "mnunberg",
+      "name": "jsonsl",
+      "purl": "pkg:github/mnunberg/jsonsl",
+      "type": "library"
+    },
+    {
+      "bom-ref": "pkg:github/troydhanson/uthash@v2.3.0",
+      "externalReferences": [
+        {
+          "type": "distribution",
+          "url": "https://github.com/troydhanson/uthash/archive/refs/tags/v2.3.0.tar.gz"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/troydhanson/uthash/tree/v2.3.0"
+        }
+      ],
+      "group": "troydhanson",
+      "name": "uthash",
+      "purl": "pkg:github/troydhanson/uthash@v2.3.0",
+      "type": "library",
+      "version": "v2.3.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pkg:github/juliastrings/utf8proc@2.8.0"
+    },
+    {
+      "ref": "pkg:github/madler/zlib@v1.2.13"
+    },
+    {
+      "ref": "pkg:github/mnunberg/jsonsl"
+    },
+    {
+      "ref": "pkg:github/troydhanson/uthash@v2.3.0"
+    }
+  ],
+  "metadata": {
+    "timestamp": "2024-05-03T19:02:40.015183+00:00",
+    "tools": [
+      {
+        "externalReferences": [
+          {
+            "type": "build-system",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/actions"
+          },
+          {
+            "type": "distribution",
+            "url": "https://pypi.org/project/cyclonedx-python-lib/"
+          },
+          {
+            "type": "documentation",
+            "url": "https://cyclonedx-python-library.readthedocs.io/"
+          },
+          {
+            "type": "issue-tracker",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/issues"
+          },
+          {
+            "type": "license",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/LICENSE"
+          },
+          {
+            "type": "release-notes",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/CHANGELOG.md"
+          },
+          {
+            "type": "vcs",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib"
+          },
+          {
+            "type": "website",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/#readme"
+          }
+        ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "6.4.4"
+      }
+    ]
+  },
+  "serialNumber": "urn:uuid:e5a75bd1-68a4-499e-81c6-64a8785adaae",
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/etc/purls.txt
+++ b/etc/purls.txt
@@ -1,0 +1,18 @@
+# These package URLs (purls) point to the versions (tags) of external dependencies
+# that are committed to the project. Refer: https://github.com/package-url/purl-spec
+
+# This file is fed to silkbomb to generate the cyclonedx.sbom.json file. Edit this file
+# instead of modifying the SBOM JSON directly. After modifying this file, be sure to
+# re-generate the SBOM JSON file!
+
+# Lives at src/zlib-*
+pkg:github/madler/zlib@v1.2.13
+
+# Lives at src/utf8proc-*
+pkg:github/JuliaStrings/utf8proc@2.8.0
+
+# Lives at src/uthash
+pkg:github/troydhanson/uthash@v2.3.0
+
+# Lives at src/libbson/src/jsonsl
+pkg:github/mnunberg/jsonsl


### PR DESCRIPTION
This is part of the changes required for CDRIVER-5535. Additional changes will be needed for posting the information into Silk, a process which is still WIP.

This gets a head-start on the SBOM-Lite aspect of the work.

Alternative: Do we want to automate this aspect, rather than committing the generated JSON results directly? If so, it will require having and managing service credentials with Artifactory in order to pull the SilkBomb container during the CI process.