### PR TITLE
CDRIVER-5715 deprecate defining `BSON_MEMCHECK`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,10 @@
 libmongoc 1.29.0 (unreleased)
 =============================
 
+Deprecated:
+
+  * Compiling with `BSON_MEMCHECK` defined is deprecated.
+
 Platform Support:
 
   * Support for Visual Studio 2013 is dropped.

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -27,6 +27,11 @@
 #include <string.h>
 #include <math.h>
 
+#ifdef BSON_MEMCHECK
+#pragma message( \
+   "Do not define BSON_MEMCHECK. BSON_MEMCHECK changes the data layout of bson_t. BSON_MEMCHECK is deprecated may be removed in a future major release")
+#endif
+
 
 #ifndef BSON_MAX_RECURSION
 #define BSON_MAX_RECURSION 200


### PR DESCRIPTION
Deprecate defining `BSON_MEMCHECK` when building libbson. See CDRIVER-5715 for rationale.

When building with the C flag `-DBSON_MEMCHECK=1`, a warning is now produced:
```
/Users/kevin.albertson/code/tasks/mongo-c-driver-2.0/src/libbson/src/bson/bson.c:31:9: warning: Do not define BSON_MEMCHECK. BSON_MEMCHECK changes the data layout of bson_t. BSON_MEMCHECK is deprecated may be removed in a future major release [-W#pragma-messages]
   31 | #pragma message( \
      |         ^
1 warning generated.
```