### PR TITLE
CDRIVER-5571 deprecate `*_hint` functions for newly added `*_serverid`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,14 @@
+libmongoc 1.28.0 (unreleased)
+=============================
+
+Deprecated:
+
+  * Use of `*_hint` functions is deprecated in favor of more aptly named `*_server_id` functions:
+    * `mongoc_bulk_operation_set_hint` is deprecated for `mongoc_bulk_operation_set_server_id`
+    * `mongoc_bulk_operation_get_hint` is deprecated for `mongoc_bulk_operation_get_server_id`
+    * `mongoc_cursor_set_hint` is deprecated for `mongoc_cursor_set_server_id`
+    * `mongoc_cursor_get_hint` is deprecated for `mongoc_cursor_get_server_id`
+
 libmongoc 1.27.1
 ================
 

--- a/src/libmongoc/doc/mongoc_bulk_operation_execute.rst
+++ b/src/libmongoc/doc/mongoc_bulk_operation_execute.rst
@@ -46,5 +46,5 @@ The ``reply`` document counts operations and collects error information. See :do
 
   | :symbol:`Bulk Write Operations <bulk>`
 
-  | :symbol:`mongoc_bulk_operation_get_hint`, which gets the id of the server used even if the operation failed.
+  | :symbol:`mongoc_bulk_operation_get_server_id`, which gets the id of the server used even if the operation failed.
 

--- a/src/libmongoc/doc/mongoc_bulk_operation_get_hint.rst
+++ b/src/libmongoc/doc/mongoc_bulk_operation_get_hint.rst
@@ -3,13 +3,21 @@
 mongoc_bulk_operation_get_hint()
 ================================
 
+.. warning::
+   .. deprecated:: 1.28.0
+
+      This function is deprecated and should not be used in new code.
+
+      Please use :symbol:`mongoc_bulk_operation_get_server_id()` in new code.
+
 Synopsis
 --------
 
 .. code-block:: c
 
   uint32_t
-  mongoc_bulk_operation_get_hint (const mongoc_bulk_operation_t *bulk);
+  mongoc_bulk_operation_get_hint (const mongoc_bulk_operation_t *bulk)
+    BSON_GNUC_DEPRECATED_FOR (mongoc_bulk_operation_get_server_id);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_bulk_operation_get_server_id.rst
+++ b/src/libmongoc/doc/mongoc_bulk_operation_get_server_id.rst
@@ -1,0 +1,25 @@
+:man_page: mongoc_bulk_operation_get_server_id
+
+mongoc_bulk_operation_get_server_id()
+=====================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  uint32_t
+  mongoc_bulk_operation_get_server_id (const mongoc_bulk_operation_t *bulk);
+
+Parameters
+----------
+
+* ``bulk``: A :symbol:`mongoc_bulk_operation_t`.
+
+Description
+-----------
+
+Retrieves the opaque id of the server used for the operation.
+
+This number is zero until the driver actually uses a server in :symbol:`mongoc_bulk_operation_execute`. The server id is the same number as the return value of a successful :symbol:`mongoc_bulk_operation_execute`, so ``mongoc_bulk_operation_get_server_id`` is useful mainly in case :symbol:`mongoc_bulk_operation_execute` fails and returns zero.
+

--- a/src/libmongoc/doc/mongoc_bulk_operation_set_hint.rst
+++ b/src/libmongoc/doc/mongoc_bulk_operation_set_hint.rst
@@ -3,14 +3,21 @@
 mongoc_bulk_operation_set_hint()
 ================================
 
+.. warning::
+   .. deprecated:: 1.28.0
+
+      This function is deprecated and should not be used in new code.
+
+      Please use :symbol:`mongoc_bulk_operation_set_server_id()` in new code.
+
 Synopsis
 --------
 
 .. code-block:: c
 
   void
-  mongoc_bulk_operation_set_hint (const mongoc_bulk_operation_t *bulk,
-                                  uint32_t server_id);
+  mongoc_bulk_operation_set_hint (mongoc_bulk_operation_t *bulk, uint32_t server_id)
+    BSON_GNUC_DEPRECATED_FOR (mongoc_bulk_operation_set_server_id);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_bulk_operation_set_server_id.rst
+++ b/src/libmongoc/doc/mongoc_bulk_operation_set_server_id.rst
@@ -1,0 +1,26 @@
+:man_page: mongoc_bulk_operation_set_server_id
+
+mongoc_bulk_operation_set_server_id()
+=====================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  void
+  mongoc_bulk_operation_set_server_id (mongoc_bulk_operation_t *bulk, uint32_t server_id);
+
+Parameters
+----------
+
+* ``bulk``: A :symbol:`mongoc_bulk_operation_t`.
+* ``server_id``: An opaque id identifying the server to use.
+
+Description
+-----------
+
+Specifies which server to use for the operation. This function has an effect only if called before :symbol:`mongoc_bulk_operation_execute`.
+
+Use ``mongoc_bulk_operation_set_server_id`` only for building a language driver that wraps the C Driver. When writing applications in C, leave the server id unset and allow the driver to choose a suitable server for the bulk operation.
+

