### PR TITLE
CDRIVER-5635 Exclude tests and examples from ALL target

### DIFF
--- a/.evergreen/scripts/compile-unix.sh
+++ b/.evergreen/scripts/compile-unix.sh
@@ -215,3 +215,6 @@ CCACHE_NOHASHDIR=1
 
 # For use by test tasks, which directly use the binary directory contents.
 "${cmake_binary}" --build . --target mongo_c_driver_tests
+
+# Also validate examples.
+"${cmake_binary}" --build . --target mongo_c_driver_examples

--- a/.evergreen/scripts/compile-unix.sh
+++ b/.evergreen/scripts/compile-unix.sh
@@ -181,6 +181,8 @@ if [[ "${OSTYPE}" == darwin* ]]; then
     sysctl -n hw.logicalcpu
   }
 fi
+export CMAKE_BUILD_PARALLEL_LEVEL
+CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
 
 declare -a extra_configure_flags
 IFS=' ' read -ra extra_configure_flags <<<"${EXTRA_CONFIGURE_FLAGS:-}"
@@ -208,5 +210,10 @@ CCACHE_BASEDIR="$(pwd)"
 CCACHE_NOHASHDIR=1
 
 "${cmake_binary}" "${configure_flags[@]}" ${extra_configure_flags[@]+"${extra_configure_flags[@]}"} .
-"${cmake_binary}" --build . -- -j "$(nproc)"
-"${cmake_binary}" --build . --target install
+"${cmake_binary}" --build .
+"${cmake_binary}" --install .
+
+# For use by test tasks, which directly use the binary directory contents.
+"${cmake_binary}" --build . --target tests || {
+  echo "Ignoring build error which may be caused by ENABLE_TESTING=OFF" 1>&2
+}

--- a/.evergreen/scripts/compile-unix.sh
+++ b/.evergreen/scripts/compile-unix.sh
@@ -214,6 +214,4 @@ CCACHE_NOHASHDIR=1
 "${cmake_binary}" --install .
 
 # For use by test tasks, which directly use the binary directory contents.
-"${cmake_binary}" --build . --target tests || {
-  echo "Ignoring build error which may be caused by ENABLE_TESTING=OFF" 1>&2
-}
+"${cmake_binary}" --build . --target mongo_c_driver_tests

--- a/.evergreen/scripts/compile-windows.sh
+++ b/.evergreen/scripts/compile-windows.sh
@@ -151,4 +151,4 @@ fi
 "${cmake_binary}" --build . --config "${build_config}" --target mongo_c_driver_tests
 
 # Also validate examples.
-"${cmake_binary}" --build . --target mongo_c_driver_examples
+"${cmake_binary}" --build . --config "${build_config}" --target mongo_c_driver_examples

--- a/.evergreen/scripts/compile-windows.sh
+++ b/.evergreen/scripts/compile-windows.sh
@@ -121,6 +121,7 @@ if [[ "${CC}" =~ mingw ]]; then
 
   env "$cmake_binary" --build "$build_dir"
   env "$cmake_binary" --build "$build_dir" --target mongo_c_driver_tests
+  env "$cmake_binary" --build "$build_dir" --target mongo_c_driver_examples
   exit 0
 fi
 
@@ -148,3 +149,6 @@ fi
 
 # For use by test tasks, which directly use the binary directory contents.
 "${cmake_binary}" --build . --config "${build_config}" --target mongo_c_driver_tests
+
+# Also validate examples.
+"${cmake_binary}" --build . --target mongo_c_driver_examples

--- a/.evergreen/scripts/compile-windows.sh
+++ b/.evergreen/scripts/compile-windows.sh
@@ -124,7 +124,7 @@ if [[ "${CC}" =~ mingw ]]; then
   exit 0
 fi
 
-# MSBUild needs additional assistance.
+# MSBuild needs additional assistance.
 # https://devblogs.microsoft.com/cppblog/improved-parallelism-in-msbuild/
 export UseMultiToolTask=1
 export EnforceProcessCountAcrossBuilds=1

