### PR TITLE
update NEWS and release instructions post 1.27.6 release

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -175,7 +175,7 @@ multibuild:
 #   Create a release archive of the source tree. (Refer to dev docs)
 release-archive:
     FROM alpine:3.20
-    RUN apk add git
+    RUN apk add git bash
     ARG --required sbom_branch
     ARG --required prefix
     ARG --required ref

--- a/NEWS
+++ b/NEWS
@@ -33,6 +33,27 @@ Deprecated:
 
   * A future minor release plans to drop support for Visual Studio 2013.
 
+libmongoc 1.27.6
+================
+
+Fixes:
+
+  * Fix TSan warning.
+  * Fix C23 compile.
+
+Improvements:
+
+  * Document expected behavior of command errors in a transaction.
+
+Thanks to everyone who contributed to the development of this release.
+
+  * Adrian Dole
+  * Ezra Chung
+  * Joshua Siegel
+  * Kevin Albertson
+
+
+
 libmongoc 1.27.5
 ================
 

--- a/docs/dev/earthly.rst
+++ b/docs/dev/earthly.rst
@@ -316,12 +316,17 @@ enumerated using ``earthly ls`` or ``earthly doc`` in the root of the repository
 
       **Do not** use the organization ID of **mongodb-default**.
 
+      The `SNYK_ORGANIZATION` may be obtained from the `Snyk organization page
+      <https://app.snyk.io/org/dev-prod/manage/settings>`_.
+
       .. _snyk: https://app.snyk.io
 
    .. envvar:: SNYK_TOKEN
 
       Set this to the value of an API token for accessing Snyk in the given
-      `SNYK_ORGANIZATION`. [#creds]_
+      `SNYK_ORGANIZATION`.
+
+      The `SNYK_TOKEN` may be obtained from the `Snyk account page <https://app.snyk.io/account>`_.
 
 .. program:: +snyk-test
 .. earthly-target:: +snyk-test
@@ -379,4 +384,6 @@ during execution. Your ``.secret`` file will look something like this:
 
 .. [#creds]
 
-   Details on obtaining credentials will not be found in this documentation.
+   Credentials are expected to be available in `AWS Secrets Manager
+   <https://wiki.corp.mongodb.com/display/DRIVERS/Using+AWS+Secrets+Manager+to+Store+Testing+Secrets>`_ under
+   ``drivers/c-driver``.

--- a/docs/dev/releasing.rst
+++ b/docs/dev/releasing.rst
@@ -112,8 +112,8 @@ To enable Snyk monitoring for a release, execute the `+snyk-monitor-snapshot`
 Earthly target for the release branch to be monitored. Be sure to specify the
 correct branch name with `--branch`, and use `--name` to identify the snapshot
 as belonging to the new release version. Let ``$RELEASE_BRANCH`` being the name
-of the branch from which we are releasing, and let ``$NEW_VERSION`` be the new
-release version that we are posting:
+of the branch from which we are releasing (e.g. ``r1.27``), and let ``$NEW_VERSION`` be the new
+release version that we are posting (e.g. ``1.27.6``):
 
 .. code-block:: console
 

--- a/docs/dev/releasing.rst
+++ b/docs/dev/releasing.rst
@@ -395,10 +395,9 @@ required for it to succeed:
    :any:`+sbom-download` targets.
 
 Once these prerequesites are met, creating the release archive can be done using
-the :any:`+signed-release` target. Let `$BRANCH` be the name of the Git branch
-from which the release is being made::
+the :any:`+signed-release` target.::
 
-   $ ./tools/earthly.sh --artifact +signed-release/dist dist --sbom_branch=$BRANCH --version=$NEW_VERSION
+   $ ./tools/earthly.sh --artifact +signed-release/dist dist --sbom_branch=$RELEASE_BRANCH --version=$NEW_VERSION
 
 .. note:: `$NEW_VERSION` must correspond to the Git tag created by the release.
 

--- a/src/libbson/NEWS
+++ b/src/libbson/NEWS
@@ -8,6 +8,21 @@ Build Configuration:
   * Remove `MONGO_USE_CCACHE` (no longer applicable; see above).
 
 
+libbson 1.27.6
+==============
+
+Fixes:
+
+  * Fix handling of malformed extended JSON for special BSON types.
+  * Fix large string handling in `bson_string_new` and `bson_string_append`.
+
+Thanks to everyone who contributed to the development of this release.
+
+  * Ezra Chung
+  * Kevin Albertson
+
+
+
 libbson 1.27.5
 ==============
 


### PR DESCRIPTION
Add NEWS from 1.27.6 release. Update release instructions to help locate credentials. Update `+release-archive` target to install `bash` to fix error observed error:

```
+release-archive | branch=r1.27 prefix=mongo-c-driver-1.27.6 ref=refs/tags/1.27.6 sbom_branch=r1.27 version=1.27.6
+release-archive | --> IF __str test "$version" -matches ".*\.0\$"
+release-archive | env: can't execute 'bash': No such file or directory
```