--- a/src/libmongoc/doc/mongoc_bulk_operation_t.rst
+++ b/src/libmongoc/doc/mongoc_bulk_operation_t.rst
@@ -38,6 +38,7 @@ After adding all of the write operations to the ``mongoc_bulk_operation_t``, cal
     mongoc_bulk_operation_destroy
     mongoc_bulk_operation_execute
     mongoc_bulk_operation_get_hint
+    mongoc_bulk_operation_get_server_id
     mongoc_bulk_operation_get_write_concern
     mongoc_bulk_operation_insert
     mongoc_bulk_operation_insert_with_opts
@@ -51,6 +52,7 @@ After adding all of the write operations to the ``mongoc_bulk_operation_t``, cal
     mongoc_bulk_operation_set_client_session
     mongoc_bulk_operation_set_comment
     mongoc_bulk_operation_set_hint
+    mongoc_bulk_operation_set_server_id
     mongoc_bulk_operation_set_let
     mongoc_bulk_operation_update
     mongoc_bulk_operation_update_many_with_opts

--- a/src/libmongoc/doc/mongoc_cursor_get_hint.rst
+++ b/src/libmongoc/doc/mongoc_cursor_get_hint.rst
@@ -3,13 +3,20 @@
 mongoc_cursor_get_hint()
 ========================
 
+.. warning::
+   .. deprecated:: 1.28.0
+
+      This function is deprecated and should not be used in new code.
+
+      Please use :symbol:`mongoc_cursor_get_server_id()` in new code.
+
 Synopsis
 --------
 
 .. code-block:: c
 
   uint32_t
-  mongoc_cursor_get_hint (const mongoc_cursor_t *cursor);
+  mongoc_cursor_get_hint (const mongoc_cursor_t *cursor) BSON_GNUC_DEPRECATED_FOR (mongoc_cursor_get_server_id);
 
 Parameters
 ----------
@@ -23,5 +30,5 @@ Retrieves the opaque id of the server used for the operation.
 
 (The function name includes the old term "hint" for the sake of backward compatibility, but we now call this number a "server id".)
 
-This number is zero until the driver actually uses a server when executing the find operation or :symbol:`mongoc_cursor_set_hint` is called.
+This number is zero until the driver actually uses a server when executing the find operation or :symbol:`mongoc_cursor_set_server_id` is called.
 

--- a/src/libmongoc/doc/mongoc_cursor_get_server_id.rst
+++ b/src/libmongoc/doc/mongoc_cursor_get_server_id.rst
@@ -1,0 +1,25 @@
+:man_page: mongoc_cursor_get_server_id
+
+mongoc_cursor_get_server_id()
+=============================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  uint32_t
+  mongoc_cursor_get_server_id (const mongoc_cursor_t *cursor);
+
+Parameters
+----------
+
+* ``cursor``: A :symbol:`mongoc_cursor_t`.
+
+Description
+-----------
+
+Retrieves the opaque id of the server used for the operation.
+
+This number is zero until the driver actually uses a server when executing the find operation or :symbol:`mongoc_cursor_set_server_id` is called.
+

--- a/src/libmongoc/doc/mongoc_cursor_set_hint.rst
+++ b/src/libmongoc/doc/mongoc_cursor_set_hint.rst
@@ -3,13 +3,21 @@
 mongoc_cursor_set_hint()
 ========================
 
+.. warning::
+   .. deprecated:: 1.28.0
+
+      This function is deprecated and should not be used in new code.
+
+      Please use :symbol:`mongoc_cursor_set_server_id()` in new code.
+
 Synopsis
 --------
 
 .. code-block:: c
 
   bool
