### PR TITLE
Miscellaneous maintenance of EVG config

### DIFF
--- a/.evergreen/config_generator/components/c_std_compile.py
+++ b/.evergreen/config_generator/components/c_std_compile.py
@@ -2,6 +2,8 @@ from shrub.v3.evg_build_variant import BuildVariant
 from shrub.v3.evg_command import EvgCommandType
 from shrub.v3.evg_task import EvgTaskRef
 
+from config_generator.components.funcs.find_cmake_latest import FindCMakeLatest
+
 from config_generator.etc.distros import find_large_distro
 from config_generator.etc.distros import make_distro_str
 from config_generator.etc.distros import to_cc
@@ -80,7 +82,10 @@ def tasks():
                     name=task_name,
                     run_on=distro.name,
                     tags=tags + [f'std-c{std}'],
-                    commands=[StdCompile.call(vars=compile_vars | with_std)],
+                    commands=[
+                        FindCMakeLatest.call(),
+                        StdCompile.call(vars=compile_vars | with_std)
+                    ],
                 )
             )
 

--- a/.evergreen/config_generator/components/funcs/find_cmake_latest.py
+++ b/.evergreen/config_generator/components/funcs/find_cmake_latest.py
@@ -1,0 +1,25 @@
+from shrub.v3.evg_command import EvgCommandType
+
+from config_generator.etc.function import Function
+from config_generator.etc.utils import bash_exec
+
+
+class FindCMakeLatest(Function):
+    name = 'find-cmake-latest'
+    command_type = EvgCommandType.SETUP
+    commands = [
+        bash_exec(
+            command_type=command_type,
+            retry_on_failure=True,
+            working_dir='mongoc',
+            script='. .evergreen/scripts/find-cmake-latest.sh && find_cmake_latest'
+        ),
+    ]
+
+    @classmethod
+    def call(cls, **kwargs):
+        return cls.default_call(**kwargs)
+
+
+def functions():
+    return FindCMakeLatest.defn()

--- a/.evergreen/config_generator/components/funcs/find_cmake_latest.py
+++ b/.evergreen/config_generator/components/funcs/find_cmake_latest.py
@@ -5,6 +5,12 @@ from config_generator.etc.utils import bash_exec
 
 
 class FindCMakeLatest(Function):
