### PR TITLE
[CDRIVER-5604 + CDRIVER-5607] replace `inline` with `BSON_INLINE`

### DIFF
--- a/src/libbson/src/bson/bson-oid.c
+++ b/src/libbson/src/bson/bson-oid.c
@@ -76,7 +76,7 @@ BSON_MAYBE_UNUSED static const uint16_t gHexCharPairs[] = {
 #endif
 };
 
-static inline void
+static BSON_INLINE void
 _oid_init (bson_oid_t *oid, bson_context_t *context, bool add_random)
 {
    BSON_ASSERT (oid);

--- a/src/libmongoc/src/mongoc/mongoc-topology-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-private.h
@@ -445,7 +445,7 @@ _mongoc_topology_set_rr_resolver (mongoc_topology_t *topology, _mongoc_rr_resolv
 /**
  * @brief Thread-safe update the SRV polling rescan interval on the given topology
  */
-static inline void
+static BSON_INLINE void
 _mongoc_topology_set_srv_polling_rescan_interval_ms (mongoc_topology_t *topology, int64_t val)
 {
    bson_atomic_int64_exchange (&topology->_atomic_srv_polling_rescan_interval_ms, val, bson_memory_order_seq_cst);
@@ -454,7 +454,7 @@ _mongoc_topology_set_srv_polling_rescan_interval_ms (mongoc_topology_t *topology
 /**
  * @brief Thread-safe get the SRV polling interval
  */
-static inline int64_t
+static BSON_INLINE int64_t
 _mongoc_topology_get_srv_polling_rescan_interval_ms (mongoc_topology_t const *topology)
 {
    return bson_atomic_int64_fetch (&topology->_atomic_srv_polling_rescan_interval_ms, bson_memory_order_seq_cst);


### PR DESCRIPTION
To fix build on VS 2013. Replaces `inline` added in CDRIVER-5604 and CDRIVER-5607.

Patch with a VS 2013 task: https://spruce.mongodb.com/version/6683efce978b630007f6b801

I also added the `release-compile` task on the `windows-2013` variant as part of the [GitHub Patch Definitions](https://spruce.mongodb.com/project/mongo-c-driver/settings/github-commitqueue) to include a VS 2013 task in the Evergreen patches created in GitHub PRs.