### PR TITLE
CDRIVER-5629 do not use `bool` in BSON DSL

### DIFF
--- a/src/common/bson-dsl.h
+++ b/src/common/bson-dsl.h
@@ -242,9 +242,8 @@ BSON_IF_GNU_LIKE (_Pragma ("GCC diagnostic ignored \"-Wshadow\""))
       bsonBuildError = "Error while appending bool(" _bsonDSL_str (b) ")"; \
    } else                                                                  \
       ((void) 0)
-#define _bsonArrayOperation_bool(X) _bsonArrayAppendValue (bool (X))
-#define _bsonValueOperation__Bool(b) _bsonValueOperation_bool (b)
-#define _bsonArrayOperation__Bool(X) _bsonArrayAppendValue (_Bool (X))
+#define _bsonArrayOperation_boolean(X) _bsonArrayAppendValue (boolean (X))
+#define _bsonValueOperation_boolean(b) _bsonValueOperation_bool (b)
 
 #define _bsonValueOperation_null                       \
    if (!bson_append_null (_bsonBuildAppendArgs)) {     \
@@ -386,9 +385,8 @@ BSON_IF_GNU_LIKE (_Pragma ("GCC diagnostic ignored \"-Wshadow\""))
 #define _bsonDSL_Type_binary BSON_TYPE_BINARY
 #define _bsonDSL_Type_undefined BSON_TYPE_UNDEFINED
 #define _bsonDSL_Type_oid BSON_TYPE_OID
-#define _bsonDSL_Type_bool BSON_TYPE_BOOL
-// ("bool" may be spelled _Bool due to macro expansion:)
-#define _bsonDSL_Type__Bool BSON_TYPE_BOOL
+// Use `boolean`, not `bool`. `bool` may be defined as a macro to `_Bool` or `int`:
+#define _bsonDSL_Type_boolean BSON_TYPE_BOOL
 #define _bsonDSL_Type_date_time BSON_TYPE_DATE_TIME
 #define _bsonDSL_Type_null BSON_TYPE_NULL
 #define _bsonDSL_Type_regex BSON_TYPE_REGEX
@@ -1069,15 +1067,9 @@ _bsonVisitIterAs_int32 (void)
 }
 
 static BSON_INLINE bool
-_bsonVisitIterAs_bool (void)
+_bsonVisitIterAs_boolean (void)
 {
    return bson_iter_as_bool (&bsonVisitIter);
-}
-
-static BSON_INLINE bool
-_bsonVisitIterAs__Bool (void)
-{
-   return _bsonVisitIterAs_bool ();
 }
 
 #define bsonAs(Type) _bsonDSL_paste (_bsonVisitIterAs_, Type) ()

--- a/src/common/bson-dsl.md
+++ b/src/common/bson-dsl.md
@@ -50,7 +50,7 @@ Result:
 ### A Simple "okay"
 
 ```c
-bsonBuildDecl(e, kv("okay", bool(true)));
+bsonBuildDecl(e, kv("okay", boolean(true)));
 ```
 
 Result:
@@ -245,7 +245,7 @@ appended to a document or array.
 Generates a BSON null value.
 
 
-#### `bool(bool b)`
+#### `boolean(bool b)`
 
 Generate a BSON boolean value from the given C boolean expression.
 
@@ -642,7 +642,7 @@ match.
 Matches if the element's current type matches the `TypeName` `t`.
 
 The `TypeName`s are: `double`, `utf8`, `doc`, `array`, `binary`, `undefined`,
-`oid`, `bool`, `date_time`, `null`, `regex`, `dbpointer`, `code`, `codewscope`,
+`oid`, `boolean`, `date_time`, `null`, `regex`, `dbpointer`, `code`, `codewscope`,
 `int32`, `timestamp`, `int64`, and `decimal128`.
 
 
