### PR TITLE
CDRIVER-5549 Address -fsanitize=function and -Wcast-function-type-strict warnings

### DIFF
--- a/.evergreen/scripts/run-tests.sh
+++ b/.evergreen/scripts/run-tests.sh
@@ -114,7 +114,18 @@ fi
 export ASAN_OPTIONS="detect_leaks=1 abort_on_error=1 symbolize=1"
 export ASAN_SYMBOLIZER_PATH="/opt/mongodbtoolchain/v3/bin/llvm-symbolizer"
 export TSAN_OPTIONS="suppressions=./.tsan-suppressions"
-export UBSAN_OPTIONS="print_stacktrace=1 abort_on_error=1"
+
+ubsan_opts=(
+  "print_stacktrace=1"
+  "abort_on_error=1"
+)
+
+# UBSan with Clang 3.8 fails to parse the suppression file.
+if [[ "${distro_id:?}" != ubuntu1604-* ]]; then
+  ubsan_opts+=("suppressions=./.ubsan-suppressions")
+fi
+
+export UBSAN_OPTIONS="${ubsan_opts[*]}"
 
 declare -a test_args=(
   "-d"

--- a/.ubsan-suppressions
+++ b/.ubsan-suppressions
@@ -1,0 +1,10 @@
+# src/utf8proc-2.8.0/utf8proc.c:368:53: runtime error: applying zero offset to null pointer
+# src/utf8proc-2.8.0/utf8proc.c:554:20: runtime error: applying zero offset to null pointer
+#
+# Upstream Fix: https://github.com/JuliaStrings/utf8proc/pull/240
+#
+# Context: https://github.com/llvm/llvm-project/commit/536b0ee40ab97f2878dc124a321cf9108ee3d233
+# > To make things more fun, in C (6.5.6p8), applying *any* offset to null pointer
+# > is undefined, although Clang front-end pessimizes the code by not lowering
+# > that info, so this UB is "harmless".
+pointer-overflow:utf8proc.c

--- a/src/common/common-macros-private.h
+++ b/src/common/common-macros-private.h
@@ -42,4 +42,17 @@
 #define MC_ENABLE_CONVERSION_WARNING_END
 #endif
 
+// Disable the -Wcast-function-type-strict warning.
+#define MC_DISABLE_CAST_FUNCTION_TYPE_STRICT_WARNING_BEGIN
+#define MC_DISABLE_CAST_FUNCTION_TYPE_STRICT_WARNING_END
+#if defined(__clang__)
+#if __has_warning("-Wcast-function-type-strict")
+#undef MC_DISABLE_CAST_FUNCTION_TYPE_STRICT_WARNING_BEGIN
+#undef MC_DISABLE_CAST_FUNCTION_TYPE_STRICT_WARNING_END
+#define MC_DISABLE_CAST_FUNCTION_TYPE_STRICT_WARNING_BEGIN \
+   _Pragma ("clang diagnostic push") _Pragma ("clang diagnostic ignored \"-Wcast-function-type-strict\"")
+#define MC_DISABLE_CAST_FUNCTION_TYPE_STRICT_WARNING_END _Pragma ("clang diagnostic pop")
+#endif // __has_warning("-Wcast-function-type-strict")
+#endif // defined(__clang__)
+
 #endif /* COMMON_MACROS_PRIVATE_H */

--- a/src/libbson/tests/test-bson-corpus.c
+++ b/src/libbson/tests/test-bson-corpus.c
@@ -267,7 +267,7 @@ test_bson_corpus_parse_error (test_bson_parse_error_type_t *test)
 
 
 static void
-test_bson_corpus_cb (bson_t *scenario)
+test_bson_corpus_cb (void *scenario)
 {
    corpus_test (scenario, test_bson_corpus_valid, test_bson_corpus_decode_error, test_bson_corpus_parse_error);
 }

--- a/src/libmongoc/src/mongoc/mongoc-cyrus.c
+++ b/src/libmongoc/src/mongoc/mongoc-cyrus.c
@@ -173,12 +173,14 @@ _mongoc_cyrus_verifyfile_cb (void *context, const char *file, sasl_verify_type_t
 void
 _mongoc_cyrus_init (mongoc_cyrus_t *sasl)
 {
+   MC_DISABLE_CAST_FUNCTION_TYPE_STRICT_WARNING_BEGIN
    sasl_callback_t callbacks[] = {{SASL_CB_AUTHNAME, SASL_CALLBACK_FN (_mongoc_cyrus_get_user), sasl},
                                   {SASL_CB_USER, SASL_CALLBACK_FN (_mongoc_cyrus_get_user), sasl},
                                   {SASL_CB_PASS, SASL_CALLBACK_FN (_mongoc_cyrus_get_pass), sasl},
                                   {SASL_CB_CANON_USER, SASL_CALLBACK_FN (_mongoc_cyrus_canon_user), sasl},
                                   {SASL_CB_VERIFYFILE, SASL_CALLBACK_FN (_mongoc_cyrus_verifyfile_cb), NULL},
                                   {SASL_CB_LIST_END}};
+   MC_DISABLE_CAST_FUNCTION_TYPE_STRICT_WARNING_END
 
    BSON_ASSERT (sasl);
 

--- a/src/libmongoc/src/mongoc/mongoc-init.c
+++ b/src/libmongoc/src/mongoc/mongoc-init.c
@@ -111,9 +111,11 @@ static BSON_ONCE_FUN (_mongoc_do_init)
    sasl_set_mutex (
       mongoc_cyrus_mutex_alloc, mongoc_cyrus_mutex_lock, mongoc_cyrus_mutex_unlock, mongoc_cyrus_mutex_free);
 
+   MC_DISABLE_CAST_FUNCTION_TYPE_STRICT_WARNING_BEGIN
    sasl_callback_t callbacks[] = {// Include callback to disable loading plugins.
                                   {SASL_CB_VERIFYFILE, SASL_CALLBACK_FN (_mongoc_cyrus_verifyfile_cb), NULL},
                                   {SASL_CB_LIST_END}};
+   MC_DISABLE_CAST_FUNCTION_TYPE_STRICT_WARNING_END
 
    status = sasl_client_init (callbacks);
    BSON_ASSERT (status == SASL_OK);

--- a/src/libmongoc/src/mongoc/mongoc-set-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-set-private.h
@@ -29,6 +29,7 @@ typedef void (*mongoc_set_item_dtor) (void *item, void *ctx);
 typedef bool (*mongoc_set_for_each_cb_t) (void *item, void *ctx);
 typedef bool (*mongoc_set_for_each_const_cb_t) (const void *item, void *ctx);
 typedef bool (*mongoc_set_for_each_with_id_cb_t) (uint32_t id, void *item, void *ctx);
+typedef bool (*mongoc_set_for_each_with_id_const_cb_t) (uint32_t id, const void *item, void *ctx);
 
 typedef struct {
    uint32_t id;
@@ -92,14 +93,14 @@ mongoc_set_destroy (mongoc_set_t *set);
 void
 mongoc_set_for_each (mongoc_set_t *set, mongoc_set_for_each_cb_t cb, void *ctx);
 
-static BSON_INLINE void
-mongoc_set_for_each_const (const mongoc_set_t *set, mongoc_set_for_each_const_cb_t cb, void *ctx)
-{
-   mongoc_set_for_each ((mongoc_set_t *) set, (mongoc_set_for_each_cb_t) cb, ctx);
-}
+void
+mongoc_set_for_each_const (const mongoc_set_t *set, mongoc_set_for_each_const_cb_t cb, void *ctx);
 
 void
 mongoc_set_for_each_with_id (mongoc_set_t *set, mongoc_set_for_each_with_id_cb_t cb, void *ctx);
+
+void
+mongoc_set_for_each_with_id_const (const mongoc_set_t *set, mongoc_set_for_each_with_id_const_cb_t cb, void *ctx);
 
 /* first item in set for which "cb" returns true */
 void *

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl.c
@@ -41,6 +41,8 @@
 #include "mongoc-log.h"
 #include "mongoc-error.h"
 
+#include "common-macros-private.h"
+
 
 #undef MONGOC_LOG_DOMAIN
 #define MONGOC_LOG_DOMAIN "stream-tls-openssl"
@@ -759,7 +761,9 @@ mongoc_stream_tls_openssl_new (mongoc_stream_t *base_stream, const char *host, m
    if (!client) {
       /* Only used by the Mock Server.
        * Set a callback to get the SNI, if provided */
+      MC_DISABLE_CAST_FUNCTION_TYPE_STRICT_WARNING_BEGIN
       SSL_CTX_set_tlsext_servername_callback (ssl_ctx, _mongoc_stream_tls_openssl_sni);
+      MC_DISABLE_CAST_FUNCTION_TYPE_STRICT_WARNING_END
    }
 
    if (opt->weak_cert_validation) {

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -285,7 +285,7 @@ _mongoc_apply_srv_max_hosts (const mongoc_host_list_t *hl, size_t max_hosts, siz
     * Drivers SHOULD use the `Fisher-Yates shuffle` for randomization. */
    for (size_t idx = hl_size - 1u; idx > 0u; --idx) {
       /* 0 <= swap_pos <= idx */
-      const size_t swap_pos = _mongoc_rand_size_t (0u, idx, _mongoc_simple_rand_size_t);
+      const size_t swap_pos = _mongoc_rand_size_t (0u, idx);
 
       const mongoc_host_list_t *tmp = hl_array[swap_pos];
       hl_array[swap_pos] = hl_array[idx];

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -194,7 +194,7 @@ _mongoc_topology_scanner_cb (
 }
 
 static void
-_server_session_init (mongoc_server_session_t *session, mongoc_topology_t *unused, bson_error_t *error)
+_server_session_init (void *session, void *unused, bson_error_t *error)
 {
    BSON_UNUSED (unused);
 
@@ -202,7 +202,7 @@ _server_session_init (mongoc_server_session_t *session, mongoc_topology_t *unuse
 }
 
 static void
-_server_session_destroy (mongoc_server_session_t *session, mongoc_topology_t *unused)
+_server_session_destroy (void *session, void *unused)
 {
    BSON_UNUSED (unused);
 
@@ -210,10 +210,13 @@ _server_session_destroy (mongoc_server_session_t *session, mongoc_topology_t *un
 }
 
 static int
-_server_session_should_prune (mongoc_server_session_t *session, mongoc_topology_t *topo)
+_server_session_should_prune (const void *session_vp, void *topo_vp)
 {
-   BSON_ASSERT_PARAM (session);
-   BSON_ASSERT_PARAM (topo);
+   BSON_ASSERT_PARAM (session_vp);
+   BSON_ASSERT_PARAM (topo_vp);
+
+   const mongoc_server_session_t *const session = session_vp;
+   mongoc_topology_t *const topo = topo_vp;
 
    /** If "dirty" (i.e. contains a network error), it should be dropped */
    if (session->dirty) {

--- a/src/libmongoc/src/mongoc/mongoc-util-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-util-private.h
@@ -214,7 +214,8 @@ _mongoc_simple_rand_uint64_t (void);
 size_t
 _mongoc_simple_rand_size_t (void);
 
-/* Returns a uniformly-distributed random integer in the range [min, max].
+/* Returns a uniformly-distributed random integer in the range [min, max]
+ * using the provided `rand` generator.
  *
  * The size of the range [min, max] must not equal the size of the representable
  * range of uint32_t (`min == 0 && max == UINT32_MAX` must not be true).
@@ -225,7 +226,8 @@ _mongoc_simple_rand_size_t (void);
 uint32_t
 _mongoc_rand_uint32_t (uint32_t min, uint32_t max, uint32_t (*rand) (void));
 
-/* Returns a uniformly-distributed random integer in the range [min, max].
+/* Returns a uniformly-distributed random integer in the range [min, max]
+ * using the provided `rand` generator.
  *
  * The size of the range [min, max] must not equal the size of the representable
  * range of uint64_t (`min == 0 && max == UINT64_MAX` must not be true).
@@ -236,16 +238,14 @@ _mongoc_rand_uint32_t (uint32_t min, uint32_t max, uint32_t (*rand) (void));
 uint64_t
 _mongoc_rand_uint64_t (uint64_t min, uint64_t max, uint64_t (*rand) (void));
 
-/* Returns a uniformly-distributed random integer in the range [min, max].
+/* Returns a uniformly-distributed random integer in the range [min, max]
+ * using the `_mongoc_simple_rand_size_t()` generator.
  *
  * The size of the range [min, max] must not equal the size of the representable
  * range of size_t (`min == 0 && max == SIZE_MAX` must not be true).
- *
- * The generator `rand` must return a random integer uniformly distributed in
- * the full range of representable values of size_t.
  */
 size_t
-_mongoc_rand_size_t (size_t min, size_t max, size_t (*rand) (void));
+_mongoc_rand_size_t (size_t min, size_t max);
 
 /* _mongoc_iter_document_as_bson attempts to read the document from @iter into
  * @bson. */

--- a/src/libmongoc/src/mongoc/mongoc-util.c
+++ b/src/libmongoc/src/mongoc/mongoc-util.c
@@ -914,12 +914,12 @@ _mongoc_simple_rand_size_t (void)
 }
 
 size_t
-_mongoc_rand_size_t (size_t min, size_t max, size_t (*rand) (void))
+_mongoc_rand_size_t (size_t min, size_t max)
 {
    BSON_ASSERT (min <= max);
    BSON_ASSERT (min != 0u || max != UINT64_MAX);
 
-   return _mongoc_rand_java64 (max - min + 1u, (uint64_t (*) (void)) rand) + min;
+   return _mongoc_rand_java64 (max - min + 1u, &_mongoc_simple_rand_uint64_t) + min;
 }
 
 #elif SIZE_MAX == UINT32_MAX
@@ -933,12 +933,12 @@ _mongoc_simple_rand_size_t (void)
 }
 
 size_t
-_mongoc_rand_size_t (size_t min, size_t max, size_t (*rand) (void))
+_mongoc_rand_size_t (size_t min, size_t max)
 {
    BSON_ASSERT (min <= max);
    BSON_ASSERT (min != 0u || max != UINT32_MAX);
 
-   return _mongoc_rand_nduid32 (max - min + 1u, (uint32_t (*) (void)) rand) + min;
+   return _mongoc_rand_nduid32 (max - min + 1u, &_mongoc_simple_rand_uint32_t) + min;
 }
 
 #else

--- a/src/libmongoc/tests/TestSuite.c
+++ b/src/libmongoc/tests/TestSuite.c
@@ -249,9 +249,7 @@ TestSuite_CheckMockServerAllowed (void)
 static void
 TestSuite_AddHelper (void *ctx)
 {
-   TestFunc cb = (TestFunc) ((TestFnCtx *) ctx)->test_fn;
-
-   cb ();
+   ((TestFnCtx *) ctx)->test_fn ();
 }
 
 void
@@ -332,9 +330,11 @@ _TestSuite_AddMockServerTest (TestSuite *suite, const char *name, TestFunc func,
 {
    Test *test;
    va_list ap;
+   TestFnCtx *ctx = bson_malloc (sizeof (TestFnCtx));
+   *ctx = (TestFnCtx){.test_fn = func, .dtor = NULL};
 
    va_start (ap, func);
-   test = _V_TestSuite_AddFull (suite, name, (TestFuncWC) func, NULL, NULL, ap);
+   test = _V_TestSuite_AddFull (suite, name, TestSuite_AddHelper, _TestSuite_TestFnCtxDtor, ctx, ap);
    va_end (ap);
 
    if (test) {

--- a/src/libmongoc/tests/json-test.c
+++ b/src/libmongoc/tests/json-test.c
@@ -1863,6 +1863,12 @@ _skip_if_unsupported (const char *test_name, bson_t *original)
    return original;
 }
 
+static void
+bson_destroy_vp (void *vp)
+{
+   bson_destroy ((bson_t *) vp);
+}
+
 /*
  *-----------------------------------------------------------------------
  *
@@ -1947,7 +1953,7 @@ _install_json_test_suite_with_check (TestSuite *suite, const char *base, const c
       }
       /* list of "check" functions that decide whether to skip the test */
       va_start (ap, callback);
-      _V_TestSuite_AddFull (suite, skip_json, (void (*) (void *)) callback, (void (*) (void *)) bson_destroy, test, ap);
+      _V_TestSuite_AddFull (suite, skip_json, (void (*) (void *)) callback, &bson_destroy_vp, test, ap);
 
       va_end (ap);
    }

--- a/src/libmongoc/tests/json-test.c
+++ b/src/libmongoc/tests/json-test.c
@@ -322,7 +322,7 @@ process_sdam_test_hello_responses (bson_t *phase, mongoc_topology_t *topology)
  *-----------------------------------------------------------------------
  */
 void
-test_server_selection_logic_cb (bson_t *test)
+test_server_selection_logic_cb (void *test_vp)
 {
    bool expected_error;
    bson_error_t error;
@@ -352,7 +352,8 @@ test_server_selection_logic_cb (bson_t *test)
 
    _mongoc_array_init (&selected_servers, sizeof (mongoc_server_description_t *));
 
-   BSON_ASSERT (test);
+   BSON_ASSERT (test_vp);
+   const bson_t *const test = test_vp;
 
    expected_error = bson_iter_init_find (&iter, test, "error") && bson_iter_as_bool (&iter);
 
@@ -1953,7 +1954,7 @@ _install_json_test_suite_with_check (TestSuite *suite, const char *base, const c
       }
       /* list of "check" functions that decide whether to skip the test */
       va_start (ap, callback);
-      _V_TestSuite_AddFull (suite, skip_json, (void (*) (void *)) callback, &bson_destroy_vp, test, ap);
+      _V_TestSuite_AddFull (suite, skip_json, callback, &bson_destroy_vp, test, ap);
 
       va_end (ap);
    }

--- a/src/libmongoc/tests/json-test.h
+++ b/src/libmongoc/tests/json-test.h
@@ -28,7 +28,7 @@
 
 #define MAX_NUM_TESTS 150
 
-typedef void (*test_hook) (bson_t *test);
+typedef void (*test_hook) (void *test);
 
 typedef struct {
    const char *description;
@@ -77,7 +77,7 @@ void
 process_sdam_test_hello_responses (bson_t *phase, mongoc_topology_t *topology);
 
 void
-test_server_selection_logic_cb (bson_t *test);
+test_server_selection_logic_cb (void *test);
 
 mongoc_server_description_type_t
 server_type_from_test (const char *type);

--- a/src/libmongoc/tests/test-atlas-executor.c
+++ b/src/libmongoc/tests/test-atlas-executor.c
@@ -64,6 +64,12 @@ TestSuite_Run_Atlas (TestSuite *suite)
    capture_logs (false);
 }
 
+static void
+bson_destroy_vp (void *vp)
+{
+   bson_destroy ((bson_t *) vp);
+}
+
 int
 main (int argc, char **argv)
 {
@@ -77,7 +83,7 @@ main (int argc, char **argv)
    ASSERT_OR_PRINT (bson, error);
 
    TestSuite_AddFull (
-      &suite, "test", (TestFuncWC) &run_one_test_file, (TestFuncDtor) &bson_destroy, bson, TestSuite_CheckLive, NULL);
+      &suite, "test", (TestFuncWC) &run_one_test_file, &bson_destroy_vp, bson, TestSuite_CheckLive, NULL);
 
    mongoc_init ();
    TestSuite_Run_Atlas (&suite);

--- a/src/libmongoc/tests/test-mcd-azure-imds.c
+++ b/src/libmongoc/tests/test-mcd-azure-imds.c
@@ -94,9 +94,8 @@ _test_with_mock_server (void *ctx)
 }
 
 static int
-have_mock_server_env (TestSuite *ctx)
+have_mock_server_env (void)
 {
-   BSON_UNUSED (ctx);
    return _get_test_imds_host () != NULL;
 }
 

--- a/src/libmongoc/tests/test-mongoc-client-session.c
+++ b/src/libmongoc/tests/test-mongoc-client-session.c
@@ -2444,7 +2444,7 @@ _test_run_operation (json_test_ctx_t *ctx, const bson_t *test, const bson_t *ope
 }
 
 static void
-test_sessions_spec_cb (bson_t *scenario)
+test_sessions_spec_cb (void *scenario)
 {
    json_test_config_t config = JSON_TEST_CONFIG_INIT;
    config.run_operation_cb = _test_run_operation;

--- a/src/libmongoc/tests/test-mongoc-client-session.c
+++ b/src/libmongoc/tests/test-mongoc-client-session.c
@@ -1190,9 +1190,10 @@ struct check_session_returned_t {
 };
 
 static int
-check_session_returned_visit (mongoc_server_session_t *ss, mongoc_topology_t *unused, void *check_state_)
+check_session_returned_visit (void *ss_vp, void *unused, void *check_state_)
 {
    match_ctx_t ctx = {{0}};
+   mongoc_server_session_t *const ss = ss_vp;
    struct check_session_returned_t *check_state = check_state_;
 
    BSON_UNUSED (unused);

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -92,7 +92,7 @@ _run_operation (json_test_ctx_t *ctx, const bson_t *test, const bson_t *operatio
 }
 
 static void
-test_client_side_encryption_cb (bson_t *scenario)
+test_client_side_encryption_cb (void *scenario)
 {
    json_test_config_t config = JSON_TEST_CONFIG_INIT;
    config.before_test_cb = _before_test;

--- a/src/libmongoc/tests/test-mongoc-command-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-command-monitoring.c
@@ -76,7 +76,7 @@ command_monitoring_test_run_operation (json_test_ctx_t *ctx, const bson_t *test,
  */
 
 static void
-test_command_monitoring_cb (bson_t *scenario)
+test_command_monitoring_cb (void *scenario)
 {
    json_test_config_t config = JSON_TEST_CONFIG_INIT;
    config.run_operation_cb = command_monitoring_test_run_operation;

--- a/src/libmongoc/tests/test-mongoc-connection-uri.c
+++ b/src/libmongoc/tests/test-mongoc-connection-uri.c
@@ -238,7 +238,7 @@ run_uri_test (const char *uri_string, bool valid, const bson_t *hosts, const bso
 }
 
 static void
-test_connection_uri_cb (bson_t *scenario)
+test_connection_uri_cb (void *scenario_vp)
 {
    bson_iter_t iter;
    bson_iter_t descendent;
@@ -250,8 +250,8 @@ test_connection_uri_cb (bson_t *scenario)
    bson_t options;
    bool valid;
 
-   BSON_ASSERT (scenario);
-
+   BSON_ASSERT_PARAM (scenario_vp);
+   const bson_t *const scenario = scenario_vp;
 
    BSON_ASSERT (bson_iter_init_find (&iter, scenario, "tests"));
    BSON_ASSERT (BSON_ITER_HOLDS_ARRAY (&iter));

--- a/src/libmongoc/tests/test-mongoc-crud.c
+++ b/src/libmongoc/tests/test-mongoc-crud.c
@@ -19,7 +19,7 @@ crud_test_operation_cb (json_test_ctx_t *ctx, const bson_t *test, const bson_t *
 }
 
 static void
-test_crud_cb (bson_t *scenario)
+test_crud_cb (void *scenario)
 {
    json_test_config_t config = JSON_TEST_CONFIG_INIT;
    config.run_operation_cb = crud_test_operation_cb;

--- a/src/libmongoc/tests/test-mongoc-dns.c
+++ b/src/libmongoc/tests/test-mongoc-dns.c
@@ -388,7 +388,7 @@ cleanup:
 
 
 static void
-test_dns (bson_t *test)
+test_dns (void *test)
 {
    _test_dns_maybe_pooled (test, false);
    _test_dns_maybe_pooled (test, true);

--- a/src/libmongoc/tests/test-mongoc-gridfs-bucket.c
+++ b/src/libmongoc/tests/test-mongoc-gridfs-bucket.c
@@ -769,7 +769,7 @@ run_gridfs_spec_test (mongoc_database_t *db, mongoc_gridfs_bucket_t *bucket, bso
 }
 
 static void
-test_gridfs_cb (bson_t *scenario)
+test_gridfs_cb (void *scenario_vp)
 {
    mongoc_gridfs_bucket_t *gridfs;
    mongoc_database_t *db;
@@ -780,6 +780,9 @@ test_gridfs_cb (bson_t *scenario)
    bson_t *data;
    bson_t *tests;
    bson_t *test;
+
+   BSON_ASSERT_PARAM (scenario_vp);
+   const bson_t *const scenario = scenario_vp;
 
    /* Make a gridfs on generated db */
    dbname = gen_collection_name ("test");

--- a/src/libmongoc/tests/test-mongoc-mongohouse.c
+++ b/src/libmongoc/tests/test-mongoc-mongohouse.c
@@ -20,7 +20,7 @@ mongohouse_test_operation_cb (json_test_ctx_t *ctx, const bson_t *test, const bs
 }
 
 static void
-test_mongohouse_cb (bson_t *scenario)
+test_mongohouse_cb (void *scenario)
 {
    json_test_config_t config = JSON_TEST_CONFIG_INIT;
 

--- a/src/libmongoc/tests/test-mongoc-read-write-concern.c
+++ b/src/libmongoc/tests/test-mongoc-read-write-concern.c
@@ -102,7 +102,7 @@ invalid:
 
 
 static void
-test_rw_concern_uri (bson_t *scenario)
+test_rw_concern_uri (void *scenario_vp)
 {
    bson_iter_t scenario_iter;
    bson_iter_t test_iter;
@@ -117,6 +117,9 @@ test_rw_concern_uri (bson_t *scenario)
    const mongoc_write_concern_t *wc;
    mongoc_write_concern_t *wc_correct;
    mongoc_read_concern_t *rc_correct;
+
+   BSON_ASSERT_PARAM (scenario_vp);
+   const bson_t *const scenario = scenario_vp;
 
    /* initialize tests with the scenario */
    BSON_ASSERT (bson_iter_init_find (&scenario_iter, scenario, "tests"));
@@ -162,7 +165,7 @@ test_rw_concern_uri (bson_t *scenario)
 }
 
 static void
-test_rw_concern_document (bson_t *scenario)
+test_rw_concern_document (void *scenario_vp)
 {
    bson_iter_t scenario_iter;
    bson_iter_t test_iter;
@@ -176,6 +179,9 @@ test_rw_concern_document (bson_t *scenario)
    const bson_t *rc_doc_result;
    bson_t rc_doc_correct;
    bson_t wc_doc_correct;
+
+   BSON_ASSERT_PARAM (scenario_vp);
+   const bson_t *const scenario = scenario_vp;
 
    BSON_ASSERT (bson_iter_init_find (&scenario_iter, scenario, "tests"));
    BSON_ASSERT (bson_iter_recurse (&scenario_iter, &test_iter));

--- a/src/libmongoc/tests/test-mongoc-retryable-reads.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-reads.c
@@ -38,7 +38,7 @@ retryable_reads_test_run_operation (json_test_ctx_t *ctx, const bson_t *test, co
 
 /* Callback for JSON tests from Retryable Reads Spec */
 static void
-test_retryable_reads_cb (bson_t *scenario)
+test_retryable_reads_cb (void *scenario)
 {
    bool explicit_session;
    json_test_config_t config = JSON_TEST_CONFIG_INIT;

--- a/src/libmongoc/tests/test-mongoc-retryable-writes.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-writes.c
@@ -32,7 +32,7 @@ static test_skip_t skips[] = {
 
 /* Callback for JSON tests from Retryable Writes Spec */
 static void
-test_retryable_writes_cb (bson_t *scenario)
+test_retryable_writes_cb (void *scenario)
 {
    bool explicit_session;
    json_test_config_t config = JSON_TEST_CONFIG_INIT;

--- a/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-sdam-monitoring.c
@@ -432,7 +432,7 @@ pool_set_heartbeat_event_callbacks (mongoc_client_pool_t *pool, context_t *conte
  *-----------------------------------------------------------------------
  */
 static void
-test_sdam_monitoring_cb (bson_t *test)
+test_sdam_monitoring_cb (void *test_vp)
 {
    mongoc_client_t *client;
    mongoc_topology_t *topology;
@@ -446,6 +446,9 @@ test_sdam_monitoring_cb (bson_t *test)
    bson_t events_expected;
    context_t context;
    bool first_phase;
+
+   BSON_ASSERT_PARAM (test_vp);
+   const bson_t *const test = test_vp;
 
    /* parse out the uri and use it to create a client */
    BSON_ASSERT (bson_iter_init_find (&iter, test, "uri"));

--- a/src/libmongoc/tests/test-mongoc-sdam.c
+++ b/src/libmongoc/tests/test-mongoc-sdam.c
@@ -130,7 +130,7 @@ _topology_has_description (const mongoc_topology_description_t *topology, bson_t
  *-----------------------------------------------------------------------
  */
 static void
-test_sdam_cb (bson_t *test)
+test_sdam_cb (void *test_vp)
 {
    mongoc_client_t *client;
    bson_t phase;
@@ -147,6 +147,9 @@ test_sdam_cb (bson_t *test)
    mc_shared_tpld td = MC_SHARED_TPLD_NULL;
    const char *set_name;
    const char *hostname;
+
+   BSON_ASSERT_PARAM (test_vp);
+   const bson_t *const test = test_vp;
 
    /* parse out the uri and use it to create a client */
    BSON_ASSERT (bson_iter_init_find (&iter, test, "uri"));
@@ -452,10 +455,13 @@ run_one_integration_test (json_test_config_t *config, bson_t *test)
 }
 
 static void
-test_sdam_integration_cb (bson_t *scenario)
+test_sdam_integration_cb (void *scenario_vp)
 {
    json_test_config_t config = JSON_TEST_CONFIG_INIT;
    bson_iter_t tests_iter;
+
+   BSON_ASSERT_PARAM (scenario_vp);
+   const bson_t *const scenario = scenario_vp;
 
    config.run_operation_cb = sdam_integration_operation_cb;
    config.scenario = scenario;

--- a/src/libmongoc/tests/test-mongoc-server-selection.c
+++ b/src/libmongoc/tests/test-mongoc-server-selection.c
@@ -16,12 +16,13 @@
  */
 
 static void
-test_rtt_calculation_cb (bson_t *test)
+test_rtt_calculation_cb (void *test_vp)
 {
    mongoc_server_description_t *description;
    bson_iter_t iter;
 
-   BSON_ASSERT (test);
+   BSON_ASSERT_PARAM (test_vp);
+   const bson_t *const test = test_vp;
 
    description = (mongoc_server_description_t *) bson_malloc0 (sizeof *description);
    mongoc_server_description_init (description, "localhost:27017", 1);

--- a/src/libmongoc/tests/test-mongoc-transactions.c
+++ b/src/libmongoc/tests/test-mongoc-transactions.c
@@ -220,7 +220,7 @@ static test_skip_t skips[] = {
 
 
 static void
-test_transactions_cb (bson_t *scenario)
+test_transactions_cb (void *scenario)
 {
    json_test_config_t config = JSON_TEST_CONFIG_INIT;
 

--- a/src/libmongoc/tests/test-mongoc-ts-pool.c
+++ b/src/libmongoc/tests/test-mongoc-ts-pool.c
@@ -42,18 +42,18 @@ test_ts_pool_simple (void)
 }
 
 static int
-_is_int_42 (int *v, void *unused)
+_is_int_42 (const void *v, void *unused)
 {
-   (void) unused;
-   return *v == 42;
+   BSON_UNUSED (unused);
+   return *(const int *) v == 42;
 }
 
 static void
-_set_int_to_7 (int *v, void *unused, bson_error_t *unused2)
+_set_int_to_7 (void *v, void *unused, bson_error_t *unused2)
 {
-   (void) unused;
-   (void) unused2;
-   *v = 7;
+   BSON_UNUSED (unused);
+   BSON_UNUSED (unused2);
+   *(int *) v = 7;
 }
 
 /* Declare a pool that contains `int`, sets each new int to seven, and drops

--- a/src/libmongoc/tests/test-service-gcp.c
+++ b/src/libmongoc/tests/test-service-gcp.c
@@ -92,9 +92,8 @@ _test_with_mock_server (void *ctx)
 }
 
 static int
-have_mock_server_env (TestSuite *ctx)
+have_mock_server_env (void)
 {
-   BSON_UNUSED (ctx);
    return _get_test_host () != NULL;
 }
 

--- a/src/libmongoc/tests/unified/runner.c
+++ b/src/libmongoc/tests/unified/runner.c
@@ -1635,11 +1635,13 @@ done:
 }
 
 void
-run_one_test_file (bson_t *bson)
+run_one_test_file (void *bson_vp)
 {
    test_runner_t *test_runner = NULL;
    test_file_t *test_file = NULL;
    bson_iter_t test_iter;
+
+   bson_t *const bson = bson_vp;
 
    test_diagnostics_init ();
 

--- a/src/libmongoc/tests/unified/runner.h
+++ b/src/libmongoc/tests/unified/runner.h
@@ -73,6 +73,6 @@ void
 run_unified_tests (TestSuite *suite, const char *base, const char *subdir);
 
 void
-run_one_test_file (bson_t *bson);
+run_one_test_file (void *bson_vp);
 
 #endif /* UNIFIED_RUNNER_H */


### PR DESCRIPTION
## Summary

Resolves CDRIVER-5549. Verified by [this patch](https://spruce.mongodb.com/version/668443c95e024f00074f6dd0/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).

Recommend reviewing this PR by-commit.

This PR identifies and addresses ~20 UBSan runtime errors (exact number depends on the server version and topology) and 154 instances of `-Wcast-function-type-strict` warnings that were locally observed when building the C Driver with Clang 17. Some instances may still be unaccounted for due to sensitivity to specific build configurations, but this PR aims to provide a template for addressing such instances in the future should they become a problem (note: this PR does not add Clang 17+ test coverage to the EVG config).

## Description

Clang 17 extends the UBSan check "function", usually enabled for C++ code, to C code as well. This check diagnoses the following clause from [the C99 draft](https://www.iso-9899.info/n1570.html#6.5.2.2p9):

> If the function is defined with a type that is not compatible with the type (of the expression) pointed to by the expression that denotes the called function, the behavior is undefined.

Many C codebases, including our own, violates this clause, often through the following commonly-seen pattern:

```c
// Target functions to invoke.
void foo (A *a);
void bar (B *b);

// A "common" function pointer type for generic code.
typedef void (*fn_t)(void *);

void invoke (fn_t fn, void *ptr) {
  fn (ptr); // <-- `fn` is invoked as `void (void *)`.
}

void example (A *a, B *b) {
  // Pass target functions via "common" function pointer type.
  invoke (&foo, a);
  invoke (&bar, b);
}
```

Unfortunately, this pattern is undefined behavior. The type of `*fn` when invoked as `fn (ptr)` is `void (void *)`, which is _not_ compatible with the type of the actual functions being invoked: `void (A *)` and `void (B *)` respectively. The convertibility of individual object pointers of type `T*` to/from `void*` does _not_ extend to the parameters of a function type.

Therefore, it is necessary to ensure that the type of the function being invoked is always compatible with the type of the function in the invocation expression. Identifying such cases can be assisted by the `-Wcast-function-type-strict` Clang warning, which warns whenever a function is cast to/from an incompatible function type.

The solution usually involved one of three kinds of common patterns:

- Change the parameter type(s) to `void *` for consistency with the "common" function pointer type and cast back to the object pointer type within the function body. (e.g. `TestFuncWC` and `TestFunc` callbacks, TS pool callbacks, etc.).
- If unable to change the target function's type, use an intermediate function whose type is consistent with the "common" function pointer type. (e.g. `bson_destroy_vp`, `_apm_func` + `_apm_func_defn`, etc.)
- If unable to use any compatible function pointer type, pass the target function via an object pointer (`void *`) instead. (e.g. `TestFnCtx` (introduced in https://github.com/mongodb/mongo-c-driver/issues/850), `make_cursor_helper_t`, etc.)

As an exception to the above, the `mongoc_set_t` const-for-each interface needed to be extended, as a pattern that reuses a common implementation that does not violate function type compatibility could not be identified.

`-Wcast-function-type-strict` warnings pertaining to external libraries are explicitly suppressed or silenced, as there is little we can do about it ourselves (e.g. OpenSSL/Cyrus callback registration APIs).

As a drive-by fix (not _quite_ related), a benign UBSan runtime error emitted by the utf8proc library is suppressed by a new `.ubsan-suppressions` file. Details are documented within the suppressions file itself.