### PR TITLE
sync w:0 client bulk write command monitoring test

### DIFF
--- a/src/libmongoc/tests/json/command-logging-and-monitoring/monitoring/unacknowledged-client-bulkWrite.json
+++ b/src/libmongoc/tests/json/command-logging-and-monitoring/monitoring/unacknowledged-client-bulkWrite.json
@@ -1,10 +1,16 @@
 {
   "description": "unacknowledged-client-bulkWrite",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.7",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "8.0"
+    }
+  ],
   "createEntities": [
     {
       "client": {
         "id": "client",
+        "useMultipleMongoses": false,
         "observeEvents": [
           "commandStartedEvent",
           "commandSucceededEvent",
@@ -112,11 +118,37 @@
               "$$unsetOrMatches": {}
             }
           }
+        },
+        {
+          "object": "collection",
+          "name": "find",
+          "arguments": {
+            "filter": {}
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 333
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
         }
       ],
       "expectEvents": [
         {
           "client": "client",
+          "ignoreExtraEvents": true,
           "events": [
             {
               "commandStartedEvent": {


### PR DESCRIPTION
Syncs changes from https://github.com/mongodb/specifications/pull/1598. C is the only driver that currently runs this test, so no language-specific tickets were generated for this change.

full patch: https://spruce.mongodb.com/version/666219ab935800000809786e/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC