### PR TITLE
CDRIVER-4755 document error handing in transactions

### DIFF
--- a/src/libmongoc/doc/mongoc_client_session_start_transaction.rst
+++ b/src/libmongoc/doc/mongoc_client_session_start_transaction.rst
@@ -18,6 +18,8 @@ Start a multi-document transaction for all following operations in this session.
 
 The transaction must be completed with :symbol:`mongoc_client_session_commit_transaction` or :symbol:`mongoc_client_session_abort_transaction`. An in-progress transaction is automatically aborted by :symbol:`mongoc_client_session_destroy`.
 
+If a command inside of the transaction fails, it may cause the transaction on the server to be aborted. An attempt to commit such transaction will be rejected with ``NoSuchTransaction`` error. 
+
 Parameters
 ----------
 

--- a/src/libmongoc/doc/mongoc_client_session_with_transaction.rst
+++ b/src/libmongoc/doc/mongoc_client_session_with_transaction.rst
@@ -24,8 +24,6 @@ This method has an internal time limit of 120 seconds, and will retry until that
 
 If a command inside ``cb`` fails, it may cause the transaction on the server to be aborted. This situation is normally handled transparently by the driver. However, if the application does not return that error from ``cb``, the driver will not be able to determine whether the transaction was aborted or not. The driver will then retry ``cb`` indefinitely. To avoid this situation, the application MUST NOT silently handle errors within ``cb``. If the application needs to handle errors within ``cb``, it MUST return them after doing so.
 
-If a command inside of the transaction fails, the driver may abort the transaction on the server. An attempt to commit such transaction will be rejected with ``NoSuchTransaction`` error.
-
 The parameter ``reply`` is initialized even upon failure to simplify memory management.
 
 Parameters

--- a/src/libmongoc/doc/mongoc_client_session_with_transaction.rst
+++ b/src/libmongoc/doc/mongoc_client_session_with_transaction.rst
@@ -22,6 +22,8 @@ This method has an internal time limit of 120 seconds, and will retry until that
 
 ``cb`` should not attempt to start new transactions, but should simply run operations meant to be contained within a transaction. The ``cb`` does not need to commit transactions; this is handled by the :symbol:`mongoc_client_session_with_transaction`. If ``cb`` does commit or abort a transaction, however, this method will return without taking further action.
 
+If a command inside ``cb`` fails, it may cause the transaction on the server to be aborted. This situation is normally handled transparently by the driver. However, if the application does not return that error from ``cb``, the driver will not be able to determine whether the transaction was aborted or not. The driver will then retry ``cb`` indefinitely. To avoid this situation, the application MUST NOT silently handle errors within ``cb``. If the application needs to handle errors within ``cb``, it MUST return them after doing so.
+
 The parameter ``reply`` is initialized even upon failure to simplify memory management.
 
 Parameters

--- a/src/libmongoc/doc/mongoc_client_session_with_transaction.rst
+++ b/src/libmongoc/doc/mongoc_client_session_with_transaction.rst
@@ -24,6 +24,8 @@ This method has an internal time limit of 120 seconds, and will retry until that
 
 If a command inside ``cb`` fails, it may cause the transaction on the server to be aborted. This situation is normally handled transparently by the driver. However, if the application does not return that error from ``cb``, the driver will not be able to determine whether the transaction was aborted or not. The driver will then retry ``cb`` indefinitely. To avoid this situation, the application MUST NOT silently handle errors within ``cb``. If the application needs to handle errors within ``cb``, it MUST return them after doing so.
 
+If a command inside of the transaction fails, the driver may abort the transaction on the server. An attempt to commit such transaction will be rejected with ``NoSuchTransaction`` error.
+
 The parameter ``reply`` is initialized even upon failure to simplify memory management.
 
 Parameters


### PR DESCRIPTION
# Summary
This ticket updates the documentation for `mongoc_client_session_with_transaction` with more information regarding error handling as to avoid infinite loops.