### PR TITLE
CDRIVER-4697: More efficient trace toggle

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-log.c
+++ b/src/libmongoc/src/mongoc/mongoc-log.c
@@ -39,7 +39,7 @@
 static bson_once_t once = BSON_ONCE_INIT;
 static bson_mutex_t gLogMutex;
 static mongoc_log_func_t gLogFunc = mongoc_log_default_handler;
-static bool gLogTrace = MONGOC_TRACE_ENABLED;
+bool gLogTrace = MONGOC_TRACE_ENABLED;
 static void *gLogData;
 
 static BSON_ONCE_FUN (_mongoc_ensure_mutex_once)

--- a/src/libmongoc/src/mongoc/mongoc-trace-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-trace-private.h
@@ -33,41 +33,41 @@ BSON_BEGIN_DECLS
 
 #define TRACE(msg, ...)                                                                                          \
    do {                                                                                                          \
-      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                                                \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                                   \
          mongoc_log (                                                                                            \
             MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, "TRACE: %s():%d " msg, BSON_FUNC, __LINE__, __VA_ARGS__); \
       }                                                                                                          \
    } while (0)
 #define ENTRY                                                                                           \
    do {                                                                                                 \
-      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                                       \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                          \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, "ENTRY: %s():%d", BSON_FUNC, __LINE__); \
       }                                                                                                 \
    } while (0)
 #define EXIT                                                                                            \
    do {                                                                                                 \
-      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                                       \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                          \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, " EXIT: %s():%d", BSON_FUNC, __LINE__); \
       }                                                                                                 \
       return;                                                                                           \
    } while (0)
 #define RETURN(ret)                                                                                     \
    do {                                                                                                 \
-      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                                       \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                          \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, " EXIT: %s():%d", BSON_FUNC, __LINE__); \
       }                                                                                                 \
       return ret;                                                                                       \
    } while (0)
 #define GOTO(label)                                                                                                \
    do {                                                                                                            \
-      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                                                  \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                                     \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, " GOTO: %s():%d %s", BSON_FUNC, __LINE__, #label); \
       }                                                                                                            \
       goto label;                                                                                                  \
    } while (0)
 #define DUMP_BYTES(_n, _b, _l)                               \
    do {                                                      \
-      if (MONGOC_TRACE_ENABLED && gLogTrace) {                            \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {               \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE,                 \
                      MONGOC_LOG_DOMAIN,                      \
                      "TRACE: %s():%d %s = %p [%d]",          \
@@ -81,7 +81,7 @@ BSON_BEGIN_DECLS
    } while (0)
 #define DUMP_BSON(_bson)                                               \
    do {                                                                \
-      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                      \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                         \
          char *_bson_str;                                              \
          if (_bson) {                                                  \
             _bson_str = bson_as_canonical_extended_json (_bson, NULL); \
@@ -100,7 +100,7 @@ BSON_BEGIN_DECLS
    } while (0)
 #define DUMP_IOVEC(_n, _iov, _iovcnt)                               \
    do {                                                             \
-      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                   \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                      \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE,                        \
                      MONGOC_LOG_DOMAIN,                             \
                      "TRACE: %s():%d %s = %p [%d]",                 \

--- a/src/libmongoc/src/mongoc/mongoc-trace-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-trace-private.h
@@ -33,41 +33,41 @@ BSON_BEGIN_DECLS
 
 #define TRACE(msg, ...)                                                                                          \
    do {                                                                                                          \
-      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                                   \
+      if (_mongoc_log_trace_is_enabled ()) {                                                                   \
          mongoc_log (                                                                                            \
             MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, "TRACE: %s():%d " msg, BSON_FUNC, __LINE__, __VA_ARGS__); \
       }                                                                                                          \
    } while (0)
 #define ENTRY                                                                                           \
    do {                                                                                                 \
-      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                          \
+      if (_mongoc_log_trace_is_enabled ()) {                                                          \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, "ENTRY: %s():%d", BSON_FUNC, __LINE__); \
       }                                                                                                 \
    } while (0)
 #define EXIT                                                                                            \
    do {                                                                                                 \
-      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                          \
+      if (_mongoc_log_trace_is_enabled ()) {                                                          \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, " EXIT: %s():%d", BSON_FUNC, __LINE__); \
       }                                                                                                 \
       return;                                                                                           \
    } while (0)
 #define RETURN(ret)                                                                                     \
    do {                                                                                                 \
-      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                          \
+      if (_mongoc_log_trace_is_enabled ()) {                                                          \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, " EXIT: %s():%d", BSON_FUNC, __LINE__); \
       }                                                                                                 \
       return ret;                                                                                       \
    } while (0)
 #define GOTO(label)                                                                                                \
    do {                                                                                                            \
-      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                                     \
+      if (_mongoc_log_trace_is_enabled ()) {                                                                     \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, " GOTO: %s():%d %s", BSON_FUNC, __LINE__, #label); \
       }                                                                                                            \
       goto label;                                                                                                  \
    } while (0)
 #define DUMP_BYTES(_n, _b, _l)                               \
    do {                                                      \
-      if (MONGOC_TRACE_ENABLED && gLogTrace) {               \
+      if (_mongoc_log_trace_is_enabled ()) {               \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE,                 \
                      MONGOC_LOG_DOMAIN,                      \
                      "TRACE: %s():%d %s = %p [%d]",          \
@@ -81,7 +81,7 @@ BSON_BEGIN_DECLS
    } while (0)
 #define DUMP_BSON(_bson)                                               \
    do {                                                                \
-      if (MONGOC_TRACE_ENABLED && gLogTrace) {                         \
+      if (_mongoc_log_trace_is_enabled ()) {                         \
          char *_bson_str;                                              \
          if (_bson) {                                                  \
             _bson_str = bson_as_canonical_extended_json (_bson, NULL); \
@@ -100,7 +100,7 @@ BSON_BEGIN_DECLS
    } while (0)
 #define DUMP_IOVEC(_n, _iov, _iovcnt)                               \
    do {                                                             \
-      if (MONGOC_TRACE_ENABLED && gLogTrace) {                      \
+      if (_mongoc_log_trace_is_enabled ()) {                      \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE,                        \
                      MONGOC_LOG_DOMAIN,                             \
                      "TRACE: %s():%d %s = %p [%d]",                 \

--- a/src/libmongoc/src/mongoc/mongoc-trace-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-trace-private.h
@@ -33,41 +33,41 @@ BSON_BEGIN_DECLS
 
 #define TRACE(msg, ...)                                                                                          \
    do {                                                                                                          \
-      if (_mongoc_log_trace_is_enabled ()) {                                                                   \
+      if (_mongoc_log_trace_is_enabled ()) {                                                                     \
          mongoc_log (                                                                                            \
             MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, "TRACE: %s():%d " msg, BSON_FUNC, __LINE__, __VA_ARGS__); \
       }                                                                                                          \
    } while (0)
 #define ENTRY                                                                                           \
    do {                                                                                                 \
-      if (_mongoc_log_trace_is_enabled ()) {                                                          \
+      if (_mongoc_log_trace_is_enabled ()) {                                                            \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, "ENTRY: %s():%d", BSON_FUNC, __LINE__); \
       }                                                                                                 \
    } while (0)
 #define EXIT                                                                                            \
    do {                                                                                                 \
-      if (_mongoc_log_trace_is_enabled ()) {                                                          \
+      if (_mongoc_log_trace_is_enabled ()) {                                                            \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, " EXIT: %s():%d", BSON_FUNC, __LINE__); \
       }                                                                                                 \
       return;                                                                                           \
    } while (0)
 #define RETURN(ret)                                                                                     \
    do {                                                                                                 \
-      if (_mongoc_log_trace_is_enabled ()) {                                                          \
+      if (_mongoc_log_trace_is_enabled ()) {                                                            \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, " EXIT: %s():%d", BSON_FUNC, __LINE__); \
       }                                                                                                 \
       return ret;                                                                                       \
    } while (0)
 #define GOTO(label)                                                                                                \
    do {                                                                                                            \
-      if (_mongoc_log_trace_is_enabled ()) {                                                                     \
+      if (_mongoc_log_trace_is_enabled ()) {                                                                       \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, " GOTO: %s():%d %s", BSON_FUNC, __LINE__, #label); \
       }                                                                                                            \
       goto label;                                                                                                  \
    } while (0)
 #define DUMP_BYTES(_n, _b, _l)                               \
    do {                                                      \
-      if (_mongoc_log_trace_is_enabled ()) {               \
+      if (_mongoc_log_trace_is_enabled ()) {                 \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE,                 \
                      MONGOC_LOG_DOMAIN,                      \
                      "TRACE: %s():%d %s = %p [%d]",          \
@@ -81,7 +81,7 @@ BSON_BEGIN_DECLS
    } while (0)
 #define DUMP_BSON(_bson)                                               \
    do {                                                                \
-      if (_mongoc_log_trace_is_enabled ()) {                         \
+      if (_mongoc_log_trace_is_enabled ()) {                           \
          char *_bson_str;                                              \
          if (_bson) {                                                  \
             _bson_str = bson_as_canonical_extended_json (_bson, NULL); \
@@ -100,7 +100,7 @@ BSON_BEGIN_DECLS
    } while (0)
 #define DUMP_IOVEC(_n, _iov, _iovcnt)                               \
    do {                                                             \
-      if (_mongoc_log_trace_is_enabled ()) {                      \
+      if (_mongoc_log_trace_is_enabled ()) {                        \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE,                        \
                      MONGOC_LOG_DOMAIN,                             \
                      "TRACE: %s():%d %s = %p [%d]",                 \

--- a/src/libmongoc/src/mongoc/mongoc-trace-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-trace-private.h
@@ -31,43 +31,46 @@
 
 BSON_BEGIN_DECLS
 
+// `gLogTrace` determines if tracing is enabled at runtime.
+extern bool gLogTrace;
+
 #define TRACE(msg, ...)                                                                                          \
    do {                                                                                                          \
-      if (_mongoc_log_trace_is_enabled ()) {                                                                     \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                                   \
          mongoc_log (                                                                                            \
             MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, "TRACE: %s():%d " msg, BSON_FUNC, __LINE__, __VA_ARGS__); \
       }                                                                                                          \
    } while (0)
 #define ENTRY                                                                                           \
    do {                                                                                                 \
-      if (_mongoc_log_trace_is_enabled ()) {                                                            \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                          \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, "ENTRY: %s():%d", BSON_FUNC, __LINE__); \
       }                                                                                                 \
    } while (0)
 #define EXIT                                                                                            \
    do {                                                                                                 \
-      if (_mongoc_log_trace_is_enabled ()) {                                                            \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                          \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, " EXIT: %s():%d", BSON_FUNC, __LINE__); \
       }                                                                                                 \
       return;                                                                                           \
    } while (0)
 #define RETURN(ret)                                                                                     \
    do {                                                                                                 \
-      if (_mongoc_log_trace_is_enabled ()) {                                                            \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                          \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, " EXIT: %s():%d", BSON_FUNC, __LINE__); \
       }                                                                                                 \
       return ret;                                                                                       \
    } while (0)
 #define GOTO(label)                                                                                                \
    do {                                                                                                            \
-      if (_mongoc_log_trace_is_enabled ()) {                                                                       \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                                     \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, " GOTO: %s():%d %s", BSON_FUNC, __LINE__, #label); \
       }                                                                                                            \
       goto label;                                                                                                  \
    } while (0)
 #define DUMP_BYTES(_n, _b, _l)                               \
    do {                                                      \
-      if (_mongoc_log_trace_is_enabled ()) {                 \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {               \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE,                 \
                      MONGOC_LOG_DOMAIN,                      \
                      "TRACE: %s():%d %s = %p [%d]",          \
@@ -81,7 +84,7 @@ BSON_BEGIN_DECLS
    } while (0)
 #define DUMP_BSON(_bson)                                               \
    do {                                                                \
-      if (_mongoc_log_trace_is_enabled ()) {                           \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                         \
          char *_bson_str;                                              \
          if (_bson) {                                                  \
             _bson_str = bson_as_canonical_extended_json (_bson, NULL); \
@@ -100,7 +103,7 @@ BSON_BEGIN_DECLS
    } while (0)
 #define DUMP_IOVEC(_n, _iov, _iovcnt)                               \
    do {                                                             \
-      if (_mongoc_log_trace_is_enabled ()) {                        \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                      \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE,                        \
                      MONGOC_LOG_DOMAIN,                             \
                      "TRACE: %s():%d %s = %p [%d]",                 \

--- a/src/libmongoc/src/mongoc/mongoc-trace-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-trace-private.h
@@ -33,41 +33,41 @@ BSON_BEGIN_DECLS
 
 #define TRACE(msg, ...)                                                                                          \
    do {                                                                                                          \
-      if (MONGOC_TRACE_ENABLED) {                                                                                \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                                                \
          mongoc_log (                                                                                            \
             MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, "TRACE: %s():%d " msg, BSON_FUNC, __LINE__, __VA_ARGS__); \
       }                                                                                                          \
    } while (0)
 #define ENTRY                                                                                           \
    do {                                                                                                 \
-      if (MONGOC_TRACE_ENABLED) {                                                                       \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                                       \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, "ENTRY: %s():%d", BSON_FUNC, __LINE__); \
       }                                                                                                 \
    } while (0)
 #define EXIT                                                                                            \
    do {                                                                                                 \
-      if (MONGOC_TRACE_ENABLED) {                                                                       \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                                       \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, " EXIT: %s():%d", BSON_FUNC, __LINE__); \
       }                                                                                                 \
       return;                                                                                           \
    } while (0)
 #define RETURN(ret)                                                                                     \
    do {                                                                                                 \
-      if (MONGOC_TRACE_ENABLED) {                                                                       \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                                       \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, " EXIT: %s():%d", BSON_FUNC, __LINE__); \
       }                                                                                                 \
       return ret;                                                                                       \
    } while (0)
 #define GOTO(label)                                                                                                \
    do {                                                                                                            \
-      if (MONGOC_TRACE_ENABLED) {                                                                                  \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                                                  \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, " GOTO: %s():%d %s", BSON_FUNC, __LINE__, #label); \
       }                                                                                                            \
       goto label;                                                                                                  \
    } while (0)
 #define DUMP_BYTES(_n, _b, _l)                               \
    do {                                                      \
-      if (MONGOC_TRACE_ENABLED) {                            \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                            \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE,                 \
                      MONGOC_LOG_DOMAIN,                      \
                      "TRACE: %s():%d %s = %p [%d]",          \
@@ -81,7 +81,7 @@ BSON_BEGIN_DECLS
    } while (0)
 #define DUMP_BSON(_bson)                                               \
    do {                                                                \
-      if (MONGOC_TRACE_ENABLED) {                                      \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                      \
          char *_bson_str;                                              \
          if (_bson) {                                                  \
             _bson_str = bson_as_canonical_extended_json (_bson, NULL); \
@@ -100,7 +100,7 @@ BSON_BEGIN_DECLS
    } while (0)
 #define DUMP_IOVEC(_n, _iov, _iovcnt)                               \
    do {                                                             \
-      if (MONGOC_TRACE_ENABLED) {                                   \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                   \
          mongoc_log (MONGOC_LOG_LEVEL_TRACE,                        \
                      MONGOC_LOG_DOMAIN,                             \
                      "TRACE: %s():%d %s = %p [%d]",                 \


### PR DESCRIPTION
Updated:
`if (MONGOC_TRACE_ENABLED)`
to
`if (MONGOC_TRACE_ENABLED && gLogTrace)`
via [_mongoc_log_trace_is_enabled](https://github.com/vector-of-bool/mongo-c-driver/blob/master/src/libmongoc/src/mongoc/mongoc-log.c#L64) which has the same logic.