### PR TITLE
CDRIVER-5583 sync KMS sources with libmongocrypt

### DIFF
--- a/.evergreen/scripts/kms-divergence-check.sh
+++ b/.evergreen/scripts/kms-divergence-check.sh
@@ -13,7 +13,7 @@ LIBMONGOCRYPT_DIR="$MONGOC_DIR/libmongocrypt-for-kms-divergence-check"
 
 # LIBMONGOCRYPT_GITREF is expected to refer to the version of libmongocrypt
 # where kms-message was last copied.
-LIBMONGOCRYPT_GITREF="4ebe317d01a0793b6225209139e9a00042a68306"
+LIBMONGOCRYPT_GITREF="f44b2973a07dec80f194014a122689b0800d8413"
 
 cleanup() {
     if [ -d "$LIBMONGOCRYPT_DIR" ]; then

--- a/src/kms-message/src/kms_gcp_request.c
+++ b/src/kms-message/src/kms_gcp_request.c
@@ -87,7 +87,7 @@ kms_gcp_request_oauth_new (const char *host,
       req->crypto.sign_ctx = opt->crypto.sign_ctx;
    }
 
-   jwt_signature = malloc (SIGNATURE_LEN);
+   jwt_signature = calloc (1, SIGNATURE_LEN);
    if (!req->crypto.sign_rsaes_pkcs1_v1_5 (
           req->crypto.sign_ctx,
           private_key_data,

--- a/src/kms-message/src/kms_kmip_reader_writer.c
+++ b/src/kms-message/src/kms_kmip_reader_writer.c
@@ -178,6 +178,14 @@ kmip_writer_write_enumeration (kmip_writer_t *writer, kmip_tag_type_t tag, int32
    kmip_writer_write_u32 (writer, 0);
 }
 
+void kmip_writer_write_bool (kmip_writer_t *writer, kmip_tag_type_t tag, bool value)
+{
+   kmip_writer_write_tag_enum (writer, tag);
+   kmip_writer_write_u8 (writer, KMIP_ITEM_TYPE_Boolean);
+   kmip_writer_write_u32 (writer, 8);
+   kmip_writer_write_u64(writer, (uint64_t) value);
+}
+
 void
 kmip_writer_write_datetime (kmip_writer_t *writer, kmip_tag_type_t tag, int64_t value)
 {
@@ -382,6 +390,15 @@ kmip_reader_read_enumeration (kmip_reader_t *reader, uint32_t *enum_value)
    uint32_t ignored;
 
    return kmip_reader_read_u32 (reader, &ignored);
+}
+
+bool
+kmip_reader_read_bool (kmip_reader_t *reader, bool *value)
+{
+   uint64_t u64;
+   CHECK_AND_RET (kmip_reader_read_u64 (reader, &u64));
+   *value = (bool) u64;
+   return true;
 }
 
 bool

--- a/src/kms-message/src/kms_kmip_reader_writer_private.h
+++ b/src/kms-message/src/kms_kmip_reader_writer_private.h
@@ -60,6 +60,9 @@ void
 kmip_writer_write_enumeration (kmip_writer_t *writer, kmip_tag_type_t tag, int32_t value);
 
 void
+kmip_writer_write_bool (kmip_writer_t *writer, kmip_tag_type_t tag, bool value);
+
+void
 kmip_writer_write_datetime (kmip_writer_t *writer, kmip_tag_type_t tag, int64_t value);
 
 void
@@ -111,6 +114,9 @@ kmip_reader_read_type (kmip_reader_t *reader, kmip_item_type_t *type);
 
 bool
 kmip_reader_read_enumeration (kmip_reader_t *reader, uint32_t *enum_value);
+
+bool
+kmip_reader_read_bool (kmip_reader_t *reader, bool *value);
 
 bool
 kmip_reader_read_integer (kmip_reader_t *reader, int32_t *value);

--- a/src/kms-message/src/kms_kmip_request.c
+++ b/src/kms-message/src/kms_kmip_request.c
@@ -16,6 +16,7 @@
 
 #include "kms_message/kms_kmip_request.h"
 
+#include "kms_kmip_tag_type_private.h"
 #include "kms_message_private.h"
 #include "kms_kmip_reader_writer_private.h"
 
@@ -254,3 +255,212 @@ kms_kmip_request_get_new (void *reserved, const char *unique_identifer)
    kmip_writer_destroy (writer);
    return req;
 }
+
+kms_request_t *
+kms_kmip_request_create_new (void *reserved) {
+   /*
+   Create a KMIP Create request of this form:
+   <RequestMessage tag="0x420078" type="Structure">
+    <RequestHeader tag="0x420077" type="Structure">
+     <ProtocolVersion tag="0x420069" type="Structure">
+      <ProtocolVersionMajor tag="0x42006a" type="Integer" value="1"/>
+      <ProtocolVersionMinor tag="0x42006b" type="Integer" value="2"/>
+     </ProtocolVersion>
+     <BatchCount tag="0x42000d" type="Integer" value="1"/>
+    </RequestHeader>
+    <BatchItem tag="0x42000f" type="Structure">
+     <Operation tag="0x42005c" type="Enumeration" value="1"/>
+     <RequestPayload tag="0x420079" type="Structure">
+      <ObjectType tag="0x420057" type="Enumeration" value="2"/>
+      <TemplateAttribute tag="0x420091" type="Structure">
+       <Attribute tag="0x420008" type="Structure">
+        <AttributeName tag="0x42000a" type="TextString" value="Cryptographic Algorithm"/>
+        <AttributeValue tag="0x42000b" type="Enumeration" value="3"/>
+       </Attribute>
+       <Attribute tag="0x420008" type="Structure">
+        <AttributeName tag="0x42000a" type="TextString" value="Cryptographic Length"/>
+        <AttributeValue tag="0x42000b" type="Integer" value="256"/>
+       </Attribute>
+       <Attribute tag="0x420008" type="Structure">
+        <AttributeName tag="0x42000a" type="TextString" value="Cryptographic
+   Usage Mask"/> <AttributeValue tag="0x42000b" type="Integer" value="12"/>
+       </Attribute>
+      </TemplateAttribute>
+     </RequestPayload>
+    </BatchItem>
+   </RequestMessage>
+   */
+   kmip_writer_t *writer;
+   kms_request_t *req;
+
+   req = calloc (1, sizeof (kms_request_t));
+   req->provider = KMS_REQUEST_PROVIDER_KMIP;
+
+   writer = kmip_writer_new();
+   kmip_writer_begin_struct(writer, KMIP_TAG_RequestMessage);
+
+   kmip_writer_begin_struct (writer, KMIP_TAG_RequestHeader);
+   kmip_writer_begin_struct (writer, KMIP_TAG_ProtocolVersion);
+   kmip_writer_write_integer (writer, KMIP_TAG_ProtocolVersionMajor, 1);
+   kmip_writer_write_integer (writer, KMIP_TAG_ProtocolVersionMinor, 2);
+   kmip_writer_close_struct (writer); /* KMIP_TAG_ProtocolVersion */
+   kmip_writer_write_integer (writer, KMIP_TAG_BatchCount, 1);
+   kmip_writer_close_struct (writer); /* KMIP_TAG_RequestHeader */
+
+   kmip_writer_begin_struct (writer, KMIP_TAG_BatchItem);
+   /* 0x01 == Create */
+   kmip_writer_write_enumeration (writer, KMIP_TAG_Operation, 0x01);
+   kmip_writer_begin_struct (writer, KMIP_TAG_RequestPayload);
+   /* 0x02 == symmetric key */
+   kmip_writer_write_enumeration(writer, KMIP_TAG_ObjectType, 0x02);
+
+   {
+      kmip_writer_begin_struct (writer, KMIP_TAG_TemplateAttribute);
+
+      kmip_writer_begin_struct (writer, KMIP_TAG_Attribute);
+      const char *cryptographicAlgorithmStr = "Cryptographic Algorithm";
+      kmip_writer_write_string (writer,
+                                KMIP_TAG_AttributeName,
+                                cryptographicAlgorithmStr,
+                                strlen (cryptographicAlgorithmStr));
+      kmip_writer_write_enumeration (writer, KMIP_TAG_AttributeValue, 3 /* AES */);
+      kmip_writer_close_struct (writer);
+      kmip_writer_begin_struct (writer, KMIP_TAG_Attribute);
+      const char *cryptographicLengthStr = "Cryptographic Length";
+      kmip_writer_write_string (writer,
+                                KMIP_TAG_AttributeName,
+                                cryptographicLengthStr,
+                                strlen (cryptographicLengthStr));
+      kmip_writer_write_integer (writer, KMIP_TAG_AttributeValue, 256);
+      kmip_writer_close_struct (writer);
+      kmip_writer_begin_struct (writer, KMIP_TAG_Attribute);
+      const char *cryptographicUsageMaskStr = "Cryptographic Usage Mask";
+      kmip_writer_write_string (writer,
+                                KMIP_TAG_AttributeName,
+                                cryptographicUsageMaskStr,
+                                strlen (cryptographicUsageMaskStr));
+      kmip_writer_write_integer (writer, KMIP_TAG_AttributeValue, 4 | 8 /* Encrypt | Decrypt */);
+      kmip_writer_close_struct (writer);
+
+      kmip_writer_close_struct (writer); /* KMIP_TAG_TemplateAttribute */
+   }
+
+   kmip_writer_close_struct (writer); /* KMIP_TAG_RequestPayload */
+   kmip_writer_close_struct (writer); /* KMIP_TAG_BatchItem */
+   kmip_writer_close_struct (writer); /* KMIP_TAG_RequestMessage */
+
+   /* Copy the KMIP writer buffer to a KMIP request. */
+   copy_writer_buffer (req, writer);
+   kmip_writer_destroy (writer);
+   return req;
+}
+
+static kms_request_t *
+kmip_encrypt_decrypt (const char* unique_identifer, const uint8_t *data, size_t len, 
+   const uint8_t *iv_data, size_t iv_len, bool encrypt) {
+   kmip_writer_t *writer;
+   kms_request_t *req;
+
+   req = calloc (1, sizeof (kms_request_t));
+   req->provider = KMS_REQUEST_PROVIDER_KMIP;
+
+   writer = kmip_writer_new();
+   kmip_writer_begin_struct(writer, KMIP_TAG_RequestMessage);
+
+   kmip_writer_begin_struct (writer, KMIP_TAG_RequestHeader);
+   kmip_writer_begin_struct (writer, KMIP_TAG_ProtocolVersion);
+   kmip_writer_write_integer (writer, KMIP_TAG_ProtocolVersionMajor, 1);
+   kmip_writer_write_integer (writer, KMIP_TAG_ProtocolVersionMinor, 2);
+   kmip_writer_close_struct (writer); /* KMIP_TAG_ProtocolVersion */
+   kmip_writer_write_integer (writer, KMIP_TAG_BatchCount, 1);
+   kmip_writer_close_struct (writer); /* KMIP_TAG_RequestHeader */
+
+   kmip_writer_begin_struct (writer, KMIP_TAG_BatchItem);
+   /* 0x1F == Encrypt, 0x20 == Decrypt*/
+   kmip_writer_write_enumeration (writer, KMIP_TAG_Operation, encrypt ? 0x1F : 0x20);
+   kmip_writer_begin_struct (writer, KMIP_TAG_RequestPayload);
+   kmip_writer_write_string (writer,
+                             KMIP_TAG_UniqueIdentifier,
+                             unique_identifer,
+                             strlen (unique_identifer));
+                             
+   kmip_writer_begin_struct (writer, KMIP_TAG_CryptographicParameters);
+   kmip_writer_write_enumeration(writer, KMIP_TAG_BlockCipherMode, 1 /* CBC */);
+   kmip_writer_write_enumeration(writer, KMIP_TAG_PaddingMethod, 3 /* PKCS5 */);
+   kmip_writer_write_enumeration(writer, KMIP_TAG_CryptographicAlgorithm, 3 /* AES */);
+   if (encrypt) kmip_writer_write_bool(writer, KMIP_TAG_RandomIV, true);
+   kmip_writer_close_struct(writer); /* KMIP_TAG_CryptographicParameters */
+
+   kmip_writer_write_bytes(writer, KMIP_TAG_Data, (char *) data, len);
+   if (!encrypt) kmip_writer_write_bytes(writer, KMIP_TAG_IVCounterNonce, (char *) iv_data, iv_len);
+
+   kmip_writer_close_struct (writer); /* KMIP_TAG_RequestPayload */
+   kmip_writer_close_struct (writer); /* KMIP_TAG_BatchItem */
+   kmip_writer_close_struct (writer); /* KMIP_TAG_RequestMessage */
+
+   /* Copy the KMIP writer buffer to a KMIP request. */
+   copy_writer_buffer (req, writer);
+   kmip_writer_destroy (writer);
+   return req;
+}
+
+kms_request_t *
+kms_kmip_request_encrypt_new (void *reserved, const char* unique_identifer, const uint8_t *plaintext, size_t len) {
+   /*
+   Create a KMIP Encrypt request of this form:
+   <RequestMessage tag="0x420078" type="Structure">
+    <RequestHeader tag="0x420077" type="Structure">
+     <ProtocolVersion tag="0x420069" type="Structure">
+      <ProtocolVersionMajor tag="0x42006a" type="Integer" value="1"/>
+      <ProtocolVersionMinor tag="0x42006b" type="Integer" value="2"/>
+     </ProtocolVersion>
+     <BatchCount tag="0x42000d" type="Integer" value="1"/>
+    </RequestHeader>
+    <BatchItem tag="0x42000f" type="Structure">
+     <Operation tag="0x42005c" type="Enumeration" value="31"/>
+     <RequestPayload tag="0x420079" type="Structure">
+      <UniqueIdentifier tag="0x420094" type="TextString" value="..."/>
+      <CryptographicParameters tag="0x42002b" type="Structure">
+       <BlockCipherMode tag="0x420011" type="Enumeration" value="1"/>
+       <PaddingMethod tag="0x42005f" type="Enumeration" value="3"/>
+       <CryptographicAlgorithm tag="0x420028" type="Enumeration" value="3"/>
+       <RandomIV tag="0x4200c5" type="Boolean" value="True"/>
+      </CryptographicParameters>
+      <Data tag="0x4200c2" type="ByteString" value="..."/>
+     </RequestPayload>
+    </BatchItem>
+   </RequestMessage>
+   */
+   return kmip_encrypt_decrypt(unique_identifer, plaintext, len, NULL, 0, true);
+}
+
+kms_request_t *
+kms_kmip_request_decrypt_new (void *reserved, const char* unique_identifer, const uint8_t *ciphertext, size_t len, const uint8_t *iv_data, size_t iv_len) {
+   /*
+   Create a KMIP Decrypt request of this form:
+   <RequestMessage tag="0x420078" type="Structure">
+    <RequestHeader tag="0x420077" type="Structure">
+     <ProtocolVersion tag="0x420069" type="Structure">
+      <ProtocolVersionMajor tag="0x42006a" type="Integer" value="1"/>
+      <ProtocolVersionMinor tag="0x42006b" type="Integer" value="2"/>
+     </ProtocolVersion>
+     <BatchCount tag="0x42000d" type="Integer" value="1"/>
+    </RequestHeader>
+    <BatchItem tag="0x42000f" type="Structure">
+     <Operation tag="0x42005c" type="Enumeration" value="32"/>
+     <RequestPayload tag="0x420079" type="Structure">
+      <UniqueIdentifier tag="0x420094" type="TextString" value="..."/>
+      <CryptographicParameters tag="0x42002b" type="Structure">
+       <BlockCipherMode tag="0x420011" type="Enumeration" value="1"/>
+       <PaddingMethod tag="0x42005f" type="Enumeration" value="3"/>
+       <CryptographicAlgorithm tag="0x420028" type="Enumeration" value="3"/>
+      </CryptographicParameters>
+      <Data tag="0x4200c2" type="ByteString" value="..."/>
+      <IVCounterNonce tag="0x42003d" type="ByteString" value="..."/>
+     </RequestPayload>
+    </BatchItem>
+   </RequestMessage>
+   */
+   return kmip_encrypt_decrypt(unique_identifer, ciphertext, len, iv_data, iv_len, false);
+}
+

--- a/src/kms-message/src/kms_kmip_tag_type_private.h
+++ b/src/kms-message/src/kms_kmip_tag_type_private.h
@@ -312,7 +312,8 @@
    KMS_X (AlwaysSensitive, 0x420121)                                                        \
    KMS_X (Extractable, 0x420122)                                                            \
    KMS_X (NeverExtractable, 0x420123)                                                       \
-   KMS_X_LAST (ReplaceExisting, 0x420124)
+   KMS_X (ReplaceExisting, 0x420124)                                                        \
+   KMS_X_LAST (Attributes, 0x420125)
 /* clang-format on */
 
 /* Generate an enum with each tag value. */

--- a/src/kms-message/src/kms_message/kms_kmip_request.h
+++ b/src/kms-message/src/kms_message/kms_kmip_request.h
@@ -51,6 +51,23 @@ kms_kmip_request_activate_new (void *reserved, const char *unique_identifier);
 KMS_MSG_EXPORT (kms_request_t *)
 kms_kmip_request_get_new (void *reserved, const char *unique_identifier);
 
+KMS_MSG_EXPORT (kms_request_t *)
+kms_kmip_request_create_new (void *reserved);
+
+KMS_MSG_EXPORT (kms_request_t *)
+kms_kmip_request_encrypt_new (void *reserved,
+                          const char *unique_identifier,
+                          const uint8_t *plaintext,
+                          size_t len);
+
+KMS_MSG_EXPORT (kms_request_t *)
+kms_kmip_request_decrypt_new (void *reserved,
+                          const char *unique_identifier,
+                          const uint8_t *ciphertext,
+                          size_t len,
+                          const uint8_t *iv,
+                          size_t iv_len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/kms-message/src/kms_message/kms_kmip_response.h
+++ b/src/kms-message/src/kms_message/kms_kmip_response.h
@@ -37,4 +37,10 @@ kms_kmip_response_get_unique_identifier (kms_response_t *res);
 KMS_MSG_EXPORT (uint8_t *)
 kms_kmip_response_get_secretdata (kms_response_t *res, size_t *secretdatalen);
 
+KMS_MSG_EXPORT (uint8_t *)
+kms_kmip_response_get_data (kms_response_t *res, size_t *datalen);
+
+KMS_MSG_EXPORT (uint8_t *)
+kms_kmip_response_get_iv (kms_response_t *res, size_t *datalen);
+
 #endif /* KMS_KMIP_RESPONSE_H */

--- a/src/kms-message/src/kms_request_str.c
+++ b/src/kms-message/src/kms_request_str.c
@@ -366,7 +366,7 @@ kms_request_str_append_hashed (_kms_crypto_t *crypto,
                                kms_request_str_t *str,
                                kms_request_str_t *appended)
 {
-   uint8_t hash[32];
+   uint8_t hash[32] = {0};
    char *hex_chars;
 
    if (!crypto->sha256 (crypto->ctx, appended->str, appended->len, hash)) {

--- a/src/kms-message/test/test_kmip_reader_writer.c
+++ b/src/kms-message/test/test_kmip_reader_writer.c
@@ -88,7 +88,13 @@ kms_kmip_writer_test (void)
       "An Enumeration with value 255");
    kmip_writer_destroy (writer);
 
-   /* Boolean is not implemented. */
+   writer = kmip_writer_new ();
+   kmip_writer_write_bool (writer, KMIP_TAG_CompromiseDate, true);
+   kms_kmip_writer_test_evaluate (
+      writer,
+      "42 00 20 | 06 | 00 00 00 08 | 00 00 00 00 00 00 00 01",
+      "An boolean containing the value true");
+   kmip_writer_destroy (writer);
 
    writer = kmip_writer_new ();
    kmip_writer_write_string (
@@ -147,6 +153,7 @@ kms_kmip_reader_test (void)
    int64_t i64;
    uint32_t u32;
    uint8_t *ptr;
+   bool b;
 
    /* The following test cases come from section 9.1.2 of
     * http://docs.oasis-open.org/kmip/spec/v1.4/os/kmip-spec-v1.4-os.html */
@@ -200,7 +207,21 @@ kms_kmip_reader_test (void)
    kmip_reader_destroy (reader);
    free (data);
 
-   /* Boolean is not implemented */
+   /* A boolean with value true */
+   data = hex_to_data ("42 00 20 | 06 | 00 00 00 08 | 00 00 00 00 00 00 00 01",
+                       &datalen);
+   reader = kmip_reader_new (data, datalen);
+   ASSERT (kmip_reader_read_tag (reader, &tag));
+   ASSERT (tag == KMIP_TAG_CompromiseDate);
+   ASSERT (kmip_reader_read_type (reader, &type));
+   ASSERT (type == KMIP_ITEM_TYPE_Boolean);
+   ASSERT (kmip_reader_read_length (reader, &length));
+   ASSERT (length == 8);
+   ASSERT (kmip_reader_read_bool (reader, &b));
+   ASSERT (b);
+   ASSERT (!kmip_reader_has_data (reader));
+   kmip_reader_destroy (reader);
+   free (data);
 
    /* A Text String with the value 'Hello World' */
    data = hex_to_data ("42 00 20 | 07 | 00 00 00 0B | 48 65 6C "


### PR DESCRIPTION
This syncs the kms-message sources vendored in the C driver with those from libmongocrypt, as of version 1.10.0 of the latter.

Evergreen patch build: https://spruce.mongodb.com/version/6658daf31dc3d50007132161/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC