### PR TITLE
[CDRIVER-5540] Introduce an `ssdlc_compliance_report.md` to the release archive

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -182,10 +182,12 @@ release-archive:
     WORKDIR /s
     COPY --dir .git .
     COPY (+sbom-download/augmented-sbom.json --branch=$sbom_branch) cyclonedx.sbom.json
+    COPY etc/ssdlc.md ssldc_compliance_report.md
     RUN git archive -o release.tar.gz \
         --prefix="$prefix/" \ # Set the archive path prefix
         "$ref" \ # Add the source tree
-        --add-file cyclonedx.sbom.json  # Add the SBOM
+        --add-file cyclonedx.sbom.json \ # Add the SBOM
+        --add-file ssldc_compliance_report.md
     SAVE ARTIFACT release.tar.gz
 
 # Obtain the signing public key. Exported as an artifact /c-driver.pub

--- a/docs/dev/earthly.rst
+++ b/docs/dev/earthly.rst
@@ -85,9 +85,10 @@ enumerated using ``earthly ls`` or ``earthly doc`` in the root of the repository
 
    .. earthly-artifact:: +signed-release/dist/
 
-      A directory artifact that contains the `+release-archive/release.tar.gz`
-      and `+sign-file/signature.asc` for the release. The exported filenames
-      are based on the `--version` argument.
+      A directory artifact that contains the `+release-archive/release.tar.gz`,
+      `+release-archive/ssdlc_compliance_report.md`, and
+      `+sign-file/signature.asc` for the release. The exported filenames are
+      based on the `--version` argument.
 
    .. rubric:: Parameters
    .. option:: --sbom_branch <branch>
@@ -123,6 +124,12 @@ enumerated using ``earthly ls`` or ``earthly doc`` in the root of the repository
       generated archive includes the source tree, but also includes other
       release artifacts that are generated on-the-fly when invoked e.g. the
       `+sbom-download/augmented-sbom.json` artifact.
+
+   .. earthly-artifact:: +release-archive/ssdlc_compliance_report.md
+
+      The SSDLC compliance report for the release. This file is based on the
+      content of ``etc/ssdlc.md``, which has certain substrings replaced based
+      on attributes of the release.
 
    .. rubric:: Parameters
    .. option:: --sbom_branch <branch>

--- a/docs/dev/releasing.rst
+++ b/docs/dev/releasing.rst
@@ -369,6 +369,7 @@ same name without the `.asc` suffix.
    $ ls dist/
    mongo-c-driver-1.27.2.tar.gz
    mongo-c-driver-1.27.2.tar.gz.asc
+   ssdlc_compliance_report.md
 
 .. note::
 

--- a/docs/dev/releasing.rst
+++ b/docs/dev/releasing.rst
@@ -353,10 +353,12 @@ from which the release is being made::
 
    $ ./tools/earthly.sh --artifact +signed-release/dist dist --sbom_branch=$BRANCH --version=$NEW_VERSION
 
+.. note:: `$NEW_VERSION` must correspond to the Git tag created by the release.
+
 The above command will create a `dist/` directory in the working directory that
 contains the release artifacts from the :any:`+signed-release/dist/` directory
 artifact. The generated filenames are based on the
-:any:`+signed-release --version` argument. The archive contenst come from the
+:any:`+signed-release --version` argument. The archive contents come from the
 Git tag corresponding to the specified version. The detached PGP signature is
 the file with the `.asc` extension and corresponds to the archive file with the
 same name without the `.asc` suffix.

--- a/etc/ssdlc.md
+++ b/etc/ssdlc.md
@@ -1,0 +1,48 @@
+# MongoDB C Driver SSDLC Compliance Report
+
+<!--
+This document is intended for distribution with release archives of the MongoDB
+C Driver. It wil be copied into the release archive as ssdlc_compliance_report.md
+-->
+
+## Release Creator
+
+For information on the release creator, refer to the
+[C/C++ Release Info Spreadsheet](https://docs.google.com/spreadsheets/d/1yHfGmDnbA5-Qt8FX4tKWC5xk9AhzYZx1SKF4AD36ecY)
+(internal link).
+
+## Process Document
+
+<!-- DRIVERS-2892: replace with link to public-facing document once available. -->
+Not yet available.
+
+## Third-Party Dependencies and Vulnerabilities
+
+The tracking of security information for bundled third-party dependencies is
+performed using Snyk. Refer to the `etc/third_party_vulnerabilities.md` file
+within the repository or the release archive for vulnerability information known
+at the time of a release. Full bundled dependency information is available in
+the `cyclonedx.sbom.json` file within the release archive.
+
+## Static Analysis Findings
+
+Refer to the
+[SSDLC Static Analysis Reports](https://drive.google.com/drive/folders/17bjBnQ3mhEXvs6IK1rrTphJr0CUO2qZh)
+folder (internal) for release-specific reports. Available as-needed from the
+MongoDB C Driver team.
+
+## Security Testing Report
+
+Refer to the
+[Driver Security Testing Summary](https://docs.google.com/document/d/1y2K_RY4GZVXpQvv4JH_35mSzFRTawNJ3mibpvSBU8H0)
+document (internal). Available as-needed from the MongoDB C Driver team.
+
+## Release Signature Information
+
+The generated release archive is signed. The detached signature is available
+alongside the release archive in the GitHub Release page and can be verified
+using the `c-driver` public key available at https://pgp.mongodb.com/.
+
+## Security Assessment Report
+
+Not applicable for the MongoDB C Driver.

--- a/etc/ssdlc.md
+++ b/etc/ssdlc.md
@@ -1,4 +1,4 @@
-# MongoDB C Driver SSDLC Compliance Report
+# MongoDB C Driver SSDLC Compliance Report (@version@)
 
 <!--
 This document is intended for distribution with release archives of the MongoDB

--- a/etc/ssdlc.md
+++ b/etc/ssdlc.md
@@ -37,6 +37,9 @@ Refer to the
 [Driver Security Testing Summary](https://docs.google.com/document/d/1y2K_RY4GZVXpQvv4JH_35mSzFRTawNJ3mibpvSBU8H0)
 document (internal). Available as-needed from the MongoDB C Driver team.
 
+<!--  The below URL is inserted as part of the Earthfile+release-archive target. -->
+Refer to the [Evergreen waterfall build](@waterfall_url@) (internal) for test results.
+
 ## Release Signature Information
 
 The generated release archive is signed. The detached signature is available


### PR DESCRIPTION
Refer: CDRIVER-5540. This simple change adds the `ssdlc_compliance_report.md` file to the repository and to the release archive. It is stored in `etc/ssdlc.md` for editing, but is copied as a top-level file `ssdlc_compliance_report.md` within the generate release archive.

The file itself is based on the similar file present in the C++ driver and libmongocrypt repositories.