### PR TITLE
CDRIVER-5579 sync $out aggregation spec tests

### DIFF
--- a/src/libmongoc/tests/json/crud/unified/aggregate-write-readPreference.json
+++ b/src/libmongoc/tests/json/crud/unified/aggregate-write-readPreference.json
@@ -78,11 +78,6 @@
           "x": 33
         }
       ]
-    },
-    {
-      "collectionName": "coll1",
-      "databaseName": "db0",
-      "documents": []
     }
   ],
   "tests": [
@@ -159,22 +154,6 @@
             }
           ]
         }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll1",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 2,
-              "x": 22
-            },
-            {
-              "_id": 3,
-              "x": 33
-            }
-          ]
-        }
       ]
     },
     {
@@ -247,22 +226,6 @@
                   }
                 }
               }
-            }
-          ]
-        }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll1",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 2,
-              "x": 22
-            },
-            {
-              "_id": 3,
-              "x": 33
             }
           ]
         }
@@ -344,22 +307,6 @@
             }
           ]
         }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll1",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 2,
-              "x": 22
-            },
-            {
-              "_id": 3,
-              "x": 33
-            }
-          ]
-        }
       ]
     },
     {
@@ -435,22 +382,6 @@
                   }
                 }
               }
-            }
-          ]
-        }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll1",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 2,
-              "x": 22
-            },
-            {
-              "_id": 3,
-              "x": 33
             }
           ]
         }

--- a/src/libmongoc/tests/json/crud/unified/db-aggregate-write-readPreference.json
+++ b/src/libmongoc/tests/json/crud/unified/db-aggregate-write-readPreference.json
@@ -52,13 +52,6 @@
       }
     }
   ],
-  "initialData": [
-    {
-      "collectionName": "coll0",
-      "databaseName": "db0",
-      "documents": []
-    }
-  ],
   "tests": [
     {
       "description": "Database-level aggregate with $out includes read preference for 5.0+ server",
@@ -138,17 +131,6 @@
                   }
                 }
               }
-            }
-          ]
-        }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll0",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 1
             }
           ]
         }
@@ -232,17 +214,6 @@
                   }
                 }
               }
-            }
-          ]
-        }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll0",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 1
             }
           ]
         }
@@ -332,17 +303,6 @@
             }
           ]
         }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll0",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 1
-            }
-          ]
-        }
       ]
     },
     {
@@ -426,17 +386,6 @@
                   }
                 }
               }
-            }
-          ]
-        }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll0",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 1
             }
           ]
         }


### PR DESCRIPTION
# Summary
This PR will sync two spec tests to match the changes made in https://github.com/mongodb/specifications/commit/30b3a75291794794152c377854df9fee1ccc6875.

# Background
See DRIVERS-2914. Server 8.0 requires aggregation tests with `$out` to not pre-create the output collection.