### PR TITLE
Update NEWS and release process

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -355,7 +355,7 @@ create-silk-asset-group:
 
 
 snyk:
-    FROM ubuntu:24.04
+    FROM --platform=linux/amd64 ubuntu:24.04
     RUN apt-get update && apt-get -y install curl
     RUN curl --location https://github.com/snyk/cli/releases/download/v1.1291.1/snyk-linux -o /usr/local/bin/snyk
     RUN chmod a+x /usr/local/bin/snyk

--- a/NEWS
+++ b/NEWS
@@ -21,6 +21,18 @@ Deprecated:
 
   * A future minor release plans to drop support for Visual Studio 2013.
 
+libmongoc 1.27.5
+================
+
+Fixes:
+
+  * Fix possible build error in environments where `bool` or `_Bool` is a macro.
+
+Thanks to everyone who contributed to the development of this release.
+
+  * Kevin Albertson
+
+
 libmongoc 1.27.4
 ================
 

--- a/docs/dev/releasing.rst
+++ b/docs/dev/releasing.rst
@@ -50,7 +50,6 @@ process.
        - [ ] Update the EVG Project
        - [ ] Stop the Release Stopwatch (end time: HH:MM)
        - [ ] Record the Release
-   - [ ] Homebrew Release
    - [ ] vcpkg
    - [ ] Conan
 
@@ -531,24 +530,6 @@ Stop the stopwatch started at :ref:`do.stopwatch`. Record the the new release
 details in the `C/C++ Release Info`__ sheet.
 
 __ https://docs.google.com/spreadsheets/d/1yHfGmDnbA5-Qt8FX4tKWC5xk9AhzYZx1SKF4AD36ecY/edit#gid=0
-
-
-Homebrew Release
-################
-
-.. note::
-
-   This step requires a macOS machine. If you are not using macOS, ask in the
-   ``#dbx-c-cxx`` channel for someone to do this step on your behalf.
-
-**If this is a stable release**, update `the mongo-c-driver homebew formula`__. Let
-`$ARCHIVE_URL` be the URL to the release tag's source archive on GitHub\ [#tar-url]_::
-
-   $ brew bump-formula-pr mongo-c-driver --url $ARCHIVE_URL
-
-__ https://github.com/Homebrew/homebrew-core/blob/master/Formula/m/mongo-c-driver.rb
-
-.. [#tar-url] For example, the tagged archive for ``1.25.0`` is at https://github.com/mongodb/mongo-c-driver/archive/refs/tags/1.25.0.tar.gz
 
 
 Linux Distribution Packages

--- a/src/libbson/NEWS
+++ b/src/libbson/NEWS
@@ -1,3 +1,13 @@
+libbson 1.27.5
+==============
+
+  * Fix large string handling in `bson_append_utf8`.
+
+Thanks to everyone who contributed to the development of this release.
+
+  * Roberto C. Sánchez
+
+
 libbson 1.27.4
 ==============
 


### PR DESCRIPTION
# Summary

- Update the NEWS following the 1.27.5 release.
- Specify `amd64` platform for `snyk-monitor-snapshot` target to ensure downloaded `snyk` binary matches container architecture.
- Remove Homebrew steps from release.

# Background & Motivation

Specifying the `amd64` platform on the `snyk-monitor-snapshot` target is intended to address an error observed during the release:

```
================================== ❌ FAILURE ===================================

+snyk-monitor-snapshot *failed* | Repeating the failure error...
+snyk-monitor-snapshot *failed* | branch=r1.27 name=release-1.27.5
+snyk-monitor-snapshot *failed* | --> RUN --no-cache snyk monitor --org=$SNYK_ORGANIZATION --target-reference=$name --unmanaged --print-deps --project-name=mongo-c-driver --remote-repo-url=https://github.com/mongodb/mongo-c-driver
+snyk-monitor-snapshot *failed* | qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory
+snyk-monitor-snapshot *failed* | ERROR Earthfile line 394:4
+snyk-monitor-snapshot *failed* |       The command
+snyk-monitor-snapshot *failed* |           RUN --no-cache snyk monitor --org=$SNYK_ORGANIZATION --target-reference=$name --unmanaged --print-deps --project-name=mongo-c-driver --remote-repo-url=https://github.com/mongodb/mongo-c-driver
+snyk-monitor-snapshot *failed* |       did not complete successfully. Exit code 255
```

I expect this was due to me running on macOS M1 (arm64). The downloaded Snyk binary is for amd64.

Homebrew steps are removed due to no longer appearing to be necessary:
```
% brew bump-formula-pr mongo-c-driver --url https://github.com/mongodb/mongo-c-driver/archive/refs/tags/1.27.5.tar.gz
Error: Whoops, the mongo-c-driver formula has its version update
pull requests automatically opened by BrewTestBot every ~3 hours!
We'd still love your contributions, though, so try another one
that's not in the autobump list:
  https://github.com/Homebrew/homebrew-core/blob/master/.github/autobump.txt
```