-  mongoc_cursor_set_hint (mongoc_cursor_t *cursor, uint32_t server_id);
+  mongoc_cursor_set_hint (mongoc_cursor_t *cursor, uint32_t server_id)
+    BSON_GNUC_DEPRECATED_FOR (mongoc_cursor_set_server_id);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_cursor_set_server_id.rst
+++ b/src/libmongoc/doc/mongoc_cursor_set_server_id.rst
@@ -1,0 +1,31 @@
+:man_page: mongoc_cursor_set_server_id
+
+mongoc_cursor_set_server_id()
+=============================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  bool
+  mongoc_cursor_set_server_id (mongoc_cursor_t *cursor, uint32_t server_id)
+
+Parameters
+----------
+
+* ``cursor``: A :symbol:`mongoc_cursor_t`.
+* ``server_id``: An opaque id identifying the server to use.
+
+Description
+-----------
+
+Specifies which server to use for the operation. This function has an effect only if called before the find operation is executed.
+
+Use ``mongoc_cursor_set_server_id`` only for building a language driver that wraps the C Driver. When writing applications in C, leave the server id unset and allow the driver to choose a suitable server from the find operation's read preference.
+
+Returns
+-------
+
+Returns true on success. If any arguments are invalid, returns false and logs an error.
+

--- a/src/libmongoc/doc/mongoc_cursor_t.rst
+++ b/src/libmongoc/doc/mongoc_cursor_t.rst
@@ -52,6 +52,7 @@ Example
     mongoc_cursor_error_document
     mongoc_cursor_get_batch_size
     mongoc_cursor_get_hint
+    mongoc_cursor_get_server_id
     mongoc_cursor_get_host
     mongoc_cursor_get_id
     mongoc_cursor_get_limit
@@ -63,6 +64,7 @@ Example
     mongoc_cursor_next
     mongoc_cursor_set_batch_size
     mongoc_cursor_set_hint
+    mongoc_cursor_set_server_id
     mongoc_cursor_set_limit
     mongoc_cursor_set_max_await_time_ms
 

--- a/src/libmongoc/src/mongoc/mongoc-bulk-operation.c
+++ b/src/libmongoc/src/mongoc/mongoc-bulk-operation.c
@@ -914,9 +914,7 @@ mongoc_bulk_operation_set_client_session (mongoc_bulk_operation_t *bulk,
 uint32_t
 mongoc_bulk_operation_get_hint (const mongoc_bulk_operation_t *bulk)
 {
-   BSON_ASSERT_PARAM (bulk);
-
-   return bulk->server_id;
+   return mongoc_bulk_operation_get_server_id (bulk);
 }
 
 uint32_t
@@ -930,9 +928,7 @@ mongoc_bulk_operation_get_server_id (const mongoc_bulk_operation_t *bulk)
 void
 mongoc_bulk_operation_set_hint (mongoc_bulk_operation_t *bulk, uint32_t server_id)
 {
-   BSON_ASSERT_PARAM (bulk);
-
-   bulk->server_id = server_id;
+   mongoc_bulk_operation_set_server_id (bulk, server_id);
 }
 
 void

--- a/src/libmongoc/src/mongoc/mongoc-bulk-operation.c
+++ b/src/libmongoc/src/mongoc/mongoc-bulk-operation.c
@@ -919,9 +919,24 @@ mongoc_bulk_operation_get_hint (const mongoc_bulk_operation_t *bulk)
    return bulk->server_id;
 }
 
+uint32_t
+mongoc_bulk_operation_get_server_id (const mongoc_bulk_operation_t *bulk)
+{
+   BSON_ASSERT_PARAM (bulk);
+
+   return bulk->server_id;
+}
 
 void
 mongoc_bulk_operation_set_hint (mongoc_bulk_operation_t *bulk, uint32_t server_id)
