### PR TITLE
CDRIVER-4831 [Vector Search GA] Add support for the new type field when creating search indexes

### DIFF
--- a/src/libmongoc/tests/json/index-management/createSearchIndex.json
+++ b/src/libmongoc/tests/json/index-management/createSearchIndex.json
@@ -50,54 +50,8 @@
                 "mappings": {
                   "dynamic": true
                 }
-              }
-            }
-          },
-          "expectError": {
-            "isError": true,
-            "errorContains": "Atlas"
-          }
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client0",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "createSearchIndexes": "collection0",
-                  "indexes": [
-                    {
-                      "definition": {
-                        "mappings": {
-                          "dynamic": true
-                        }
-                      }
-                    }
-                  ],
-                  "$db": "database0"
-                }
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "name provided for an index definition",
-      "operations": [
-        {
-          "name": "createSearchIndex",
-          "object": "collection0",
-          "arguments": {
-            "model": {
-              "definition": {
-                "mappings": {
-                  "dynamic": true
-                }
               },
-              "name": "test index"
+              "type": "search"
             }
           },
           "expectError": {
@@ -121,7 +75,117 @@
                           "dynamic": true
                         }
                       },
-                      "name": "test index"
+                      "type": "search"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "name provided for an index definition",
+      "operations": [
+        {
+          "name": "createSearchIndex",
+          "object": "collection0",
+          "arguments": {
+            "model": {
+              "definition": {
+                "mappings": {
+                  "dynamic": true
+                }
+              },
+              "name": "test index",
+              "type": "search"
+            }
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "mappings": {
+                          "dynamic": true
+                        }
+                      },
+                      "name": "test index",
+                      "type": "search"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "create a vector search index",
+      "operations": [
+        {
+          "name": "createSearchIndex",
+          "object": "collection0",
+          "arguments": {
+            "model": {
+              "definition": {
+                "fields": [
+                  {
+                    "type": "vector",
+                    "path": "plot_embedding",
+                    "numDimensions": 1536,
+                    "similarity": "euclidean"
+                  }
+                ]
+              },
+              "name": "test index",
+              "type": "vectorSearch"
+            }
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "fields": [
+                          {
+                            "type": "vector",
+                            "path": "plot_embedding",
+                            "numDimensions": 1536,
+                            "similarity": "euclidean"
+                          }
+                        ]
+                      },
+                      "name": "test index",
+                      "type": "vectorSearch"
                     }
                   ],
                   "$db": "database0"

--- a/src/libmongoc/tests/json/index-management/createSearchIndexes.json
+++ b/src/libmongoc/tests/json/index-management/createSearchIndexes.json
@@ -83,56 +83,8 @@
                   "mappings": {
                     "dynamic": true
                   }
-                }
-              }
-            ]
-          },
-          "expectError": {
-            "isError": true,
-            "errorContains": "Atlas"
-          }
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client0",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "createSearchIndexes": "collection0",
-                  "indexes": [
-                    {
-                      "definition": {
-                        "mappings": {
-                          "dynamic": true
-                        }
-                      }
-                    }
-                  ],
-                  "$db": "database0"
-                }
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "name provided for an index definition",
-      "operations": [
-        {
-          "name": "createSearchIndexes",
-          "object": "collection0",
-          "arguments": {
-            "models": [
-              {
-                "definition": {
-                  "mappings": {
-                    "dynamic": true
-                  }
                 },
-                "name": "test index"
+                "type": "search"
               }
             ]
           },
@@ -157,7 +109,121 @@
                           "dynamic": true
                         }
                       },
-                      "name": "test index"
+                      "type": "search"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "name provided for an index definition",
+      "operations": [
+        {
+          "name": "createSearchIndexes",
+          "object": "collection0",
+          "arguments": {
+            "models": [
+              {
+                "definition": {
+                  "mappings": {
+                    "dynamic": true
+                  }
+                },
+                "name": "test index",
+                "type": "search"
+              }
+            ]
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "mappings": {
+                          "dynamic": true
+                        }
+                      },
+                      "name": "test index",
+                      "type": "search"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "create a vector search index",
+      "operations": [
+        {
+          "name": "createSearchIndexes",
+          "object": "collection0",
+          "arguments": {
+            "models": [
+              {
+                "definition": {
+                  "fields": [
+                    {
+                      "type": "vector",
+                      "path": "plot_embedding",
+                      "numDimensions": 1536,
+                      "similarity": "euclidean"
+                    }
+                  ]
+                },
+                "name": "test index",
+                "type": "vectorSearch"
+              }
+            ]
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "fields": [
+                          {
+                            "type": "vector",
+                            "path": "plot_embedding",
+                            "numDimensions": 1536,
+                            "similarity": "euclidean"
+                          }
+                        ]
+                      },
+                      "name": "test index",
+                      "type": "vectorSearch"
                     }
                   ],
                   "$db": "database0"


### PR DESCRIPTION
### Summary
This PR implements necessary driver changes requested by the spec change [DRIVERS-2768](https://jira.mongodb.org/browse/DRIVERS-2768): "Drivers must support use of the type field when creating search indexes. Creating a vector search index requires specifying type=vectorSearch."

### Changes 
Since the C driver doesn't have a dedicated API for managing search indexes, the only changes made were to the JSON specification tests:
- Copied updated JSON test files from https://github.com/mongodb/specifications/commit/b746fcc71ad7c1b376482852c3c9cbba4eed7d26 into index-management 
- No updates were necessary to the unified test runner as`operation_createSearchIndex` and  `operation_createSearchIndexes` just pass along the search index model without examining its contents.

