### PR TITLE
CDRIVER-5727 zero `parts->assembled.payload`

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-cmd.c
@@ -56,6 +56,7 @@ mongoc_cmd_parts_init (mongoc_cmd_parts_t *parts,
    parts->assembled.query_flags = MONGOC_QUERY_NONE;
    parts->assembled.op_msg_is_exhaust = false;
    parts->assembled.payloads_count = 0;
+   memset (parts->assembled.payloads, 0, sizeof parts->assembled.payloads);
    parts->assembled.session = NULL;
    parts->assembled.is_acknowledged = true;
    parts->assembled.is_txn_finish = false;


### PR DESCRIPTION
To silence Coverity warning of uninitialized variable. See issue with CID 118911.

I expect the reported issue is a false positive. The report notes a possible uninitialized read of [cmd->payloads[i]](https://github.com/mongodb/mongo-c-driver/blob/a2ecf927d6e2a8709621b2b6be7158ca3ce9a265/src/libmongoc/src/mongoc/mongoc-cluster.c#L3251).  `mongoc_cmd_parts_init` sets `cmd->payloads_count` to 0. All assignments of `cmd->payloads_count` appear to initialize the associated `cmd->payloads`. Regardless, this change zeros the payloads struct to silence the warning.

This is cherry-picked from the commit e45fd98b0884342881991d568ba291d8025b88a6. e45fd98b0884342881991d568ba291d8025b88a6 appears to have been unexpectedly committed to `r1.27` without being applied to `master`.