### PR TITLE
[CDRIVER-5537] A Signed Release Archive + Augmented SBOM Publication

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -197,7 +197,7 @@ signing-pubkey:
 
 # sign-file :
 #   Sign an arbitrary file. This uses internal MongoDB tools and requires authentication
-#   to be used access them. (Refer to dev docs)
+#   to be used to access them. (Refer to dev docs)
 sign-file:
     # Pull from Garasign:
     FROM artifactory.corp.mongodb.com/release-tools-container-registry-local/garasign-gpg

--- a/Earthfile
+++ b/Earthfile
@@ -202,7 +202,6 @@ sbom-generate:
 # Requires credentials for silk access.
 sbom-download:
     FROM alpine:3.20
-    # ARG --required out
     ARG --required branch
     # Run the SilkBomb tool to download the artifact that matches the requested branch
     FROM +silkbomb

--- a/Earthfile
+++ b/Earthfile
@@ -196,26 +196,24 @@ sbom-generate:
     SAVE ARTIFACT /s/cyclonedx.sbom.json AS LOCAL etc/cyclonedx.sbom.json
 
 # sbom-download :
-#   Download an augmented SBOM from the Silk server. The `--out` argument will be
-#   the destination (on the host) where the augmented SBOM file will be written.
+#   Download an augmented SBOM from the Silk server for the given branch. Exports
+#   the artifact as /augmented-sbom.json
 #
 # Requires credentials for silk access.
-#
-# If --branch is not specified, it will be inferred from the current Git branch
 sbom-download:
     FROM alpine:3.20
     # ARG --required out
     ARG --required branch
-    # Run the SilkBomb tool to download the artifact that matches the current branch
+    # Run the SilkBomb tool to download the artifact that matches the requested branch
     FROM +silkbomb
-    LET date_cachebust=$(date +%F)
-    RUN --secret SILK_CLIENT_ID \
+    # Set --no-cache, because the remote artifact could change arbitrarily over time
+    RUN --no-cache \
+        --secret SILK_CLIENT_ID \
         --secret SILK_CLIENT_SECRET \
-        env date_cachebust=${date_cachebust} \
         silkbomb download \
             --sbom-out augmented-sbom.json \
             --silk-asset-group mongo-c-driver-${branch}
-    # Copy the downloaded file onto the host
+    # Export as /augmented-sbom.json
     SAVE ARTIFACT augmented-sbom.json
 
 # create-silk-asset-group :

--- a/docs/dev/conf.py
+++ b/docs/dev/conf.py
@@ -7,6 +7,12 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 from pathlib import Path
+import re
+from typing import Callable
+
+from sphinx import addnodes
+from sphinx.application import Sphinx
+from sphinx.environment import BuildEnvironment
 
 THIS_FILE = Path(__file__).resolve()
 THIS_DIR = THIS_FILE.parent
@@ -23,6 +29,7 @@ release = (REPO_ROOT / "VERSION_CURRENT").read_text().strip()
 extensions = []
 templates_path = []
 exclude_patterns = []
+default_role = "any"
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
@@ -35,3 +42,59 @@ rst_prolog = rf"""
 .. role:: bash(code)
     :language: bash
 """
+
+
+def annotator(
+    annot: str,
+) -> Callable[[BuildEnvironment, str, addnodes.desc_signature], str]:
+    """
+    Create a parse_node function that adds a parenthesized annotation to an object signature.
+    """
+
+    def parse_node(
+        env: BuildEnvironment, sig: str, signode: addnodes.desc_signature
+    ) -> str:
+        signode += addnodes.desc_name(sig, sig)
+        signode += addnodes.desc_sig_space()
+        signode += addnodes.desc_annotation("", f"({annot})")
+        return sig
+
+    return parse_node
+
+
+def parse_earthly_artifact(
+    env: BuildEnvironment, sig: str, signode: addnodes.desc_signature
+) -> str:
+    """
+    Parse and render the signature of an '.. earthly-artifact::' signature"""
+    mat = re.match(r"(?P<target>\+.+?)(?P<path>/.*)$", sig)
+    if not mat:
+        raise RuntimeError(
+            f"Invalid earthly-artifact signature: {sig!r} (expected “+<target>/<path> string)"
+        )
+    signode += addnodes.desc_addname(mat["target"], mat["target"])
+    signode += addnodes.desc_name(mat["path"], mat["path"])
+    signode += addnodes.desc_sig_space()
+    signode += addnodes.desc_annotation("", "(Earthly Artifact)")
+    return sig
+
+
+def setup(app: Sphinx):
+    app.add_object_type(  # type: ignore
+        "earthly-target",
+        "earthly-target",
+        indextemplate="pair: earthly target; %s",
+        parse_node=annotator("Earthly target"),
+    )
+    app.add_object_type(  # type: ignore
+        "script",
+        "script",
+        indextemplate="pair: shell script; %s",
+        parse_node=annotator("shell script"),
+    )
+    app.add_object_type(  # type: ignore
+        "earthly-artifact",
+        "earthly-artifact",
+        indextemplate="pair: earthly artifact; %s",
+        parse_node=parse_earthly_artifact,
+    )

