### PR TITLE
CDRIVER-5584 delay OP_MSG flag bit access until after opCode check

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -3395,7 +3395,8 @@ _mongoc_cluster_run_opmsg_recv (
       if (op_code != MONGOC_OP_CODE_MSG) {
          RUN_CMD_ERR (MONGOC_ERROR_PROTOCOL,
                       MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
-                      "malformed message from server: expected opCode 2013, got %" PRId32,
+                      "malformed message from server: expected opCode %" PRId32 ", got %" PRId32,
+                      MONGOC_OP_CODE_MSG,
                       op_code);
          _handle_network_error (cluster, server_stream, error);
          server_stream->stream = NULL;


### PR DESCRIPTION
Addresses CDRIVER-5584.

https://github.com/mongodb/mongo-c-driver/commit/1c8da0ee199661a4276c87fb9ec2fbb375a2a4ad introduced a [call](https://github.com/mongodb/mongo-c-driver/commit/1c8da0ee199661a4276c87fb9ec2fbb375a2a4ad#diff-7723202fa2b19410a0b6dd42b6dda8d3708c52f85e7b553977c0bbe324031b41R3709) to `mcd_rpc_op_msg_get_flag_bits`, which has a [precondition](https://github.com/mongodb/mongo-c-driver/blob/1c8da0ee199661a4276c87fb9ec2fbb375a2a4ad/src/libmongoc/src/mongoc/mcd-rpc.c#L2156) that the RPC message's opCode is `OP_MSG` (2013).

Prior to https://github.com/mongodb/mongo-c-driver/commit/1c8da0ee199661a4276c87fb9ec2fbb375a2a4ad, the opCode was validated by a [call](https://github.com/mongodb/mongo-c-driver/blob/6f58b9d7f32d5ea83b32c162a59d1f97e958657b/src/libmongoc/src/mongoc/mongoc-cluster.c#L3705) to `mcd_rpc_message_get_body`, which [gracefully handles](https://github.com/mongodb/mongo-c-driver/blob/6f58b9d7f32d5ea83b32c162a59d1f97e958657b/src/libmongoc/src/mongoc/mongoc-rpc.c#L1007) invalid opCodes (that are not `OP_MSG` or `OP_REPLY`) and leads to a [cursor error](https://github.com/mongodb/mongo-c-driver/blob/1c8da0ee199661a4276c87fb9ec2fbb375a2a4ad/src/libmongoc/src/mongoc/mongoc-cluster.c#L3713).

This PR proposes delaying access of the `OP_MSG` flag bits until _after_ the call to `mcd_rpc_message_get_body` which validates the opCode of the received message. This should restore behavior such that a valid RPC message with an unexpected opCode leads to a recoverable error rather than an assertion violation. It is still unclear how or why an opCode other than the expected OP_MSG may be observed in this code path (which _should_ be reserved for `OP_MSG` messages), but given the circumstances related to CDRIVER-5584, this may be worth accounting for regardless of the possible causes.

Note, the addition of the `mcd_rpc_header_get_op_code (rpc) != MONGOC_OP_CODE_MSG` check is required to account for the possibility of a _valid_ RPC message with an _unexpected_ opCode of `OP_REPLY`, as `mcd_rpc_message_get_body` is designed to permit `OP_REPLY`. (We _could_ allow an OP_MSG message to receive an OP_REPLY response and continue on as-if everything is okay, but my understanding is that such a scenario isn't meant to ever occur per MongoDB Wire Protocol specification.)

An alternative solution would be to add a new opCode check prior to the call to `mcd_rpc_op_msg_get_flag_bits` in its current placement:

```c
if (mcd_rpc_header_get_op_code (rpc) != MONGOC_OP_CODE_MSG) { // <--
   // cursor error
   goto done;
}

cluster->client->in_exhaust = mcd_rpc_op_msg_get_flag_bits (rpc) & MONGOC_OP_MSG_FLAG_MORE_TO_COME;

bson_t body;

if (!mcd_rpc_message_get_body (rpc, &body)) {
   // cursor error
   goto done;
}
```

This may be preferable if the timing of setting `cluster->client->in_exhaust` must come before an attempt to parse the OP_MSG body. It is unclear whether this is actually necessary or desirable (updating `cluster->client->in_exhaust` before a subsequent cursor error). Therefore, this PR initially proposes grouping the updates to `cluster->client` together _after_ all potential cursor error paths have been skipped.