### PR TITLE
CDRIVER-5740 fix fprintf call

### DIFF
--- a/src/libmongoc/tests/TestSuite.c
+++ b/src/libmongoc/tests/TestSuite.c
@@ -828,7 +828,6 @@ TestSuite_PrintJsonHeader (TestSuite *suite, /* IN */
             "    \"futureTimeoutMS\": %" PRIu64 ",\n"
             "    \"majorityReadConcern\": %s,\n"
             "    \"skipLiveTests\": %s,\n"
-            "    \"IPv6\": %s\n"
             "  },\n"
             "  \"options\": {\n"
             "    \"fork\": %s,\n"


### PR DESCRIPTION
Minor follow-up to https://github.com/mongodb/mongo-c-driver/pull/1742 to address:

```
../../../src/libmongoc/tests/TestSuite.c: In function 'TestSuite_PrintJsonHeader':
../../../src/libmongoc/tests/TestSuite.c:862:13: error: format '%s' expects a matching 'char *' argument [-Werror=format=]
             getenv_or ("MONGODB_API_VERSION", "null"));
             ^
```