### PR TITLE
CDRIVER-5535 Minor improvements to create-silk-asset-group.py

### DIFF
--- a/tools/create-silk-asset-group.py
+++ b/tools/create-silk-asset-group.py
@@ -161,7 +161,7 @@ class SimpleSilkClient:
                     "name": project,
                     "code_repo_url": code_repo_url,
                     "branch": branch,
-                    "file_path": [],
+                    "file_paths": ["*"],
                     "metadata": {
                         "sbom_lite_path": sbom_lite_path,
                     },
@@ -172,7 +172,7 @@ class SimpleSilkClient:
         )
         try:
             with urllib.request.urlopen(req) as resp:
-                json.loads(resp.read())  # No-op, but validates that JSON was returned
+                print(json.loads(resp.read()))  # No-op, but validates that JSON was returned
         except urllib.error.HTTPError as err:
             if err.status == 409 and exist_ok:
                 # 409: Conflict


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1619 that ensures the `"file_paths"` field (which tells Silk how vulnerabilities should be directed when multiple distinct asset groups are in the same repo) is set to `["*"]` (current recommended default, details pending further review).

Additionally ensures the `silk_id` of the new asset group is emitted in output on successful creation for asset group tracking and maintenance purposes, as it is currently swallowed by the `json.loads()` call.