### PR TITLE
Remove reference to `ubuntu1804` distro

### DIFF
--- a/.evergreen/config_generator/components/earthly.py
+++ b/.evergreen/config_generator/components/earthly.py
@@ -242,7 +242,6 @@ CONTAINER_RUN_DISTROS = [
     "ubuntu2204-large",
     "ubuntu2004-small",
     "ubuntu2004",
-    "ubuntu1804",
     "ubuntu1804-medium",
     "debian10",
     "debian11",

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -981,7 +981,6 @@ tasks:
       - ubuntu2204-large
       - ubuntu2004-small
       - ubuntu2004
-      - ubuntu1804
       - ubuntu1804-medium
       - debian10
       - debian11
@@ -1019,7 +1018,6 @@ tasks:
       - ubuntu2204-large
       - ubuntu2004-small
       - ubuntu2004
-      - ubuntu1804
       - ubuntu1804-medium
       - debian10
       - debian11
@@ -1057,7 +1055,6 @@ tasks:
       - ubuntu2204-large
       - ubuntu2004-small
       - ubuntu2004
-      - ubuntu1804
       - ubuntu1804-medium
       - debian10
       - debian11
@@ -1095,7 +1092,6 @@ tasks:
       - ubuntu2204-large
       - ubuntu2004-small
       - ubuntu2004
-      - ubuntu1804
       - ubuntu1804-medium
       - debian10
       - debian11
@@ -1133,7 +1129,6 @@ tasks:
       - ubuntu2204-large
       - ubuntu2004-small
       - ubuntu2004
-      - ubuntu1804
       - ubuntu1804-medium
       - debian10
       - debian11
@@ -1171,7 +1166,6 @@ tasks:
       - ubuntu2204-large
       - ubuntu2004-small
       - ubuntu2004
-      - ubuntu1804
       - ubuntu1804-medium
       - debian10
       - debian11
@@ -1209,7 +1203,6 @@ tasks:
       - ubuntu2204-large
       - ubuntu2004-small
       - ubuntu2004
-      - ubuntu1804
       - ubuntu1804-medium
       - debian10
       - debian11
@@ -1251,7 +1244,6 @@ tasks:
       - ubuntu2204-large
       - ubuntu2004-small
       - ubuntu2004
-      - ubuntu1804
       - ubuntu1804-medium
       - debian10
       - debian11


### PR DESCRIPTION
Remove reference to distro `ubuntu1804` (without `-small` or `-large` suffix). Fixes warnings produced by `evergreen validate`:

```bash
$ evergreen validate ./.evergreen/config.yml --project mongo-c-driver
NOTICE: task 'create-silk-asset-group' in buildvariant 'misc' references distro 'ubuntu1804' with the following admin-defined warning(s): This distro was created for ops-manager testing: DEVPROD-7666.  It should be deleted in about 3 weeks from June 3, 2024
[... many more ...]
```