### PR TITLE
CDRIVER-5696 deprecate `ENABLE_SASL=CYRUS` on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,9 @@ mongo_setting(
       if(ENABLE_SASL STREQUAL "SSPI" AND NOT WIN32)
          message(WARNING "ENABLE_SASL=SSPI is only supported on Windows platforms")
       endif()
+      if(ENABLE_SASL STREQUAL "CYRUS" AND WIN32)
+         message(DEPRECATION "ENABLE_SASL=CYRUS on Windows platforms is deprecated and may be removed in a future major release")
+      endif()
    ]]
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,11 @@ mongo_setting(
 mongo_setting(CYRUS_PLUGIN_PATH_PREFIX "An absolute path prefix to enable loading Cyrus SASL plugins on Windows"
    TYPE STRING
    VISIBLE_IF [[ENABLE_SASL STREQUAL "CYRUS" AND WIN32]]
+   VALIDATE CODE [[
+      if (CYRUS_PLUGIN_PATH_PREFIX)
+         message(DEPRECATION "CYRUS_PLUGIN_PATH_PREFIX is deprecated and may be removed in a future major release")
+      endif ()
+   ]]
 )
 
 mongo_setting(ENABLE_CLIENT_SIDE_ENCRYPTION "Enable In-Use Encryption support. Requires additional support libraries."

--- a/NEWS
+++ b/NEWS
@@ -33,6 +33,9 @@ Deprecated:
 
   * A future minor release plans to drop support for Visual Studio 2013.
 
+  * `ENABLE_SASL=CYRUS` on Windows platforms is deprecated. Support for `ENABLE_SASL=CYRUS` on Windows may be dropped in a future major release.
+    * The associated Windows-only option `CYRUS_PLUGIN_PATH_PREFIX` is deprecated.
+
 libmongoc 1.27.6
 ================
 


### PR DESCRIPTION
Deprecates `ENABLE_SASL=CYRUS` on Windows and the Windows-only option `CYRUS_PLUGIN_PATH_PREFIX`.

See CDRIVER-5696 for rationale.