### PR TITLE
CDRIVER-5672 Fix C23 compile; don't return bool when return type is a pointer

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-database.c
+++ b/src/libmongoc/src/mongoc/mongoc-database.c
@@ -1261,7 +1261,7 @@ mongoc_database_create_collection (mongoc_database_t *database,
                                                 error)) {
       // Error during fields lookup
       bson_destroy (&encryptedFields);
-      return false;
+      return NULL;
    }
 
    if (!bson_empty (&encryptedFields)) {


### PR DESCRIPTION
C23 removed the conversion between boolean and pointers. But this is just a typo and should've been NULL originally.