### PR TITLE
Address -Wunused-parameter warnings for SHM counter functions

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-counters-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-counters-private.h
@@ -191,21 +191,21 @@ enum {
 
 #else
 /* when counters are disabled, these functions are no-ops */
-#define COUNTER(ident, Category, Name, Description)                   \
-   static BSON_INLINE void mongoc_counter_##ident##_add (int64_t val) \
-   {                                                                  \
-   }                                                                  \
-   static BSON_INLINE void mongoc_counter_##ident##_inc (void)        \
-   {                                                                  \
-   }                                                                  \
-   static BSON_INLINE void mongoc_counter_##ident##_dec (void)        \
-   {                                                                  \
-   }                                                                  \
-   static BSON_INLINE void mongoc_counter_##ident##_reset (void)      \
-   {                                                                  \
-   }                                                                  \
-   static BSON_INLINE void mongoc_counter_##ident##_count (void)      \
-   {                                                                  \
+#define COUNTER(ident, Category, Name, Description)                                     \
+   static BSON_INLINE void mongoc_counter_##ident##_add (BSON_MAYBE_UNUSED int64_t val) \
+   {                                                                                    \
+   }                                                                                    \
+   static BSON_INLINE void mongoc_counter_##ident##_inc (void)                          \
+   {                                                                                    \
+   }                                                                                    \
+   static BSON_INLINE void mongoc_counter_##ident##_dec (void)                          \
+   {                                                                                    \
+   }                                                                                    \
+   static BSON_INLINE void mongoc_counter_##ident##_reset (void)                        \
+   {                                                                                    \
+   }                                                                                    \
+   static BSON_INLINE void mongoc_counter_##ident##_count (void)                        \
+   {                                                                                    \
    }
 #include "mongoc-counters.defs"
 #undef COUNTER


### PR DESCRIPTION
This PR address the wall of nearly 1K `-Wunused-parameter` warnings emitted by the C Driver when being built-from-source by the CXX Driver in certain EVG tasks ([example](https://parsley.mongodb.com/evergreen/mongo_cxx_driver_macos_1100_latest_compile_and_test_with_static_libs_735cb4d5a668c2068dfe9afa1acc50c4ee9afad7_24_07_01_16_16_07/0/task?bookmarks=0,14099&shareLine=456)).

Most other warnings were already addressed by https://github.com/mongodb/mongo-c-driver/pull/1543.