### PR TITLE
CDRIVER-5733 fix behavior of `bson_string_truncate`

### DIFF
--- a/src/libbson/doc/bson_string_append.rst
+++ b/src/libbson/doc/bson_string_append.rst
@@ -22,4 +22,4 @@ Description
 
 Appends the ASCII or UTF-8 encoded string ``str`` to ``string``. This is not suitable for embedding NULLs in strings.
 
-.. warning:: This function will abort if the length of the resulting string (including the NULL terminator) would exceed ``UINT32_MAX``.
+.. warning:: The length of the resulting string (including the ``NULL`` terminator) MUST NOT exceed ``UINT32_MAX``.

--- a/src/libbson/doc/bson_string_append_c.rst
+++ b/src/libbson/doc/bson_string_append_c.rst
@@ -22,4 +22,4 @@ Description
 
 Appends ``c`` to the string builder ``string``.
 
-.. warning:: This function will abort if the length of the resulting string (including the NULL terminator) would exceed ``UINT32_MAX``.
+.. warning:: The length of the resulting string (including the ``NULL`` terminator) MUST NOT exceed ``UINT32_MAX``.

--- a/src/libbson/doc/bson_string_append_printf.rst
+++ b/src/libbson/doc/bson_string_append_printf.rst
@@ -23,4 +23,4 @@ Description
 
 Like bson_string_append() but formats a printf style string and then appends that to ``string``.
 
-.. warning:: This function will abort if the length of the resulting string (including the NULL terminator) would exceed ``UINT32_MAX``.
+.. warning:: The length of the resulting string (including the ``NULL`` terminator) MUST NOT exceed ``UINT32_MAX``.

--- a/src/libbson/doc/bson_string_append_unichar.rst
+++ b/src/libbson/doc/bson_string_append_unichar.rst
@@ -22,4 +22,4 @@ Description
 
 Appends a unicode character to string. The character will be encoded into its multi-byte UTF-8 representation.
 
-.. warning:: This function will abort if the length of the resulting string (including the NULL terminator) would exceed ``UINT32_MAX``.
+.. warning:: The length of the resulting string (including the ``NULL`` terminator) MUST NOT exceed ``UINT32_MAX``.

--- a/src/libbson/doc/bson_string_new.rst
+++ b/src/libbson/doc/bson_string_new.rst
@@ -21,7 +21,7 @@ Description
 
 Creates a new string builder, which uses power-of-two growth of buffers. Use the various bson_string_append*() functions to append to the string.
 
-.. warning:: This function will abort if the length of the resulting string (including the NULL terminator) would exceed ``UINT32_MAX``.
+.. warning:: The length of the resulting string (including the ``NULL`` terminator) MUST NOT exceed ``UINT32_MAX``.
 
 Returns
 -------

--- a/src/libbson/doc/bson_string_truncate.rst
+++ b/src/libbson/doc/bson_string_truncate.rst
@@ -24,4 +24,4 @@ Truncates the string so that it is ``len`` bytes in length. This must be smaller
 
 A ``\0`` byte will be placed where the end of the string occurs.
 
-.. warning:: This function will abort if the length of the resulting string (including the NULL terminator) would exceed ``UINT32_MAX``.
+.. warning:: The length of the resulting string (including the ``NULL`` terminator) MUST NOT exceed ``UINT32_MAX``.

--- a/src/libbson/doc/bson_string_truncate.rst
+++ b/src/libbson/doc/bson_string_truncate.rst
@@ -24,3 +24,4 @@ Truncates the string so that it is ``len`` bytes in length. This must be smaller
 
 A ``\0`` byte will be placed where the end of the string occurs.
 
+.. warning:: This function will abort if the length of the resulting string (including the NULL terminator) would exceed ``UINT32_MAX``.

--- a/src/libbson/src/bson/bson-string.c
+++ b/src/libbson/src/bson/bson-string.c
@@ -312,7 +312,7 @@ bson_string_truncate (bson_string_t *string, /* IN */
       return;
    }
    uint32_t needed = len;
