### PR TITLE
[CDRIVER-5535] Add an +sbom-download target for getting the augmented SBOM

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -202,7 +202,6 @@ sbom-generate:
 # Requires credentials for silk access.
 sbom-download:
     FROM alpine:3.20
-    # ARG --required out
     ARG --required branch
     # Run the SilkBomb tool to download the artifact that matches the requested branch
     FROM +silkbomb

--- a/Earthfile
+++ b/Earthfile
@@ -196,26 +196,24 @@ sbom-generate:
     SAVE ARTIFACT /s/cyclonedx.sbom.json AS LOCAL etc/cyclonedx.sbom.json
 
 # sbom-download :
-#   Download an augmented SBOM from the Silk server. The `--out` argument will be
-#   the destination (on the host) where the augmented SBOM file will be written.
+#   Download an augmented SBOM from the Silk server for the given branch. Exports
+#   the artifact as /augmented-sbom.json
 #
 # Requires credentials for silk access.
-#
-# If --branch is not specified, it will be inferred from the current Git branch
 sbom-download:
     FROM alpine:3.20
     # ARG --required out
     ARG --required branch
-    # Run the SilkBomb tool to download the artifact that matches the current branch
+    # Run the SilkBomb tool to download the artifact that matches the requested branch
     FROM +silkbomb
-    LET date_cachebust=$(date +%F)
-    RUN --secret SILK_CLIENT_ID \
+    # Set --no-cache, because the remote artifact could change arbitrarily over time
+    RUN --no-cache \
+        --secret SILK_CLIENT_ID \
         --secret SILK_CLIENT_SECRET \
-        env date_cachebust=${date_cachebust} \
         silkbomb download \
             --sbom-out augmented-sbom.json \
             --silk-asset-group mongo-c-driver-${branch}
-    # Copy the downloaded file onto the host
+    # Export as /augmented-sbom.json
     SAVE ARTIFACT augmented-sbom.json
 
 # create-silk-asset-group :


### PR DESCRIPTION
This changeset progresses along CDRIVER-5535 by adding automation to obtain an augmented SBOM for a particular branch. This is a follow-up to #1594 and #1619.

This defines an Earthly target `+sbom-download` that downloads the latest augmented SBOM file from Silk baesd on the specified Git branch. This artifact is not currently used, but will be part of upcoming changes related to a new signed release archive artifact for CDRIVER-5537.