### PR TITLE
CDRIVER-4363 document `mongoc_bulkwrite_t`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,12 @@ documentation to be generated:
 ./tools/poetry.sh run sphinx-build -WEn -bhtml src/libmongoc/doc/ src/libmongoc/doc/html
 ```
 
+`sphinx-autobuild` can be used to serve docs locally. This can be convienient when editing. Files are rebuilt
+when changes are detected:
+
+```sh
+./tools/poetry.sh run sphinx-autobuild -b html src/libmongoc/doc/ src/libmongoc/doc/html --re-ignore ".*.pickle" --re-ignore ".*.doctree" -j auto
+```
 
 ### Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,7 @@ documentation to be generated:
 ./tools/poetry.sh run sphinx-build -WEn -bhtml src/libmongoc/doc/ src/libmongoc/doc/html
 ```
 
-`sphinx-autobuild` can be used to serve docs locally. This can be convienient when editing. Files are rebuilt
+`sphinx-autobuild` can be used to serve docs locally. This can be convenient when editing. Files are rebuilt
 when changes are detected:
 
 ```sh

--- a/src/libmongoc/doc/api.rst
+++ b/src/libmongoc/doc/api.rst
@@ -13,6 +13,7 @@ API Reference
    mongoc_auto_encryption_opts_t
    mongoc_bulkwriteopts_t
    mongoc_bulkwriteresult_t
+   mongoc_bulkwriteexception_t
    mongoc_bulk_operation_t
    mongoc_change_stream_t
    mongoc_client_encryption_t

--- a/src/libmongoc/doc/api.rst
+++ b/src/libmongoc/doc/api.rst
@@ -11,6 +11,7 @@ API Reference
    lifecycle
    gridfs
    mongoc_auto_encryption_opts_t
+   mongoc_bulkwriteopts_t
    mongoc_bulk_operation_t
    mongoc_change_stream_t
    mongoc_client_encryption_t

--- a/src/libmongoc/doc/api.rst
+++ b/src/libmongoc/doc/api.rst
@@ -12,6 +12,7 @@ API Reference
    gridfs
    mongoc_auto_encryption_opts_t
    mongoc_bulkwriteopts_t
+   mongoc_bulkwriteresult_t
    mongoc_bulk_operation_t
    mongoc_change_stream_t
    mongoc_client_encryption_t

--- a/src/libmongoc/doc/api.rst
+++ b/src/libmongoc/doc/api.rst
@@ -11,6 +11,7 @@ API Reference
    lifecycle
    gridfs
    mongoc_auto_encryption_opts_t
+   mongoc_bulkwrite_t
    mongoc_bulkwriteopts_t
    mongoc_bulkwriteresult_t
    mongoc_bulkwriteexception_t

--- a/src/libmongoc/doc/includes/bulkwrite-vs-bulk_operation.txt
+++ b/src/libmongoc/doc/includes/bulkwrite-vs-bulk_operation.txt
@@ -1,0 +1,10 @@
+If using MongoDB server 8.0+, prefer :symbol:`mongoc_bulkwrite_t` over :symbol:`mongoc_bulk_operation_t` to reduce
+network round trips.
+
+:symbol:`mongoc_bulkwrite_t` uses the ``bulkWrite`` server command introduced in MongoDB server 8.0. ``bulkWrite``
+command supports insert, update, and delete operations in the same payload. ``bulkWrite`` supports use of multiple
+collection namespaces in the same payload.
+
+:symbol:`mongoc_bulk_operation_t` uses the ``insert``, ``update`` and ``delete`` server commands available in all
+current MongoDB server versions. Write operations are grouped by type (insert, update, delete) and sent in separate
+commands. Only one collection may be specified per bulk write.

--- a/src/libmongoc/doc/mongoc_bulk_operation_t.rst
+++ b/src/libmongoc/doc/mongoc_bulk_operation_t.rst
@@ -23,6 +23,11 @@ After adding all of the write operations to the ``mongoc_bulk_operation_t``, cal
 .. seealso::
 
   | `Bulk Write Operations <bulk_>`_
+  | :symbol:`mongoc_bulkwrite_t`
+
+.. note::
+
+  .. include:: includes/bulkwrite-vs-bulk_operation.txt
 
 .. only:: html
 

--- a/src/libmongoc/doc/mongoc_bulk_operation_t.rst
+++ b/src/libmongoc/doc/mongoc_bulk_operation_t.rst
@@ -12,9 +12,13 @@ Synopsis
 
   typedef struct _mongoc_bulk_operation_t mongoc_bulk_operation_t;
 
-The opaque type ``mongoc_bulk_operation_t`` provides an abstraction for submitting multiple write operations as a single batch.
+Description
+-----------
 
-After adding all of the write operations to the ``mongoc_bulk_operation_t``, call :symbol:`mongoc_bulk_operation_execute()` to execute the operation.
+:symbol:`mongoc_bulk_operation_t` provides an abstraction for submitting multiple write operations as a single batch.
+
+After adding all of the write operations to the :symbol:`mongoc_bulk_operation_t`, call
+:symbol:`mongoc_bulk_operation_execute()` to execute the operation.
 
 .. warning::
 

--- a/src/libmongoc/doc/mongoc_bulkwrite_append_deletemany.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_append_deletemany.rst
@@ -1,0 +1,22 @@
+:man_page: mongoc_bulkwrite_append_deletemany
+
+mongoc_bulkwrite_append_deletemany()
+====================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   bool
+   mongoc_bulkwrite_append_deletemany (mongoc_bulkwrite_t *self,
+                                       const char *ns,
+                                       const bson_t *filter,
+                                       const mongoc_bulkwrite_deletemanyopts_t *opts /* May be NULL */,
+                                       bson_error_t *error);
+
+Description
+-----------
+
+Adds a multi-document delete into the namespace ``ns``. Returns true on success. Returns false and sets ``error`` if an
+error occured.

--- a/src/libmongoc/doc/mongoc_bulkwrite_append_deleteone.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_append_deleteone.rst
@@ -1,0 +1,22 @@
+:man_page: mongoc_bulkwrite_append_deleteone
+
+mongoc_bulkwrite_append_deleteone()
+===================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   bool
+   mongoc_bulkwrite_append_deleteone (mongoc_bulkwrite_t *self,
+                                      const char *ns,
+                                      const bson_t *filter,
+                                      const mongoc_bulkwrite_deleteoneopts_t *opts /* May be NULL */,
+                                      bson_error_t *error);
+
+Description
+-----------
+
+Adds a single-document delete into the namespace ``ns``. Returns true on success. Returns false and sets ``error`` if an
+error occured.

--- a/src/libmongoc/doc/mongoc_bulkwrite_append_insertone.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_append_insertone.rst
@@ -1,0 +1,22 @@
+:man_page: mongoc_bulkwrite_append_insertone
+
+mongoc_bulkwrite_append_insertone()
+===================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   bool
+   mongoc_bulkwrite_append_insertone (mongoc_bulkwrite_t *self,
+                                      const char *ns,
+                                      const bson_t *document,
+                                      const mongoc_bulkwrite_insertoneopts_t *opts /* May be NULL */,
+                                      bson_error_t *error);
+
+Description
+-----------
+
+Adds a document to insert into the namespace ``ns``. Returns true on success. Returns false and sets ``error`` if an
+error occured.

--- a/src/libmongoc/doc/mongoc_bulkwrite_append_replaceone.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_append_replaceone.rst
@@ -1,0 +1,23 @@
+:man_page: mongoc_bulkwrite_append_replaceone
+
+mongoc_bulkwrite_append_replaceone()
+====================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   bool
+   mongoc_bulkwrite_append_replaceone (mongoc_bulkwrite_t *self,
+                                       const char *ns,
+                                       const bson_t *filter,
+                                       const bson_t *replacement,
+                                       const mongoc_bulkwrite_replaceoneopts_t *opts /* May be NULL */,
+                                       bson_error_t *error);
+
+Description
+-----------
+
+Adds a replace operation for the namespace ``ns``. Returns true on success. Returns false and sets ``error`` if an
+error occured.

--- a/src/libmongoc/doc/mongoc_bulkwrite_append_updatemany.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_append_updatemany.rst
@@ -1,0 +1,23 @@
+:man_page: mongoc_bulkwrite_append_updatemany
+
+mongoc_bulkwrite_append_updatemany()
+====================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   bool
+   mongoc_bulkwrite_append_updatemany (mongoc_bulkwrite_t *self,
+                                       const char *ns,
+                                       const bson_t *filter,
+                                       const bson_t *update,
+                                       const mongoc_bulkwrite_updatemanyopts_t *opts /* May be NULL */,
+                                       bson_error_t *error);
+
+Description
+-----------
+
+Adds a multi-document update for the namespace ``ns``. Returns true on success. Returns false and sets ``error`` if an
+error occured.

--- a/src/libmongoc/doc/mongoc_bulkwrite_append_updateone.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_append_updateone.rst
@@ -1,0 +1,23 @@
+:man_page: mongoc_bulkwrite_append_updateone
+
+mongoc_bulkwrite_append_updateone()
+===================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   bool
+   mongoc_bulkwrite_append_updateone (mongoc_bulkwrite_t *self,
+                                      const char *ns,
+                                      const bson_t *filter,
+                                      const bson_t *update,
+                                      const mongoc_bulkwrite_updateoneopts_t *opts /* May be NULL */,
+                                      bson_error_t *error);
+
+Description
+-----------
+
+Adds a single-document update for the namespace ``ns``. Returns true on success. Returns false and sets ``error`` if an
+error occured.

--- a/src/libmongoc/doc/mongoc_bulkwrite_deletemanyopts_destroy.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_deletemanyopts_destroy.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwrite_deletemanyopts_destroy
+
+mongoc_bulkwrite_deletemanyopts_destroy()
+=========================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwrite_deletemanyopts_destroy (mongoc_bulkwrite_deletemanyopts_t *self);
+
+Description
+-----------
+
+Frees a :symbol:`mongoc_bulkwrite_deletemanyopts_t`.

--- a/src/libmongoc/doc/mongoc_bulkwrite_deletemanyopts_new.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_deletemanyopts_new.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwrite_deletemanyopts_new
+
+mongoc_bulkwrite_deletemanyopts_new()
+=====================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   mongoc_bulkwrite_deletemanyopts_t *
+   mongoc_bulkwrite_deletemanyopts_new (void);
+
+Description
+-----------
+
+Returns a new :symbol:`mongoc_bulkwrite_deletemanyopts_new`.

--- a/src/libmongoc/doc/mongoc_bulkwrite_deletemanyopts_set_collation.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_deletemanyopts_set_collation.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwrite_deletemanyopts_set_collation
+
+mongoc_bulkwrite_deletemanyopts_set_collation()
+===============================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwrite_deletemanyopts_set_collation (mongoc_bulkwrite_deletemanyopts_t *self, const bson_t *collation);
+
+Description
+-----------
+
+Specifies a collation.

--- a/src/libmongoc/doc/mongoc_bulkwrite_deletemanyopts_set_hint.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_deletemanyopts_set_hint.rst
@@ -1,0 +1,18 @@
+:man_page: mongoc_bulkwrite_deletemanyopts_set_hint
+
+mongoc_bulkwrite_deletemanyopts_set_hint()
+==========================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwrite_deletemanyopts_set_hint (mongoc_bulkwrite_deletemanyopts_t *self, const bson_value_t *hint);
+
+Description
+-----------
+
+Specifies the index to use. Specify either the index name as a string or the index key pattern. If specified, then the
+query system will only consider plans using the hinted index.

--- a/src/libmongoc/doc/mongoc_bulkwrite_deletemanyopts_t.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_deletemanyopts_t.rst
@@ -1,0 +1,25 @@
+:man_page: mongoc_bulkwrite_deletemanyopts_t
+
+mongoc_bulkwrite_deletemanyopts_t
+=================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  typedef struct _mongoc_bulkwrite_deletemanyopts_t mongoc_bulkwrite_deletemanyopts_t;
+
+.. only:: html
+
+  Functions
+  ---------
+
+  .. toctree::
+    :titlesonly:
+    :maxdepth: 1
+
+    mongoc_bulkwrite_deletemanyopts_new
+    mongoc_bulkwrite_deletemanyopts_destroy
+    mongoc_bulkwrite_deletemanyopts_set_collation
+    mongoc_bulkwrite_deletemanyopts_set_hint

--- a/src/libmongoc/doc/mongoc_bulkwrite_deleteoneopts_destroy.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_deleteoneopts_destroy.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwrite_deleteoneopts_destroy
+
+mongoc_bulkwrite_deleteoneopts_destroy()
+========================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwrite_deleteoneopts_destroy (mongoc_bulkwrite_deleteoneopts_t *self);
+
+Description
+-----------
+
+Frees a :symbol:`mongoc_bulkwrite_deleteoneopts_t`.

--- a/src/libmongoc/doc/mongoc_bulkwrite_deleteoneopts_new.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_deleteoneopts_new.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwrite_deleteoneopts_new
+
+mongoc_bulkwrite_deleteoneopts_new()
+====================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   mongoc_bulkwrite_deleteoneopts_t *
+   mongoc_bulkwrite_deleteoneopts_new (void);
+
+Description
+-----------
+
+Returns a new :symbol:`mongoc_bulkwrite_deleteoneopts_t`.

--- a/src/libmongoc/doc/mongoc_bulkwrite_deleteoneopts_set_collation.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_deleteoneopts_set_collation.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwrite_deleteoneopts_set_collation
+
+mongoc_bulkwrite_deleteoneopts_set_collation()
+==============================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwrite_deleteoneopts_set_collation (mongoc_bulkwrite_deleteoneopts_t *self, const bson_t *collation);
+
+Description
+-----------
+
+Specifies a collation.

--- a/src/libmongoc/doc/mongoc_bulkwrite_deleteoneopts_set_hint.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_deleteoneopts_set_hint.rst
@@ -1,0 +1,18 @@
+:man_page: mongoc_bulkwrite_deleteoneopts_set_hint
+
+mongoc_bulkwrite_deleteoneopts_set_hint()
+=========================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwrite_deleteoneopts_set_hint (mongoc_bulkwrite_deleteoneopts_t *self, const bson_value_t *hint);
+
+Description
+-----------
+
+Specifies the index to use. Specify either the index name as a string or the index key pattern. If specified, then the
+query system will only consider plans using the hinted index.

--- a/src/libmongoc/doc/mongoc_bulkwrite_deleteoneopts_t.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_deleteoneopts_t.rst
@@ -1,0 +1,25 @@
+:man_page: mongoc_bulkwrite_deleteoneopts_t
+
+mongoc_bulkwrite_deleteoneopts_t
+================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  typedef struct _mongoc_bulkwrite_deleteoneopts_t mongoc_bulkwrite_deleteoneopts_t;
+
+.. only:: html
+
+  Functions
+  ---------
+
+  .. toctree::
+    :titlesonly:
+    :maxdepth: 1
+
+    mongoc_bulkwrite_deleteoneopts_new
+    mongoc_bulkwrite_deleteoneopts_destroy
+    mongoc_bulkwrite_deleteoneopts_set_collation
+    mongoc_bulkwrite_deleteoneopts_set_hint

--- a/src/libmongoc/doc/mongoc_bulkwrite_destroy.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_destroy.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwrite_destroy
+
+mongoc_bulkwrite_destroy()
+==========================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwrite_destroy (mongoc_bulkwrite_t *self);
+
+Description
+-----------
+
+Frees a :symbol:`mongoc_bulkwrite_t`.

--- a/src/libmongoc/doc/mongoc_bulkwrite_execute.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_execute.rst
@@ -14,5 +14,5 @@ Synopsis
 Description
 -----------
 
-Executes a :symbol:`mongoc_bulkwrite_t`. Once executed, it is an error to call other functions on ``self`` aside from
+Executes a :symbol:`mongoc_bulkwrite_t`. Once executed, it is an error to call other functions on ``self``, aside from
 :symbol:`mongoc_bulkwrite_destroy`.

--- a/src/libmongoc/doc/mongoc_bulkwrite_execute.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_execute.rst
@@ -1,0 +1,18 @@
+:man_page: mongoc_bulkwrite_execute
+
+mongoc_bulkwrite_execute()
+==========================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   mongoc_bulkwritereturn_t
+   mongoc_bulkwrite_execute (mongoc_bulkwrite_t *self, const mongoc_bulkwriteopts_t *opts);
+
+Description
+-----------
+
+Executes a :symbol:`mongoc_bulkwrite_t`. Once executed, it is an error to call other functions on ``self`` aside from
+:symbol:`mongoc_bulkwrite_destroy`.

--- a/src/libmongoc/doc/mongoc_bulkwrite_insertoneopts_destroy.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_insertoneopts_destroy.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwrite_insertoneopts_destroy
+
+mongoc_bulkwrite_insertoneopts_destroy()
+========================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwrite_insertoneopts_destroy (mongoc_bulkwrite_insertoneopts_t *self);
+
+Description
+-----------
+
+Frees a :symbol:`mongoc_bulkwrite_insertoneopts_t`.

--- a/src/libmongoc/doc/mongoc_bulkwrite_insertoneopts_new.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_insertoneopts_new.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwrite_insertoneopts_new
+
+mongoc_bulkwrite_insertoneopts_new()
+====================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   mongoc_bulkwrite_insertoneopts_t *
+   mongoc_bulkwrite_insertoneopts_new (void);
+
+Description
+-----------
+
+Returns a new :symbol:`mongoc_bulkwrite_insertoneopts_t`. Free with :symbol:`mongoc_bulkwrite_insertoneopts_destroy`.

--- a/src/libmongoc/doc/mongoc_bulkwrite_insertoneopts_t.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_insertoneopts_t.rst
@@ -1,0 +1,23 @@
+:man_page: mongoc_bulkwrite_insertoneopts_t
+
+mongoc_bulkwrite_insertoneopts_t
+================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  typedef struct _mongoc_bulkwrite_insertoneopts_t mongoc_bulkwrite_insertoneopts_t;
+
+.. only:: html
+
+  Functions
+  ---------
+
+  .. toctree::
+    :titlesonly:
+    :maxdepth: 1
+
+    mongoc_bulkwrite_insertoneopts_new
+    mongoc_bulkwrite_insertoneopts_destroy

--- a/src/libmongoc/doc/mongoc_bulkwrite_replaceoneopts_destroy.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_replaceoneopts_destroy.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwrite_replaceoneopts_destroy
+
+mongoc_bulkwrite_replaceoneopts_destroy()
+=========================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwrite_replaceoneopts_destroy (mongoc_bulkwrite_replaceoneopts_t *self);
+
+Description
+-----------
+
+Frees a :symbol:`mongoc_bulkwrite_replaceoneopts_t`.

--- a/src/libmongoc/doc/mongoc_bulkwrite_replaceoneopts_new.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_replaceoneopts_new.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwrite_replaceoneopts_new
+
+mongoc_bulkwrite_replaceoneopts_new()
+=====================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   mongoc_bulkwrite_replaceoneopts_t *
+   mongoc_bulkwrite_replaceoneopts_new (void);
+
+Description
+-----------
+
+Returns a new :symbol:`mongoc_bulkwrite_replaceoneopts_t`.

--- a/src/libmongoc/doc/mongoc_bulkwrite_replaceoneopts_set_collation.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_replaceoneopts_set_collation.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwrite_replaceoneopts_set_collation
+
+mongoc_bulkwrite_replaceoneopts_set_collation()
+===============================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwrite_replaceoneopts_set_collation (mongoc_bulkwrite_replaceoneopts_t *self, const bson_t *collation);
+
+Description
+-----------
+
+Specifies a collation.

--- a/src/libmongoc/doc/mongoc_bulkwrite_replaceoneopts_set_hint.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_replaceoneopts_set_hint.rst
@@ -1,0 +1,18 @@
+:man_page: mongoc_bulkwrite_replaceoneopts_set_hint
+
+mongoc_bulkwrite_replaceoneopts_set_hint()
+==========================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwrite_replaceoneopts_set_hint (mongoc_bulkwrite_replaceoneopts_t *self, const bson_value_t *hint);
+
+Description
+-----------
+
+Specifies the index to use. Specify either the index name as a string or the index key pattern. If specified, then the
+query system will only consider plans using the hinted index.

--- a/src/libmongoc/doc/mongoc_bulkwrite_replaceoneopts_set_upsert.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_replaceoneopts_set_upsert.rst
@@ -1,0 +1,19 @@
+:man_page: mongoc_bulkwrite_replaceoneopts_set_upsert
+
+mongoc_bulkwrite_replaceoneopts_set_upsert()
+============================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwrite_replaceoneopts_set_upsert (mongoc_bulkwrite_replaceoneopts_t *self, bool upsert);
+
+Description
+-----------
+
+If ``upsert`` is true, creates a new document if no document matches the query.
+
+The ``upsert`` option is not sent if this function is not called. The server's default value is false.

--- a/src/libmongoc/doc/mongoc_bulkwrite_replaceoneopts_t.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_replaceoneopts_t.rst
@@ -1,0 +1,26 @@
+:man_page: mongoc_bulkwrite_replaceoneopts_t
+
+mongoc_bulkwrite_replaceoneopts_t
+=================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  typedef struct _mongoc_bulkwrite_replaceoneopts_t mongoc_bulkwrite_replaceoneopts_t;
+
+.. only:: html
+
+  Functions
+  ---------
+
+  .. toctree::
+    :titlesonly:
+    :maxdepth: 1
+
+    mongoc_bulkwrite_replaceoneopts_new
+    mongoc_bulkwrite_replaceoneopts_set_collation
+    mongoc_bulkwrite_replaceoneopts_set_hint
+    mongoc_bulkwrite_replaceoneopts_set_upsert
+    mongoc_bulkwrite_replaceoneopts_destroy

--- a/src/libmongoc/doc/mongoc_bulkwrite_set_session.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_set_session.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwrite_set_session
+
+mongoc_bulkwrite_set_session()
+==============================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwrite_set_session (mongoc_bulkwrite_t *self, mongoc_client_session_t *session);
+
+Description
+-----------
+
+Sets an explicit session.

--- a/src/libmongoc/doc/mongoc_bulkwrite_t.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_t.rst
@@ -1,0 +1,55 @@
+:man_page: mongoc_bulkwrite_t
+
+mongoc_bulkwrite_t
+==================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  typedef struct _mongoc_bulkwrite_t mongoc_bulkwrite_t;
+
+Description
+-----------
+
+:symbol:`mongoc_bulkwrite_t` provides an abstraction for submitting multiple write operations as a single batch.
+
+After adding all of the write operations to the :symbol:`mongoc_bulkwrite_t`, call :symbol:`mongoc_bulkwrite_execute()`
+to execute the operation.
+
+.. warning::
+
+  It is only valid to call :symbol:`mongoc_bulkwrite_execute()` once. The :symbol:`mongoc_bulkwrite_t` must be destroyed
+  afterwards.
+
+.. note::
+
+  .. include:: includes/bulkwrite-vs-bulk_operation.txt
+
+.. only:: html
+
+  API
+  ---
+
+  .. toctree::
+    :titlesonly:
+    :maxdepth: 1
+
+
+    mongoc_bulkwrite_insertoneopts_t
+    mongoc_bulkwrite_append_insertone
+    mongoc_bulkwrite_updateoneopts_t
+    mongoc_bulkwrite_append_updateone
+    mongoc_bulkwrite_updatemanyopts_t
+    mongoc_bulkwrite_append_updatemany
+    mongoc_bulkwrite_replaceoneopts_t
+    mongoc_bulkwrite_append_replaceone
+    mongoc_bulkwrite_deleteoneopts_t
+    mongoc_bulkwrite_append_deleteone
+    mongoc_bulkwrite_deletemanyopts_t
+    mongoc_bulkwrite_append_deletemany
+    mongoc_bulkwritereturn_t
+    mongoc_bulkwrite_set_session
+    mongoc_bulkwrite_execute
+    mongoc_bulkwrite_destroy

--- a/src/libmongoc/doc/mongoc_bulkwrite_updatemanyopts_destroy.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_updatemanyopts_destroy.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwrite_updatemanyopts_destroy
+
+mongoc_bulkwrite_updatemanyopts_destroy()
+=========================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwrite_updatemanyopts_destroy (mongoc_bulkwrite_updatemanyopts_t *self);
+
+Description
+-----------
+
+Frees a :symbol:`mongoc_bulkwrite_updatemanyopts_t`.

--- a/src/libmongoc/doc/mongoc_bulkwrite_updatemanyopts_new.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_updatemanyopts_new.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwrite_updatemanyopts_new
+
+mongoc_bulkwrite_updatemanyopts_new()
+=====================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   mongoc_bulkwrite_updatemanyopts_t *
+   mongoc_bulkwrite_updatemanyopts_new (void);
+
+Description
+-----------
+
+Returns a new :symbol:`mongoc_bulkwrite_updatemanyopts_t`.

--- a/src/libmongoc/doc/mongoc_bulkwrite_updatemanyopts_set_arrayfilters.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_updatemanyopts_set_arrayfilters.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwrite_updatemanyopts_set_arrayfilters
+
+mongoc_bulkwrite_updatemanyopts_set_arrayfilters()
+==================================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwrite_updatemanyopts_set_arrayfilters (mongoc_bulkwrite_updatemanyopts_t *self, const bson_t *arrayfilters);
+
+Description
+-----------
+
+Sets a set of filters specifying to which array elements an update should apply.

--- a/src/libmongoc/doc/mongoc_bulkwrite_updatemanyopts_set_collation.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_updatemanyopts_set_collation.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwrite_updatemanyopts_set_collation
+
+mongoc_bulkwrite_updatemanyopts_set_collation()
+===============================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwrite_updatemanyopts_set_collation (mongoc_bulkwrite_updatemanyopts_t *self, const bson_t *collation);
+
+Description
+-----------
+
+Specifies a collation.

--- a/src/libmongoc/doc/mongoc_bulkwrite_updatemanyopts_set_hint.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_updatemanyopts_set_hint.rst
@@ -1,0 +1,18 @@
+:man_page: mongoc_bulkwrite_updatemanyopts_set_hint
+
+mongoc_bulkwrite_updatemanyopts_set_hint()
+==========================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwrite_updatemanyopts_set_hint (mongoc_bulkwrite_updatemanyopts_t *self, const bson_value_t *hint);
+
+Description
+-----------
+
+Specifies the index to use. Specify either the index name as a string or the index key pattern. If specified, then the
+query system will only consider plans using the hinted index.

--- a/src/libmongoc/doc/mongoc_bulkwrite_updatemanyopts_set_upsert.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_updatemanyopts_set_upsert.rst
@@ -1,0 +1,19 @@
+:man_page: mongoc_bulkwrite_updatemanyopts_set_upsert
+
+mongoc_bulkwrite_updatemanyopts_set_upsert()
+============================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwrite_updatemanyopts_set_upsert (mongoc_bulkwrite_updatemanyopts_t *self, bool upsert);
+
+Description
+-----------
+
+If ``upsert`` is true, creates a new document if no document matches the query.
+
+The ``upsert`` option is not sent if this function is not called. The server's default value is false.

--- a/src/libmongoc/doc/mongoc_bulkwrite_updatemanyopts_t.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_updatemanyopts_t.rst
@@ -1,0 +1,27 @@
+:man_page: mongoc_bulkwrite_updatemanyopts_t
+
+mongoc_bulkwrite_updatemanyopts_t
+=================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  typedef struct _mongoc_bulkwrite_updatemanyopts_t mongoc_bulkwrite_updatemanyopts_t;
+
+.. only:: html
+
+  Functions
+  ---------
+
+  .. toctree::
+    :titlesonly:
+    :maxdepth: 1
+
+    mongoc_bulkwrite_updatemanyopts_new
+    mongoc_bulkwrite_updatemanyopts_set_arrayfilters
+    mongoc_bulkwrite_updatemanyopts_set_collation
+    mongoc_bulkwrite_updatemanyopts_set_hint
+    mongoc_bulkwrite_updatemanyopts_set_upsert
+    mongoc_bulkwrite_updatemanyopts_destroy

--- a/src/libmongoc/doc/mongoc_bulkwrite_updateoneopts_destroy.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_updateoneopts_destroy.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwrite_updateoneopts_destroy
+
+mongoc_bulkwrite_updateoneopts_destroy()
+========================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwrite_updateoneopts_destroy (mongoc_bulkwrite_updateoneopts_t *self);
+
+Description
+-----------
+
+Frees a :symbol:`mongoc_bulkwrite_updateoneopts_t`.

--- a/src/libmongoc/doc/mongoc_bulkwrite_updateoneopts_new.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_updateoneopts_new.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwrite_updateoneopts_new
+
+mongoc_bulkwrite_updateoneopts_new()
+====================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   mongoc_bulkwrite_updateoneopts_t *
+   mongoc_bulkwrite_updateoneopts_new (void);
+
+Description
+-----------
+
+Returns a new :symbol:`mongoc_bulkwrite_updateoneopts_t`. Free with :symbol:`mongoc_bulkwrite_updateoneopts_destroy`.

--- a/src/libmongoc/doc/mongoc_bulkwrite_updateoneopts_set_arrayfilters.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_updateoneopts_set_arrayfilters.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwrite_updateoneopts_set_arrayfilters
+
+mongoc_bulkwrite_updateoneopts_set_arrayfilters()
+=================================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwrite_updateoneopts_set_arrayfilters (mongoc_bulkwrite_updateoneopts_t *self, const bson_t *arrayfilters);
+
+Description
+-----------
+
+Sets a set of filters specifying to which array elements an update should apply.

--- a/src/libmongoc/doc/mongoc_bulkwrite_updateoneopts_set_collation.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_updateoneopts_set_collation.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwrite_updateoneopts_set_collation
+
+mongoc_bulkwrite_updateoneopts_set_collation()
+==============================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwrite_updateoneopts_set_collation (mongoc_bulkwrite_updateoneopts_t *self, const bson_t *collation);
+
+Description
+-----------
+
+Specifies a collation.

--- a/src/libmongoc/doc/mongoc_bulkwrite_updateoneopts_set_hint.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_updateoneopts_set_hint.rst
@@ -1,0 +1,18 @@
+:man_page: mongoc_bulkwrite_updateoneopts_set_hint
+
+mongoc_bulkwrite_updateoneopts_set_hint()
+=========================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwrite_updateoneopts_set_hint (mongoc_bulkwrite_updateoneopts_t *self, const bson_value_t *hint);
+
+Description
+-----------
+
+Specifies the index to use. Specify either the index name as a string or the index key pattern. If specified, then the
+query system will only consider plans using the hinted index.

--- a/src/libmongoc/doc/mongoc_bulkwrite_updateoneopts_set_upsert.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_updateoneopts_set_upsert.rst
@@ -1,0 +1,19 @@
+:man_page: mongoc_bulkwrite_updateoneopts_set_upsert
+
+mongoc_bulkwrite_updateoneopts_set_upsert()
+===========================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwrite_updateoneopts_set_upsert (mongoc_bulkwrite_updateoneopts_t *self, bool upsert);
+
+Description
+-----------
+
+If ``upsert`` is true, creates a new document if no document matches the query.
+
+The ``upsert`` option is not sent if this function is not called. The server's default value is false.

--- a/src/libmongoc/doc/mongoc_bulkwrite_updateoneopts_t.rst
+++ b/src/libmongoc/doc/mongoc_bulkwrite_updateoneopts_t.rst
@@ -1,0 +1,27 @@
+:man_page: mongoc_bulkwrite_updateoneopts_t
+
+mongoc_bulkwrite_updateoneopts_t
+================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  typedef struct _mongoc_bulkwrite_updateoneopts_t mongoc_bulkwrite_updateoneopts_t;
+
+.. only:: html
+
+  Functions
+  ---------
+
+  .. toctree::
+    :titlesonly:
+    :maxdepth: 1
+
+    mongoc_bulkwrite_updateoneopts_new
+    mongoc_bulkwrite_updateoneopts_set_arrayfilters
+    mongoc_bulkwrite_updateoneopts_set_collation
+    mongoc_bulkwrite_updateoneopts_set_hint
+    mongoc_bulkwrite_updateoneopts_set_upsert
+    mongoc_bulkwrite_updateoneopts_destroy

--- a/src/libmongoc/doc/mongoc_bulkwriteexception_destroy.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteexception_destroy.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwriteexception_destroy
+
+mongoc_bulkwriteexception_destroy()
+===================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwriteexception_destroy (mongoc_bulkwriteexception_t *self);
+
+Description
+-----------
+
+Frees a :symbol:`mongoc_bulkwriteexception_t`.

--- a/src/libmongoc/doc/mongoc_bulkwriteexception_error.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteexception_error.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwriteexception_error
+
+mongoc_bulkwriteexception_error()
+=================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   bool
+   mongoc_bulkwriteexception_error (const mongoc_bulkwriteexception_t *self, bson_error_t *error);
+
+Description
+-----------
+
+Returns true and sets ``error`` if there was a top-level error. Returns false if there was no top-level error.

--- a/src/libmongoc/doc/mongoc_bulkwriteexception_errorreply.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteexception_errorreply.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwriteexception_errorreply
+
+mongoc_bulkwriteexception_errorreply()
+======================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   const bson_t *
+   mongoc_bulkwriteexception_errorreply (const mongoc_bulkwriteexception_t *self);
+
+Description
+-----------
+
+Returns a possible server reply related to the error, or an empty document.

--- a/src/libmongoc/doc/mongoc_bulkwriteexception_t.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteexception_t.rst
@@ -1,0 +1,27 @@
+:man_page: mongoc_bulkwriteexception_t
+
+mongoc_bulkwriteexception_t
+===========================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  typedef struct _mongoc_bulkwriteexception_t mongoc_bulkwriteexception_t;
+
+.. only:: html
+
+  Functions
+  ---------
+
+  .. toctree::
+    :titlesonly:
+    :maxdepth: 1
+
+
+    mongoc_bulkwriteexception_error
+    mongoc_bulkwriteexception_writeerrors
+    mongoc_bulkwriteexception_writeconcernerrors
+    mongoc_bulkwriteexception_errorreply
+    mongoc_bulkwriteexception_destroy

--- a/src/libmongoc/doc/mongoc_bulkwriteexception_writeconcernerrors.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteexception_writeconcernerrors.rst
@@ -1,0 +1,26 @@
+:man_page: mongoc_bulkwriteexception_writeconcernerrors
+
+mongoc_bulkwriteexception_writeconcernerrors()
+==============================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   const bson_t *
+   mongoc_bulkwriteexception_writeconcernerrors (const mongoc_bulkwriteexception_t *self);
+
+Description
+-----------
+
+Returns a BSON array of write concern errors. Example:
+
+.. code:: json
+
+   [
+      { "code" : 123, "message" : "foo", "details" : {  } },
+      { "code" : 456, "message" : "bar", "details" : {  } }
+   ]
+
+Returns an empty array if there are no write concern errors.

--- a/src/libmongoc/doc/mongoc_bulkwriteexception_writeerrors.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteexception_writeerrors.rst
@@ -1,0 +1,26 @@
+:man_page: mongoc_bulkwriteexception_writeerrors
+
+mongoc_bulkwriteexception_writeerrors()
+=======================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   const bson_t *
+   mongoc_bulkwriteexception_writeerrors (const mongoc_bulkwriteexception_t *self);
+
+Description
+-----------
+
+Returns a BSON document mapping model indexes to write errors. Example:
+
+.. code:: json
+
+   {
+     "0" : { "code" : 123, "message" : "foo", "details" : {  } },
+     "1" : { "code" : 456, "message" : "bar", "details" : {  } }
+   }
+
+Returns an empty document if there are no write errors.

--- a/src/libmongoc/doc/mongoc_bulkwriteopts_destroy.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteopts_destroy.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwriteopts_destroy
+
+mongoc_bulkwriteopts_destroy()
+==============================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwriteopts_destroy (mongoc_bulkwriteopts_t *self);
+
+Description
+-----------
+
+Frees a :symbol:`mongoc_bulkwriteopts_t`.

--- a/src/libmongoc/doc/mongoc_bulkwriteopts_new.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteopts_new.rst
@@ -1,0 +1,18 @@
+:man_page: mongoc_bulkwriteopts_new
+
+mongoc_bulkwriteopts_new()
+==========================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  mongoc_bulkwriteopts_t *
+  mongoc_bulkwriteopts_new (void);
+
+Description
+-----------
+
+Returns a new :symbol:`mongoc_bulkwriteopts_t`. Free with :symbol:`mongoc_bulkwriteopts_destroy`.
+

--- a/src/libmongoc/doc/mongoc_bulkwriteopts_set_bypassdocumentvalidation.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteopts_set_bypassdocumentvalidation.rst
@@ -1,0 +1,20 @@
+:man_page: mongoc_bulkwriteopts_set_bypassdocumentvalidation
+
+mongoc_bulkwriteopts_set_bypassdocumentvalidation()
+===================================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwriteopts_set_bypassdocumentvalidation (mongoc_bulkwriteopts_t *self, bool bypassdocumentvalidation);
+
+Description
+-----------
+
+If ``bypassdocumentvalidation`` is true, allows the writes to opt out of document-level validation.
+
+This option is only sent to the server if :symbol:`mongoc_bulkwriteopts_set_bypassdocumentvalidation` is called. The
+server's default value is false.

--- a/src/libmongoc/doc/mongoc_bulkwriteopts_set_comment.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteopts_set_comment.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
    void
-   mongoc_bulkwriteopts_set_comment (mongoc_bulkwriteopts_t *self, const bson_t *comment);
+   mongoc_bulkwriteopts_set_comment (mongoc_bulkwriteopts_t *self, const bson_value_t *comment);
 
 Description
 -----------

--- a/src/libmongoc/doc/mongoc_bulkwriteopts_set_comment.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteopts_set_comment.rst
@@ -1,0 +1,18 @@
+:man_page: mongoc_bulkwriteopts_set_comment
+
+mongoc_bulkwriteopts_set_comment()
+==================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwriteopts_set_comment (mongoc_bulkwriteopts_t *self, const bson_t *comment);
+
+Description
+-----------
+
+Enables users to specify an arbitrary comment to help trace the operation through the database profiler, currentOp and
+logs.

--- a/src/libmongoc/doc/mongoc_bulkwriteopts_set_extra.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteopts_set_extra.rst
@@ -1,0 +1,18 @@
+:man_page: mongoc_bulkwriteopts_set_extra
+
+mongoc_bulkwriteopts_set_extra()
+================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwriteopts_set_extra (mongoc_bulkwriteopts_t *self, const bson_t *extra);
+
+Description
+-----------
+
+Appends all fields in ``extra`` to the outgoing ``bulkWrite`` command. Intended to support future server options. Prefer
+other ``mongoc_bulkwriteopts_set_*`` helpers to avoid unexpected option conflicts.

--- a/src/libmongoc/doc/mongoc_bulkwriteopts_set_let.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteopts_set_let.rst
@@ -1,0 +1,19 @@
+:man_page: mongoc_bulkwriteopts_set_let
+
+mongoc_bulkwriteopts_set_let()
+==============================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+    void
+    mongoc_bulkwriteopts_set_let (mongoc_bulkwriteopts_t *self, const bson_t *let);
+
+Description
+-----------
+
+``let`` is a map of parameter names and values to apply to all operations within the bulk write. Value must be constant
+or closed expressions that do not reference document fields. Parameters can then be accessed as variables in an
+aggregate expression context (e.g. "$$var").

--- a/src/libmongoc/doc/mongoc_bulkwriteopts_set_ordered.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteopts_set_ordered.rst
@@ -1,0 +1,21 @@
+:man_page: mongoc_bulkwriteopts_set_ordered
+
+mongoc_bulkwriteopts_set_ordered()
+==================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  void
+  mongoc_bulkwriteopts_set_ordered (mongoc_bulkwriteopts_t *self, bool ordered);
+
+Description
+-----------
+
+``ordered`` specifies whether the operations in this bulk write should be executed in the order in which they were
+specified. If false, writes will continue to be executed if an individual write fails. If true, writes will stop
+executing if an individual write fails.
+
+By default, bulk writes are ordered.

--- a/src/libmongoc/doc/mongoc_bulkwriteopts_set_serverid.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteopts_set_serverid.rst
@@ -1,0 +1,18 @@
+:man_page: mongoc_bulkwriteopts_set_serverid
+
+mongoc_bulkwriteopts_set_serverid()
+===================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwriteopts_set_serverid (mongoc_bulkwriteopts_t *self, uint32_t serverid);
+
+Description
+-----------
+
+Identifies which server to perform the operation. Intended for use by wrapping drivers that select a server before
+running the operation.

--- a/src/libmongoc/doc/mongoc_bulkwriteopts_set_verboseresults.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteopts_set_verboseresults.rst
@@ -1,0 +1,25 @@
+:man_page: mongoc_bulkwriteopts_set_verboseresults
+
+mongoc_bulkwriteopts_set_verboseresults()
+=========================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwriteopts_set_verboseresults (mongoc_bulkwriteopts_t *self, bool verboseresults);
+
+Description
+-----------
+
+If ``verboseresults`` is true, detailed results for each successful operation will be included in the returned results.
+
+By default, verbose results are not included.
+
+Verbose results can be obtained with the following:
+
+- :symbol:`mongoc_bulkwriteresult_insertresults`
+- :symbol:`mongoc_bulkwriteresult_updateresults`
+- :symbol:`mongoc_bulkwriteresult_deleteresults`

--- a/src/libmongoc/doc/mongoc_bulkwriteopts_set_writeconcern.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteopts_set_writeconcern.rst
@@ -1,0 +1,18 @@
+:man_page: mongoc_bulkwriteopts_set_writeconcern
+
+mongoc_bulkwriteopts_set_writeconcern()
+=======================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwriteopts_set_writeconcern (mongoc_bulkwriteopts_t *self, const mongoc_write_concern_t *writeconcern);
+
+Description
+-----------
+
+``writeconcern`` is the write concern to use for this bulk write. If a write concern is not set, defaults to the write
+concern set on the :symbol:`mongoc_client_t` passed in :symbol:`mongoc_client_bulkwrite_new`.

--- a/src/libmongoc/doc/mongoc_bulkwriteopts_t.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteopts_t.rst
@@ -1,0 +1,31 @@
+:man_page: mongoc_bulkwriteopts_t
+
+mongoc_bulkwriteopts_t
+======================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  typedef struct _mongoc_bulkwriteopts_t mongoc_bulkwriteopts_t;
+
+.. only:: html
+
+  Functions
+  ---------
+
+  .. toctree::
+    :titlesonly:
+    :maxdepth: 1
+
+    mongoc_bulkwriteopts_new
+    mongoc_bulkwriteopts_set_ordered
+    mongoc_bulkwriteopts_set_bypassdocumentvalidation
+    mongoc_bulkwriteopts_set_let
+    mongoc_bulkwriteopts_set_writeconcern
+    mongoc_bulkwriteopts_set_comment
+    mongoc_bulkwriteopts_set_verboseresults
+    mongoc_bulkwriteopts_set_extra
+    mongoc_bulkwriteopts_set_serverid
+    mongoc_bulkwriteopts_destroy

--- a/src/libmongoc/doc/mongoc_bulkwriteresult_deletedcount.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteresult_deletedcount.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwriteresult_deletedcount
+
+mongoc_bulkwriteresult_deletedcount()
+=====================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   int64_t
+   mongoc_bulkwriteresult_deletedcount (const mongoc_bulkwriteresult_t *self);
+
+Description
+-----------
+
+Returns the total number of documents deleted across all delete operations.

--- a/src/libmongoc/doc/mongoc_bulkwriteresult_deleteresults.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteresult_deleteresults.rst
@@ -1,0 +1,27 @@
+:man_page: mongoc_bulkwriteresult_deleteresults
+
+mongoc_bulkwriteresult_deleteresults()
+======================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   const bson_t *
+   mongoc_bulkwriteresult_deleteresults (const mongoc_bulkwriteresult_t *self);
+
+Description
+-----------
+
+Returns the results of each individual delete operation that was successfully performed. Example:
+
+.. code:: json
+
+   {
+     "0" : { "deletedCount" : 1 },
+     "1" : { "deletedCount" : 2 }
+   }
+
+Returns NULL if verbose results were not requested. Request verbose results with
+:symbol:`mongoc_bulkwriteopts_set_verboseresults`.

--- a/src/libmongoc/doc/mongoc_bulkwriteresult_destroy.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteresult_destroy.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwriteresult_destroy
+
+mongoc_bulkwriteresult_destroy()
+================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   void
+   mongoc_bulkwriteresult_destroy (mongoc_bulkwriteresult_t *self);
+
+Description
+-----------
+
+Frees a :symbol:`mongoc_bulkwriteresult_t`.

--- a/src/libmongoc/doc/mongoc_bulkwriteresult_insertedcount.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteresult_insertedcount.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwriteresult_insertedcount
+
+mongoc_bulkwriteresult_insertedcount()
+======================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   int64_t
+   mongoc_bulkwriteresult_insertedcount (const mongoc_bulkwriteresult_t *self);
+
+Description
+-----------
+
+Returns the total number of documents inserted across all insert operations.

--- a/src/libmongoc/doc/mongoc_bulkwriteresult_insertresults.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteresult_insertresults.rst
@@ -1,0 +1,27 @@
+:man_page: mongoc_bulkwriteresult_insertresults
+
+mongoc_bulkwriteresult_insertresults()
+======================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   const bson_t *
+   mongoc_bulkwriteresult_insertresults (const mongoc_bulkwriteresult_t *self);
+
+Description
+-----------
+
+Returns the results of each individual insert operation that was successfully performed. Example:
+
+.. code:: json
+
+   {
+     "0" : { "insertedId" : "foo" },
+     "1" : { "insertedId" : "bar" }
+   }
+
+Returns NULL if verbose results were not requested. Request verbose results with
+:symbol:`mongoc_bulkwriteopts_set_verboseresults`.

--- a/src/libmongoc/doc/mongoc_bulkwriteresult_matchedcount.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteresult_matchedcount.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwriteresult_matchedcount
+
+mongoc_bulkwriteresult_matchedcount()
+=====================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   int64_t
+   mongoc_bulkwriteresult_matchedcount (const mongoc_bulkwriteresult_t *self);
+
+Description
+-----------
+
+Returns the total number of documents matched across all update operations.

--- a/src/libmongoc/doc/mongoc_bulkwriteresult_modifiedcount.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteresult_modifiedcount.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwriteresult_modifiedcount
+
+mongoc_bulkwriteresult_modifiedcount()
+======================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   int64_t
+   mongoc_bulkwriteresult_modifiedcount (const mongoc_bulkwriteresult_t *self);
+
+Description
+-----------
+
+Returns the total number of documents modified across all update operations.

--- a/src/libmongoc/doc/mongoc_bulkwriteresult_serverid.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteresult_serverid.rst
@@ -1,0 +1,19 @@
+:man_page: mongoc_bulkwriteresult_serverid
+
+mongoc_bulkwriteresult_serverid()
+=================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   uint32_t
+   mongoc_bulkwriteresult_serverid (const mongoc_bulkwriteresult_t *self);
+
+Description
+-----------
+
+Returns the most recently selected server. The returned value may differ from a ``serverid`` previously set with
+:symbol:`mongoc_bulkwriteopts_set_serverid` if a retry occurred. Intended for use by wrapping drivers that select a
+server before running the operation.

--- a/src/libmongoc/doc/mongoc_bulkwriteresult_t.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteresult_t.rst
@@ -1,0 +1,32 @@
+:man_page: mongoc_bulkwriteresult_t
+
+mongoc_bulkwriteresult_t
+========================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  typedef struct _mongoc_bulkwriteresult_t mongoc_bulkwriteresult_t;
+
+.. only:: html
+
+  Functions
+  ---------
+
+  .. toctree::
+    :titlesonly:
+    :maxdepth: 1
+
+
+    mongoc_bulkwriteresult_insertedcount
+    mongoc_bulkwriteresult_upsertedcount
+    mongoc_bulkwriteresult_matchedcount
+    mongoc_bulkwriteresult_modifiedcount
+    mongoc_bulkwriteresult_deletedcount
+    mongoc_bulkwriteresult_insertresults
+    mongoc_bulkwriteresult_updateresults
+    mongoc_bulkwriteresult_deleteresults
+    mongoc_bulkwriteresult_serverid
+    mongoc_bulkwriteresult_destroy

--- a/src/libmongoc/doc/mongoc_bulkwriteresult_updateresults.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteresult_updateresults.rst
@@ -1,0 +1,27 @@
+:man_page: mongoc_bulkwriteresult_updateresults
+
+mongoc_bulkwriteresult_updateresults()
+======================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   const bson_t *
+   mongoc_bulkwriteresult_updateresults (const mongoc_bulkwriteresult_t *self);
+
+Description
+-----------
+
+Returns the results of each individual update operation that was successfully performed. Example:
+
+.. code:: json
+
+   {
+     "0" : { "matchedCount" : 2, "modifiedCount" : 2 },
+     "1" : { "matchedCount" : 1, "modifiedCount" : 0, "upsertedId" : "foo" }
+   }
+
+Returns NULL if verbose results were not requested. Request verbose results with
+:symbol:`mongoc_bulkwriteopts_set_verboseresults`.

--- a/src/libmongoc/doc/mongoc_bulkwriteresult_upsertedcount.rst
+++ b/src/libmongoc/doc/mongoc_bulkwriteresult_upsertedcount.rst
@@ -1,0 +1,17 @@
+:man_page: mongoc_bulkwriteresult_upsertedcount
+
+mongoc_bulkwriteresult_upsertedcount()
+======================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   int64_t
+   mongoc_bulkwriteresult_upsertedcount (const mongoc_bulkwriteresult_t *self);
+
+Description
+-----------
+
+Returns the total number of documents upserted across all update operations.

--- a/src/libmongoc/doc/mongoc_bulkwritereturn_t.rst
+++ b/src/libmongoc/doc/mongoc_bulkwritereturn_t.rst
@@ -1,0 +1,30 @@
+:man_page: mongoc_bulkwritereturn_t
+
+mongoc_bulkwritereturn_t
+========================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   typedef struct {
+     mongoc_bulkwriteresult_t *res;    // NULL if write was unacknowledged.
+     mongoc_bulkwriteexception_t *exc; // NULL if no error.
+   } mongoc_bulkwritereturn_t;
+
+Description
+-----------
+
+:symbol:`mongoc_bulkwritereturn_t` is returned by :symbol:`mongoc_bulkwrite_execute`.
+
+``res`` or ``exc`` may outlive the :symbol:`mongoc_bulkwrite_t` that was executed.
+
+``res`` is NULL if the :symbol:`mongoc_bulkwrite_t` was executed with an unacknowledged write concern.
+
+``res`` must be freed with :symbol:`mongoc_bulkwriteresult_destroy`.
+
+``exc`` is NULL if no error occurred.
+
+``exc`` must be freed with :symbol:`mongoc_bulkwriteexception_destroy`.
+

--- a/src/libmongoc/doc/mongoc_client_bulkwrite_new.rst
+++ b/src/libmongoc/doc/mongoc_client_bulkwrite_new.rst
@@ -1,0 +1,18 @@
+:man_page: mongoc_client_bulkwrite_new
+
+mongoc_client_bulkwrite_new()
+=============================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   mongoc_bulkwrite_t *
+   mongoc_client_bulkwrite_new (mongoc_client_t *self);
+   
+
+Description
+-----------
+
+Returns a new :symbol:`mongoc_bulkwrite_t`. Free with :symbol:`mongoc_bulkwrite_destroy()`.

--- a/src/libmongoc/doc/mongoc_client_t.rst
+++ b/src/libmongoc/doc/mongoc_client_t.rst
@@ -52,6 +52,7 @@ Example
     :titlesonly:
     :maxdepth: 1
 
+    mongoc_client_bulkwrite_new
     mongoc_client_command
     mongoc_client_command_simple
     mongoc_client_command_simple_with_server_id
@@ -95,5 +96,3 @@ Example
     mongoc_client_watch
     mongoc_client_write_command_with_opts
     mongoc_handshake_data_append
-
-

--- a/src/libmongoc/src/mongoc/mongoc-bulkwrite.c
+++ b/src/libmongoc/src/mongoc/mongoc-bulkwrite.c
@@ -55,7 +55,7 @@ set_bson_opt (bson_t **dst, const bson_t *src)
 }
 
 static void
-set_hint_opt (bson_value_t *dst, const bson_value_t *src)
+set_bson_value_opt (bson_value_t *dst, const bson_value_t *src)
 {
    BSON_ASSERT_PARAM (dst);
    bson_value_destroy (dst);
@@ -351,7 +351,7 @@ mongoc_bulkwrite_updateoneopts_set_hint (mongoc_bulkwrite_updateoneopts_t *self,
 {
    BSON_ASSERT_PARAM (self);
    BSON_OPTIONAL_PARAM (hint);
-   set_hint_opt (&self->hint, hint);
+   set_bson_value_opt (&self->hint, hint);
 }
 void
 mongoc_bulkwrite_updateoneopts_set_upsert (mongoc_bulkwrite_updateoneopts_t *self, bool upsert)
@@ -454,7 +454,7 @@ mongoc_bulkwrite_replaceoneopts_set_hint (mongoc_bulkwrite_replaceoneopts_t *sel
 {
    BSON_ASSERT_PARAM (self);
    BSON_OPTIONAL_PARAM (hint);
-   set_hint_opt (&self->hint, hint);
+   set_bson_value_opt (&self->hint, hint);
 }
 void
 mongoc_bulkwrite_replaceoneopts_set_upsert (mongoc_bulkwrite_replaceoneopts_t *self, bool upsert)
@@ -583,7 +583,7 @@ mongoc_bulkwrite_updatemanyopts_set_hint (mongoc_bulkwrite_updatemanyopts_t *sel
 {
    BSON_ASSERT_PARAM (self);
    BSON_OPTIONAL_PARAM (hint);
-   set_hint_opt (&self->hint, hint);
+   set_bson_value_opt (&self->hint, hint);
 }
 void
 mongoc_bulkwrite_updatemanyopts_set_upsert (mongoc_bulkwrite_updatemanyopts_t *self, bool upsert)
@@ -686,7 +686,7 @@ mongoc_bulkwrite_deleteoneopts_set_hint (mongoc_bulkwrite_deleteoneopts_t *self,
 {
    BSON_ASSERT_PARAM (self);
    BSON_OPTIONAL_PARAM (hint);
-   set_hint_opt (&self->hint, hint);
+   set_bson_value_opt (&self->hint, hint);
 }
 void
 mongoc_bulkwrite_deleteoneopts_destroy (mongoc_bulkwrite_deleteoneopts_t *self)
@@ -760,7 +760,7 @@ void
 mongoc_bulkwrite_deletemanyopts_set_hint (mongoc_bulkwrite_deletemanyopts_t *self, const bson_value_t *hint)
 {
    BSON_ASSERT_PARAM (self);
-   set_hint_opt (&self->hint, hint);
+   set_bson_value_opt (&self->hint, hint);
 }
 void
 mongoc_bulkwrite_deletemanyopts_destroy (mongoc_bulkwrite_deletemanyopts_t *self)

--- a/src/libmongoc/src/mongoc/mongoc-bulkwrite.c
+++ b/src/libmongoc/src/mongoc/mongoc-bulkwrite.c
@@ -37,7 +37,7 @@ struct _mongoc_bulkwriteopts_t {
    bson_t *let;
    mongoc_write_concern_t *writeconcern;
    mongoc_optional_t verboseresults;
-   bson_t *comment;
+   bson_value_t comment;
    bson_t *extra;
    uint32_t serverid;
 };
@@ -104,11 +104,11 @@ mongoc_bulkwriteopts_set_verboseresults (mongoc_bulkwriteopts_t *self, bool verb
    mongoc_optional_set_value (&self->verboseresults, verboseresults);
 }
 void
-mongoc_bulkwriteopts_set_comment (mongoc_bulkwriteopts_t *self, const bson_t *comment)
+mongoc_bulkwriteopts_set_comment (mongoc_bulkwriteopts_t *self, const bson_value_t *comment)
 {
    BSON_ASSERT_PARAM (self);
    BSON_OPTIONAL_PARAM (comment);
-   set_bson_opt (&self->comment, comment);
+   set_bson_value_opt (&self->comment, comment);
 }
 void
 mongoc_bulkwriteopts_set_extra (mongoc_bulkwriteopts_t *self, const bson_t *extra)
@@ -130,7 +130,7 @@ mongoc_bulkwriteopts_destroy (mongoc_bulkwriteopts_t *self)
       return;
    }
    bson_destroy (self->extra);
-   bson_destroy (self->comment);
+   bson_value_destroy (&self->comment);
    mongoc_write_concern_destroy (self->writeconcern);
    bson_destroy (self->let);
    bson_free (self);
@@ -1509,8 +1509,8 @@ mongoc_bulkwrite_execute (mongoc_bulkwrite_t *self, const mongoc_bulkwriteopts_t
       BSON_ASSERT (BSON_APPEND_BOOL (
          &cmd, "ordered", (mongoc_optional_is_set (&opts->ordered)) ? mongoc_optional_value (&opts->ordered) : true));
 
-      if (opts->comment) {
-         BSON_ASSERT (BSON_APPEND_DOCUMENT (&cmd, "comment", opts->comment));
+      if (opts->comment.value_type != BSON_TYPE_EOD) {
+         BSON_ASSERT (BSON_APPEND_VALUE (&cmd, "comment", &opts->comment));
       }
 
       if (mongoc_optional_is_set (&opts->bypassdocumentvalidation)) {

--- a/src/libmongoc/src/mongoc/mongoc-bulkwrite.h
+++ b/src/libmongoc/src/mongoc/mongoc-bulkwrite.h
@@ -36,7 +36,7 @@ mongoc_bulkwriteopts_set_let (mongoc_bulkwriteopts_t *self, const bson_t *let);
 MONGOC_EXPORT (void)
 mongoc_bulkwriteopts_set_writeconcern (mongoc_bulkwriteopts_t *self, const mongoc_write_concern_t *writeconcern);
 MONGOC_EXPORT (void)
-mongoc_bulkwriteopts_set_comment (mongoc_bulkwriteopts_t *self, const bson_t *comment);
+mongoc_bulkwriteopts_set_comment (mongoc_bulkwriteopts_t *self, const bson_value_t *comment);
 MONGOC_EXPORT (void)
 mongoc_bulkwriteopts_set_verboseresults (mongoc_bulkwriteopts_t *self, bool verboseresults);
 // `mongoc_bulkwriteopts_set_extra` appends `extra` to bulkWrite command.

--- a/src/libmongoc/tests/unified/operation.c
+++ b/src/libmongoc/tests/unified/operation.c
@@ -421,7 +421,7 @@ operation_client_bulkwrite (test_t *test, operation_t *op, result_t *result, bso
       bson_t *args_models = NULL;
       bool *args_verboseResults = NULL;
       bool *args_ordered = NULL;
-      bson_t *args_comment = NULL;
+      bson_val_t *args_comment = NULL;
       bool *args_bypassDocumentValidation = NULL;
       bson_t *args_let = NULL;
       mongoc_write_concern_t *args_wc = NULL;
@@ -430,7 +430,7 @@ operation_client_bulkwrite (test_t *test, operation_t *op, result_t *result, bso
       bson_parser_array (parser, "models", &args_models);
       bson_parser_bool_optional (parser, "verboseResults", &args_verboseResults);
       bson_parser_bool_optional (parser, "ordered", &args_ordered);
-      bson_parser_doc_optional (parser, "comment", &args_comment);
+      bson_parser_any_optional (parser, "comment", &args_comment);
       bson_parser_bool_optional (parser, "bypassDocumentValidation", &args_bypassDocumentValidation);
       bson_parser_doc_optional (parser, "let", &args_let);
       bson_parser_write_concern_optional (parser, &args_wc);
@@ -444,7 +444,7 @@ operation_client_bulkwrite (test_t *test, operation_t *op, result_t *result, bso
          mongoc_bulkwriteopts_set_ordered (opts, *args_ordered);
       }
       if (args_comment) {
-         mongoc_bulkwriteopts_set_comment (opts, args_comment);
+         mongoc_bulkwriteopts_set_comment (opts, bson_val_to_value (args_comment));
       }
       if (args_bypassDocumentValidation) {
          mongoc_bulkwriteopts_set_bypassdocumentvalidation (opts, *args_bypassDocumentValidation);


### PR DESCRIPTION
# Summary

Add API documentation for `mongoc_bulkwrite_t` and related API introduced in https://github.com/mongodb/mongo-c-driver/pull/1590

Change the `comment` type to `bson_value_t *`.

As a drive-by improvement, `sphinx-autobuild` is mentioned in CONTRIBUTING.md as a convenient alternative to serving docs locally.

# Background & Motivation 

`Description` sections were mostly modeled from the API comments in the [spec](https://github.com/mongodb/specifications/blob/57bb0f2af7a46872f5d0457bd34032f3bdc8ab15/source/crud/bulk-write.md).

The type of `comment` in `mongoc_bulkwriteopts_set_comment` was incorrectly a `bson_t *` (a BSON document). It is changed to `bson_value_t *` (any BSON value) to better match the spec's [BulkWriteOptions.comment](https://github.com/mongodb/specifications/blob/57bb0f2af7a46872f5d0457bd34032f3bdc8ab15/source/crud/bulk-write.md#options). This follows existing C driver patterns. Example: `comment` is represented as `bson_value_t *` in [mongoc_collection_aggregate](https://mongoc.org/libmongoc/current/mongoc_collection_aggregate.html]).

Rendered docs can be viewed from the `Files` tab of this `make-docs` task [here](https://spruce.mongodb.com/version/664665866bb3c10007f86c65)
