### PR TITLE
CDRIVER-5634 account for embedded NULL when copying `salt`

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-crypto-cng.c
+++ b/src/libmongoc/src/mongoc/mongoc-crypto-cng.c
@@ -176,15 +176,15 @@ _bcrypt_derive_key_pbkdf2 (BCRYPT_ALG_HANDLE prf,
    }
 
    // Make non-const versions of password and salt.
-   char *password_copy = bson_malloc (sizeof (char) * password_len);
+   unsigned char *password_copy = bson_malloc (password_len);
    memcpy (password_copy, password, password_len);
-   uint8_t *salt_copy = bson_malloc (sizeof (uint8_t) * salt_len);
+   unsigned char *salt_copy = bson_malloc (salt_len);
    memcpy (salt_copy, salt, salt_len);
 
    NTSTATUS status = BCryptDeriveKeyPBKDF2 (prf,
-                                            (unsigned char *) password_copy,
+                                            password_copy,
                                             (ULONG) password_len,
-                                            (unsigned char *) salt_copy,
+                                            salt_copy,
                                             (ULONG) salt_len,
                                             (ULONGLONG) iterations,
                                             output,

--- a/src/libmongoc/src/mongoc/mongoc-crypto-cng.c
+++ b/src/libmongoc/src/mongoc/mongoc-crypto-cng.c
@@ -176,8 +176,10 @@ _bcrypt_derive_key_pbkdf2 (BCRYPT_ALG_HANDLE prf,
    }
 
    // Make non-const versions of password and salt.
-   char *password_copy = bson_strndup (password, password_len);
-   char *salt_copy = bson_strndup ((const char *) salt, salt_len);
+   char *password_copy = bson_malloc (sizeof (char) * password_len);
+   memcpy (password_copy, password, password_len);
+   uint8_t *salt_copy = bson_malloc (sizeof (uint8_t) * salt_len);
+   memcpy (salt_copy, salt, salt_len);
 
    NTSTATUS status = BCryptDeriveKeyPBKDF2 (prf,
                                             (unsigned char *) password_copy,


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1684. Fixes test failures on Windows with SCRAM auth. [Example failure](https://spruce.mongodb.com/task/mongo_c_driver_sasl_matrix_winssl_sasl_sspi_winssl_windows_2019_vs2017_x86_test_latest_server_auth_b4bf5a1bdc47236450e1ae365e87123a3029ef2b_24_08_12_18_01_53/logs?execution=0):

```
Begin /scram/cache_invalidation, seed 1723487056
    { "status": "fail", "test_file": "/scram/cache_invalidation", "seed": "1723487056", "start": 965.718000, "end": 974.359000, "elapsed": 8.641000  },
FAIL:C:\data\mci\26ca9ede4b9bb4808634a41a0bd207c0\mongoc\src\libmongoc\tests\test-mongoc-scram.c:457  _try_auth_from_uri()
  res
  Authentication failed.
```

Verified with this [patch build](https://spruce.mongodb.com/version/66ba56cdeb143c00071e6b38/).

Running `/scram/cache_invalidation` (which auths many times) on a spawn host showed `salt` may contain NULL bytes. This resulted in truncation when `salt` is copied with `bson_strndup`. This PR changes the copy to use `bson_malloc` + `memcpy`.

I expect embedded NULLs are not permitted in passwords, but copying the password was updated similarly for consistency.
