### PR TITLE
fix broken documentation link

### DIFF
--- a/src/libmongoc/doc/index.rst
+++ b/src/libmongoc/doc/index.rst
@@ -10,7 +10,7 @@ Introduction
 
 The MongoDB C Driver, also known as "libmongoc", is a library for using MongoDB from C applications, and for writing MongoDB drivers in higher-level languages.
 
-It depends on :doc:`libbson <bson:index>` to generate and parse BSON documents, the native data format of MongoDB.
+It depends on `libbson <bson:index_>_` to generate and parse BSON documents, the native data format of MongoDB.
 
 
 .. toctree::


### PR DESCRIPTION
Follow-up for 151975f9677b1157d94badd1085aac424b15633a

I encountered a failure related to a broken documentation link while working on syncing the RPM spec file:

```
[2024/05/17 17:42:02.600] Warning, treated as error:
[2024/05/17 17:42:02.600] /builddir/build/BUILD/mongo-c-driver-1.28.0/src/libmongoc/doc/index.rst:13:unknown document: bson:index
[2024/05/17 17:42:02.600] gmake[2]: *** [src/libmongoc/doc/CMakeFiles/mongoc-man.dir/build.make:1588: src/libmongoc/doc/man/mongoc_application_performance_monitoring.3] Error 2
[2024/05/17 17:42:02.600] gmake[2]: *** Deleting file 'src/libmongoc/doc/man/mongoc_application_performance_monitoring.3'
[2024/05/17 17:42:02.600] gmake[2]: Leaving directory '/builddir/build/BUILD/mongo-c-driver-1.28.0'
[2024/05/17 17:42:02.600] gmake[1]: Leaving directory '/builddir/build/BUILD/mongo-c-driver-1.28.0'
[2024/05/17 17:42:02.600] gmake[1]: *** [CMakeFiles/Makefile2:1166: src/libmongoc/doc/CMakeFiles/mongoc-man.dir/all] Error 2
[2024/05/17 17:42:02.600] gmake: *** [Makefile:169: all] Error 2
[2024/05/17 17:42:02.600] error: Bad exit status from /var/tmp/rpm-tmp.2bYtbc (%build)
```

- [failing build](https://spruce.mongodb.com/task/mongo_c_driver_packaging_rpm_package_build_patch_59443b78c6336fedaf9d0b850634b11d5b24fc1b_6647cc244b507b000758bdfa_24_05_17_21_29_10/logs?execution=0)
- [successful build](https://spruce.mongodb.com/task/mongo_c_driver_packaging_rpm_package_build_patch_59443b78c6336fedaf9d0b850634b11d5b24fc1b_6647d69f4c12f90007a24922_24_05_17_22_13_53/logs?execution=0)