### PR TITLE
CDRIVER-3645 Close operation connections to removed servers

### DIFF
--- a/src/libmongoc/doc/mongoc_client_pool_pop.rst
+++ b/src/libmongoc/doc/mongoc_client_pool_pop.rst
@@ -16,6 +16,10 @@ Retrieve a :symbol:`mongoc_client_t` from the client pool, or create one. The to
 
 The returned :symbol:`mongoc_client_t` must be returned to the pool with :symbol:`mongoc_client_pool_push()`.
 
+.. note::
+
+   Return a checked out :symbol:`mongoc_client_t` to the pool with :symbol:`mongoc_client_pool_push` quickly to encourage reuse of clients among threads.
+
 Parameters
 ----------
 

--- a/src/libmongoc/doc/mongoc_client_pool_try_pop.rst
+++ b/src/libmongoc/doc/mongoc_client_pool_try_pop.rst
@@ -14,6 +14,10 @@ Synopsis
 
 This function is identical to :symbol:`mongoc_client_pool_pop()` except it will return ``NULL`` instead of blocking for a client to become available.
 
+.. note::
+
+   Return a checked out :symbol:`mongoc_client_t` to the pool with :symbol:`mongoc_client_pool_push` quickly to encourage reuse of clients among threads.
+
 Parameters
 ----------
 

--- a/src/libmongoc/src/mongoc/mongoc-client-pool.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-pool.c
@@ -370,8 +370,8 @@ typedef struct {
 static int
 server_id_cmp (const void *a_, const void *b_)
 {
-   uint32_t *a = (uint32_t *) a_;
-   uint32_t *b = (uint32_t *) b_;
+   const uint32_t *const a = (const uint32_t *) a_;
+   const uint32_t *const b = (const uint32_t *) b_;
 
    if (*a == *b) {
       return 0;

--- a/src/libmongoc/src/mongoc/mongoc-client-pool.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-pool.c
@@ -378,7 +378,7 @@ server_id_cmp (const void *a_, const void *b_)
       return 0;
    }
 
-   return a < b ? -1 : 1;
+   return *a < *b ? -1 : 1;
 }
 
 static bool

--- a/src/libmongoc/src/mongoc/mongoc-client-pool.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-pool.c
@@ -406,33 +406,6 @@ prune_client (mongoc_client_t *client, mongoc_array_t *known_server_ids)
    BSON_ASSERT_PARAM (known_server_ids);
 
    mongoc_cluster_t *cluster = &client->cluster;
-
-   bool needs_prune = false;
-   // Do a fast initial check to see if a prune is needed.
-   size_t idx1 = 0;
-   size_t idx2 = 0;
-   for (; idx1 < cluster->nodes->items_len; idx1++) {
-      // Compare both sorted lists in order. `cluster->nodes` may be a smaller list if not all servers were used.
-      mongoc_set_item_t *cn = &cluster->nodes->items[idx1];
-      bool found = false;
-      for (; idx2 < known_server_ids->len; idx2++) {
-         uint32_t last_known = _mongoc_array_index (known_server_ids, uint32_t, idx2);
-         if (cn->id == last_known) {
-            found = true;
-            break;
-         }
-      }
-      if (!found) {
-         // A server in the cluster is not in the last known server ids. Prune it.
-         needs_prune = true;
-         break;
-      }
-   }
-
-   if (!needs_prune) {
-      return;
-   }
-
    prune_ctx ctx = {.cluster = cluster, .known_server_ids = known_server_ids};
    mongoc_set_for_each (cluster->nodes, maybe_prune, &ctx);
 }

--- a/src/libmongoc/src/mongoc/mongoc-client-pool.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-pool.c
@@ -17,6 +17,7 @@
 
 #include "mongoc.h"
 #include "mongoc-apm-private.h"
+#include "mongoc-array-private.h"
 #include "mongoc-counters-private.h"
 #include "mongoc-client-pool-private.h"
 #include "mongoc-client-pool.h"

--- a/src/libmongoc/tests/TestSuite.h
+++ b/src/libmongoc/tests/TestSuite.h
@@ -588,6 +588,42 @@ test_bulkwriteexception_str (const mongoc_bulkwriteexception_t *bwe);
    } else                                                                  \
       (void) 0
 
+// `get_current_connection_count` returns the server reported connection count.
+int32_t
+get_current_connection_count (const char *host_and_port);
+
+#define ASSERT_CONN_COUNT(host, expect)                           \
+   if (1) {                                                       \
+      int32_t _got = get_current_connection_count (host);         \
+      if (_got != expect) {                                       \
+         test_error ("Got unexpected connection count to %s:\n"   \
+                     "  Expected %" PRId32 ", got %" PRId32 "\n", \
+                     host,                                        \
+                     expect,                                      \
+                     _got);                                       \
+      }                                                           \
+   } else                                                         \
+      (void) 0
+
+#define ASSERT_EVENTUAL_CONN_COUNT(host, expect)                                   \
+   if (1) {                                                                        \
+      int64_t _start = bson_get_monotonic_time ();                                 \
+      while (true) {                                                               \
+         int32_t _got = get_current_connection_count (host);                       \
+         if (_got == expect) {                                                     \
+            break;                                                                 \
+         }                                                                         \
+         int64_t _now = bson_get_monotonic_time ();                                \
+         if (_now - _start > 5 * 1000 * 1000 /* five seconds */) {                 \
+            test_error ("Timed out waiting for expected connection count to %s:\n" \
+                        "  Expected %" PRId32 ", got %" PRId32 "\n",               \
+                        host,                                                      \
+                        expect,                                                    \
+                        _got);                                                     \
+         }                                                                         \
+      }                                                                            \
+   } else                                                                          \
+      (void) 0
 
 #define MAX_TEST_NAME_LENGTH 500
 #define MAX_TEST_CHECK_FUNCS 10

--- a/src/libmongoc/tests/test-mongoc-client-pool.c
+++ b/src/libmongoc/tests/test-mongoc-client-pool.c
@@ -481,6 +481,160 @@ test_client_pool_can_override_sockettimeoutms (void)
    mongoc_uri_destroy (uri);
 }
 
