### PR TITLE
set `MONGODB_BINARIES`

### DIFF
--- a/.evergreen/scripts/integration-tests.sh
+++ b/.evergreen/scripts/integration-tests.sh
@@ -29,6 +29,17 @@ DIR=$(dirname $0)
 # mongoc/.evergreen/scripts -> drivers-evergreen-tools/.evergreen/download-mongodb.sh
 . $DIR/../../../drivers-evergreen-tools/.evergreen/download-mongodb.sh
 
+# Set destination path for binary downloads to mongoc/mongodb/bin.
+export MONGODB_BINARIES
+case "$OS" in
+   cygwin*)
+      MONGODB_BINARIES=$(cygpath -m -a "$DIR/../../mongodb/bin")
+      ;;
+   *)
+      MONGODB_BINARIES="$DIR/../../mongodb/bin"
+      ;;
+esac
+
 get_distro
 get_mongodb_download_url_for "$DISTRO" "$MONGODB_VERSION"
 DRIVERS_TOOLS=./ download_and_extract "$MONGODB_DOWNLOAD_URL" "$EXTRACT" "$MONGOSH_DOWNLOAD_URL" "$EXTRACT_MONGOSH"


### PR DESCRIPTION
This PR is intended to address recently occurring `Setup Failure` task failures. Verified by this [patch build](https://spruce.mongodb.com/version/66df39cf6495c60007e3e822).

https://github.com/mongodb-labs/drivers-evergreen-tools/commit/57cadda5a5ea4ee272daa20cf402bdb58c5280e7 appeared to result in downloading MongoDB binaries to a location that differed from C driver expectations. This resulted in `Setup Failure` on test tasks: [example](https://spruce.mongodb.com/version/66df1aafc5b87d0007d692e8/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&variant=%5Esanitizers-matrix-asan%24). The attached orchestration.log (under Files) includes error logs:
```
FileNotFoundError: [Errno 2] No such file or directory: '/data/mci/b15d555f806324a511e4c66f6c01ff29/mongoc/mongodb/bin/mongod'
```

I expect this is caused by download-mongodb.sh now sourcing handle-paths.sh. handle-paths.sh [sets a default `MONGODB_BINARIES`](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/57cadda5a5ea4ee272daa20cf402bdb58c5280e7/.evergreen/handle-paths.sh#L60).