+{
+   BSON_ASSERT_PARAM (bulk);
+
+   bulk->server_id = server_id;
+}
+
+void
+mongoc_bulk_operation_set_server_id (mongoc_bulk_operation_t *bulk, uint32_t server_id)
 {
    BSON_ASSERT_PARAM (bulk);
 

--- a/src/libmongoc/src/mongoc/mongoc-bulk-operation.h
+++ b/src/libmongoc/src/mongoc/mongoc-bulk-operation.h
@@ -131,12 +131,18 @@ mongoc_bulk_operation_set_client (mongoc_bulk_operation_t *bulk, void *client);
 MONGOC_EXPORT (void)
 mongoc_bulk_operation_set_client_session (mongoc_bulk_operation_t *bulk,
                                           struct _mongoc_client_session_t *client_session);
-/* These names include the term "hint" for backward compatibility, should be
- * mongoc_bulk_operation_get_server_id, mongoc_bulk_operation_set_server_id. */
+// `mongoc_bulk_operation_set_hint` is deprecated for the more aptly named `mongoc_bulk_operation_set_server_id`.
 MONGOC_EXPORT (void)
-mongoc_bulk_operation_set_hint (mongoc_bulk_operation_t *bulk, uint32_t server_id);
+mongoc_bulk_operation_set_hint (mongoc_bulk_operation_t *bulk, uint32_t server_id)
+   BSON_GNUC_DEPRECATED_FOR (mongoc_bulk_operation_set_server_id);
+MONGOC_EXPORT (void)
+mongoc_bulk_operation_set_server_id (mongoc_bulk_operation_t *bulk, uint32_t server_id);
+// `mongoc_bulk_operation_get_hint` is deprecated for the more aptly named `mongoc_bulk_operation_get_server_id`.
 MONGOC_EXPORT (uint32_t)
-mongoc_bulk_operation_get_hint (const mongoc_bulk_operation_t *bulk);
+mongoc_bulk_operation_get_hint (const mongoc_bulk_operation_t *bulk)
+   BSON_GNUC_DEPRECATED_FOR (mongoc_bulk_operation_get_server_id);
+MONGOC_EXPORT (uint32_t)
+mongoc_bulk_operation_get_server_id (const mongoc_bulk_operation_t *bulk);
 MONGOC_EXPORT (const mongoc_write_concern_t *)
 mongoc_bulk_operation_get_write_concern (const mongoc_bulk_operation_t *bulk);
 BSON_END_DECLS

--- a/src/libmongoc/src/mongoc/mongoc-cursor.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor.c
@@ -291,7 +291,7 @@ _mongoc_cursor_new_with_opts (mongoc_client_t *client,
       }
 
       if (server_id) {
-         (void) mongoc_cursor_set_hint (cursor, server_id);
+         (void) mongoc_cursor_set_server_id (cursor, server_id);
       }
 
       // Selectively copy the options:

--- a/src/libmongoc/src/mongoc/mongoc-cursor.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor.c
@@ -1455,9 +1455,37 @@ mongoc_cursor_set_hint (mongoc_cursor_t *cursor, uint32_t server_id)
    return true;
 }
 
+bool
+mongoc_cursor_set_server_id (mongoc_cursor_t *cursor, uint32_t server_id)
+{
+   BSON_ASSERT (cursor);
+
+   if (cursor->server_id) {
+      MONGOC_ERROR ("mongoc_cursor_set_server_id: server_id already set");
+      return false;
+   }
+
+   if (!server_id) {
+      MONGOC_ERROR ("mongoc_cursor_set_server_id: cannot set server_id to 0");
+      return false;
+   }
+
+   cursor->server_id = server_id;
+
+   return true;
+}
+
 
 uint32_t
 mongoc_cursor_get_hint (const mongoc_cursor_t *cursor)