+// Test connections to removed servers are closed when a client is pushed back to the pool.
+static void
+disconnects_removed_servers_on_push (void *unused)
+{
+   BSON_UNUSED (unused);
+   bson_error_t error;
+   bool ok;
+   bson_t *ping = BCON_NEW ("ping", BCON_INT32 (1));
+
+   // Create a client pool to two servers.
+   mongoc_client_pool_t *pool;
+   {
+      mongoc_uri_t *uri = mongoc_uri_new ("mongodb://localhost:27017,localhost:27018");
+      // Set a short heartbeat so server monitors get quick responses.
+      mongoc_uri_set_option_as_int32 (uri, MONGOC_URI_HEARTBEATFREQUENCYMS, MONGOC_TOPOLOGY_MIN_HEARTBEAT_FREQUENCY_MS);
+      pool = mongoc_client_pool_new (uri);
+      test_framework_set_pool_ssl_opts (pool);
+      mongoc_uri_destroy (uri);
+   }
+
+   // Count connections to both servers.
+   int32_t conns_27017_before = get_current_connection_count ("localhost:27017");
+   int32_t conns_27018_before = get_current_connection_count ("localhost:27018");
+
+   // Pop (and push) a client to start background monitoring.
+   {
+      mongoc_client_t *client = mongoc_client_pool_pop (pool);
+      mongoc_client_pool_push (pool, client);
+      // Wait for monitoring connections to be created.
+      // Expect two monitoring connections per server to be created in background.
+      ASSERT_EVENTUAL_CONN_COUNT ("localhost:27017", conns_27017_before + 2);
+      ASSERT_EVENTUAL_CONN_COUNT ("localhost:27018", conns_27018_before + 2);
+   }
+
+   // Send 'ping' commands on a client to each server to create operation connections.
+   {
+      mongoc_client_t *client = mongoc_client_pool_pop (pool);
+      ok = mongoc_client_command_simple_with_server_id (client, "admin", ping, NULL, 1 /* server ID */, NULL, &error);
+      ASSERT_OR_PRINT (ok, error);
+      ok = mongoc_client_command_simple_with_server_id (client, "admin", ping, NULL, 2 /* server ID */, NULL, &error);
+      ASSERT_OR_PRINT (ok, error);
+      mongoc_client_pool_push (pool, client);
+      // Expect an operation connection is created.
+      ASSERT_CONN_COUNT ("localhost:27017", conns_27017_before + 2 + 1);
+      ASSERT_CONN_COUNT ("localhost:27018", conns_27018_before + 2 + 1);
+   }
+
+   // Mock removal of server 27018 from topology.
+   {
+      mongoc_topology_t *tp = _mongoc_client_pool_get_topology (pool);
+      mc_tpld_modification tdmod = mc_tpld_modify_begin (tp);
+      mongoc_set_rm (mc_tpld_servers (tdmod.new_td), 2 /* server ID */);
+      mc_tpld_modify_commit (tdmod);
+   }
+
+   // Expect connections are closed to removed server.
+   {
+      // Expect monitoring connections to be closed in background.
+      ASSERT_EVENTUAL_CONN_COUNT ("localhost:27017", conns_27017_before + 2 + 1);
+      ASSERT_EVENTUAL_CONN_COUNT ("localhost:27018", conns_27018_before + 1);
+
+      // Pop and push the client to "prune" the stale operation connections.
+      mongoc_client_t *client = mongoc_client_pool_pop (pool);
+      mongoc_client_pool_push (pool, client);
+      ASSERT_CONN_COUNT ("localhost:27017", conns_27017_before + 2 + 1);
+      ASSERT_CONN_COUNT ("localhost:27018", conns_27018_before);
+   }
+
+   mongoc_client_pool_destroy (pool);
+   bson_destroy (ping);
+}
+
+// Test that connections are closed to servers removed from the topology on clients checked into the pool.
+static void
+disconnects_removed_servers_in_pool (void *unused)
+{
+   BSON_UNUSED (unused);
+   bson_error_t error;
+   bool ok;
+   bson_t *ping = BCON_NEW ("ping", BCON_INT32 (1));
+
+   // Create a client pool to two servers.
+   mongoc_client_pool_t *pool;
+   {
+      mongoc_uri_t *uri = mongoc_uri_new ("mongodb://localhost:27017,localhost:27018");
+      // Set a short heartbeat so server monitors get quick responses.
+      mongoc_uri_set_option_as_int32 (uri, MONGOC_URI_HEARTBEATFREQUENCYMS, MONGOC_TOPOLOGY_MIN_HEARTBEAT_FREQUENCY_MS);
+      pool = mongoc_client_pool_new (uri);
+      test_framework_set_pool_ssl_opts (pool);
+      mongoc_uri_destroy (uri);
+   }
+
+   // Count connections to both servers.
+   int32_t conns_27017_before = get_current_connection_count ("localhost:27017");
+   int32_t conns_27018_before = get_current_connection_count ("localhost:27018");
+
+   // Pop (and push) a client to start background monitoring.
+   {
+      mongoc_client_t *client = mongoc_client_pool_pop (pool);
+      mongoc_client_pool_push (pool, client);
+      // Wait for monitoring connections to be created.
+      // Expect two monitoring connections per server to be created in background.
+      ASSERT_EVENTUAL_CONN_COUNT ("localhost:27017", conns_27017_before + 2);
+      ASSERT_EVENTUAL_CONN_COUNT ("localhost:27018", conns_27018_before + 2);
+   }
+
+   // Send 'ping' commands on two clients to each server to create operation connections.
+   {
+      mongoc_client_t *client1 = mongoc_client_pool_pop (pool);
+      mongoc_client_t *client2 = mongoc_client_pool_pop (pool);
+
+      ok = mongoc_client_command_simple_with_server_id (client1, "admin", ping, NULL, 1 /* server ID */, NULL, &error);
+      ASSERT_OR_PRINT (ok, error);
+      ok = mongoc_client_command_simple_with_server_id (client1, "admin", ping, NULL, 2 /* server ID */, NULL, &error);
+      ASSERT_OR_PRINT (ok, error);
+
+      ok = mongoc_client_command_simple_with_server_id (client2, "admin", ping, NULL, 1 /* server ID */, NULL, &error);
+      ASSERT_OR_PRINT (ok, error);
+      ok = mongoc_client_command_simple_with_server_id (client2, "admin", ping, NULL, 2 /* server ID */, NULL, &error);
+      ASSERT_OR_PRINT (ok, error);
+
+      mongoc_client_pool_push (pool, client2);
+      mongoc_client_pool_push (pool, client1);
+
+      // Expect an operation connection is created per client.
+      ASSERT_CONN_COUNT ("localhost:27017", conns_27017_before + 2 + 2);
+      ASSERT_CONN_COUNT ("localhost:27018", conns_27018_before + 2 + 2);
+   }
+
+   // Mock removal of server 27018 from topology.
+   {
+      mongoc_topology_t *tp = _mongoc_client_pool_get_topology (pool);
+      mc_tpld_modification tdmod = mc_tpld_modify_begin (tp);
+      mongoc_set_rm (mc_tpld_servers (tdmod.new_td), 2 /* server ID */);
+      mc_tpld_modify_commit (tdmod);
+   }
+
+   // Expect connections are closed to removed server.
+   {
+      // Expect monitoring connections to be closed in background.
+      ASSERT_EVENTUAL_CONN_COUNT ("localhost:27017", conns_27017_before + 2 + 2);
+      ASSERT_EVENTUAL_CONN_COUNT ("localhost:27018", conns_27018_before + 2);
+
+      // Pop and push one client to "prune" the stale operation connections for both clients.
+      mongoc_client_t *client = mongoc_client_pool_pop (pool);
+      mongoc_client_pool_push (pool, client);
+      ASSERT_CONN_COUNT ("localhost:27017", conns_27017_before + 2 + 2);
+      ASSERT_CONN_COUNT ("localhost:27018", conns_27018_before);
+   }
+
+   mongoc_client_pool_destroy (pool);
+   bson_destroy (ping);
+}
+
 void
 test_client_pool_install (TestSuite *suite)
 {
@@ -506,4 +660,22 @@ test_client_pool_install (TestSuite *suite)
    TestSuite_AddLive (suite, "/ClientPool/destroy_without_push", test_client_pool_destroy_without_pushing);
    TestSuite_AddLive (suite, "/ClientPool/max_pool_size_exceeded", test_client_pool_max_pool_size_exceeded);
    TestSuite_Add (suite, "/ClientPool/can_override_sockettimeoutms", test_client_pool_can_override_sockettimeoutms);
+
+   TestSuite_AddFull (
+      suite,
+      "/client_pool/disconnects_removed_servers/on_push",
+      disconnects_removed_servers_on_push,
+      NULL,
+      NULL,
+      test_framework_skip_if_not_mongos /* require mongos to ensure two servers available */,
+      test_framework_skip_if_max_wire_version_less_than_9 /* require server 4.4+ for streaming monitoring protocol */);
+
+   TestSuite_AddFull (
+      suite,
+      "/client_pool/disconnects_removed_servers/in_pool",
+      disconnects_removed_servers_in_pool,
+      NULL,
+      NULL,
+      test_framework_skip_if_not_mongos /* require mongos to ensure two servers available */,
+      test_framework_skip_if_max_wire_version_less_than_9 /* require server 4.4+ for streaming monitoring protocol */);
 }

