### PR TITLE
CDRIVER-4162 remove remaining solaris workarounds

### DIFF
--- a/src/libbson/src/bson/bson-endian.h
+++ b/src/libbson/src/bson/bson-endian.h
@@ -20,11 +20,6 @@
 #ifndef BSON_ENDIAN_H
 #define BSON_ENDIAN_H
 
-
-#if defined(__sun)
-#include <sys/byteorder.h>
-#endif
-
 #include <bson/bson-config.h>
 #include <bson/bson-macros.h>
 #include <bson/bson-compat.h>
@@ -36,12 +31,7 @@ BSON_BEGIN_DECLS
 #define BSON_BIG_ENDIAN 4321
 #define BSON_LITTLE_ENDIAN 1234
 
-
-#if defined(__sun)
-#define BSON_UINT16_SWAP_LE_BE(v) BSWAP_16 ((uint16_t) v)
-#define BSON_UINT32_SWAP_LE_BE(v) BSWAP_32 ((uint32_t) v)
-#define BSON_UINT64_SWAP_LE_BE(v) BSWAP_64 ((uint64_t) v)
-#elif defined(__clang__) && defined(__clang_major__) && defined(__clang_minor__) && (__clang_major__ >= 3) && \
+#if defined(__clang__) && defined(__clang_major__) && defined(__clang_minor__) && (__clang_major__ >= 3) && \
    (__clang_minor__ >= 1)
 #if __has_builtin(__builtin_bswap16)
 #define BSON_UINT16_SWAP_LE_BE(v) __builtin_bswap16 (v)

--- a/src/libbson/tests/test-json.c
+++ b/src/libbson/tests/test-json.c
@@ -1927,7 +1927,7 @@ test_bson_json_double (void)
 
 /* check that "x" is -0.0. signbit not available on Solaris, FreeBSD, or VS 2010
  */
-#if !defined(__sun) && !defined(__FreeBSD__) && (!defined(_MSC_VER) || (_MSC_VER >= 1800))
+#if !defined(__FreeBSD__) && (!defined(_MSC_VER) || (_MSC_VER >= 1800))
    BSON_ASSERT (signbit (bson_iter_double (&iter)));
 #endif
 

--- a/src/libbson/tests/test-json.c
+++ b/src/libbson/tests/test-json.c
@@ -1925,7 +1925,7 @@ test_bson_json_double (void)
    BSON_ASSERT (BSON_ITER_HOLDS_DOUBLE (&iter));
    ASSERT_CMPDOUBLE (bson_iter_double (&iter), ==, 0.0);
 
-/* check that "x" is -0.0. signbit not available on Solaris, FreeBSD, or VS 2010
+/* check that "x" is -0.0. signbit not available on FreeBSD or VS 2010
  */
 #if !defined(__FreeBSD__) && (!defined(_MSC_VER) || (_MSC_VER >= 1800))
    BSON_ASSERT (signbit (bson_iter_double (&iter)));

--- a/src/libmongoc/src/mongoc/mongoc-counters-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-counters-private.h
@@ -75,7 +75,7 @@ _mongoc_get_cpu_count (void)
    }
 
    return len;
-#elif defined(__APPLE__) || defined(__sun) || defined(_AIX)
+#elif defined(__APPLE__) || defined(_AIX)
    int ncpu;
 
    ncpu = (int) sysconf (_SC_NPROCESSORS_ONLN);

--- a/src/libmongoc/src/mongoc/mongoc-errno-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-errno-private.h
@@ -33,11 +33,6 @@ BSON_BEGIN_DECLS
 #if defined(_WIN32)
 #define MONGOC_ERRNO_IS_AGAIN(errno) ((errno == EAGAIN) || (errno == WSAEWOULDBLOCK) || (errno == WSAEINPROGRESS))
 #define MONGOC_ERRNO_IS_TIMEDOUT(errno) (errno == WSAETIMEDOUT)
-#elif defined(__sun)
-/* for some reason, accept() returns -1 and errno of 0 */
-#define MONGOC_ERRNO_IS_AGAIN(errno) \
-   ((errno == EINTR) || (errno == EAGAIN) || (errno == EWOULDBLOCK) || (errno == EINPROGRESS) || (errno == 0))
-#define MONGOC_ERRNO_IS_TIMEDOUT(errno) (errno == ETIMEDOUT)
 #else
 #define MONGOC_ERRNO_IS_AGAIN(errno) \
    ((errno == EINTR) || (errno == EAGAIN) || (errno == EWOULDBLOCK) || (errno == EINPROGRESS))

--- a/src/libmongoc/tests/test-mongoc-stream-tls-error.c
+++ b/src/libmongoc/tests/test-mongoc-stream-tls-error.c
@@ -101,7 +101,7 @@ static BSON_THREAD_FUN (ssl_error_server, ptr)
 }
 
 
-#if !defined(__sun) && !defined(__APPLE__)
+#if !defined(__APPLE__)
 /** run as a child thread by test_mongoc_tls_hangup
  *
  * It:


### PR DESCRIPTION
[evergreen](https://spruce.mongodb.com/version/6659f980b0f8570007c19bdf/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

This pr removes preprocessor checks for __sun since solaris is not longer supported.