### PR TITLE
Address -Wunused-parameter warnings

### DIFF
--- a/src/libmongoc/examples/example-bulkwrite.c
+++ b/src/libmongoc/examples/example-bulkwrite.c
@@ -11,7 +11,7 @@
       (void) 0
 
 int
-main (int argc, char *argv[])
+main (void)
 {
    bool ok = false;
 

--- a/src/libmongoc/src/mongoc/mongoc-bulkwrite.c
+++ b/src/libmongoc/src/mongoc/mongoc-bulkwrite.c
@@ -222,7 +222,7 @@ bool
 mongoc_bulkwrite_append_insertone (mongoc_bulkwrite_t *self,
                                    const char *ns,
                                    const bson_t *document,
-                                   const mongoc_bulkwrite_insertoneopts_t *opts, // may be NULL
+                                   BSON_MAYBE_UNUSED const mongoc_bulkwrite_insertoneopts_t *opts, // may be NULL
                                    bson_error_t *error)
 {
    BSON_ASSERT_PARAM (self);

--- a/src/libmongoc/src/mongoc/mongoc-cyrus.c
+++ b/src/libmongoc/src/mongoc/mongoc-cyrus.c
@@ -146,6 +146,8 @@ sasl_verify_type_to_str (sasl_verify_type_t type)
 int
 _mongoc_cyrus_verifyfile_cb (void *context, const char *file, sasl_verify_type_t type)
 {
+   BSON_UNUSED (context);
+
    TRACE ("Attempting to load file: `%s`. Type is %s\n", file, sasl_verify_type_to_str (type));
 
 #ifdef _WIN32

--- a/src/libmongoc/tests/unified/operation.c
+++ b/src/libmongoc/tests/unified/operation.c
@@ -413,8 +413,6 @@ operation_client_bulkwrite (test_t *test, operation_t *op, result_t *result, bso
       goto done;
    }
 
-   int64_t nmodels = 0;
-
    // Parse arguments.
    {
       bool parse_ok = false;
@@ -461,7 +459,6 @@ operation_client_bulkwrite (test_t *test, operation_t *op, result_t *result, bso
       BSON_ASSERT (bson_iter_init (&args_models_iter, args_models));
       bw = mongoc_client_bulkwrite_new (client);
       while (bson_iter_next (&args_models_iter)) {
-         nmodels++;
          bson_t model_wrapper;
          bson_iter_bson (&args_models_iter, &model_wrapper);
          if (!append_client_bulkwritemodel (bw, &model_wrapper, error)) {
@@ -491,7 +488,7 @@ operation_client_bulkwrite (test_t *test, operation_t *op, result_t *result, bso
    mongoc_bulkwrite_set_session (bw, op->session);
    mongoc_bulkwritereturn_t bwr = mongoc_bulkwrite_execute (bw, opts);
 
-   result_from_bulkwritereturn (result, bwr, nmodels);
+   result_from_bulkwritereturn (result, bwr);
    mongoc_bulkwriteexception_destroy (bwr.exc);
    mongoc_bulkwriteresult_destroy (bwr.res);
    ret = true;

--- a/src/libmongoc/tests/unified/result.c
+++ b/src/libmongoc/tests/unified/result.c
@@ -662,7 +662,7 @@ done:
 }
 
 void
-result_from_bulkwritereturn (result_t *result, mongoc_bulkwritereturn_t bwr, size_t nmodels)
+result_from_bulkwritereturn (result_t *result, mongoc_bulkwritereturn_t bwr)
 {
    // Build up the result value as a BSON document.
    bson_t bwr_bson = BSON_INITIALIZER;

--- a/src/libmongoc/tests/unified/result.h
+++ b/src/libmongoc/tests/unified/result.h
@@ -35,7 +35,7 @@ void
 result_from_bulk_write (result_t *result, const bson_t *reply, const bson_error_t *error);
 
 void
-result_from_bulkwritereturn (result_t *result, mongoc_bulkwritereturn_t bwr, size_t nmodels);
+result_from_bulkwritereturn (result_t *result, mongoc_bulkwritereturn_t bwr);
 
 void
 result_from_insert_one (result_t *result, const bson_t *reply, const bson_error_t *error);


### PR DESCRIPTION
Identifies and addresses some `-Wunused-parameter` warnings following https://github.com/mongodb/mongo-c-driver/pull/1590.