### PR TITLE
CDRIVER-5589 add option to prefer TCP for SRV lookup

### DIFF
--- a/src/libmongoc/doc/mongoc_uri_t.rst
+++ b/src/libmongoc/doc/mongoc_uri_t.rst
@@ -79,7 +79,7 @@ The driver prefixes the service name with "_mongodb._tcp.", then performs a DNS 
 
 On Unix, the MongoDB C Driver relies on libresolv to look up SRV and TXT records. If libresolv is unavailable, then using a "mongodb+srv" URI will cause an error. If your libresolv lacks ``res_nsearch`` then the driver will fall back to ``res_search``, which is not thread-safe.
 
-Set the environment variable `MONGOC_SRV_PREFER_TCP=ON` to prefer TCP for the initial queries. The environment variable is ignored for ``res_search``. Large DNS responses over UDP may be truncated due to UDP size limitations. DNS resolvers are expected to retry over TCP if the UDP response indicates truncation. Some observed DNS environments do not set the truncation flag (TC), preventing the TCP retry.
+Set the environment variable ``MONGOC_SRV_PREFER_TCP=ON`` to prefer TCP for the initial queries. The environment variable is ignored for ``res_search``. Large DNS responses over UDP may be truncated due to UDP size limitations. DNS resolvers are expected to retry over TCP if the UDP response indicates truncation. Some observed DNS environments do not set the truncation flag (TC), preventing the TCP retry.
 
 IPv4 and IPv6
 -------------

--- a/src/libmongoc/doc/mongoc_uri_t.rst
+++ b/src/libmongoc/doc/mongoc_uri_t.rst
@@ -79,6 +79,8 @@ The driver prefixes the service name with "_mongodb._tcp.", then performs a DNS 
 
 On Unix, the MongoDB C Driver relies on libresolv to look up SRV and TXT records. If libresolv is unavailable, then using a "mongodb+srv" URI will cause an error. If your libresolv lacks ``res_nsearch`` then the driver will fall back to ``res_search``, which is not thread-safe.
 
+Set the environment variable `MONGOC_SRV_PREFER_TCP=ON` to prefer TCP for the initial queries. The environment variable is ignored for ``res_search``. Large DNS responses over UDP may be truncated due to UDP size limitations. DNS resolvers are expected to retry over TCP if the UDP response indicates truncation. Some observed DNS environments do not set the truncation flag (TC), preventing the TCP retry.
+
 IPv4 and IPv6
 -------------
 

--- a/src/libmongoc/doc/mongoc_uri_t.rst
+++ b/src/libmongoc/doc/mongoc_uri_t.rst
@@ -79,7 +79,7 @@ The driver prefixes the service name with "_mongodb._tcp.", then performs a DNS 
 
 On Unix, the MongoDB C Driver relies on libresolv to look up SRV and TXT records. If libresolv is unavailable, then using a "mongodb+srv" URI will cause an error. If your libresolv lacks ``res_nsearch`` then the driver will fall back to ``res_search``, which is not thread-safe.
 
-Set the environment variable ``MONGOC_EXPERIMENTAL_SRV_PREFER_TCP`` to prefer TCP for the initial queries. The environment variable is ignored for ``res_search``. Large DNS responses over UDP may be truncated due to UDP size limitations. DNS resolvers are expected to retry over TCP if the UDP response indicates truncation. Some observed DNS environments do not set the truncation flag (TC), preventing the TCP retry.
+Set the environment variable ``MONGOC_EXPERIMENTAL_SRV_PREFER_TCP=ON`` to prefer TCP for the initial queries. The environment variable is ignored for ``res_search``. Large DNS responses over UDP may be truncated due to UDP size limitations. DNS resolvers are expected to retry over TCP if the UDP response indicates truncation. Some observed DNS environments do not set the truncation flag (TC), preventing the TCP retry. This environment variable is currently experimental and subject to change.
 
 IPv4 and IPv6
 -------------

--- a/src/libmongoc/doc/mongoc_uri_t.rst
+++ b/src/libmongoc/doc/mongoc_uri_t.rst
@@ -79,7 +79,7 @@ The driver prefixes the service name with "_mongodb._tcp.", then performs a DNS 
 
 On Unix, the MongoDB C Driver relies on libresolv to look up SRV and TXT records. If libresolv is unavailable, then using a "mongodb+srv" URI will cause an error. If your libresolv lacks ``res_nsearch`` then the driver will fall back to ``res_search``, which is not thread-safe.
 
