### PR TITLE
CDRIVER-5676 implement bson_validate libfuzzer entrypoint

### DIFF
--- a/build/cmake/Sanitizers.cmake
+++ b/build/cmake/Sanitizers.cmake
@@ -35,7 +35,7 @@ string(REPLACE ";" "," _sanitize "${MONGO_SANITIZE}")
 if (_sanitize)
     string (MAKE_C_IDENTIFIER "HAVE_SANITIZE_${_sanitize}" ident)
     string (TOUPPER "${ident}" varname)
-    set (flag "-fsanitize=${_sanitize}")
+    set (flag -fsanitize=${_sanitize} -fno-sanitize-recover)
 
     cmake_push_check_state ()
         set (CMAKE_REQUIRED_FLAGS "${flag}")

--- a/build/cmake/Sanitizers.cmake
+++ b/build/cmake/Sanitizers.cmake
@@ -35,7 +35,7 @@ string(REPLACE ";" "," _sanitize "${MONGO_SANITIZE}")
 if (_sanitize)
     string (MAKE_C_IDENTIFIER "HAVE_SANITIZE_${_sanitize}" ident)
     string (TOUPPER "${ident}" varname)
-    set (flag -fsanitize=${_sanitize} -fno-sanitize-recover)
+    set (flag -fsanitize=${_sanitize} -fno-sanitize-recover=all)
 
     cmake_push_check_state ()
         set (CMAKE_REQUIRED_FLAGS "${flag}")

--- a/src/libbson/fuzz/CMakeLists.txt
+++ b/src/libbson/fuzz/CMakeLists.txt
@@ -2,3 +2,8 @@ add_executable(fuzz_test_init_from_json EXCLUDE_FROM_ALL
    fuzz_test_init_from_json.c)
 target_link_libraries(fuzz_test_init_from_json PRIVATE bson_static)
 set_property(TARGET fuzz_test_init_from_json APPEND PROPERTY LINK_OPTIONS -fsanitize=fuzzer)
+
+add_executable(fuzz_test_validate EXCLUDE_FROM_ALL
+   fuzz_test_validate.c)
+target_link_libraries(fuzz_test_validate PRIVATE bson_static)
+set_property(TARGET fuzz_test_validate APPEND PROPERTY LINK_OPTIONS -fsanitize=fuzzer)

--- a/src/libbson/fuzz/fuzz_test_validate.c
+++ b/src/libbson/fuzz/fuzz_test_validate.c
@@ -9,7 +9,7 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
    bson_t b;
    if (bson_init_static (&b, data, size)) {
       bson_validate (&b,
-                     BSON_VALIDATE_NONE | BSON_VALIDATE_UTF8 | BSON_VALIDATE_DOLLAR_KEYS | BSON_VALIDATE_DOT_KEYS |
+                     BSON_VALIDATE_UTF8 | BSON_VALIDATE_DOLLAR_KEYS | BSON_VALIDATE_DOT_KEYS |
                         BSON_VALIDATE_UTF8_ALLOW_NULL | BSON_VALIDATE_EMPTY_KEYS,
                      NULL);
    }

--- a/src/libbson/fuzz/fuzz_test_validate.c
+++ b/src/libbson/fuzz/fuzz_test_validate.c
@@ -1,0 +1,18 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <bson/bson.h>
+
+int
+LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
+{
+   bson_t b;
+   if (bson_init_static (&b, data, size)) {
+      bson_validate (&b,
+                     BSON_VALIDATE_NONE | BSON_VALIDATE_UTF8 | BSON_VALIDATE_DOLLAR_KEYS | BSON_VALIDATE_DOT_KEYS |
+                        BSON_VALIDATE_UTF8_ALLOW_NULL | BSON_VALIDATE_EMPTY_KEYS,
+                     NULL);
+   }
+
+   return 0;
+}

--- a/src/libbson/fuzz/fuzz_test_validate.c
+++ b/src/libbson/fuzz/fuzz_test_validate.c
@@ -12,7 +12,7 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
                      BSON_VALIDATE_UTF8 | BSON_VALIDATE_DOLLAR_KEYS | BSON_VALIDATE_DOT_KEYS |
                         BSON_VALIDATE_UTF8_ALLOW_NULL | BSON_VALIDATE_EMPTY_KEYS,
                      NULL);
+      return 0;
    }
-
-   return 0;
+   return -1;
 }


### PR DESCRIPTION
This patch implements a fuzzer for bson_validate. It works be performing the following steps:
1. Implement a new entrypoint
2. Adding the entrypoint to CMakeLists
3. Adding '-fno-sanitize-recover=all' to sanitizer flags, so that UBSan faults become unrecoverable.