### PR TITLE
CDRIVER-4479 drop VS 2013

### DIFF
--- a/.evergreen/config_generator/components/sasl/winssl.py
+++ b/.evergreen/config_generator/components/sasl/winssl.py
@@ -15,8 +15,6 @@ TAG = f'sasl-matrix-{SSL}'
 # pylint: disable=line-too-long
 # fmt: off
 COMPILE_MATRIX = [
-    ('windows-64-vs2013', 'vs2013x64', None, [       'cyrus',       ]),
-    ('windows-64-vs2013', 'vs2013x86', None, ['off',                ]),
     ('windows-64-vs2015', 'vs2015x64', None, [       'cyrus',       ]),
     ('windows-64-vs2015', 'vs2015x86', None, ['off',                ]),
     ('windows-vsCurrent', 'mingw',     None, [                'sspi']),

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -16662,26 +16662,6 @@ buildvariants:
   - debug-compile-sspi-winssl
   - debug-compile-no-align
   - .authentication-tests .winssl
-- name: windows-2013
-  display_name: Windows (VS 2013)
-  expansions:
-    CC: Visual Studio 12 2013 Win64
-  run_on: windows-64-vs2013-compile
-  tasks:
-  - .compression !.snappy !.zstd !.latest
-  - release-compile
-  - debug-compile-sspi-winssl
-  - .authentication-tests .winssl
-- name: windows-2013-32
-  display_name: Windows (i686) (VS 2013)
-  expansions:
-    CC: Visual Studio 12 2013
-  run_on: windows-64-vs2013-compile
-  tasks:
-  - release-compile
-  - debug-compile-rdtscp
-  - debug-compile-sspi-winssl
-  - .authentication-tests .winssl
 - name: mingw-windows2016
   display_name: MinGW-W64 (Windows Server 2016)
   expansions:

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -3959,15 +3959,6 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: sasl-cyrus-winssl-vs2013-x64-compile
-    run_on: windows-64-vs2013-large
-    tags: [sasl-matrix-winssl, compile, windows-64-vs2013, vs2013x64, sasl-cyrus]
-    commands:
-      - func: find-cmake-latest
-      - func: sasl-cyrus-winssl-compile
-        vars:
-          CC: Visual Studio 12 2013 Win64
-      - func: upload-build
   - name: sasl-cyrus-winssl-vs2015-x64-compile
     run_on: windows-64-vs2015-large
     tags: [sasl-matrix-winssl, compile, windows-64-vs2015, vs2015x64, sasl-cyrus]
@@ -4661,15 +4652,6 @@ tasks:
       - func: sasl-off-nossl-compile
         vars:
           CC: Visual Studio 15 2017 Win64
-      - func: upload-build
-  - name: sasl-off-winssl-vs2013-x86-compile
-    run_on: windows-64-vs2013-large
-    tags: [sasl-matrix-winssl, compile, windows-64-vs2013, vs2013x86, sasl-off]
-    commands:
-      - func: find-cmake-latest
-      - func: sasl-off-winssl-compile
-        vars:
-          CC: Visual Studio 12 2013
       - func: upload-build
   - name: sasl-off-winssl-vs2015-x86-compile
     run_on: windows-64-vs2015-large

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -329,25 +329,6 @@ all_variants = [
         {"CC": "Visual Studio 14 2015"},
     ),
     Variant(
-        "windows-2013",
-        "Windows (VS 2013)",
-        "windows-64-vs2013-compile",
-        [
-            ".compression !.snappy !.zstd !.latest",
-            "release-compile",
-            "debug-compile-sspi-winssl",
-            ".authentication-tests .winssl",
-        ],
-        {"CC": "Visual Studio 12 2013 Win64"},
-    ),
-    Variant(
-        "windows-2013-32",
-        "Windows (i686) (VS 2013)",
-        "windows-64-vs2013-compile",
-        ["release-compile", "debug-compile-rdtscp", "debug-compile-sspi-winssl", ".authentication-tests .winssl"],
-        {"CC": "Visual Studio 12 2013"},
-    ),
-    Variant(
         "mingw-windows2016",
         "MinGW-W64 (Windows Server 2016)",
         "windows-vsCurrent-large",

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,11 @@
-libmongoc 1.28.0 (Unreleased)
+libmongoc 1.29.0 (unreleased)
+=============================
+
+Platform Support:
+
+  * Support for Visual Studio 2013 is dropped.
+
+libmongoc 1.28.0 (unreleased)
 =============================
 
 New features:


### PR DESCRIPTION
# Summary

Resolves CDRIVER-4479. Drop Evergreen tasks for VS 2013. Document dropping support.

# Future work

This PR does not drop workarounds to support VS 2013 (e.g. https://github.com/mongodb/mongo-c-driver/commit/77bbfee6a927af39a8040f18a6a2c37624b5791c and https://github.com/mongodb/mongo-c-driver/pull/1229/commits/61a4a8d80c254791b190aafdcd39ffefe5229d53).
