### PR TITLE
CDRIVER-5612 Bump maxWireVersion for MongoDB 8.0

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-client-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-private.h
@@ -77,12 +77,14 @@ BSON_BEGIN_DECLS
 /* version corresponding to server 7.1 release */
 #define WIRE_VERSION_7_1 22
 #define WIRE_VERSION_MONGOS_EXHAUST 22
+/* version corresponding to server 8.0 release */
+#define WIRE_VERSION_8_0 25
 
 /* Range of wire protocol versions this driver supports. Bumping
  * WIRE_VERSION_MAX must be accompanied by an update to
  * `_mongoc_wire_version_to_server_version`. */
 #define WIRE_VERSION_MIN WIRE_VERSION_4_0 /* a.k.a. minWireVersion */
-#define WIRE_VERSION_MAX WIRE_VERSION_7_0 /* a.k.a. maxWireVersion */
+#define WIRE_VERSION_MAX WIRE_VERSION_8_0 /* a.k.a. maxWireVersion */
 
 struct _mongoc_collection_t;
 

--- a/src/libmongoc/src/mongoc/mongoc-util.c
+++ b/src/libmongoc/src/mongoc/mongoc-util.c
@@ -307,6 +307,8 @@ _mongoc_wire_version_to_server_version (int32_t version)
       return "6.0";
    case WIRE_VERSION_7_0:
       return "7.0";
+   case WIRE_VERSION_8_0:
+      return "8.0";
    default:
       return "Unknown";
    }


### PR DESCRIPTION
# Summary
- Increase `WIRE_VERSION_MAX` to `WIRE_VERSION_8_0`.