### PR TITLE
CDRIVER-5645 skip auth tests running against MongoDB 3.6.

### DIFF
--- a/.evergreen/scripts/run-auth-tests.sh
+++ b/.evergreen/scripts/run-auth-tests.sh
@@ -100,12 +100,15 @@ elif command -v otool >/dev/null; then
 fi
 
 if [[ "${ssl}" != "OFF" ]]; then
+  if true; then
+    echo "Skipping tests on server 3.6 (using 'auth_host' or 'auth_gssapi') until DEVPROD-9029 is addressed."
+  else
   # FIXME: CDRIVER-2008 for the cygwin check
   if [[ "${OSTYPE}" != "cygwin" ]]; then
     echo "Authenticating using X.509"
     LD_LIBRARY_PATH="${openssl_lib_prefix}" "${ping}" "mongodb://CN=client,OU=kerneluser,O=10Gen,L=New York City,ST=New York,C=US@${auth_host}/?ssl=true&authMechanism=MONGODB-X509&sslClientCertificateKeyFile=src/libmongoc/tests/x509gen/ldaptest-client-key-and-cert.pem&sslCertificateAuthorityFile=src/libmongoc/tests/x509gen/ldaptest-ca-cert.crt&sslAllowInvalidHostnames=true&${c_timeout}"
   fi
-
+  fi # Skip 3.6. Remove this block when resolving CDRIVER-5645.
   echo "Connecting to Atlas Free Tier"
   LD_LIBRARY_PATH="${openssl_lib_prefix}" "${ping}" "${atlas_free:?}&${c_timeout}"
   echo "Connecting to Atlas Free Tier with SRV"
@@ -145,6 +148,9 @@ if [[ "${ssl}" != "OFF" ]]; then
   fi
 fi
 
+if true; then
+  echo "Skipping tests on server 3.6 (using 'auth_host' or 'auth_gssapi') until DEVPROD-9029 is addressed."
+else
 echo "Authenticating using PLAIN"
 LD_LIBRARY_PATH="${openssl_lib_prefix}" "${ping}" "mongodb://${auth_plain:?}@${auth_host}/?authMechanism=PLAIN&${c_timeout}"
 
@@ -174,3 +180,4 @@ if [[ "${sasl}" != "OFF" ]]; then
     LD_LIBRARY_PATH="${openssl_lib_prefix}" "${ping}" "mongodb://${auth_gssapi_utf8:?}@${auth_host}/?authMechanism=GSSAPI&${c_timeout}"
   fi
 fi
+fi # Skip 3.6. Remove this block when resolving CDRIVER-5645.

--- a/.evergreen/scripts/run-auth-tests.sh
+++ b/.evergreen/scripts/run-auth-tests.sh
@@ -100,15 +100,16 @@ elif command -v otool >/dev/null; then
 fi
 
 if [[ "${ssl}" != "OFF" ]]; then
-  if true; then
+  {
+    # Skip 3.6. Remove this block when resolving CDRIVER-5645.
     echo "Skipping tests on server 3.6 (using 'auth_host' or 'auth_gssapi') until DEVPROD-9029 is addressed."
-  else
+  } || {
   # FIXME: CDRIVER-2008 for the cygwin check
   if [[ "${OSTYPE}" != "cygwin" ]]; then
     echo "Authenticating using X.509"
     LD_LIBRARY_PATH="${openssl_lib_prefix}" "${ping}" "mongodb://CN=client,OU=kerneluser,O=10Gen,L=New York City,ST=New York,C=US@${auth_host}/?ssl=true&authMechanism=MONGODB-X509&sslClientCertificateKeyFile=src/libmongoc/tests/x509gen/ldaptest-client-key-and-cert.pem&sslCertificateAuthorityFile=src/libmongoc/tests/x509gen/ldaptest-ca-cert.crt&sslAllowInvalidHostnames=true&${c_timeout}"
   fi
-  fi # Skip 3.6. Remove this block when resolving CDRIVER-5645.
+  }
   echo "Connecting to Atlas Free Tier"
   LD_LIBRARY_PATH="${openssl_lib_prefix}" "${ping}" "${atlas_free:?}&${c_timeout}"
   echo "Connecting to Atlas Free Tier with SRV"
@@ -148,9 +149,10 @@ if [[ "${ssl}" != "OFF" ]]; then
   fi
 fi
 
-if true; then
+{
+  # Skip 3.6. Remove this block when resolving CDRIVER-5645.
   echo "Skipping tests on server 3.6 (using 'auth_host' or 'auth_gssapi') until DEVPROD-9029 is addressed."
-else
+} || {
 echo "Authenticating using PLAIN"
 LD_LIBRARY_PATH="${openssl_lib_prefix}" "${ping}" "mongodb://${auth_plain:?}@${auth_host}/?authMechanism=PLAIN&${c_timeout}"
 
@@ -180,4 +182,4 @@ if [[ "${sasl}" != "OFF" ]]; then
     LD_LIBRARY_PATH="${openssl_lib_prefix}" "${ping}" "mongodb://${auth_gssapi_utf8:?}@${auth_host}/?authMechanism=GSSAPI&${c_timeout}"
   fi
 fi
-fi # Skip 3.6. Remove this block when resolving CDRIVER-5645.
+}


### PR DESCRIPTION
# Summary

Skip authentication tests running against 3.6 servers.

Verified by [this patch](https://spruce.mongodb.com/version/66a29f2adf4e6a00076a62fa)

# Background & Motivation

CDRIVER-4815 dropped support for 3.6 servers. Some test servers are running 3.6, resulting in task failures. [Example](https://spruce.mongodb.com/task/mongo_c_driver_gcc48rhel_authentication_tests_openssl_75ec9c31cd974e9bfab0fecd8aa2eca92399543f_24_07_23_19_57_35/logs?execution=0):

```
Ping failure: Server at <REDACTED:auth_host>:27017 reports wire version 6, but this version of libmongoc requires at least 7 (MongoDB 4.0)
```

[DEVPROD-9029](https://jira.mongodb.org/browse/DEVPROD-9029) tracks upgrading test servers. This PR proposes skipping tests in the short-term as they are expected to fail.