### PR TITLE
Miscellaneous EVG compilation script improvements

### DIFF
--- a/.evergreen/config_generator/components/cse/darwinssl.py
+++ b/.evergreen/config_generator/components/cse/darwinssl.py
@@ -62,7 +62,6 @@ def tasks():
 def variants():
     expansions = {
         'CLIENT_SIDE_ENCRYPTION': 'on',
-        'DEBUG': 'ON',
     }
 
     return [

--- a/.evergreen/config_generator/components/cse/openssl.py
+++ b/.evergreen/config_generator/components/cse/openssl.py
@@ -85,7 +85,6 @@ def tasks():
 def variants():
     expansions = {
         'CLIENT_SIDE_ENCRYPTION': 'on',
-        'DEBUG': 'ON',
     }
 
     return [

--- a/.evergreen/config_generator/components/cse/winssl.py
+++ b/.evergreen/config_generator/components/cse/winssl.py
@@ -63,7 +63,6 @@ def tasks():
 def variants():
     expansions = {
         'CLIENT_SIDE_ENCRYPTION': 'on',
-        'DEBUG': 'ON',
     }
 
     return [

--- a/.evergreen/config_generator/components/sasl/darwinssl.py
+++ b/.evergreen/config_generator/components/sasl/darwinssl.py
@@ -55,9 +55,7 @@ def tasks():
 
 
 def variants():
-    expansions = {
-        'DEBUG': 'ON'
-    }
+    expansions = {}
 
     return [
         BuildVariant(

--- a/.evergreen/config_generator/components/sasl/nossl.py
+++ b/.evergreen/config_generator/components/sasl/nossl.py
@@ -58,9 +58,7 @@ def tasks():
 
 
 def variants():
-    expansions = {
-        'DEBUG': 'ON'
-    }
+    expansions = {}
 
     return [
         BuildVariant(

--- a/.evergreen/config_generator/components/sasl/openssl.py
+++ b/.evergreen/config_generator/components/sasl/openssl.py
@@ -81,9 +81,7 @@ def tasks():
 
 
 def variants():
-    expansions = {
-        'DEBUG': 'ON'
-    }
+    expansions = {}
 
     return [
         BuildVariant(

--- a/.evergreen/config_generator/components/sasl/winssl.py
+++ b/.evergreen/config_generator/components/sasl/winssl.py
@@ -78,9 +78,7 @@ def tasks():
 
 
 def variants():
-    expansions = {
-        'DEBUG': 'ON'
-    }
+    expansions = {}
 
     return [
         BuildVariant(

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -259,7 +259,7 @@ functions:
         echo "Waiting for mongohouse to start... done."
         pgrep -a "mongohouse"
         export RUN_MONGOHOUSE_TESTS=ON
-        ./build/src/libmongoc/test-libmongoc --no-fork -l /mongohouse/* -d --skip-tests .evergreen/etc/skip-tests.txt
+        ./cmake-build/src/libmongoc/test-libmongoc --no-fork -l /mongohouse/* -d --skip-tests .evergreen/etc/skip-tests.txt
   run aws tests:
   - command: ec2.assume_role
     params:

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -304,7 +304,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env CFLAGS="-fno-strict-overflow -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIE -O" DEBUG="ON" LDFLAGS="-pie -Wl,-z,relro -Wl,-z,now" SNAPPY="OFF" ZLIB="OFF" ZSTD="OFF" .evergreen/scripts/compile.sh
+        env CFLAGS="-fno-strict-overflow -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIE -O" LDFLAGS="-pie -Wl,-z,relro -Wl,-z,now" SNAPPY="OFF" ZLIB="OFF" ZSTD="OFF" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-compression-zlib
   tags:
@@ -319,7 +319,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG="ON" SNAPPY="OFF" ZLIB="BUNDLED" ZSTD="OFF" .evergreen/scripts/compile.sh
+        env SNAPPY="OFF" ZLIB="BUNDLED" ZSTD="OFF" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-compression-snappy
   tags:
@@ -334,7 +334,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG="ON" SNAPPY="ON" ZLIB="OFF" ZSTD="OFF" .evergreen/scripts/compile.sh
+        env SNAPPY="ON" ZLIB="OFF" ZSTD="OFF" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-compression-zstd
   tags:
@@ -349,7 +349,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG="ON" SNAPPY="OFF" ZLIB="OFF" ZSTD="ON" .evergreen/scripts/compile.sh
+        env SNAPPY="OFF" ZLIB="OFF" ZSTD="ON" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-compression
   tags:
@@ -366,7 +366,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG="ON" SNAPPY="ON" ZLIB="BUNDLED" ZSTD="ON" .evergreen/scripts/compile.sh
+        env SNAPPY="ON" ZLIB="BUNDLED" ZSTD="ON" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-no-align
   tags:
@@ -380,7 +380,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_EXTRA_ALIGNMENT=OFF" SNAPPY="OFF" ZLIB="BUNDLED" ZSTD="OFF" .evergreen/scripts/compile.sh
+        env EXTRA_CONFIGURE_FLAGS="-DENABLE_EXTRA_ALIGNMENT=OFF" SNAPPY="OFF" ZLIB="BUNDLED" ZSTD="OFF" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-nosasl-nossl
   tags:
@@ -396,7 +396,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG="ON" SSL="OFF" .evergreen/scripts/compile.sh
+        env SSL="OFF" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-lto
   commands:
@@ -408,7 +408,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env CFLAGS="-flto" DEBUG="ON" .evergreen/scripts/compile.sh
+        env CFLAGS="-flto" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-lto-thin
   commands:
@@ -420,7 +420,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env CFLAGS="-flto=thin" DEBUG="ON" .evergreen/scripts/compile.sh
+        env CFLAGS="-flto=thin" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-no-counters
   tags:
@@ -435,7 +435,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG="ON" ENABLE_SHM_COUNTERS="OFF" .evergreen/scripts/compile.sh
+        env ENABLE_SHM_COUNTERS="OFF" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-asan-clang
   tags:
@@ -451,7 +451,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env CFLAGS="-fno-omit-frame-pointer" CHECK_LOG="ON" DEBUG="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_EXTRA_ALIGNMENT=OFF" SANITIZE="address" SNAPPY="OFF" ZLIB="BUNDLED" ZSTD="OFF" .evergreen/scripts/compile.sh
+        env CFLAGS="-fno-omit-frame-pointer" CHECK_LOG="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_EXTRA_ALIGNMENT=OFF" SANITIZE="address" SNAPPY="OFF" ZLIB="BUNDLED" ZSTD="OFF" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-asan-clang-openssl
   tags:
@@ -467,7 +467,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env CFLAGS="-fno-omit-frame-pointer" CHECK_LOG="ON" DEBUG="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_EXTRA_ALIGNMENT=OFF" SANITIZE="address" SNAPPY="OFF" SSL="OPENSSL" ZLIB="BUNDLED" ZSTD="OFF" .evergreen/scripts/compile.sh
+        env CFLAGS="-fno-omit-frame-pointer" CHECK_LOG="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_EXTRA_ALIGNMENT=OFF" SANITIZE="address" SNAPPY="OFF" SSL="OPENSSL" ZLIB="BUNDLED" ZSTD="OFF" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: compile-tracing
   commands:
@@ -479,7 +479,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env CFLAGS="-Werror -Wno-cast-align" DEBUG="ON" TRACING="ON" .evergreen/scripts/compile.sh
+        env CFLAGS="-Werror -Wno-cast-align" TRACING="ON" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: release-compile
   commands:
@@ -507,7 +507,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG="ON" SSL="OPENSSL" .evergreen/scripts/compile.sh
+        env SSL="OPENSSL" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-nosasl-openssl-static
   tags:
@@ -523,7 +523,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG="ON" SSL="OPENSSL_STATIC" .evergreen/scripts/compile.sh
+        env SSL="OPENSSL_STATIC" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-nosasl-darwinssl
   tags:
@@ -539,7 +539,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG="ON" SSL="DARWIN" .evergreen/scripts/compile.sh
+        env SSL="DARWIN" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-nosasl-winssl
   tags:
@@ -555,7 +555,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG="ON" SSL="WINDOWS" .evergreen/scripts/compile.sh
+        env SSL="WINDOWS" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-sasl-nossl
   tags:
@@ -571,7 +571,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG="ON" SASL="AUTO" SSL="OFF" .evergreen/scripts/compile.sh
+        env SASL="AUTO" SSL="OFF" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-sasl-openssl
   tags:
@@ -587,7 +587,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG="ON" SASL="AUTO" SSL="OPENSSL" .evergreen/scripts/compile.sh
+        env SASL="AUTO" SSL="OPENSSL" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-sasl-openssl-static
   tags:
@@ -603,7 +603,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG="ON" SASL="AUTO" SSL="OPENSSL_STATIC" .evergreen/scripts/compile.sh
+        env SASL="AUTO" SSL="OPENSSL_STATIC" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-sasl-darwinssl
   tags:
@@ -619,7 +619,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG="ON" SASL="AUTO" SSL="DARWIN" .evergreen/scripts/compile.sh
+        env SASL="AUTO" SSL="DARWIN" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-sspi-nossl
   tags:
@@ -635,7 +635,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG="ON" SASL="SSPI" SSL="OFF" .evergreen/scripts/compile.sh
+        env SASL="SSPI" SSL="OFF" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-sspi-openssl
   tags:
@@ -651,7 +651,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG="ON" SASL="SSPI" SSL="OPENSSL" .evergreen/scripts/compile.sh
+        env SASL="SSPI" SSL="OPENSSL" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-sspi-openssl-static
   tags:
@@ -667,7 +667,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG="ON" SASL="SSPI" SSL="OPENSSL_STATIC" .evergreen/scripts/compile.sh
+        env SASL="SSPI" SSL="OPENSSL_STATIC" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-rdtscp
   commands:
@@ -679,7 +679,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG="ON" ENABLE_RDTSCP="ON" .evergreen/scripts/compile.sh
+        env ENABLE_RDTSCP="ON" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-sspi-winssl
   tags:
@@ -695,7 +695,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG="ON" SASL="SSPI" SSL="WINDOWS" .evergreen/scripts/compile.sh
+        env SASL="SSPI" SSL="WINDOWS" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-nosrv
   tags:
@@ -709,7 +709,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG="ON" SRV="OFF" .evergreen/scripts/compile.sh
+        env SRV="OFF" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: link-with-cmake
   commands:
@@ -992,7 +992,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env CFLAGS="-Werror -Wno-cast-align" DEBUG="ON" .evergreen/scripts/compile.sh
+        env CFLAGS="-Werror -Wno-cast-align" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-sasl-openssl-static-cse
   tags:
@@ -1010,7 +1010,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env COMPILE_LIBMONGOCRYPT="ON" DEBUG="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON" SASL="AUTO" SSL="OPENSSL_STATIC" .evergreen/scripts/compile.sh
+        env COMPILE_LIBMONGOCRYPT="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON" SASL="AUTO" SSL="OPENSSL_STATIC" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-nosasl-openssl-1.0.1
   commands:
@@ -1025,7 +1025,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env CFLAGS="-Wno-redundant-decls" DEBUG="ON" SASL="OFF" SSL="OPENSSL" .evergreen/scripts/compile.sh
+        env CFLAGS="-Wno-redundant-decls" SASL="OFF" SSL="OPENSSL" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: build-and-test-with-toolchain
   commands:
@@ -1446,7 +1446,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env SANITIZE=address SASL=AUTO SSL=OPENSSL EXTRA_CONFIGURE_FLAGS='-DENABLE_EXTRA_ALIGNMENT=OFF' .evergreen/scripts/compile.sh
+        env SANITIZE=address DEBUG=ON SASL=AUTO SSL=OPENSSL EXTRA_CONFIGURE_FLAGS='-DENABLE_EXTRA_ALIGNMENT=OFF' .evergreen/scripts/compile.sh
   - func: prepare-kerberos
   - func: run auth tests
     vars:
@@ -1656,7 +1656,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env CFLAGS=-Wno-redundant-decls SASL=OFF SSL=OPENSSL .evergreen/scripts/compile.sh
+        env CFLAGS=-Wno-redundant-decls DEBUG=ON SASL=OFF SSL=OPENSSL .evergreen/scripts/compile.sh
   - func: run auth tests
   - func: upload-build
 - name: build-and-run-authentication-tests-openssl-1.0.1-fips
@@ -1672,7 +1672,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env CFLAGS=-Wno-redundant-decls SASL=OFF SSL=OPENSSL .evergreen/scripts/compile.sh
+        env CFLAGS=-Wno-redundant-decls DEBUG=ON SASL=OFF SSL=OPENSSL .evergreen/scripts/compile.sh
   - func: run auth tests
   - func: upload-build
 - name: build-and-run-authentication-tests-openssl-1.0.2
@@ -1688,7 +1688,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env CFLAGS=-Wno-redundant-decls SASL=OFF SSL=OPENSSL .evergreen/scripts/compile.sh
+        env CFLAGS=-Wno-redundant-decls DEBUG=ON SASL=OFF SSL=OPENSSL .evergreen/scripts/compile.sh
   - func: run auth tests
   - func: upload-build
 - name: build-and-run-authentication-tests-openssl-1.1.0
@@ -1704,7 +1704,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env SASL=OFF SSL=OPENSSL .evergreen/scripts/compile.sh
+        env DEBUG=ON SASL=OFF SSL=OPENSSL .evergreen/scripts/compile.sh
   - func: run auth tests
   - func: upload-build
 - name: build-and-run-authentication-tests-libressl-2.5
@@ -1720,7 +1720,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env SASL=OFF SSL=LIBRESSL .evergreen/scripts/compile.sh
+        env DEBUG=ON SASL=OFF SSL=LIBRESSL .evergreen/scripts/compile.sh
   - func: run auth tests
     vars:
       require_tls12: true
@@ -1738,7 +1738,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env SASL=OFF SSL=AUTO .evergreen/scripts/compile.sh
+        env DEBUG=ON SASL=OFF SSL=AUTO .evergreen/scripts/compile.sh
   - func: run auth tests
     vars:
       require_tls12: true
@@ -1756,7 +1756,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env SASL=OFF SSL=LIBRESSL .evergreen/scripts/compile.sh
+        env DEBUG=ON SASL=OFF SSL=LIBRESSL .evergreen/scripts/compile.sh
   - func: run auth tests
     vars:
       require_tls12: true

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -213,7 +213,7 @@ functions:
       shell: bash
       script: |-
         set -o errexit
-        COVERAGE=ON DEBUG=ON .evergreen/scripts/compile.sh
+        COVERAGE=ON .evergreen/scripts/compile.sh
   build mongohouse:
   - command: shell.exec
     type: test
@@ -1446,7 +1446,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env SANITIZE=address DEBUG=ON SASL=AUTO SSL=OPENSSL EXTRA_CONFIGURE_FLAGS='-DENABLE_EXTRA_ALIGNMENT=OFF' .evergreen/scripts/compile.sh
+        env SANITIZE=address SASL=AUTO SSL=OPENSSL EXTRA_CONFIGURE_FLAGS='-DENABLE_EXTRA_ALIGNMENT=OFF' .evergreen/scripts/compile.sh
   - func: prepare-kerberos
   - func: run auth tests
     vars:
@@ -1656,7 +1656,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env CFLAGS=-Wno-redundant-decls DEBUG=ON SASL=OFF SSL=OPENSSL .evergreen/scripts/compile.sh
+        env CFLAGS=-Wno-redundant-decls SASL=OFF SSL=OPENSSL .evergreen/scripts/compile.sh
   - func: run auth tests
   - func: upload-build
 - name: build-and-run-authentication-tests-openssl-1.0.1-fips
@@ -1672,7 +1672,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env CFLAGS=-Wno-redundant-decls DEBUG=ON SASL=OFF SSL=OPENSSL .evergreen/scripts/compile.sh
+        env CFLAGS=-Wno-redundant-decls SASL=OFF SSL=OPENSSL .evergreen/scripts/compile.sh
   - func: run auth tests
   - func: upload-build
 - name: build-and-run-authentication-tests-openssl-1.0.2
@@ -1688,7 +1688,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env CFLAGS=-Wno-redundant-decls DEBUG=ON SASL=OFF SSL=OPENSSL .evergreen/scripts/compile.sh
+        env CFLAGS=-Wno-redundant-decls SASL=OFF SSL=OPENSSL .evergreen/scripts/compile.sh
   - func: run auth tests
   - func: upload-build
 - name: build-and-run-authentication-tests-openssl-1.1.0
@@ -1704,7 +1704,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG=ON SASL=OFF SSL=OPENSSL .evergreen/scripts/compile.sh
+        env SASL=OFF SSL=OPENSSL .evergreen/scripts/compile.sh
   - func: run auth tests
   - func: upload-build
 - name: build-and-run-authentication-tests-libressl-2.5
@@ -1720,7 +1720,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG=ON SASL=OFF SSL=LIBRESSL .evergreen/scripts/compile.sh
+        env SASL=OFF SSL=LIBRESSL .evergreen/scripts/compile.sh
   - func: run auth tests
     vars:
       require_tls12: true
@@ -1738,7 +1738,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG=ON SASL=OFF SSL=AUTO .evergreen/scripts/compile.sh
+        env SASL=OFF SSL=AUTO .evergreen/scripts/compile.sh
   - func: run auth tests
     vars:
       require_tls12: true
@@ -1756,7 +1756,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG=ON SASL=OFF SSL=LIBRESSL .evergreen/scripts/compile.sh
+        env SASL=OFF SSL=LIBRESSL .evergreen/scripts/compile.sh
   - func: run auth tests
     vars:
       require_tls12: true

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -1446,7 +1446,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env SANITIZE=address DEBUG=ON SASL=AUTO SSL=OPENSSL EXTRA_CONFIGURE_FLAGS='-DENABLE_EXTRA_ALIGNMENT=OFF' .evergreen/scripts/compile.sh
+        env SANITIZE=address SASL=AUTO SSL=OPENSSL EXTRA_CONFIGURE_FLAGS='-DENABLE_EXTRA_ALIGNMENT=OFF' .evergreen/scripts/compile.sh
   - func: prepare-kerberos
   - func: run auth tests
     vars:
@@ -1656,7 +1656,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env CFLAGS=-Wno-redundant-decls DEBUG=ON SASL=OFF SSL=OPENSSL .evergreen/scripts/compile.sh
+        env CFLAGS=-Wno-redundant-decls SASL=OFF SSL=OPENSSL .evergreen/scripts/compile.sh
   - func: run auth tests
   - func: upload-build
 - name: build-and-run-authentication-tests-openssl-1.0.1-fips
@@ -1672,7 +1672,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env CFLAGS=-Wno-redundant-decls DEBUG=ON SASL=OFF SSL=OPENSSL .evergreen/scripts/compile.sh
+        env CFLAGS=-Wno-redundant-decls SASL=OFF SSL=OPENSSL .evergreen/scripts/compile.sh
   - func: run auth tests
   - func: upload-build
 - name: build-and-run-authentication-tests-openssl-1.0.2
@@ -1688,7 +1688,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env CFLAGS=-Wno-redundant-decls DEBUG=ON SASL=OFF SSL=OPENSSL .evergreen/scripts/compile.sh
+        env CFLAGS=-Wno-redundant-decls SASL=OFF SSL=OPENSSL .evergreen/scripts/compile.sh
   - func: run auth tests
   - func: upload-build
 - name: build-and-run-authentication-tests-openssl-1.1.0
@@ -1704,7 +1704,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG=ON SASL=OFF SSL=OPENSSL .evergreen/scripts/compile.sh
+        env SASL=OFF SSL=OPENSSL .evergreen/scripts/compile.sh
   - func: run auth tests
   - func: upload-build
 - name: build-and-run-authentication-tests-libressl-2.5
@@ -1720,7 +1720,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG=ON SASL=OFF SSL=LIBRESSL .evergreen/scripts/compile.sh
+        env SASL=OFF SSL=LIBRESSL .evergreen/scripts/compile.sh
   - func: run auth tests
     vars:
       require_tls12: true
@@ -1738,7 +1738,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG=ON SASL=OFF SSL=AUTO .evergreen/scripts/compile.sh
+        env SASL=OFF SSL=AUTO .evergreen/scripts/compile.sh
   - func: run auth tests
     vars:
       require_tls12: true
@@ -1756,7 +1756,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env DEBUG=ON SASL=OFF SSL=LIBRESSL .evergreen/scripts/compile.sh
+        env SASL=OFF SSL=LIBRESSL .evergreen/scripts/compile.sh
   - func: run auth tests
     vars:
       require_tls12: true

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -259,7 +259,7 @@ functions:
         echo "Waiting for mongohouse to start... done."
         pgrep -a "mongohouse"
         export RUN_MONGOHOUSE_TESTS=ON
-        ./src/libmongoc/test-libmongoc --no-fork -l /mongohouse/* -d --skip-tests .evergreen/etc/skip-tests.txt
+        ./build/src/libmongoc/test-libmongoc --no-fork -l /mongohouse/* -d --skip-tests .evergreen/etc/skip-tests.txt
   run aws tests:
   - command: ec2.assume_role
     params:

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -80,21 +80,18 @@ buildvariants:
     display_name: cse-matrix-darwinssl
     expansions:
       CLIENT_SIDE_ENCRYPTION: "on"
-      DEBUG: "ON"
     tasks:
       - name: .cse-matrix-darwinssl
   - name: cse-matrix-openssl
     display_name: cse-matrix-openssl
     expansions:
       CLIENT_SIDE_ENCRYPTION: "on"
-      DEBUG: "ON"
     tasks:
       - name: .cse-matrix-openssl
   - name: cse-matrix-winssl
     display_name: cse-matrix-winssl
     expansions:
       CLIENT_SIDE_ENCRYPTION: "on"
-      DEBUG: "ON"
     tasks:
       - name: .cse-matrix-winssl
   - name: loadbalanced
@@ -140,26 +137,22 @@ buildvariants:
       - name: .sanitizers-matrix-tsan
   - name: sasl-matrix-darwinssl
     display_name: sasl-matrix-darwinssl
-    expansions:
-      DEBUG: "ON"
+    expansions: {}
     tasks:
       - name: .sasl-matrix-darwinssl
   - name: sasl-matrix-nossl
     display_name: sasl-matrix-nossl
-    expansions:
-      DEBUG: "ON"
+    expansions: {}
     tasks:
       - name: .sasl-matrix-nossl
   - name: sasl-matrix-openssl
     display_name: sasl-matrix-openssl
-    expansions:
-      DEBUG: "ON"
+    expansions: {}
     tasks:
       - name: .sasl-matrix-openssl
   - name: sasl-matrix-winssl
     display_name: sasl-matrix-winssl
-    expansions:
-      DEBUG: "ON"
+    expansions: {}
     tasks:
       - name: .sasl-matrix-winssl
   - name: scan-build-matrix

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/functions.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/functions.py
@@ -155,7 +155,7 @@ all_functions = OD([
     )),
     ('compile coverage', Function(
         shell_mongoc(r'''
-        COVERAGE=ON DEBUG=ON .evergreen/scripts/compile.sh
+        COVERAGE=ON .evergreen/scripts/compile.sh
         ''', add_expansions_to_env=True),
     )),
     ('build mongohouse', Function(

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/functions.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/functions.py
@@ -191,7 +191,7 @@ all_functions = OD([
         echo "Waiting for mongohouse to start... done."
         pgrep -a "mongohouse"
         export RUN_MONGOHOUSE_TESTS=ON
-        ./src/libmongoc/test-libmongoc --no-fork -l /mongohouse/* -d --skip-tests .evergreen/etc/skip-tests.txt
+        ./build/src/libmongoc/test-libmongoc --no-fork -l /mongohouse/* -d --skip-tests .evergreen/etc/skip-tests.txt
         '''),
     )),
     ('run aws tests', Function(

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/functions.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/functions.py
@@ -191,7 +191,7 @@ all_functions = OD([
         echo "Waiting for mongohouse to start... done."
         pgrep -a "mongohouse"
         export RUN_MONGOHOUSE_TESTS=ON
-        ./build/src/libmongoc/test-libmongoc --no-fork -l /mongohouse/* -d --skip-tests .evergreen/etc/skip-tests.txt
+        ./cmake-build/src/libmongoc/test-libmongoc --no-fork -l /mongohouse/* -d --skip-tests .evergreen/etc/skip-tests.txt
         '''),
     )),
     ('run aws tests', Function(

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -735,7 +735,7 @@ all_tasks = chain(
             commands=[
                 shell_mongoc(
                     """
-            env SANITIZE=address DEBUG=ON SASL=AUTO SSL=OPENSSL EXTRA_CONFIGURE_FLAGS='-DENABLE_EXTRA_ALIGNMENT=OFF' .evergreen/scripts/compile.sh
+            env SANITIZE=address SASL=AUTO SSL=OPENSSL EXTRA_CONFIGURE_FLAGS='-DENABLE_EXTRA_ALIGNMENT=OFF' .evergreen/scripts/compile.sh
             """,
                     add_expansions_to_env=True,
                 ),
@@ -807,7 +807,7 @@ class SSLTask(Task):
         if cflags:
             script += f" CFLAGS={cflags}"
 
-        script += " DEBUG=ON SASL=OFF"
+        script += " SASL=OFF"
 
         if enable_ssl is not False:
             script += " SSL=" + enable_ssl

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -70,9 +70,8 @@ class CompileTask(NamedTask):
 
         # Environment variables for .evergreen/scripts/compile.sh.
         self.compile_sh_opt: dict[str, str] = {}
-        if config == "debug":
-            self.compile_sh_opt["DEBUG"] = "ON"
-        else:
+
+        if config != "debug":
             assert config == "release"
             self.compile_sh_opt["RELEASE"] = "ON"
 
@@ -736,7 +735,7 @@ all_tasks = chain(
             commands=[
                 shell_mongoc(
                     """
-            env SANITIZE=address SASL=AUTO SSL=OPENSSL EXTRA_CONFIGURE_FLAGS='-DENABLE_EXTRA_ALIGNMENT=OFF' .evergreen/scripts/compile.sh
+            env SANITIZE=address DEBUG=ON SASL=AUTO SSL=OPENSSL EXTRA_CONFIGURE_FLAGS='-DENABLE_EXTRA_ALIGNMENT=OFF' .evergreen/scripts/compile.sh
             """,
                     add_expansions_to_env=True,
                 ),
@@ -808,7 +807,7 @@ class SSLTask(Task):
         if cflags:
             script += f" CFLAGS={cflags}"
 
-        script += " SASL=OFF"
+        script += " DEBUG=ON SASL=OFF"
 
         if enable_ssl is not False:
             script += " SSL=" + enable_ssl

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -736,7 +736,7 @@ all_tasks = chain(
             commands=[
                 shell_mongoc(
                     """
-            env SANITIZE=address DEBUG=ON SASL=AUTO SSL=OPENSSL EXTRA_CONFIGURE_FLAGS='-DENABLE_EXTRA_ALIGNMENT=OFF' .evergreen/scripts/compile.sh
+            env SANITIZE=address SASL=AUTO SSL=OPENSSL EXTRA_CONFIGURE_FLAGS='-DENABLE_EXTRA_ALIGNMENT=OFF' .evergreen/scripts/compile.sh
             """,
                     add_expansions_to_env=True,
                 ),
@@ -808,7 +808,7 @@ class SSLTask(Task):
         if cflags:
             script += f" CFLAGS={cflags}"
 
-        script += " DEBUG=ON SASL=OFF"
+        script += " SASL=OFF"
 
         if enable_ssl is not False:
             script += " SSL=" + enable_ssl

--- a/.evergreen/scripts/compile-libmongocrypt.sh
+++ b/.evergreen/scripts/compile-libmongocrypt.sh
@@ -19,7 +19,8 @@ compile_libmongocrypt() {
     "-DBUILD_VERSION=1.11.0-pre"
   )
 
-  DEBUG="0" \
+  env \
+    DEBUG="0" \
     CMAKE_EXE="${cmake_binary}" \
     MONGOCRYPT_INSTALL_PREFIX=${install_dir} \
     DEFAULT_BUILD_ONLY=true \

--- a/.evergreen/scripts/compile-libmongocrypt.sh
+++ b/.evergreen/scripts/compile-libmongocrypt.sh
@@ -9,14 +9,7 @@ compile_libmongocrypt() {
   # libmongocrypt's kms-message in `src/kms-message`. Run
   # `.evergreen/scripts/kms-divergence-check.sh` to ensure that there is no
   # divergence in the copied files.
-
-  # TODO: once 1.11.0 is released (containing MONGOCRYPT-705) replace the following with:
-  # git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.11.0 || return
-  {
-    git clone -q https://github.com/mongodb/libmongocrypt || return
-    # Check out commit containing MONGOCRYPT-705
-    git -C libmongocrypt checkout bb12cda6504fecbf7a8ffc97d0cadc9cafbd1a29
-  }
+  git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.11.0 || return
 
   declare -a crypt_cmake_flags=(
     "-DMONGOCRYPT_MONGOC_DIR=${mongoc_dir}"

--- a/.evergreen/scripts/compile-unix.sh
+++ b/.evergreen/scripts/compile-unix.sh
@@ -210,12 +210,12 @@ fi
 . "${script_dir:?}/find-ccache.sh"
 find_ccache_and_export_vars "$(pwd)" || true
 
-"${cmake_binary}" "${configure_flags[@]}" ${extra_configure_flags[@]+"${extra_configure_flags[@]}"} .
-"${cmake_binary}" --build .
-"${cmake_binary}" --install .
+"${cmake_binary}" -S . -B build "${configure_flags[@]}" ${extra_configure_flags[@]+"${extra_configure_flags[@]}"} .
+"${cmake_binary}" --build build
+"${cmake_binary}" --install build
 
 # For use by test tasks, which directly use the binary directory contents.
-"${cmake_binary}" --build . --target mongo_c_driver_tests
+"${cmake_binary}" --build build --target mongo_c_driver_tests
 
 # Also validate examples.
-"${cmake_binary}" --build . --target mongo_c_driver_examples
+"${cmake_binary}" --build build --target mongo_c_driver_examples

--- a/.evergreen/scripts/compile-unix.sh
+++ b/.evergreen/scripts/compile-unix.sh
@@ -82,8 +82,14 @@ configure_flags_append_if_not_null SRV "-DENABLE_SRV=${SRV}"
 configure_flags_append_if_not_null TRACING "-DENABLE_TRACING=${TRACING}"
 configure_flags_append_if_not_null ZLIB "-DENABLE_ZLIB=${ZLIB}"
 
+if [[ "${DEBUG:-}" == "ON" && "${RELEASE:-}" == "ON" ]]; then
+  echo "Cannot configure a build to be both debug and release!" 1>&2
+  exit 1
+fi
+
 if [[ "${DEBUG}" == "ON" ]]; then
   configure_flags_append "-DCMAKE_BUILD_TYPE=Debug"
+  configure_flags_append "-DENABLE_DEBUG_ASSERTIONS=ON"
 else
   configure_flags_append "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
 fi
@@ -96,10 +102,6 @@ fi
 
 if [[ "${COVERAGE}" == "ON" ]]; then
   configure_flags_append "-DENABLE_COVERAGE=ON" "-DENABLE_EXAMPLES=OFF"
-fi
-
-if [[ "${RELEASE}" != "ON" ]]; then
-  configure_flags_append "-DENABLE_DEBUG_ASSERTIONS=ON"
 fi
 
 declare -a flags

--- a/.evergreen/scripts/compile-unix.sh
+++ b/.evergreen/scripts/compile-unix.sh
@@ -15,7 +15,6 @@ check_var_opt CHECK_LOG "OFF"
 check_var_opt COMPILE_LIBMONGOCRYPT "OFF"
 check_var_opt COVERAGE # CMake default: OFF.
 check_var_opt CXXFLAGS
-check_var_opt DEBUG "OFF"
 check_var_opt ENABLE_SHM_COUNTERS # CMake default: AUTO.
 check_var_opt EXTRA_CMAKE_PREFIX_PATH
 check_var_opt EXTRA_CONFIGURE_FLAGS
@@ -82,16 +81,11 @@ configure_flags_append_if_not_null SRV "-DENABLE_SRV=${SRV}"
 configure_flags_append_if_not_null TRACING "-DENABLE_TRACING=${TRACING}"
 configure_flags_append_if_not_null ZLIB "-DENABLE_ZLIB=${ZLIB}"
 
-if [[ "${DEBUG:-}" == "ON" && "${RELEASE:-}" == "ON" ]]; then
-  echo "Cannot configure a build to be both debug and release!" 1>&2
-  exit 1
-fi
-
-if [[ "${DEBUG}" == "ON" ]]; then
+if [[ "${RELEASE}" == "ON" ]]; then
+  configure_flags_append "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+else
   configure_flags_append "-DCMAKE_BUILD_TYPE=Debug"
   configure_flags_append "-DENABLE_DEBUG_ASSERTIONS=ON"
-else
-  configure_flags_append "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
 fi
 
 if [[ "${SSL}" == "OPENSSL_STATIC" ]]; then

--- a/.evergreen/scripts/compile-unix.sh
+++ b/.evergreen/scripts/compile-unix.sh
@@ -204,12 +204,15 @@ fi
 . "${script_dir:?}/find-ccache.sh"
 find_ccache_and_export_vars "$(pwd)" || true
 
-"${cmake_binary}" -S . -B build "${configure_flags[@]}" ${extra_configure_flags[@]+"${extra_configure_flags[@]}"} .
-"${cmake_binary}" --build build
-"${cmake_binary}" --install build
+declare build_dir
+build_dir="cmake-build"
+
+"${cmake_binary}" -S . -B "${build_dir:?}" "${configure_flags[@]}" ${extra_configure_flags[@]+"${extra_configure_flags[@]}"} .
+"${cmake_binary}" --build "${build_dir:?}"
+"${cmake_binary}" --install "${build_dir:?}"
 
 # For use by test tasks, which directly use the binary directory contents.
-"${cmake_binary}" --build build --target mongo_c_driver_tests
+"${cmake_binary}" --build "${build_dir:?}" --target mongo_c_driver_tests
 
 # Also validate examples.
-"${cmake_binary}" --build build --target mongo_c_driver_examples
+"${cmake_binary}" --build "${build_dir:?}" --target mongo_c_driver_examples

--- a/.evergreen/scripts/compile-windows.sh
+++ b/.evergreen/scripts/compile-windows.sh
@@ -13,7 +13,6 @@ check_var_opt BYPASS_FIND_CMAKE "OFF"
 check_var_opt C_STD_VERSION # CMake default: 99.
 check_var_opt CC "Visual Studio 15 2017 Win64"
 check_var_opt COMPILE_LIBMONGOCRYPT "OFF"
-check_var_opt DEBUG "OFF"
 check_var_opt EXTRA_CONFIGURE_FLAGS
 check_var_opt RELEASE "OFF"
 check_var_opt SASL "SSPI"   # CMake default: AUTO.
@@ -64,17 +63,12 @@ configure_flags_append_if_not_null SNAPPY "-DENABLE_SNAPPY=${SNAPPY:-}"
 configure_flags_append_if_not_null SRV "-DENABLE_SRV=${SRV:-}"
 configure_flags_append_if_not_null ZLIB "-DENABLE_ZLIB=${ZLIB:-}"
 
-if [[ "${DEBUG:-}" == "ON" && "${RELEASE:-}" == "ON" ]]; then
-  echo "Cannot configure a build to be both debug and release!" 1>&2
-  exit 1
-fi
-
 declare build_config
-if [[ "${DEBUG}" == "ON" ]]; then
+if [[ "${RELEASE}" == "ON" ]]; then
+  build_config="RelWithDebInfo"
+else
   build_config="Debug"
   configure_flags_append "-DENABLE_DEBUG_ASSERTIONS=ON"
-else
-  build_config="RelWithDebInfo"
 fi
 configure_flags_append "-DCMAKE_BUILD_TYPE=${build_config:?}"
 

--- a/.evergreen/scripts/compile-windows.sh
+++ b/.evergreen/scripts/compile-windows.sh
@@ -103,24 +103,19 @@ if [[ "${CC}" =~ mingw ]]; then
   # MinGW has trouble compiling src/cpp-check.cpp without some assistance.
   configure_flags_append "-DCMAKE_CXX_STANDARD=11"
 
-  cmake_binary=$(native-path "$cmake_binary")
-  build_dir=$(native-path "$mongoc_dir")
-  prefix_path=$(native-path "$install_dir/lib/cmake")
-
   env \
     "CC=gcc" \
     "CXX=g++" \
-    "$cmake_binary" \
+    "${cmake_binary:?}" \
+    -S . \
+    -B build \
     -G "MinGW Makefiles" \
-    -D CMAKE_PREFIX_PATH="$prefix_path" \
     "${configure_flags[@]}" \
-    "${extra_configure_flags[@]}" \
-    -B "$build_dir" \
-    -S "$(native-path "$mongoc_dir")"
+    "${extra_configure_flags[@]}"
 
-  env "$cmake_binary" --build "$build_dir"
-  env "$cmake_binary" --build "$build_dir" --target mongo_c_driver_tests
-  env "$cmake_binary" --build "$build_dir" --target mongo_c_driver_examples
+  env "${cmake_binary:?}" --build build
+  env "${cmake_binary:?}" --build build --target mongo_c_driver_tests
+  env "${cmake_binary:?}" --build build --target mongo_c_driver_examples
   exit 0
 fi
 
@@ -142,12 +137,12 @@ if [ "${COMPILE_LIBMONGOCRYPT}" = "ON" ]; then
   configure_flags_append "-DENABLE_CLIENT_SIDE_ENCRYPTION=ON"
 fi
 
-"${cmake_binary}" -G "$CC" "${configure_flags[@]}" "${extra_configure_flags[@]}"
-"${cmake_binary}" --build . --config "${build_config}"
-"${cmake_binary}" --install . --config "${build_config}"
+"${cmake_binary:?}" -S . -B build -G "$CC" "${configure_flags[@]}" "${extra_configure_flags[@]}"
+"${cmake_binary:?}" --build build --config "${build_config:?}"
+"${cmake_binary:?}" --install build --config "${build_config:?}"
 
 # For use by test tasks, which directly use the binary directory contents.
-"${cmake_binary}" --build . --config "${build_config}" --target mongo_c_driver_tests
+"${cmake_binary:?}" --build build --config "${build_config:?}" --target mongo_c_driver_tests
 
 # Also validate examples.
-"${cmake_binary}" --build . --config "${build_config}" --target mongo_c_driver_examples
+"${cmake_binary:?}" --build build --config "${build_config:?}" --target mongo_c_driver_examples

--- a/.evergreen/scripts/compile-windows.sh
+++ b/.evergreen/scripts/compile-windows.sh
@@ -93,6 +93,9 @@ fi
 export CMAKE_BUILD_PARALLEL_LEVEL
 CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
 
+declare build_dir
+build_dir="cmake-build"
+
 if [[ "${CC}" =~ mingw ]]; then
   # MinGW has trouble compiling src/cpp-check.cpp without some assistance.
   configure_flags_append "-DCMAKE_CXX_STANDARD=11"
@@ -102,14 +105,14 @@ if [[ "${CC}" =~ mingw ]]; then
     "CXX=g++" \
     "${cmake_binary:?}" \
     -S . \
-    -B build \
+    -B "${build_dir:?}" \
     -G "MinGW Makefiles" \
     "${configure_flags[@]}" \
     "${extra_configure_flags[@]}"
 
-  env "${cmake_binary:?}" --build build
-  env "${cmake_binary:?}" --build build --target mongo_c_driver_tests
-  env "${cmake_binary:?}" --build build --target mongo_c_driver_examples
+  env "${cmake_binary:?}" --build "${build_dir:?}"
+  env "${cmake_binary:?}" --build "${build_dir:?}" --target mongo_c_driver_tests
+  env "${cmake_binary:?}" --build "${build_dir:?}" --target mongo_c_driver_examples
   exit 0
 fi
 
@@ -131,12 +134,12 @@ if [ "${COMPILE_LIBMONGOCRYPT}" = "ON" ]; then
   configure_flags_append "-DENABLE_CLIENT_SIDE_ENCRYPTION=ON"
 fi
 
-"${cmake_binary:?}" -S . -B build -G "$CC" "${configure_flags[@]}" "${extra_configure_flags[@]}"
-"${cmake_binary:?}" --build build --config "${build_config:?}"
-"${cmake_binary:?}" --install build --config "${build_config:?}"
+"${cmake_binary:?}" -S . -B "${build_dir:?}" -G "$CC" "${configure_flags[@]}" "${extra_configure_flags[@]}"
+"${cmake_binary:?}" --build "${build_dir:?}" --config "${build_config:?}"
+"${cmake_binary:?}" --install "${build_dir:?}" --config "${build_config:?}"
 
 # For use by test tasks, which directly use the binary directory contents.
-"${cmake_binary:?}" --build build --config "${build_config:?}" --target mongo_c_driver_tests
+"${cmake_binary:?}" --build "${build_dir:?}" --config "${build_config:?}" --target mongo_c_driver_tests
 
 # Also validate examples.
-"${cmake_binary:?}" --build build --config "${build_config:?}" --target mongo_c_driver_examples
+"${cmake_binary:?}" --build "${build_dir:?}" --config "${build_config:?}" --target mongo_c_driver_examples

--- a/.evergreen/scripts/debug-core-evergreen.sh
+++ b/.evergreen/scripts/debug-core-evergreen.sh
@@ -8,7 +8,7 @@ fi
 shopt -s nullglob
 for i in *.core; do
    echo $i
-   echo "backtrace full" | gdb -q ./build/src/libmongoc/test-libmongoc $i
+   echo "backtrace full" | gdb -q ./cmake-build/src/libmongoc/test-libmongoc $i
 done
 
 # If there is still a test-libmongoc process running (perhaps due to

--- a/.evergreen/scripts/debug-core-evergreen.sh
+++ b/.evergreen/scripts/debug-core-evergreen.sh
@@ -8,7 +8,7 @@ fi
 shopt -s nullglob
 for i in *.core; do
    echo $i
-   echo "backtrace full" | gdb -q ./src/libmongoc/test-libmongoc $i
+   echo "backtrace full" | gdb -q ./build/src/libmongoc/test-libmongoc $i
 done
 
 # If there is still a test-libmongoc process running (perhaps due to

--- a/.evergreen/scripts/find-ccache.sh
+++ b/.evergreen/scripts/find-ccache.sh
@@ -62,6 +62,10 @@ find_ccache_and_export_vars() {
   export CMAKE_CXX_COMPILER_LAUNCHER="${ccache_binary:?}"
 
   # Allow reuse of ccache compilation results between different build directories.
-  export CCACHE_BASEDIR="${base_dir:?}"
+  if [[ "${OSTYPE:?}" =~ cygwin ]]; then
+    export CCACHE_BASEDIR="$(cygpath -aw ${base_dir:?})"
+  else
+    export CCACHE_BASEDIR="${base_dir:?}"
+  fi
   export CCACHE_NOHASHDIR=1
 }

--- a/.evergreen/scripts/run-mock-server-tests.sh
+++ b/.evergreen/scripts/run-mock-server-tests.sh
@@ -46,12 +46,12 @@ fi
 
 case "${OSTYPE}" in
 cygwin)
-  LD_PRELOAD="${ld_preload:-}" ./build/src/libmongoc/test-libmongoc.exe "${test_args[@]}"
+  LD_PRELOAD="${ld_preload:-}" ./cmake-build/src/libmongoc/test-libmongoc.exe "${test_args[@]}"
   ;;
 
 *)
   ulimit -c unlimited || true
 
-  LD_PRELOAD="${ld_preload:-}" ./build/src/libmongoc/test-libmongoc --no-fork "${test_args[@]}"
+  LD_PRELOAD="${ld_preload:-}" ./cmake-build/src/libmongoc/test-libmongoc --no-fork "${test_args[@]}"
   ;;
 esac

--- a/.evergreen/scripts/run-mock-server-tests.sh
+++ b/.evergreen/scripts/run-mock-server-tests.sh
@@ -46,12 +46,12 @@ fi
 
 case "${OSTYPE}" in
 cygwin)
-  LD_PRELOAD="${ld_preload:-}" ./src/libmongoc/test-libmongoc.exe "${test_args[@]}"
+  LD_PRELOAD="${ld_preload:-}" ./build/src/libmongoc/test-libmongoc.exe "${test_args[@]}"
   ;;
 
 *)
   ulimit -c unlimited || true
 
-  LD_PRELOAD="${ld_preload:-}" ./src/libmongoc/test-libmongoc --no-fork "${test_args[@]}"
+  LD_PRELOAD="${ld_preload:-}" ./build/src/libmongoc/test-libmongoc --no-fork "${test_args[@]}"
   ;;
 esac

--- a/.evergreen/scripts/run-tests-mingw.bat
+++ b/.evergreen/scripts/run-tests-mingw.bat
@@ -12,6 +12,6 @@ rmdir /Q /S C:\mongo-c-driver
 md C:\mongo-c-driver
 md C:\mongo-c-driver\bin
 copy /Y libmongoc-1.0.dll C:\mongo-c-driver\bin
-copy /Y build\src\libbson\libbson-1.0.dll C:\mongo-c-driver\bin
+copy /Y cmake-build\src\libbson\libbson-1.0.dll C:\mongo-c-driver\bin
 
-.\build\src\libmongoc\test-libmongoc.exe --no-fork -d -F test-results.json --skip-tests .evergreen\etc\skip-tests.txt
+.\cmake-build\src\libmongoc\test-libmongoc.exe --no-fork -d -F test-results.json --skip-tests .evergreen\etc\skip-tests.txt

--- a/.evergreen/scripts/run-tests-mingw.bat
+++ b/.evergreen/scripts/run-tests-mingw.bat
@@ -12,6 +12,6 @@ rmdir /Q /S C:\mongo-c-driver
 md C:\mongo-c-driver
 md C:\mongo-c-driver\bin
 copy /Y libmongoc-1.0.dll C:\mongo-c-driver\bin
-copy /Y src\libbson\libbson-1.0.dll C:\mongo-c-driver\bin
+copy /Y build\src\libbson\libbson-1.0.dll C:\mongo-c-driver\bin
 
-.\src\libmongoc\test-libmongoc.exe --no-fork -d -F test-results.json --skip-tests .evergreen\etc\skip-tests.txt
+.\build\src\libmongoc\test-libmongoc.exe --no-fork -d -F test-results.json --skip-tests .evergreen\etc\skip-tests.txt

--- a/.evergreen/scripts/run-tests.sh
+++ b/.evergreen/scripts/run-tests.sh
@@ -175,7 +175,7 @@ if [[ "${CC}" =~ mingw ]]; then
   wait_for_server "simple HTTP" 8000
   echo "Waiting for simple HTTP server to start... done."
 
-  chmod -f +x ./build/src/libmongoc/test-libmongoc.exe
+  chmod -f +x ./cmake-build/src/libmongoc/test-libmongoc.exe
   cmd.exe /c "$(native-path "${script_dir}/run-tests-mingw.bat")"
   exit
 fi
@@ -266,8 +266,8 @@ cygwin)
 
   check_mongocryptd
 
-  chmod -f +x build/src/libmongoc/Debug/test-libmongoc.exe
-  LD_PRELOAD="${ld_preload:-}" ./build/src/libmongoc/Debug/test-libmongoc.exe "${test_args[@]}"
+  chmod -f +x cmake-build/src/libmongoc/Debug/test-libmongoc.exe
+  LD_PRELOAD="${ld_preload:-}" ./cmake-build/src/libmongoc/Debug/test-libmongoc.exe "${test_args[@]}"
   ;;
 
 *)
@@ -284,7 +284,7 @@ cygwin)
     openssl_lib_prefix="${openssl_install_dir}/lib:${openssl_lib_prefix:-}"
   fi
 
-  LD_LIBRARY_PATH="${openssl_lib_prefix}" LD_PRELOAD="${ld_preload:-}" ./build/src/libmongoc/test-libmongoc --no-fork "${test_args[@]}"
+  LD_LIBRARY_PATH="${openssl_lib_prefix}" LD_PRELOAD="${ld_preload:-}" ./cmake-build/src/libmongoc/test-libmongoc --no-fork "${test_args[@]}"
   ;;
 esac
 

--- a/.evergreen/scripts/run-tests.sh
+++ b/.evergreen/scripts/run-tests.sh
@@ -175,7 +175,7 @@ if [[ "${CC}" =~ mingw ]]; then
   wait_for_server "simple HTTP" 8000
   echo "Waiting for simple HTTP server to start... done."
 
-  chmod -f +x ./src/libmongoc/test-libmongoc.exe
+  chmod -f +x ./build/src/libmongoc/test-libmongoc.exe
   cmd.exe /c "$(native-path "${script_dir}/run-tests-mingw.bat")"
   exit
 fi
@@ -266,8 +266,8 @@ cygwin)
 
   check_mongocryptd
 
-  chmod -f +x src/libmongoc/Debug/test-libmongoc.exe
-  LD_PRELOAD="${ld_preload:-}" ./src/libmongoc/Debug/test-libmongoc.exe "${test_args[@]}"
+  chmod -f +x build/src/libmongoc/Debug/test-libmongoc.exe
+  LD_PRELOAD="${ld_preload:-}" ./build/src/libmongoc/Debug/test-libmongoc.exe "${test_args[@]}"
   ;;
 
 *)
@@ -284,7 +284,7 @@ cygwin)
     openssl_lib_prefix="${openssl_install_dir}/lib:${openssl_lib_prefix:-}"
   fi
 
-  LD_LIBRARY_PATH="${openssl_lib_prefix}" LD_PRELOAD="${ld_preload:-}" ./src/libmongoc/test-libmongoc --no-fork "${test_args[@]}"
+  LD_LIBRARY_PATH="${openssl_lib_prefix}" LD_PRELOAD="${ld_preload:-}" ./build/src/libmongoc/test-libmongoc --no-fork "${test_args[@]}"
   ;;
 esac
 


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1524. Verified by [this patch](https://spruce.mongodb.com/version/66ce1342e0dea500075ee87d).

Addresses the following error on some Windows distros when used with the old `CCache.cmake` module (discovered while testing the C++ Driver; this does not break builds but does impact ccache efficiency):

```
ccache: error: CCACHE_BASEDIR: not an absolute path: "/cygdrive/c/data/mci/.../mongo-cxx-driver"
```

Applies a proper transformation to Windows path form on Windows distros to avoid Windows-side cmake or ccache confusion of file paths.

Additional improvements include:

- removing a pre-1.11.0 libmongocrypt workaround now that 1.11.0 is released.
- simplifying DEBUG vs. RELEASE variable checks in compile scripts (mutually exclusive options). We should consider refactoring the config to use only one or the other.
- Avoiding in-source builds of the C Driver by using the `build` subdirectory as the binary directory for CMake.