-Set the environment variable ``MONGOC_EXPERIMENTAL_SRV_PREFER_TCP=ON`` to prefer TCP for the initial queries. The environment variable is ignored for ``res_search``. Large DNS responses over UDP may be truncated due to UDP size limitations. DNS resolvers are expected to retry over TCP if the UDP response indicates truncation. Some observed DNS environments do not set the truncation flag (TC), preventing the TCP retry. This environment variable is currently experimental and subject to change.
+Set the environment variable ``MONGOC_EXPERIMENTAL_SRV_PREFER_TCP`` to prefer TCP for the initial queries. The environment variable is ignored for ``res_search``. Large DNS responses over UDP may be truncated due to UDP size limitations. DNS resolvers are expected to retry over TCP if the UDP response indicates truncation. Some observed DNS environments do not set the truncation flag (TC), preventing the TCP retry. This environment variable is currently experimental and subject to change.
 
 IPv4 and IPv6
 -------------

--- a/src/libmongoc/doc/mongoc_uri_t.rst
+++ b/src/libmongoc/doc/mongoc_uri_t.rst
@@ -79,7 +79,7 @@ The driver prefixes the service name with "_mongodb._tcp.", then performs a DNS 
 
 On Unix, the MongoDB C Driver relies on libresolv to look up SRV and TXT records. If libresolv is unavailable, then using a "mongodb+srv" URI will cause an error. If your libresolv lacks ``res_nsearch`` then the driver will fall back to ``res_search``, which is not thread-safe.
 
-Set the environment variable ``MONGOC_SRV_PREFER_TCP=ON`` to prefer TCP for the initial queries. The environment variable is ignored for ``res_search``. Large DNS responses over UDP may be truncated due to UDP size limitations. DNS resolvers are expected to retry over TCP if the UDP response indicates truncation. Some observed DNS environments do not set the truncation flag (TC), preventing the TCP retry.
+Set the environment variable ``MONGOC_EXPERIMENTAL_SRV_PREFER_TCP`` to prefer TCP for the initial queries. The environment variable is ignored for ``res_search``. Large DNS responses over UDP may be truncated due to UDP size limitations. DNS resolvers are expected to retry over TCP if the UDP response indicates truncation. Some observed DNS environments do not set the truncation flag (TC), preventing the TCP retry.
 
 IPv4 and IPv6
 -------------

--- a/src/libmongoc/src/mongoc/mongoc-client-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-private.h
@@ -146,6 +146,7 @@ _mongoc_client_get_rr (const char *hostname,
                        mongoc_rr_type_t rr_type,
                        mongoc_rr_data_t *rr_data,
                        size_t initial_buffer_size,
+                       bool prefer_tcp,
                        bson_error_t *error);
 
 mongoc_client_t *

