### PR TITLE
Add fuzz_test_properties for common target options for fuzz executables

### DIFF
--- a/src/libbson/fuzz/CMakeLists.txt
+++ b/src/libbson/fuzz/CMakeLists.txt
@@ -1,9 +1,9 @@
-add_executable(fuzz_test_init_from_json EXCLUDE_FROM_ALL
-   fuzz_test_init_from_json.c)
-target_link_libraries(fuzz_test_init_from_json PRIVATE bson_static)
-set_property(TARGET fuzz_test_init_from_json APPEND PROPERTY LINK_OPTIONS -fsanitize=fuzzer)
+add_library(fuzz_test_properties INTERFACE)
+target_link_libraries(fuzz_test_properties INTERFACE bson_static)
+set_property(TARGET fuzz_test_properties APPEND PROPERTY INTERFACE_LINK_OPTIONS -fsanitize=fuzzer)
 
-add_executable(fuzz_test_validate EXCLUDE_FROM_ALL
-   fuzz_test_validate.c)
-target_link_libraries(fuzz_test_validate PRIVATE bson_static)
-set_property(TARGET fuzz_test_validate APPEND PROPERTY LINK_OPTIONS -fsanitize=fuzzer)
+add_executable(fuzz_test_init_from_json EXCLUDE_FROM_ALL fuzz_test_init_from_json.c)
+target_link_libraries(fuzz_test_init_from_json PRIVATE fuzz_test_properties)
+
+add_executable(fuzz_test_validate EXCLUDE_FROM_ALL fuzz_test_validate.c)
+target_link_libraries(fuzz_test_validate PRIVATE fuzz_test_properties)


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1705.

A small refactor that extracts common target properties of fuzz test executables into an interface library for reusability as more fuzz test executables are expected to be introduced.