### PR TITLE
CDRIVER-5706 spawn pooled client in unified test runner

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-topology-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description.c
@@ -1015,7 +1015,8 @@ mongoc_topology_description_select (const mongoc_topology_description_t *topolog
    if (topology->type == MONGOC_TOPOLOGY_SINGLE) {
       mongoc_server_description_t const *const sd = mongoc_set_get_item_const (mc_tpld_servers_const (topology), 0);
 
-      if (optype == MONGOC_SS_AGGREGATE_WITH_WRITE && sd->max_wire_version < WIRE_VERSION_5_0) {
+      if (optype == MONGOC_SS_AGGREGATE_WITH_WRITE && sd->type != MONGOC_SERVER_UNKNOWN &&
+          sd->max_wire_version < WIRE_VERSION_5_0) {
          /* The single server may be part of an unseen replica set that may not
           * support aggr-with-write operations on secondaries. Force the read
           * preference to use a primary. */

--- a/src/libmongoc/src/mongoc/mongoc-topology-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description.c
@@ -714,7 +714,7 @@ _check_any_server_less_than_wire_version_13 (const void *sd_, void *any_too_old_
 {
    const mongoc_server_description_t *sd = sd_;
    bool *any_too_old = any_too_old_;
-   if (sd->max_wire_version < WIRE_VERSION_5_0) {
+   if (sd->type != MONGOC_SERVER_UNKNOWN && sd->max_wire_version < WIRE_VERSION_5_0) {
       *any_too_old = true;
       return false /* Stop searching */;
    }

--- a/src/libmongoc/tests/unified/entity-map.h
+++ b/src/libmongoc/tests/unified/entity-map.h
@@ -56,6 +56,7 @@ typedef struct _entity_t {
    mongoc_array_t store_events;      // store_event_t [N].
    bson_t *lsid;
    char *session_client_id;
+   int callbacks_disabled;
 } entity_t;
 
 struct _entity_findcursor_t;

--- a/src/libmongoc/tests/unified/entity-map.h
+++ b/src/libmongoc/tests/unified/entity-map.h
@@ -57,6 +57,7 @@ typedef struct _entity_t {
    bson_t *lsid;
    char *session_client_id;
    int callbacks_disabled;
+   mongoc_client_pool_t *pool;
 } entity_t;
 
 struct _entity_findcursor_t;


### PR DESCRIPTION
# Description
This ticket updates the unified test runner to run tests on a pooled client instead of a single-threaded client.

# Background
Some unified tests require the client to be from a pool in order to test expected behavior (e.g. stream monitoring tests in SDAM). This motivated the change of having all unified tests run on a pooled client. Existing spec tests shouldn't be affected by this behavior.

# `entity->callback_disabled`
Because `mongoc_client_pool_set_apm_callbacks` prevents callbacks from getting set more than once on a pool, functionality in `entity_map_disable_event_listeners` wouldn't work with a simple call to disable the APM callbacks in a pool. To mimic this functionality, an atomic int was added to `entity_t` that is set in `entity_map_disable_event_listeners` and checked in `apm_command_callback` before observing events.

# What's New
- `callback_disabled` atomic int in `entity_t`
- Pooled client used to run unified tests