### PR TITLE
CDRIVER-5694 deprecate use of `ENABLE_SSL=LIBRESSL`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,8 @@ mongo_setting(
          message(WARNING "ENABLE_SSL=DARWIN is only supported on Apple platforms")
       elseif(ENABLE_SSL STREQUAL "WINDOWS" AND NOT WIN32)
          message(WARNING "ENABLE_SSL=WINDOWS is only supported on Windows platforms")
+      elseif (ENABLE_SSL STREQUAL "LIBRESSL")
+         message(DEPRECATION "ENABLE_SSL=LIBRESSL is deprecated and may be removed in a future major release")
       endif()
    ]]
 )

--- a/NEWS
+++ b/NEWS
@@ -33,6 +33,8 @@ Deprecated:
 
   * A future minor release plans to drop support for Visual Studio 2013.
 
+  * `ENABLE_SSL=LIBRESSL` is deprecated along with `mongoc_stream_tls_libressl_new`. Support for LibreSSL may be dropped in a future major release.
+
 libmongoc 1.27.6
 ================
 

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -180,6 +180,7 @@ function(_auto_pick_tls_lib)
          # No OpenSSL. What about LibreSSL?
          find_package(LibreSSL)
          if(LibreSSL_FOUND)
+            message(DEPRECATION "LibreSSL was automatically chosen as the TLS library. Support for LibreSSL is deprecated and may be removed in a future major release. Use ENABLE_SSL option to specify a different TLS library.")
             _use_named_tls_lib(LIBRESSL)
          endif()
       endif()

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-libressl.h
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-libressl.h
@@ -29,7 +29,7 @@ BSON_BEGIN_DECLS
 
 MONGOC_EXPORT (mongoc_stream_t *)
 mongoc_stream_tls_libressl_new (mongoc_stream_t *base_stream, const char *host, mongoc_ssl_opt_t *opt, int client)
-   BSON_GNUC_WARN_UNUSED_RESULT;
+   BSON_GNUC_DEPRECATED BSON_GNUC_WARN_UNUSED_RESULT;
 
 BSON_END_DECLS
 

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls.c
@@ -42,6 +42,7 @@
 #include "mongoc-stream-tls-secure-channel.h"
 #endif
 #include "mongoc-stream-tls.h"
+#include "mongoc-util-private.h" // BEGIN_IGNORE_DEPRECATIONS
 
 #undef MONGOC_LOG_DOMAIN
 #define MONGOC_LOG_DOMAIN "stream-tls"
@@ -206,7 +207,9 @@ mongoc_stream_tls_new_with_hostname (mongoc_stream_t *base_stream, const char *h
 #if defined(MONGOC_ENABLE_SSL_OPENSSL)
    return mongoc_stream_tls_openssl_new (base_stream, host, opt, client);
 #elif defined(MONGOC_ENABLE_SSL_LIBRESSL)
+   BEGIN_IGNORE_DEPRECATIONS
    return mongoc_stream_tls_libressl_new (base_stream, host, opt, client);
+   END_IGNORE_DEPRECATIONS
 #elif defined(MONGOC_ENABLE_SSL_SECURE_TRANSPORT)
    return mongoc_stream_tls_secure_transport_new (base_stream, host, opt, client);
 #elif defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)


### PR DESCRIPTION
**Summary**
Deprecate the CMake configuration `ENABLE_SSL=LIBRESSL` and function `mongoc_stream_tls_libressl_new`.

Verified by this [patch build](https://spruce.mongodb.com/version/66df176a75c93d00079e20d3).

**Motivation**
Removal of `ENABLE_SSL=LIBRESSL` is proposed for [C driver 2.0](https://docs.google.com/document/d/121Oc5VQdHZ63PS62gDWozt8FbCKrK_MRe-iJUNmoCfM/edit)