+    '''
+    Call `find_cmake_latest` in an attempt to download-and-build the latest
+    CMake version as a Setup task with `retry_on_failure: true` prior to
+    subsequent use of `find-cmake-latest.sh` by compile and build scripts.
+    '''
+
     name = 'find-cmake-latest'
     command_type = EvgCommandType.SETUP
     commands = [

--- a/.evergreen/config_generator/components/loadbalanced.py
+++ b/.evergreen/config_generator/components/loadbalanced.py
@@ -5,6 +5,7 @@ from shrub.v3.evg_task import EvgTaskRef, EvgTaskDependency
 from config_generator.components.funcs.bootstrap_mongo_orchestration import BootstrapMongoOrchestration
 from config_generator.components.funcs.fetch_build import FetchBuild
 from config_generator.components.funcs.fetch_det import FetchDET
+from config_generator.components.funcs.find_cmake_latest import FindCMakeLatest
 from config_generator.components.funcs.run_simple_http_server import RunSimpleHTTPServer
 from config_generator.components.funcs.run_tests import RunTests
 from config_generator.components.funcs.upload_build import UploadBuild
@@ -76,6 +77,7 @@ def tasks():
         run_on=find_large_distro(_DISTRO_NAME).name,
         tags=['loadbalanced', _DISTRO_NAME, _COMPILER],
         commands=[
+            FindCMakeLatest.call(),
             bash_exec(
                 command_type=EvgCommandType.TEST,
                 env={

--- a/.evergreen/config_generator/components/make_docs.py
+++ b/.evergreen/config_generator/components/make_docs.py
@@ -2,6 +2,8 @@ from shrub.v3.evg_command import EvgCommandType
 from shrub.v3.evg_command import s3_put
 from shrub.v3.evg_task import EvgTask
 
+from config_generator.components.funcs.find_cmake_latest import FindCMakeLatest
+
 from config_generator.etc.function import Function
 from config_generator.etc.function import merge_defns
 from config_generator.etc.utils import bash_exec
@@ -132,6 +134,7 @@ def tasks():
         EvgTask(
             name="make-docs",
             commands=[
+                FindCMakeLatest.call(),
                 MakeDocs.call(),
                 UploadDocs.call(),
                 UploadManPages.call(),

--- a/.evergreen/config_generator/components/mock_server.py
+++ b/.evergreen/config_generator/components/mock_server.py
@@ -3,6 +3,7 @@ from shrub.v3.evg_command import EvgCommandType
 from shrub.v3.evg_task import EvgTaskRef
 
 from config_generator.components.funcs.fetch_det import FetchDET
+from config_generator.components.funcs.find_cmake_latest import FindCMakeLatest
 from config_generator.components.funcs.run_simple_http_server import RunSimpleHTTPServer
 from config_generator.etc.utils import Task
 from config_generator.etc.utils import bash_exec
@@ -16,6 +17,7 @@ def tasks():
                 # Call fetch-det to define PYTHON3_BINARY expansion required for run-simple-http-server.
                 FetchDET.call(),
                 RunSimpleHTTPServer.call(),
+                FindCMakeLatest.call(),
                 bash_exec(
                     command_type=EvgCommandType.TEST,
                     add_expansions_to_env=True,

--- a/.evergreen/config_generator/components/openssl_static_compile.py
+++ b/.evergreen/config_generator/components/openssl_static_compile.py
@@ -2,6 +2,8 @@ from shrub.v3.evg_build_variant import BuildVariant
 from shrub.v3.evg_command import EvgCommandType
 from shrub.v3.evg_task import EvgTaskRef
 
+from config_generator.components.funcs.find_cmake_latest import FindCMakeLatest
+
 from config_generator.etc.distros import find_large_distro
 from config_generator.etc.distros import make_distro_str
 from config_generator.etc.distros import to_cc
@@ -69,7 +71,10 @@ def tasks():
                 name=task_name,
                 run_on=distro.name,
                 tags=tags,
-                commands=[StaticOpenSSLCompile.call(vars=compile_vars)],
+                commands=[
+                    FindCMakeLatest.call(),
+                    StaticOpenSSLCompile.call(vars=compile_vars),
+                ],
             )
         )
 

--- a/.evergreen/config_generator/components/scan_build.py
+++ b/.evergreen/config_generator/components/scan_build.py
@@ -3,6 +3,8 @@ from shrub.v3.evg_command import EvgCommandType
 from shrub.v3.evg_command import FunctionCall
 from shrub.v3.evg_task import EvgTaskRef
 
+from config_generator.components.funcs.find_cmake_latest import FindCMakeLatest
+
 from config_generator.etc.distros import find_large_distro
 from config_generator.etc.distros import make_distro_str
 from config_generator.etc.distros import to_cc
@@ -74,6 +76,7 @@ def tasks():
                 run_on=distro.name,
                 tags=tags,
                 commands=[
+                    FindCMakeLatest.call(),
                     ScanBuild.call(vars=compile_vars),
                     FunctionCall(func='upload scan artifacts'),
                 ],

--- a/.evergreen/config_generator/etc/compile.py
+++ b/.evergreen/config_generator/etc/compile.py
@@ -3,6 +3,7 @@ from config_generator.etc.distros import make_distro_str
 from config_generator.etc.distros import to_cc
 from config_generator.etc.utils import Task
 
+from config_generator.components.funcs.find_cmake_latest import FindCMakeLatest
 from config_generator.components.funcs.upload_build import UploadBuild
 
 
@@ -35,6 +36,7 @@ def generate_compile_tasks(SSL, TAG, SASL_TO_FUNC, MATRIX, MORE_TAGS=None, MORE_
                 task_name = f'{tag}-{task_name}'
 
             commands = []
+            commands.append(FindCMakeLatest.call())
             commands.append(SASL_TO_FUNC[sasl].call(vars=compile_vars))
             commands.append(UploadBuild.call())
 

--- a/.evergreen/config_generator/etc/sasl/compile.py
+++ b/.evergreen/config_generator/etc/sasl/compile.py
@@ -3,6 +3,8 @@ from typing import ClassVar
 from shrub.v3.evg_command import EvgCommand
 from shrub.v3.evg_command import EvgCommandType
 
+from config_generator.components.funcs.find_cmake_latest import FindCMakeLatest
+
 from config_generator.etc.utils import bash_exec
 
 from config_generator.etc.function import Function

--- a/.evergreen/config_generator/etc/sasl/compile.py
+++ b/.evergreen/config_generator/etc/sasl/compile.py
@@ -3,8 +3,6 @@ from typing import ClassVar
 from shrub.v3.evg_command import EvgCommand
 from shrub.v3.evg_command import EvgCommandType
 
-from config_generator.components.funcs.find_cmake_latest import FindCMakeLatest
-
 from config_generator.etc.utils import bash_exec
 
 from config_generator.etc.function import Function

--- a/.evergreen/config_generator/etc/utils.py
+++ b/.evergreen/config_generator/etc/utils.py
@@ -34,10 +34,11 @@ def bash_exec(
     include_expansions_in_env: Iterable[str] | None = None,
     working_dir: str | None = None,
     command_type: EvgCommandType | None = None,
+    retry_on_failure: bool | None = None,
     env: Mapping[str, str] | None = None,
     **kwargs,
 ):
-    return subprocess_exec(
+    ret = subprocess_exec(
         binary="bash",
         args=["-c", dedent(script)],
         include_expansions_in_env=list(include_expansions_in_env) if include_expansions_in_env else None,
@@ -46,6 +47,11 @@ def bash_exec(
         env=dict(env) if env else None,
         **kwargs,
     )
+
+    if retry_on_failure is not None:
+        ret.params |= {"retry_on_failure": retry_on_failure}
+
+    return ret
 
 
 def all_components():

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -248,6 +248,16 @@ functions:
             for file in $(find .evergreen/scripts -type f); do
                 chmod +rx "$file" || exit
             done
+  find-cmake-latest:
+    - command: subprocess.exec
+      type: setup
+      params:
+        binary: bash
+        working_dir: mongoc
+        retry_on_failure: true
+        args:
+          - -c
+          - . .evergreen/scripts/find-cmake-latest.sh && find_cmake_latest
   kms-divergence-check:
     - command: subprocess.exec
       type: test

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -296,6 +296,7 @@ tasks:
   tags:
   - hardened
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -311,6 +312,7 @@ tasks:
   - compression
   - zlib
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -326,6 +328,7 @@ tasks:
   - compression
   - snappy
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -341,6 +344,7 @@ tasks:
   - compression
   - zstd
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -358,6 +362,7 @@ tasks:
   - zlib
   - zstd
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -372,6 +377,7 @@ tasks:
   tags:
   - debug-compile
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -388,6 +394,7 @@ tasks:
   - nosasl
   - nossl
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -400,6 +407,7 @@ tasks:
   - func: upload-build
 - name: debug-compile-lto
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -412,6 +420,7 @@ tasks:
   - func: upload-build
 - name: debug-compile-lto-thin
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -427,6 +436,7 @@ tasks:
   - debug-compile
   - no-counters
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -443,6 +453,7 @@ tasks:
   - debug-compile
   - special
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -459,6 +470,7 @@ tasks:
   - debug-compile
   - special
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -471,6 +483,7 @@ tasks:
   - func: upload-build
 - name: compile-tracing
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -483,6 +496,7 @@ tasks:
   - func: upload-build
 - name: release-compile
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -499,6 +513,7 @@ tasks:
   - nosasl
   - openssl
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -515,6 +530,7 @@ tasks:
   - nosasl
   - openssl-static
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -531,6 +547,7 @@ tasks:
   - debug-compile
   - nosasl
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -547,6 +564,7 @@ tasks:
   - nosasl
   - winssl
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -563,6 +581,7 @@ tasks:
   - nossl
   - sasl
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -579,6 +598,7 @@ tasks:
   - openssl
   - sasl
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -595,6 +615,7 @@ tasks:
   - openssl-static
   - sasl
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -611,6 +632,7 @@ tasks:
   - debug-compile
   - sasl
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -627,6 +649,7 @@ tasks:
   - nossl
   - sspi
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -643,6 +666,7 @@ tasks:
   - openssl
   - sspi
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -659,6 +683,7 @@ tasks:
   - openssl-static
   - sspi
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -671,6 +696,7 @@ tasks:
   - func: upload-build
 - name: debug-compile-rdtscp
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -687,6 +713,7 @@ tasks:
   - sspi
   - winssl
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -701,6 +728,7 @@ tasks:
   tags:
   - debug-compile
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -936,6 +964,7 @@ tasks:
         .evergreen/scripts/build_snapshot_rpm.sh
 - name: install-uninstall-check-mingw
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -952,6 +981,7 @@ tasks:
         cmd.exe /c .\\.evergreen\\scripts\\install-uninstall-check-windows.cmd
 - name: install-uninstall-check-msvc
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -968,6 +998,7 @@ tasks:
         cmd.exe /c .\\.evergreen\\scripts\\install-uninstall-check-windows.cmd
 - name: install-uninstall-check
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -984,6 +1015,7 @@ tasks:
         .evergreen/scripts/install-uninstall-check.sh
 - name: debug-compile-with-warnings
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -1002,6 +1034,7 @@ tasks:
   - sasl
   - special
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -1017,6 +1050,7 @@ tasks:
   - func: install ssl
     vars:
       SSL: openssl-1.0.1u
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -1438,6 +1472,7 @@ tasks:
   - asan
   - authentication-tests
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -1648,6 +1683,7 @@ tasks:
   - func: install ssl
     vars:
       SSL: openssl-1.0.1u
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -1664,6 +1700,7 @@ tasks:
   - func: install ssl
     vars:
       SSL: openssl-1.0.1u-fips
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -1680,6 +1717,7 @@ tasks:
   - func: install ssl
     vars:
       SSL: openssl-1.0.2l
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -1696,6 +1734,7 @@ tasks:
   - func: install ssl
     vars:
       SSL: openssl-1.1.0l
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -1712,6 +1751,7 @@ tasks:
   - func: install ssl
     vars:
       SSL: libressl-2.5.2
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -1730,6 +1770,7 @@ tasks:
   - func: install ssl
     vars:
       SSL: libressl-3.0.2
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -1748,6 +1789,7 @@ tasks:
   - func: install ssl
     vars:
       SSL: libressl-3.0.2
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -1851,6 +1893,7 @@ tasks:
       URI: mongodb://localhost/
 - name: debug-compile-aws
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     type: test
     params:
@@ -16260,6 +16303,7 @@ tasks:
 - name: testazurekms-task
   commands:
   - func: fetch-source
+  - func: find-cmake-latest
   - command: shell.exec
     params:
       add_expansions_to_env: true
@@ -16302,6 +16346,7 @@ tasks:
 - name: testazurekms-fail-task
   commands:
   - func: fetch-source
+  - func: find-cmake-latest
   - command: shell.exec
     params:
       add_expansions_to_env: true
@@ -16326,6 +16371,7 @@ tasks:
 - name: testgcpkms-task
   commands:
   - func: fetch-source
+  - func: find-cmake-latest
   - command: shell.exec
     params:
       add_expansions_to_env: true
@@ -16365,6 +16411,7 @@ tasks:
         GCPKMS_CMD="LD_LIBRARY_PATH=./testgcpkms MONGODB_URI='mongodb://localhost:27017' ./testgcpkms/test-gcpkms" $DRIVERS_TOOLS/.evergreen/csfle/gcpkms/run-command.sh
 - name: testgcpkms-fail-task
   commands:
+  - func: find-cmake-latest
   - command: shell.exec
     params:
       add_expansions_to_env: true

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -355,24 +355,6 @@ tasks:
         set -o errexit
         env SNAPPY="OFF" ZLIB="OFF" ZSTD="ON" .evergreen/scripts/compile.sh
   - func: upload-build
-- name: debug-compile-compression
-  tags:
-  - compression
-  - snappy
-  - zlib
-  - zstd
-  commands:
-  - func: find-cmake-latest
-  - command: shell.exec
-    type: test
-    params:
-      working_dir: mongoc
-      add_expansions_to_env: true
-      shell: bash
-      script: |-
-        set -o errexit
-        env SNAPPY="ON" ZLIB="BUNDLED" ZSTD="ON" .evergreen/scripts/compile.sh
-  - func: upload-build
 - name: debug-compile-no-align
   tags:
   - debug-compile
@@ -446,40 +428,6 @@ tasks:
       script: |-
         set -o errexit
         env ENABLE_SHM_COUNTERS="OFF" .evergreen/scripts/compile.sh
-  - func: upload-build
-- name: debug-compile-asan-clang
-  tags:
-  - asan-clang
-  - debug-compile
-  - special
-  commands:
-  - func: find-cmake-latest
-  - command: shell.exec
-    type: test
-    params:
-      working_dir: mongoc
-      add_expansions_to_env: true
-      shell: bash
-      script: |-
-        set -o errexit
-        env CFLAGS="-fno-omit-frame-pointer" CHECK_LOG="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_EXTRA_ALIGNMENT=OFF" SANITIZE="address" SNAPPY="OFF" ZLIB="BUNDLED" ZSTD="OFF" .evergreen/scripts/compile.sh
-  - func: upload-build
-- name: debug-compile-asan-clang-openssl
-  tags:
-  - asan-clang
-  - debug-compile
-  - special
-  commands:
-  - func: find-cmake-latest
-  - command: shell.exec
-    type: test
-    params:
-      working_dir: mongoc
-      add_expansions_to_env: true
-      shell: bash
-      script: |-
-        set -o errexit
-        env CFLAGS="-fno-omit-frame-pointer" CHECK_LOG="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_EXTRA_ALIGNMENT=OFF" SANITIZE="address" SNAPPY="OFF" SSL="OPENSSL" ZLIB="BUNDLED" ZSTD="OFF" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: compile-tracing
   commands:
@@ -575,23 +523,6 @@ tasks:
         set -o errexit
         env SSL="WINDOWS" .evergreen/scripts/compile.sh
   - func: upload-build
-- name: debug-compile-sasl-nossl
-  tags:
-  - debug-compile
-  - nossl
-  - sasl
-  commands:
-  - func: find-cmake-latest
-  - command: shell.exec
-    type: test
-    params:
-      working_dir: mongoc
-      add_expansions_to_env: true
-      shell: bash
-      script: |-
-        set -o errexit
-        env SASL="AUTO" SSL="OFF" .evergreen/scripts/compile.sh
-  - func: upload-build
 - name: debug-compile-sasl-openssl
   tags:
   - debug-compile
@@ -642,57 +573,6 @@ tasks:
       script: |-
         set -o errexit
         env SASL="AUTO" SSL="DARWIN" .evergreen/scripts/compile.sh
-  - func: upload-build
-- name: debug-compile-sspi-nossl
-  tags:
-  - debug-compile
-  - nossl
-  - sspi
-  commands:
-  - func: find-cmake-latest
-  - command: shell.exec
-    type: test
-    params:
-      working_dir: mongoc
-      add_expansions_to_env: true
-      shell: bash
-      script: |-
-        set -o errexit
-        env SASL="SSPI" SSL="OFF" .evergreen/scripts/compile.sh
-  - func: upload-build
-- name: debug-compile-sspi-openssl
-  tags:
-  - debug-compile
-  - openssl
-  - sspi
-  commands:
-  - func: find-cmake-latest
-  - command: shell.exec
-    type: test
-    params:
-      working_dir: mongoc
-      add_expansions_to_env: true
-      shell: bash
-      script: |-
-        set -o errexit
-        env SASL="SSPI" SSL="OPENSSL" .evergreen/scripts/compile.sh
-  - func: upload-build
-- name: debug-compile-sspi-openssl-static
-  tags:
-  - debug-compile
-  - openssl-static
-  - sspi
-  commands:
-  - func: find-cmake-latest
-  - command: shell.exec
-    type: test
-    params:
-      working_dir: mongoc
-      add_expansions_to_env: true
-      shell: bash
-      script: |-
-        set -o errexit
-        env SASL="SSPI" SSL="OPENSSL_STATIC" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-rdtscp
   commands:
@@ -1026,25 +906,6 @@ tasks:
         set -o errexit
         env CFLAGS="-Werror -Wno-cast-align" .evergreen/scripts/compile.sh
   - func: upload-build
-- name: debug-compile-sasl-openssl-static-cse
-  tags:
-  - client-side-encryption
-  - debug-compile
-  - openssl-static
-  - sasl
-  - special
-  commands:
-  - func: find-cmake-latest
-  - command: shell.exec
-    type: test
-    params:
-      working_dir: mongoc
-      add_expansions_to_env: true
-      shell: bash
-      script: |-
-        set -o errexit
-        env COMPILE_LIBMONGOCRYPT="ON" EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON" SASL="AUTO" SSL="OPENSSL_STATIC" .evergreen/scripts/compile.sh
-  - func: upload-build
 - name: debug-compile-nosasl-openssl-1.0.1
   commands:
   - func: install ssl
@@ -1343,31 +1204,6 @@ tasks:
     vars:
       AUTH: noauth
       COMPRESSORS: zstd
-      SSL: nossl
-- name: test-latest-server-compression
-  tags:
-  - compression
-  - latest
-  - snappy
-  - zlib
-  - zstd
-  depends_on:
-    name: debug-compile-compression
-  commands:
-  - func: fetch-build
-    vars:
-      BUILD_NAME: debug-compile-compression
-  - func: fetch-det
-  - func: bootstrap-mongo-orchestration
-    vars:
-      AUTH: noauth
-      ORCHESTRATION_FILE: snappy-zlib-zstd
-      SSL: nossl
-  - func: run-simple-http-server
-  - func: run-tests
-    vars:
-      AUTH: noauth
-      COMPRESSORS: snappy,zlib,zstd
       SSL: nossl
 - name: retry-true-latest-server
   depends_on:

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -6,6 +6,7 @@ tasks:
     run_on: ubuntu1804-large
     tags: [sanitizers-matrix-asan, compile, ubuntu1804, clang, cse, asan, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: clang
@@ -194,6 +195,7 @@ tasks:
     run_on: ubuntu2004-large
     tags: [sanitizers-matrix-asan, compile, ubuntu2004, clang, cse, asan, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: clang
@@ -472,6 +474,7 @@ tasks:
     run_on: ubuntu1604-large
     tags: [sanitizers-matrix-asan, compile, ubuntu1604, clang, asan, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: clang
@@ -480,6 +483,7 @@ tasks:
     run_on: ubuntu1804-large
     tags: [sanitizers-matrix-asan, compile, ubuntu1804, clang, asan, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: clang
@@ -788,6 +792,7 @@ tasks:
     run_on: ubuntu2004-large
     tags: [sanitizers-matrix-asan, compile, ubuntu2004, clang, asan, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: clang
@@ -1267,6 +1272,7 @@ tasks:
     run_on: macos-1100
     tags: [cse-matrix-darwinssl, compile, macos-1100, clang, cse, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: cse-sasl-cyrus-darwinssl-compile
         vars:
           CC: clang
@@ -1555,6 +1561,7 @@ tasks:
     run_on: debian10-large
     tags: [cse-matrix-openssl, compile, debian10, gcc, cse, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: gcc
@@ -1563,6 +1570,7 @@ tasks:
     run_on: debian11-large
     tags: [cse-matrix-openssl, compile, debian11, gcc, cse, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: gcc
@@ -1571,6 +1579,7 @@ tasks:
     run_on: debian92-large
     tags: [cse-matrix-openssl, compile, debian92, clang, cse, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: clang
@@ -1579,6 +1588,7 @@ tasks:
     run_on: debian92-large
     tags: [cse-matrix-openssl, compile, debian92, gcc, cse, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: gcc
@@ -1587,6 +1597,7 @@ tasks:
     run_on: rhel80-large
     tags: [cse-matrix-openssl, compile, rhel80, gcc, cse, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: gcc
@@ -1595,6 +1606,7 @@ tasks:
     run_on: rhel83-zseries-large
     tags: [cse-matrix-openssl, compile, rhel83-zseries, gcc, cse, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: gcc
@@ -1743,6 +1755,7 @@ tasks:
     run_on: ubuntu1604-large
     tags: [cse-matrix-openssl, compile, ubuntu1604, clang, cse, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: clang
@@ -1751,6 +1764,7 @@ tasks:
     run_on: ubuntu1804-arm64-large
     tags: [cse-matrix-openssl, compile, ubuntu1804-arm64, gcc, cse, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: gcc
@@ -1839,6 +1853,7 @@ tasks:
     run_on: ubuntu1804-large
     tags: [cse-matrix-openssl, compile, ubuntu1804, gcc, cse, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: gcc
@@ -1927,6 +1942,7 @@ tasks:
     run_on: ubuntu2004-arm64-large
     tags: [cse-matrix-openssl, compile, ubuntu2004-arm64, gcc, cse, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: gcc
@@ -2055,6 +2071,7 @@ tasks:
     run_on: ubuntu2004-large
     tags: [cse-matrix-openssl, compile, ubuntu2004, gcc, cse, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: gcc
@@ -2183,6 +2200,7 @@ tasks:
     run_on: windows-vsCurrent-large
     tags: [cse-matrix-openssl, compile, windows-vsCurrent, vs2017x64, cse, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: Visual Studio 15 2017 Win64
@@ -2391,6 +2409,7 @@ tasks:
     run_on: windows-64-vs2015-large
     tags: [cse-matrix-winssl, compile, windows-64-vs2015, vs2015x64, cse, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: cse-sasl-cyrus-winssl-compile
         vars:
           CC: Visual Studio 14 2015 Win64
@@ -2399,6 +2418,7 @@ tasks:
     run_on: windows-vsCurrent-large
     tags: [cse-matrix-winssl, compile, windows-vsCurrent, vs2017x64, cse, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: cse-sasl-cyrus-winssl-compile
         vars:
           CC: Visual Studio 15 2017 Win64
@@ -2610,6 +2630,7 @@ tasks:
     run_on: rhel87-large
     tags: [loadbalanced, rhel87, gcc]
     commands:
+      - func: find-cmake-latest
       - command: subprocess.exec
         type: test
         params:
@@ -2886,6 +2907,7 @@ tasks:
           SSL: nossl
   - name: make-docs
     commands:
+      - func: find-cmake-latest
       - func: make-docs
       - func: upload-docs
       - func: upload-man-pages
@@ -2894,6 +2916,7 @@ tasks:
     commands:
       - func: fetch-det
       - func: run-simple-http-server
+      - func: find-cmake-latest
       - command: subprocess.exec
         type: test
         params:
@@ -2915,6 +2938,7 @@ tasks:
     run_on: debian10-large
     tags: [openssl-static-matrix, debian10, gcc]
     commands:
+      - func: find-cmake-latest
       - func: openssl-static-compile
         vars:
           CC: gcc
@@ -2922,6 +2946,7 @@ tasks:
     run_on: debian11-large
     tags: [openssl-static-matrix, debian11, gcc]
     commands:
+      - func: find-cmake-latest
       - func: openssl-static-compile
         vars:
           CC: gcc
@@ -2929,6 +2954,7 @@ tasks:
     run_on: debian92-large
     tags: [openssl-static-matrix, debian92, gcc]
     commands:
+      - func: find-cmake-latest
       - func: openssl-static-compile
         vars:
           CC: gcc
@@ -2936,6 +2962,7 @@ tasks:
     run_on: ubuntu2004-large
     tags: [openssl-static-matrix, ubuntu2004, gcc]
     commands:
+      - func: find-cmake-latest
       - func: openssl-static-compile
         vars:
           CC: gcc
@@ -2943,6 +2970,7 @@ tasks:
     run_on: macos-1100-arm64
     tags: [sasl-matrix-darwinssl, compile, macos-1100-arm64, clang, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: sasl-cyrus-darwinssl-compile
         vars:
           CC: clang
@@ -2951,6 +2979,7 @@ tasks:
     run_on: macos-1100
     tags: [sasl-matrix-darwinssl, compile, macos-1100, clang, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: sasl-cyrus-darwinssl-compile
         vars:
           CC: clang
@@ -3119,6 +3148,7 @@ tasks:
     run_on: debian10-large
     tags: [sasl-matrix-openssl, compile, debian10, gcc, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: gcc
@@ -3127,6 +3157,7 @@ tasks:
     run_on: debian11-large
     tags: [sasl-matrix-openssl, compile, debian11, gcc, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: gcc
@@ -3135,6 +3166,7 @@ tasks:
     run_on: debian92-large
     tags: [sasl-matrix-openssl, compile, debian92, clang, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: clang
@@ -3143,6 +3175,7 @@ tasks:
     run_on: debian92-large
     tags: [sasl-matrix-openssl, compile, debian92, gcc, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: gcc
@@ -3151,6 +3184,7 @@ tasks:
     run_on: rhel70-large
     tags: [sasl-matrix-openssl, compile, rhel70, gcc, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: gcc
@@ -3159,6 +3193,7 @@ tasks:
     run_on: rhel80-large
     tags: [sasl-matrix-openssl, compile, rhel80, gcc, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: gcc
@@ -3167,6 +3202,7 @@ tasks:
     run_on: rhel81-power8-large
     tags: [sasl-matrix-openssl, compile, rhel81-power8, gcc, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: gcc
@@ -3315,6 +3351,7 @@ tasks:
     run_on: rhel83-zseries-large
     tags: [sasl-matrix-openssl, compile, rhel83-zseries, gcc, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: gcc
@@ -3423,6 +3460,7 @@ tasks:
     run_on: ubuntu1604-arm64-large
     tags: [sasl-matrix-openssl, compile, ubuntu1604-arm64, gcc, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: gcc
@@ -3451,6 +3489,7 @@ tasks:
     run_on: ubuntu1604-large
     tags: [sasl-matrix-openssl, compile, ubuntu1604, clang, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: clang
@@ -3459,6 +3498,7 @@ tasks:
     run_on: ubuntu1804-arm64-large
     tags: [sasl-matrix-openssl, compile, ubuntu1804-arm64, gcc, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: gcc
@@ -3547,6 +3587,7 @@ tasks:
     run_on: ubuntu1804-large
     tags: [sasl-matrix-openssl, compile, ubuntu1804, gcc, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: gcc
@@ -3755,6 +3796,7 @@ tasks:
     run_on: ubuntu2004-arm64-large
     tags: [sasl-matrix-openssl, compile, ubuntu2004-arm64, gcc, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: gcc
@@ -3823,6 +3865,7 @@ tasks:
     run_on: ubuntu2004-large
     tags: [sasl-matrix-openssl, compile, ubuntu2004, gcc, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: gcc
@@ -3891,6 +3934,7 @@ tasks:
     run_on: windows-vsCurrent-large
     tags: [sasl-matrix-openssl, compile, windows-vsCurrent, vs2017x64, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: Visual Studio 15 2017 Win64
@@ -3919,6 +3963,7 @@ tasks:
     run_on: windows-64-vs2013-large
     tags: [sasl-matrix-winssl, compile, windows-64-vs2013, vs2013x64, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: sasl-cyrus-winssl-compile
         vars:
           CC: Visual Studio 12 2013 Win64
@@ -3927,6 +3972,7 @@ tasks:
     run_on: windows-64-vs2015-large
     tags: [sasl-matrix-winssl, compile, windows-64-vs2015, vs2015x64, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: sasl-cyrus-winssl-compile
         vars:
           CC: Visual Studio 14 2015 Win64
@@ -3935,6 +3981,7 @@ tasks:
     run_on: windows-vsCurrent-large
     tags: [sasl-matrix-winssl, compile, windows-vsCurrent, vs2017x64, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: sasl-cyrus-winssl-compile
         vars:
           CC: Visual Studio 15 2017 Win64
@@ -4103,6 +4150,7 @@ tasks:
     run_on: ubuntu1604-large
     tags: [sasl-matrix-nossl, compile, ubuntu1604, gcc, sasl-off]
     commands:
+      - func: find-cmake-latest
       - func: sasl-off-nossl-compile
         vars:
           CC: gcc
@@ -4111,6 +4159,7 @@ tasks:
     run_on: ubuntu1804-large
     tags: [sasl-matrix-nossl, compile, ubuntu1804, gcc, sasl-off]
     commands:
+      - func: find-cmake-latest
       - func: sasl-off-nossl-compile
         vars:
           CC: gcc
@@ -4419,6 +4468,7 @@ tasks:
     run_on: ubuntu2004-large
     tags: [sasl-matrix-nossl, compile, ubuntu2004, gcc, sasl-off]
     commands:
+      - func: find-cmake-latest
       - func: sasl-off-nossl-compile
         vars:
           CC: gcc
@@ -4607,6 +4657,7 @@ tasks:
     run_on: windows-vsCurrent-large
     tags: [sasl-matrix-nossl, compile, windows-vsCurrent, vs2017x64, sasl-off]
     commands:
+      - func: find-cmake-latest
       - func: sasl-off-nossl-compile
         vars:
           CC: Visual Studio 15 2017 Win64
@@ -4615,6 +4666,7 @@ tasks:
     run_on: windows-64-vs2013-large
     tags: [sasl-matrix-winssl, compile, windows-64-vs2013, vs2013x86, sasl-off]
     commands:
+      - func: find-cmake-latest
       - func: sasl-off-winssl-compile
         vars:
           CC: Visual Studio 12 2013
@@ -4623,6 +4675,7 @@ tasks:
     run_on: windows-64-vs2015-large
     tags: [sasl-matrix-winssl, compile, windows-64-vs2015, vs2015x86, sasl-off]
     commands:
+      - func: find-cmake-latest
       - func: sasl-off-winssl-compile
         vars:
           CC: Visual Studio 14 2015
@@ -4631,6 +4684,7 @@ tasks:
     run_on: windows-vsCurrent-large
     tags: [sasl-matrix-winssl, compile, windows-vsCurrent, vs2017x64, sasl-off]
     commands:
+      - func: find-cmake-latest
       - func: sasl-off-winssl-compile
         vars:
           CC: Visual Studio 15 2017 Win64
@@ -4639,6 +4693,7 @@ tasks:
     run_on: windows-vsCurrent-large
     tags: [sasl-matrix-winssl, compile, windows-vsCurrent, vs2017x86, sasl-off]
     commands:
+      - func: find-cmake-latest
       - func: sasl-off-winssl-compile
         vars:
           CC: Visual Studio 15 2017
@@ -4647,6 +4702,7 @@ tasks:
     run_on: windows-vsCurrent-large
     tags: [sasl-matrix-winssl, compile, windows-vsCurrent, mingw, sasl-sspi]
     commands:
+      - func: find-cmake-latest
       - func: sasl-sspi-winssl-compile
         vars:
           CC: mingw
@@ -4695,6 +4751,7 @@ tasks:
     run_on: windows-vsCurrent-large
     tags: [sasl-matrix-winssl, compile, windows-vsCurrent, vs2017x64, sasl-sspi]
     commands:
+      - func: find-cmake-latest
       - func: sasl-sspi-winssl-compile
         vars:
           CC: Visual Studio 15 2017 Win64
@@ -4743,6 +4800,7 @@ tasks:
     run_on: windows-vsCurrent-large
     tags: [sasl-matrix-winssl, compile, windows-vsCurrent, vs2017x86, sasl-sspi]
     commands:
+      - func: find-cmake-latest
       - func: sasl-sspi-winssl-compile
         vars:
           CC: Visual Studio 15 2017
@@ -4791,6 +4849,7 @@ tasks:
     run_on: macos-1100
     tags: [scan-build-matrix, macos-1100, clang]
     commands:
+      - func: find-cmake-latest
       - func: scan-build
         vars:
           CC: clang
@@ -4799,6 +4858,7 @@ tasks:
     run_on: ubuntu1604-arm64-large
     tags: [scan-build-matrix, ubuntu1604-arm64, clang]
     commands:
+      - func: find-cmake-latest
       - func: scan-build
         vars:
           CC: clang
@@ -4807,6 +4867,7 @@ tasks:
     run_on: ubuntu1604-large
     tags: [scan-build-matrix, ubuntu1604, clang]
     commands:
+      - func: find-cmake-latest
       - func: scan-build
         vars:
           CC: clang
@@ -4815,6 +4876,7 @@ tasks:
     run_on: ubuntu1604-large
     tags: [scan-build-matrix, ubuntu1604, clang, i686]
     commands:
+      - func: find-cmake-latest
       - func: scan-build
         vars:
           CC: clang
@@ -4824,6 +4886,7 @@ tasks:
     run_on: ubuntu1804-arm64-large
     tags: [scan-build-matrix, ubuntu1804-arm64, clang]
     commands:
+      - func: find-cmake-latest
       - func: scan-build
         vars:
           CC: clang
@@ -4832,6 +4895,7 @@ tasks:
     run_on: ubuntu1804-large
     tags: [scan-build-matrix, ubuntu1804, clang, i686]
     commands:
+      - func: find-cmake-latest
       - func: scan-build
         vars:
           CC: clang
@@ -4841,6 +4905,7 @@ tasks:
     run_on: debian10-large
     tags: [std-matrix, debian10, clang, compile, std-c11]
     commands:
+      - func: find-cmake-latest
       - func: std-compile
         vars:
           CC: clang
@@ -4849,6 +4914,7 @@ tasks:
     run_on: debian10-large
     tags: [std-matrix, debian10, gcc, compile, std-c11]
     commands:
+      - func: find-cmake-latest
       - func: std-compile
         vars:
           CC: gcc
@@ -4857,6 +4923,7 @@ tasks:
     run_on: debian11-large
     tags: [std-matrix, debian11, clang, compile, std-c11]
     commands:
+      - func: find-cmake-latest
       - func: std-compile
         vars:
           CC: clang
@@ -4865,6 +4932,7 @@ tasks:
     run_on: debian11-large
     tags: [std-matrix, debian11, gcc, compile, std-c11]
     commands:
+      - func: find-cmake-latest
       - func: std-compile
         vars:
           CC: gcc
@@ -4873,6 +4941,7 @@ tasks:
     run_on: debian92-large
     tags: [std-matrix, debian92, clang, compile, std-c11]
     commands:
+      - func: find-cmake-latest
       - func: std-compile
         vars:
           CC: clang
@@ -4881,6 +4950,7 @@ tasks:
     run_on: ubuntu1604-large
     tags: [std-matrix, ubuntu1604, clang, compile, std-c11]
     commands:
+      - func: find-cmake-latest
       - func: std-compile
         vars:
           CC: clang
@@ -4889,6 +4959,7 @@ tasks:
     run_on: ubuntu1604-large
     tags: [std-matrix, ubuntu1604, clang, compile, i686, std-c11]
     commands:
+      - func: find-cmake-latest
       - func: std-compile
         vars:
           CC: clang
@@ -4898,6 +4969,7 @@ tasks:
     run_on: ubuntu1804-large
     tags: [std-matrix, ubuntu1804, clang, compile, i686, std-c11]
     commands:
+      - func: find-cmake-latest
       - func: std-compile
         vars:
           CC: clang
@@ -4907,6 +4979,7 @@ tasks:
     run_on: ubuntu1804-large
     tags: [std-matrix, ubuntu1804, gcc, compile, std-c11]
     commands:
+      - func: find-cmake-latest
       - func: std-compile
         vars:
           CC: gcc
@@ -4915,6 +4988,7 @@ tasks:
     run_on: ubuntu2004-large
     tags: [std-matrix, ubuntu2004, clang, compile, std-c11]
     commands:
+      - func: find-cmake-latest
       - func: std-compile
         vars:
           CC: clang
@@ -4923,6 +4997,7 @@ tasks:
     run_on: ubuntu2004-large
     tags: [std-matrix, ubuntu2004, gcc, compile, std-c11]
     commands:
+      - func: find-cmake-latest
       - func: std-compile
         vars:
           CC: gcc
@@ -4931,6 +5006,7 @@ tasks:
     run_on: windows-vsCurrent-large
     tags: [std-matrix, windows-vsCurrent, vs2017x64, compile, std-c11]
     commands:
+      - func: find-cmake-latest
       - func: std-compile
         vars:
           CC: Visual Studio 15 2017 Win64
@@ -4939,6 +5015,7 @@ tasks:
     run_on: debian10-large
     tags: [std-matrix, debian10, gcc, compile, std-c17]
     commands:
+      - func: find-cmake-latest
       - func: std-compile
         vars:
           CC: gcc
@@ -4947,6 +5024,7 @@ tasks:
     run_on: debian11-large
     tags: [std-matrix, debian11, gcc, compile, std-c17]
     commands:
+      - func: find-cmake-latest
       - func: std-compile
         vars:
           CC: gcc
@@ -4955,6 +5033,7 @@ tasks:
     run_on: windows-vsCurrent-large
     tags: [std-matrix, windows-vsCurrent, vs2017x64, compile, std-c17]
     commands:
+      - func: find-cmake-latest
       - func: std-compile
         vars:
           CC: Visual Studio 15 2017 Win64
@@ -4963,6 +5042,7 @@ tasks:
     run_on: ubuntu1804-large
     tags: [sanitizers-matrix-tsan, compile, ubuntu1804, clang, tsan, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: clang
@@ -5271,6 +5351,7 @@ tasks:
     run_on: ubuntu2004-large
     tags: [sanitizers-matrix-tsan, compile, ubuntu2004, clang, tsan, sasl-cyrus]
     commands:
+      - func: find-cmake-latest
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: clang

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -121,6 +121,8 @@ class CompileTask(NamedTask):
             script += ' %s="%s"' % (opt, value)
 
         script += " .evergreen/scripts/compile.sh"
+
+        commands.append(func('find-cmake-latest'))
         commands.append(shell_mongoc(script, add_expansions_to_env=True))
         commands.append(func("upload-build"))
         commands.extend(self.suffix_commands)
@@ -346,6 +348,7 @@ all_tasks = [
     NamedTask(
         "install-uninstall-check-mingw",
         commands=[
+            func("find-cmake-latest"),
             shell_mongoc(
                 r"""
                 . .evergreen/scripts/find-cmake-latest.sh
@@ -360,6 +363,7 @@ all_tasks = [
     NamedTask(
         "install-uninstall-check-msvc",
         commands=[
+            func("find-cmake-latest"),
             shell_mongoc(
                 r"""
                 . .evergreen/scripts/find-cmake-latest.sh
@@ -374,6 +378,7 @@ all_tasks = [
     NamedTask(
         "install-uninstall-check",
         commands=[
+            func("find-cmake-latest"),
             shell_mongoc(
                 r"""
                 . .evergreen/scripts/find-cmake-latest.sh
@@ -733,6 +738,7 @@ all_tasks = chain(
             "authentication-tests-asan-memcheck",
             tags=["authentication-tests", "asan"],
             commands=[
+                func("find-cmake-latest"),
                 shell_mongoc(
                     """
             env SANITIZE=address SASL=AUTO SSL=OPENSSL EXTRA_CONFIGURE_FLAGS='-DENABLE_EXTRA_ALIGNMENT=OFF' .evergreen/scripts/compile.sh
@@ -821,6 +827,7 @@ class SSLTask(Task):
         super(SSLTask, self).__init__(
             commands=[
                 func("install ssl", SSL=full_version),
+                func("find-cmake-latest"),
                 shell_mongoc(script, add_expansions_to_env=True),
                 func("run auth tests", **(test_params or {})),
                 func("upload-build"),
@@ -923,6 +930,7 @@ all_tasks = chain(all_tasks, IPTask.matrix())
 aws_compile_task = NamedTask(
     "debug-compile-aws",
     commands=[
+        func('find-cmake-latest'),
         shell_mongoc(
             """
             export distro_id='${distro_id}' # Required by find_cmake_latest.

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -187,7 +187,6 @@ all_tasks = [
     CompileTask("debug-compile-compression-zlib", tags=["zlib", "compression"], compression="zlib"),
     CompileTask("debug-compile-compression-snappy", tags=["snappy", "compression"], compression="snappy"),
     CompileTask("debug-compile-compression-zstd", tags=["zstd", "compression"], compression="zstd"),
-    CompileTask("debug-compile-compression", tags=["zlib", "snappy", "zstd", "compression"], compression="all"),
     CompileTask(
         "debug-compile-no-align",
         tags=["debug-compile"],
@@ -198,25 +197,6 @@ all_tasks = [
     CompileTask("debug-compile-lto", CFLAGS="-flto"),
     CompileTask("debug-compile-lto-thin", CFLAGS="-flto=thin"),
     CompileTask("debug-compile-no-counters", tags=["debug-compile", "no-counters"], ENABLE_SHM_COUNTERS="OFF"),
-    SpecialTask(
-        "debug-compile-asan-clang",
-        tags=["debug-compile", "asan-clang"],
-        compression="zlib",
-        CFLAGS="-fno-omit-frame-pointer",
-        CHECK_LOG="ON",
-        sanitize=["address"],
-        EXTRA_CONFIGURE_FLAGS="-DENABLE_EXTRA_ALIGNMENT=OFF",
-    ),
-    SpecialTask(
-        "debug-compile-asan-clang-openssl",
-        tags=["debug-compile", "asan-clang"],
-        compression="zlib",
-        CFLAGS="-fno-omit-frame-pointer",
-        CHECK_LOG="ON",
-        sanitize=["address"],
-        EXTRA_CONFIGURE_FLAGS="-DENABLE_EXTRA_ALIGNMENT=OFF",
-        SSL="OPENSSL",
-    ),
     CompileTask("compile-tracing", TRACING="ON", CFLAGS="-Werror -Wno-cast-align"),
     CompileTask("release-compile", config="release"),
     CompileTask("debug-compile-nosasl-openssl", tags=["debug-compile", "nosasl", "openssl"], SSL="OPENSSL"),
@@ -225,7 +205,6 @@ all_tasks = [
     ),
     CompileTask("debug-compile-nosasl-darwinssl", tags=["debug-compile", "nosasl", "darwinssl"], SSL="DARWIN"),
     CompileTask("debug-compile-nosasl-winssl", tags=["debug-compile", "nosasl", "winssl"], SSL="WINDOWS"),
-    CompileTask("debug-compile-sasl-nossl", tags=["debug-compile", "sasl", "nossl"], SASL="AUTO", SSL="OFF"),
     CompileTask("debug-compile-sasl-openssl", tags=["debug-compile", "sasl", "openssl"], SASL="AUTO", SSL="OPENSSL"),
     CompileTask(
         "debug-compile-sasl-openssl-static",
@@ -234,14 +213,6 @@ all_tasks = [
         SSL="OPENSSL_STATIC",
     ),
     CompileTask("debug-compile-sasl-darwinssl", tags=["debug-compile", "sasl", "darwinssl"], SASL="AUTO", SSL="DARWIN"),
-    CompileTask("debug-compile-sspi-nossl", tags=["debug-compile", "sspi", "nossl"], SASL="SSPI", SSL="OFF"),
-    CompileTask("debug-compile-sspi-openssl", tags=["debug-compile", "sspi", "openssl"], SASL="SSPI", SSL="OPENSSL"),
-    CompileTask(
-        "debug-compile-sspi-openssl-static",
-        tags=["debug-compile", "sspi", "openssl-static"],
-        SASL="SSPI",
-        SSL="OPENSSL_STATIC",
-    ),
     CompileTask("debug-compile-rdtscp", ENABLE_RDTSCP="ON"),
     CompileTask("debug-compile-sspi-winssl", tags=["debug-compile", "sspi", "winssl"], SASL="SSPI", SSL="WINDOWS"),
     CompileTask("debug-compile-nosrv", tags=["debug-compile"], SRV="OFF"),
@@ -391,12 +362,6 @@ all_tasks = [
         ],
     ),
     CompileTask("debug-compile-with-warnings", CFLAGS="-Werror -Wno-cast-align"),
-    CompileWithClientSideEncryption(
-        "debug-compile-sasl-openssl-static-cse",
-        tags=["debug-compile", "sasl", "openssl-static"],
-        SASL="AUTO",
-        SSL="OPENSSL_STATIC",
-    ),
     CompileTask(
         "debug-compile-nosasl-openssl-1.0.1",
         prefix_commands=[func("install ssl", SSL="openssl-1.0.1u")],
@@ -589,7 +554,7 @@ all_tasks = chain(all_tasks, DNSTask.matrix())
 
 
 class CompressionTask(MatrixTask):
-    axes = OD([("compression", ["zlib", "snappy", "zstd", "compression"])])
+    axes = OD([("compression", ["zlib", "snappy", "zstd"])])
     name_prefix = "test-latest-server"
 
     def additional_dependencies(self) -> Iterable[DependencySpec]:

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/testazurekms.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/testazurekms.py
@@ -18,6 +18,8 @@
 from collections import OrderedDict as OD
 from typing import MutableSequence
 
+from config_generator.components.funcs.find_cmake_latest import FindCMakeLatest
+
 from evergreen_config_generator.functions import shell_exec, func
 from evergreen_config_generator.tasks import NamedTask
 from evergreen_config_generator.variants import Variant
@@ -29,6 +31,7 @@ def _create_tasks():
     passtask = NamedTask(task_name="testazurekms-task")
     passtask.commands = [
         func("fetch-source"),
+        func("find-cmake-latest"),
         shell_exec(
             r"""
             echo "Building test-azurekms ... begin"
@@ -73,6 +76,7 @@ def _create_tasks():
     failtask = NamedTask(task_name="testazurekms-fail-task")
     failtask.commands = [
         func("fetch-source"),
+        func("find-cmake-latest"),
         shell_exec(
             r"""
             pushd mongoc

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/testgcpkms.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/testgcpkms.py
@@ -17,6 +17,8 @@
 from collections import OrderedDict as OD
 from typing import MutableSequence
 
+from config_generator.components.funcs.find_cmake_latest import FindCMakeLatest
+
 from evergreen_config_generator.functions import shell_exec, func
 from evergreen_config_generator.tasks import NamedTask
 from evergreen_config_generator.variants import Variant
@@ -28,6 +30,7 @@ def _create_tasks():
         task_name="testgcpkms-task",
         commands=[
             func("fetch-source"),
+            func("find-cmake-latest"),
             shell_exec(
                 r"""
             echo "Building test-gcpkms ... begin"
@@ -69,6 +72,7 @@ def _create_tasks():
     failtask = NamedTask(
         task_name="testgcpkms-fail-task",
         commands=[
+            func("find-cmake-latest"),
             shell_exec(
                 r"""
             pushd mongoc

--- a/.evergreen/scripts/find-cmake-latest.sh
+++ b/.evergreen/scripts/find-cmake-latest.sh
@@ -9,5 +9,5 @@ find_cmake_latest() {
   # shellcheck source=.evergreen/scripts/find-cmake-version.sh
   . "${script_dir}/find-cmake-version.sh" || return
 
-  find_cmake_version 3 29 0
+  find_cmake_version 3 30 2
 }

--- a/.evergreen/scripts/find-cmake-version.sh
+++ b/.evergreen/scripts/find-cmake-version.sh
@@ -231,7 +231,7 @@ find_cmake_version() {
 
     cd "${tmp_cmake_dir}" || return
 
-    curl "${curl_args[@]}" "${cmake_url}" --output "cmake.tar.gz" || return
+    curl "${cmake_url}" --output "cmake.tar.gz" || return
     tar xzf cmake.tar.gz || return
 
     if [[ "${OSTYPE}" == darwin* ]]; then

--- a/poetry.lock
+++ b/poetry.lock
@@ -174,6 +174,20 @@ files = [
 ]
 
 [[package]]
+name = "croniter"
+version = "1.4.1"
+description = "croniter provides iteration for datetime object with cron like format"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+files = [
+    {file = "croniter-1.4.1-py2.py3-none-any.whl", hash = "sha256:9595da48af37ea06ec3a9f899738f1b2c1c13da3c38cea606ef7cd03ea421128"},
+    {file = "croniter-1.4.1.tar.gz", hash = "sha256:1a6df60eacec3b7a0aa52a8f2ef251ae3dd2a7c7c8b9874e73e791636d55a361"},
+]
+
+[package.dependencies]
+python-dateutil = "*"
+
+[[package]]
 name = "docutils"
 version = "0.19"
 description = "Docutils -- Python Documentation Utilities"
@@ -200,21 +214,6 @@ beautifulsoup4 = "*"
 pygments = ">=2.7"
 sphinx = ">=6.0,<8.0"
 sphinx-basic-ng = "*"
-
-[[package]]
-name = "git-url-parse"
-version = "1.2.2"
-description = "git-url-parse - A simple GIT URL parser."
-optional = false
-python-versions = "*"
-files = [
-    {file = "git-url-parse-1.2.2.tar.gz", hash = "sha256:7b5f4e3aeb1d693afeee67a3bd4ac063f7206c2e8e46e559f0da0da98445f117"},
-    {file = "git_url_parse-1.2.2-py2-none-any.whl", hash = "sha256:9353ff40d69488ff2299b27f40e0350ad87bd5348ea6ea09a1895eda9e5733de"},
-    {file = "git_url_parse-1.2.2-py3-none-any.whl", hash = "sha256:4655ee22f1d8bf7a1eb1066c1da16529b186966c6d8331f7f55686a76a9f7aef"},
-]
-
-[package.dependencies]
-pbr = "*"
 
 [[package]]
 name = "idna"
@@ -370,17 +369,6 @@ files = [
 ]
 
 [[package]]
-name = "pbr"
-version = "5.11.1"
-description = "Python Build Reasonableness"
-optional = false
-python-versions = ">=2.6"
-files = [
-    {file = "pbr-5.11.1-py2.py3-none-any.whl", hash = "sha256:567f09558bae2b3ab53cb3c1e2e33e726ff3338e7bae3db5dc954b3a44eef12b"},
-    {file = "pbr-5.11.1.tar.gz", hash = "sha256:aefc51675b0b533d56bb5fd1c8c6c0522fe31896679882e1c4c63d5e4a0fccb3"},
-]
-
-[[package]]
 name = "pydantic"
 version = "1.10.13"
 description = "Data validation and settings management using python type hints"
@@ -447,6 +435,20 @@ files = [
 plugins = ["importlib-metadata"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "pytz"
 version = "2023.3"
 description = "World timezone definitions, modern and historical"
@@ -502,19 +504,19 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "shrub-py"
-version = "3.0.4"
+version = "3.1.3"
 description = "Library for creating evergreen configurations"
 optional = false
-python-versions = ">3.6.1"
+python-versions = ">3.7.0"
 files = [
-    {file = "shrub.py-3.0.4-py3-none-any.whl", hash = "sha256:57d783e3cfe85573906c330a7612ade7eadca8b7c41006bdc75d0faf0b835300"},
-    {file = "shrub.py-3.0.4.tar.gz", hash = "sha256:17890e04c4c05437708247b13d70a7d9a8c80de1b159e757889787eed3919b41"},
+    {file = "shrub_py-3.1.3-py3-none-any.whl", hash = "sha256:04b2353b84546045d6c79265e1a32945209678fb1333e79bc591bac8dd5becf7"},
+    {file = "shrub_py-3.1.3.tar.gz", hash = "sha256:e728a4cdb32f395ce1214bf1422682123240ff893062e692726fc63754443b43"},
 ]
 
 [package.dependencies]
-git-url-parse = ">=1,<2"
-pydantic = ">=1.8,<2.0"
-PyYaml = ">=5.1,<6.0"
+croniter = ">=1.4.1,<2.0.0"
+pydantic = ">=1.8,<3.0"
+PyYaml = ">=5.1,<7.0"
 typing-extensions = ">=4,<5"
 
 [[package]]
@@ -823,4 +825,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "9916a7c201b92660ab4699c728b9993cbd4ffbbed709c31a8db83746bf589963"
+content-hash = "f8afaf1007d523ce4d02b4e7e9f86b5fb8d42785fa08cb687f2d23daae1ad59a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ optional = true
 [tool.poetry.group.dev.dependencies]
 clang-format = "^17"
 sphinx-autobuild = "^2021.3.14"
-shrub-py = "3.0.4"
+shrub-py = "3.1.3"
 yamlordereddictloader = "^0.4.0"
 types-docutils = "^0.20.0.1"
 


### PR DESCRIPTION
Verified by [this patch](https://spruce.mongodb.com/version/66d0a3ea10a09d0007ad3b6c). (Note: this patch includes `BYPASS_CMAKE_CACHE=ON`.)

Applies some miscellaneous improvements and updates to the EVG config:

- Raise CMake latest version from 3.29.0 to 3.30.2.
- Raise shrub.py version from 3.0.4 to 3.1.3.
- Address potential nounset error due to obsolete `curl_args` variable expansion when requiring building CMake from source.
- Add a standalone `find-cmake-latest` EVG function with `retry_on_failure: true` before (most) commands that use CMake in an attempt to improve the quality (report CMake download-or-build failures as a "Setup" task failure) and robustness (automatically retry on spurious network failures) of obtaining CMake (e.g. as observed in [this patch](https://spruce.mongodb.com/version/66d088f0e095040007ec2d31/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&statuses=failed,setup-failed)).
- Remove obsolete and unused `debug-compile-*` EVG tasks as reported by `evergreen validate`.