### PR TITLE
Reduce Warnings - platform-dependent integer conversions for PBKDF functions

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-crypto-common-crypto.c
+++ b/src/libmongoc/src/mongoc/mongoc-crypto-common-crypto.c
@@ -23,6 +23,9 @@
 #include <CommonCrypto/CommonKeyDerivation.h>
 #include <CommonCrypto/CommonCryptoError.h>
 
+// Ensure lossless conversion between `uint32_t` and `uint` below.
+BSON_STATIC_ASSERT2 (sizeof_uint_uint32_t, sizeof (uint) == sizeof (uint32_t));
+
 bool
 mongoc_crypto_common_crypto_pbkdf2_hmac_sha1 (mongoc_crypto_t *crypto,
                                               const char *password,
@@ -33,9 +36,17 @@ mongoc_crypto_common_crypto_pbkdf2_hmac_sha1 (mongoc_crypto_t *crypto,
                                               size_t output_len,
                                               unsigned char *output)
 {
-   return kCCSuccess ==
-          CCKeyDerivationPBKDF (
-             kCCPBKDF2, password, password_len, salt, salt_len, kCCPRFHmacAlgSHA1, iterations, output, output_len);
+   BSON_UNUSED (crypto);
+
+   return kCCSuccess == CCKeyDerivationPBKDF (kCCPBKDF2,
+                                              password,
+                                              password_len,
+                                              salt,
+                                              salt_len,
+                                              kCCPRFHmacAlgSHA1,
+                                              (uint) iterations,
+                                              output,
+                                              output_len);
 }
 
 void
@@ -72,9 +83,17 @@ mongoc_crypto_common_crypto_pbkdf2_hmac_sha256 (mongoc_crypto_t *crypto,
                                                 size_t output_len,
                                                 unsigned char *output)
 {
-   return kCCSuccess ==
-          CCKeyDerivationPBKDF (
-             kCCPBKDF2, password, password_len, salt, salt_len, kCCPRFHmacAlgSHA256, iterations, output, output_len);
+   BSON_UNUSED (crypto);
+
+   return kCCSuccess == CCKeyDerivationPBKDF (kCCPBKDF2,
+                                              password,
+                                              password_len,
+                                              salt,
+                                              salt_len,
+                                              kCCPRFHmacAlgSHA256,
+                                              (uint) iterations,
+                                              output,
+                                              output_len);
 }
 
 void

--- a/src/libmongoc/src/mongoc/mongoc-crypto-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-crypto-openssl.c
@@ -20,6 +20,7 @@
 #ifdef MONGOC_ENABLE_CRYPTO_LIBCRYPTO
 #include "mongoc-crypto-openssl-private.h"
 #include "mongoc-crypto-private.h"
+#include "mongoc-log.h"
 
 #include <openssl/sha.h>
 #include <openssl/evp.h>
@@ -35,7 +36,36 @@ mongoc_crypto_openssl_pbkdf2_hmac_sha1 (mongoc_crypto_t *crypto,
                                         size_t output_len,
                                         unsigned char *output)
 {
-   return PKCS5_PBKDF2_HMAC (password, password_len, salt, salt_len, iterations, EVP_sha1 (), output_len, output);
+   BSON_UNUSED (crypto);
+
+   if (BSON_UNLIKELY (bson_cmp_greater_us (password_len, INT_MAX))) {
+      MONGOC_ERROR ("PBKDF2 HMAC password length exceeds INT_MAX");
+      return false;
+   }
+
+   if (BSON_UNLIKELY (bson_cmp_greater_us (salt_len, INT_MAX))) {
+      MONGOC_ERROR ("PBKDF2 HMAC salt length exceeds INT_MAX");
+      return false;
+   }
+
+   if (BSON_UNLIKELY (bson_cmp_greater_us (iterations, INT_MAX))) {
+      MONGOC_ERROR ("PBKDF2 HMAC iteration count exceeds INT_MAX");
+      return false;
+   }
+
+   if (BSON_UNLIKELY (bson_cmp_greater_us (iterations, INT_MAX))) {
+      MONGOC_ERROR ("PBKDF2 HMAC output buffer length exceeds INT_MAX");
+      return false;
+   }
+
+   return 0 != PKCS5_PBKDF2_HMAC (password,
+                                  (int) password_len,
+                                  salt,
+                                  (int) salt_len,
+                                  (int) iterations,
+                                  EVP_sha1 (),
+                                  (int) output_len,
+                                  output);
 }
 
 void
@@ -104,7 +134,36 @@ mongoc_crypto_openssl_pbkdf2_hmac_sha256 (mongoc_crypto_t *crypto,
                                           size_t output_len,
                                           unsigned char *output)
 {
-   return PKCS5_PBKDF2_HMAC (password, password_len, salt, salt_len, iterations, EVP_sha256 (), output_len, output);
+   BSON_UNUSED (crypto);
+
+   if (BSON_UNLIKELY (bson_cmp_greater_us (password_len, INT_MAX))) {
+      MONGOC_ERROR ("PBKDF2 HMAC password length exceeds INT_MAX");
+      return false;
+   }
+
+   if (BSON_UNLIKELY (bson_cmp_greater_us (salt_len, INT_MAX))) {
+      MONGOC_ERROR ("PBKDF2 HMAC salt length exceeds INT_MAX");
+      return false;
+   }
+
+   if (BSON_UNLIKELY (bson_cmp_greater_us (iterations, INT_MAX))) {
+      MONGOC_ERROR ("PBKDF2 HMAC iteration count exceeds INT_MAX");
+      return false;
+   }
+
+   if (BSON_UNLIKELY (bson_cmp_greater_us (iterations, INT_MAX))) {
+      MONGOC_ERROR ("PBKDF2 HMAC output buffer length exceeds INT_MAX");
+      return false;
+   }
+
+   return 0 != PKCS5_PBKDF2_HMAC (password,
+                                  (int) password_len,
+                                  salt,
+                                  (int) salt_len,
+                                  (int) iterations,
+                                  EVP_sha256 (),
+                                  (int) output_len,
+                                  output);
 }
 
 void

--- a/src/libmongoc/src/mongoc/mongoc-scram.c
+++ b/src/libmongoc/src/mongoc/mongoc-scram.c
@@ -456,9 +456,14 @@ _mongoc_scram_salt_password (mongoc_scram_t *scram,
                              uint32_t salt_len,
                              uint32_t iterations)
 {
-   uint8_t *output = scram->salted_password;
-   return mongoc_crypto_pbkdf (
-      &scram->crypto, password, password_len, salt, salt_len, iterations, MONGOC_SCRAM_HASH_MAX_SIZE, output);
+   return mongoc_crypto_pbkdf (&scram->crypto,
+                               password,
+                               password_len,
+                               salt,
+                               salt_len,
+                               iterations,
+                               MONGOC_SCRAM_HASH_MAX_SIZE,
+                               (unsigned char *) scram->salted_password);
 }
 
 


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1684. Verified by [this patch](https://spruce.mongodb.com/version/66ba33965fd3510007b8997d).

Addresses integral type conversion warnings for the new PBKDF2-related functions due to platform- and library-specific crypto library function parameter types.