### PR TITLE
sync RPM spec file from downstream

### DIFF
--- a/.evergreen/etc/mongo-c-driver.spec
+++ b/.evergreen/etc/mongo-c-driver.spec
@@ -10,7 +10,7 @@
 %global gh_project   mongo-c-driver
 %global libname      libmongoc
 %global libver       1.0
-%global up_version   1.27.4
+%global up_version   1.27.5
 #global up_prever    rc0
 # disabled as require a MongoDB server
 %bcond_with          tests
@@ -27,7 +27,7 @@
 Name:      mongo-c-driver
 Summary:   Client library written in C for MongoDB
 Version:   %{up_version}%{?up_prever:~%{up_prever}}
-Release:   2%{?dist}
+Release:   1%{?dist}
 # See THIRD_PARTY_NOTICES
 License:   Apache-2.0 AND ISC AND MIT AND Zlib
 URL:       https://github.com/%{gh_owner}/%{gh_project}
@@ -259,6 +259,9 @@ exit $ret
 
 
 %changelog
+* Wed Aug  7 2024 Remi Collet <remi@remirepo.net> - 1.27.5-1
+- update to 1.27.5
+
 * Thu Jul 18 2024 Fedora Release Engineering <releng@fedoraproject.org> - 1.27.4-2
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_41_Mass_Rebuild
 

--- a/.evergreen/etc/spec.patch
+++ b/.evergreen/etc/spec.patch
@@ -4,19 +4,17 @@
  %global gh_project   mongo-c-driver
  %global libname      libmongoc
  %global libver       1.0
--%global up_version   1.27.4
+-%global up_version   1.27.5
 +%global up_version   1.28.0
  #global up_prever    rc0
  # disabled as require a MongoDB server
  %bcond_with          tests
-@@ -20,8 +20,8 @@
+@@ -20,7 +20,7 @@
  
  Name:      mongo-c-driver
  Summary:   Client library written in C for MongoDB
 -Version:   %{up_version}%{?up_prever:~%{up_prever}}
--Release:   2%{?dist}
 +Version:   %{up_version}%{?up_prever}
-+Release:   1%{?dist}
+ Release:   1%{?dist}
  # See THIRD_PARTY_NOTICES
  License:   Apache-2.0 AND ISC AND MIT AND Zlib
- URL:       https://github.com/%{gh_owner}/%{gh_project}


### PR DESCRIPTION
This task is still failing even after this PR, but that is because of a transitory issue with the mock environment. It should clear on its own in another day or two.

ETA: the problem is actually that `master` now required libmongocrypt 1.11.0 and that version has not yet landed in Fedora. Once it does then mock will start pulling it in and the build should go green (assuming that this PR has been merged as well).