--- a/.evergreen/scripts/compile-windows.sh
+++ b/.evergreen/scripts/compile-windows.sh
@@ -97,12 +97,6 @@ fi
 
 "${cmake_binary:?}" --version
 
-if [[ "${OSTYPE}" == darwin* ]]; then
-  # MacOS does not have nproc.
-  nproc() {
-    sysctl -n hw.logicalcpu
-  }
-fi
 export CMAKE_BUILD_PARALLEL_LEVEL
 CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
 

--- a/.evergreen/scripts/compile-windows.sh
+++ b/.evergreen/scripts/compile-windows.sh
@@ -120,7 +120,7 @@ if [[ "${CC}" =~ mingw ]]; then
     -S "$(native-path "$mongoc_dir")"
 
   env "$cmake_binary" --build "$build_dir"
-  env "$cmake_binary" --build "$build_dir" --target tests
+  env "$cmake_binary" --build "$build_dir" --target mongo_c_driver_tests
   exit 0
 fi
 
@@ -147,6 +147,4 @@ fi
 "${cmake_binary}" --install . --config "${build_config}"
 
 # For use by test tasks, which directly use the binary directory contents.
-"${cmake_binary}" --build . --config "${build_config}" --target tests || {
-  echo "Ignoring build error which may be caused by ENABLE_TESTING=OFF" 1>&2
-}
+"${cmake_binary}" --build . --config "${build_config}" --target mongo_c_driver_tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,10 +91,10 @@ mongo_bool_setting(ENABLE_DEBUG_ASSERTIONS "Build library with runtime debug ass
 include(Sanitizers)
 
 # Toggle optional components:
-mongo_bool_setting(ENABLE_TESTS "Build MongoDB C Driver tests")
-mongo_bool_setting(ENABLE_EXAMPLES "Build MongoDB C Driver examples")
-mongo_bool_setting(ENABLE_MAN_PAGES "Build the manual pages" DEFAULT VALUE OFF)
-mongo_bool_setting(ENABLE_HTML_DOCS "Build the HTML documentation" DEFAULT VALUE OFF)
+mongo_bool_setting(ENABLE_TESTS "Enable building MongoDB C Driver tests")
+mongo_bool_setting(ENABLE_EXAMPLES "Enable building MongoDB C Driver examples")
+mongo_bool_setting(ENABLE_MAN_PAGES "Enable building the manual pages" DEFAULT VALUE OFF)
+mongo_bool_setting(ENABLE_HTML_DOCS "Enable building the HTML documentation" DEFAULT VALUE OFF)
 mongo_bool_setting(ENABLE_UNINSTALL "Generate an 'uninstall' script and an 'uninstall' build target")
 mongo_bool_setting(ENABLE_SRV "Enable support for mongodb+srv URIs.")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,6 +424,10 @@ if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
    list (APPEND CMAKE_REQUIRED_DEFINITIONS -D_DARWIN_C_SOURCE)
 endif ()
 
+# Convenience targets to build all tests or all examples.
+add_custom_target(mongo_c_driver_tests)
+add_custom_target(mongo_c_driver_examples)
+
 add_subdirectory (src/common)
 
 if (NOT USING_SYSTEM_BSON)

--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,12 @@ Notes:
 
   * Bump minimum wire protocol version from 6 (MongoDB 3.6) to 7 (MongoDB 4.0).
 
+Changed:
+
+  * Test and example targets are excluded from the `ALL` target.
+    * All test targets can be built using the `tests` target (not to be confused with the `test` target, which _runs_ the built test executables via CTest).
+    * All example targets can be built using the `examples` target.
+
 Deprecated:
 
   * Use of `*_hint` functions is deprecated in favor of more aptly named `*_server_id` functions:

--- a/NEWS
+++ b/NEWS
@@ -8,8 +8,8 @@ Notes:
 Changed:
 
   * Test and example targets are excluded from the `ALL` target.
-    * All test targets can be built using the `tests` target (not to be confused with the `test` target, which _runs_ the built test executables via CTest).
-    * All example targets can be built using the `examples` target.
+    * All test targets can be built using the `mongo_c_driver_tests` target.
+    * All example targets can be built using the `mongo_c_driver_examples` target.
 
 Deprecated:
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,7 @@ configure_file (
 if (CMAKE_CXX_COMPILER)
    # Add a C++ source file that will #include the main C headers. This "library"
    # does nothing other than validate that the C headers are valid C++ headers.
-   add_library (mongoc-cxx-check STATIC cpp-check.cpp)
+   add_library (mongoc-cxx-check OBJECT cpp-check.cpp)
    if (TARGET mongoc_static)
       target_link_libraries (mongoc-cxx-check PRIVATE mongoc_static)
    else ()

--- a/src/libbson/CMakeLists.txt
+++ b/src/libbson/CMakeLists.txt
@@ -262,21 +262,25 @@ endif ()
 #                                            888
 #                                            888
 
-function (add_example bin src)
-   set (BSON_EXAMPLE_SOURCES ${PROJECT_SOURCE_DIR}/${src})
-   add_executable (${bin} ${BSON_EXAMPLE_SOURCES})
-
-   # Link against the shared lib like normal apps
-   if(TARGET bson_shared)
-      target_link_libraries (${bin} bson_shared)
-   elseif(TARGET bson_static)
-      target_link_libraries (${bin} bson_static)
-   else()
-      return()
-   endif()
-endfunction ()
-
 if (ENABLE_EXAMPLES)
+   if (NOT TARGET examples)
+      add_custom_target (examples)
+   endif ()
+
+   function (add_example bin src)
+      add_executable (${bin} EXCLUDE_FROM_ALL ${src})
+      add_dependencies (examples ${bin})
+
+      # Link against the shared lib like normal apps
+      if(TARGET bson_shared)
+         target_link_libraries (${bin} bson_shared)
+      elseif(TARGET bson_static)
+         target_link_libraries (${bin} bson_static)
+      else()
+         return()
+      endif()
+   endfunction ()
+
    add_example (bcon-col-view examples/bcon-col-view.c)
    add_example (bcon-speed examples/bcon-speed.c)
    add_example (bson-metrics examples/bson-metrics.c)

--- a/src/libbson/CMakeLists.txt
+++ b/src/libbson/CMakeLists.txt
@@ -263,13 +263,9 @@ endif ()
 #                                            888
 
 if (ENABLE_EXAMPLES)
-   if (NOT TARGET examples)
-      add_custom_target (examples)
-   endif ()
-
    function (add_example bin src)
       add_executable (${bin} EXCLUDE_FROM_ALL ${src})
-      add_dependencies (examples ${bin})
+      add_dependencies (mongo_c_driver_examples ${bin})
 
       # Link against the shared lib like normal apps
       if(TARGET bson_shared)

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -1124,7 +1124,11 @@ if (MONGOC_ENABLE_SASL_CYRUS)
 endif ()
 
 if (ENABLE_TESTS)
-   add_library (test-libmongoc-lib STATIC ${test-libmongoc-sources})
+   if (NOT TARGET tests)
+      add_custom_target (tests)
+   endif ()
+
+   add_library (test-libmongoc-lib STATIC EXCLUDE_FROM_ALL ${test-libmongoc-sources})
    if (MSVC AND MSVC_VERSION VERSION_LESS 1900)
       message (STATUS "Disabling warning C4756 for VS 2013 and older")
       # Macro constant INFINITY triggers constant arithmetic overflow warnings in
@@ -1151,7 +1155,9 @@ if (ENABLE_TESTS)
    )
 
    function (mongoc_add_test test)
-      add_executable (${test} ${ARGN})
+      add_executable (${test} EXCLUDE_FROM_ALL ${ARGN})
+      add_dependencies (tests ${test})
+
       target_link_libraries (${test}
          PUBLIC
             $<$<C_COMPILER_ID:MSVC>:DbgHelp.dll>
@@ -1194,13 +1200,18 @@ if (ENABLE_TESTS)
 endif ()
 
 if (ENABLE_EXAMPLES AND ENABLE_SHARED)
+   if (NOT TARGET examples)
+      add_custom_target (examples)
+   endif ()
+
    function (mongoc_add_example example)
-      add_executable (${example} ${ARGN})
+      add_executable (${example} EXCLUDE_FROM_ALL ${ARGN})
+      add_dependencies (examples ${example})
+
       target_link_libraries (${example} mongoc_shared ${LIBRARIES})
       if (WIN32)
          target_link_libraries (${example} shlwapi)
       endif ()
-      set (EXAMPLES ${EXAMPLES} ${example})
    endfunction ()
 
    # examples/
@@ -1286,7 +1297,7 @@ set (MONGOC_HEADER_INSTALL_DIR
 )
 
 install (
-   TARGETS ${TARGETS_TO_INSTALL} ${EXAMPLES}
+   TARGETS ${TARGETS_TO_INSTALL}
    EXPORT mongoc-targets
    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -1124,10 +1124,6 @@ if (MONGOC_ENABLE_SASL_CYRUS)
 endif ()
 
 if (ENABLE_TESTS)
-   if (NOT TARGET tests)
-      add_custom_target (tests)
-   endif ()
-
    add_library (test-libmongoc-lib STATIC EXCLUDE_FROM_ALL ${test-libmongoc-sources})
    if (MSVC AND MSVC_VERSION VERSION_LESS 1900)
       message (STATUS "Disabling warning C4756 for VS 2013 and older")
@@ -1156,7 +1152,7 @@ if (ENABLE_TESTS)
 
    function (mongoc_add_test test)
       add_executable (${test} EXCLUDE_FROM_ALL ${ARGN})
-      add_dependencies (tests ${test})
+      add_dependencies (mongo_c_driver_tests ${test})
 
       target_link_libraries (${test}
          PUBLIC
@@ -1200,13 +1196,9 @@ if (ENABLE_TESTS)
 endif ()
 
 if (ENABLE_EXAMPLES AND ENABLE_SHARED)
-   if (NOT TARGET examples)
-      add_custom_target (examples)
-   endif ()
-
    function (mongoc_add_example example)
       add_executable (${example} EXCLUDE_FROM_ALL ${ARGN})
-      add_dependencies (examples ${example})
+      add_dependencies (mongo_c_driver_examples ${example})
 
       target_link_libraries (${example} mongoc_shared ${LIBRARIES})
       if (WIN32)


### PR DESCRIPTION
## Summary

Resolves CDRIVER-5635. Verified by [this patch](https://spruce.mongodb.com/version/669a9f647a1e2e0007b0e750).

## The ALL Target and Installation

Although tests and examples are correctly _disabled_ via `ENABLE_TESTS` and `ENABLE_EXAMPLES`, they are not being correctly _excluded_ from the `ALL` target when enabled. The `ALL` target should only build targets which are required by the `install` target (that is, targets which produce artifacts intended to be installed, with the exception of excluded components, which does not apply to our project. This is the same in spirit to the `make && make install` pattern).

Grepping the CMake build output for "Linking" is an approximate means of identifying the list of executable/library targets being built. The base commit currently emits the following list of artifacts for a simple `cmake --build <binary-dir>` (ALL target) configured with tests and examples enabled:

```
C shared library src/libbson/libbson-1.0.so.0.0.0
C static library src/libbson/libbson-static-1.0.a
C static library src/libmongoc/libmongoc-static-1.0.a
CXX static library src/libmongoc-cxx-check.a
C executable src/libmongoc/test-awsauth
C executable src/libmongoc/test-gcpkms
C executable src/libmongoc/test-azurekms
C executable src/libmongoc/test-mongoc-cache
C executable src/libmongoc/test-mongoc-gssapi
C static library src/libmongoc/libtest-libmongoc-lib.a
C shared library src/libmongoc/libmongoc-1.0.so.0.0.0
C executable src/libbson/creating
C executable src/libbson/bson-check-depth
C executable src/libbson/json-to-bson
C executable src/libbson/bson-validate
C executable src/libbson/bson-to-json
C executable src/libbson/bson-streaming-reader
C executable src/libbson/bson-metrics
C executable src/libbson/bcon-speed
C executable src/libbson/bcon-col-view
C executable src/libmongoc/test-atlas-executor
C executable src/libmongoc/test-libmongoc
C executable src/libmongoc/appending
C executable src/libmongoc/executing
C executable src/libmongoc/fam
C executable src/libmongoc/common-operations
C executable src/libmongoc/bulk6
C executable src/libmongoc/bulk5
C executable src/libmongoc/bulk4
C executable src/libmongoc/bulk3
C executable src/libmongoc/bulk2
C executable src/libmongoc/bulk1
C executable src/libmongoc/bulk-collation
C executable src/libmongoc/basic-aggregation
C executable src/libmongoc/aggregation1
C executable src/libmongoc/example-bulkwrite
C executable src/libmongoc/example-collection-command
C executable src/libmongoc/mongoc-tail
C executable src/libmongoc/mongoc-ping
C executable src/libmongoc/mongoc-dump
C executable src/libmongoc/hello_mongoc
C executable src/libmongoc/find-and-modify
C executable src/libmongoc/example-update
C executable src/libmongoc/example-transaction
C executable src/libmongoc/example-session
C executable src/libmongoc/example-sdam-monitoring
C executable src/libmongoc/example-scram
C executable src/libmongoc/example-pool
C executable src/libmongoc/example-gridfs-bucket
C executable src/libmongoc/example-gridfs
C executable src/libmongoc/example-manage-search-indexes
C executable src/libmongoc/example-manage-collection-indexes
C executable src/libmongoc/example-command-with-opts
C executable src/libmongoc/example-command-monitoring
C executable src/libmongoc/example-start-at-optime
C executable src/libmongoc/example-resume
C executable src/libmongoc/example-collection-watch
C executable src/libmongoc/example-client
C executable src/libmongoc/mongoc-stat
```

This PR proposes reducing the list to only the following:

```
Linking C shared library src/libbson/libbson-1.0.so.0.0.0
Linking C static library src/libbson/libbson-static-1.0.a
Linking C static library src/libmongoc/libmongoc-static-1.0.a
Linking C shared library src/libmongoc/libmongoc-1.0.so.0.0.0
Linking C executable src/libmongoc/mongoc-stat
```

Note: man pages and html docs are _not_ excluded, as they are also installed artifacts under `share/`.

The new `tests` and `examples` custom targets are defined as a convenient means of compiling all test and example targets. The `if (NOT TARGET)` pattern is used to ensure compatibility with parent projects (where C Driver is imported via `add_subdirectory()`) which may have already defined the `tests` or `examples` target. The new `tests` target is used by the updated EVG scripts to ensure test binaries are available for use by test tasks.

## Miscellaneous

- Use `CMAKE_BUILD_PARALLEL_LEVEL` instead of `--parallel`, `-- -j`, or `/m`.
- Set `UseMultiToolTask` and `EnforceProcessCountAcrossBuilds` for better MSBuild parallelism with VS2019+.
- Changed `mongoc-cxx-check` from STATIC to OBJECT to avoid the unnecessary "Linking" step.
- Remove unused `EXAMPLES` variable ([incorrect for its entire existence?](https://github.com/mongodb/libbson/commit/8086fcf575c6ebce6f68c8b08673dae160989b1a#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR282)).