### PR TITLE
CDRIVER-5713 fix bson_utf8_escape_for_json crash

### DIFF
--- a/src/libbson/doc/bson_utf8_escape_for_json.rst
+++ b/src/libbson/doc/bson_utf8_escape_for_json.rst
@@ -32,3 +32,7 @@ Returns
 -------
 
 A newly allocated string that should be freed with :symbol:`bson_free()`.
+
+.. warning::
+  If ``utf8`` represents invalid UTF-8 data :symbol:`bson_utf8_escape_for_json` may return NULL or have undefined behavior.
+  UTF-8 may be validated with :symbol:`bson_utf8_validate`.

--- a/src/libbson/doc/bson_utf8_escape_for_json.rst
+++ b/src/libbson/doc/bson_utf8_escape_for_json.rst
@@ -31,8 +31,4 @@ byte is found before ``utf8_len`` bytes, it is converted to
 Returns
 -------
 
-A newly allocated string that should be freed with :symbol:`bson_free()`.
-
-.. warning::
-  If ``utf8`` represents invalid UTF-8 data :symbol:`bson_utf8_escape_for_json` may return NULL or have undefined behavior.
-  UTF-8 may be validated with :symbol:`bson_utf8_validate`.
+A newly allocated string that should be freed with :symbol:`bson_free()` when ``utf8`` is a valid UTF-8 string, or ``NULL`` if the (possibly invalid UTF-8) string could not be escaped.

--- a/src/libbson/doc/bson_utf8_get_char.rst
+++ b/src/libbson/doc/bson_utf8_get_char.rst
@@ -14,7 +14,7 @@ Synopsis
 Parameters
 ----------
 
-* ``utf8``: A UTF-8 encoded string.
+* ``utf8``: A validated UTF-8 encoded string.
 
 Description
 -----------

--- a/src/libbson/fuzz/CMakeLists.txt
+++ b/src/libbson/fuzz/CMakeLists.txt
@@ -7,3 +7,6 @@ target_link_libraries(fuzz_test_init_from_json PRIVATE fuzz_test_properties)
 
 add_executable(fuzz_test_validate EXCLUDE_FROM_ALL fuzz_test_validate.c)
 target_link_libraries(fuzz_test_validate PRIVATE fuzz_test_properties)
+
+add_executable(fuzz_test_bson_utf8_escape_for_json EXCLUDE_FROM_ALL fuzz_test_bson_utf8_escape_for_json.c)
+target_link_libraries(fuzz_test_bson_utf8_escape_for_json PRIVATE fuzz_test_properties)

--- a/src/libbson/fuzz/fuzz_test_bson_utf8_escape_for_json.c
+++ b/src/libbson/fuzz/fuzz_test_bson_utf8_escape_for_json.c
@@ -1,0 +1,16 @@
+#include <bson/bson.h>
+
+int
+LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
+{
+   // Check if input crashes program (ok if return NULL)
+   char *got = bson_utf8_escape_for_json ((const char *) data, (ssize_t) size);
+
+   // If UTF-8 is valid, we should get some non-null response
+   if (bson_utf8_validate ((const char *) data, size, false)) {
+      BSON_ASSERT (got);
+   }
+
+   bson_free (got);
+   return 0;
+}