--- a/docs/dev/earthly.rst
+++ b/docs/dev/earthly.rst
@@ -227,7 +227,7 @@ enumerated using ``earthly ls`` or ``earthly doc`` in the root of the repository
 .. _earthly.secrets:
 
 Setting Earthly Secrets
-=======================
+***********************
 
 Some of the above targets require defining `earthly secrets`_\
 [#creds]_.

--- a/docs/dev/earthly.rst
+++ b/docs/dev/earthly.rst
@@ -96,7 +96,8 @@ enumerated using ``earthly ls`` or ``earthly doc`` in the root of the repository
 
    .. option:: --version <version>
 
-      Forwarded to `+release-archive --version`. Only affects output filenames.
+      Forwarded to `+release-archive --version` and used to name the artifact
+      files in `+signed-release/dist/`.
 
    .. rubric:: Secrets
 

--- a/docs/dev/earthly.rst
+++ b/docs/dev/earthly.rst
@@ -90,14 +90,20 @@ enumerated using ``earthly ls`` or ``earthly doc`` in the root of the repository
       are based on the `--version` argument.
 
    .. rubric:: Parameters
-   .. option:: --branch <branch>
+   .. option:: --sbom_branch <branch>
 
-      Forwarded to `+release-archive --branch` and `+sbom-download --branch`
+      Forwarded to `+release-archive --sbom_branch`
 
    .. option:: --version <version>
 
-      Forwarded to `+release-archive --version` and used to name the artifact
-      files in `+signed-release/dist/`.
+      Affects the output filename and archive prefix paths in
+      `+signed-release/dist/` and sets the default value for `--ref`.
+
+   .. option:: --ref <git-ref>
+
+      Specify the git revision to be archived. Forwarded to
+      `+release-archive --ref`. If unspecified, archives the Git tag
+      corresponding to `--version`.
 
    .. rubric:: Secrets
 
@@ -119,7 +125,11 @@ enumerated using ``earthly ls`` or ``earthly doc`` in the root of the repository
       `+sbom-download/augmented-sbom.json` artifact.
 
    .. rubric:: Parameters
-   .. option:: --branch <branch>
+   .. option:: --sbom_branch <branch>
+
+      Forwarded as `+sbom-download --branch` to download the augmented SBOM.
+
+   .. option:: --ref <git-ref>
 
       Specifies the Git revision that is used when we use ``git archive`` to
       generate the repository archive snapshot. Use of ``git archive`` ensures
@@ -127,14 +137,11 @@ enumerated using ``earthly ls`` or ``earthly doc`` in the root of the repository
       include local changes and ignored files). This also allows a release
       snapshot to be taken for a non-active branch.
 
-      Forwarded as `+sbom-download --branch` to download the augmented
-      SBOM.
+   .. option:: --prefix <path>
 
-   .. option:: --version <version>
-
-      Specify a version number to appear in the generated filepaths. This has no
-      effect on the files archived, which is selected by
-      `+release-archive --branch`.
+      Specify a filepath prefix to appear in the generated filepaths. This has
+      no effect on the files archived, which is selected by
+      `+release-archive --ref`.
 
 
 .. program:: +sbom-download

--- a/docs/dev/earthly.rst
+++ b/docs/dev/earthly.rst
@@ -152,7 +152,7 @@ enumerated using ``earthly ls`` or ``earthly doc`` in the root of the repository
    .. option:: --branch <branch>
 
       **Required**. Specifies the branch of the repository from which we are
-      requested an SBOM.
+      requesting an SBOM.
 
       .. note::
 
@@ -183,7 +183,7 @@ enumerated using ``earthly ls`` or ``earthly doc`` in the root of the repository
    .. option:: --file <filepath>
 
       **Required**. Specify a path to a file (on the host) to be signed. This