--- a/src/libmongoc/tests/test-mongoc-dns.c
+++ b/src/libmongoc/tests/test-mongoc-dns.c
@@ -1185,6 +1185,128 @@ prose_test_12_pooled (void *unused)
    _prose_test_12 (&_prose_test_pooled_fns);
 }
 
+typedef struct {
+   bson_mutex_t lock;
+   mongoc_host_list_t *hosts;
+} rr_override_t;
+
+rr_override_t rr_override;
+
+// `_mock_rr_resolver_with_override` allows setting a custom list of hosts with the global override.
+static bool
+_mock_rr_resolver_with_override (const char *service,
+                                 mongoc_rr_type_t rr_type,
+                                 mongoc_rr_data_t *rr_data,
+                                 size_t initial_buffer_size,
+                                 bson_error_t *error)
+{
+   BSON_UNUSED (initial_buffer_size);
+
+   BSON_ASSERT_PARAM (service);
+   BSON_ASSERT_PARAM (rr_data);
+   BSON_ASSERT_PARAM (error);
+
+   if (rr_type == MONGOC_RR_SRV) {
+      bson_mutex_lock (&rr_override.lock);
+      const size_t count = _mongoc_host_list_length (rr_override.hosts);
+      BSON_ASSERT (bson_in_range_unsigned (uint32_t, count));
+      rr_data->hosts = _mongoc_host_list_copy_all (rr_override.hosts);
+      rr_data->count = (uint32_t) count;
+      rr_data->txt_record_opts = NULL;
+      bson_mutex_unlock (&rr_override.lock);
+   }
+
+   error->code = 0u;
+
+   return true;
+}
+
+// Test that after a server is removed from SRV records, all connections are closed.
+static void
+test_removing_servers_closes_connections (void *unused)
+{
+   BSON_UNUSED (unused);
+   bson_error_t error;
+   bool ok;
+   bson_t *ping = BCON_NEW ("ping", BCON_INT32 (1));
+
+   // Create a client pool to mongodb+srv://test1.test.build.10gen.cc. The URI resolves to two SRV records:
+   // - localhost.test.build.10gen.cc:27017
+   // - localhost.test.build.10gen.cc:27018
+   mongoc_client_pool_t *pool;
+   {
+      mongoc_uri_t *uri = mongoc_uri_new ("mongodb+srv://test1.test.build.10gen.cc");
+      // Set a short heartbeat so server monitors get quick responses.
+      mongoc_uri_set_option_as_int32 (uri, MONGOC_URI_HEARTBEATFREQUENCYMS, RESCAN_INTERVAL_MS);
+      pool = mongoc_client_pool_new (uri);
+#if defined(MONGOC_ENABLE_SSL)
+      mongoc_ssl_opt_t ssl_opts = *test_framework_get_ssl_opts ();
+      ssl_opts.allow_invalid_hostname = true;
+      mongoc_client_pool_set_ssl_opts (pool, &ssl_opts);
+#endif /* defined(MONGOC_ENABLE_SSL) */
+      // Override the SRV polling callback:
+      mongoc_topology_t *topology = _mongoc_client_pool_get_topology (pool);
+      bson_mutex_init (&rr_override.lock);
+      rr_override.hosts = MAKE_HOSTS ("localhost.test.build.10gen.cc:27017", "localhost.test.build.10gen.cc:27018");
+      _mongoc_topology_set_rr_resolver (topology, _mock_rr_resolver_with_override);
+      // Set a shorter SRV rescan interval.
+      _mongoc_topology_set_srv_polling_rescan_interval_ms (topology, RESCAN_INTERVAL_MS);
+      mongoc_uri_destroy (uri);
+   }
+
+   // Count connections to both servers.
+   int32_t conns_27017_before = get_current_connection_count ("localhost:27017");
+   int32_t conns_27018_before = get_current_connection_count ("localhost:27018");
+
+   // Pop (and push) a client to start background monitoring.
+   {
+      mongoc_client_t *client = mongoc_client_pool_pop (pool);
+      mongoc_client_pool_push (pool, client);
+      // Wait for monitoring connections to be created.
+      // Expect two monitoring connections per server to be created in background.
+      ASSERT_EVENTUAL_CONN_COUNT ("localhost:27017", conns_27017_before + 2);
+      ASSERT_EVENTUAL_CONN_COUNT ("localhost:27018", conns_27018_before + 2);
+   }
+
+   // Send 'ping' commands on a client to each server to create operation connections.
+   {
+      mongoc_client_t *client = mongoc_client_pool_pop (pool);
+      ok = mongoc_client_command_simple_with_server_id (client, "admin", ping, NULL, 1 /* server ID */, NULL, &error);
+      ASSERT_OR_PRINT (ok, error);
+      ok = mongoc_client_command_simple_with_server_id (client, "admin", ping, NULL, 2 /* server ID */, NULL, &error);
+      ASSERT_OR_PRINT (ok, error);
+      mongoc_client_pool_push (pool, client);
+      // Expect an operation connection is created.
+      ASSERT_CONN_COUNT ("localhost:27017", conns_27017_before + 2 + 1);
+      ASSERT_CONN_COUNT ("localhost:27018", conns_27018_before + 2 + 1);
+   }
+
+   // Mock removal of localhost:27018.
+   {
+      bson_mutex_lock (&rr_override.lock);
+      _mongoc_host_list_destroy_all (rr_override.hosts);
+      rr_override.hosts = MAKE_HOSTS ("localhost.test.build.10gen.cc:27017");
+      bson_mutex_unlock (&rr_override.lock);
+   }
+
+   // Expect connections are closed to removed server.
+   {
+      // Expect monitoring connections to be closed in background.
+      ASSERT_EVENTUAL_CONN_COUNT ("localhost:27017", conns_27017_before + 2 + 1);
+      ASSERT_EVENTUAL_CONN_COUNT ("localhost:27018", conns_27018_before + 1);
+
+      // Pop and push the client to "prune" the stale operation connections.
+      mongoc_client_t *client = mongoc_client_pool_pop (pool);
+      mongoc_client_pool_push (pool, client);
+      ASSERT_CONN_COUNT ("localhost:27017", conns_27017_before + 2 + 1);
+      ASSERT_CONN_COUNT ("localhost:27018", conns_27018_before);
+   }
+
+   mongoc_client_pool_destroy (pool);
+   bson_mutex_destroy (&rr_override.lock);
+   bson_destroy (ping);
+}
+
 void
 test_dns_install (TestSuite *suite)
 {
@@ -1257,4 +1379,13 @@ test_dns_install (TestSuite *suite)
                       NULL,
                       NULL,
                       test_dns_check_srv_polling);