--- a/src/libbson/fuzz/fuzz_test_bson_utf8_escape_for_json.c
+++ b/src/libbson/fuzz/fuzz_test_bson_utf8_escape_for_json.c
@@ -3,11 +3,16 @@
 int
 LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
 {
+   // Reject inputs with lengths greater than ssize_t
+   if (bson_cmp_greater_us (size, SSIZE_MAX)) {
+      return -1;
+   }
+
    // Check if input crashes program (ok if return NULL)
    char *got = bson_utf8_escape_for_json ((const char *) data, (ssize_t) size);
 
    // If UTF-8 is valid, we should get some non-null response
-   if (bson_utf8_validate ((const char *) data, size, false)) {
+   if (bson_utf8_validate ((const char *) data, size, true)) {
       BSON_ASSERT (got);
    }
 

--- a/src/libbson/src/bson/bson-utf8.c
+++ b/src/libbson/src/bson/bson-utf8.c
@@ -265,6 +265,8 @@ bson_utf8_escape_for_json (const char *utf8, /* IN */
    bson_string_t *str;
    bool length_provided = true;
    const char *end;
+   uint8_t mask;
+   uint8_t length_of_char;
 
    BSON_ASSERT (utf8);
 
@@ -278,6 +280,14 @@ bson_utf8_escape_for_json (const char *utf8, /* IN */
    end = utf8 + utf8_len;
 
    while (utf8 < end) {
+      // Check if expected char length goes past end
+      _bson_utf8_get_sequence (utf8, &length_of_char, &mask);
+      if (utf8 + length_of_char > end) {
+         // Invalid UTF-8
+         bson_string_free (str, true);
+         return NULL;
+      }
+
       c = bson_utf8_get_char (utf8);
 
       switch (c) {

--- a/src/libbson/src/bson/bson-utf8.c
+++ b/src/libbson/src/bson/bson-utf8.c
@@ -245,7 +245,7 @@ bson_utf8_validate (const char *utf8, /* IN */
  *       two byte UTF-8 sequence.
  *
  * Parameters:
- *       @utf8: A validated UTF-8 encoded string.
+ *       @utf8: A UTF-8 encoded string.
  *       @utf8_len: The length of @utf8 in bytes or -1 if NUL terminated.
  *
  * Returns:
@@ -265,8 +265,6 @@ bson_utf8_escape_for_json (const char *utf8, /* IN */
    bson_string_t *str;
    bool length_provided = true;
    const char *end;
-   uint8_t mask;
-   uint8_t length_of_char;
 
    BSON_ASSERT (utf8);
 
@@ -280,9 +278,12 @@ bson_utf8_escape_for_json (const char *utf8, /* IN */
    end = utf8 + utf8_len;
 
    while (utf8 < end) {
+      uint8_t mask;
+      uint8_t length_of_char;
+
       // Check if expected char length goes past end
       _bson_utf8_get_sequence (utf8, &length_of_char, &mask);
-      if (utf8 + length_of_char > end) {
+      if (utf8 > end - length_of_char) {
          goto invalid_utf8;
       }
 

--- a/src/libbson/src/bson/bson-utf8.c
+++ b/src/libbson/src/bson/bson-utf8.c
@@ -245,7 +245,7 @@ bson_utf8_validate (const char *utf8, /* IN */
  *       two byte UTF-8 sequence.
  *
  * Parameters:
- *       @utf8: A UTF-8 encoded string.
+ *       @utf8: A validated UTF-8 encoded string.
  *       @utf8_len: The length of @utf8 in bytes or -1 if NUL terminated.
  *
  * Returns:

--- a/src/libbson/tests/test-utf8.c
+++ b/src/libbson/tests/test-utf8.c
@@ -66,6 +66,10 @@ test_bson_utf8_escape_for_json (void)
    BSON_ASSERT (0 == memcmp (str, "my\\u0000key", 7));
    bson_free (str);
 
+   str = bson_utf8_escape_for_json ("my\xc0\x80key", 7);
+   BSON_ASSERT (0 == memcmp (str, "my\\u0000key", strlen (str)));
+   bson_free (str);
+
    str = bson_utf8_escape_for_json ("my\"key", 6);
    BSON_ASSERT (0 == memcmp (str, "my\\\"key", 8));
    bson_free (str);
@@ -85,8 +89,14 @@ test_bson_utf8_escape_for_json (void)
    // Invalid UTF-8 strings (should return null)
 
    // 2 bytes expected
-   str = bson_utf8_escape_for_json ("\xc2", -1);
-   BSON_ASSERT (!str);
+   {
+      str = bson_utf8_escape_for_json ("\xc2", -1);
+      BSON_ASSERT (!str);
+
+      str = bson_utf8_escape_for_json ("\xc3\xa9", -1);
+      BSON_ASSERT (str);
+      bson_free (str);
+   }
 
    // 3 bytes expected
    {
@@ -95,6 +105,10 @@ test_bson_utf8_escape_for_json (void)
 
       str = bson_utf8_escape_for_json ("\xed\x90", -1);
       BSON_ASSERT (!str);
+
+      str = bson_utf8_escape_for_json ("\xe4\xb8\xad", -1);
+      BSON_ASSERT (str);
+      bson_free (str);
    }
 
    // 4 bytes expected
@@ -107,12 +121,11 @@ test_bson_utf8_escape_for_json (void)
 
       str = bson_utf8_escape_for_json ("\xf0\x9f\x9f", -1);
       BSON_ASSERT (!str);
-   }
 
-   // Convert both types of null chars (0x0 and 0xc0 0x80) to correct unicode
-   str = bson_utf8_escape_for_json ("\x0\xc0\x80", 3);
-   BSON_ASSERT (0 == memcmp (str, "\\u0000\\u0000", 4));
-   bson_free (str);
+      str = bson_utf8_escape_for_json ("\xf0\xa0\x9c\x8f", -1);
+      BSON_ASSERT (str);
+      bson_free (str);
+   }
 }
 
 

--- a/src/libbson/tests/test-utf8.c
+++ b/src/libbson/tests/test-utf8.c
@@ -104,6 +104,11 @@ test_bson_utf8_escape_for_json (void)
 
    str = bson_utf8_escape_for_json ("\xf0\x9f\x9f", -1);
    BSON_ASSERT (!str);
+
+   // Convert both types of null chars (0x0 and 0xc0 0x80) to correct unicode
+   str = bson_utf8_escape_for_json ("\x0\xc0\x80", 3);
+   BSON_ASSERT (0 == memcmp (str, "\\u0000\\u0000", 4));
+   bson_free (str);
 }
 
 

--- a/src/libbson/tests/test-utf8.c
+++ b/src/libbson/tests/test-utf8.c
@@ -89,21 +89,25 @@ test_bson_utf8_escape_for_json (void)
    BSON_ASSERT (!str);
 
    // 3 bytes expected
-   str = bson_utf8_escape_for_json ("\xed", -1);
-   BSON_ASSERT (!str);
+   {
+      str = bson_utf8_escape_for_json ("\xed", -1);
+      BSON_ASSERT (!str);
 
-   str = bson_utf8_escape_for_json ("\xed\x90", -1);
-   BSON_ASSERT (!str);
+      str = bson_utf8_escape_for_json ("\xed\x90", -1);
+      BSON_ASSERT (!str);
+   }
 
    // 4 bytes expected
-   str = bson_utf8_escape_for_json ("\xf0", -1);
-   BSON_ASSERT (!str);
+   {
+      str = bson_utf8_escape_for_json ("\xf0", -1);
+      BSON_ASSERT (!str);
 
-   str = bson_utf8_escape_for_json ("\xf0\x9f", -1);
-   BSON_ASSERT (!str);
+      str = bson_utf8_escape_for_json ("\xf0\x9f", -1);
+      BSON_ASSERT (!str);
 
-   str = bson_utf8_escape_for_json ("\xf0\x9f\x9f", -1);
-   BSON_ASSERT (!str);
+      str = bson_utf8_escape_for_json ("\xf0\x9f\x9f", -1);
+      BSON_ASSERT (!str);
+   }
 
    // Convert both types of null chars (0x0 and 0xc0 0x80) to correct unicode
    str = bson_utf8_escape_for_json ("\x0\xc0\x80", 3);

--- a/src/libbson/tests/test-utf8.c
+++ b/src/libbson/tests/test-utf8.c
@@ -63,67 +63,65 @@ test_bson_utf8_escape_for_json (void)
    char *unescaped = "\x0e";
 
    str = bson_utf8_escape_for_json ("my\0key", 6);
-   BSON_ASSERT (0 == memcmp (str, "my\\u0000key", 7));
+   ASSERT_CMPSTR (str, "my\\u0000key");
    bson_free (str);
 
    str = bson_utf8_escape_for_json ("my\xc0\x80key", 7);
-   BSON_ASSERT (0 == memcmp (str, "my\\u0000key", strlen (str)));
+   ASSERT_CMPSTR (str, "my\\u0000key");
    bson_free (str);
 
    str = bson_utf8_escape_for_json ("my\"key", 6);
-   BSON_ASSERT (0 == memcmp (str, "my\\\"key", 8));
+   ASSERT_CMPSTR (str, "my\\\"key");
    bson_free (str);
 
    str = bson_utf8_escape_for_json ("my\\key", 6);
-   BSON_ASSERT (0 == memcmp (str, "my\\\\key", 8));
+   ASSERT_CMPSTR (str, "my\\\\key");
    bson_free (str);
 
    str = bson_utf8_escape_for_json ("\\\"\\\"", -1);
-   BSON_ASSERT (0 == memcmp (str, "\\\\\\\"\\\\\\\"", 9));
+   ASSERT_CMPSTR (str, "\\\\\\\"\\\\\\\"");
    bson_free (str);
 
    str = bson_utf8_escape_for_json (unescaped, -1);
-   BSON_ASSERT (0 == memcmp (str, "\\u000e", 7));
+   ASSERT_CMPSTR (str, "\\u000e");
    bson_free (str);
-
-   // Invalid UTF-8 strings (should return null)
 
    // 2 bytes expected
    {
       str = bson_utf8_escape_for_json ("\xc2", -1);
-      BSON_ASSERT (!str);
+      ASSERT (!str);
 
       str = bson_utf8_escape_for_json ("\xc3\xa9", -1);
-      BSON_ASSERT (str);
+      ASSERT_CMPSTR (str, "é");
       bson_free (str);
    }
 
    // 3 bytes expected
    {
       str = bson_utf8_escape_for_json ("\xed", -1);
-      BSON_ASSERT (!str);
+      ASSERT (!str);
 
       str = bson_utf8_escape_for_json ("\xed\x90", -1);
-      BSON_ASSERT (!str);
+      ASSERT (!str);
 
       str = bson_utf8_escape_for_json ("\xe4\xb8\xad", -1);
-      BSON_ASSERT (str);
+      ASSERT_CMPSTR (str, "中");
       bson_free (str);
    }
 
    // 4 bytes expected
    {
       str = bson_utf8_escape_for_json ("\xf0", -1);
-      BSON_ASSERT (!str);
+      ASSERT (!str);
 
       str = bson_utf8_escape_for_json ("\xf0\x9f", -1);
-      BSON_ASSERT (!str);
+      ASSERT (!str);
 
       str = bson_utf8_escape_for_json ("\xf0\x9f\x9f", -1);
-      BSON_ASSERT (!str);
+      ASSERT (!str);
 
       str = bson_utf8_escape_for_json ("\xf0\xa0\x9c\x8f", -1);
-      BSON_ASSERT (str);
+      ASSERT_CMPSTR (str, "𠜏");
       bson_free (str);
    }
 }

--- a/src/libbson/tests/test-utf8.c
+++ b/src/libbson/tests/test-utf8.c
@@ -81,6 +81,29 @@ test_bson_utf8_escape_for_json (void)
    str = bson_utf8_escape_for_json (unescaped, -1);
    BSON_ASSERT (0 == memcmp (str, "\\u000e", 7));
    bson_free (str);
+
+   // Invalid UTF-8 strings (should return null)
+
+   // 2 bytes expected
+   str = bson_utf8_escape_for_json ("\xc2", -1);
+   BSON_ASSERT (!str);
+
+   // 3 bytes expected
+   str = bson_utf8_escape_for_json ("\xed", -1);
+   BSON_ASSERT (!str);
+
+   str = bson_utf8_escape_for_json ("\xed\x90", -1);
+   BSON_ASSERT (!str);
+
+   // 4 bytes expected
+   str = bson_utf8_escape_for_json ("\xf0", -1);
+   BSON_ASSERT (!str);
+
+   str = bson_utf8_escape_for_json ("\xf0\x9f", -1);
+   BSON_ASSERT (!str);
+
+   str = bson_utf8_escape_for_json ("\xf0\x9f\x9f", -1);
+   BSON_ASSERT (!str);
 }
 
 


### PR DESCRIPTION
# Summary
This ticket patches an issue in `bson_utf8_escape_for_json` that causes a crash for some invalid inputs. 

See [CDRIVER-5713](https://jira.mongodb.org/browse/CDRIVER-5713)