--- a/src/libmongoc/src/mongoc/mongoc-topology-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-private.h
@@ -85,6 +85,7 @@ typedef bool (*_mongoc_rr_resolver_fn) (const char *hostname,
                                         mongoc_rr_type_t rr_type,
                                         mongoc_rr_data_t *rr_data,
                                         size_t initial_buffer_size,
+                                        bool prefer_tcp,
                                         bson_error_t *error);
 
 /**
@@ -217,6 +218,11 @@ typedef struct _mongoc_topology_t {
    // `mongoc_client_set_usleep_impl`.
    mongoc_usleep_func_t usleep_fn;
    void *usleep_data;
+
+   // `srv_prefer_tcp` determines if DNS lookup for SRV tries TCP first instead of UDP.
+   // DNS implementations are expected to try UDP first, then retry with TCP if the UDP response indicates truncation.
+   // Some DNS servers truncate UDP responses without setting the truncated (TC) flag. This may result in no TCP retry.
+   bool srv_prefer_tcp;
 } mongoc_topology_t;
 
 mongoc_topology_t *

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -385,11 +385,11 @@ mongoc_topology_new (const mongoc_uri_t *uri, bool single_threaded)
    topology = (mongoc_topology_t *) bson_malloc0 (sizeof *topology);
    // Check if requested to use TCP for SRV lookup.
    {
-      char *MONGOC_SRV_PREFER_TCP = _mongoc_getenv ("MONGOC_SRV_PREFER_TCP");
-      if (MONGOC_SRV_PREFER_TCP && 0 == strcmp (MONGOC_SRV_PREFER_TCP, "ON")) {
+      char *MONGOC_EXPERIMENTAL_SRV_PREFER_TCP = _mongoc_getenv ("MONGOC_EXPERIMENTAL_SRV_PREFER_TCP");
+      if (MONGOC_EXPERIMENTAL_SRV_PREFER_TCP && 0 == strcmp (MONGOC_EXPERIMENTAL_SRV_PREFER_TCP, "ON")) {
          topology->srv_prefer_tcp = true;
       }
-      bson_free (MONGOC_SRV_PREFER_TCP);
+      bson_free (MONGOC_EXPERIMENTAL_SRV_PREFER_TCP);
    }
    topology->usleep_fn = mongoc_usleep_default_impl;
    topology->session_pool = mongoc_server_session_pool_new_with_params (

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -385,11 +385,11 @@ mongoc_topology_new (const mongoc_uri_t *uri, bool single_threaded)
    topology = (mongoc_topology_t *) bson_malloc0 (sizeof *topology);
    // Check if requested to use TCP for SRV lookup.
    {
-      char *MONGOC_EXPERIMENTAL_SRV_PREFER_TCP = _mongoc_getenv ("MONGOC_EXPERIMENTAL_SRV_PREFER_TCP");
-      if (MONGOC_EXPERIMENTAL_SRV_PREFER_TCP) {
+      char *srv_prefer_tcp = _mongoc_getenv ("MONGOC_EXPERIMENTAL_SRV_PREFER_TCP");
+      if (srv_prefer_tcp) {
          topology->srv_prefer_tcp = true;
       }
-      bson_free (MONGOC_EXPERIMENTAL_SRV_PREFER_TCP);
+      bson_free (srv_prefer_tcp);
    }
    topology->usleep_fn = mongoc_usleep_default_impl;
    topology->session_pool = mongoc_server_session_pool_new_with_params (

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -383,6 +383,14 @@ mongoc_topology_new (const mongoc_uri_t *uri, bool single_threaded)
 #endif
 
    topology = (mongoc_topology_t *) bson_malloc0 (sizeof *topology);
+   // Check if requested to use TCP for SRV lookup.
+   {
+      char *MONGOC_SRV_PREFER_TCP = _mongoc_getenv ("MONGOC_SRV_PREFER_TCP");
+      if (MONGOC_SRV_PREFER_TCP && 0 == strcmp (MONGOC_SRV_PREFER_TCP, "ON")) {
+         topology->srv_prefer_tcp = true;
+      }
+      bson_free (MONGOC_SRV_PREFER_TCP);
+   }
    topology->usleep_fn = mongoc_usleep_default_impl;
    topology->session_pool = mongoc_server_session_pool_new_with_params (
       _server_session_init, _server_session_destroy, _server_session_should_prune, topology);
@@ -476,16 +484,24 @@ mongoc_topology_new (const mongoc_uri_t *uri, bool single_threaded)
 
       /* a mongodb+srv URI. try SRV lookup, if no error then also try TXT */
       prefixed_hostname = bson_strdup_printf ("_%s._tcp.%s", mongoc_uri_get_srv_service_name (uri), srv_hostname);
