### PR TITLE
CDRIVER-4815 Mark Server version 3.6 as EOL from driver's PoV (Min server version as 4.0, minWireVersion as 7.0)

### DIFF
--- a/.evergreen/config_generator/components/sanitizers/asan_sasl.py
+++ b/.evergreen/config_generator/components/sanitizers/asan_sasl.py
@@ -16,8 +16,7 @@ COMPILE_MATRIX = [
 ]
 
 TEST_MATRIX = [
-    ('ubuntu1604', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], ['3.6',                                  ]),
-    ('ubuntu1804', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], [       '4.0', '4.2', '4.4', '5.0', '6.0']),
+    ('ubuntu1804', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], ['4.0', '4.2', '4.4', '5.0', '6.0']),
 
     # Test 7.0+ with Ubuntu 20.04+ since MongoDB 7.0 no longer ships binaries for Ubuntu 18.04.
     ('ubuntu2004', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], ['7.0', '8.0', 'latest']),

--- a/.evergreen/config_generator/components/sasl/darwinssl.py
+++ b/.evergreen/config_generator/components/sasl/darwinssl.py
@@ -20,7 +20,7 @@ COMPILE_MATRIX = [
 ]
 
 TEST_MATRIX = [
-    ('macos-1100', 'clang', None, 'cyrus', ['auth'], ['server'], ['3.6', '4.0', '4.2', '4.4', '5.0', '6.0', '7.0', '8.0', 'latest']),
+    ('macos-1100', 'clang', None, 'cyrus', ['auth'], ['server'], ['4.0', '4.2', '4.4', '5.0', '6.0', '7.0', '8.0', 'latest']),
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/sasl/nossl.py
+++ b/.evergreen/config_generator/components/sasl/nossl.py
@@ -22,9 +22,8 @@ COMPILE_MATRIX = [
 ]
 
 TEST_MATRIX = [
-    ('ubuntu1604', 'gcc', None, 'off', ['noauth'], ['server', 'replica', 'sharded'], ['3.6',                                                   ]),
-    ('ubuntu1804', 'gcc', None, 'off', ['noauth'], ['server', 'replica', 'sharded'], [       '4.0', '4.2', '4.4', '5.0', '6.0',                ]),
-    ('ubuntu2004', 'gcc', None, 'off', ['noauth'], ['server', 'replica', 'sharded'], [                                          '7.0', '8.0', 'latest']),
+    ('ubuntu1804', 'gcc', None, 'off', ['noauth'], ['server', 'replica', 'sharded'], ['4.0', '4.2', '4.4', '5.0', '6.0',                ]),
+    ('ubuntu2004', 'gcc', None, 'off', ['noauth'], ['server', 'replica', 'sharded'], [                                   '7.0', '8.0', 'latest']),
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/sasl/winssl.py
+++ b/.evergreen/config_generator/components/sasl/winssl.py
@@ -25,7 +25,7 @@ COMPILE_MATRIX = [
 ]
 
 TEST_MATRIX = [
-    ('windows-vsCurrent', 'vs2017x64', None, 'cyrus', ['auth'], ['server'], ['3.6', '4.0', '4.2', '4.4', '5.0', '6.0', '7.0', '8.0', 'latest']),
+    ('windows-vsCurrent', 'vs2017x64', None, 'cyrus', ['auth'], ['server'], ['4.0', '4.2', '4.4', '5.0', '6.0', '7.0', '8.0', 'latest']),
 
     ('windows-vsCurrent', 'mingw',     None, 'sspi',  ['auth'], ['server'], ['8.0', 'latest']),
     ('windows-vsCurrent', 'vs2017x64', None, 'sspi',  ['auth'], ['server'], ['8.0', 'latest']),

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -476,66 +476,6 @@ tasks:
         vars:
           CC: clang
       - func: upload-build
-  - name: asan-sasl-cyrus-openssl-ubuntu1604-clang-test-3.6-replica-auth
-    run_on: ubuntu1604-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1604, clang, sasl-cyrus, asan, auth, replica, "3.6", openssl]
-    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu1604-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu1604-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "3.6" }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: asan-sasl-cyrus-openssl-ubuntu1604-clang-test-3.6-server-auth
-    run_on: ubuntu1604-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1604, clang, sasl-cyrus, asan, auth, server, "3.6", openssl]
-    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu1604-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu1604-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "3.6" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: asan-sasl-cyrus-openssl-ubuntu1604-clang-test-3.6-sharded-auth
-    run_on: ubuntu1604-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1604, clang, sasl-cyrus, asan, auth, sharded, "3.6", openssl]
-    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu1604-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu1604-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "3.6" }
-            - { key: TOPOLOGY, value: sharded_cluster }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
   - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile
     run_on: ubuntu1804-large
     tags: [sanitizers-matrix-asan, compile, ubuntu1804, clang, asan, sasl-cyrus]
