### PR TITLE
CDRIVER-4479 announce plan to drop VS 2013

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,7 @@ Deprecated:
     * `mongoc_cursor_set_hint` is deprecated for `mongoc_cursor_set_server_id`
     * `mongoc_cursor_get_hint` is deprecated for `mongoc_cursor_get_server_id`
 
+  * A future minor release plans to drop support for Visual Studio 2013.
 
 
 libmongoc 1.27.3


### PR DESCRIPTION
# Summary

Announce plan to drop VS 2013.

# Background & Motivation

Dropping VS 2013 is [tentatively planned](https://docs.google.com/spreadsheets/d/1V8N9L9m2SZewWEvAoaKIOlKdZUUF12E7dEl_hTW3Wv0/edit?gid=1420163819#gid=1420163819) in FY25Q3. [Visual Studio Product Lifecycle and Servicing](https://learn.microsoft.com/en-us/visualstudio/productinfo/vs-servicing) documents that "Visual Studio 2013" was in the "Lifecycle Stage" of "Extended" until April 2024.

[Server, language or runtime version compatibility changes](https://docs.google.com/document/d/1Y3aNiHP_g7uqgLLdRnEDQRLl6yz45PVRDoUDsjMkRD0/edit#heading=h.pzmp88gu5q0e) notes:

> Version compatibility changes will be communicated at least one minor version (Y) before compatibility with a version is removed.

