### PR TITLE
CDRIVER-5601 CDRIVER-5602 more robust bson append

### DIFF
--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -302,7 +302,7 @@ _bson_encode_length (bson_t *bson) /* IN */
 
 static BSON_INLINE bool
 _bson_append_va (bson_t *bson,              /* IN */
-                 uint64_t n_bytes,          /* IN */
+                 uint32_t n_bytes,          /* IN */
                  uint32_t n_pairs,          /* IN */
                  uint32_t first_len,        /* IN */
                  const uint8_t *first_data, /* IN */
@@ -324,7 +324,7 @@ _bson_append_va (bson_t *bson,              /* IN */
 
    buf = _bson_data (bson) + bson->len - 1;
 
-   /* Track running sum of bytes written in a uint64_t to prevent possible overflow. */
+   /* Track running sum of bytes written in a uint64_t to detect possible overflow of `n_bytes`. */
    uint64_t n_bytes_sum = 0;
    do {
       n_bytes_sum += data_len;
@@ -1513,10 +1513,22 @@ bson_append_utf8 (bson_t *bson, const char *key, int key_length, const char *val
    }
 
    length_le = BSON_UINT32_TO_LE (length + 1);
-   const uint64_t num_bytes = UINT64_C (1) + key_length + UINT64_C (1) + UINT64_C (4) + length + UINT64_C (1);
 
-   return _bson_append (
-      bson, 6, num_bytes, 1, &type, key_length, key, 1, &gZero, 4, &length_le, length, value, 1, &gZero);
+   return _bson_append (bson,
+                        6,
+                        (1 + key_length + 1 + 4 + length + 1),
+                        1,
+                        &type,
+                        key_length,
+                        key,
+                        1,
+                        &gZero,
+                        4,
+                        &length_le,
+                        length,
+                        value,
+                        1,
+                        &gZero);
 }
 
 

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -327,10 +327,15 @@ _bson_append_va (bson_t *bson,              /* IN */
    /* Track running sum of bytes written in a uint64_t to detect possible overflow of `n_bytes`. */
    uint64_t n_bytes_sum = 0;
    do {
-      n_bytes_sum += data_len;
-      if (BSON_UNLIKELY (bson_cmp_greater_uu (n_bytes_sum, n_bytes))) {
+      // Size of any individual data being appended should not exceed the total byte limit.
+      if (BSON_UNLIKELY (bson_cmp_less_uu (n_bytes, data_len))) {
          return false;
       }
+      // Total size of data being appended should not exceed the total byte limit.
+      if (BSON_UNLIKELY (bson_cmp_greater_uu (n_bytes_sum, n_bytes - data_len))) {
+         return false;
+      }
+      n_bytes_sum += data_len;
       n_pairs--;
       /* data may be NULL if data_len is 0. memcpy is not safe to call with
        * NULL. */

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -385,7 +385,7 @@ _bson_append_va (bson_t *bson,              /* IN */
 static bool
 _bson_append (bson_t *bson,              /* IN */
               uint32_t n_pairs,          /* IN */
-              uint64_t n_bytes,          /* IN */
+              uint32_t n_bytes,          /* IN */
               uint32_t first_len,        /* IN */
               const uint8_t *first_data, /* IN */
               ...)


### PR DESCRIPTION
This PR makes the BSON append operation more robust. Specifically, it now checks that the lengths of the key and the value being appended will not cause overflows. Rather than using assertions, I have done as suggested by @eramongodb and used `return` instead. I defaulted to returning `false` or `NULL` (the expected behavior for a wide variety of failure modes of public functions) and in one instance used a return of `bson_append_null (...)` (which follows another available patter in `bson_append_utf8 ()`.

As far as documentation goes, it seems to me that the existing documentation still describes the behavior even following these changes. `src/libbson/doc/bson_append_utf8.rst` contains the following:

```
Returns
-------

Returns ``true`` if the operation was applied successfully. The function will fail if appending the value grows ``bson`` larger than INT32_MAX.
```

In effect, this PR changes the failure mode from an application crash to a `false`/`NULL` return from the API (which is still indicative of a failure, but one that can be more gracefully handled by the caller).

Evergreen patch build: https://spruce.mongodb.com/version/66733c7ca766200007e0e44d/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC