### PR TITLE
CDRIVER-4656 check if server is running with TLS in tests

### DIFF
--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -2624,3 +2624,12 @@ test_framework_is_loadbalanced (void)
    return test_framework_getenv_bool ("MONGOC_TEST_LOADBALANCED") ||
           test_framework_getenv_bool ("MONGOC_TEST_DNS_LOADBALANCED");
 }
+
+int
+test_framework_skip_if_no_server_ssl (void)
+{
+   if (test_framework_get_ssl ()) {
+      return 1; // Proceed.
+   }
+   return 0; // Skip.
+}

--- a/src/libmongoc/tests/test-libmongoc.h
+++ b/src/libmongoc/tests/test-libmongoc.h
@@ -284,4 +284,8 @@ test_framework_skip_if_serverless (void);
 bool
 test_framework_is_loadbalanced (void);
 
+// `test_framework_skip_if_no_server_ssl` skips if test runner was not told to connect to the server with SSL.
+int
+test_framework_skip_if_no_server_ssl (void);
+
 #endif

--- a/src/libmongoc/tests/test-mongoc-client.c
+++ b/src/libmongoc/tests/test-mongoc-client.c
@@ -2222,14 +2222,9 @@ test_client_buildinfo_hang (void)
 #if defined(MONGOC_ENABLE_SSL_OPENSSL)
 
 static void
-test_mongoc_client_change_openssl_ctx_before_ops (void)
+test_mongoc_client_change_openssl_ctx_before_ops (void *unused)
 {
-   if (!test_framework_get_ssl ()) {
-      MONGOC_DEBUG ("Skipping test. Test requires server to be running with TLS enabled, but MONGOC_SSL_* environment "
-                    "variables are not set.");
-      return;
-   }
-
+   BSON_UNUSED (unused);
    mongoc_client_t *client;
    const mongoc_ssl_opt_t *ssl_opts;
    bson_error_t error;
@@ -2249,14 +2244,9 @@ test_mongoc_client_change_openssl_ctx_before_ops (void)
 }
 
 static void
-test_mongoc_client_change_openssl_ctx_between_ops (void)
+test_mongoc_client_change_openssl_ctx_between_ops (void *unused)
 {
-   if (!test_framework_get_ssl ()) {
-      MONGOC_DEBUG ("Skipping test. Test requires server to be running with TLS enabled, but MONGOC_SSL_* environment "
-                    "variables are not set.");
-      return;
-   }
-
+   BSON_UNUSED (unused);
    mongoc_client_t *client;
    const mongoc_ssl_opt_t *ssl_opts;
    bson_error_t error;
@@ -4151,9 +4141,17 @@ test_client_install (TestSuite *suite)
       suite, "/Client/resends_handshake_on_network_error", test_mongoc_client_resends_handshake_on_network_error);
    TestSuite_Add (suite, "/Client/failure_to_auth", test_failure_to_auth);
 #if defined(MONGOC_ENABLE_SSL_OPENSSL)
-   TestSuite_Add (
-      suite, "/Client/openssl/change_ssl_opts_before_ops", test_mongoc_client_change_openssl_ctx_before_ops);
-   TestSuite_Add (
-      suite, "/Client/openssl/change_ssl_opts_after_ops", test_mongoc_client_change_openssl_ctx_between_ops);
+   TestSuite_AddFull (suite,
+                      "/Client/openssl/change_ssl_opts_before_ops",
+                      test_mongoc_client_change_openssl_ctx_before_ops,
+                      NULL,
+                      NULL,
+                      test_framework_skip_if_no_server_ssl);
+   TestSuite_AddFull (suite,
+                      "/Client/openssl/change_ssl_opts_after_ops",
+                      test_mongoc_client_change_openssl_ctx_between_ops,
+                      NULL,
+                      NULL,
+                      test_framework_skip_if_no_server_ssl);
 #endif
 }

--- a/src/libmongoc/tests/test-mongoc-client.c
+++ b/src/libmongoc/tests/test-mongoc-client.c
@@ -2224,6 +2224,12 @@ test_client_buildinfo_hang (void)
 static void
 test_mongoc_client_change_openssl_ctx_before_ops (void)
 {
+   if (!test_framework_get_ssl ()) {
+      MONGOC_DEBUG ("Skipping test. Test requires server to be running with TLS enabled, but MONGOC_SSL_* environment "
+                    "variables are not set.");
+      return;
+   }
+
    mongoc_client_t *client;
    const mongoc_ssl_opt_t *ssl_opts;
    bson_error_t error;
@@ -2245,6 +2251,12 @@ test_mongoc_client_change_openssl_ctx_before_ops (void)
 static void
 test_mongoc_client_change_openssl_ctx_between_ops (void)
 {
+   if (!test_framework_get_ssl ()) {
+      MONGOC_DEBUG ("Skipping test. Test requires server to be running with TLS enabled, but MONGOC_SSL_* environment "
+                    "variables are not set.");
+      return;
+   }
+
    mongoc_client_t *client;
    const mongoc_ssl_opt_t *ssl_opts;
    bson_error_t error;


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1673. Fixes failing `retry-true-latest-server` task. [Example failure](https://spruce.mongodb.com/task/mongo_c_driver_gcc75_retry_true_latest_server_f6971f8c49ccca3c840f65233ae514ccf1df8709_24_08_12_18_29_56/logs?execution=0):

```
FAIL:tests/test-mongoc-client.c:2240  test_mongoc_client_change_openssl_ctx_before_ops()
  ret
  No suitable servers found: `serverSelectionTimeoutMS` expired: [TLS handshake failed: Connection timed out calling hello on 'localhost:27017']. Topology type: Single
```

Tests require the server to be running with TLS enabled. The `retry-true-latest-server` uses a C driver built with OpenSSL, but does not run against a server with TLS enabled.

Verified with [this patch](https://spruce.mongodb.com/version/66ba6e28866ccc0007091cd2/).