+
+   TestSuite_AddFull (
+      suite,
+      "/initial_dns_seedlist_discovery/srv_polling/removing_servers_closes_connections",
+      test_removing_servers_closes_connections,
+      NULL,
+      NULL,
+      test_dns_check_srv_polling,
+      test_framework_skip_if_max_wire_version_less_than_9 /* require server 4.4+ for streaming monitoring protocol */);
 }


### PR DESCRIPTION
# Summary

Close operation connections to removed servers.

Verified with this patch build: https://spruce.mongodb.com/version/665489593f686b000739adf0

# Background & Motivation

Motivated by an issue reported in [HELP-59749](https://jira.mongodb.org/browse/HELP-59749). Tests observed an unexpected increasing connection count. This may have been triggered by (misconfigured?) DNS records resulting in servers being frequently added/removed from the topology during SRV polling.

## Rejected alternative: callback

I considered adding a callback to `_mongoc_topology_description_remove_server` to more immediately signal to close connections. This was rejected to reduce risk of an AB-BA deadlock.

`_mongoc_topology_description_remove_server` expects the caller to hold `mongoc_topology_t::tpld_modification_mtx`. Modifying pooled client requires holding `mongoc_client_pool_t::mutex`.

There is an existing pattern of locking `mongoc_client_pool_t::mutex` then `mongoc_topology_t::tpld_modification_mtx` (via `mongoc_client_pool_try_pop` => `_start_scanner_if_needed` => `_mongoc_topology_background_monitoring_start` => `mc_tpld_modify_begin`).

Instead, this PR proposes lazily pruning stale connections on `mongoc_client_pool_push`. I expect multi-threaded applications to pop/push clients frequently to encourage reuse of clients among threads. A note is added to documentation to make this recommendation explicit.

## Performance Impact

[A benchmark](https://spruce.mongodb.com/version/6653e2ad7f76a90007f5b338) was run to compare throughput of repeated use of the pool through pop+command+push with pruning:


| Test                                   |   Baseline (mb/sec) | With simple pruning   | With conditional pruning   |
|----------------------------------------|------------|-----------------------|----------------------------|
| Parallel/Pool/ShareClients/Threads:1   |     251995 | 236063 (-6.32%)       | 248131 (-1.53%)            |
| Parallel/Pool/ShareClients/Threads:10  |    1364224 | 873991 (-35.93%)      | 1337326 (-1.97%)           |
| Parallel/Pool/ShareClients/Threads:100 |    2017530 | 1050534 (-47.93%)     | 2020829 (0.16%)            |
| Parallel/Pool/ShareClients/Threads:150 |    1540427 | 1571373 (2.01%)       | 1552121 (0.76%)            |

An initial solution ("With simple pruning") iterated over all pooled clients to prune on each call to `mongoc_client_pool_push`. Due to the performance impact, checks were added to only prune if topology description change was detected ("With conditional pruning"). This motivated storing the `last_known_serverids` in the `mongoc_client_pool_t` to quickly determine if the set of server IDs changes. I expect the set of server IDs changing is a "rare" event (e.g. HELP-59749 notes an extreme case where SRV records unexpectedly change. Even then, I expect the set of server IDs would change about once per minute).
