### PR TITLE
CDRIVER-4352 unskip `/Samples` tests

### DIFF
--- a/.evergreen/etc/skip-tests.txt
+++ b/.evergreen/etc/skip-tests.txt
@@ -28,6 +28,5 @@
 
 /transactions/legacy/mongos-recovery-token/"commitTransaction retry fails on new mongos" # fails with server selection timeout (CDRIVER-4268)
 /transactions/legacy/pin-mongos/"unpin after transient error within a transaction and commit" # (CDRIVER-4351) server selection timeout (on ASAN Tests Ubuntu 18.04 build variant)
-/Samples # (CDRIVER-4352) strange "heartbeat failed" error
 
 /client_side_encryption/bypass_spawning_mongocryptd/mongocryptdBypassSpawn  # Fails if crypt_shared is visible

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -2676,7 +2676,7 @@ test_example_59 (mongoc_database_t *db)
    /* End Snapshot Query Example 1 */
 
    if (adoptable_pets_count != 2) {
-      MONGOC_ERROR ("there should be exatly 2 adoptable_pets_count, found: %" PRId64, adoptable_pets_count);
+      MONGOC_ERROR ("there should be exactly 2 adoptable_pets_count, found: %" PRId64, adoptable_pets_count);
    }
 
    /* Start Snapshot Query Example 1 Post */

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -53,6 +53,8 @@ test_sample_command (sample_command_fn_t fn,
 
    ASSERT_NO_CAPTURED_LOGS (example_name);
 
+   capture_logs (false);
+
    if (drop_collection) {
       mongoc_collection_drop (collection, NULL);
    }
@@ -2913,6 +2915,7 @@ test_sample_change_stream_command (sample_command_fn_t fn,
       capture_logs (true);
       fn (db);
       ASSERT_NO_CAPTURED_LOGS ("change stream examples");
+      capture_logs (false);
 
       bson_mutex_lock (&ctx.lock);
       ctx.done = true;
@@ -3861,6 +3864,7 @@ test_sample_txn_commands (mongoc_client_t *client)
    /* test transactions retry example 3 */
    example_func (client);
    ASSERT_NO_CAPTURED_LOGS ("transactions retry example 3");
+   capture_logs (false);
    find_and_match (employees, "{'employee': 3}", "{'status': 'Inactive'}");
 
    mongoc_collection_destroy (employees);

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -3057,11 +3057,6 @@ test_sample_causal_consistency (mongoc_client_t *client)
       return;
    }
 
-   if (test_framework_is_replset () && test_framework_data_nodes_count () == 1) {
-      MONGOC_DEBUG ("Skipping test. Detected single-node replica set. Test requires a secondary.\n");
-      return;
-   }
-
    /* Seed the 'db.items' collection with a document. */
    coll = mongoc_client_get_collection (client, "db", "items");
    mongoc_collection_drop (coll, &error);

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -2602,14 +2602,9 @@ cleanup:
    return rc;
 }
 
-/*
- * JIRA: https://jira.mongodb.org/browse/DRIVERS-2181
- */
 static void
-test_example_59 (mongoc_database_t *db)
+test_snapshot_query_example_1 (void)
 {
-   BSON_UNUSED (db);
-
    if (!test_framework_skip_if_no_txns ()) {
       return;
    }
@@ -2733,10 +2728,8 @@ cleanup:
 
 
 static void
-test_example_60 (mongoc_database_t *db)
+test_snapshot_query_example_2 (void)
 {
-   BSON_UNUSED (db);
-
    if (!test_framework_skip_if_no_txns ()) {
       return;
    }
@@ -2852,6 +2845,18 @@ cleanup:
    bson_destroy (pipeline);
    mongoc_client_destroy (client);
    /* End Snapshot Query Example 2 Post */
+}
+
+// `test_snapshot_query_examples` examples for DRIVERS-2181.
+static void
+test_snapshot_query_examples (void)
+{
+   capture_logs (true);
+   test_snapshot_query_example_1 ();
+   ASSERT_NO_CAPTURED_LOGS ("test_snapshot_query_example_1");
+   test_snapshot_query_example_2 ();
+   ASSERT_NO_CAPTURED_LOGS ("test_snapshot_query_example_2");
+   capture_logs (false);
 }
 
 /* clang-format off */
@@ -4423,8 +4428,6 @@ test_sample_commands (void)
    test_sample_command (test_example_57, 57, db, collection, false);
    test_sample_command (test_example_58, 58, db, collection, false);
    test_sample_command (test_example_56, 56, db, collection, true);
-   test_sample_command (test_example_59, 59, db, collection, true);
-   test_sample_command (test_example_60, 60, db, collection, true);
    test_sample_change_stream_command (test_example_change_stream, db);
    test_sample_causal_consistency (client);
    test_sample_aggregation (db);
@@ -4432,6 +4435,7 @@ test_sample_commands (void)
    test_sample_indexes (db);
    test_sample_run_command (db);
    test_sample_txn_commands (client);
+   test_snapshot_query_examples ();
 
    if (test_framework_max_wire_version_at_least (WIRE_VERSION_4_9)) {
       test_sample_versioned_api ();

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -2607,7 +2607,7 @@ test_snapshot_query_example_1 (void)
       return;
    }
 
-   if (!test_framework_max_wire_version_at_least (MONGOC_READ_SECONDARY)) {
+   if (!test_framework_max_wire_version_at_least (WIRE_VERSION_SNAPSHOT_READS)) {
       MONGOC_DEBUG ("Skipping test. Server does not support snapshot reads\n");
       return;
    }

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -2732,8 +2732,8 @@ test_snapshot_query_example_2 (void)
       return;
    }
 
-   if (test_framework_get_server_version () < test_framework_str_to_version ("5.0.0")) {
-      MONGOC_DEBUG ("Skipping test. Test requires server version 5.0.0\n");
+   if (!test_framework_max_wire_version_at_least (WIRE_VERSION_SNAPSHOT_READS)) {
+      MONGOC_DEBUG ("Skipping test. Server does not support snapshot reads\n");
       return;
    }
 

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -2853,10 +2853,13 @@ test_snapshot_query_examples (void)
 {
    capture_logs (true);
    test_snapshot_query_example_1 ();
-   ASSERT_NO_CAPTURED_LOGS ("test_snapshot_query_example_1");
-   test_snapshot_query_example_2 ();
-   ASSERT_NO_CAPTURED_LOGS ("test_snapshot_query_example_2");
    capture_logs (false);
+   ASSERT_NO_CAPTURED_LOGS ("test_snapshot_query_example_1");
+
+   capture_logs (true);
+   test_snapshot_query_example_2 ();
+   capture_logs (false);
+   ASSERT_NO_CAPTURED_LOGS ("test_snapshot_query_example_2");
 }
 
 /* clang-format off */

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -2607,8 +2607,8 @@ test_snapshot_query_example_1 (void)
       return;
    }
 
-   if (test_framework_get_server_version () < test_framework_str_to_version ("5.0.0")) {
-      MONGOC_DEBUG ("Skipping test. Test requires server version 5.0.0\n");
+   if (!test_framework_max_wire_version_at_least (MONGOC_READ_SECONDARY)) {
+      MONGOC_DEBUG ("Skipping test. Server does not support snapshot reads\n");
       return;
    }
 

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -3018,6 +3018,11 @@ test_sample_causal_consistency (mongoc_client_t *client)
       return;
    }
 
+   if (test_framework_is_replset () && test_framework_data_nodes_count () == 1) {
+      MONGOC_DEBUG ("Skipping test. Detected single-node replica set. Test requires a secondary.\n");
+      return;
+   }
+
    /* Seed the 'db.items' collection with a document. */
    coll = mongoc_client_get_collection (client, "db", "items");
    mongoc_collection_drop (coll, &error);

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -3678,7 +3678,7 @@ commit_with_retry (mongoc_client_session_t *cs, bson_error_t *error)
        * mongoc_transaction_opts_set_write_concern */
       r = mongoc_client_session_commit_transaction (cs, &reply, error);
       if (r) {
-         MONGOC_INFO ("Transaction committed");
+         MONGOC_DEBUG ("Transaction committed");
          break;
       }
 

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -2602,6 +2602,11 @@ test_example_59 (mongoc_database_t *db)
       return;
    }
 
+   if (test_framework_get_server_version () < test_framework_str_to_version ("5.0.0")) {
+      MONGOC_DEBUG ("Skipping test. Test requires server version 5.0.0\n");
+      return;
+   }
+
    mongoc_client_t *client = NULL;
    client = test_framework_new_default_client ();
 
@@ -2711,6 +2716,11 @@ test_example_60 (mongoc_database_t *db)
    BSON_UNUSED (db);
 
    if (!test_framework_skip_if_no_txns ()) {
+      return;
+   }
+
+   if (test_framework_get_server_version () < test_framework_str_to_version ("5.0.0")) {
+      MONGOC_DEBUG ("Skipping test. Test requires server version 5.0.0\n");
       return;
    }
 

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -47,13 +47,11 @@ test_sample_command (sample_command_fn_t fn,
                      bool drop_collection)
 {
    char *example_name = bson_strdup_printf ("example %d", exampleno);
+
    capture_logs (true);
-
    fn (db);
-
-   ASSERT_NO_CAPTURED_LOGS (example_name);
-
    capture_logs (false);
+   ASSERT_NO_CAPTURED_LOGS (example_name);
 
    if (drop_collection) {
       mongoc_collection_drop (collection, NULL);

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -4427,6 +4427,7 @@ test_sample_commands (void)
    test_sample_command (test_example_55, 55, db, collection, false);
    test_sample_command (test_example_57, 57, db, collection, false);
    test_sample_command (test_example_58, 58, db, collection, false);
+   // Run 56 after 57 and 58. 56 deletes all data. 57 and 58 expect data present.
    test_sample_command (test_example_56, 56, db, collection, true);
    test_sample_change_stream_command (test_example_change_stream, db);
    test_sample_causal_consistency (client);


### PR DESCRIPTION
# Summary

Resolves CDRIVER-4352. Unskips the `/Samples*` tests and applies fixes.

To verify changes, the `/Samples*` tests were run 100 times in [this patch build](https://spruce.mongodb.com/version/66b41bb6f1658d0007fc2a18).

# Details

Several test errors were addressed. See commits for details. Notably:

- An informational `MONGOC_INFO` log was replaced with `MONGOC_DEBUG`. This was to fix a failing `ASSERT_NO_CAPTURED_LOGS`. CDRIVER-4282 changed test log capture to [include `MONGOC_LOG_LEVEL_INFO`](https://github.com/mongodb/mongo-c-driver/pull/1374/files#diff-b71f20ac0b55a16f43592d6bc46791721a0a075febda9e508f3c66d555fae9e9L209). 
- Snapshot query examples added in CDRIVER-4295 were updated to skip on server <= 5.0. Drivers [error](https://jira.mongodb.org/browse/DRIVERS-1820) if using snapshot sessions with server < 5.0.
- Snapshot query examples now use majority write concern to insert data. This is to address errors observed in Evergreen [described here](https://jira.mongodb.org/browse/DRIVERS-2181?focusedCommentId=6589519&focusedId=6589519&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-6589519).

Drive-by improvements:

- Skip `test_sample_causal_consistency` on single-node replica sets. The test requires a secondary. This is not strictly needed (as Evergreen tests with three-node replica sets) but is intended as a local convenience. This can be removed if preferred.
- `capture_logs (false)` calls were added to reduce scope of log capture.
- The snapshot query examples were renamed to avoid using the numbers 59 and 60. The numbers 1-58 are associated with [examples in DRIVERS-356](https://jira.mongodb.org/browse/DRIVERS-356?focusedCommentId=1521532&focusedId=1521532&page=com.atlassian.jira.plugin.system.). 59 and 60 have no known reference.
