### PR TITLE
CDRIVER-5581: Add missing license attributions

### DIFF
--- a/src/common/common-macros-private.h
+++ b/src/common/common-macros-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-present MongoDB Inc.
+ * Copyright 2009-present MongoDB Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/common-macros-private.h
+++ b/src/common/common-macros-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-present MongoDB Inc.
+ * Copyright 2009-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/common-macros-private.h
+++ b/src/common/common-macros-private.h
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "common-prelude.h"
 
@@ -27,4 +42,4 @@
 #define MC_ENABLE_CONVERSION_WARNING_END
 #endif
 
-#endif
+#endif /* COMMON_MACROS_PRIVATE_H */

--- a/src/libmongoc/src/mongoc/mongoc-opts-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-opts-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-present MongoDB Inc.
+ * Copyright 2009-present MongoDB Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/libmongoc/src/mongoc/mongoc-opts-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-opts-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-present MongoDB Inc.
+ * Copyright 2009-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/libmongoc/src/mongoc/mongoc-opts-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-opts-private.h
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "mongoc-prelude.h"
 
 #ifndef MONGOC_OPTS_H

--- a/src/libmongoc/src/mongoc/mongoc-ts-pool-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-ts-pool-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-present MongoDB Inc.
+ * Copyright 2009-present MongoDB Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/libmongoc/src/mongoc/mongoc-ts-pool-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-ts-pool-private.h
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "mongoc-prelude.h"
 
 #ifndef MONGOC_TS_POOL_PRIVATE_H

--- a/src/libmongoc/src/mongoc/mongoc-ts-pool-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-ts-pool-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-present MongoDB Inc.
+ * Copyright 2009-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Added this header:
`/*
 * Copyright 2018-present MongoDB Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
 *   http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */`

To the files:
- mongoc-ts-pool-private.h
- mongoc-opts-private.h
- common/common-macros-private.h