### PR TITLE
CDRIVER-5673 Fix unused warnings for legacy atomic impls

### DIFF
--- a/src/libbson/src/bson/bson-atomic.h
+++ b/src/libbson/src/bson/bson-atomic.h
@@ -187,6 +187,7 @@ enum bson_memory_order {
             BSON_UNREACHABLE ("Invalid bson_memory_order value");                                                      \
       })                                                                                                               \
       BSON_IF_GNU_LEGACY_ATOMICS ({                                                                                    \
+         BSON_UNUSED (order);                                                                                          \
          __sync_synchronize ();                                                                                        \
          return *a;                                                                                                    \
       })                                                                                                               \
@@ -213,7 +214,7 @@ enum bson_memory_order {
          default:                                                                                                      \
             BSON_UNREACHABLE ("Invalid bson_memory_order value");                                                      \
       })                                                                                                               \
-      BSON_IF_GNU_LEGACY_ATOMICS (return __sync_val_compare_and_swap (a, *a, value);)                                  \
+      BSON_IF_GNU_LEGACY_ATOMICS (BSON_UNUSED (ord); return __sync_val_compare_and_swap (a, *a, value);)               \
    }                                                                                                                   \
                                                                                                                        \
    static BSON_INLINE Type bson_atomic_##NamePart##_compare_exchange_strong (                                          \


### PR DESCRIPTION
When investigating CXX-3088, building the C++ driver resulted in warnings building the C driver:

```
../../../mongo-c-driver-src/src/libbson/src/bson/bson-atomic.h: In function 'bson_atomic_int8_fetch':
../../../mongo-c-driver-src/src/libbson/src/bson/bson-atomic.h:203:54: warning: unused parameter 'order' [-Wunused-parameter]
       Type volatile const *a, enum bson_memory_order order)                   \
                                                      ^
../../../mongo-c-driver-src/src/libbson/src/bson/bson-atomic.h:364:1: note: in expansion of macro 'DECL_ATOMIC_INTEGRAL'
 DECL_ATOMIC_INTEGRAL (int8, DECL_ATOMIC_INTEGRAL_INT8, 8)
```

This PR adds `BSON_UNUSED` to fix the warning. Fix was verified with [this patch build](https://spruce.mongodb.com/version/66bbb3d2d10acd0007b8896e) of the C++ driver referring to this branch of the C driver. 


