### PR TITLE
CDRIVER-4726 make delimiting slash in URI optional

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-uri.c
+++ b/src/libmongoc/src/mongoc/mongoc-uri.c
@@ -1427,7 +1427,7 @@ mongoc_uri_parse (mongoc_uri_t *uri, const char *str, bson_error_t *error)
    if (!before_slash) {
       // Handle cases of optional delimiting slash
       char *userpass = NULL;
-      char *hostname = NULL;
+      char *hosts = NULL;
 
       // Skip any "?"s that exist in the userpass
       userpass = scan_to_unichar (str, '@', "", &tmp);
@@ -1437,17 +1437,17 @@ mongoc_uri_parse (mongoc_uri_t *uri, const char *str, bson_error_t *error)
       } else {
          const size_t userpass_len = (size_t) (tmp - str);
          // Otherwise, see if options exist after userpass and concatenate result
-         hostname = scan_to_unichar (tmp, '?', "", &tmp);
+         hosts = scan_to_unichar (tmp, '?', "", &tmp);
 
-         if (hostname) {
-            const size_t hostname_len = (size_t) (tmp - str) - userpass_len;
+         if (hosts) {
+            const size_t hosts_len = (size_t) (tmp - str) - userpass_len;
 
-            before_slash = bson_strndup (str, userpass_len + hostname_len);
+            before_slash = bson_strndup (str, userpass_len + hosts_len);
          }
       }
 
       bson_free (userpass);
-      bson_free (hostname);
+      bson_free (hosts);
    }
 
    if (!before_slash) {

--- a/src/libmongoc/src/mongoc/mongoc-uri.c
+++ b/src/libmongoc/src/mongoc/mongoc-uri.c
@@ -1429,13 +1429,13 @@ mongoc_uri_parse (mongoc_uri_t *uri, const char *str, bson_error_t *error)
    if (!before_slash) {
       // Handle cases of optional delimiting slash
 
-      // Skip any "?" that exist is the userpass
+      // Skip any "?"s that exist in the userpass
       userpass = scan_to_unichar (str, '@', "", &tmp);
       if (!userpass) {
-         // If none found, we can safely check for "?" indicating beginning of options
+         // If none found, safely check for "?" indicating beginning of options
          before_slash = scan_to_unichar (str, '?', "", &tmp);
       } else {
-         // Otherwise, see if options exist after username/password and concatenate result
+         // Otherwise, see if options exist after userpass and concatenate result
          hostname = scan_to_unichar (tmp, '?', "", &tmp);
 
          if (hostname) {

--- a/src/libmongoc/src/mongoc/mongoc-uri.c
+++ b/src/libmongoc/src/mongoc/mongoc-uri.c
@@ -1444,25 +1444,30 @@ mongoc_uri_parse (mongoc_uri_t *uri, const char *str, bson_error_t *error)
 
    if (*str) {
       // Check for valid end of hostname delimeter (skip slash if necessary)
-      if (*str == '?' || *str++ == '/') {
+      if (*str != '/' && *str != '?') {
+         MONGOC_URI_ERROR (error, "%s", "Expected end of hostname delimiter");
+         goto error;
+      }
+
+      if (*str == '/') {
+         // Try to parse database.
+         str++;
          if (*str) {
             if (!mongoc_uri_parse_database (uri, str, &str)) {
                MONGOC_URI_ERROR (error, "%s", "Invalid database name in URI");
                goto error;
             }
          }
+      }
 
-         if (*str == '?') {
-            str++;
-            if (*str) {
-               if (!mongoc_uri_parse_options (uri, str, false /* from DNS */, error)) {
-                  goto error;
-               }
+      if (*str == '?') {
+         // Try to parse options.
+         str++;
+         if (*str) {
+            if (!mongoc_uri_parse_options (uri, str, false /* from DNS */, error)) {
+               goto error;
             }
          }
-      } else {
-         MONGOC_URI_ERROR (error, "%s", "Expected end of hostname delimiter");
-         goto error;
       }
    }
 

--- a/src/libmongoc/tests/json/connection_uri/invalid-uris.json
+++ b/src/libmongoc/tests/json/connection_uri/invalid-uris.json
@@ -163,15 +163,6 @@
       "options": null
     },
     {
-      "description": "Missing delimiting slash between hosts and options",
-      "uri": "mongodb://example.com?w=1",
-      "valid": false,
-      "warning": null,
-      "hosts": null,
-      "auth": null,
-      "options": null
-    },
-    {
       "description": "Incomplete key value pair for option",
       "uri": "mongodb://example.com/?w",
       "valid": false,

--- a/src/libmongoc/tests/json/connection_uri/valid-options.json
+++ b/src/libmongoc/tests/json/connection_uri/valid-options.json
@@ -20,6 +20,23 @@
       "options": {
         "authmechanism": "MONGODB-CR"
       }
+     },
+    {
+      "description": "Missing delimiting slash between hosts and options",
+      "uri": "mongodb://example.com?tls=true",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": {
+        "tls": true
+      }
     }
   ]
 }

--- a/src/libmongoc/tests/test-mongoc-uri.c
+++ b/src/libmongoc/tests/test-mongoc-uri.c
@@ -256,10 +256,11 @@ test_mongoc_uri_new (void)
    mongoc_uri_destroy (uri);
 
    /* should recognize a question mark in the the username/password (not mistake it for beginning of options) */
-   uri = mongoc_uri_new ("mongodb://us?r:pa?s@localhost");
+   uri = mongoc_uri_new ("mongodb://us?r:pa?s@localhost?" MONGOC_URI_AUTHMECHANISM "=SCRAM-SHA1");
    ASSERT (uri);
    ASSERT_CMPSTR (mongoc_uri_get_username (uri), "us?r");
    ASSERT_CMPSTR (mongoc_uri_get_password (uri), "pa?s");
+   ASSERT_CMPSTR (mongoc_uri_get_auth_mechanism (uri), "SCRAM-SHA1");
    mongoc_uri_destroy (uri);
 
    /* should fail on invalid escaped characters */

--- a/src/libmongoc/tests/test-mongoc-uri.c
+++ b/src/libmongoc/tests/test-mongoc-uri.c
@@ -255,6 +255,13 @@ test_mongoc_uri_new (void)
    ASSERT_CMPSTR (mongoc_uri_get_username (uri), "christian@realm");
    mongoc_uri_destroy (uri);
 
+   /* should recognize a question mark in the the username/password (not mistake it for beginning of options) */
+   uri = mongoc_uri_new ("mongodb://us?r:pa?s@localhost");
+   ASSERT (uri);
+   ASSERT_CMPSTR (mongoc_uri_get_username (uri), "us?r");
+   ASSERT_CMPSTR (mongoc_uri_get_password (uri), "pa?s");
+   mongoc_uri_destroy (uri);
+
    /* should fail on invalid escaped characters */
    capture_logs (true);
    uri = mongoc_uri_new ("mongodb://u%ser:pwd@localhost:27017");

--- a/src/libmongoc/tests/test-mongoc-uri.c
+++ b/src/libmongoc/tests/test-mongoc-uri.c
@@ -255,7 +255,7 @@ test_mongoc_uri_new (void)
    ASSERT_CMPSTR (mongoc_uri_get_username (uri), "christian@realm");
    mongoc_uri_destroy (uri);
 
-   /* should recognize a question mark in the the username/password (not mistake it for beginning of options) */
+   /* should recognize a question mark in the userpass instead of mistaking it for the beginning of options */
    uri = mongoc_uri_new ("mongodb://us?r:pa?s@localhost?" MONGOC_URI_AUTHMECHANISM "=SCRAM-SHA1");
    ASSERT (uri);
    ASSERT_CMPSTR (mongoc_uri_get_username (uri), "us?r");


### PR DESCRIPTION
# Summary
This ticket removes the requirement for URIs to have a delimiting slash in between the hosts and options (e.g. `mongodb://example.com?w=1` is equivalent to `mongodb://example.com/?w=1`).

# Testing
Relevant spec tests were updated according to [this](https://github.com/mongodb/specifications/pull/1447) PR.