### PR TITLE
CDRIVER-4820 check return values of `bson_snprintf`

### DIFF
--- a/src/libbson/src/bson/bson-decimal128.c
+++ b/src/libbson/src/bson/bson-decimal128.c
@@ -269,7 +269,8 @@ bson_decimal128_to_string (const bson_decimal128_t *dec, /* IN  */
       }
       /* Exponent */
       *(str_out++) = 'E';
-      bson_snprintf (str_out, 6, "%+d", scientific_exponent);
+      int req = bson_snprintf (str_out, 6, "%+d", scientific_exponent);
+      BSON_ASSERT (req > 0);
    } else {
       /* Regular format with no decimal place */
       if (exponent >= 0) {

--- a/src/libbson/src/bson/bson-decimal128.c
+++ b/src/libbson/src/bson/bson-decimal128.c
@@ -269,7 +269,7 @@ bson_decimal128_to_string (const bson_decimal128_t *dec, /* IN  */
       }
       /* Exponent */
       *(str_out++) = 'E';
-      // Truncation is OK. 
+      // Truncation is OK.
       int req = bson_snprintf (str_out, 6, "%+d", scientific_exponent);
       BSON_ASSERT (req > 0);
    } else {

--- a/src/libbson/src/bson/bson-decimal128.c
+++ b/src/libbson/src/bson/bson-decimal128.c
@@ -269,6 +269,7 @@ bson_decimal128_to_string (const bson_decimal128_t *dec, /* IN  */
       }
       /* Exponent */
       *(str_out++) = 'E';
+      // Truncation is OK. Assert no error occurred.
       int req = bson_snprintf (str_out, 6, "%+d", scientific_exponent);
       BSON_ASSERT (req > 0);
    } else {

--- a/src/libbson/src/bson/bson-decimal128.c
+++ b/src/libbson/src/bson/bson-decimal128.c
@@ -269,7 +269,7 @@ bson_decimal128_to_string (const bson_decimal128_t *dec, /* IN  */
       }
       /* Exponent */
       *(str_out++) = 'E';
-      // Truncation is OK. Assert no error occurred.
+      // Truncation is OK. 
       int req = bson_snprintf (str_out, 6, "%+d", scientific_exponent);
       BSON_ASSERT (req > 0);
    } else {

--- a/src/libbson/src/bson/bson-keys.c
+++ b/src/libbson/src/bson/bson-keys.c
@@ -143,9 +143,8 @@ bson_uint32_to_string (uint32_t value,      /* IN */
    *strptr = str;
 
    int ret = bson_snprintf (str, size, "%u", value);
-   // Truncation is OK. Assert no error occurred.
+   // Truncation is OK. 
    BSON_ASSERT (ret > 0);
-   // Check in bounds of a size_t.
    BSON_ASSERT (bson_in_range_size_t_signed (ret));
-   return (int) ret;
+   return (size_t) ret;
 }

--- a/src/libbson/src/bson/bson-keys.c
+++ b/src/libbson/src/bson/bson-keys.c
@@ -143,7 +143,9 @@ bson_uint32_to_string (uint32_t value,      /* IN */
    *strptr = str;
 
    int ret = bson_snprintf (str, size, "%u", value);
+   // Truncation is OK. Assert no error occurred.
    BSON_ASSERT (ret > 0);
+   // Check in bounds of a size_t.
    BSON_ASSERT (bson_in_range_size_t_signed (ret));
    return (int) ret;
 }

--- a/src/libbson/src/bson/bson-keys.c
+++ b/src/libbson/src/bson/bson-keys.c
@@ -19,6 +19,7 @@
 
 #include <bson/bson-keys.h>
 #include <bson/bson-string.h>
+#include <bson/bson-cmp.h>
 
 
 static const char *gUint32Strs[] = {
@@ -141,5 +142,8 @@ bson_uint32_to_string (uint32_t value,      /* IN */
 
    *strptr = str;
 
-   return bson_snprintf (str, size, "%u", value);
+   int ret = bson_snprintf (str, size, "%u", value);
+   BSON_ASSERT (ret > 0);
+   BSON_ASSERT (bson_in_range_size_t_signed (ret));
+   return (int) ret;
 }

--- a/src/libbson/src/bson/bson-keys.c
+++ b/src/libbson/src/bson/bson-keys.c
@@ -143,7 +143,7 @@ bson_uint32_to_string (uint32_t value,      /* IN */
    *strptr = str;
 
    int ret = bson_snprintf (str, size, "%u", value);
-   // Truncation is OK. 
+   // Truncation is OK.
    BSON_ASSERT (ret > 0);
    BSON_ASSERT (bson_in_range_size_t_signed (ret));
    return (size_t) ret;

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -618,6 +618,8 @@ mongoc_client_connect_tcp (int32_t connecttimeoutms, const mongoc_host_list_t *h
    BSON_ASSERT (connecttimeoutms);
    BSON_ASSERT (host);
 
+   // Assert no truncation occurred.
+   // UINT16_MAX is representable in 5 characters. Add 1 for trailing NULL. `portstr` has capacity 8.
    int req = bson_snprintf (portstr, sizeof portstr, "%hu", host->port);
    BSON_ASSERT (bson_in_range_size_t_signed (req));
    BSON_ASSERT ((size_t) req < sizeof portstr);
@@ -714,6 +716,7 @@ mongoc_client_connect_unix (const mongoc_host_list_t *host, bson_error_t *error)
 
    memset (&saddr, 0, sizeof saddr);
    saddr.sun_family = AF_UNIX;
+   // TODO: check return value and return error if truncation occurs.
    int req = bson_snprintf (saddr.sun_path, sizeof saddr.sun_path - 1, "%s", host->host);
 
    if (!bson_in_range_size_t_signed (req) || (size_t) req >= sizeof saddr.sun_path - 1) {

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -716,7 +716,7 @@ mongoc_client_connect_unix (const mongoc_host_list_t *host, bson_error_t *error)
    saddr.sun_family = AF_UNIX;
    int req = bson_snprintf (saddr.sun_path, sizeof saddr.sun_path - 1, "%s", host->host);
 
-   if (bson_in_range_size_t_signed (req) || (size_t) req < sizeof saddr.sun_path - 1) {
+   if (!bson_in_range_size_t_signed (req) || (size_t) req >= sizeof saddr.sun_path - 1) {
       bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Failed to define socket address path.");
       RETURN (false);
    }

--- a/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
@@ -354,10 +354,9 @@ generate_AWS_ROLE_SESSION_NAME (bson_error_t *error)
 
    size_t i;
    for (i = 0; i < NUM_BYTES; i++) {
-      // Assert no truncation occurred. Destination is expected to fit all input.
+      // Expect no truncation. 
       int req = bson_snprintf (out + (2 * i), 3, "%02x", data[i]);
-      BSON_ASSERT (bson_in_range_size_t_signed (req));
-      BSON_ASSERT ((size_t) req < 3);
+      BSON_ASSERT (req < 3);
    }
    out[NUM_BYTES * 2] = '\0';
 

--- a/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
@@ -354,7 +354,7 @@ generate_AWS_ROLE_SESSION_NAME (bson_error_t *error)
 
    size_t i;
    for (i = 0; i < NUM_BYTES; i++) {
-      // Expect no truncation. 
+      // Expect no truncation.
       int req = bson_snprintf (out + (2 * i), 3, "%02x", data[i]);
       BSON_ASSERT (req < 3);
    }

--- a/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
@@ -354,6 +354,7 @@ generate_AWS_ROLE_SESSION_NAME (bson_error_t *error)
 
    size_t i;
    for (i = 0; i < NUM_BYTES; i++) {
+      // Assert no truncation occurred. Destination is expected to fit all input.
       int req = bson_snprintf (out + (2 * i), 3, "%02x", data[i]);
       BSON_ASSERT (bson_in_range_size_t_signed (req));
       BSON_ASSERT ((size_t) req < 3);

--- a/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
@@ -354,7 +354,9 @@ generate_AWS_ROLE_SESSION_NAME (bson_error_t *error)
 
    size_t i;
    for (i = 0; i < NUM_BYTES; i++) {
-      bson_snprintf (out + (2 * i), 3, "%02x", data[i]);
+      int req = bson_snprintf (out + (2 * i), 3, "%02x", data[i]);
+      BSON_ASSERT (bson_in_range_size_t_signed (req));
+      BSON_ASSERT ((size_t) req < 3);
    }
    out[NUM_BYTES * 2] = '\0';
 

--- a/src/libmongoc/src/mongoc/mongoc-counters.c
+++ b/src/libmongoc/src/mongoc/mongoc-counters.c
@@ -136,7 +136,8 @@ _mongoc_counters_cleanup (void)
       int pid;
 
       pid = getpid ();
-      bson_snprintf (name, sizeof name, "/mongoc-%u", pid);
+      int req = bson_snprintf (name, sizeof name, "/mongoc-%u", pid);
+      BSON_ASSERT (req > 0);
       shm_unlink (name);
 #endif
    }
@@ -168,7 +169,8 @@ mongoc_counters_alloc (size_t size)
    }
 
    pid = getpid ();
-   bson_snprintf (name, sizeof name, "/mongoc-%u", pid);
+   int req = bson_snprintf (name, sizeof name, "/mongoc-%u", pid);
+   BSON_ASSERT (req > 0);
 
 #ifndef O_NOFOLLOW
 #define O_NOFOLLOW 0

--- a/src/libmongoc/src/mongoc/mongoc-counters.c
+++ b/src/libmongoc/src/mongoc/mongoc-counters.c
@@ -136,7 +136,7 @@ _mongoc_counters_cleanup (void)
       int pid;
 
       pid = getpid ();
-      // Truncation is OK. 
+      // Truncation is OK.
       int req = bson_snprintf (name, sizeof name, "/mongoc-%u", pid);
       BSON_ASSERT (req > 0);
       shm_unlink (name);
@@ -170,7 +170,7 @@ mongoc_counters_alloc (size_t size)
    }
 
    pid = getpid ();
-   // Truncation is OK. 
+   // Truncation is OK.
    int req = bson_snprintf (name, sizeof name, "/mongoc-%u", pid);
    BSON_ASSERT (req > 0);
 

--- a/src/libmongoc/src/mongoc/mongoc-counters.c
+++ b/src/libmongoc/src/mongoc/mongoc-counters.c
@@ -136,6 +136,7 @@ _mongoc_counters_cleanup (void)
       int pid;
 
       pid = getpid ();
+      // Truncation is OK. Assert no error occurred. Not harmful to truncate.
       int req = bson_snprintf (name, sizeof name, "/mongoc-%u", pid);
       BSON_ASSERT (req > 0);
       shm_unlink (name);
@@ -169,6 +170,7 @@ mongoc_counters_alloc (size_t size)
    }
 
    pid = getpid ();
+   // Truncation is OK. Assert no error occurred. Not harmful to truncate.
    int req = bson_snprintf (name, sizeof name, "/mongoc-%u", pid);
    BSON_ASSERT (req > 0);
 

--- a/src/libmongoc/src/mongoc/mongoc-counters.c
+++ b/src/libmongoc/src/mongoc/mongoc-counters.c
@@ -136,7 +136,7 @@ _mongoc_counters_cleanup (void)
       int pid;
 
       pid = getpid ();
-      // Truncation is OK. Assert no error occurred. Not harmful to truncate.
+      // Truncation is OK. 
       int req = bson_snprintf (name, sizeof name, "/mongoc-%u", pid);
       BSON_ASSERT (req > 0);
       shm_unlink (name);
@@ -170,7 +170,7 @@ mongoc_counters_alloc (size_t size)
    }
 
    pid = getpid ();
-   // Truncation is OK. Assert no error occurred. Not harmful to truncate.
+   // Truncation is OK. 
    int req = bson_snprintf (name, sizeof name, "/mongoc-%u", pid);
    BSON_ASSERT (req > 0);
 

--- a/src/libmongoc/src/mongoc/mongoc-crypt.c
+++ b/src/libmongoc/src/mongoc/mongoc-crypt.c
@@ -166,6 +166,7 @@ _prefix_mongocryptd_error (bson_error_t *error)
 {
    char buf[sizeof (error->message)];
 
+   // Truncation is OK. Assert no error occurred. Not harmful to truncate.
    int req = bson_snprintf (buf, sizeof (buf), "mongocryptd error: %s:", error->message);
    BSON_ASSERT (req > 0);
    memcpy (error->message, buf, sizeof (buf));
@@ -176,6 +177,7 @@ _prefix_keyvault_error (bson_error_t *error)
 {
    char buf[sizeof (error->message)];
 
+   // Truncation is OK. Assert no error occurred. Not harmful to truncate.
    int req = bson_snprintf (buf, sizeof (buf), "key vault error: %s:", error->message);
    BSON_ASSERT (req > 0);
    memcpy (error->message, buf, sizeof (buf));

--- a/src/libmongoc/src/mongoc/mongoc-crypt.c
+++ b/src/libmongoc/src/mongoc/mongoc-crypt.c
@@ -166,7 +166,8 @@ _prefix_mongocryptd_error (bson_error_t *error)
 {
    char buf[sizeof (error->message)];
 
-   bson_snprintf (buf, sizeof (buf), "mongocryptd error: %s:", error->message);
+   int req = bson_snprintf (buf, sizeof (buf), "mongocryptd error: %s:", error->message);
+   BSON_ASSERT (req > 0);
    memcpy (error->message, buf, sizeof (buf));
 }
 
@@ -175,7 +176,8 @@ _prefix_keyvault_error (bson_error_t *error)
 {
    char buf[sizeof (error->message)];
 
-   bson_snprintf (buf, sizeof (buf), "key vault error: %s:", error->message);
+   int req = bson_snprintf (buf, sizeof (buf), "key vault error: %s:", error->message);
+   BSON_ASSERT (req > 0);
    memcpy (error->message, buf, sizeof (buf));
 }
 

--- a/src/libmongoc/src/mongoc/mongoc-crypt.c
+++ b/src/libmongoc/src/mongoc/mongoc-crypt.c
@@ -166,7 +166,7 @@ _prefix_mongocryptd_error (bson_error_t *error)
 {
    char buf[sizeof (error->message)];
 
-   // Truncation is OK. Assert no error occurred. Not harmful to truncate.
+   // Truncation is OK. 
    int req = bson_snprintf (buf, sizeof (buf), "mongocryptd error: %s:", error->message);
    BSON_ASSERT (req > 0);
    memcpy (error->message, buf, sizeof (buf));
@@ -177,7 +177,7 @@ _prefix_keyvault_error (bson_error_t *error)
 {
    char buf[sizeof (error->message)];
 
-   // Truncation is OK. Assert no error occurred. Not harmful to truncate.
+   // Truncation is OK. 
    int req = bson_snprintf (buf, sizeof (buf), "key vault error: %s:", error->message);
    BSON_ASSERT (req > 0);
    memcpy (error->message, buf, sizeof (buf));

--- a/src/libmongoc/src/mongoc/mongoc-crypt.c
+++ b/src/libmongoc/src/mongoc/mongoc-crypt.c
@@ -166,7 +166,7 @@ _prefix_mongocryptd_error (bson_error_t *error)
 {
    char buf[sizeof (error->message)];
 
-   // Truncation is OK. 
+   // Truncation is OK.
    int req = bson_snprintf (buf, sizeof (buf), "mongocryptd error: %s:", error->message);
    BSON_ASSERT (req > 0);
    memcpy (error->message, buf, sizeof (buf));
@@ -177,7 +177,7 @@ _prefix_keyvault_error (bson_error_t *error)
 {
    char buf[sizeof (error->message)];
 
-   // Truncation is OK. 
+   // Truncation is OK.
    int req = bson_snprintf (buf, sizeof (buf), "key vault error: %s:", error->message);
    BSON_ASSERT (req > 0);
    memcpy (error->message, buf, sizeof (buf));

--- a/src/libmongoc/src/mongoc/mongoc-gridfs-bucket.c
+++ b/src/libmongoc/src/mongoc/mongoc-gridfs-bucket.c
@@ -108,7 +108,7 @@ mongoc_gridfs_bucket_new (mongoc_database_t *db,
 
    int req = bson_snprintf (buf, sizeof (buf), "%s.chunks", gridfs_opts.bucketName);
    if (!bson_in_range_size_t_signed (req) || (size_t) req >= sizeof (buf)) {
-            bson_set_error (error,
+      bson_set_error (error,
                       MONGOC_ERROR_COMMAND,
                       MONGOC_ERROR_COMMAND_INVALID_ARG,
                       "bucketName \"%s\" must have fewer than %d characters",
@@ -119,12 +119,12 @@ mongoc_gridfs_bucket_new (mongoc_database_t *db,
 
    req = bson_snprintf (buf, sizeof (buf), "%s.files", gridfs_opts.bucketName);
    if (!bson_in_range_size_t_signed (req) || (size_t) req >= sizeof (buf)) {
-         bson_set_error (error,
-                     MONGOC_ERROR_COMMAND,
-                     MONGOC_ERROR_COMMAND_INVALID_ARG,
-                     "bucketName \"%s\" must have fewer than %d characters",
-                     gridfs_opts.bucketName,
-                     (int) (sizeof (buf) - (strlen (".files") + 1)));
+      bson_set_error (error,
+                      MONGOC_ERROR_COMMAND,
+                      MONGOC_ERROR_COMMAND_INVALID_ARG,
+                      "bucketName \"%s\" must have fewer than %d characters",
+                      gridfs_opts.bucketName,
+                      (int) (sizeof (buf) - (strlen (".files") + 1)));
    }
    bucket->files = mongoc_database_get_collection (db, buf);
 

--- a/src/libmongoc/src/mongoc/mongoc-gridfs-bucket.c
+++ b/src/libmongoc/src/mongoc/mongoc-gridfs-bucket.c
@@ -107,7 +107,7 @@ mongoc_gridfs_bucket_new (mongoc_database_t *db,
    bucket = (mongoc_gridfs_bucket_t *) bson_malloc0 (sizeof *bucket);
 
    int req = bson_snprintf (buf, sizeof (buf), "%s.chunks", gridfs_opts.bucketName);
-   if (bson_in_range_size_t_signed (req) ||(size_t) req < sizeof (buf)) {
+   if (!bson_in_range_size_t_signed (req) || (size_t) req >= sizeof (buf)) {
             bson_set_error (error,
                       MONGOC_ERROR_COMMAND,
                       MONGOC_ERROR_COMMAND_INVALID_ARG,
@@ -118,7 +118,7 @@ mongoc_gridfs_bucket_new (mongoc_database_t *db,
    bucket->chunks = mongoc_database_get_collection (db, buf);
 
    req = bson_snprintf (buf, sizeof (buf), "%s.files", gridfs_opts.bucketName);
-   if (bson_in_range_size_t_signed (req) ||(size_t) req < sizeof (buf)) {
+   if (!bson_in_range_size_t_signed (req) || (size_t) req >= sizeof (buf)) {
          bson_set_error (error,
                      MONGOC_ERROR_COMMAND,
                      MONGOC_ERROR_COMMAND_INVALID_ARG,

--- a/src/libmongoc/src/mongoc/mongoc-gridfs-bucket.c
+++ b/src/libmongoc/src/mongoc/mongoc-gridfs-bucket.c
@@ -102,32 +102,18 @@ mongoc_gridfs_bucket_new (mongoc_database_t *db,
                       "bucketName \"%s\" must have fewer than %d characters",
                       gridfs_opts.bucketName,
                       (int) (sizeof (buf) - (strlen (".chunks") + 1)));
+      return NULL;
    }
 
    bucket = (mongoc_gridfs_bucket_t *) bson_malloc0 (sizeof *bucket);
 
-   // Return error if truncation occured.
+   // Expect no truncation from above, checking no error occurred.
    int req = bson_snprintf (buf, sizeof (buf), "%s.chunks", gridfs_opts.bucketName);
-   if (!bson_in_range_size_t_signed (req) || (size_t) req >= sizeof (buf)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "bucketName \"%s\" must have fewer than %d characters",
-                      gridfs_opts.bucketName,
-                      (int) (sizeof (buf) - (strlen (".chunks") + 1)));
-   }
+   BSON_ASSERT (req > 0);
    bucket->chunks = mongoc_database_get_collection (db, buf);
 
-   // Return error if truncation occured.
    req = bson_snprintf (buf, sizeof (buf), "%s.files", gridfs_opts.bucketName);
-   if (!bson_in_range_size_t_signed (req) || (size_t) req >= sizeof (buf)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "bucketName \"%s\" must have fewer than %d characters",
-                      gridfs_opts.bucketName,
-                      (int) (sizeof (buf) - (strlen (".files") + 1)));
-   }
+   BSON_ASSERT (req > 0);
    bucket->files = mongoc_database_get_collection (db, buf);
 
    if (gridfs_opts.writeConcern) {

--- a/src/libmongoc/src/mongoc/mongoc-gridfs-bucket.c
+++ b/src/libmongoc/src/mongoc/mongoc-gridfs-bucket.c
@@ -106,6 +106,7 @@ mongoc_gridfs_bucket_new (mongoc_database_t *db,
 
    bucket = (mongoc_gridfs_bucket_t *) bson_malloc0 (sizeof *bucket);
 
+   // Return error if truncation occured.
    int req = bson_snprintf (buf, sizeof (buf), "%s.chunks", gridfs_opts.bucketName);
    if (!bson_in_range_size_t_signed (req) || (size_t) req >= sizeof (buf)) {
       bson_set_error (error,
@@ -117,6 +118,7 @@ mongoc_gridfs_bucket_new (mongoc_database_t *db,
    }
    bucket->chunks = mongoc_database_get_collection (db, buf);
 
+   // Return error if truncation occured.
    req = bson_snprintf (buf, sizeof (buf), "%s.files", gridfs_opts.bucketName);
    if (!bson_in_range_size_t_signed (req) || (size_t) req >= sizeof (buf)) {
       bson_set_error (error,

--- a/src/libmongoc/src/mongoc/mongoc-gridfs-bucket.c
+++ b/src/libmongoc/src/mongoc/mongoc-gridfs-bucket.c
@@ -106,10 +106,26 @@ mongoc_gridfs_bucket_new (mongoc_database_t *db,
 
    bucket = (mongoc_gridfs_bucket_t *) bson_malloc0 (sizeof *bucket);
 
-   bson_snprintf (buf, sizeof (buf), "%s.chunks", gridfs_opts.bucketName);
+   int req = bson_snprintf (buf, sizeof (buf), "%s.chunks", gridfs_opts.bucketName);
+   if (bson_in_range_size_t_signed (req) ||(size_t) req < sizeof (buf)) {
+            bson_set_error (error,
+                      MONGOC_ERROR_COMMAND,
+                      MONGOC_ERROR_COMMAND_INVALID_ARG,
+                      "bucketName \"%s\" must have fewer than %d characters",
+                      gridfs_opts.bucketName,
+                      (int) (sizeof (buf) - (strlen (".chunks") + 1)));
+   }
    bucket->chunks = mongoc_database_get_collection (db, buf);
 
-   bson_snprintf (buf, sizeof (buf), "%s.files", gridfs_opts.bucketName);
+   req = bson_snprintf (buf, sizeof (buf), "%s.files", gridfs_opts.bucketName);
+   if (bson_in_range_size_t_signed (req) ||(size_t) req < sizeof (buf)) {
+         bson_set_error (error,
+                     MONGOC_ERROR_COMMAND,
+                     MONGOC_ERROR_COMMAND_INVALID_ARG,
+                     "bucketName \"%s\" must have fewer than %d characters",
+                     gridfs_opts.bucketName,
+                     (int) (sizeof (buf) - (strlen (".files") + 1)));
+   }
    bucket->files = mongoc_database_get_collection (db, buf);
 
    if (gridfs_opts.writeConcern) {

--- a/src/libmongoc/src/mongoc/mongoc-gridfs.c
+++ b/src/libmongoc/src/mongoc/mongoc-gridfs.c
@@ -116,10 +116,26 @@ _mongoc_gridfs_new (mongoc_client_t *client, const char *db, const char *prefix,
 
    gridfs->client = client;
 
-   bson_snprintf (buf, sizeof (buf), "%s.chunks", prefix);
+   int req = bson_snprintf (buf, sizeof (buf), "%s.chunks", prefix);
+   if (bson_in_range_size_t_signed (req) ||(size_t) req < sizeof (buf)) {
+         bson_set_error (error,
+                     MONGOC_ERROR_COMMAND,
+                     MONGOC_ERROR_COMMAND_INVALID_ARG,
+                     "prefix \"%s\" must have fewer than %d characters",
+                     prefix,
+                     (int) (sizeof (buf) - (strlen (".chunks") + 1)));
+   }
    gridfs->chunks = mongoc_client_get_collection (client, db, buf);
 
-   bson_snprintf (buf, sizeof (buf), "%s.files", prefix);
+   req = bson_snprintf (buf, sizeof (buf), "%s.files", prefix);
+   if (bson_in_range_size_t_signed (req) ||(size_t) req < sizeof (buf)) {
+         bson_set_error (error,
+                     MONGOC_ERROR_COMMAND,
+                     MONGOC_ERROR_COMMAND_INVALID_ARG,
+                     "prefix \"%s\" must have fewer than %d characters",
+                     prefix,
+                     (int) (sizeof (buf) - (strlen (".files") + 1)));
+   }
    gridfs->files = mongoc_client_get_collection (client, db, buf);
 
    r = _mongoc_gridfs_ensure_index (gridfs, error);

--- a/src/libmongoc/src/mongoc/mongoc-gridfs.c
+++ b/src/libmongoc/src/mongoc/mongoc-gridfs.c
@@ -116,6 +116,7 @@ _mongoc_gridfs_new (mongoc_client_t *client, const char *db, const char *prefix,
 
    gridfs->client = client;
 
+   // Return error if truncation occured.
    int req = bson_snprintf (buf, sizeof (buf), "%s.chunks", prefix);
    if (!bson_in_range_size_t_signed (req) || (size_t) req >= sizeof (buf)) {
       bson_set_error (error,
@@ -127,6 +128,7 @@ _mongoc_gridfs_new (mongoc_client_t *client, const char *db, const char *prefix,
    }
    gridfs->chunks = mongoc_client_get_collection (client, db, buf);
 
+   // Return error if truncation occured.
    req = bson_snprintf (buf, sizeof (buf), "%s.files", prefix);
    if (!bson_in_range_size_t_signed (req) || (size_t) req >= sizeof (buf)) {
       bson_set_error (error,

--- a/src/libmongoc/src/mongoc/mongoc-gridfs.c
+++ b/src/libmongoc/src/mongoc/mongoc-gridfs.c
@@ -118,23 +118,23 @@ _mongoc_gridfs_new (mongoc_client_t *client, const char *db, const char *prefix,
 
    int req = bson_snprintf (buf, sizeof (buf), "%s.chunks", prefix);
    if (!bson_in_range_size_t_signed (req) || (size_t) req >= sizeof (buf)) {
-         bson_set_error (error,
-                     MONGOC_ERROR_COMMAND,
-                     MONGOC_ERROR_COMMAND_INVALID_ARG,
-                     "prefix \"%s\" must have fewer than %d characters",
-                     prefix,
-                     (int) (sizeof (buf) - (strlen (".chunks") + 1)));
+      bson_set_error (error,
+                      MONGOC_ERROR_COMMAND,
+                      MONGOC_ERROR_COMMAND_INVALID_ARG,
+                      "prefix \"%s\" must have fewer than %d characters",
+                      prefix,
+                      (int) (sizeof (buf) - (strlen (".chunks") + 1)));
    }
    gridfs->chunks = mongoc_client_get_collection (client, db, buf);
 
    req = bson_snprintf (buf, sizeof (buf), "%s.files", prefix);
    if (!bson_in_range_size_t_signed (req) || (size_t) req >= sizeof (buf)) {
-         bson_set_error (error,
-                     MONGOC_ERROR_COMMAND,
-                     MONGOC_ERROR_COMMAND_INVALID_ARG,
-                     "prefix \"%s\" must have fewer than %d characters",
-                     prefix,
-                     (int) (sizeof (buf) - (strlen (".files") + 1)));
+      bson_set_error (error,
+                      MONGOC_ERROR_COMMAND,
+                      MONGOC_ERROR_COMMAND_INVALID_ARG,
+                      "prefix \"%s\" must have fewer than %d characters",
+                      prefix,
+                      (int) (sizeof (buf) - (strlen (".files") + 1)));
    }
    gridfs->files = mongoc_client_get_collection (client, db, buf);
 

--- a/src/libmongoc/src/mongoc/mongoc-gridfs.c
+++ b/src/libmongoc/src/mongoc/mongoc-gridfs.c
@@ -117,7 +117,7 @@ _mongoc_gridfs_new (mongoc_client_t *client, const char *db, const char *prefix,
    gridfs->client = client;
 
    int req = bson_snprintf (buf, sizeof (buf), "%s.chunks", prefix);
-   if (bson_in_range_size_t_signed (req) ||(size_t) req < sizeof (buf)) {
+   if (!bson_in_range_size_t_signed (req) || (size_t) req >= sizeof (buf)) {
          bson_set_error (error,
                      MONGOC_ERROR_COMMAND,
                      MONGOC_ERROR_COMMAND_INVALID_ARG,
@@ -128,7 +128,7 @@ _mongoc_gridfs_new (mongoc_client_t *client, const char *db, const char *prefix,
    gridfs->chunks = mongoc_client_get_collection (client, db, buf);
 
    req = bson_snprintf (buf, sizeof (buf), "%s.files", prefix);
-   if (bson_in_range_size_t_signed (req) ||(size_t) req < sizeof (buf)) {
+   if (!bson_in_range_size_t_signed (req) || (size_t) req >= sizeof (buf)) {
          bson_set_error (error,
                      MONGOC_ERROR_COMMAND,
                      MONGOC_ERROR_COMMAND_INVALID_ARG,

--- a/src/libmongoc/src/mongoc/mongoc-gridfs.c
+++ b/src/libmongoc/src/mongoc/mongoc-gridfs.c
@@ -116,28 +116,13 @@ _mongoc_gridfs_new (mongoc_client_t *client, const char *db, const char *prefix,
 
    gridfs->client = client;
 
-   // Return error if truncation occured.
+   // Expect no truncation from above, checking no error occurred.
    int req = bson_snprintf (buf, sizeof (buf), "%s.chunks", prefix);
-   if (!bson_in_range_size_t_signed (req) || (size_t) req >= sizeof (buf)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "prefix \"%s\" must have fewer than %d characters",
-                      prefix,
-                      (int) (sizeof (buf) - (strlen (".chunks") + 1)));
-   }
+   BSON_ASSERT (req > 0);
    gridfs->chunks = mongoc_client_get_collection (client, db, buf);
 
-   // Return error if truncation occured.
    req = bson_snprintf (buf, sizeof (buf), "%s.files", prefix);
-   if (!bson_in_range_size_t_signed (req) || (size_t) req >= sizeof (buf)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "prefix \"%s\" must have fewer than %d characters",
-                      prefix,
-                      (int) (sizeof (buf) - (strlen (".files") + 1)));
-   }
+   BSON_ASSERT (req > 0);
    gridfs->files = mongoc_client_get_collection (client, db, buf);
 
    r = _mongoc_gridfs_ensure_index (gridfs, error);

--- a/src/libmongoc/src/mongoc/mongoc-handshake.c
+++ b/src/libmongoc/src/mongoc/mongoc-handshake.c
@@ -301,6 +301,8 @@ _get_os_version (void)
 #endif
 
    if (res) {
+      // Truncation is OK. Assert no error occurred.
+      // Truncation not harmful. Handshake platform field is already truncated as needed.
       int req = bson_snprintf (
          ret, HANDSHAKE_OS_VERSION_MAX, "%lu.%lu (%lu)", osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber);
       BSON_ASSERT (req > 0);

--- a/src/libmongoc/src/mongoc/mongoc-handshake.c
+++ b/src/libmongoc/src/mongoc/mongoc-handshake.c
@@ -301,7 +301,7 @@ _get_os_version (void)
 #endif
 
    if (res) {
-      // Truncation is OK. 
+      // Truncation is OK.
       int req = bson_snprintf (
          ret, HANDSHAKE_OS_VERSION_MAX, "%lu.%lu (%lu)", osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber);
       BSON_ASSERT (req > 0);

--- a/src/libmongoc/src/mongoc/mongoc-handshake.c
+++ b/src/libmongoc/src/mongoc/mongoc-handshake.c
@@ -301,8 +301,7 @@ _get_os_version (void)
 #endif
 
    if (res) {
-      // Truncation is OK. Assert no error occurred.
-      // Truncation not harmful. Handshake platform field is already truncated as needed.
+      // Truncation is OK. 
       int req = bson_snprintf (
          ret, HANDSHAKE_OS_VERSION_MAX, "%lu.%lu (%lu)", osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber);
       BSON_ASSERT (req > 0);

--- a/src/libmongoc/src/mongoc/mongoc-handshake.c
+++ b/src/libmongoc/src/mongoc/mongoc-handshake.c
@@ -301,8 +301,9 @@ _get_os_version (void)
 #endif
 
    if (res) {
-      bson_snprintf (
+      int req = bson_snprintf (
          ret, HANDSHAKE_OS_VERSION_MAX, "%lu.%lu (%lu)", osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber);
+      BSON_ASSERT (req > 0);
       found = true;
    } else {
       MONGOC_WARNING ("Error with GetVersionEx(): %lu", GetLastError ());

--- a/src/libmongoc/src/mongoc/mongoc-host-list-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-host-list-private.h
@@ -24,9 +24,6 @@
 
 BSON_BEGIN_DECLS
 
-mongoc_host_list_t *
-_mongoc_host_list_push (const char *host, uint16_t port, int family, mongoc_host_list_t *next);
-
 void
 _mongoc_host_list_upsert (mongoc_host_list_t **list, const mongoc_host_list_t *new_host);
 

--- a/src/libmongoc/src/mongoc/mongoc-host-list.c
+++ b/src/libmongoc/src/mongoc/mongoc-host-list.c
@@ -21,36 +21,6 @@
 #include "mongoc-util-private.h"
 #include "utlist.h"
 
-/*
- *--------------------------------------------------------------------------
- *
- * _mongoc_host_list_push --
- *
- *       Add a host to the front of the list and return it.
- *
- * Side effects:
- *       None.
- *
- *--------------------------------------------------------------------------
- */
-mongoc_host_list_t *
-_mongoc_host_list_push (const char *host, uint16_t port, int family, mongoc_host_list_t *next)
-{
-   mongoc_host_list_t *h;
-
-   BSON_ASSERT (host);
-
-   h = bson_malloc0 (sizeof (mongoc_host_list_t));
-   bson_strncpy (h->host, host, sizeof h->host);
-   h->port = port;
-   bson_snprintf (h->host_and_port, sizeof h->host_and_port, "%s:%hu", host, port);
-
-   h->family = family;
-   h->next = next;
-
-   return h;
-}
-
 static mongoc_host_list_t *
 _mongoc_host_list_find_host_and_port (mongoc_host_list_t *hosts, const char *host_and_port)
 {

--- a/src/libmongoc/src/mongoc/mongoc-read-prefs.c
+++ b/src/libmongoc/src/mongoc/mongoc-read-prefs.c
@@ -85,11 +85,9 @@ mongoc_read_prefs_add_tag (mongoc_read_prefs_t *read_prefs, const bson_t *tag)
    BSON_ASSERT (read_prefs);
 
    key = bson_count_keys (&read_prefs->tags);
-   // Assert no truncation occurred.
-   // Truncation would be harmful (would not respect user input). Cannot return error.
+   // Expect no truncation.
    int req = bson_snprintf (str, sizeof str, "%d", key);
-   BSON_ASSERT (bson_in_range_size_t_signed (req));
-   BSON_ASSERT ((size_t) req < sizeof str);
+   BSON_ASSERT (bson_cmp_less_su (req, sizeof str));
 
    if (tag) {
       bson_append_document (&read_prefs->tags, str, -1, tag);

--- a/src/libmongoc/src/mongoc/mongoc-read-prefs.c
+++ b/src/libmongoc/src/mongoc/mongoc-read-prefs.c
@@ -85,6 +85,8 @@ mongoc_read_prefs_add_tag (mongoc_read_prefs_t *read_prefs, const bson_t *tag)
    BSON_ASSERT (read_prefs);
 
    key = bson_count_keys (&read_prefs->tags);
+   // Assert no truncation occurred.
+   // Truncation would be harmful (would not respect user input). Cannot return error.
    int req = bson_snprintf (str, sizeof str, "%d", key);
    BSON_ASSERT (bson_in_range_size_t_signed (req));
    BSON_ASSERT ((size_t) req < sizeof str);

--- a/src/libmongoc/src/mongoc/mongoc-read-prefs.c
+++ b/src/libmongoc/src/mongoc/mongoc-read-prefs.c
@@ -85,8 +85,10 @@ mongoc_read_prefs_add_tag (mongoc_read_prefs_t *read_prefs, const bson_t *tag)
    BSON_ASSERT (read_prefs);
 
    key = bson_count_keys (&read_prefs->tags);
-   bson_snprintf (str, sizeof str, "%d", key);
-
+   int req = bson_snprintf (str, sizeof str, "%d", key);
+   BSON_ASSERT (bson_in_range_size_t_signed (req));
+   BSON_ASSERT ((size_t) req < sizeof str);
+   
    if (tag) {
       bson_append_document (&read_prefs->tags, str, -1, tag);
    } else {

--- a/src/libmongoc/src/mongoc/mongoc-read-prefs.c
+++ b/src/libmongoc/src/mongoc/mongoc-read-prefs.c
@@ -88,7 +88,7 @@ mongoc_read_prefs_add_tag (mongoc_read_prefs_t *read_prefs, const bson_t *tag)
    int req = bson_snprintf (str, sizeof str, "%d", key);
    BSON_ASSERT (bson_in_range_size_t_signed (req));
    BSON_ASSERT ((size_t) req < sizeof str);
-   
+
    if (tag) {
       bson_append_document (&read_prefs->tags, str, -1, tag);
    } else {

--- a/src/libmongoc/src/mongoc/mongoc-sasl.c
+++ b/src/libmongoc/src/mongoc/mongoc-sasl.c
@@ -165,7 +165,7 @@ _mongoc_sasl_get_canonicalized_name (mongoc_stream_t *node_stream, /* IN */
       if (sock) {
          canonicalized = mongoc_socket_getnameinfo (sock);
          if (canonicalized) {
-            // Truncation is OK. Assert no error occurred.
+            // Truncation is OK. 
             int req = bson_snprintf (name, namelen, "%s", canonicalized);
             BSON_ASSERT (req > 0);
             bson_free (canonicalized);

--- a/src/libmongoc/src/mongoc/mongoc-sasl.c
+++ b/src/libmongoc/src/mongoc/mongoc-sasl.c
@@ -165,7 +165,8 @@ _mongoc_sasl_get_canonicalized_name (mongoc_stream_t *node_stream, /* IN */
       if (sock) {
          canonicalized = mongoc_socket_getnameinfo (sock);
          if (canonicalized) {
-            bson_snprintf (name, namelen, "%s", canonicalized);
+            int req = bson_snprintf (name, namelen, "%s", canonicalized);
+            BSON_ASSERT (req > 0);
             bson_free (canonicalized);
             RETURN (true);
          }

--- a/src/libmongoc/src/mongoc/mongoc-sasl.c
+++ b/src/libmongoc/src/mongoc/mongoc-sasl.c
@@ -165,6 +165,7 @@ _mongoc_sasl_get_canonicalized_name (mongoc_stream_t *node_stream, /* IN */
       if (sock) {
          canonicalized = mongoc_socket_getnameinfo (sock);
          if (canonicalized) {
+            // Truncation is OK. Assert no error occurred.
             int req = bson_snprintf (name, namelen, "%s", canonicalized);
             BSON_ASSERT (req > 0);
             bson_free (canonicalized);

--- a/src/libmongoc/src/mongoc/mongoc-sasl.c
+++ b/src/libmongoc/src/mongoc/mongoc-sasl.c
@@ -165,7 +165,7 @@ _mongoc_sasl_get_canonicalized_name (mongoc_stream_t *node_stream, /* IN */
       if (sock) {
          canonicalized = mongoc_socket_getnameinfo (sock);
          if (canonicalized) {
-            // Truncation is OK. 
+            // Truncation is OK.
             int req = bson_snprintf (name, namelen, "%s", canonicalized);
             BSON_ASSERT (req > 0);
             bson_free (canonicalized);

--- a/src/libmongoc/src/mongoc/mongoc-socket.c
+++ b/src/libmongoc/src/mongoc/mongoc-socket.c
@@ -1522,16 +1522,19 @@ mongoc_socket_inet_ntop (struct addrinfo *rp, /* IN */
    case AF_INET:
       ptr = &((struct sockaddr_in *) rp->ai_addr)->sin_addr;
       inet_ntop (rp->ai_family, ptr, tmp, sizeof (tmp));
+      // Truncation is OK. Assert no error occurred.
       req = bson_snprintf (buf, buflen, "ipv4 %s", tmp);
       BSON_ASSERT (req > 0);
       break;
    case AF_INET6:
       ptr = &((struct sockaddr_in6 *) rp->ai_addr)->sin6_addr;
       inet_ntop (rp->ai_family, ptr, tmp, sizeof (tmp));
+      // Truncation is OK. Assert no error occurred.
       req = bson_snprintf (buf, buflen, "ipv6 %s", tmp);
       BSON_ASSERT (req > 0);
       break;
    default:
+      // Truncation is OK. Assert no error occurred.
       req = bson_snprintf (buf, buflen, "unknown ip %d", rp->ai_family);
       BSON_ASSERT (req > 0);
       break;

--- a/src/libmongoc/src/mongoc/mongoc-socket.c
+++ b/src/libmongoc/src/mongoc/mongoc-socket.c
@@ -1516,20 +1516,24 @@ mongoc_socket_inet_ntop (struct addrinfo *rp, /* IN */
 {
    void *ptr;
    char tmp[256];
+   int req;
 
    switch (rp->ai_family) {
    case AF_INET:
       ptr = &((struct sockaddr_in *) rp->ai_addr)->sin_addr;
       inet_ntop (rp->ai_family, ptr, tmp, sizeof (tmp));
-      bson_snprintf (buf, buflen, "ipv4 %s", tmp);
+      req = bson_snprintf (buf, buflen, "ipv4 %s", tmp);
+      BSON_ASSERT (req > 0);
       break;
    case AF_INET6:
       ptr = &((struct sockaddr_in6 *) rp->ai_addr)->sin6_addr;
       inet_ntop (rp->ai_family, ptr, tmp, sizeof (tmp));
-      bson_snprintf (buf, buflen, "ipv6 %s", tmp);
+      req = bson_snprintf (buf, buflen, "ipv6 %s", tmp);
+      BSON_ASSERT (req > 0);
       break;
    default:
-      bson_snprintf (buf, buflen, "unknown ip %d", rp->ai_family);
+      req = bson_snprintf (buf, buflen, "unknown ip %d", rp->ai_family);
+      BSON_ASSERT (req > 0);
       break;
    }
 }

--- a/src/libmongoc/src/mongoc/mongoc-socket.c
+++ b/src/libmongoc/src/mongoc/mongoc-socket.c
@@ -1522,19 +1522,19 @@ mongoc_socket_inet_ntop (struct addrinfo *rp, /* IN */
    case AF_INET:
       ptr = &((struct sockaddr_in *) rp->ai_addr)->sin_addr;
       inet_ntop (rp->ai_family, ptr, tmp, sizeof (tmp));
-      // Truncation is OK. 
+      // Truncation is OK.
       req = bson_snprintf (buf, buflen, "ipv4 %s", tmp);
       BSON_ASSERT (req > 0);
       break;
    case AF_INET6:
       ptr = &((struct sockaddr_in6 *) rp->ai_addr)->sin6_addr;
       inet_ntop (rp->ai_family, ptr, tmp, sizeof (tmp));
-      // Truncation is OK. 
+      // Truncation is OK.
       req = bson_snprintf (buf, buflen, "ipv6 %s", tmp);
       BSON_ASSERT (req > 0);
       break;
    default:
-      // Truncation is OK. 
+      // Truncation is OK.
       req = bson_snprintf (buf, buflen, "unknown ip %d", rp->ai_family);
       BSON_ASSERT (req > 0);
       break;

--- a/src/libmongoc/src/mongoc/mongoc-socket.c
+++ b/src/libmongoc/src/mongoc/mongoc-socket.c
@@ -1522,19 +1522,19 @@ mongoc_socket_inet_ntop (struct addrinfo *rp, /* IN */
    case AF_INET:
       ptr = &((struct sockaddr_in *) rp->ai_addr)->sin_addr;
       inet_ntop (rp->ai_family, ptr, tmp, sizeof (tmp));
-      // Truncation is OK. Assert no error occurred.
+      // Truncation is OK. 
       req = bson_snprintf (buf, buflen, "ipv4 %s", tmp);
       BSON_ASSERT (req > 0);
       break;
    case AF_INET6:
       ptr = &((struct sockaddr_in6 *) rp->ai_addr)->sin6_addr;
       inet_ntop (rp->ai_family, ptr, tmp, sizeof (tmp));
-      // Truncation is OK. Assert no error occurred.
+      // Truncation is OK. 
       req = bson_snprintf (buf, buflen, "ipv6 %s", tmp);
       BSON_ASSERT (req > 0);
       break;
    default:
-      // Truncation is OK. Assert no error occurred.
+      // Truncation is OK. 
       req = bson_snprintf (buf, buflen, "unknown ip %d", rp->ai_family);
       BSON_ASSERT (req > 0);
       break;

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
@@ -914,7 +914,7 @@ mongoc_topology_scanner_node_connect_unix (mongoc_topology_scanner_node_t *node,
    saddr.sun_family = AF_UNIX;
    int req = bson_snprintf (saddr.sun_path, sizeof saddr.sun_path - 1, "%s", host->host);
 
-   if (bson_in_range_size_t_signed (req) || (size_t) req < sizeof saddr.sun_path - 1) {
+   if (!bson_in_range_size_t_signed (req) || (size_t) req >= sizeof saddr.sun_path - 1) {
       bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Failed to define socket address path.");
       RETURN (false);
    }

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
@@ -850,6 +850,8 @@ mongoc_topology_scanner_node_setup_tcp (mongoc_topology_scanner_node_t *node, bs
    }
 
    if (!node->dns_results) {
+      // Assert no truncation occurred.
+      // Expect UINT16 string to fit in 8 characters.
       int req = bson_snprintf (portstr, sizeof portstr, "%hu", host->port);
       BSON_ASSERT (bson_in_range_size_t_signed (req));
       BSON_ASSERT ((size_t) req < sizeof portstr);
@@ -912,6 +914,7 @@ mongoc_topology_scanner_node_connect_unix (mongoc_topology_scanner_node_t *node,
 
    memset (&saddr, 0, sizeof saddr);
    saddr.sun_family = AF_UNIX;
+   // Return error if truncation occured.
    int req = bson_snprintf (saddr.sun_path, sizeof saddr.sun_path - 1, "%s", host->host);
 
    if (!bson_in_range_size_t_signed (req) || (size_t) req >= sizeof saddr.sun_path - 1) {

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
@@ -850,11 +850,9 @@ mongoc_topology_scanner_node_setup_tcp (mongoc_topology_scanner_node_t *node, bs
    }
 
    if (!node->dns_results) {
-      // Assert no truncation occurred.
-      // Expect UINT16 string to fit in 8 characters.
+      // Expect no truncation.
       int req = bson_snprintf (portstr, sizeof portstr, "%hu", host->port);
-      BSON_ASSERT (bson_in_range_size_t_signed (req));
-      BSON_ASSERT ((size_t) req < sizeof portstr);
+      BSON_ASSERT (bson_cmp_less_su (req, sizeof portstr));
 
       memset (&hints, 0, sizeof hints);
       hints.ai_family = host->family;
@@ -914,10 +912,10 @@ mongoc_topology_scanner_node_connect_unix (mongoc_topology_scanner_node_t *node,
 
    memset (&saddr, 0, sizeof saddr);
    saddr.sun_family = AF_UNIX;
-   // Return error if truncation occured.
+   // Expect no truncation.
    int req = bson_snprintf (saddr.sun_path, sizeof saddr.sun_path - 1, "%s", host->host);
 
-   if (!bson_in_range_size_t_signed (req) || (size_t) req >= sizeof saddr.sun_path - 1) {
+   if (bson_cmp_greater_equal_su (req, sizeof saddr.sun_path - 1)) {
       bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Failed to define socket address path.");
       RETURN (false);
    }

--- a/src/libmongoc/src/mongoc/mongoc-util.c
+++ b/src/libmongoc/src/mongoc/mongoc-util.c
@@ -74,6 +74,7 @@ _mongoc_hex_md5 (const char *input)
    mcommon_md5_finish (&md5, digest);
 
    for (i = 0; i < sizeof digest; i++) {
+      // Assert no truncation occurred. Destination is expected to fit all input.
       int req = bson_snprintf (&digest_str[i * 2], 3, "%02x", digest[i]);
       BSON_ASSERT (bson_in_range_size_t_signed (req));
       BSON_ASSERT ((size_t) req < 3);
@@ -1010,6 +1011,7 @@ bin_to_hex (const uint8_t *bin, uint32_t len)
    char *out = bson_malloc0 (2u * len + 1u);
 
    for (uint32_t i = 0u; i < len; i++) {
+      // Expect no truncation.
       int req = bson_snprintf (out + (2u * i), 3, "%02x", bin[i]);
       BSON_ASSERT (bson_in_range_size_t_signed (req));
       BSON_ASSERT ((size_t) req < 3);

--- a/src/libmongoc/src/mongoc/mongoc-util.c
+++ b/src/libmongoc/src/mongoc/mongoc-util.c
@@ -74,10 +74,9 @@ _mongoc_hex_md5 (const char *input)
    mcommon_md5_finish (&md5, digest);
 
    for (i = 0; i < sizeof digest; i++) {
-      // Assert no truncation occurred. Destination is expected to fit all input.
+      // Expect no truncation.
       int req = bson_snprintf (&digest_str[i * 2], 3, "%02x", digest[i]);
-      BSON_ASSERT (bson_in_range_size_t_signed (req));
-      BSON_ASSERT ((size_t) req < 3);
+      BSON_ASSERT (req < 3);
    }
    digest_str[sizeof digest_str - 1] = '\0';
 
@@ -1013,8 +1012,7 @@ bin_to_hex (const uint8_t *bin, uint32_t len)
    for (uint32_t i = 0u; i < len; i++) {
       // Expect no truncation.
       int req = bson_snprintf (out + (2u * i), 3, "%02x", bin[i]);
-      BSON_ASSERT (bson_in_range_size_t_signed (req));
-      BSON_ASSERT ((size_t) req < 3);
+      BSON_ASSERT (req < 3);
    }
 
    return out;

--- a/src/libmongoc/src/mongoc/mongoc-util.c
+++ b/src/libmongoc/src/mongoc/mongoc-util.c
@@ -74,7 +74,9 @@ _mongoc_hex_md5 (const char *input)
    mcommon_md5_finish (&md5, digest);
 
    for (i = 0; i < sizeof digest; i++) {
-      bson_snprintf (&digest_str[i * 2], 3, "%02x", digest[i]);
+      int req = bson_snprintf (&digest_str[i * 2], 3, "%02x", digest[i]);
+      BSON_ASSERT (bson_in_range_size_t_signed (req));
+      BSON_ASSERT ((size_t) req < 3);
    }
    digest_str[sizeof digest_str - 1] = '\0';
 
@@ -1008,7 +1010,9 @@ bin_to_hex (const uint8_t *bin, uint32_t len)
    char *out = bson_malloc0 (2u * len + 1u);
 
    for (uint32_t i = 0u; i < len; i++) {
-      bson_snprintf (out + (2u * i), 3, "%02x", bin[i]);
+      int req = bson_snprintf (out + (2u * i), 3, "%02x", bin[i]);
+      BSON_ASSERT (bson_in_range_size_t_signed (req));
+      BSON_ASSERT ((size_t) req < 3);
    }
 
    return out;

--- a/src/libmongoc/tests/test-mongoc-dns.c
+++ b/src/libmongoc/tests/test-mongoc-dns.c
@@ -86,7 +86,7 @@ typedef struct {
  *
  *--------------------------------------------------------------------------
  */
-mongoc_host_list_t *
+static mongoc_host_list_t *
 _mongoc_host_list_push (const char *host, uint16_t port, int family, mongoc_host_list_t *next)
 {
    mongoc_host_list_t *h;

--- a/src/libmongoc/tests/test-mongoc-dns.c
+++ b/src/libmongoc/tests/test-mongoc-dns.c
@@ -74,6 +74,36 @@ typedef struct {
 } context_t;
 
 
+/*
+ *--------------------------------------------------------------------------
+ *
+ * _mongoc_host_list_push --
+ *
+ *       Add a host to the front of the list and return it.
+ *
+ * Side effects:
+ *       None.
+ *
+ *--------------------------------------------------------------------------
+ */
+mongoc_host_list_t *
+_mongoc_host_list_push (const char *host, uint16_t port, int family, mongoc_host_list_t *next)
+{
+   mongoc_host_list_t *h;
+
+   BSON_ASSERT (host);
+
+   h = bson_malloc0 (sizeof (mongoc_host_list_t));
+   bson_strncpy (h->host, host, sizeof h->host);
+   h->port = port;
+   bson_snprintf (h->host_and_port, sizeof h->host_and_port, "%s:%hu", host, port);
+
+   h->family = family;
+   h->next = next;
+
+   return h;
+}
+
 static void
 topology_changed (const mongoc_apm_topology_changed_t *event)
 {

--- a/src/libmongoc/tests/test-mongoc-gridfs-bucket.c
+++ b/src/libmongoc/tests/test-mongoc-gridfs-bucket.c
@@ -1035,8 +1035,8 @@ test_gridfs_bucket_opts (void)
    bson_destroy (opts);
    mongoc_gridfs_bucket_destroy (gridfs);
 
-   /* one character shorter should be okay though. */
-   *(bucket_name + ((int) (128 - strlen ("chunks") - 1))) = '\0';
+   /* two characters shorter should be okay though. */
+   *(bucket_name + ((int) (128 - strlen ("chunks") - 2))) = '\0';
    opts = BCON_NEW ("bucketName", bucket_name);
    gridfs = mongoc_gridfs_bucket_new (db, opts, NULL, &error);
    ASSERT_OR_PRINT (gridfs, error);


### PR DESCRIPTION
[ticket](https://jira.mongodb.org/browse/CDRIVER-4820)

[evergreen](https://spruce.mongodb.com/version/6669e4353d2b3f0007b8a217/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

Evergreen test failures look unrelated, but could be double checked.

See https://github.com/mongodb/mongo-c-driver/compare/master...kevinAlbs:mongo-c-driver:bson_snprintf-hints.CDRIVER-4820?expand=1 for more details.