-      file must be a descendent of the directory that contains the ``Earthfile``
+      file must be a descendant of the directory that contains the ``Earthfile``
       and must not be excluded by an ``.earthlyignore`` file (it is copied
       into the container using the COPY__ command.)
 

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -20,6 +20,7 @@ the mongo-c-driver project directory:
 .. toctree::
 
    debian
+   earthly
 
 .. Add the `releasing` page to a hidden toctree. We don't want to include it
    directly in a visible toctree because the top-level sections would render inline

--- a/docs/dev/releasing.rst
+++ b/docs/dev/releasing.rst
@@ -278,14 +278,15 @@ Once these prerequesites are met, creating the release archive can be done using
 the :any:`+signed-release` target. Let `$BRANCH` be the name of the Git branch
 from which the release is being made::
 
-   $ ./tools/earthly.sh --artifact +signed-release/dist dist --branch=$BRANCH --version=$NEW_VERSION
+   $ ./tools/earthly.sh --artifact +signed-release/dist dist --sbom_branch=$BRANCH --version=$NEW_VERSION
 
 The above command will create a `dist/` directory in the working directory that
-contains the release artifacts for specified branch from the
-:any:`+signed-release/dist/` directory artifact. The generated filenames are
-based on the :any:`+signed-release --version` argument. The detached PGP
-signature is the file with the `.asc` extension and corresponds to the archive
-file with the same name without the `.asc` suffix.
+contains the release artifacts from the :any:`+signed-release/dist/` directory
+artifact. The generated filenames are based on the
+:any:`+signed-release --version` argument. The archive contenst come from the
+Git tag corresponding to the specified version. The detached PGP signature is
+the file with the `.asc` extension and corresponds to the archive file with the
+same name without the `.asc` suffix.
 
 .. code-block::
    :caption: Example :any:`+signed-release` output with `$NEW_VERSION="1.27.2"`

--- a/docs/dev/releasing.rst
+++ b/docs/dev/releasing.rst
@@ -271,9 +271,8 @@ running :any:`+signed-release`, one will need to set up some environment that is
 required for it to succeed:
 
 1. :ref:`Authenticate with Artifactory <earthly.artifactory-auth>`
-2. Set the following Earthly secrets: :envvar:`GRS_CONFIG_USER1_PASSWORD`,
-   :envvar:`GRS_CONFIG_USER1_USERNAME`, :envvar:`SILK_CLIENT_ID`, and
-   :envvar:`SILK_CLIENT_SECRET`.
+2. Set the Earthly secrets required for the :any:`+sign-file` and
+   :any:`+sbom-download` targets.
 
 Once these prerequesites are met, creating the release archive can be done using
 the :any:`+signed-release` target. Let `$BRANCH` be the name of the Git branch
@@ -282,10 +281,11 @@ from which the release is being made::
    $ ./tools/earthly.sh --artifact +signed-release/dist dist --branch=$BRANCH --version=$NEW_VERSION
 
 The above command will create a `dist/` directory in the working directory that
-contains the release artifacts for specified branch. The generated filenames are
-based on the `--version` argument. The detached PGP signature is the file with
-the `.asc` extension and corresponds to the archive file with the same name
-without the `.asc` suffix.
+contains the release artifacts for specified branch from the
+:any:`+signed-release/dist/` directory artifact. The generated filenames are
+based on the :any:`+signed-release --version` argument. The detached PGP
+signature is the file with the `.asc` extension and corresponds to the archive
+file with the same name without the `.asc` suffix.
 
 .. code-block::
    :caption: Example :any:`+signed-release` output with `$NEW_VERSION="1.27.2"`
@@ -305,7 +305,7 @@ Attach the Release Artifacts
 
 In the :ref:`do.upload` step, a GitHub release was created. Navigate to that
 GitHub release and edit the release to attach additional artifacts. Attach the
-created ``.tar.gz`` and ``.tar.gz.asc`` files to the newly created release.
+files from :any:`+signed-release/dist/` to the newly created release.
 
 
 Publish Documentation

--- a/docs/dev/releasing.rst
+++ b/docs/dev/releasing.rst
@@ -220,6 +220,8 @@ yet: That step will be handled automatically by the release script in the next
 steps.
 
 
+.. _do.upload:
+
 Sign & Upload the Release
 *************************
 
