### PR TITLE
CDRIVER-5667 Add missing BSON type checks in special key handlers

### DIFF
--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -362,20 +362,27 @@ _noop (void)
       return;                                                                                                \
    } else                                                                                                    \
       (void) 0
-#define HANDLE_OPTION(_selection_statement, _key, _type, _state)                                 \
-   _selection_statement (len == strlen (_key) && strncmp ((const char *) val, (_key), len) == 0) \
-   {                                                                                             \
-      if (bson->bson_type && bson->bson_type != (_type)) {                                       \
-         _bson_json_read_set_error (reader,                                                      \
-                                    "Invalid key \"%s\".  Looking for values "                   \
-                                    "for type \"%s\", got \"%s\"",                               \
-                                    (_key),                                                      \
-                                    _bson_json_type_name (bson->bson_type),                      \
-                                    _bson_json_type_name (_type));                               \
-         return;                                                                                 \
-      }                                                                                          \
-      bson->bson_type = (_type);                                                                 \
-      bson->bson_state = (_state);                                                               \
+
+#define HANDLE_OPTION_KEY_COMPARE(_key) (len == strlen (_key) && memcmp (key, (_key), len) == 0)
+
+#define HANDLE_OPTION_TYPE_CHECK(_key, _type)                               \
+   if (bson->bson_type && bson->bson_type != (_type)) {                     \
+      _bson_json_read_set_error (reader,                                    \
+                                 "Invalid key \"%s\".  Looking for values " \
+                                 "for type \"%s\", got \"%s\"",             \
+                                 (_key),                                    \
+                                 _bson_json_type_name (bson->bson_type),    \
+                                 _bson_json_type_name (_type));             \
+      return;                                                               \
+   }                                                                        \
+   ((void) 0)
+
+#define HANDLE_OPTION(_selection_statement, _key, _type, _state) \
+   _selection_statement (HANDLE_OPTION_KEY_COMPARE (_key))       \
+   {                                                             \
+      HANDLE_OPTION_TYPE_CHECK (_key, _type);                    \
+      bson->bson_type = (_type);                                 \
+      bson->bson_state = (_state);                               \
    }
 
 
@@ -1259,9 +1266,10 @@ _bson_json_read_map_key (bson_json_reader_t *reader, /* IN */
       return;
    }
 
+   const char *const key = (const char *) val;
+
    if (bson->read_state == BSON_JSON_IN_START_MAP) {
-      if (len > 0 && val[0] == '$' && _is_known_key ((const char *) val, len) &&
-          bson->n >= 0 /* key is in subdocument */) {
+      if (len > 0 && key[0] == '$' && _is_known_key (key, len) && bson->n >= 0 /* key is in subdocument */) {
          bson->read_state = BSON_JSON_IN_BSON_TYPE;
          bson->bson_type = (bson_type_t) 0;
          memset (&bson->bson_type_data, 0, sizeof bson->bson_type_data);
@@ -1298,17 +1306,17 @@ _bson_json_read_map_key (bson_json_reader_t *reader, /* IN */
       HANDLE_OPTION (else if, "$numberDouble", BSON_TYPE_DOUBLE, BSON_JSON_LF_DOUBLE)
       HANDLE_OPTION (else if, "$symbol", BSON_TYPE_SYMBOL, BSON_JSON_LF_SYMBOL)
       HANDLE_OPTION (else if, "$numberDecimal", BSON_TYPE_DECIMAL128, BSON_JSON_LF_DECIMAL128)
-      else if (!strcmp ("$timestamp", (const char *) val))
+      else if (HANDLE_OPTION_KEY_COMPARE ("$timestamp"))
       {
          bson->bson_type = BSON_TYPE_TIMESTAMP;
          bson->read_state = BSON_JSON_IN_BSON_TYPE_TIMESTAMP_STARTMAP;
       }
-      else if (!strcmp ("$regularExpression", (const char *) val))
+      else if (HANDLE_OPTION_KEY_COMPARE ("$regularExpression"))
       {
          bson->bson_type = BSON_TYPE_REGEX;
          bson->read_state = BSON_JSON_IN_BSON_TYPE_REGEX_STARTMAP;
       }
-      else if (!strcmp ("$dbPointer", (const char *) val))
+      else if (HANDLE_OPTION_KEY_COMPARE ("$dbPointer"))
       {
          /* start parsing "key": {"$dbPointer": {...}}, save "key" for later */
          _bson_json_buf_set (&bson->dbpointer_key, bson->key, bson->key_buf.len);
@@ -1316,11 +1324,11 @@ _bson_json_read_map_key (bson_json_reader_t *reader, /* IN */
          bson->bson_type = BSON_TYPE_DBPOINTER;
          bson->read_state = BSON_JSON_IN_BSON_TYPE_DBPOINTER_STARTMAP;
       }
-      else if (!strcmp ("$code", (const char *) val))
+      else if (HANDLE_OPTION_KEY_COMPARE ("$code"))
       {
          _bson_json_read_code_or_scope_key (bson, false /* is_scope */, val, len);
       }
-      else if (!strcmp ("$scope", (const char *) val))
+      else if (HANDLE_OPTION_KEY_COMPARE ("$scope"))
       {
          _bson_json_read_code_or_scope_key (bson, true /* is_scope */, val, len);
       }

--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -1159,23 +1159,40 @@ _bson_json_read_start_map (bson_json_reader_t *reader) /* IN */
 }
 
 
+#define BSON_PRIVATE_SPECIAL_KEYS_XMACRO(X) \
+   X (binary)                               \
+   X (code)                                 \
+   X (date)                                 \
+   X (dbPointer)                            \
+   X (maxKey)                               \
+   X (minKey)                               \
+   X (numberDecimal)                        \
+   X (numberDouble)                         \
+   X (numberInt)                            \
+   X (numberLong)                           \
+   X (oid)                                  \
+   X (options)                              \
+   X (regex)                                \
+   X (regularExpression)                    \
+   X (scope)                                \
+   X (symbol)                               \
+   X (timestamp)                            \
+   X (type)                                 \
+   X (undefined)                            \
+   X (uuid)
+
+
 static bool
 _is_known_key (const char *key, size_t len)
 {
-   bool ret;
-
-#define IS_KEY(k) (len == strlen (k) && (0 == memcmp (k, key, len)))
-
-   ret = (IS_KEY ("$regularExpression") || IS_KEY ("$regex") || IS_KEY ("$options") || IS_KEY ("$code") ||
-          IS_KEY ("$scope") || IS_KEY ("$oid") || IS_KEY ("$binary") || IS_KEY ("$type") || IS_KEY ("$date") ||
-          IS_KEY ("$undefined") || IS_KEY ("$maxKey") || IS_KEY ("$minKey") || IS_KEY ("$timestamp") ||
-          IS_KEY ("$numberInt") || IS_KEY ("$numberLong") || IS_KEY ("$numberDouble") || IS_KEY ("$numberDecimal") ||
-          IS_KEY ("$numberInt") || IS_KEY ("$numberLong") || IS_KEY ("$numberDouble") || IS_KEY ("$numberDecimal") ||
-          IS_KEY ("$dbPointer") || IS_KEY ("$symbol") || IS_KEY ("$uuid"));
-
+#define IS_KEY(k)                                                    \
+   if (len == strlen ("$" #k) && (0 == memcmp ("$" #k, key, len))) { \
+      return true;                                                   \
+   }
+   BSON_PRIVATE_SPECIAL_KEYS_XMACRO (IS_KEY)
 #undef IS_KEY
 
-   return ret;
+   return false;
 }
 
 static void

--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -1308,16 +1308,20 @@ _bson_json_read_map_key (bson_json_reader_t *reader, /* IN */
       HANDLE_OPTION (else if, "$numberDecimal", BSON_TYPE_DECIMAL128, BSON_JSON_LF_DECIMAL128)
       else if (HANDLE_OPTION_KEY_COMPARE ("$timestamp"))
       {
+         HANDLE_OPTION_TYPE_CHECK ("$timestamp", BSON_TYPE_TIMESTAMP);
          bson->bson_type = BSON_TYPE_TIMESTAMP;
          bson->read_state = BSON_JSON_IN_BSON_TYPE_TIMESTAMP_STARTMAP;
       }
       else if (HANDLE_OPTION_KEY_COMPARE ("$regularExpression"))
       {
+         HANDLE_OPTION_TYPE_CHECK ("$regularExpression", BSON_TYPE_REGEX);
          bson->bson_type = BSON_TYPE_REGEX;
          bson->read_state = BSON_JSON_IN_BSON_TYPE_REGEX_STARTMAP;
       }
       else if (HANDLE_OPTION_KEY_COMPARE ("$dbPointer"))
       {
+         HANDLE_OPTION_TYPE_CHECK ("$dbPointer", BSON_TYPE_DBPOINTER);
+
          /* start parsing "key": {"$dbPointer": {...}}, save "key" for later */
          _bson_json_buf_set (&bson->dbpointer_key, bson->key, bson->key_buf.len);
 
@@ -1326,10 +1330,18 @@ _bson_json_read_map_key (bson_json_reader_t *reader, /* IN */
       }
       else if (HANDLE_OPTION_KEY_COMPARE ("$code"))
       {
+         // "$code" may come after "$scope".
+         if (bson->bson_type != BSON_TYPE_CODEWSCOPE) {
+            HANDLE_OPTION_TYPE_CHECK ("$code", BSON_TYPE_CODE);
+         }
          _bson_json_read_code_or_scope_key (bson, false /* is_scope */, val, len);
       }
       else if (HANDLE_OPTION_KEY_COMPARE ("$scope"))
       {
+         // "$scope" may come after "$code".
+         if (bson->bson_type != BSON_TYPE_CODE) {
+            HANDLE_OPTION_TYPE_CHECK ("$scope", BSON_TYPE_CODEWSCOPE);
+         }
          _bson_json_read_code_or_scope_key (bson, true /* is_scope */, val, len);
       }
       else

--- a/src/libbson/tests/test-json.c
+++ b/src/libbson/tests/test-json.c
@@ -2551,12 +2551,14 @@ test_bson_json_errors (void)
 {
    typedef const char *test_bson_json_error_t[2];
    test_bson_json_error_t tests[] = {
-      {"{\"x\": {\"$numberLong\": 1}}", "Invalid state for integer read: INT64"},
-      {"{\"x\": {\"$binary\": 1}}", "Unexpected integer 1 in type \"binary\""},
-      {"{\"x\": {\"$numberInt\": true}}", "Invalid read of boolean in state IN_BSON_TYPE"},
-      {"{\"x\": {\"$dbPointer\": true}}", "Invalid read of boolean in state IN_BSON_TYPE_DBPOINTER_STARTMAP"},
-      {"[{\"$code\": {}}]", "Unexpected nested object value for \"$code\" key"},
-      {"{\"x\": {\"$numberInt\": \"8589934592\"}}", "Invalid input string \"8589934592\", looking for INT32"},
+      {BSON_STR ({"x" : {"$numberLong" : 1}}), "Invalid state for integer read: INT64"},
+      {BSON_STR ({"x" : {"$binary" : 1}}), "Unexpected integer 1 in type \"binary\""},
+      {BSON_STR ({"x" : {"$numberInt" : true}}), "Invalid read of boolean in state IN_BSON_TYPE"},
+      {BSON_STR ({"x" : {"$dbPointer" : true}}), "Invalid read of boolean in state IN_BSON_TYPE_DBPOINTER_STARTMAP"},
+      {BSON_STR ([ {"$code" : {}} ]), "Unexpected nested object value for \"$code\" key"},
+      {BSON_STR ([ {"$scope" : {}, "$dbPointer" : {"" : {"$code" : ""}}} ]),
+       "Invalid key \"$dbPointer\".  Looking for values for type \"code\", got \"dbpointer\""},
+      {BSON_STR ({"x" : {"$numberInt" : "8589934592"}}), "Invalid input string \"8589934592\", looking for INT32"},
       {0},
    };
 


### PR DESCRIPTION
Resolves CDRIVER-5667. Verified by [this patch](https://spruce.mongodb.com/version/66b53769e4b2620007435635).

Traced the issue to a code pattern discrepancy in `_bson_json_read_map_key` when handling special keys in the `BSON_JSON_IN_BSON_TYPE` read state. The BSON type field is reset to `BSON_TYPE_EOD` (value: `0`) when transitioning from `BSON_JSON_IN_START_MAP` -> `BSON_JSON_IN_BSON_TYPE`. This PR identified that when subsequently identifying the special key value on re-entry into this function (such as when parsing the key of a subdocument), only some branches performed a check for a pre-existing non-EOD BSON type. Simplified:

```c
if (bson->read_state == BSON_JSON_IN_BSON_TYPE) {
   // Via HANDLE_OPTION expansion.
   if (len == strlen ("$regex") && strncmp ((const char *) val, ("$regex"), len) == 0) {
      if (bson->bson_type && bson->bson_type != BSON_TYPE_REGEX) { // BSON type check. (!)
         _bson_json_read_set_error (...);
         return;
      }
      bson->bson_type = BSON_TYPE_REGEX;
      bson->bson_state = BSON_JSON_LF_REGEX; // LF: "Looking For"
   }

   // Similar pattern for "$options", "$oid", ..., "$numberDecimal".
   else if ...

   // Pattern break: `strcmp` instead of `strlen` + `strncmp`.
   else if (!strcmp ("$timestamp", (const char *) val)) {
      // Pattern break: no BSON type check. (!!)
      bson->bson_type = BSON_TYPE_TIMESTAMP;
      bson->read_state = BSON_JSON_IN_BSON_TYPE_TIMESTAMP_STARTMAP;
   }

   // Similar pattern for "$regularExpression", "$dbPointer", "$code", and "$scope".
   else if ...

   else {
      _bson_json_bad_key_in_type (reader, val);
   }
}
```

Adding the missing BSON type checks was sufficient to detect and handle the malformed input described in CDRIVER-5667. These checks prevent the state machine from reaching the point where `_bson_json_read_append_code` is invoked with a precondition violation (the top of JSON stack frame is not a previously-parsed scope document) by detecting+forbidding the presence of any intermediate and unrelated BSON types that could overwrite the current JSON stack frame with their own state.

Some drive-by improvements include:

- Use of an X macro for special key strings to better identify and maintain the list of special keys (e.g. this PR removes several redundant `strlen` + `memcmp` calls for duplicate key checks).
- Refactor of the `strlen` + `memcmp` (formerly `strncmp`) pattern into a dedicated macro for consistent reuse.
- Refactor the BSON type check into a macro for consistent reuse.
- Update JSON error test input values with `BSON_STR` to reduce need for escape characters.