+{
+   BSON_ASSERT (cursor);
+
+   return cursor->server_id;
+}
+
+uint32_t
+mongoc_cursor_get_server_id (const mongoc_cursor_t *cursor)
 {
    BSON_ASSERT (cursor);
 

--- a/src/libmongoc/src/mongoc/mongoc-cursor.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor.c
@@ -1438,21 +1438,7 @@ mongoc_cursor_get_limit (const mongoc_cursor_t *cursor)
 bool
 mongoc_cursor_set_hint (mongoc_cursor_t *cursor, uint32_t server_id)
 {
-   BSON_ASSERT (cursor);
-
-   if (cursor->server_id) {
-      MONGOC_ERROR ("mongoc_cursor_set_hint: server_id already set");
-      return false;
-   }
-
-   if (!server_id) {
-      MONGOC_ERROR ("mongoc_cursor_set_hint: cannot set server_id to 0");
-      return false;
-   }
-
-   cursor->server_id = server_id;
-
-   return true;
+   return mongoc_cursor_set_server_id (cursor, server_id);
 }
 
 bool
@@ -1479,9 +1465,7 @@ mongoc_cursor_set_server_id (mongoc_cursor_t *cursor, uint32_t server_id)
 uint32_t
 mongoc_cursor_get_hint (const mongoc_cursor_t *cursor)
 {
-   BSON_ASSERT (cursor);
-
-   return cursor->server_id;
+   return mongoc_cursor_get_server_id (cursor);
 }
 
 uint32_t

--- a/src/libmongoc/src/mongoc/mongoc-cursor.h
+++ b/src/libmongoc/src/mongoc/mongoc-cursor.h
@@ -59,12 +59,17 @@ MONGOC_EXPORT (bool)
 mongoc_cursor_set_limit (mongoc_cursor_t *cursor, int64_t limit);
 MONGOC_EXPORT (int64_t)
 mongoc_cursor_get_limit (const mongoc_cursor_t *cursor);
-/* These names include the term "hint" for backward compatibility, should be
- * mongoc_cursor_get_server_id, mongoc_cursor_set_server_id. */
+// `mongoc_cursor_set_hint` is deprecated for more aptly named `mongoc_cursor_set_server_id`.
 MONGOC_EXPORT (bool)
-mongoc_cursor_set_hint (mongoc_cursor_t *cursor, uint32_t server_id);
+mongoc_cursor_set_hint (mongoc_cursor_t *cursor, uint32_t server_id)
+   BSON_GNUC_DEPRECATED_FOR (mongoc_cursor_set_server_id);
+MONGOC_EXPORT (bool)
+mongoc_cursor_set_server_id (mongoc_cursor_t *cursor, uint32_t server_id);
+// `mongoc_cursor_get_hint` is deprecated for more aptly named `mongoc_cursor_get_server_id`.
 MONGOC_EXPORT (uint32_t)
-mongoc_cursor_get_hint (const mongoc_cursor_t *cursor);
+mongoc_cursor_get_hint (const mongoc_cursor_t *cursor) BSON_GNUC_DEPRECATED_FOR (mongoc_cursor_get_server_id);
+MONGOC_EXPORT (uint32_t)
+mongoc_cursor_get_server_id (const mongoc_cursor_t *cursor);
 MONGOC_EXPORT (int64_t)
 mongoc_cursor_get_id (const mongoc_cursor_t *cursor);
 MONGOC_EXPORT (void)

--- a/src/libmongoc/tests/test-mongoc-bulk.c
+++ b/src/libmongoc/tests/test-mongoc-bulk.c
@@ -3928,15 +3928,15 @@ _test_bulk_hint (bool pooled, bool use_primary)
 
    collection = mongoc_client_get_collection (client, "test", "test");
    bulk = mongoc_collection_create_bulk_operation_with_opts (collection, NULL);
-   ASSERT_CMPUINT32 ((uint32_t) 0, ==, mongoc_bulk_operation_get_hint (bulk));
+   ASSERT_CMPUINT32 ((uint32_t) 0, ==, mongoc_bulk_operation_get_server_id (bulk));
    if (use_primary) {
       server_id = server_id_for_read_mode (client, MONGOC_READ_PRIMARY);
    } else {
       server_id = server_id_for_read_mode (client, MONGOC_READ_SECONDARY);
    }
 
-   mongoc_bulk_operation_set_hint (bulk, server_id);
-   ASSERT_CMPUINT32 (server_id, ==, mongoc_bulk_operation_get_hint (bulk));
+   mongoc_bulk_operation_set_server_id (bulk, server_id);
+   ASSERT_CMPUINT32 (server_id, ==, mongoc_bulk_operation_get_server_id (bulk));
    mongoc_bulk_operation_insert (bulk, tmp_bson ("{'_id': 1}"));
    future = future_bulk_operation_execute (bulk, &reply, &error);
 

--- a/src/libmongoc/tests/test-mongoc-client.c
+++ b/src/libmongoc/tests/test-mongoc-client.c
@@ -587,7 +587,7 @@ test_mongoc_client_authenticate_cached (bool pooled)
       r = mongoc_cursor_next (cursor, &doc);
       ASSERT_OR_PRINT (!mongoc_cursor_error (cursor, &error), error);
       ASSERT (r);
-      server_id = mongoc_cursor_get_hint (cursor);
+      server_id = mongoc_cursor_get_server_id (cursor);
       mongoc_cursor_destroy (cursor);
 
       if (pooled) {
@@ -911,7 +911,7 @@ test_mongoc_client_command_secondary (void)
    mongoc_cursor_next (cursor, &reply);
 
    if (test_framework_is_replset ()) {
-      BSON_ASSERT (test_framework_server_is_secondary (client, mongoc_cursor_get_hint (cursor)));
+      BSON_ASSERT (test_framework_server_is_secondary (client, mongoc_cursor_get_server_id (cursor)));
    }
 
    mongoc_read_prefs_destroy (read_prefs);
@@ -2256,7 +2256,7 @@ _test_mongoc_client_get_description (bool pooled)
    collection = get_test_collection (client, "test_mongoc_client_description");
    cursor = mongoc_collection_find_with_opts (collection, tmp_bson ("{}"), NULL, NULL);
    ASSERT (!mongoc_cursor_next (cursor, &doc));
-   server_id = mongoc_cursor_get_hint (cursor);
+   server_id = mongoc_cursor_get_server_id (cursor);
    ASSERT (0 != server_id);
    sd = mongoc_client_get_server_description (client, server_id);
    ASSERT (sd);

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -4151,7 +4151,7 @@ test_aggregate_secondary (void *ctx)
    ASSERT_OR_PRINT (!mongoc_cursor_error (cursor, &error), error);
 
    if (test_framework_is_replset ()) {
-      ASSERT (test_framework_server_is_secondary (client, mongoc_cursor_get_hint (cursor)));
+      ASSERT (test_framework_server_is_secondary (client, mongoc_cursor_get_server_id (cursor)));
    }
 
    mongoc_read_prefs_destroy (pref);

--- a/src/libmongoc/tests/test-mongoc-exhaust.c
+++ b/src/libmongoc/tests/test-mongoc-exhaust.c
@@ -76,7 +76,7 @@ get_generation (mongoc_client_t *client, mongoc_cursor_t *cursor)
 
    mc_shared_tpld td = mc_tpld_take_ref (client->topology);
 
-   server_id = mongoc_cursor_get_hint (cursor);
+   server_id = mongoc_cursor_get_server_id (cursor);
 
    sd = mongoc_topology_description_server_by_id_const (td.ptr, server_id, &error);
    ASSERT_OR_PRINT (sd, error);
@@ -535,7 +535,7 @@ _check_error (mongoc_client_t *client, mongoc_cursor_t *cursor, exhaust_error_ty
 
    ASSERT (client);
 
-   server_id = mongoc_cursor_get_hint (cursor);
+   server_id = mongoc_cursor_get_server_id (cursor);
    ASSERT (server_id);
    ASSERT (mongoc_cursor_error (cursor, &error));
 
@@ -705,7 +705,7 @@ test_exhaust_in_child (void)
       mongoc_collection_find_with_opts (coll, tmp_bson ("{}"), tmp_bson ("{'exhaust': true }"), NULL /* read prefs */);
    BSON_ASSERT (mongoc_cursor_next (cursor, &doc));
    BSON_ASSERT (client->in_exhaust);
-   server_id = mongoc_cursor_get_hint (cursor);
+   server_id = mongoc_cursor_get_server_id (cursor);
 
    pid = fork ();
    if (pid == 0) {

--- a/src/libmongoc/tests/test-mongoc-retryable-writes.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-writes.c
@@ -824,7 +824,7 @@ test_bulk_retry_tracks_new_server (void *unused)
    read_prefs = mongoc_read_prefs_new (MONGOC_READ_SECONDARY);
    sd = mongoc_client_select_server (client, false /* for_writes */, read_prefs, &error);
    ASSERT_OR_PRINT (sd, error);
-   mongoc_bulk_operation_set_hint (bulk, mongoc_server_description_id (sd));
+   mongoc_bulk_operation_set_server_id (bulk, mongoc_server_description_id (sd));
    ret = mongoc_bulk_operation_execute (bulk, NULL /* reply */, &error);
    ASSERT_OR_PRINT (ret, error);
 
@@ -834,7 +834,7 @@ test_bulk_retry_tracks_new_server (void *unused)
     * the first try. */
    ASSERT_CMPINT (counters.num_inserts, ==, 2);
    ASSERT_CMPINT (counters.num_updates, ==, 1);
-   ASSERT_CMPINT (mongoc_bulk_operation_get_hint (bulk), !=, mongoc_server_description_id (sd));
+   ASSERT_CMPINT (mongoc_bulk_operation_get_server_id (bulk), !=, mongoc_server_description_id (sd));
 
    mongoc_apm_callbacks_destroy (callbacks);
    mongoc_server_description_destroy (sd);


### PR DESCRIPTION
# Summary

* `mongoc_bulk_operation_set_hint` is deprecated for newly added `mongoc_bulk_operation_set_server_id`
* `mongoc_bulk_operation_get_hint` is deprecated for newly added `mongoc_bulk_operation_get_server_id`
* `mongoc_cursor_set_hint` is deprecated for newly added `mongoc_cursor_set_server_id`
* `mongoc_cursor_get_hint` is deprecated for newly added `mongoc_cursor_get_server_id`

# Background & Motivation

See this comment: https://github.com/mongodb/mongo-c-driver/pull/1590/files#r1595496465