@@ -3035,26 +2975,6 @@ tasks:
         vars:
           CC: clang
       - func: upload-build
-  - name: sasl-cyrus-darwinssl-macos-1100-clang-test-3.6-server-auth
-    run_on: macos-1100
-    tags: [sasl-matrix-darwinssl, test, macos-1100, clang, sasl-cyrus, auth, server, "3.6", darwinssl]
-    depends_on: [{ name: sasl-cyrus-darwinssl-macos-1100-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-cyrus-darwinssl-macos-1100-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "3.6" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: darwinssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
   - name: sasl-cyrus-darwinssl-macos-1100-clang-test-4.0-server-auth
     run_on: macos-1100
     tags: [sasl-matrix-darwinssl, test, macos-1100, clang, sasl-cyrus, auth, server, "4.0", darwinssl]
@@ -4039,26 +3959,6 @@ tasks:
         vars:
           CC: Visual Studio 15 2017 Win64
       - func: upload-build
-  - name: sasl-cyrus-winssl-windows-2019-vs2017-x64-test-3.6-server-auth
-    run_on: windows-vsCurrent-small
-    tags: [sasl-matrix-winssl, test, windows-vsCurrent, vs2017x64, sasl-cyrus, auth, server, "3.6", winssl]
-    depends_on: [{ name: sasl-cyrus-winssl-windows-2019-vs2017-x64-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-cyrus-winssl-windows-2019-vs2017-x64-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "3.6" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: winssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
   - name: sasl-cyrus-winssl-windows-2019-vs2017-x64-test-4.0-server-auth
     run_on: windows-vsCurrent-small
     tags: [sasl-matrix-winssl, test, windows-vsCurrent, vs2017x64, sasl-cyrus, auth, server, "4.0", winssl]
@@ -4227,66 +4127,6 @@ tasks:
         vars:
           CC: gcc
       - func: upload-build
-  - name: sasl-off-nossl-ubuntu1604-gcc-test-3.6-replica-noauth
-    run_on: ubuntu1604-small
-    tags: [sasl-matrix-nossl, test, ubuntu1604, gcc, sasl-off, noauth, replica, "3.6"]
-    depends_on: [{ name: sasl-off-nossl-ubuntu1604-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-off-nossl-ubuntu1604-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: noauth }
-            - { key: MONGODB_VERSION, value: "3.6" }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: nossl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-off-nossl-ubuntu1604-gcc-test-3.6-server-noauth
-    run_on: ubuntu1604-small
-    tags: [sasl-matrix-nossl, test, ubuntu1604, gcc, sasl-off, noauth, server, "3.6"]
-    depends_on: [{ name: sasl-off-nossl-ubuntu1604-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-off-nossl-ubuntu1604-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: noauth }
-            - { key: MONGODB_VERSION, value: "3.6" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: nossl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-off-nossl-ubuntu1604-gcc-test-3.6-sharded-noauth
-    run_on: ubuntu1604-small
-    tags: [sasl-matrix-nossl, test, ubuntu1604, gcc, sasl-off, noauth, sharded, "3.6"]
-    depends_on: [{ name: sasl-off-nossl-ubuntu1604-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-off-nossl-ubuntu1604-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: noauth }
-            - { key: MONGODB_VERSION, value: "3.6" }
-            - { key: TOPOLOGY, value: sharded_cluster }
-            - { key: SSL, value: nossl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
   - name: sasl-off-nossl-ubuntu1804-gcc-compile
     run_on: ubuntu1804-large
     tags: [sasl-matrix-nossl, compile, ubuntu1804, gcc, sasl-off]

--- a/.evergreen/scripts/integration-tests.sh
+++ b/.evergreen/scripts/integration-tests.sh
@@ -3,7 +3,7 @@
 #
 # Specify the following environment variables:
 #
-# MONGODB_VERSION: latest, 4.2, 4.0, 3.6
+# MONGODB_VERSION: latest, 4.2, 4.0
 # TOPOLOGY: server, replica_set, sharded_cluster
 # AUTH: auth, noauth
 # AUTHSOURCE

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,10 @@
 libmongoc 1.28.0 (unreleased)
 =============================
 
+Notes:
+
+  * Bump minimum wire protocol version from 6 (MongoDB 3.6) to 7 (MongoDB 4.0).
+
 Deprecated:
 
   * Use of `*_hint` functions is deprecated in favor of more aptly named `*_server_id` functions:

--- a/src/libmongoc/src/mongoc/mongoc-client-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-private.h
@@ -41,8 +41,6 @@
 
 BSON_BEGIN_DECLS
 
-/* version corresponding to server 3.6 release */
-#define WIRE_VERSION_3_6 6
 /* version corresponding to server 4.0 release */
 #define WIRE_VERSION_4_0 7
 /* first version to support hint for "update" command */
@@ -83,7 +81,7 @@ BSON_BEGIN_DECLS
 /* Range of wire protocol versions this driver supports. Bumping
  * WIRE_VERSION_MAX must be accompanied by an update to
  * `_mongoc_wire_version_to_server_version`. */
-#define WIRE_VERSION_MIN WIRE_VERSION_3_6 /* a.k.a. minWireVersion */
+#define WIRE_VERSION_MIN WIRE_VERSION_4_0 /* a.k.a. minWireVersion */
 #define WIRE_VERSION_MAX WIRE_VERSION_7_0 /* a.k.a. maxWireVersion */
 
 struct _mongoc_collection_t;

--- a/src/libmongoc/tests/json/server_discovery_and_monitoring/rs/compatible.json
+++ b/src/libmongoc/tests/json/server_discovery_and_monitoring/rs/compatible.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [

--- a/src/libmongoc/tests/json/server_discovery_and_monitoring/rs/compatible_unknown.json
+++ b/src/libmongoc/tests/json/server_discovery_and_monitoring/rs/compatible_unknown.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/src/libmongoc/tests/json/server_discovery_and_monitoring/sharded/compatible.json
+++ b/src/libmongoc/tests/json/server_discovery_and_monitoring/sharded/compatible.json
@@ -23,7 +23,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/src/libmongoc/tests/json/server_discovery_and_monitoring/single/compatible.json
+++ b/src/libmongoc/tests/json/server_discovery_and_monitoring/single/compatible.json
@@ -11,7 +11,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/src/libmongoc/tests/json/server_discovery_and_monitoring/single/too_old_then_upgraded.json
+++ b/src/libmongoc/tests/json/server_discovery_and_monitoring/single/too_old_then_upgraded.json
@@ -35,7 +35,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],


### PR DESCRIPTION
[ticket](https://jira.mongodb.org/browse/CDRIVER-4815)

Updated minWireVersion to 7. removed server version 3.6 from evergreen config files (asan_sasl, darwinssl, nossl, winssl) then generated evergreen config files, removed 3.6 from documentation in integration-tests.sh,and bumped up maxWireVersion in [specified](https://github.com/mongodb/specifications/commit/959a5de6c3e4cb84033f1505d66a0b109f38918f) sdam tests.