### PR TITLE
CDRIVER-5707 ignore unknown servers in aggregate-with-write check

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-topology-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description.c
@@ -726,7 +726,7 @@ _check_any_server_less_than_wire_version_13 (const void *sd_, void *any_too_old_
  * @brief Calculate the read mode that we should be using, based on what was
  * requested and what is available in the topology.
  *
- * Per the CRUD spec, if the requested read mode is *not* primary, and *any*
+ * Per the CRUD spec, if the requested read mode is *not* primary, and *any* available
  * server in the topology has a wire version < server v5.0, we must override the
  * read mode preference with "primary." Server v5.0 indicates support on a
  * secondary server for using aggregate pipelines that contain writing stages
@@ -751,7 +751,7 @@ _must_use_primary (const mongoc_topology_description_t *td,
       /* Maintain the requested read mode if it is a regular read operation */
       return false;
    case MONGOC_SS_AGGREGATE_WITH_WRITE: {
-      /* Check if any of the servers are too old to support the
+      /* Check if any of the available servers are too old to support the
        * aggregate-with-write on a secondary server */
       bool any_too_old = false;
       mongoc_set_for_each_const (mc_tpld_servers_const (td), _check_any_server_less_than_wire_version_13, &any_too_old);

--- a/src/libmongoc/src/mongoc/mongoc-topology-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description.c
@@ -1015,7 +1015,8 @@ mongoc_topology_description_select (const mongoc_topology_description_t *topolog
    if (topology->type == MONGOC_TOPOLOGY_SINGLE) {
       mongoc_server_description_t const *const sd = mongoc_set_get_item_const (mc_tpld_servers_const (topology), 0);
 
-      if (optype == MONGOC_SS_AGGREGATE_WITH_WRITE && sd->max_wire_version < WIRE_VERSION_5_0) {
+      if (optype == MONGOC_SS_AGGREGATE_WITH_WRITE && sd->type != MONGOC_SERVER_UNKNOWN &&
+          sd->max_wire_version < WIRE_VERSION_5_0) {
          /* The single server may be part of an unseen replica set that may not
           * support aggr-with-write operations on secondaries. Force the read
           * preference to use a primary. */

--- a/src/libmongoc/src/mongoc/mongoc-topology-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description.c
@@ -714,7 +714,7 @@ _check_any_server_less_than_wire_version_13 (const void *sd_, void *any_too_old_
 {
    const mongoc_server_description_t *sd = sd_;
    bool *any_too_old = any_too_old_;
-   if (sd->max_wire_version < WIRE_VERSION_5_0) {
+   if (sd->type != MONGOC_SERVER_UNKNOWN && sd->max_wire_version < WIRE_VERSION_5_0) {
       *any_too_old = true;
       return false /* Stop searching */;
    }

--- a/src/libmongoc/src/mongoc/mongoc-topology-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description.c
@@ -741,7 +741,7 @@ _must_use_primary (const mongoc_topology_description_t *td,
       /* We never alter from a primary read mode. This early-return is just an
        * optimization to skip scanning for old servers, as we would end up
        * returning MONGOC_READ_PRIMARY regardless. */
-      return requested_read_mode;
+      return true;
    }
    switch (optype) {
    case MONGOC_SS_WRITE:

--- a/src/libmongoc/tests/test-mongoc-aggregate.c
+++ b/src/libmongoc/tests/test-mongoc-aggregate.c
@@ -92,8 +92,80 @@ test_query_flags (void)
    }
 }
 
+typedef struct {
+   bson_t *cmd;
+   bson_mutex_t lock;
+} last_captured_t;
+
+static void
+command_started (const mongoc_apm_command_started_t *event)
+{
+   const bson_t *cmd = mongoc_apm_command_started_get_command (event);
+   last_captured_t *lc = mongoc_apm_command_started_get_context (event);
+   bson_mutex_lock (&lc->lock);
+   bson_destroy (lc->cmd);
+   lc->cmd = bson_copy (cmd);
+   bson_mutex_unlock (&lc->lock);
+}
+
+// `test_write_respects_read_prefs` tests that an aggregate with a write stage respects the original read preferences
+// when talking to >= 5.0 servers. This is a regression test for CDRIVER-5707.
+static void
+test_write_respects_read_prefs (void *unused)
+{
+   BSON_UNUSED (unused);
+
+   last_captured_t lc = {0};
+   bson_mutex_init (&lc.lock);
+
+   mongoc_client_pool_t *pool = test_framework_new_default_client_pool ();
+   // Capture the most recent command-started event.
+   {
+      mongoc_apm_callbacks_t *cbs = mongoc_apm_callbacks_new ();
+      mongoc_apm_set_command_started_cb (cbs, command_started);
+      mongoc_client_pool_set_apm_callbacks (pool, cbs, &lc);
+      mongoc_apm_callbacks_destroy (cbs);
+   }
+
+   // Use agg with $out.
+   bson_t *pipeline = BCON_NEW ("pipeline", "[", "{", "$out", "foo", "}", "]");
+   mongoc_client_t *client = mongoc_client_pool_pop (pool);
+   mongoc_collection_t *coll = mongoc_client_get_collection (client, "db", "coll");
+   mongoc_read_prefs_t *rp = mongoc_read_prefs_new (MONGOC_READ_SECONDARY_PREFERRED);
+   mongoc_cursor_t *cursor = mongoc_collection_aggregate (coll, MONGOC_QUERY_NONE, pipeline, NULL /* opts */, rp);
+   // Iterate cursor to send `aggregate` command.
+   const bson_t *ignored;
+   ASSERT (!mongoc_cursor_next (cursor, &ignored));
+   bson_error_t error;
+   ASSERT_OR_PRINT (!mongoc_cursor_error (cursor, &error), error);
+
+   // Check that `aggregate` command contains $readPreference.
+   bson_t *cmd;
+   bson_mutex_lock (&lc.lock);
+   cmd = bson_copy (lc.cmd);
+   bson_mutex_unlock (&lc.lock);
+   ASSERT_MATCH (cmd, BSON_STR ({"$readPreference" : {"mode" : "secondaryPreferred"}}));
+
+   bson_destroy (cmd);
+   mongoc_read_prefs_destroy (rp);
+   mongoc_cursor_destroy (cursor);
+   bson_destroy (pipeline);
+   mongoc_collection_destroy (coll);
+   mongoc_client_pool_push (pool, client);
+   mongoc_client_pool_destroy (pool);
+   bson_destroy (lc.cmd);
+   bson_mutex_destroy (&lc.lock);
+}
+
 void
 test_aggregate_install (TestSuite *suite)
 {
    TestSuite_AddMockServerTest (suite, "/Aggregate/query_flags", test_query_flags);
+   TestSuite_AddFull (suite,
+                      "/Aggregate/write_respects_read_prefs",
+                      test_write_respects_read_prefs,
+                      NULL,
+                      NULL,
+                      test_framework_skip_if_not_replset,
+                      test_framework_skip_if_max_wire_version_less_than_13 /* require server 5.0+ */);
 }


### PR DESCRIPTION
# Summary

Ignore unknown servers when checking to override read preferences for an aggregate-with-write.

Verified by this patch build: https://spruce.mongodb.com/version/66e0ad1ebdf6d3000745d0ba

# Background & Motivation

See CDRIVER-5707.