@@ -858,7 +858,7 @@ bsonParse(
   find(key("readonly"),
        // bsonPredicate() will evaluate a predicate on bsonVisitIter
        // (which here points to the "readonly" property in "input")
-       append(*output, kv("readonly", bool(bsonPredicate(truthy))))));
+       append(*output, kv("readonly", boolean(bsonPredicate(truthy))))));
 ```
 
 

--- a/src/libmongoc/src/mongoc/mongoc-uri.c
+++ b/src/libmongoc/src/mongoc/mongoc-uri.c
@@ -1633,9 +1633,9 @@ _mongoc_uri_build_write_concern (mongoc_uri_t *uri, bson_error_t *error)
    uri->write_concern = write_concern;
 
    bsonParse (uri->options,
-              find (iKeyWithType (MONGOC_URI_SAFE, bool),
+              find (iKeyWithType (MONGOC_URI_SAFE, boolean),
                     do (mongoc_write_concern_set_w (write_concern,
-                                                    bsonAs (bool) ? 1 : MONGOC_WRITE_CONCERN_W_UNACKNOWLEDGED))));
+                                                    bsonAs (boolean) ? 1 : MONGOC_WRITE_CONCERN_W_UNACKNOWLEDGED))));
 
    if (bsonParseError) {
       MONGOC_URI_ERROR (error, "Error while parsing 'safe' URI option: %s", bsonParseError);
@@ -1651,8 +1651,8 @@ _mongoc_uri_build_write_concern (mongoc_uri_t *uri, bson_error_t *error)
    }
 
    bsonParse (uri->options,
-              find (iKeyWithType (MONGOC_URI_JOURNAL, bool),
-                    do (mongoc_write_concern_set_journal (write_concern, bsonAs (bool)))));
+              find (iKeyWithType (MONGOC_URI_JOURNAL, boolean),
+                    do (mongoc_write_concern_set_journal (write_concern, bsonAs (boolean)))));
    if (bsonParseError) {
       MONGOC_URI_ERROR (error, "Error while parsing 'journal' URI option: %s", bsonParseError);
       return false;

--- a/src/libmongoc/tests/test-mongoc-client-session.c
+++ b/src/libmongoc/tests/test-mongoc-client-session.c
@@ -2557,7 +2557,7 @@ test_sessions_snapshot_prose_test_1 (void *ctx)
    mongoc_client_t *client = NULL;
    mongoc_session_opt_t *session_opts = NULL;
    bson_error_t error;
-   bool r;
+   mongoc_client_session_t *r;
 
    BSON_UNUSED (ctx);
 

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -5842,9 +5842,9 @@ CEC_TEST (test_create_encrypted_collection_bad_keyId, const char *const kmsProvi
    bsonBuildDecl (
       ccOpts,
       kv ("encryptedFields",
-          doc (kv (
-             "fields",
-             array (doc (kv ("path", cstr ("ssn")), kv ("bsonType", cstr ("string")), kv ("keyId", bool (true))))))));
+          doc (kv ("fields",
+                   array (doc (
+                      kv ("path", cstr ("ssn")), kv ("bsonType", cstr ("string")), kv ("keyId", boolean (true))))))));
    mongoc_database_t *const db = mongoc_client_get_database (client, dbName);
    bson_t *const mkey = _make_kms_masterkey (kmsProvider);
    mongoc_collection_t *const coll = mongoc_client_encryption_create_encrypted_collection (

--- a/src/libmongoc/tests/unified/entity-map.c
+++ b/src/libmongoc/tests/unified/entity-map.c
@@ -581,7 +581,7 @@ entity_client_new (entity_map_t *em, bson_t *bson, bson_error_t *error)
             storeDocDupPtr (uri_options)),
       // Optional 'useMultipleMongoses' bool
       find (key ("useMultipleMongoses"),
-            if (not(type (bool)), then (error ("'useMultipleMongoses' must be a bool value"))),
+            if (not(type (boolean)), then (error ("'useMultipleMongoses' must be a bool value"))),
             do (use_multiple_mongoses_set = true),
             storeBool (use_multiple_mongoses)),
       // Events to observe:
@@ -626,18 +626,18 @@ entity_client_new (entity_map_t *em, bson_t *bson, bson_error_t *error)
                else (error ("Missing 'version' property in 'serverApi' object")),
                // Toggle strictness:
                find (key ("strict"),
-                     if (not(type (bool)), then (error ("'serverApi.strict' must be a bool"))),
-                     do (mongoc_server_api_strict (api, bsonAs (bool)))),
+                     if (not(type (boolean)), then (error ("'serverApi.strict' must be a bool"))),
+                     do (mongoc_server_api_strict (api, bsonAs (boolean)))),
                // Toggle deprecation errors:
                find (key ("deprecationErrors"),
-                     if (not(type (bool)), then (error ("serverApi.deprecationErrors must be a bool"))),
-                     do (mongoc_server_api_deprecation_errors (api, bsonAs (bool)))))),
+                     if (not(type (boolean)), then (error ("serverApi.deprecationErrors must be a bool"))),
+                     do (mongoc_server_api_deprecation_errors (api, bsonAs (boolean)))))),
       // Toggle observation of sensitive commands
       find (key ("observeSensitiveCommands"),
-            if (not(type (bool)), then (error ("'observeSensitiveCommands' must be a bool"))),
+            if (not(type (boolean)), then (error ("'observeSensitiveCommands' must be a bool"))),
             do ({
                bool *p = entity->observe_sensitive_commands = bson_malloc (sizeof (bool));
-               *p = bsonAs (bool);
+               *p = bsonAs (boolean);
             })),
       // Which events should be available as entities:
       find (key ("storeEventsAsEntities"),

--- a/src/libmongoc/tests/unified/operation.c
+++ b/src/libmongoc/tests/unified/operation.c
@@ -3582,7 +3582,7 @@ operation_rename (test_t *test, operation_t *op, result_t *result, bson_error_t 
 
    // Rename the collection in the server,
    mongoc_collection_t *coll = ent->value;
-   if (!mongoc_collection_rename (coll, NULL, new_name, drop_target, error)) {
+   if (!mongoc_collection_rename (coll, NULL, new_name, *drop_target, error)) {
       goto done;
    }
    result_from_ok (result);

--- a/src/libmongoc/tests/unified/operation.c
+++ b/src/libmongoc/tests/unified/operation.c
@@ -3555,7 +3555,7 @@ operation_rename (test_t *test, operation_t *op, result_t *result, bson_error_t 
    const char *object = op->object;
    bson_parser_t *bp = bson_parser_new ();
    bool ret = false;
-   bool *drop_target = false;
+   bool *drop_target = NULL;
    char *new_name = NULL;
    bson_parser_utf8 (bp, "to", &new_name);
    bson_parser_bool_optional (bp, "dropTarget", &drop_target);
@@ -3582,7 +3582,7 @@ operation_rename (test_t *test, operation_t *op, result_t *result, bson_error_t 
 
    // Rename the collection in the server,
    mongoc_collection_t *coll = ent->value;
-   if (!mongoc_collection_rename (coll, NULL, new_name, *drop_target, error)) {
+   if (!mongoc_collection_rename (coll, NULL, new_name, drop_target ? *drop_target : false, error)) {
       goto done;
    }
    result_from_ok (result);


### PR DESCRIPTION
# Summary

Replace `bool` in BSON DSL with `boolean`.

Evergreen patch: https://spruce.mongodb.com/version/668c26d644a2bb0007db5a0f

# Background & Motivation

Intended to avoid possible build errors when `bool` is defined as a macro. This [forum post](https://www.mongodb.com/community/forums/t/error-when-build-mongo-c-driver-with-visual-studio-2019/287062/4) suggests the user's build environment defines `bool` (or `_Bool`) as `int`, resulting in a build error due to BSON DSL macros evaluating to an undeclared identifier:

```
mongoc-uri.c:1635:4: error: use of undeclared identifier '_bsonDSL_Type_int'
 1635 |    bsonParse (uri->options,
      |    ^
```

To reproduce the reported issue, a `stdbool.h` was added locally to define `bool` as `int`:

```c
#ifndef __STDBOOL_CUSTOM_H
#define __STDBOOL_CUSTOM_H

#define bool int
#define true 1
#define false 0
#define __bool_true_false_are_defined 1

#endif /* __STDBOOL_CUSTOM_H */
```

In the process of testing, other misuse of `bool` variables in tests were discovered and addressed as drive-by fixes.
