### PR TITLE
remove extra artifact from `release-archive`

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -215,7 +215,6 @@ release-archive:
         --add-file cyclonedx.sbom.json \ # Add the SBOM
         --add-file ssldc_compliance_report.md
     SAVE ARTIFACT release.tar.gz
-    SAVE ARTIFACT ssldc_compliance_report.md
 
 # Obtain the signing public key. Exported as an artifact /c-driver.pub
 signing-pubkey:

--- a/Earthfile
+++ b/Earthfile
@@ -203,17 +203,17 @@ release-archive:
     # The full link to the build for this commit
     LET waterfall_url = "https://spruce.mongodb.com/version/${base}_${revision}"
     # Insert the URL into the SSDLC report
-    COPY etc/ssdlc.md ssldc_compliance_report.md
+    COPY etc/ssdlc.md ssdlc_compliance_report.md
     RUN sed -i "
         s|@waterfall_url@|$waterfall_url|g
         s|@version@|$version|g
-    " ssldc_compliance_report.md
+    " ssdlc_compliance_report.md
     # Generate the archive
     RUN git archive -o release.tar.gz \
         --prefix="$prefix/" \ # Set the archive path prefix
         "$revision" \ # Add the source tree
         --add-file cyclonedx.sbom.json \ # Add the SBOM
-        --add-file ssldc_compliance_report.md
+        --add-file ssdlc_compliance_report.md
     SAVE ARTIFACT release.tar.gz
 
 # Obtain the signing public key. Exported as an artifact /c-driver.pub

--- a/docs/dev/releasing.rst
+++ b/docs/dev/releasing.rst
@@ -417,7 +417,6 @@ same name without the `.asc` suffix.
    $ ls dist/
    mongo-c-driver-1.27.2.tar.gz
    mongo-c-driver-1.27.2.tar.gz.asc
-   ssdlc_compliance_report.md
 
 .. note::
 


### PR DESCRIPTION
This PR includes two changes to the release process:

- Do not save report in the `dist` directory. The report is already included in the release tarball.
- Fix typo in report name: `ssldc` => `ssdlc`.