### PR TITLE
CDRIVER-5740 Remove stray references to MONGOC_CHECK_IPV6

### DIFF
--- a/.evergreen/scripts/run-tests.sh
+++ b/.evergreen/scripts/run-tests.sh
@@ -54,7 +54,6 @@ export MONGOC_TEST_URI="${URI}"
 export MONGOC_TEST_SERVER_LOG="json"
 export MONGOC_TEST_SKIP_MOCK="on"
 export MONGOC_TEST_IPV4_AND_IPV6_HOST="ipv4_and_ipv6.test.build.10gen.cc"
-export MONGOC_CHECK_IPV6="on"
 
 # Only set creds if testing with Client Side Encryption.
 # libmongoc may build with CSE enabled (if the host has libmongocrypt installed)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,10 +227,6 @@ Some tests run against a local mock server, these can be skipped with:
 
 * `MONGOC_TEST_SKIP_MOCK=on`
 
-If you have started with MongoDB with `--ipv6`, you can test IPv6 with:
-
-* `MONGOC_CHECK_IPV6=on`
-
 The tests for mongodb+srv:// connection strings require some setup, see the
 Initial DNS Seedlist Discovery Spec. By default these connection strings are
 NOT tested, enable them with:


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1742 which missed removal of some references to `MONGOC_CHECK_IPV6`.