### PR TITLE
CDRIVER-4800 return from trace functions if no logger

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-log-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-log-private.h
@@ -34,14 +34,12 @@ mongoc_log_trace_bytes (const char *domain, const uint8_t *_b, size_t _l);
 void
 mongoc_log_trace_iovec (const char *domain, const mongoc_iovec_t *_iov, size_t _iovcnt);
 
-BSON_BEGIN_DECLS
-#define STOP_LOGGING_CHECK                                          \
-   int stop_logging;                                                \
-   stop_logging = !gLogFunc;                                        \
-   stop_logging = stop_logging || !_mongoc_log_trace_is_enabled (); \
-   if (stop_logging) {                                              \
-      return;                                                       \
-   }
+#define STOP_LOGGING_CHECK                                 \
+   if (1) {                                                \
+      if (!gLogFunc || !_mongoc_log_trace_is_enabled ()) { \
+         return;                                           \
+      }                                                    \
+   } else                                                  \
+      (void) 0
 
-BSON_END_DECLS
 #endif /* MONGOC_LOG_PRIVATE_H */

--- a/src/libmongoc/src/mongoc/mongoc-log-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-log-private.h
@@ -34,4 +34,14 @@ mongoc_log_trace_bytes (const char *domain, const uint8_t *_b, size_t _l);
 void
 mongoc_log_trace_iovec (const char *domain, const mongoc_iovec_t *_iov, size_t _iovcnt);
 
+BSON_BEGIN_DECLS
+#define STOP_LOGGING_CHECK                                          \
+   int stop_logging;                                                \
+   stop_logging = !gLogFunc;                                        \
+   stop_logging = stop_logging || !_mongoc_log_trace_is_enabled (); \
+   if (stop_logging) {                                              \
+      return;                                                       \
+   }
+
+BSON_END_DECLS
 #endif /* MONGOC_LOG_PRIVATE_H */

--- a/src/libmongoc/src/mongoc/mongoc-log.c
+++ b/src/libmongoc/src/mongoc/mongoc-log.c
@@ -217,9 +217,7 @@ mongoc_log_default_handler (mongoc_log_level_t log_level, const char *log_domain
 void
 mongoc_log_trace_bytes (const char *domain, const uint8_t *_b, size_t _l)
 {
-   if (!_mongoc_log_trace_is_enabled ()) {
-      return;
-   }
+   STOP_LOGGING_CHECK;
 
    bson_string_t *const str = bson_string_new (NULL);
    bson_string_t *const astr = bson_string_new (NULL);
@@ -269,9 +267,7 @@ mongoc_log_trace_iovec (const char *domain, const mongoc_iovec_t *_iov, size_t _
    size_t _l = 0;
    uint8_t _v;
 
-   if (!_mongoc_log_trace_is_enabled ()) {
-      return;
-   }
+   STOP_LOGGING_CHECK;
 
    for (_i = 0; _i < _iovcnt; _i++) {
       _l += _iov[_i].iov_len;


### PR DESCRIPTION
# Summary
This ticket adds a macro to return early from `mongoc_log_trace_bytes()` and `mongoc_log_trace_iovec()` if no log handler is registered.