-      if (!topology->rr_resolver (
-             prefixed_hostname, MONGOC_RR_SRV, &rr_data, MONGOC_RR_DEFAULT_BUFFER_SIZE, &topology->scanner->error)) {
+      if (!topology->rr_resolver (prefixed_hostname,
+                                  MONGOC_RR_SRV,
+                                  &rr_data,
+                                  MONGOC_RR_DEFAULT_BUFFER_SIZE,
+                                  topology->srv_prefer_tcp,
+                                  &topology->scanner->error)) {
          GOTO (srv_fail);
       }
 
       /* Failure to find TXT records will not return an error (since it is only
        * for options). But _mongoc_client_get_rr may return an error if
        * there is more than one TXT record returned. */
-      if (!topology->rr_resolver (
-             srv_hostname, MONGOC_RR_TXT, &rr_data, MONGOC_RR_DEFAULT_BUFFER_SIZE, &topology->scanner->error)) {
+      if (!topology->rr_resolver (srv_hostname,
+                                  MONGOC_RR_TXT,
+                                  &rr_data,
+                                  MONGOC_RR_DEFAULT_BUFFER_SIZE,
+                                  topology->srv_prefer_tcp,
+                                  &topology->scanner->error)) {
          GOTO (srv_fail);
       }
 
@@ -812,8 +828,12 @@ mongoc_topology_rescan_srv (mongoc_topology_t *topology)
    prefixed_hostname =
       bson_strdup_printf ("_%s._tcp.%s", mongoc_uri_get_srv_service_name (topology->uri), srv_hostname);
 
-   ret = topology->rr_resolver (
-      prefixed_hostname, MONGOC_RR_SRV, &rr_data, MONGOC_RR_DEFAULT_BUFFER_SIZE, &topology->scanner->error);
+   ret = topology->rr_resolver (prefixed_hostname,
+                                MONGOC_RR_SRV,
+                                &rr_data,
+                                MONGOC_RR_DEFAULT_BUFFER_SIZE,
+                                topology->srv_prefer_tcp,
+                                &topology->scanner->error);
 
    td = mc_tpld_take_ref (topology);
    topology->srv_polling_last_scan_ms = bson_get_monotonic_time () / 1000;

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -386,7 +386,7 @@ mongoc_topology_new (const mongoc_uri_t *uri, bool single_threaded)
    // Check if requested to use TCP for SRV lookup.
    {
       char *MONGOC_EXPERIMENTAL_SRV_PREFER_TCP = _mongoc_getenv ("MONGOC_EXPERIMENTAL_SRV_PREFER_TCP");
-      if (MONGOC_EXPERIMENTAL_SRV_PREFER_TCP && 0 == strcmp (MONGOC_EXPERIMENTAL_SRV_PREFER_TCP, "ON")) {
+      if (MONGOC_EXPERIMENTAL_SRV_PREFER_TCP) {
          topology->srv_prefer_tcp = true;
       }
       bson_free (MONGOC_EXPERIMENTAL_SRV_PREFER_TCP);

--- a/src/libmongoc/tests/test-mongoc-dns.c
+++ b/src/libmongoc/tests/test-mongoc-dns.c
@@ -599,9 +599,9 @@ test_small_initial_buffer (void *unused)
    BSON_UNUSED (unused);
 
    memset (&rr_data, 0, sizeof (rr_data));
-   ASSERT_OR_PRINT (
-      _mongoc_client_get_rr ("_mongodb._tcp.test1.test.build.10gen.cc", rr_type, &rr_data, small_buffer_size, &error),
-      error);
+   ASSERT_OR_PRINT (_mongoc_client_get_rr (
+                       "_mongodb._tcp.test1.test.build.10gen.cc", rr_type, &rr_data, small_buffer_size, false, &error),
+                    error);
    ASSERT_CMPINT (rr_data.count, ==, 2);
    bson_free (rr_data.txt_record_opts);
    _mongoc_host_list_destroy_all (rr_data.hosts);
@@ -612,12 +612,14 @@ _mock_rr_resolver_prose_test_9 (const char *service,
                                 mongoc_rr_type_t rr_type,
                                 mongoc_rr_data_t *rr_data,
                                 size_t initial_buffer_size,
+                                bool prefer_tcp,
                                 bson_error_t *error)
 {
    BSON_UNUSED (service);
    BSON_UNUSED (rr_type);
    BSON_UNUSED (rr_data);
    BSON_UNUSED (initial_buffer_size);
+   BSON_UNUSED (prefer_tcp);
    BSON_UNUSED (error);
 
    test_error ("Expected mock resolver to not be called");
@@ -853,12 +855,14 @@ _mock_rr_resolver_prose_test_10 (const char *service,
                                  mongoc_rr_type_t rr_type,
                                  mongoc_rr_data_t *rr_data,
                                  size_t initial_buffer_size,
+                                 bool prefer_tcp,
                                  bson_error_t *error)
 {
    BSON_UNUSED (initial_buffer_size);
 
    BSON_ASSERT_PARAM (service);
    BSON_ASSERT_PARAM (rr_data);
+   BSON_UNUSED (prefer_tcp);
    BSON_ASSERT_PARAM (error);
 
    if (rr_type == MONGOC_RR_SRV) {
@@ -953,12 +957,14 @@ _mock_rr_resolver_prose_test_11 (const char *service,
                                  mongoc_rr_type_t rr_type,
                                  mongoc_rr_data_t *rr_data,
                                  size_t initial_buffer_size,
+                                 bool prefer_tcp,
                                  bson_error_t *error)
 {
    BSON_UNUSED (initial_buffer_size);
 
    BSON_ASSERT_PARAM (service);
    BSON_ASSERT_PARAM (rr_data);
+   BSON_UNUSED (prefer_tcp);
    BSON_ASSERT_PARAM (error);
 
    if (rr_type == MONGOC_RR_SRV) {
@@ -1050,12 +1056,14 @@ _mock_rr_resolver_prose_test_12 (const char *service,
                                  mongoc_rr_type_t rr_type,
                                  mongoc_rr_data_t *rr_data,
                                  size_t initial_buffer_size,
+                                 bool prefer_tcp,
                                  bson_error_t *error)
 {
    BSON_UNUSED (initial_buffer_size);
 
    BSON_ASSERT_PARAM (service);
    BSON_ASSERT_PARAM (rr_data);
+   BSON_UNUSED (prefer_tcp);
    BSON_ASSERT_PARAM (error);
 
    if (rr_type == MONGOC_RR_SRV) {
@@ -1198,12 +1206,14 @@ _mock_rr_resolver_with_override (const char *service,
                                  mongoc_rr_type_t rr_type,
                                  mongoc_rr_data_t *rr_data,
                                  size_t initial_buffer_size,
+                                 bool prefer_tcp,
                                  bson_error_t *error)
 {
    BSON_UNUSED (initial_buffer_size);
 
    BSON_ASSERT_PARAM (service);
    BSON_ASSERT_PARAM (rr_data);
+   BSON_UNUSED (prefer_tcp);
    BSON_ASSERT_PARAM (error);
 
    if (rr_type == MONGOC_RR_SRV) {


### PR DESCRIPTION
# Summary

Add option to prefer TCP for SRV lookup.

Checks for the environment variable `MONGOC_SRV_PREFER_TCP=ON`.

Verified with this [patch build](https://spruce.mongodb.com/version/665dcc280dd80b00072d4d37).

# Background & Motivation

See DRIVERS-2919 for a description of the problem this is intended to solve. DRIVERS-2919 proposes a solution for all drivers. This PR is intended as a libmongoc-only solution for the problem impacting [HELP-59749](https://jira.mongodb.org/browse/HELP-59749).

## Rejected alternatives

### Adding an option setter

Initially considered was adding an option setter:

```c
MONGOC_EXPORT (void)
mongoc_client_pool_set_srv_prefer_tcp (mongoc_client_pool_t *pool, bool value);
```

SRV lookup first occurs in `mongoc_client_pool_new_with_error`. An option setter like `mongoc_client_pool_set_ssl_opts` requires a client pool to already be constructed.

### Adding a new constructor

Also considered was a new `mongoc_client_pool_new_with_opts` constructor and new options struct:

```c
MONGOC_EXPORT (mongoc_client_pool_opts_t *)
mongoc_client_pool_opts_new (void);

MONGOC_EXPORT (void)
mongoc_client_pool_opts_destroy (mongoc_client_pool_opts_t *opts);

MONGOC_EXPORT (void)
mongoc_client_pool_opts_set_srv_prefer_tcp (mongoc_client_pool_opts_t *opts, bool value);

MONGOC_EXPORT (mongoc_client_pool_t *)
mongoc_client_pool_new_with_opts (const mongoc_uri_t *uri,
                                  mongoc_client_pool_opts_t *opts,
                                  bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT;
```

However, this breaks established patterns for passing options to the client pool. I prefer to avoid a significant API addition.

### Adding a URI option

Also considered was adding a URI option `srvPreferTCP`. This may result in a non-portable URI connection string. URIs are intended to be [portable among drivers](https://github.com/mongodb/specifications/blob/master/source/connection-string/connection-string-spec.md):

> Connection Strings should be portable