### PR TITLE
backport the secutity patch of CVE-2024-6383

### DIFF
--- a/src/libbson/src/bson/bson-string.c
+++ b/src/libbson/src/bson/bson-string.c
@@ -20,6 +20,7 @@
 
 #include <bson/bson-compat.h>
 #include <bson/bson-config.h>
+#include <bson/bson-cmp.h>
 #include <bson/bson-string.h>
 #include <bson/bson-memory.h>
 #include <bson/bson-utf8.h>
@@ -61,16 +62,25 @@ bson_string_t *
 bson_string_new (const char *str) /* IN */
 {
    bson_string_t *ret;
+   size_t len_sz;
 
    ret = bson_malloc0 (sizeof *ret);
-   ret->len = str ? (int) strlen (str) : 0;
+   if (str) {
+      len_sz = strlen (str);
+      BSON_ASSERT (len_sz <= UINT32_MAX);
+      ret->len = (uint32_t) len_sz;
+   } else {
+      ret->len = 0;
+   }
    ret->alloc = ret->len + 1;
 
    if (!bson_is_power_of_two (ret->alloc)) {
-      ret->alloc = (uint32_t) bson_next_power_of_two ((size_t) ret->alloc);
+      len_sz = bson_next_power_of_two ((size_t) ret->alloc);
+      BSON_ASSERT (len_sz <= UINT32_MAX);
+      ret->alloc = (uint32_t) len_sz;
    }
 
-   BSON_ASSERT (ret->alloc >= 1);
+   BSON_ASSERT (ret->alloc >= ret->len + 1);
 
    ret->str = bson_malloc (ret->alloc);
 
@@ -126,18 +136,24 @@ bson_string_append (bson_string_t *string, /* IN */
                     const char *str)       /* IN */
 {
    uint32_t len;
+   size_t len_sz;
 
    BSON_ASSERT (string);
    BSON_ASSERT (str);
 
-   len = (uint32_t) strlen (str);
+   len_sz = strlen (str);
+   BSON_ASSERT (bson_in_range_unsigned (uint32_t, len_sz));
+   len = (uint32_t) len_sz;
 
    if ((string->alloc - string->len - 1) < len) {
+      BSON_ASSERT (string->alloc <= UINT32_MAX - len);
       string->alloc += len;
       if (!bson_is_power_of_two (string->alloc)) {
-         string->alloc =
-            (uint32_t) bson_next_power_of_two ((size_t) string->alloc);
+         len_sz = bson_next_power_of_two ((size_t) string->alloc);
+         BSON_ASSERT (len_sz <= UINT32_MAX);
+         string->alloc = (uint32_t) len_sz;
       }
+      BSON_ASSERT (string->alloc >= string->len + len);
       string->str = bson_realloc (string->str, string->alloc);
    }
 


### PR DESCRIPTION
Here is a vulnerability which is mentioned in https://github.com/mongodb/mongo-c-driver/pull/1593 and is fixed in the r1.27 branch in https://github.com/mongodb/mongo-c-driver/commit/7c34461863211be172e6317221d72e4429bed45e, but is not fixed in the branch of r1.26, maybe it should be backported?