### PR TITLE
CDRIVER-3685 address TSAN warning for mongoc_handshake_t::frozen

### DIFF
--- a/.tsan-suppressions
+++ b/.tsan-suppressions
@@ -1,2 +1,1 @@
 race:mongoc_counter*
-race:_mongoc_handshake_freeze

--- a/src/libmongoc/src/mongoc/mongoc-handshake.c
+++ b/src/libmongoc/src/mongoc/mongoc-handshake.c
@@ -726,7 +726,9 @@ _mongoc_handshake_build_doc_with_application (const char *appname)
 void
 _mongoc_handshake_freeze (void)
 {
+   bson_mutex_lock (&gHandshakeLock);
    _mongoc_handshake_get ()->frozen = true;
+   bson_mutex_unlock (&gHandshakeLock);
 }
 
 /*


### PR DESCRIPTION
Resolves CDRIVER-3685. Verified by [this patch](https://spruce.mongodb.com/version/66ba44e25db9c000071f03c9).

Encountered while investigating [ongoing task failures due to /scram/cache_invalidation](https://spruce.mongodb.com/version/mongo_c_driver_7b2ed297c5c546d520e7ae878ba23338f826bcfa/) following https://github.com/mongodb/mongo-c-driver/pull/1684.

Access of `_mongoc_handshake_get ()` following initialization must be guarded by `gHandshakeLock` (even for single-threaded clients).