-   BSON_ASSERT (needed <= UINT32_MAX - 1u);
+   BSON_ASSERT (needed < UINT32_MAX);
    needed += 1u; // Add one for trailing NULL byte.
    uint32_t alloc = bson_next_power_of_two_u32 (needed);
    if (alloc == 0) {

--- a/src/libbson/src/bson/bson-string.c
+++ b/src/libbson/src/bson/bson-string.c
@@ -292,7 +292,7 @@ bson_string_append_printf (bson_string_t *string, const char *format, ...)
  *       Truncate the string @string to @len bytes.
  *
  *       The underlying memory will be released via realloc() down to
- *       the minimum required size specified by @len.
+ *       the minimum required size (at power-of-two boundary) specified by @len.
  *
  * Returns:
  *       None.

--- a/src/libbson/src/bson/bson-string.c
+++ b/src/libbson/src/bson/bson-string.c
@@ -308,6 +308,9 @@ bson_string_truncate (bson_string_t *string, /* IN */
                       uint32_t len)          /* IN */
 {
    BSON_ASSERT_PARAM (string);
+   if (len == string->len) {
+      return;
+   }
    uint32_t needed = len;
    BSON_ASSERT (needed <= UINT32_MAX - 1u);
    needed += 1u; // Add one for trailing NULL byte.

--- a/src/libbson/src/bson/bson-string.c
+++ b/src/libbson/src/bson/bson-string.c
@@ -307,19 +307,14 @@ void
 bson_string_truncate (bson_string_t *string, /* IN */
                       uint32_t len)          /* IN */
 {
-   uint32_t alloc;
-
-   BSON_ASSERT (string);
-   BSON_ASSERT (len < INT_MAX);
-
-   alloc = len + 1;
-
-   if (alloc < 16) {
-      alloc = 16;
-   }
-
-   if (!bson_is_power_of_two (alloc)) {
-      alloc = (uint32_t) bson_next_power_of_two ((size_t) alloc);
+   BSON_ASSERT_PARAM (string);
+   uint32_t needed = len;
+   BSON_ASSERT (needed <= UINT32_MAX - 1u);
+   needed += 1u; // Add one for trailing NULL byte.
+   uint32_t alloc = bson_next_power_of_two_u32 (needed);
+   if (alloc == 0) {
+      // Overflowed: saturate at UINT32_MAX.
+      alloc = UINT32_MAX;
    }
 
    string->str = bson_realloc (string->str, alloc);

--- a/src/libbson/tests/test-string.c
+++ b/src/libbson/tests/test-string.c
@@ -356,6 +356,16 @@ test_bson_string_capacity (void *unused)
       large_str[UINT32_MAX - 2u] = 's'; // Restore.
    }
 
+   // Can truncate strings of length close to UINT32_MAX - 1.
+   {
+      large_str[UINT32_MAX - 1u] = '\0'; // Set size.
+      bson_string_t *str = bson_string_new (large_str);
+      bson_string_truncate (str, UINT32_MAX - 2); // Truncate one character.
+      ASSERT_CMPSIZE_T (strlen (str->str), ==, UINT32_MAX - 2u);
+      bson_string_free (str, true);
+      large_str[UINT32_MAX - 1u] = 's'; // Restore.
+   }
+
    bson_free (large_str);
 }
 


### PR DESCRIPTION
Fixes behavior of `bson_string_truncate` with large lengths. Verified with [this patch build](https://spruce.mongodb.com/version/66f186c226f05a00072fb0a4). See CDRIVER-5733 for details.

Also adds tests for behavior of `bson_string_truncate`. In the process of this fix, other unexpected behavior was observed: `bson_string_truncate` [documents](https://mongoc.org/libbson/1.28.0/bson_string_truncate.html) the truncated length "must be smaller or equal to the current length of the string.". However, `bson_string_truncate` does not reject greater lengths.
```c
bson_string_t *str = bson_string_new ("a");
bson_string_truncate (str, 2u); // Is not rejected.
ASSERT_CMPUINT32 (str->len, ==, 2u);
ASSERT_CMPUINT32 (str->alloc, ==, 4u);
bson_string_free (str, true);
```
This behavior is preserved (and now tested) for backwards compatibility. I expect there may be a possible use-case for calling `bson_string_truncate` with larger lengths to reserve space.