@@ -242,6 +244,68 @@ to post the release to GitHub:
 Update the ``VERSION_CURRENT`` file on the release branch::
 
    $ python $CDRIVER_TOOLS/release.py post_release_bump
+
+
+Publish Additional Artifacts
+****************************
+
+.. note::
+
+   This is currently a manual additional process, but may be automated to be
+   part of the release scripts in the future.
+
+We publish a release archive that contains a snapshot of the repository and some
+additional metadata, along with an OpenPGP signature of that archive. This
+archive is created using scripts in the C driver repository itself, not in
+`$CDRIVER_TOOLS`.
+
+
+.. _releasing.gen-archive:
+
+Generate the Release Artifacts
+==============================
+
+The release artifacts are generated using :doc:`Earthly <earthly>`.
+Specifically, it is generated using the :any:`+signed-release` target. Before
+running :any:`+signed-release`, one will need to set up some environment that is
+required for it to succeed:
+
+1. :ref:`Authenticate with Artifactory <earthly.artifactory-auth>`
+2. Set the following Earthly secrets: :envvar:`GRS_CONFIG_USER1_PASSWORD`,
+   :envvar:`GRS_CONFIG_USER1_USERNAME`, :envvar:`SILK_CLIENT_ID`, and
+   :envvar:`SILK_CLIENT_SECRET`.
+
+Once these prerequesites are met, creating the release archive can be done using
+the :any:`+signed-release` target. Let `$BRANCH` be the name of the Git branch
+from which the release is being made::
+
+   $ ./tools/earthly.sh --artifact +signed-release/dist dist --branch=$BRANCH --version=$NEW_VERSION
+
+The above command will create a `dist/` directory in the working directory that
+contains the release artifacts for specified branch. The generated filenames are
+based on the `--version` argument. The detached PGP signature is the file with
+the `.asc` extension and corresponds to the archive file with the same name
+without the `.asc` suffix.
+
+.. code-block::
+   :caption: Example :any:`+signed-release` output with `$NEW_VERSION="1.27.2"`
+
+   $ ls dist/
+   mongo-c-driver-1.27.2.tar.gz
+   mongo-c-driver-1.27.2.tar.gz.asc
+
+.. note::
+
+   The public key that corresponds to the signature is available at
+   https://pgp.mongodb.com/c-driver.pub
+
+
+Attach the Release Artifacts
+============================
+
+In the :ref:`do.upload` step, a GitHub release was created. Navigate to that
+GitHub release and edit the release to attach additional artifacts. Attach the
+created ``.tar.gz`` and ``.tar.gz.asc`` files to the newly created release.
 
 
 Publish Documentation
@@ -281,7 +345,7 @@ Create a new branch from the C driver ``master`` branch, which will be used to
 publish a PR to merge the updates to the release files back into ``master``::
 
    $ git checkout master
-   $ git checkout post-release-merge
+   $ git checkout -b post-release-merge
 
 (Here we have named the branch ``post-release-merge``, but the branch name is
 arbitrary.)


### PR DESCRIPTION
# Summary 

This changeset re-introduces a release archive process as part of the release process. This is significantly simplified from the old `makedist` archive, and is mostly just an archive produced by Git with some additional goodies, with more to be added in later changes.

## What's Included

- New Earthly targets are added to automate aspects of the release process, including generation of the source archive and signing thereof. Currently, this creates an unfortunate split of the release tools between the c-driver-tools repo and this repository, but it is anticipated that future changes will progressively migrate additional components from the c-driver-tools repo back into the main source repository.
- More documentation has been added on using Earthly and the Earthfile targets, hopefully to accelerate future onboarding and troubleshooting for those that don't work with Earthly on a daily basis. Using separate documentation from the inline comments in the `Earthfile` allows for far more comprehensive descriptions of what is possible.
- A new semi-automated step has been introduced in the release process that utilizes the new Earthly targets to attach additional artifacts to the GitHub release for the C driver. This includes the new release archive, as well as a detached PGP signature, satisfying the requirements of CDRIVER-5537.
- In addition to the source repository, the release archive also includes the augmented SBOM, which is downloaded on-the fly as part of the archive generation. This will satisfy the requirements of CDRIVER-5535.

## Other Notes

- This PR builds upon the #1629 changes, so its commits are included in the commit history here, but can be ignored.
- The choice of Earthly was primarily made to just extend "what we already have" and to ensure isolation and uniformity of execution across different systems, but it was found that Earthly's secret-handling functionality is extremely convenient for these processes!
- No new EVG tasks are defined.