### PR TITLE
CDRIVER-5697 deprecate `bson_string_t`

### DIFF
--- a/.evergreen/scripts/compile-libmongocrypt.sh
+++ b/.evergreen/scripts/compile-libmongocrypt.sh
@@ -9,7 +9,12 @@ compile_libmongocrypt() {
   # libmongocrypt's kms-message in `src/kms-message`. Run
   # `.evergreen/scripts/kms-divergence-check.sh` to ensure that there is no
   # divergence in the copied files.
-  git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.11.0 || return
+  # TODO: once 1.12.0 is released replace the following with:
+  # git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.12.0 || return
+  {
+    git clone -q https://github.com/mongodb/libmongocrypt || return
+    git -C libmongocrypt checkout bca8e7dc1ecb7b1c039132e07de5e0db2703c701
+  }
 
   declare -a crypt_cmake_flags=(
     "-DMONGOCRYPT_MONGOC_DIR=${mongoc_dir}"

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,7 @@ libmongoc 1.29.0 (unreleased)
 Deprecated:
 
   * Compiling with `BSON_MEMCHECK` defined is deprecated.
+  * `bson_string_t` and associated functions.
 
 Platform Support:
 

--- a/src/common/common-macros-private.h
+++ b/src/common/common-macros-private.h
@@ -55,4 +55,17 @@
 #endif // __has_warning("-Wcast-function-type-strict")
 #endif // defined(__clang__)
 
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+#define BEGIN_IGNORE_DEPRECATIONS \
+   _Pragma ("GCC diagnostic push") _Pragma ("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#define END_IGNORE_DEPRECATIONS _Pragma ("GCC diagnostic pop")
+#elif defined(__clang__)
+#define BEGIN_IGNORE_DEPRECATIONS \
+   _Pragma ("clang diagnostic push") _Pragma ("clang diagnostic ignored \"-Wdeprecated-declarations\"")
+#define END_IGNORE_DEPRECATIONS _Pragma ("clang diagnostic pop")
+#else
+#define BEGIN_IGNORE_DEPRECATIONS
+#define END_IGNORE_DEPRECATIONS
+#endif
+
 #endif /* COMMON_MACROS_PRIVATE_H */

--- a/src/common/mcd-string.h
+++ b/src/common/mcd-string.h
@@ -19,13 +19,8 @@
 #ifndef MCD_STRING_H
 #define MCD_STRING_H
 
-#pragma push_macro("BSON_INSIDE")
-#undef BSON_INSIDE
-#define BSON_INSIDE 1
-#include <bson/bson-private.h> // BEGIN_IGNORE_DEPRECATIONS
-#include <bson/bson-string.h>
-#undef BSON_INSIDE
-#pragma pop_macro("BSON_INSIDE")
+#include <bson/bson.h>
+#include "common-macros-private.h" // BEGIN_IGNORE_DEPRECATIONS
 
 // mcd_string_t is an internal string type intended to replace the deprecated bson_string_t.
 // When bson_string_t is removed, migrate the implementation to mcd_string_t.

--- a/src/common/mcd-string.h
+++ b/src/common/mcd-string.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2009-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "common-prelude.h"
+
+#ifndef MCD_STRING_H
+#define MCD_STRING_H
+
+#pragma push_macro("BSON_INSIDE")
+#undef BSON_INSIDE
+#define BSON_INSIDE 1
+#include <bson/bson-private.h> // BEGIN_IGNORE_DEPRECATIONS
+#include <bson/bson-string.h>
+#undef BSON_INSIDE
+#pragma pop_macro("BSON_INSIDE")
+
+// mcd_string_t is an internal string type intended to replace the deprecated bson_string_t.
+// When bson_string_t is removed, migrate the implementation to mcd_string_t.
+typedef bson_string_t mcd_string_t;
+
+static BSON_INLINE mcd_string_t *
+mcd_string_new (const char *str)
+{
+   BEGIN_IGNORE_DEPRECATIONS
+   return bson_string_new (str);
+   END_IGNORE_DEPRECATIONS
+}
+static BSON_INLINE char *
+mcd_string_free (mcd_string_t *string, bool free_segment)
+{
+   BEGIN_IGNORE_DEPRECATIONS
+   return bson_string_free (string, free_segment);
+   END_IGNORE_DEPRECATIONS
+}
+static BSON_INLINE void
+mcd_string_append (mcd_string_t *string, const char *str)
+{
+   BEGIN_IGNORE_DEPRECATIONS
+   bson_string_append (string, str);
+   END_IGNORE_DEPRECATIONS
+}
+static BSON_INLINE void
+mcd_string_append_c (mcd_string_t *string, char str)
+{
+   BEGIN_IGNORE_DEPRECATIONS
+   bson_string_append_c (string, str);
+   END_IGNORE_DEPRECATIONS
+}
+static BSON_INLINE void
+mcd_string_append_unichar (mcd_string_t *string, bson_unichar_t unichar)
+{
+   BEGIN_IGNORE_DEPRECATIONS
+   bson_string_append_unichar (string, unichar);
+   END_IGNORE_DEPRECATIONS
+}
+
+static BSON_INLINE void
+mcd_string_append_printf (mcd_string_t *string, const char *format, ...) BSON_GNUC_PRINTF (2, 3);
+
+static BSON_INLINE void
+mcd_string_append_printf (mcd_string_t *string, const char *format, ...)
+{
+   va_list args;
+   char *ret;
+
+   BSON_ASSERT_PARAM (string);
+   BSON_ASSERT_PARAM (format);
+
+   va_start (args, format);
+   ret = bson_strdupv_printf (format, args);
+   va_end (args);
+   BEGIN_IGNORE_DEPRECATIONS
+   bson_string_append (string, ret);
+   END_IGNORE_DEPRECATIONS
+   bson_free (ret);
+}
+
+static BSON_INLINE void
+mcd_string_truncate (mcd_string_t *string, uint32_t len)
+{
+   BEGIN_IGNORE_DEPRECATIONS
+   bson_string_truncate (string, len);
+   END_IGNORE_DEPRECATIONS
+}
+
+#endif /* MCD_STRING_H */

--- a/src/common/mcd-string.h
+++ b/src/common/mcd-string.h
@@ -20,7 +20,7 @@
 #define MCD_STRING_H
 
 #include <bson/bson.h>
-#include "common-macros-private.h" // BEGIN_IGNORE_DEPRECATIONS
+#include <common-macros-private.h> // BEGIN_IGNORE_DEPRECATIONS
 
 // mcd_string_t is an internal string type intended to replace the deprecated bson_string_t.
 // When bson_string_t is removed, migrate the implementation to mcd_string_t.

--- a/src/libbson/NEWS
+++ b/src/libbson/NEWS
@@ -1,3 +1,10 @@
+libbson 1.29.0 (Unreleased)
+===========================
+
+Deprecated:
+
+  * `bson_string_t` and associated functions are deprecated and planned for removal in a future major release.
+
 libbson 1.28.0
 ==============
 

--- a/src/libbson/doc/bson_string_append.rst
+++ b/src/libbson/doc/bson_string_append.rst
@@ -3,6 +3,11 @@
 bson_string_append()
 ====================
 
+.. warning::
+   .. deprecated:: 1.29.0
+
+      This function is deprecated and should not be used in new code.
+
 Synopsis
 --------
 

--- a/src/libbson/doc/bson_string_append_c.rst
+++ b/src/libbson/doc/bson_string_append_c.rst
@@ -3,6 +3,11 @@
 bson_string_append_c()
 ======================
 
+.. warning::
+   .. deprecated:: 1.29.0
+
+      This function is deprecated and should not be used in new code.
+
 Synopsis
 --------
 

--- a/src/libbson/doc/bson_string_append_printf.rst
+++ b/src/libbson/doc/bson_string_append_printf.rst
@@ -3,6 +3,11 @@
 bson_string_append_printf()
 ===========================
 
+.. warning::
+   .. deprecated:: 1.29.0
+
+      This function is deprecated and should not be used in new code.
+
 Synopsis
 --------
 

--- a/src/libbson/doc/bson_string_append_unichar.rst
+++ b/src/libbson/doc/bson_string_append_unichar.rst
@@ -3,6 +3,11 @@
 bson_string_append_unichar()
 ============================
 
+.. warning::
+   .. deprecated:: 1.29.0
+
+      This function is deprecated and should not be used in new code.
+
 Synopsis
 --------
 

--- a/src/libbson/doc/bson_string_free.rst
+++ b/src/libbson/doc/bson_string_free.rst
@@ -3,6 +3,11 @@
 bson_string_free()
 ==================
 
+.. warning::
+   .. deprecated:: 1.29.0
+
+      This function is deprecated and should not be used in new code.
+
 Synopsis
 --------
 

--- a/src/libbson/doc/bson_string_new.rst
+++ b/src/libbson/doc/bson_string_new.rst
@@ -3,6 +3,11 @@
 bson_string_new()
 =================
 
+.. warning::
+   .. deprecated:: 1.29.0
+
+      This function is deprecated and should not be used in new code.
+
 Synopsis
 --------
 

--- a/src/libbson/doc/bson_string_t.rst
+++ b/src/libbson/doc/bson_string_t.rst
@@ -3,6 +3,11 @@
 bson_string_t
 =============
 
+.. warning::
+   .. deprecated:: 1.29.0
+
+      This struct is deprecated and should not be used in new code.
+
 String Building Abstraction
 
 Synopsis

--- a/src/libbson/doc/bson_string_truncate.rst
+++ b/src/libbson/doc/bson_string_truncate.rst
@@ -3,6 +3,11 @@
 bson_string_truncate()
 ======================
 
+.. warning::
+   .. deprecated:: 1.29.0
+
+      This function is deprecated and should not be used in new code.
+
 Synopsis
 --------
 

--- a/src/libbson/src/bson/bson-decimal128.c
+++ b/src/libbson/src/bson/bson-decimal128.c
@@ -23,7 +23,7 @@
 #include <bson/bson-decimal128.h>
 #include <bson/bson-types.h>
 #include <bson/bson-macros.h>
-#include <bson/bson-string.h>
+#include <mcd-string.h>
 
 
 #define BSON_DECIMAL128_EXPONENT_MAX 6111

--- a/src/libbson/src/bson/bson-error.c
+++ b/src/libbson/src/bson/bson-error.c
@@ -22,7 +22,7 @@
 #include <bson/bson-config.h>
 #include <bson/bson-error.h>
 #include <bson/bson-memory.h>
-#include <bson/bson-string.h>
+#include <mcd-string.h>
 #include <bson/bson-types.h>
 
 // See `bson_strerror_r()` definition below.

--- a/src/libbson/src/bson/bson-iso8601-private.h
+++ b/src/libbson/src/bson/bson-iso8601-private.h
@@ -23,7 +23,7 @@
 
 #include <bson/bson-compat.h>
 #include <bson/bson-macros.h>
-#include <bson/bson-string.h>
+#include <mcd-string.h>
 
 
 BSON_BEGIN_DECLS
@@ -39,7 +39,7 @@ _bson_iso8601_date_parse (const char *str, int32_t len, int64_t *out, bson_error
  * Appends a date formatted like "2012-12-24T12:15:30.500Z" to @str.
  */
 void
-_bson_iso8601_date_format (int64_t msecs_since_epoch, bson_string_t *str);
+_bson_iso8601_date_format (int64_t msecs_since_epoch, mcd_string_t *str);
 
 BSON_END_DECLS
 

--- a/src/libbson/src/bson/bson-iso8601.c
+++ b/src/libbson/src/bson/bson-iso8601.c
@@ -282,7 +282,7 @@ _bson_iso8601_date_parse (const char *str, int32_t len, int64_t *out, bson_error
 
 
 void
-_bson_iso8601_date_format (int64_t msec_since_epoch, bson_string_t *str)
+_bson_iso8601_date_format (int64_t msec_since_epoch, mcd_string_t *str)
 {
    time_t t;
    int64_t msecs_part;
@@ -309,9 +309,9 @@ _bson_iso8601_date_format (int64_t msec_since_epoch, bson_string_t *str)
 #endif
 
    if (msecs_part) {
-      bson_string_append_printf (str, "%s.%03" PRId64 "Z", buf, msecs_part);
+      mcd_string_append_printf (str, "%s.%03" PRId64 "Z", buf, msecs_part);
    } else {
-      bson_string_append (str, buf);
-      bson_string_append_c (str, 'Z');
+      mcd_string_append (str, buf);
+      mcd_string_append_c (str, 'Z');
    }
 }

--- a/src/libbson/src/bson/bson-keys.c
+++ b/src/libbson/src/bson/bson-keys.c
@@ -18,7 +18,7 @@
 #include <stdio.h>
 
 #include <bson/bson-keys.h>
-#include <bson/bson-string.h>
+#include <mcd-string.h>
 #include <bson/bson-cmp.h>
 
 

--- a/src/libbson/src/bson/bson-oid.c
+++ b/src/libbson/src/bson/bson-oid.c
@@ -25,7 +25,7 @@
 
 #include <bson/bson-context-private.h>
 #include <bson/bson-oid.h>
-#include <bson/bson-string.h>
+#include <mcd-string.h>
 
 
 /*

--- a/src/libbson/src/bson/bson-private.h
+++ b/src/libbson/src/bson/bson-private.h
@@ -26,20 +26,6 @@
 #include <bson/bson-types.h>
 
 
-#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
-#define BEGIN_IGNORE_DEPRECATIONS \
-   _Pragma ("GCC diagnostic push") _Pragma ("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
-#define END_IGNORE_DEPRECATIONS _Pragma ("GCC diagnostic pop")
-#elif defined(__clang__)
-#define BEGIN_IGNORE_DEPRECATIONS \
-   _Pragma ("clang diagnostic push") _Pragma ("clang diagnostic ignored \"-Wdeprecated-declarations\"")
-#define END_IGNORE_DEPRECATIONS _Pragma ("clang diagnostic pop")
-#else
-#define BEGIN_IGNORE_DEPRECATIONS
-#define END_IGNORE_DEPRECATIONS
-#endif
-
-
 BSON_BEGIN_DECLS
 
 

--- a/src/libbson/src/bson/bson-string.c
+++ b/src/libbson/src/bson/bson-string.c
@@ -21,7 +21,7 @@
 #include <bson/bson-compat.h>
 #include <bson/bson-config.h>
 #include <bson/bson-cmp.h>
-#include <bson/bson-string.h>
+#include <mcd-string.h>
 #include <bson/bson-memory.h>
 #include <bson/bson-utf8.h>
 #include <bson/bson-string-private.h>
@@ -273,7 +273,7 @@ bson_string_append_c (bson_string_t *string, /* IN */
    if (BSON_UNLIKELY (string->alloc == (string->len + 1))) {
       cc[0] = c;
       cc[1] = '\0';
-      bson_string_append (string, cc);
+      mcd_string_append (string, cc);
       return;
    }
 
@@ -312,7 +312,7 @@ bson_string_append_unichar (bson_string_t *string,  /* IN */
 
    if (len <= 6) {
       str[len] = '\0';
-      bson_string_append (string, str);
+      mcd_string_append (string, str);
    }
 }
 
@@ -345,7 +345,7 @@ bson_string_append_printf (bson_string_t *string, const char *format, ...)
    va_start (args, format);
    ret = bson_strdupv_printf (format, args);
    va_end (args);
-   bson_string_append (string, ret);
+   mcd_string_append (string, ret);
    bson_free (ret);
 }
 

--- a/src/libbson/src/bson/bson-string.h
+++ b/src/libbson/src/bson/bson-string.h
@@ -38,19 +38,19 @@ typedef struct {
 
 
 BSON_EXPORT (bson_string_t *)
-bson_string_new (const char *str);
+bson_string_new (const char *str) BSON_GNUC_DEPRECATED;
 BSON_EXPORT (char *)
-bson_string_free (bson_string_t *string, bool free_segment);
+bson_string_free (bson_string_t *string, bool free_segment) BSON_GNUC_DEPRECATED;
 BSON_EXPORT (void)
-bson_string_append (bson_string_t *string, const char *str);
+bson_string_append (bson_string_t *string, const char *str) BSON_GNUC_DEPRECATED;
 BSON_EXPORT (void)
-bson_string_append_c (bson_string_t *string, char str);
+bson_string_append_c (bson_string_t *string, char str) BSON_GNUC_DEPRECATED;
 BSON_EXPORT (void)
-bson_string_append_unichar (bson_string_t *string, bson_unichar_t unichar);
+bson_string_append_unichar (bson_string_t *string, bson_unichar_t unichar) BSON_GNUC_DEPRECATED;
 BSON_EXPORT (void)
-bson_string_append_printf (bson_string_t *string, const char *format, ...) BSON_GNUC_PRINTF (2, 3);
+bson_string_append_printf (bson_string_t *string, const char *format, ...) BSON_GNUC_PRINTF (2, 3) BSON_GNUC_DEPRECATED;
 BSON_EXPORT (void)
-bson_string_truncate (bson_string_t *string, uint32_t len);
+bson_string_truncate (bson_string_t *string, uint32_t len) BSON_GNUC_DEPRECATED;
 BSON_EXPORT (char *)
 bson_strdup (const char *str);
 BSON_EXPORT (char *)

--- a/src/libbson/src/bson/bson-utf8.c
+++ b/src/libbson/src/bson/bson-utf8.c
@@ -18,7 +18,7 @@
 #include <string.h>
 
 #include <bson/bson-memory.h>
-#include <bson/bson-string.h>
+#include <mcd-string.h>
 #include <bson/bson-utf8.h>
 #include <bson/bson-string-private.h>
 
@@ -298,33 +298,33 @@ _is_special_char (unsigned char c)
  */
 
 static BSON_INLINE void
-_bson_utf8_handle_special_char (const uint8_t c,    /* IN */
-                                bson_string_t *str) /* OUT */
+_bson_utf8_handle_special_char (const uint8_t c,   /* IN */
+                                mcd_string_t *str) /* OUT */
 {
    BSON_ASSERT (c < 0x80u);
    BSON_ASSERT (str);
 
    switch (c) {
    case '"':
-      bson_string_append (str, "\\\"");
+      mcd_string_append (str, "\\\"");
       break;
    case '\\':
-      bson_string_append (str, "\\\\");
+      mcd_string_append (str, "\\\\");
       break;
    case '\b':
-      bson_string_append (str, "\\b");
+      mcd_string_append (str, "\\b");
       break;
    case '\f':
-      bson_string_append (str, "\\f");
+      mcd_string_append (str, "\\f");
       break;
    case '\n':
-      bson_string_append (str, "\\n");
+      mcd_string_append (str, "\\n");
       break;
    case '\r':
-      bson_string_append (str, "\\r");
+      mcd_string_append (str, "\\r");
       break;
    case '\t':
-      bson_string_append (str, "\\t");
+      mcd_string_append (str, "\\t");
       break;
    default: {
       // ASCII control character
@@ -390,7 +390,7 @@ bson_utf8_escape_for_json (const char *utf8, /* IN */
 
    const char *const end = utf8 + utf8_ulen;
 
-   bson_string_t *const str = _bson_string_alloc (utf8_ulen);
+   mcd_string_t *const str = _bson_string_alloc (utf8_ulen);
 
    size_t normal_chars_seen = 0u;
 
@@ -436,7 +436,7 @@ bson_utf8_escape_for_json (const char *utf8, /* IN */
             goto invalid_utf8;
          }
 
-         bson_string_append (str, "\\u0000");
+         mcd_string_append (str, "\\u0000");
          utf8_ulen -= *utf8 ? 2u : 1u;
          utf8 += *utf8 ? 2 : 1;
          continue;
@@ -453,7 +453,7 @@ bson_utf8_escape_for_json (const char *utf8, /* IN */
             goto invalid_utf8;
          }
 
-         bson_string_append_unichar (str, unichar);
+         mcd_string_append_unichar (str, unichar);
          utf8 = bson_utf8_next_char (utf8);
 
          char_len = (size_t) (utf8 - utf8_old);
@@ -475,10 +475,10 @@ bson_utf8_escape_for_json (const char *utf8, /* IN */
       utf8_ulen--;
    } while (utf8_ulen > 0);
 
-   return bson_string_free (str, false);
+   return mcd_string_free (str, false);
 
 invalid_utf8:
-   bson_string_free (str, true);
+   mcd_string_free (str, true);
    return NULL;
 }
 

--- a/src/libbson/src/bson/bson-value.c
+++ b/src/libbson/src/bson/bson-value.c
@@ -16,7 +16,7 @@
 
 
 #include <bson/bson-memory.h>
-#include <bson/bson-string.h>
+#include <mcd-string.h>
 #include <bson/bson-value.h>
 #include <bson/bson-oid.h>
 #include <bson/bson-cmp.h>

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -19,7 +19,7 @@
 #include <bson/bson-config.h>
 #include <bson/bson-private.h>
 #include <bson/bson-json-private.h>
-#include <bson/bson-string.h>
+#include <mcd-string.h>
 #include <bson/bson-iso8601-private.h>
 #include <bson/bson-string-private.h>
 
@@ -67,7 +67,7 @@ typedef struct {
    bool keys;
    ssize_t *err_offset;
    uint32_t depth;
-   bson_string_t *str;
+   mcd_string_t *str;
    bson_json_mode_t mode;
    int32_t max_len;
    bool max_len_reached;
@@ -1460,14 +1460,14 @@ append_failure:
  */
 
 static BSON_INLINE void
-_bson_append_regex_options_sorted (bson_string_t *buffer, /* IN */
-                                   const char *options)   /* IN */
+_bson_append_regex_options_sorted (mcd_string_t *buffer, /* IN */
+                                   const char *options)  /* IN */
 {
    const char *c;
 
    for (c = BSON_REGEX_OPTIONS_SORTED; *c; c++) {
       if (strchr (options, *c)) {
-         bson_string_append_c (buffer, *c);
+         mcd_string_append_c (buffer, *c);
       }
    }
 }
@@ -1499,7 +1499,7 @@ bson_append_regex_w_len (
       options = "";
    }
 
-   bson_string_t *const options_sorted = _bson_string_alloc (strlen (options));
+   mcd_string_t *const options_sorted = _bson_string_alloc (strlen (options));
    _bson_append_regex_options_sorted (options_sorted, options);
 
    if (options_sorted->len > UINT32_MAX - 1u) {
@@ -1520,7 +1520,7 @@ bson_append_regex_w_len (
    ret = true;
 
 append_failure:
-   (void) bson_string_free (options_sorted, true);
+   (void) mcd_string_free (options_sorted, true);
 
    return ret;
 }
@@ -2398,9 +2398,9 @@ _bson_as_json_visit_utf8 (const bson_iter_t *iter, const char *key, size_t v_utf
    escaped = bson_utf8_escape_for_json (v_utf8, v_utf8_len);
 
    if (escaped) {
-      bson_string_append (state->str, "\"");
-      bson_string_append (state->str, escaped);
-      bson_string_append (state->str, "\"");
+      mcd_string_append (state->str, "\"");
+      mcd_string_append (state->str, escaped);
+      mcd_string_append (state->str, "\"");
       bson_free (escaped);
       return false;
    }
@@ -2418,9 +2418,9 @@ _bson_as_json_visit_int32 (const bson_iter_t *iter, const char *key, int32_t v_i
    BSON_UNUSED (key);
 
    if (state->mode == BSON_JSON_MODE_CANONICAL) {
-      bson_string_append_printf (state->str, "{ \"$numberInt\" : \"%" PRId32 "\" }", v_int32);
+      mcd_string_append_printf (state->str, "{ \"$numberInt\" : \"%" PRId32 "\" }", v_int32);
    } else {
-      bson_string_append_printf (state->str, "%" PRId32, v_int32);
+      mcd_string_append_printf (state->str, "%" PRId32, v_int32);
    }
 
    return false;
@@ -2436,9 +2436,9 @@ _bson_as_json_visit_int64 (const bson_iter_t *iter, const char *key, int64_t v_i
    BSON_UNUSED (key);
 
    if (state->mode == BSON_JSON_MODE_CANONICAL) {
-      bson_string_append_printf (state->str, "{ \"$numberLong\" : \"%" PRId64 "\" }", v_int64);
+      mcd_string_append_printf (state->str, "{ \"$numberLong\" : \"%" PRId64 "\" }", v_int64);
    } else {
-      bson_string_append_printf (state->str, "%" PRId64, v_int64);
+      mcd_string_append_printf (state->str, "%" PRId64, v_int64);
    }
 
    return false;
@@ -2456,9 +2456,9 @@ _bson_as_json_visit_decimal128 (const bson_iter_t *iter, const char *key, const 
 
    bson_decimal128_to_string (value, decimal128_string);
 
-   bson_string_append (state->str, "{ \"$numberDecimal\" : \"");
-   bson_string_append (state->str, decimal128_string);
-   bson_string_append (state->str, "\" }");
+   mcd_string_append (state->str, "{ \"$numberDecimal\" : \"");
+   mcd_string_append (state->str, decimal128_string);
+   mcd_string_append (state->str, "\" }");
 
    return false;
 }
@@ -2468,7 +2468,7 @@ static bool
 _bson_as_json_visit_double (const bson_iter_t *iter, const char *key, double v_double, void *data)
 {
    bson_json_state_t *state = data;
-   bson_string_t *str = state->str;
+   mcd_string_t *str = state->str;
    uint32_t start_len;
    bool legacy;
 
@@ -2482,29 +2482,29 @@ _bson_as_json_visit_double (const bson_iter_t *iter, const char *key, double v_d
             (state->mode == BSON_JSON_MODE_RELAXED && !(v_double != v_double || v_double * 0 != 0));
 
    if (!legacy) {
-      bson_string_append (state->str, "{ \"$numberDouble\" : \"");
+      mcd_string_append (state->str, "{ \"$numberDouble\" : \"");
    }
 
    if (!legacy && v_double != v_double) {
-      bson_string_append (str, "NaN");
+      mcd_string_append (str, "NaN");
    } else if (!legacy && v_double * 0 != 0) {
       if (v_double > 0) {
-         bson_string_append (str, "Infinity");
+         mcd_string_append (str, "Infinity");
       } else {
-         bson_string_append (str, "-Infinity");
+         mcd_string_append (str, "-Infinity");
       }
    } else {
       start_len = str->len;
-      bson_string_append_printf (str, "%.20g", v_double);
+      mcd_string_append_printf (str, "%.20g", v_double);
 
       /* ensure trailing ".0" to distinguish "3" from "3.0" */
       if (strspn (&str->str[start_len], "0123456789-") == str->len - start_len) {
-         bson_string_append (str, ".0");
+         mcd_string_append (str, ".0");
       }
    }
 
    if (!legacy) {
-      bson_string_append (state->str, "\" }");
+      mcd_string_append (state->str, "\" }");
    }
 
    return false;
@@ -2519,7 +2519,7 @@ _bson_as_json_visit_undefined (const bson_iter_t *iter, const char *key, void *d
    BSON_UNUSED (iter);
    BSON_UNUSED (key);
 
-   bson_string_append (state->str, "{ \"$undefined\" : true }");
+   mcd_string_append (state->str, "{ \"$undefined\" : true }");
 
    return false;
 }
@@ -2533,7 +2533,7 @@ _bson_as_json_visit_null (const bson_iter_t *iter, const char *key, void *data)
    BSON_UNUSED (iter);
    BSON_UNUSED (key);
 
-   bson_string_append (state->str, "null");
+   mcd_string_append (state->str, "null");
 
    return false;
 }
@@ -2549,9 +2549,9 @@ _bson_as_json_visit_oid (const bson_iter_t *iter, const char *key, const bson_oi
    BSON_UNUSED (key);
 
    bson_oid_to_string (oid, str);
-   bson_string_append (state->str, "{ \"$oid\" : \"");
-   bson_string_append (state->str, str);
-   bson_string_append (state->str, "\" }");
+   mcd_string_append (state->str, "{ \"$oid\" : \"");
+   mcd_string_append (state->str, str);
+   mcd_string_append (state->str, "\" }");
 
    return false;
 }
@@ -2577,17 +2577,17 @@ _bson_as_json_visit_binary (const bson_iter_t *iter,
    BSON_ASSERT (mcommon_b64_ntop (v_binary, v_binary_len, b64, b64_len) != -1);
 
    if (state->mode == BSON_JSON_MODE_CANONICAL || state->mode == BSON_JSON_MODE_RELAXED) {
-      bson_string_append (state->str, "{ \"$binary\" : { \"base64\" : \"");
-      bson_string_append (state->str, b64);
-      bson_string_append (state->str, "\", \"subType\" : \"");
-      bson_string_append_printf (state->str, "%02x", v_subtype);
-      bson_string_append (state->str, "\" } }");
+      mcd_string_append (state->str, "{ \"$binary\" : { \"base64\" : \"");
+      mcd_string_append (state->str, b64);
+      mcd_string_append (state->str, "\", \"subType\" : \"");
+      mcd_string_append_printf (state->str, "%02x", v_subtype);
+      mcd_string_append (state->str, "\" } }");
    } else {
-      bson_string_append (state->str, "{ \"$binary\" : \"");
-      bson_string_append (state->str, b64);
-      bson_string_append (state->str, "\", \"$type\" : \"");
-      bson_string_append_printf (state->str, "%02x", v_subtype);
-      bson_string_append (state->str, "\" }");
+      mcd_string_append (state->str, "{ \"$binary\" : \"");
+      mcd_string_append (state->str, b64);
+      mcd_string_append (state->str, "\", \"$type\" : \"");
+      mcd_string_append_printf (state->str, "%02x", v_subtype);
+      mcd_string_append (state->str, "\" }");
    }
 
    bson_free (b64);
@@ -2604,7 +2604,7 @@ _bson_as_json_visit_bool (const bson_iter_t *iter, const char *key, bool v_bool,
    BSON_UNUSED (iter);
    BSON_UNUSED (key);
 
-   bson_string_append (state->str, v_bool ? "true" : "false");
+   mcd_string_append (state->str, v_bool ? "true" : "false");
 
    return false;
 }
@@ -2619,17 +2619,17 @@ _bson_as_json_visit_date_time (const bson_iter_t *iter, const char *key, int64_t
    BSON_UNUSED (key);
 
    if (state->mode == BSON_JSON_MODE_CANONICAL || (state->mode == BSON_JSON_MODE_RELAXED && msec_since_epoch < 0)) {
-      bson_string_append (state->str, "{ \"$date\" : { \"$numberLong\" : \"");
-      bson_string_append_printf (state->str, "%" PRId64, msec_since_epoch);
-      bson_string_append (state->str, "\" } }");
+      mcd_string_append (state->str, "{ \"$date\" : { \"$numberLong\" : \"");
+      mcd_string_append_printf (state->str, "%" PRId64, msec_since_epoch);
+      mcd_string_append (state->str, "\" } }");
    } else if (state->mode == BSON_JSON_MODE_RELAXED) {
-      bson_string_append (state->str, "{ \"$date\" : \"");
+      mcd_string_append (state->str, "{ \"$date\" : \"");
       _bson_iso8601_date_format (msec_since_epoch, state->str);
-      bson_string_append (state->str, "\" }");
+      mcd_string_append (state->str, "\" }");
    } else {
-      bson_string_append (state->str, "{ \"$date\" : ");
-      bson_string_append_printf (state->str, "%" PRId64, msec_since_epoch);
-      bson_string_append (state->str, " }");
+      mcd_string_append (state->str, "{ \"$date\" : ");
+      mcd_string_append_printf (state->str, "%" PRId64, msec_since_epoch);
+      mcd_string_append (state->str, " }");
    }
 
    return false;
@@ -2652,17 +2652,17 @@ _bson_as_json_visit_regex (
    }
 
    if (state->mode == BSON_JSON_MODE_CANONICAL || state->mode == BSON_JSON_MODE_RELAXED) {
-      bson_string_append (state->str, "{ \"$regularExpression\" : { \"pattern\" : \"");
-      bson_string_append (state->str, escaped);
-      bson_string_append (state->str, "\", \"options\" : \"");
+      mcd_string_append (state->str, "{ \"$regularExpression\" : { \"pattern\" : \"");
+      mcd_string_append (state->str, escaped);
+      mcd_string_append (state->str, "\", \"options\" : \"");
       _bson_append_regex_options_sorted (state->str, v_options);
-      bson_string_append (state->str, "\" } }");
+      mcd_string_append (state->str, "\" } }");
    } else {
-      bson_string_append (state->str, "{ \"$regex\" : \"");
-      bson_string_append (state->str, escaped);
-      bson_string_append (state->str, "\", \"$options\" : \"");
+      mcd_string_append (state->str, "{ \"$regex\" : \"");
+      mcd_string_append (state->str, escaped);
+      mcd_string_append (state->str, "\", \"$options\" : \"");
       _bson_append_regex_options_sorted (state->str, v_options);
-      bson_string_append (state->str, "\" }");
+      mcd_string_append (state->str, "\" }");
    }
 
    bson_free (escaped);
@@ -2680,11 +2680,11 @@ _bson_as_json_visit_timestamp (
    BSON_UNUSED (iter);
    BSON_UNUSED (key);
 
-   bson_string_append (state->str, "{ \"$timestamp\" : { \"t\" : ");
-   bson_string_append_printf (state->str, "%u", v_timestamp);
-   bson_string_append (state->str, ", \"i\" : ");
-   bson_string_append_printf (state->str, "%u", v_increment);
-   bson_string_append (state->str, " } }");
+   mcd_string_append (state->str, "{ \"$timestamp\" : { \"t\" : ");
+   mcd_string_append_printf (state->str, "%u", v_timestamp);
+   mcd_string_append (state->str, ", \"i\" : ");
+   mcd_string_append_printf (state->str, "%u", v_increment);
+   mcd_string_append (state->str, " } }");
 
    return false;
 }
@@ -2712,31 +2712,31 @@ _bson_as_json_visit_dbpointer (const bson_iter_t *iter,
    }
 
    if (state->mode == BSON_JSON_MODE_CANONICAL || state->mode == BSON_JSON_MODE_RELAXED) {
-      bson_string_append (state->str, "{ \"$dbPointer\" : { \"$ref\" : \"");
-      bson_string_append (state->str, escaped);
-      bson_string_append (state->str, "\"");
+      mcd_string_append (state->str, "{ \"$dbPointer\" : { \"$ref\" : \"");
+      mcd_string_append (state->str, escaped);
+      mcd_string_append (state->str, "\"");
 
       if (v_oid) {
          bson_oid_to_string (v_oid, str);
-         bson_string_append (state->str, ", \"$id\" : { \"$oid\" : \"");
-         bson_string_append (state->str, str);
-         bson_string_append (state->str, "\" }");
+         mcd_string_append (state->str, ", \"$id\" : { \"$oid\" : \"");
+         mcd_string_append (state->str, str);
+         mcd_string_append (state->str, "\" }");
       }
 
-      bson_string_append (state->str, " } }");
+      mcd_string_append (state->str, " } }");
    } else {
-      bson_string_append (state->str, "{ \"$ref\" : \"");
-      bson_string_append (state->str, escaped);
-      bson_string_append (state->str, "\"");
+      mcd_string_append (state->str, "{ \"$ref\" : \"");
+      mcd_string_append (state->str, escaped);
+      mcd_string_append (state->str, "\"");
 
       if (v_oid) {
          bson_oid_to_string (v_oid, str);
-         bson_string_append (state->str, ", \"$id\" : \"");
-         bson_string_append (state->str, str);
-         bson_string_append (state->str, "\"");
+         mcd_string_append (state->str, ", \"$id\" : \"");
+         mcd_string_append (state->str, str);
+         mcd_string_append (state->str, "\"");
       }
 
-      bson_string_append (state->str, " }");
+      mcd_string_append (state->str, " }");
    }
 
    bson_free (escaped);
@@ -2753,7 +2753,7 @@ _bson_as_json_visit_minkey (const bson_iter_t *iter, const char *key, void *data
    BSON_UNUSED (iter);
    BSON_UNUSED (key);
 
-   bson_string_append (state->str, "{ \"$minKey\" : 1 }");
+   mcd_string_append (state->str, "{ \"$minKey\" : 1 }");
 
    return false;
 }
@@ -2767,7 +2767,7 @@ _bson_as_json_visit_maxkey (const bson_iter_t *iter, const char *key, void *data
    BSON_UNUSED (iter);
    BSON_UNUSED (key);
 
-   bson_string_append (state->str, "{ \"$maxKey\" : 1 }");
+   mcd_string_append (state->str, "{ \"$maxKey\" : 1 }");
 
    return false;
 }
@@ -2786,15 +2786,15 @@ _bson_as_json_visit_before (const bson_iter_t *iter, const char *key, void *data
    }
 
    if (state->count) {
-      bson_string_append (state->str, ", ");
+      mcd_string_append (state->str, ", ");
    }
 
    if (state->keys) {
       escaped = bson_utf8_escape_for_json (key, -1);
       if (escaped) {
-         bson_string_append (state->str, "\"");
-         bson_string_append (state->str, escaped);
-         bson_string_append (state->str, "\" : ");
+         mcd_string_append (state->str, "\"");
+         mcd_string_append (state->str, escaped);
+         mcd_string_append (state->str, "\" : ");
          bson_free (escaped);
       } else {
          return true;
@@ -2825,7 +2825,7 @@ _bson_as_json_visit_after (const bson_iter_t *iter, const char *key, void *data)
       if (bson_cmp_greater_us (state->str->len, state->max_len)) {
          BSON_ASSERT (bson_in_range_signed (uint32_t, state->max_len));
          /* Truncate string to maximum length */
-         bson_string_truncate (state->str, (uint32_t) state->max_len);
+         mcd_string_truncate (state->str, (uint32_t) state->max_len);
       }
 
       return true;
@@ -2856,9 +2856,9 @@ _bson_as_json_visit_code (const bson_iter_t *iter, const char *key, size_t v_cod
       return true;
    }
 
-   bson_string_append (state->str, "{ \"$code\" : \"");
-   bson_string_append (state->str, escaped);
-   bson_string_append (state->str, "\" }");
+   mcd_string_append (state->str, "{ \"$code\" : \"");
+   mcd_string_append (state->str, escaped);
+   mcd_string_append (state->str, "\" }");
    bson_free (escaped);
 
    return false;
@@ -2881,13 +2881,13 @@ _bson_as_json_visit_symbol (
    }
 
    if (state->mode == BSON_JSON_MODE_CANONICAL || state->mode == BSON_JSON_MODE_RELAXED) {
-      bson_string_append (state->str, "{ \"$symbol\" : \"");
-      bson_string_append (state->str, escaped);
-      bson_string_append (state->str, "\" }");
+      mcd_string_append (state->str, "{ \"$symbol\" : \"");
+      mcd_string_append (state->str, escaped);
+      mcd_string_append (state->str, "\" }");
    } else {
-      bson_string_append (state->str, "\"");
-      bson_string_append (state->str, escaped);
-      bson_string_append (state->str, "\"");
+      mcd_string_append (state->str, "\"");
+      mcd_string_append (state->str, escaped);
+      mcd_string_append (state->str, "\"");
    }
 
    bson_free (escaped);
@@ -2913,9 +2913,9 @@ _bson_as_json_visit_codewscope (
       return true;
    }
 
-   bson_string_append (state->str, "{ \"$code\" : \"");
-   bson_string_append (state->str, code_escaped);
-   bson_string_append (state->str, "\", \"$scope\" : ");
+   mcd_string_append (state->str, "{ \"$code\" : \"");
+   mcd_string_append (state->str, code_escaped);
+   mcd_string_append (state->str, "\", \"$scope\" : ");
 
    bson_free (code_escaped);
 
@@ -2931,8 +2931,8 @@ _bson_as_json_visit_codewscope (
       return true;
    }
 
-   bson_string_append (state->str, scope);
-   bson_string_append (state->str, " }");
+   mcd_string_append (state->str, scope);
+   mcd_string_append (state->str, " }");
 
    bson_free (scope);
 
@@ -2964,12 +2964,12 @@ _bson_as_json_visit_document (const bson_iter_t *iter, const char *key, const bs
    BSON_UNUSED (key);
 
    if (state->depth >= BSON_MAX_RECURSION) {
-      bson_string_append (state->str, "{ ... }");
+      mcd_string_append (state->str, "{ ... }");
       return false;
    }
 
    if (bson_iter_init (&child, v_document)) {
-      child_state.str = bson_string_new ("{ ");
+      child_state.str = mcd_string_new ("{ ");
       child_state.depth = state->depth + 1;
       child_state.mode = state->mode;
       child_state.max_len = BSON_MAX_LEN_UNLIMITED;
@@ -2982,10 +2982,10 @@ _bson_as_json_visit_document (const bson_iter_t *iter, const char *key, const bs
 
       if (bson_iter_visit_all (&child, &bson_as_json_visitors, &child_state)) {
          if (child_state.max_len_reached) {
-            bson_string_append (state->str, child_state.str->str);
+            mcd_string_append (state->str, child_state.str->str);
          }
 
-         bson_string_free (child_state.str, true);
+         mcd_string_free (child_state.str, true);
 
          /* If max_len was reached, we return a success state to ensure that
           * VISIT_AFTER is still called
@@ -2993,9 +2993,9 @@ _bson_as_json_visit_document (const bson_iter_t *iter, const char *key, const bs
          return !child_state.max_len_reached;
       }
 
-      bson_string_append (child_state.str, " }");
-      bson_string_append (state->str, child_state.str->str);
-      bson_string_free (child_state.str, true);
+      mcd_string_append (child_state.str, " }");
+      mcd_string_append (state->str, child_state.str->str);
+      mcd_string_free (child_state.str, true);
    }
 
    return false;
@@ -3013,12 +3013,12 @@ _bson_as_json_visit_array (const bson_iter_t *iter, const char *key, const bson_
    BSON_UNUSED (key);
 
    if (state->depth >= BSON_MAX_RECURSION) {
-      bson_string_append (state->str, "{ ... }");
+      mcd_string_append (state->str, "{ ... }");
       return false;
    }
 
    if (bson_iter_init (&child, v_array)) {
-      child_state.str = bson_string_new ("[ ");
+      child_state.str = mcd_string_new ("[ ");
       child_state.depth = state->depth + 1;
       child_state.mode = state->mode;
       child_state.max_len = BSON_MAX_LEN_UNLIMITED;
@@ -3031,10 +3031,10 @@ _bson_as_json_visit_array (const bson_iter_t *iter, const char *key, const bson_
 
       if (bson_iter_visit_all (&child, &bson_as_json_visitors, &child_state)) {
          if (child_state.max_len_reached) {
-            bson_string_append (state->str, child_state.str->str);
+            mcd_string_append (state->str, child_state.str->str);
          }
 
-         bson_string_free (child_state.str, true);
+         mcd_string_free (child_state.str, true);
 
          /* If max_len was reached, we return a success state to ensure that
           * VISIT_AFTER is still called
@@ -3042,9 +3042,9 @@ _bson_as_json_visit_array (const bson_iter_t *iter, const char *key, const bson_
          return !child_state.max_len_reached;
       }
 
-      bson_string_append (child_state.str, " ]");
-      bson_string_append (state->str, child_state.str->str);
-      bson_string_free (child_state.str, true);
+      mcd_string_append (child_state.str, " ]");
+      mcd_string_append (state->str, child_state.str->str);
+      mcd_string_free (child_state.str, true);
    }
 
    return false;
@@ -3080,7 +3080,7 @@ _bson_as_json_visit_all (
 
    state.count = 0;
    state.keys = !is_outermost_array;
-   state.str = bson_string_new (is_outermost_array ? "[ " : "{ ");
+   state.str = mcd_string_new (is_outermost_array ? "[ " : "{ ");
    state.depth = 0;
    state.err_offset = &err_offset;
    state.mode = mode;
@@ -3091,7 +3091,7 @@ _bson_as_json_visit_all (
       /*
        * We were prematurely exited due to corruption or failed visitor.
        */
-      bson_string_free (state.str, true);
+      mcd_string_free (state.str, true);
       if (length) {
          *length = 0;
       }
@@ -3102,16 +3102,16 @@ _bson_as_json_visit_all (
     */
    remaining = state.max_len - state.str->len;
    if (state.max_len == BSON_MAX_LEN_UNLIMITED || remaining > 1) {
-      bson_string_append (state.str, is_outermost_array ? " ]" : " }");
+      mcd_string_append (state.str, is_outermost_array ? " ]" : " }");
    } else if (remaining == 1) {
-      bson_string_append (state.str, " ");
+      mcd_string_append (state.str, " ");
    }
 
    if (length) {
       *length = state.str->len;
    }
 
-   return bson_string_free (state.str, false);
+   return mcd_string_free (state.str, false);
 }
 
 

--- a/src/libbson/tests/test-bson-corpus.c
+++ b/src/libbson/tests/test-bson-corpus.c
@@ -2,6 +2,7 @@
 #include "TestSuite.h"
 #include "json-test.h"
 #include "corpus-test.h"
+#include <mcd-string.h>
 
 
 #define IS_NAN(dec) (dec).high == 0x7c00000000000000ull
@@ -39,19 +40,19 @@ skipped_corpus_test_t VS2013_SKIPPED_CORPUS_TESTS[] = {
 static void
 compare_data (const uint8_t *a, uint32_t a_len, const uint8_t *b, uint32_t b_len)
 {
-   bson_string_t *a_str;
-   bson_string_t *b_str;
+   mcd_string_t *a_str;
+   mcd_string_t *b_str;
    uint32_t i;
 
    if (a_len != b_len || memcmp (a, b, (size_t) a_len)) {
-      a_str = bson_string_new (NULL);
+      a_str = mcd_string_new (NULL);
       for (i = 0; i < a_len; i++) {
-         bson_string_append_printf (a_str, "%02X", (int) a[i]);
+         mcd_string_append_printf (a_str, "%02X", (int) a[i]);
       }
 
-      b_str = bson_string_new (NULL);
+      b_str = mcd_string_new (NULL);
       for (i = 0; i < b_len; i++) {
-         bson_string_append_printf (b_str, "%02X", (int) b[i]);
+         mcd_string_append_printf (b_str, "%02X", (int) b[i]);
       }
 
       fprintf (stderr, "unequal data of length %d and %d:\n%s\n%s\n", a_len, b_len, a_str->str, b_str->str);

--- a/src/libbson/tests/test-iso8601.c
+++ b/src/libbson/tests/test-iso8601.c
@@ -32,14 +32,14 @@ test_date (const char *str, int64_t millis)
 static void
 test_date_io (const char *str_in, const char *str_out, int64_t millis)
 {
-   bson_string_t *bson_str;
+   mcd_string_t *bson_str;
 
    test_date (str_in, millis);
 
-   bson_str = bson_string_new (NULL);
+   bson_str = mcd_string_new (NULL);
    _bson_iso8601_date_format (millis, bson_str);
    ASSERT_CMPSTR (bson_str->str, str_out);
-   bson_string_free (bson_str, true);
+   mcd_string_free (bson_str, true);
 }
 
 

--- a/src/libbson/tests/test-json.c
+++ b/src/libbson/tests/test-json.c
@@ -6,6 +6,7 @@
 
 #include "TestSuite.h"
 #include "test-conveniences.h"
+#include <mcd-string.h>
 
 static ssize_t
 test_bson_json_read_cb_helper (void *string, uint8_t *buf, size_t len)
@@ -752,7 +753,7 @@ test_bson_json_read_buffering (void)
 {
    bson_t **bsons;
    char *json_tmp;
-   bson_string_t *json;
+   mcd_string_t *json;
    bson_error_t error;
    bson_t bson_out = BSON_INITIALIZER;
    int i;
@@ -764,7 +765,7 @@ test_bson_json_read_buffering (void)
    bson_json_reader_t *reader;
    int r;
 
-   json = bson_string_new (NULL);
+   json = mcd_string_new (NULL);
 
    /* parse between 1 and 10 JSON objects */
    for (n_docs = 1; n_docs < 10; n_docs++) {
@@ -785,7 +786,7 @@ test_bson_json_read_buffering (void)
             /* append the BSON document's JSON representation to "json" */
             json_tmp = bson_as_json (bsons[docs_idx], NULL);
             BSON_ASSERT (json_tmp);
-            bson_string_append (json, json_tmp);
+            mcd_string_append (json, json_tmp);
             bson_free (json_tmp);
          }
 
@@ -810,7 +811,7 @@ test_bson_json_read_buffering (void)
          ASSERT_CMPINT (0, ==, bson_json_reader_read (reader, &bson_out, &error));
 
          bson_json_reader_destroy (reader);
-         bson_string_truncate (json, 0);
+         mcd_string_truncate (json, 0);
 
          for (docs_idx = 0; docs_idx < n_docs; docs_idx++) {
             bson_destroy (bsons[docs_idx]);
@@ -820,7 +821,7 @@ test_bson_json_read_buffering (void)
       }
    }
 
-   bson_string_free (json, true);
+   mcd_string_free (json, true);
    bson_destroy (&bson_out);
 }
 

--- a/src/libbson/tests/test-oid.c
+++ b/src/libbson/tests/test-oid.c
@@ -228,11 +228,11 @@ test_bson_oid_init_sequence (void)
 static char *
 get_time_as_string (const bson_oid_t *oid)
 {
-   bson_string_t *str = bson_string_new (NULL);
+   mcd_string_t *str = mcd_string_new (NULL);
    time_t time = bson_oid_get_time_t (oid);
 
    _bson_iso8601_date_format (time * 1000, str);
-   return bson_string_free (str, false);
+   return mcd_string_free (str, false);
 }
 
 

--- a/src/libbson/tests/test-oid.c
+++ b/src/libbson/tests/test-oid.c
@@ -29,6 +29,7 @@
 #include <limits.h>
 
 #include "TestSuite.h"
+#include <common-macros-private.h> // BEGIN_IGNORE_DEPRECATIONS
 
 #define N_THREADS 4
 

--- a/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
@@ -30,6 +30,7 @@
 #include "mongoc-trace-private.h"
 #include "mongoc-database-private.h"
 #include "mongoc-util-private.h"
+#include <mcd-string.h>
 
 /*--------------------------------------------------------------------------
  * Auto Encryption options.
@@ -1317,25 +1318,25 @@ _uri_construction_error (bson_error_t *error)
 static bool
 _do_spawn (const char *path, char **args, bson_error_t *error)
 {
-   bson_string_t *command;
+   mcd_string_t *command;
    char **arg;
    PROCESS_INFORMATION process_information;
    STARTUPINFO startup_info;
 
    /* Construct the full command, quote path and arguments. */
-   command = bson_string_new ("");
-   bson_string_append (command, "\"");
+   command = mcd_string_new ("");
+   mcd_string_append (command, "\"");
    if (path) {
-      bson_string_append (command, path);
+      mcd_string_append (command, path);
    }
-   bson_string_append (command, "mongocryptd.exe");
-   bson_string_append (command, "\"");
+   mcd_string_append (command, "mongocryptd.exe");
+   mcd_string_append (command, "\"");
    /* skip the "mongocryptd" first arg. */
    arg = args + 1;
    while (*arg) {
-      bson_string_append (command, " \"");
-      bson_string_append (command, *arg);
-      bson_string_append (command, "\"");
+      mcd_string_append (command, " \"");
+      mcd_string_append (command, *arg);
+      mcd_string_append (command, "\"");
       arg++;
    }
 
@@ -1372,11 +1373,11 @@ _do_spawn (const char *path, char **args, bson_error_t *error)
                       "failed to spawn mongocryptd: %s",
                       message);
       LocalFree (message);
-      bson_string_free (command, true);
+      mcd_string_free (command, true);
       return false;
    }
 
-   bson_string_free (command, true);
+   mcd_string_free (command, true);
    return true;
 }
 #else

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -28,10 +28,6 @@
 #include <netinet/tcp.h>
 #include <arpa/nameser.h>
 #include <resolv.h>
-#define BSON_INSIDE
-#include <bson/bson-string.h>
-#undef BSON_INSIDE
-
 #endif
 #endif
 
@@ -73,6 +69,8 @@
 #include "mongoc-openssl-private.h"
 #include "mongoc-stream-tls-private.h"
 #endif
+
+#include <mcd-string.h>
 
 #undef MONGOC_LOG_DOMAIN
 #define MONGOC_LOG_DOMAIN "client"
@@ -134,16 +132,16 @@ static bool
 txt_callback (const char *hostname, PDNS_RECORD pdns, mongoc_rr_data_t *rr_data, bson_error_t *error)
 {
    DWORD i;
-   bson_string_t *txt;
+   mcd_string_t *txt;
 
-   txt = bson_string_new (NULL);
+   txt = mcd_string_new (NULL);
 
    for (i = 0; i < pdns->Data.TXT.dwStringCount; i++) {
-      bson_string_append (txt, pdns->Data.TXT.pStringArray[i]);
+      mcd_string_append (txt, pdns->Data.TXT.pStringArray[i]);
    }
 
    rr_data->txt_record_opts = bson_strdup (txt->str);
-   bson_string_free (txt, true);
+   mcd_string_free (txt, true);
 
    return true;
 }
@@ -331,7 +329,7 @@ txt_callback (const char *hostname, ns_msg *ns_answer, ns_rr *rr, mongoc_rr_data
 {
    char s[256];
    const uint8_t *data;
-   bson_string_t *txt;
+   mcd_string_t *txt;
    uint16_t pos, total;
    uint8_t len;
    bool ret = false;
@@ -345,7 +343,7 @@ txt_callback (const char *hostname, ns_msg *ns_answer, ns_rr *rr, mongoc_rr_data
 
    /* a TXT record has one or more strings, each up to 255 chars, each is
     * prefixed by its length as 1 byte. thus endianness doesn't matter. */
-   txt = bson_string_new (NULL);
+   txt = mcd_string_new (NULL);
    pos = 0;
    data = ns_rr_rdata (*rr);
 
@@ -353,12 +351,12 @@ txt_callback (const char *hostname, ns_msg *ns_answer, ns_rr *rr, mongoc_rr_data
       memcpy (&len, data + pos, sizeof (uint8_t));
       pos++;
       bson_strncpy (s, (const char *) (data + pos), (size_t) len + 1);
-      bson_string_append (txt, s);
+      mcd_string_append (txt, s);
       pos += len;
    }
 
    rr_data->txt_record_opts = bson_strdup (txt->str);
-   bson_string_free (txt, true);
+   mcd_string_free (txt, true);
    ret = true;
 
 done:

--- a/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
@@ -29,6 +29,7 @@
 #include "mongoc-http-private.h"
 #include "mongoc-rand-private.h"
 #include "mongoc-ssl-private.h"
+#include <mcd-string.h>
 
 #undef MONGOC_LOG_DOMAIN
 #define MONGOC_LOG_DOMAIN "aws_auth"
@@ -455,7 +456,7 @@ _obtain_creds_from_assumerolewithwebidentity (_mongoc_aws_credentials_t *creds, 
    const char *session_token = NULL;
    bson_error_t http_error;
    mongoc_stream_t *fstream = NULL;
-   bson_string_t *token_file_contents = NULL;
+   mcd_string_t *token_file_contents = NULL;
    char *path_and_query = NULL;
 
    aws_web_identity_token_file = _mongoc_getenv ("AWS_WEB_IDENTITY_TOKEN_FILE");
@@ -485,7 +486,7 @@ _obtain_creds_from_assumerolewithwebidentity (_mongoc_aws_credentials_t *creds, 
                               strerror (errno));
       }
 
-      token_file_contents = bson_string_new (NULL);
+      token_file_contents = mcd_string_new (NULL);
 
       for (;;) {
          char buf[128];
@@ -498,7 +499,7 @@ _obtain_creds_from_assumerolewithwebidentity (_mongoc_aws_credentials_t *creds, 
          if (got > 0) {
             // add null terminator.
             buf[got] = '\0';
-            bson_string_append (token_file_contents, (const char *) buf);
+            mcd_string_append (token_file_contents, (const char *) buf);
          } else if (got == 0) {
             // EOF.
             break;
@@ -620,7 +621,7 @@ fail:
    bson_destroy (response_bson);
    bson_free (http_response_headers);
    bson_free (http_response_body);
-   bson_string_free (token_file_contents, true /* free segment */);
+   mcd_string_free (token_file_contents, true /* free segment */);
    mongoc_stream_destroy (fstream);
    bson_free (aws_role_session_name);
    bson_free (aws_role_arn);

--- a/src/libmongoc/src/mongoc/mongoc-collection.c
+++ b/src/libmongoc/src/mongoc/mongoc-collection.c
@@ -41,6 +41,7 @@
 #include "mongoc-write-command-private.h"
 #include "mongoc-error-private.h"
 #include "mongoc-database-private.h"
+#include <common-macros-private.h> // BEGIN_IGNORE_DEPRECATIONS
 
 #include <bson-dsl.h>
 #include <mcd-string.h>

--- a/src/libmongoc/src/mongoc/mongoc-collection.c
+++ b/src/libmongoc/src/mongoc/mongoc-collection.c
@@ -43,6 +43,7 @@
 #include "mongoc-database-private.h"
 
 #include <bson-dsl.h>
+#include <mcd-string.h>
 
 #undef MONGOC_LOG_DOMAIN
 #define MONGOC_LOG_DOMAIN "collection"
@@ -1187,7 +1188,7 @@ mongoc_collection_drop_index_with_opts (mongoc_collection_t *collection,
 char *
 mongoc_collection_keys_to_index_string (const bson_t *keys)
 {
-   bson_string_t *s;
+   mcd_string_t *s;
    bson_iter_t iter;
    bson_type_t type;
    int i = 0;
@@ -1198,25 +1199,25 @@ mongoc_collection_keys_to_index_string (const bson_t *keys)
       return NULL;
    }
 
-   s = bson_string_new (NULL);
+   s = mcd_string_new (NULL);
 
    while (bson_iter_next (&iter)) {
       /* Index type can be specified as a string ("2d") or as an integer
        * representing direction */
       type = bson_iter_type (&iter);
       if (type == BSON_TYPE_UTF8) {
-         bson_string_append_printf (s, (i++ ? "_%s_%s" : "%s_%s"), bson_iter_key (&iter), bson_iter_utf8 (&iter, NULL));
+         mcd_string_append_printf (s, (i++ ? "_%s_%s" : "%s_%s"), bson_iter_key (&iter), bson_iter_utf8 (&iter, NULL));
       } else if (type == BSON_TYPE_INT32) {
-         bson_string_append_printf (s, (i++ ? "_%s_%d" : "%s_%d"), bson_iter_key (&iter), bson_iter_int32 (&iter));
+         mcd_string_append_printf (s, (i++ ? "_%s_%d" : "%s_%d"), bson_iter_key (&iter), bson_iter_int32 (&iter));
       } else if (type == BSON_TYPE_INT64) {
-         bson_string_append_printf (
+         mcd_string_append_printf (
             s, (i++ ? "_%s_%" PRId64 : "%s_%" PRId64), bson_iter_key (&iter), bson_iter_int64 (&iter));
       } else {
-         bson_string_free (s, true);
+         mcd_string_free (s, true);
          return NULL;
       }
    }
-   return bson_string_free (s, false);
+   return mcd_string_free (s, false);
 }
 
 

--- a/src/libmongoc/src/mongoc/mongoc-crypt.c
+++ b/src/libmongoc/src/mongoc/mongoc-crypt.c
@@ -33,6 +33,7 @@
 #include "mcd-azure.h"
 #include "mcd-time.h"
 #include "service-gcp.h"
+#include <mcd-string.h>
 
 // `mcd_mapof_kmsid_to_tlsopts` maps a KMS ID (e.g. `aws` or `aws:myname`) to a
 // `mongoc_ssl_opt_t`. The acryonym TLS is preferred over SSL for
@@ -1111,10 +1112,10 @@ _parse_one_tls_opts (bson_iter_t *iter, mongoc_ssl_opt_t *out_opt, bson_error_t 
    bson_t tls_opts_doc;
    const uint8_t *data;
    uint32_t len;
-   bson_string_t *errmsg;
+   mcd_string_t *errmsg;
    bson_iter_t permitted_iter;
 
-   errmsg = bson_string_new (NULL);
+   errmsg = mcd_string_new (NULL);
    kms_provider = bson_iter_key (iter);
    memset (out_opt, 0, sizeof (mongoc_ssl_opt_t));
 
@@ -1178,7 +1179,7 @@ _parse_one_tls_opts (bson_iter_t *iter, mongoc_ssl_opt_t *out_opt, bson_error_t 
 
    ok = true;
 fail:
-   bson_string_free (errmsg, true /* free_segment */);
+   mcd_string_free (errmsg, true /* free_segment */);
    return ok;
 }
 

--- a/src/libmongoc/src/mongoc/mongoc-cyrus.c
+++ b/src/libmongoc/src/mongoc/mongoc-cyrus.c
@@ -25,6 +25,7 @@
 #include "mongoc-util-private.h"
 #include "mongoc-trace-private.h"
 #include "common-b64-private.h"
+#include <mcd-string.h>
 
 #undef MONGOC_LOG_DOMAIN
 #define MONGOC_LOG_DOMAIN "CYRUS-SASL"
@@ -32,7 +33,7 @@
 bool
 _mongoc_cyrus_set_mechanism (mongoc_cyrus_t *sasl, const char *mechanism, bson_error_t *error)
 {
-   bson_string_t *str = bson_string_new ("");
+   mcd_string_t *str = mcd_string_new ("");
    const char **mechs = sasl_global_listmech ();
    int i = 0;
    bool ok = false;
@@ -44,9 +45,9 @@ _mongoc_cyrus_set_mechanism (mongoc_cyrus_t *sasl, const char *mechanism, bson_e
          ok = true;
          break;
       }
-      bson_string_append (str, mechs[i]);
+      mcd_string_append (str, mechs[i]);
       if (mechs[i + 1]) {
-         bson_string_append (str, ",");
+         mcd_string_append (str, ",");
       }
    }
 
@@ -63,7 +64,7 @@ _mongoc_cyrus_set_mechanism (mongoc_cyrus_t *sasl, const char *mechanism, bson_e
                       str->str);
    }
 
-   bson_string_free (str, true);
+   mcd_string_free (str, true);
    return ok;
 }
 
@@ -274,19 +275,19 @@ _mongoc_cyrus_is_failure (int status, bson_error_t *error)
          bson_set_error (error, MONGOC_ERROR_SASL, status, "SASL Failure: insufficient memory.");
          break;
       case SASL_NOMECH: {
-         bson_string_t *str = bson_string_new ("available mechanisms: ");
+         mcd_string_t *str = mcd_string_new ("available mechanisms: ");
          const char **mechs = sasl_global_listmech ();
          int i = 0;
 
          for (i = 0; mechs[i]; i++) {
-            bson_string_append (str, mechs[i]);
+            mcd_string_append (str, mechs[i]);
             if (mechs[i + 1]) {
-               bson_string_append (str, ",");
+               mcd_string_append (str, ",");
             }
          }
          bson_set_error (
             error, MONGOC_ERROR_SASL, status, "SASL Failure: failure to negotiate mechanism (%s)", str->str);
-         bson_string_free (str, 0);
+         mcd_string_free (str, 0);
       } break;
       case SASL_BADPARAM:
          bson_set_error (error,

--- a/src/libmongoc/src/mongoc/mongoc-handshake.c
+++ b/src/libmongoc/src/mongoc/mongoc-handshake.c
@@ -37,6 +37,7 @@
 #include "mongoc-util-private.h"
 
 #include <bson-dsl.h>
+#include <mcd-string.h>
 
 /*
  * Global handshake data instance. Initialized at startup from mongoc_init
@@ -199,13 +200,13 @@ _mongoc_handshake_get_config_hex_string (void)
       _set_bit (bf, byte_count, MONGOC_MD_FLAG_ENABLE_SRV);
    }
 
-   bson_string_t *const str = bson_string_new ("0x");
+   mcd_string_t *const str = mcd_string_new ("0x");
    for (uint32_t i = 0u; i < byte_count; i++) {
-      bson_string_append_printf (str, "%02x", bf[i]);
+      mcd_string_append_printf (str, "%02x", bf[i]);
    }
    bson_free (bf);
-   /* free the bson_string_t, but keep the underlying char* alive. */
-   return bson_string_free (str, false);
+   /* free the mcd_string_t, but keep the underlying char* alive. */
+   return mcd_string_free (str, false);
 }
 
 static char *
@@ -376,11 +377,11 @@ _free_driver_info (mongoc_handshake_t *handshake)
 static void
 _set_platform_string (mongoc_handshake_t *handshake)
 {
-   bson_string_t *str;
+   mcd_string_t *str;
 
-   str = bson_string_new ("");
+   str = mcd_string_new ("");
 
-   handshake->platform = bson_string_free (str, false);
+   handshake->platform = mcd_string_free (str, false);
 }
 
 static void
@@ -472,47 +473,47 @@ cleanup:
 static void
 _set_compiler_info (mongoc_handshake_t *handshake)
 {
-   bson_string_t *str;
+   mcd_string_t *str;
    char *config_str;
 
-   str = bson_string_new ("");
+   str = mcd_string_new ("");
 
    config_str = _mongoc_handshake_get_config_hex_string ();
-   bson_string_append_printf (str, "cfg=%s", config_str);
+   mcd_string_append_printf (str, "cfg=%s", config_str);
    bson_free (config_str);
 
 #ifdef _POSIX_VERSION
-   bson_string_append_printf (str, " posix=%ld", _POSIX_VERSION);
+   mcd_string_append_printf (str, " posix=%ld", _POSIX_VERSION);
 #endif
 
 #ifdef __STDC_VERSION__
-   bson_string_append_printf (str, " stdc=%ld", __STDC_VERSION__);
+   mcd_string_append_printf (str, " stdc=%ld", __STDC_VERSION__);
 #endif
 
-   bson_string_append_printf (str, " CC=%s", MONGOC_COMPILER);
+   mcd_string_append_printf (str, " CC=%s", MONGOC_COMPILER);
 
 #ifdef MONGOC_COMPILER_VERSION
-   bson_string_append_printf (str, " %s", MONGOC_COMPILER_VERSION);
+   mcd_string_append_printf (str, " %s", MONGOC_COMPILER_VERSION);
 #endif
-   handshake->compiler_info = bson_string_free (str, false);
+   handshake->compiler_info = mcd_string_free (str, false);
 }
 
 static void
 _set_flags (mongoc_handshake_t *handshake)
 {
-   bson_string_t *str;
+   mcd_string_t *str;
 
-   str = bson_string_new ("");
+   str = mcd_string_new ("");
 
    if (strlen (MONGOC_EVALUATE_STR (MONGOC_USER_SET_CFLAGS)) > 0) {
-      bson_string_append_printf (str, " CFLAGS=%s", MONGOC_EVALUATE_STR (MONGOC_USER_SET_CFLAGS));
+      mcd_string_append_printf (str, " CFLAGS=%s", MONGOC_EVALUATE_STR (MONGOC_USER_SET_CFLAGS));
    }
 
    if (strlen (MONGOC_EVALUATE_STR (MONGOC_USER_SET_LDFLAGS)) > 0) {
-      bson_string_append_printf (str, " LDFLAGS=%s", MONGOC_EVALUATE_STR (MONGOC_USER_SET_LDFLAGS));
+      mcd_string_append_printf (str, " LDFLAGS=%s", MONGOC_EVALUATE_STR (MONGOC_USER_SET_LDFLAGS));
    }
 
-   handshake->flags = bson_string_free (str, false);
+   handshake->flags = mcd_string_free (str, false);
 }
 
 static void
@@ -555,7 +556,7 @@ _append_platform_field (bson_t *doc, const char *platform, bool truncate)
 {
    char *compiler_info = _mongoc_handshake_get ()->compiler_info;
    char *flags = _mongoc_handshake_get ()->flags;
-   bson_string_t *combined_platform = bson_string_new (platform);
+   mcd_string_t *combined_platform = mcd_string_new (platform);
 
    /* Compute space left for platform field */
    const int max_platform_str_size = HANDSHAKE_MAX_SIZE - ((int) doc->len +
@@ -569,7 +570,7 @@ _append_platform_field (bson_t *doc, const char *platform, bool truncate)
                                                            4);
 
    if (truncate && max_platform_str_size <= 0) {
-      bson_string_free (combined_platform, true);
+      mcd_string_free (combined_platform, true);
       return;
    }
 
@@ -579,10 +580,10 @@ _append_platform_field (bson_t *doc, const char *platform, bool truncate)
     * drop compiler info */
    if (!truncate ||
        bson_cmp_greater_equal_su (max_platform_str_size, combined_platform->len + strlen (compiler_info) + 1u)) {
-      bson_string_append (combined_platform, compiler_info);
+      mcd_string_append (combined_platform, compiler_info);
    }
    if (!truncate || bson_cmp_greater_equal_su (max_platform_str_size, combined_platform->len + strlen (flags) + 1u)) {
-      bson_string_append (combined_platform, flags);
+      mcd_string_append (combined_platform, flags);
    }
 
    /* We use the flags_index field to check if the CLAGS/LDFLAGS need to be
@@ -591,7 +592,7 @@ _append_platform_field (bson_t *doc, const char *platform, bool truncate)
    int length = truncate ? BSON_MIN (max_platform_str_size - 1, (int) combined_platform->len) : -1;
    bson_append_utf8 (doc, HANDSHAKE_PLATFORM_FIELD, -1, combined_platform->str, length);
 
-   bson_string_free (combined_platform, true);
+   mcd_string_free (combined_platform, true);
 }
 
 static bool

--- a/src/libmongoc/src/mongoc/mongoc-http.c
+++ b/src/libmongoc/src/mongoc/mongoc-http.c
@@ -22,6 +22,7 @@
 #include "mongoc-stream-private.h"
 #include "mongoc-buffer-private.h"
 #include "mcd-time.h"
+#include <mcd-string.h>
 
 void
 _mongoc_http_request_init (mongoc_http_request_t *request)
@@ -45,7 +46,7 @@ _mongoc_http_response_cleanup (mongoc_http_response_t *response)
    bson_free (response->body);
 }
 
-bson_string_t *
+mcd_string_t *
 _mongoc_http_render_request_head (const mongoc_http_request_t *req)
 {
    BSON_ASSERT_PARAM (req);
@@ -63,27 +64,27 @@ _mongoc_http_render_request_head (const mongoc_http_request_t *req)
       path = bson_strdup (req->path);
    }
 
-   bson_string_t *const string = bson_string_new ("");
+   mcd_string_t *const string = mcd_string_new ("");
    // Set the request line
-   bson_string_append_printf (string, "%s %s HTTP/1.0\r\n", req->method, path);
+   mcd_string_append_printf (string, "%s %s HTTP/1.0\r\n", req->method, path);
    // (We're done with the path string:)
    bson_free (path);
 
    /* Always add Host header. */
-   bson_string_append_printf (string, "Host: %s:%d\r\n", req->host, req->port);
+   mcd_string_append_printf (string, "Host: %s:%d\r\n", req->host, req->port);
    /* Always add Connection: close header to ensure server closes connection. */
-   bson_string_append_printf (string, "Connection: close\r\n");
+   mcd_string_append_printf (string, "Connection: close\r\n");
    /* Add Content-Length if body is included. */
    if (req->body_len) {
-      bson_string_append_printf (string, "Content-Length: %d\r\n", req->body_len);
+      mcd_string_append_printf (string, "Content-Length: %d\r\n", req->body_len);
    }
    // Add any extra headers
    if (req->extra_headers) {
-      bson_string_append (string, req->extra_headers);
+      mcd_string_append (string, req->extra_headers);
    }
 
    // Final terminator
-   bson_string_append (string, "\r\n");
+   mcd_string_append (string, "\r\n");
    return string;
 }
 
@@ -108,7 +109,7 @@ _mongoc_http_send (const mongoc_http_request_t *req,
    bool ret = false;
    mongoc_iovec_t iovec;
    char *path = NULL;
-   bson_string_t *http_request = NULL;
+   mcd_string_t *http_request = NULL;
    mongoc_buffer_t http_response_buf;
    char *http_response_str;
    char *ptr;
@@ -281,7 +282,7 @@ _mongoc_http_send (const mongoc_http_request_t *req,
 fail:
    mongoc_stream_destroy (stream);
    if (http_request) {
-      bson_string_free (http_request, true);
+      mcd_string_free (http_request, true);
    }
    _mongoc_buffer_destroy (&http_response_buf);
    bson_free (path);

--- a/src/libmongoc/src/mongoc/mongoc-log.c
+++ b/src/libmongoc/src/mongoc/mongoc-log.c
@@ -35,6 +35,7 @@
 #include "mongoc-log.h"
 #include "mongoc-log-private.h"
 #include "mongoc-thread-private.h"
+#include <mcd-string.h>
 
 
 static bson_once_t once = BSON_ONCE_INIT;
@@ -226,8 +227,8 @@ mongoc_log_trace_bytes (const char *domain, const uint8_t *_b, size_t _l)
 {
    STOP_LOGGING_CHECK;
 
-   bson_string_t *const str = bson_string_new (NULL);
-   bson_string_t *const astr = bson_string_new (NULL);
+   mcd_string_t *const str = mcd_string_new (NULL);
+   mcd_string_t *const astr = mcd_string_new (NULL);
 
    size_t _i;
    for (_i = 0u; _i < _l; _i++) {
@@ -235,23 +236,23 @@ mongoc_log_trace_bytes (const char *domain, const uint8_t *_b, size_t _l)
       const size_t rem = _i % 16u;
 
       if (rem == 0u) {
-         bson_string_append_printf (str, "%05zx: ", _i);
+         mcd_string_append_printf (str, "%05zx: ", _i);
       }
 
-      bson_string_append_printf (str, " %02x", _v);
+      mcd_string_append_printf (str, " %02x", _v);
       if (isprint (_v)) {
-         bson_string_append_printf (astr, " %c", _v);
+         mcd_string_append_printf (astr, " %c", _v);
       } else {
-         bson_string_append (astr, " .");
+         mcd_string_append (astr, " .");
       }
 
       if (rem == 15u) {
          mongoc_log (MONGOC_LOG_LEVEL_TRACE, domain, "%s %s", str->str, astr->str);
-         bson_string_truncate (str, 0);
-         bson_string_truncate (astr, 0);
+         mcd_string_truncate (str, 0);
+         mcd_string_truncate (astr, 0);
       } else if (rem == 7u) {
-         bson_string_append (str, " ");
-         bson_string_append (astr, " ");
+         mcd_string_append (str, " ");
+         mcd_string_append (astr, " ");
       }
    }
 
@@ -259,14 +260,14 @@ mongoc_log_trace_bytes (const char *domain, const uint8_t *_b, size_t _l)
       mongoc_log (MONGOC_LOG_LEVEL_TRACE, domain, "%-56s %s", str->str, astr->str);
    }
 
-   bson_string_free (str, true);
-   bson_string_free (astr, true);
+   mcd_string_free (str, true);
+   mcd_string_free (astr, true);
 }
 
 void
 mongoc_log_trace_iovec (const char *domain, const mongoc_iovec_t *_iov, size_t _iovcnt)
 {
-   bson_string_t *str, *astr;
+   mcd_string_t *str, *astr;
    const char *_b;
    unsigned _i = 0;
    unsigned _j = 0;
@@ -281,8 +282,8 @@ mongoc_log_trace_iovec (const char *domain, const mongoc_iovec_t *_iov, size_t _
    }
 
    _i = 0;
-   str = bson_string_new (NULL);
-   astr = bson_string_new (NULL);
+   str = mcd_string_new (NULL);
+   astr = mcd_string_new (NULL);
 
    for (_j = 0; _j < _iovcnt; _j++) {
       _b = (char *) _iov[_j].iov_base;
@@ -291,23 +292,23 @@ mongoc_log_trace_iovec (const char *domain, const mongoc_iovec_t *_iov, size_t _
       for (_k = 0; _k < _l; _k++, _i++) {
          _v = *(_b + _k);
          if ((_i % 16) == 0) {
-            bson_string_append_printf (str, "%05x: ", _i);
+            mcd_string_append_printf (str, "%05x: ", _i);
          }
 
-         bson_string_append_printf (str, " %02x", _v);
+         mcd_string_append_printf (str, " %02x", _v);
          if (isprint (_v)) {
-            bson_string_append_printf (astr, " %c", _v);
+            mcd_string_append_printf (astr, " %c", _v);
          } else {
-            bson_string_append (astr, " .");
+            mcd_string_append (astr, " .");
          }
 
          if ((_i % 16) == 15) {
             mongoc_log (MONGOC_LOG_LEVEL_TRACE, domain, "%s %s", str->str, astr->str);
-            bson_string_truncate (str, 0);
-            bson_string_truncate (astr, 0);
+            mcd_string_truncate (str, 0);
+            mcd_string_truncate (astr, 0);
          } else if ((_i % 16) == 7) {
-            bson_string_append (str, " ");
-            bson_string_append (astr, " ");
+            mcd_string_append (str, " ");
+            mcd_string_append (astr, " ");
          }
       }
    }
@@ -316,6 +317,6 @@ mongoc_log_trace_iovec (const char *domain, const mongoc_iovec_t *_iov, size_t _
       mongoc_log (MONGOC_LOG_LEVEL_TRACE, domain, "%-56s %s", str->str, astr->str);
    }
 
-   bson_string_free (str, true);
-   bson_string_free (astr, true);
+   mcd_string_free (str, true);
+   mcd_string_free (astr, true);
 }

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -29,6 +29,7 @@
 #include "mongoc-stream-tls-secure-channel-private.h"
 #include "mongoc-errno-private.h"
 #include "mongoc-error.h"
+#include <mcd-string.h>
 
 
 #undef MONGOC_LOG_DOMAIN
@@ -239,7 +240,7 @@ mongoc_secure_channel_setup_certificate (mongoc_stream_tls_secure_channel_t *sec
 }
 
 void
-_bson_append_szoid (bson_string_t *retval, PCCERT_CONTEXT cert, const char *label, void *oid)
+_bson_append_szoid (mcd_string_t *retval, PCCERT_CONTEXT cert, const char *label, void *oid)
 {
    DWORD oid_len = CertGetNameString (cert, CERT_NAME_ATTR_TYPE, 0, oid, NULL, 0);
 
@@ -247,14 +248,14 @@ _bson_append_szoid (bson_string_t *retval, PCCERT_CONTEXT cert, const char *labe
       char *tmp = bson_malloc0 (oid_len);
 
       CertGetNameString (cert, CERT_NAME_ATTR_TYPE, 0, oid, tmp, oid_len);
-      bson_string_append_printf (retval, "%s%s", label, tmp);
+      mcd_string_append_printf (retval, "%s%s", label, tmp);
       bson_free (tmp);
    }
 }
 char *
 _mongoc_secure_channel_extract_subject (const char *filename, const char *passphrase)
 {
-   bson_string_t *retval;
+   mcd_string_t *retval;
    PCCERT_CONTEXT cert;
 
    cert = mongoc_secure_channel_setup_certificate_from_file (filename);
@@ -262,7 +263,7 @@ _mongoc_secure_channel_extract_subject (const char *filename, const char *passph
       return NULL;
    }
 
-   retval = bson_string_new ("");
+   retval = mcd_string_new ("");
    ;
    _bson_append_szoid (retval, cert, "C=", szOID_COUNTRY_NAME);
    _bson_append_szoid (retval, cert, ",ST=", szOID_STATE_OR_PROVINCE_NAME);
@@ -272,7 +273,7 @@ _mongoc_secure_channel_extract_subject (const char *filename, const char *passph
    _bson_append_szoid (retval, cert, ",CN=", szOID_COMMON_NAME);
    _bson_append_szoid (retval, cert, ",STREET=", szOID_STREET_ADDRESS);
 
-   return bson_string_free (retval, false);
+   return mcd_string_free (retval, false);
 }
 
 bool

--- a/src/libmongoc/src/mongoc/mongoc-secure-transport.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-transport.c
@@ -36,6 +36,7 @@
 #include <Security/Security.h>
 #include <Security/SecureTransport.h>
 #include <CoreFoundation/CoreFoundation.h>
+#include <mcd-string.h>
 
 /* Jailbreak Darwin Private API */
 /*
@@ -80,7 +81,7 @@ _mongoc_cfstringref_to_cstring (CFStringRef str)
 }
 
 static void
-_bson_append_cftyperef (bson_string_t *retval, const char *label, CFTypeRef str)
+_bson_append_cftyperef (mcd_string_t *retval, const char *label, CFTypeRef str)
 {
    char *cs;
 
@@ -88,10 +89,10 @@ _bson_append_cftyperef (bson_string_t *retval, const char *label, CFTypeRef str)
       cs = _mongoc_cfstringref_to_cstring (str);
 
       if (cs) {
-         bson_string_append_printf (retval, "%s%s", label, cs);
+         mcd_string_append_printf (retval, "%s%s", label, cs);
          bson_free (cs);
       } else {
-         bson_string_append_printf (retval, "%s(null)", label);
+         mcd_string_append_printf (retval, "%s(null)", label);
       }
    }
 }
@@ -124,7 +125,7 @@ char *
 _mongoc_secure_transport_RFC2253_from_cert (SecCertificateRef cert)
 {
    CFTypeRef value;
-   bson_string_t *retval;
+   mcd_string_t *retval;
    CFTypeRef subject_name;
    CFDictionaryRef cert_dict;
 
@@ -145,7 +146,7 @@ _mongoc_secure_transport_RFC2253_from_cert (SecCertificateRef cert)
       return NULL;
    }
 
-   retval = bson_string_new ("");
+   retval = mcd_string_new ("");
    ;
 
    value = _mongoc_secure_transport_dict_get (subject_name, kSecOIDCountryName);
@@ -187,7 +188,7 @@ _mongoc_secure_transport_RFC2253_from_cert (SecCertificateRef cert)
    _bson_append_cftyperef (retval, ",STREET", value);
 
    CFRelease (cert_dict);
-   return bson_string_free (retval, false);
+   return mcd_string_free (retval, false);
 }
 
 

--- a/src/libmongoc/src/mongoc/mongoc-ssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-ssl.c
@@ -24,6 +24,7 @@
 #include "mongoc-log.h"
 #include "mongoc-uri.h"
 #include "mongoc-util-private.h"
+#include <mcd-string.h>
 
 #if defined(MONGOC_ENABLE_SSL_OPENSSL)
 #include "mongoc-openssl-private.h"
@@ -167,19 +168,19 @@ _mongoc_ssl_opts_disable_ocsp_endpoint_check (const mongoc_ssl_opt_t *ssl_opt)
 }
 
 bool
-_mongoc_ssl_opts_from_bson (mongoc_ssl_opt_t *ssl_opt, const bson_t *bson, bson_string_t *errmsg)
+_mongoc_ssl_opts_from_bson (mongoc_ssl_opt_t *ssl_opt, const bson_t *bson, mcd_string_t *errmsg)
 {
    bson_iter_t iter;
 
    if (ssl_opt->internal) {
-      bson_string_append (errmsg, "SSL options must not have internal state set");
+      mcd_string_append (errmsg, "SSL options must not have internal state set");
       return false;
    }
 
    ssl_opt->internal = bson_malloc0 (sizeof (_mongoc_internal_tls_opts_t));
 
    if (!bson_iter_init (&iter, bson)) {
-      bson_string_append (errmsg, "error initializing iterator to BSON SSL options");
+      mcd_string_append (errmsg, "error initializing iterator to BSON SSL options");
       return false;
    }
 
@@ -227,7 +228,7 @@ _mongoc_ssl_opts_from_bson (mongoc_ssl_opt_t *ssl_opt, const bson_t *bson, bson_
          }
       }
 
-      bson_string_append_printf (
+      mcd_string_append_printf (
          errmsg, "unexpected %s option: %s", _mongoc_bson_type_to_str (bson_iter_type (&iter)), key);
       return false;
    }

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl.c
@@ -41,7 +41,7 @@
 #include "mongoc-log.h"
 #include "mongoc-error.h"
 
-#include "common-macros-private.h"
+#include <common-macros-private.h>
 
 
 #undef MONGOC_LOG_DOMAIN

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-transport.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-transport.c
@@ -36,6 +36,7 @@
 #include "mongoc-stream-tls-private.h"
 #include "mongoc-stream-private.h"
 #include "mongoc-stream-tls-secure-transport-private.h"
+#include <mcd-string.h>
 
 #undef MONGOC_LOG_DOMAIN
 #define MONGOC_LOG_DOMAIN "stream-tls-secure_transport"
@@ -409,35 +410,35 @@ _set_error_from_osstatus (OSStatus status, const char *prefix, bson_error_t *err
 static char *
 explain_trust_result (SecTrustRef trust, SecTrustResultType trust_result)
 {
-   bson_string_t *reason;
+   mcd_string_t *reason;
    CFArrayRef cfprops = NULL;
    CFIndex count, i;
 
-   reason = bson_string_new ("");
+   reason = mcd_string_new ("");
    switch (trust_result) {
    case kSecTrustResultDeny:
-      bson_string_append (reason, "Certificate trust denied");
+      mcd_string_append (reason, "Certificate trust denied");
       break;
    case kSecTrustResultRecoverableTrustFailure:
-      bson_string_append (reason, "Certificate trust failure");
+      mcd_string_append (reason, "Certificate trust failure");
       break;
    case kSecTrustResultFatalTrustFailure:
-      bson_string_append (reason, "Certificate trust fatal failure");
+      mcd_string_append (reason, "Certificate trust fatal failure");
       break;
    case kSecTrustResultInvalid:
-      bson_string_append (reason, "Certificate trust evaluation failure");
+      mcd_string_append (reason, "Certificate trust evaluation failure");
       break;
    default:
-      bson_string_append_printf (reason, "Certificate trust failure #%d", (int) trust_result);
+      mcd_string_append_printf (reason, "Certificate trust failure #%d", (int) trust_result);
       break;
    }
-   bson_string_append (reason, ": ");
+   mcd_string_append (reason, ": ");
 
    cfprops = SecTrustCopyProperties (trust);
    /* This contains an array of dictionaries, each representing a cert in the
     * chain. Append the first failure reason found. */
    if (!cfprops) {
-      bson_string_append (reason, "Unable to retreive cause for trust failure");
+      mcd_string_append (reason, "Unable to retreive cause for trust failure");
       goto done;
    }
 
@@ -450,7 +451,7 @@ explain_trust_result (SecTrustRef trust, SecTrustResultType trust_result)
 
       elem = CFArrayGetValueAtIndex (cfprops, i);
       if (CFGetTypeID (elem) != CFDictionaryGetTypeID ()) {
-         bson_string_append (reason, "Unable to parse cause for trust failure");
+         mcd_string_append (reason, "Unable to parse cause for trust failure");
          goto done;
       }
 
@@ -460,24 +461,24 @@ explain_trust_result (SecTrustRef trust, SecTrustResultType trust_result)
          continue;
       }
       if (CFGetTypeID (reason_elem) != CFStringGetTypeID ()) {
-         bson_string_append (reason, "Unable to parse trust failure error");
+         mcd_string_append (reason, "Unable to parse trust failure error");
          goto done;
       }
       reason_str = _mongoc_cfstringref_to_cstring (reason_elem);
       if (reason_str) {
-         bson_string_append (reason, reason_str);
+         mcd_string_append (reason, reason_str);
          bson_free (reason_str);
          goto done;
       } else {
-         bson_string_append (reason, "Unable to express trust failure error");
+         mcd_string_append (reason, "Unable to express trust failure error");
          goto done;
       }
    }
 
-   bson_string_append (reason, "No trust failure reason available");
+   mcd_string_append (reason, "No trust failure reason available");
 done:
    CFReleaseSafe (cfprops);
-   return bson_string_free (reason, false);
+   return mcd_string_free (reason, false);
 }
 
 /* Returns a boolean indicating success. If false is returned, then an error is

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls.c
@@ -42,7 +42,7 @@
 #include "mongoc-stream-tls-secure-channel.h"
 #endif
 #include "mongoc-stream-tls.h"
-#include "mongoc-util-private.h" // BEGIN_IGNORE_DEPRECATIONS
+#include <common-macros-private.h> // BEGIN_IGNORE_DEPRECATIONS
 
 #undef MONGOC_LOG_DOMAIN
 #define MONGOC_LOG_DOMAIN "stream-tls"

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
@@ -43,6 +43,7 @@
 #include "mongoc-cluster-private.h"
 #include "mongoc-client-private.h"
 #include "mongoc-util-private.h"
+#include <mcd-string.h>
 
 #undef MONGOC_LOG_DOMAIN
 #define MONGOC_LOG_DOMAIN "topology_scanner"
@@ -1167,20 +1168,20 @@ _mongoc_topology_scanner_finish (mongoc_topology_scanner_t *ts)
 {
    mongoc_topology_scanner_node_t *node, *tmp;
    bson_error_t *error = &ts->error;
-   bson_string_t *msg;
+   mcd_string_t *msg;
 
    memset (&ts->error, 0, sizeof (bson_error_t));
 
-   msg = bson_string_new (NULL);
+   msg = mcd_string_new (NULL);
 
    DL_FOREACH_SAFE (ts->nodes, node, tmp)
    {
       if (node->last_error.code) {
          if (msg->len) {
-            bson_string_append_c (msg, ' ');
+            mcd_string_append_c (msg, ' ');
          }
 
-         bson_string_append_printf (msg, "[%s]", node->last_error.message);
+         mcd_string_append_printf (msg, "[%s]", node->last_error.message);
 
          /* last error domain and code win */
          error->domain = node->last_error.domain;
@@ -1189,7 +1190,7 @@ _mongoc_topology_scanner_finish (mongoc_topology_scanner_t *ts)
    }
 
    bson_strncpy ((char *) &error->message, msg->str, sizeof (error->message));
-   bson_string_free (msg, true);
+   mcd_string_free (msg, true);
 
    _delete_retired_nodes (ts);
 }

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -36,6 +36,7 @@
 #include "utlist.h"
 
 #include <stdint.h>
+#include <mcd-string.h>
 
 static void
 _topology_collect_errors (const mongoc_topology_description_t *topology, bson_error_t *error_out);
@@ -1121,8 +1122,8 @@ mongoc_topology_select_server_id (mongoc_topology_t *topology,
    uint32_t server_id;
    mc_shared_tpld td = mc_tpld_take_ref (topology);
 
-   bson_string_t *topology_type = bson_string_new (". Topology type: ");
-   bson_string_append (topology_type, mongoc_topology_description_type (td.ptr));
+   mcd_string_t *topology_type = mcd_string_new (". Topology type: ");
+   mcd_string_append (topology_type, mongoc_topology_description_type (td.ptr));
 
    /* These names come from the Server Selection Spec pseudocode */
    int64_t loop_start;  /* when we entered this function */
@@ -1330,7 +1331,7 @@ done:
          _mongoc_error_append (error, topology_type->str);
       }
    }
-   bson_string_free (topology_type, true);
+   mcd_string_free (topology_type, true);
    mc_tpld_drop_ref (&td);
    return server_id;
 }
@@ -1868,10 +1869,10 @@ static void
 _topology_collect_errors (const mongoc_topology_description_t *td, bson_error_t *error_out)
 {
    const mongoc_server_description_t *server_description;
-   bson_string_t *error_message;
+   mcd_string_t *error_message;
 
    memset (error_out, 0, sizeof (bson_error_t));
-   error_message = bson_string_new ("");
+   error_message = mcd_string_new ("");
 
    for (size_t i = 0u; i < mc_tpld_servers_const (td)->items_len; i++) {
       const bson_error_t *error;
@@ -1880,9 +1881,9 @@ _topology_collect_errors (const mongoc_topology_description_t *td, bson_error_t 
       error = &server_description->error;
       if (error->code) {
          if (error_message->len > 0) {
-            bson_string_append_c (error_message, ' ');
+            mcd_string_append_c (error_message, ' ');
          }
-         bson_string_append_printf (error_message, "[%s]", server_description->error.message);
+         mcd_string_append_printf (error_message, "[%s]", server_description->error.message);
          /* The last error's code and domain wins. */
          error_out->code = error->code;
          error_out->domain = error->domain;
@@ -1890,7 +1891,7 @@ _topology_collect_errors (const mongoc_topology_description_t *td, bson_error_t 
    }
 
    bson_strncpy ((char *) &error_out->message, error_message->str, sizeof (error_out->message));
-   bson_string_free (error_message, true);
+   mcd_string_free (error_message, true);
 }
 
 void

--- a/src/libmongoc/src/mongoc/mongoc-uri.c
+++ b/src/libmongoc/src/mongoc/mongoc-uri.c
@@ -38,6 +38,7 @@
 #include "utlist.h"
 
 #include <bson-dsl.h>
+#include <mcd-string.h>
 
 struct _mongoc_uri_t {
    char *str;
@@ -2205,7 +2206,7 @@ char *
 mongoc_uri_unescape (const char *escaped_string)
 {
    bson_unichar_t c;
-   bson_string_t *str;
+   mcd_string_t *str;
    unsigned int hex = 0;
    const char *ptr;
    const char *end;
@@ -2226,7 +2227,7 @@ mongoc_uri_unescape (const char *escaped_string)
 
    ptr = escaped_string;
    end = ptr + len;
-   str = bson_string_new (NULL);
+   str = mcd_string_new (NULL);
 
    for (; *ptr; ptr = bson_utf8_next_char (ptr)) {
       c = bson_utf8_get_char (ptr);
@@ -2239,16 +2240,16 @@ mongoc_uri_unescape (const char *escaped_string)
              (1 != sscanf (&ptr[1], "%02x", &hex))
 #endif
              || 0 == hex) {
-            bson_string_free (str, true);
+            mcd_string_free (str, true);
             MONGOC_WARNING ("Invalid %% escape sequence");
             return NULL;
          }
-         bson_string_append_c (str, hex);
+         mcd_string_append_c (str, hex);
          ptr += 2;
          unescape_occurred = true;
          break;
       default:
-         bson_string_append_unichar (str, c);
+         mcd_string_append_unichar (str, c);
          break;
       }
    }
@@ -2256,11 +2257,11 @@ mongoc_uri_unescape (const char *escaped_string)
    /* Check that after unescaping, it is still valid UTF-8 */
    if (unescape_occurred && !bson_utf8_validate (str->str, str->len, false)) {
       MONGOC_WARNING ("Invalid %% escape sequence: unescaped string contains invalid UTF-8");
-      bson_string_free (str, true);
+      mcd_string_free (str, true);
       return NULL;
    }
 
-   return bson_string_free (str, false);
+   return mcd_string_free (str, false);
 }
 
 

--- a/src/libmongoc/src/mongoc/mongoc-util-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-util-private.h
@@ -34,19 +34,6 @@
 #define strncasecmp _strnicmp
 #endif
 
-#if BSON_GNUC_CHECK_VERSION(4, 6)
-#define BEGIN_IGNORE_DEPRECATIONS \
-   _Pragma ("GCC diagnostic push") _Pragma ("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
-#define END_IGNORE_DEPRECATIONS _Pragma ("GCC diagnostic pop")
-#elif defined(__clang__)
-#define BEGIN_IGNORE_DEPRECATIONS \
-   _Pragma ("clang diagnostic push") _Pragma ("clang diagnostic ignored \"-Wdeprecated-declarations\"")
-#define END_IGNORE_DEPRECATIONS _Pragma ("clang diagnostic pop")
-#else
-#define BEGIN_IGNORE_DEPRECATIONS
-#define END_IGNORE_DEPRECATIONS
-#endif
-
 #ifndef _WIN32
 #define MONGOC_PRINTF_FORMAT(a, b) __attribute__ ((format (__printf__, a, b)))
 #else

--- a/src/libmongoc/src/mongoc/mongoc-write-command.c
+++ b/src/libmongoc/src/mongoc/mongoc-write-command.c
@@ -26,6 +26,7 @@
 #include "mongoc-write-concern-private.h"
 #include "mongoc-util-private.h"
 #include "mongoc-opts-private.h"
+#include <mcd-string.h>
 
 
 /* indexed by MONGOC_WRITE_COMMAND_DELETE, INSERT, UPDATE */
@@ -986,15 +987,15 @@ _set_error_from_response (bson_t *bson_array,
 {
    bson_iter_t array_iter;
    bson_iter_t doc_iter;
-   bson_string_t *compound_err;
+   mcd_string_t *compound_err;
    const char *errmsg = NULL;
    int32_t code = 0;
    uint32_t n_keys, i;
 
-   compound_err = bson_string_new (NULL);
+   compound_err = mcd_string_new (NULL);
    n_keys = bson_count_keys (bson_array);
    if (n_keys > 1) {
-      bson_string_append_printf (compound_err, "Multiple %s errors: ", error_type);
+      mcd_string_append_printf (compound_err, "Multiple %s errors: ", error_type);
    }
 
    if (!bson_empty0 (bson_array) && bson_iter_init (&array_iter, bson_array)) {
@@ -1013,13 +1014,13 @@ _set_error_from_response (bson_t *bson_array,
 
                   /* build message like 'Multiple write errors: "foo", "bar"' */
                   if (n_keys > 1) {
-                     bson_string_append_printf (compound_err, "\"%s\"", errmsg);
+                     mcd_string_append_printf (compound_err, "\"%s\"", errmsg);
                      if (i < n_keys - 1) {
-                        bson_string_append (compound_err, ", ");
+                        mcd_string_append (compound_err, ", ");
                      }
                   } else {
                      /* single error message */
-                     bson_string_append (compound_err, errmsg);
+                     mcd_string_append (compound_err, errmsg);
                   }
                }
             }
@@ -1033,7 +1034,7 @@ _set_error_from_response (bson_t *bson_array,
       }
    }
 
-   bson_string_free (compound_err, true);
+   mcd_string_free (compound_err, true);
 }
 
 

--- a/src/libmongoc/src/mongoc/mongoc-write-concern.c
+++ b/src/libmongoc/src/mongoc/mongoc-write-concern.c
@@ -20,6 +20,7 @@
 #include "mongoc-util-private.h"
 #include "mongoc-write-concern.h"
 #include "mongoc-write-concern-private.h"
+#include <common-macros-private.h> // BEGIN_IGNORE_DEPRECATIONS
 
 
 static void

--- a/src/libmongoc/tests/TestSuite.c
+++ b/src/libmongoc/tests/TestSuite.c
@@ -42,6 +42,7 @@
 #include "test-conveniences.h"
 #include "test-libmongoc.h"
 #include "TestSuite.h"
+#include <mcd-string.h>
 
 #define SKIP_LINE_BUFFER_SIZE 1024
 
@@ -202,7 +203,7 @@ TestSuite_Init (TestSuite *suite, const char *name, int argc, char **argv)
       } else if (!strcmp (mock_server_log, "stderr")) {
          suite->mock_server_log = stderr;
       } else if (!strcmp (mock_server_log, "json")) {
-         suite->mock_server_log_buf = bson_string_new (NULL);
+         suite->mock_server_log_buf = mcd_string_new (NULL);
       } else {
          test_error ("Unrecognized option: MONGOC_TEST_SERVER_LOG=%s", mock_server_log);
       }
@@ -506,7 +507,7 @@ TestSuite_RunFuncInChild (TestSuite *suite, /* IN */
       close (pipefd[1]);
       while ((nread = read (pipefd[0], buf, sizeof (buf) - 1)) > 0) {
          buf[nread] = '\0';
-         bson_string_append (suite->mock_server_log_buf, buf);
+         mcd_string_append (suite->mock_server_log_buf, buf);
       }
    }
 
@@ -521,10 +522,10 @@ TestSuite_RunFuncInChild (TestSuite *suite, /* IN */
 
 /* replace " with \", newline with \n, tab with four spaces */
 static void
-_append_json_escaped (bson_string_t *buf, const char *s)
+_append_json_escaped (mcd_string_t *buf, const char *s)
 {
    char *escaped = bson_utf8_escape_for_json (s, -1);
-   bson_string_append (buf, escaped);
+   mcd_string_append (buf, escaped);
    bson_free (escaped);
 }
 
@@ -537,14 +538,14 @@ TestSuite_RunTest (TestSuite *suite, /* IN */
 {
    int64_t t1, t2, t3;
    char name[MAX_TEST_NAME_LENGTH];
-   bson_string_t *buf;
-   bson_string_t *mock_server_log_buf;
+   mcd_string_t *buf;
+   mcd_string_t *mock_server_log_buf;
    size_t i;
    int status = 0;
 
    bson_snprintf (name, sizeof name, "%s%s", suite->name, test->name);
 
-   buf = bson_string_new (NULL);
+   buf = mcd_string_new (NULL);
 
    if (suite->flags & TEST_DEBUGOUTPUT) {
       test_msg ("Begin %s, seed %u", name, test->seed);
@@ -558,12 +559,12 @@ TestSuite_RunTest (TestSuite *suite, /* IN */
             test_msg ("@@ctest-skipped@@");
          }
          if (!suite->silent) {
-            bson_string_append_printf (buf,
-                                       "    { \"status\": \"skip\", \"test_file\": \"%s\","
-                                       " \"reason\": \"%s\" }%s",
-                                       test->name,
-                                       skip->reason,
-                                       ((*count) == 1) ? "" : ",");
+            mcd_string_append_printf (buf,
+                                      "    { \"status\": \"skip\", \"test_file\": \"%s\","
+                                      " \"reason\": \"%s\" }%s",
+                                      test->name,
+                                      skip->reason,
+                                      ((*count) == 1) ? "" : ",");
             test_msg ("%s", buf->str);
             if (suite->outfile) {
                fprintf (suite->outfile, "%s", buf->str);
@@ -582,7 +583,7 @@ TestSuite_RunTest (TestSuite *suite, /* IN */
             test_msg ("@@ctest-skipped@@");
          }
          if (!suite->silent) {
-            bson_string_append_printf (
+            mcd_string_append_printf (
                buf, "    { \"status\": \"skip\", \"test_file\": \"%s\" }%s", test->name, ((*count) == 1) ? "" : ",");
             test_msg ("%s", buf->str);
             if (suite->outfile) {
@@ -625,37 +626,37 @@ TestSuite_RunTest (TestSuite *suite, /* IN */
    ASSERT_CMPINT64 (t2, >=, t1);
    t3 = t2 - t1;
 
-   bson_string_append_printf (buf,
-                              "    { \"status\": \"%s\", "
-                              "\"test_file\": \"%s\", "
-                              "\"seed\": \"%u\", "
-                              "\"start\": %u.%06u, "
-                              "\"end\": %u.%06u, "
-                              "\"elapsed\": %u.%06u ",
-                              (status == 0) ? "pass" : "fail",
-                              name,
-                              test->seed,
-                              (unsigned) t1 / (1000 * 1000),
-                              (unsigned) t1 % (1000 * 1000),
-                              (unsigned) t2 / (1000 * 1000),
-                              (unsigned) t2 % (1000 * 1000),
-                              (unsigned) t3 / (1000 * 1000),
-                              (unsigned) t3 % (1000 * 1000));
+   mcd_string_append_printf (buf,
+                             "    { \"status\": \"%s\", "
+                             "\"test_file\": \"%s\", "
+                             "\"seed\": \"%u\", "
+                             "\"start\": %u.%06u, "
+                             "\"end\": %u.%06u, "
+                             "\"elapsed\": %u.%06u ",
+                             (status == 0) ? "pass" : "fail",
+                             name,
+                             test->seed,
+                             (unsigned) t1 / (1000 * 1000),
+                             (unsigned) t1 % (1000 * 1000),
+                             (unsigned) t2 / (1000 * 1000),
+                             (unsigned) t2 % (1000 * 1000),
+                             (unsigned) t3 / (1000 * 1000),
+                             (unsigned) t3 % (1000 * 1000));
 
    mock_server_log_buf = suite->mock_server_log_buf;
 
    if (mock_server_log_buf && mock_server_log_buf->len) {
-      bson_string_append (buf, ", \"log_raw\": \"");
+      mcd_string_append (buf, ", \"log_raw\": \"");
       _append_json_escaped (buf, mock_server_log_buf->str);
-      bson_string_append (buf, "\"");
+      mcd_string_append (buf, "\"");
 
-      bson_string_truncate (mock_server_log_buf, 0);
+      mcd_string_truncate (mock_server_log_buf, 0);
    }
 
-   bson_string_append_printf (buf, " }");
+   mcd_string_append_printf (buf, " }");
 
    if (*count > 1) {
-      bson_string_append_printf (buf, ",");
+      mcd_string_append_printf (buf, ",");
    }
 
    test_msg ("%s", buf->str);
@@ -665,7 +666,7 @@ TestSuite_RunTest (TestSuite *suite, /* IN */
    }
 
 done:
-   bson_string_free (buf, true);
+   mcd_string_free (buf, true);
 
    return status ? 1 : 0;
 }
@@ -1126,7 +1127,7 @@ TestSuite_Destroy (TestSuite *suite)
    }
 
    if (suite->mock_server_log_buf) {
-      bson_string_free (suite->mock_server_log_buf, true);
+      mcd_string_free (suite->mock_server_log_buf, true);
    }
 
    bson_free (suite->name);
@@ -1179,7 +1180,7 @@ test_suite_mock_server_log (const char *msg, ...)
       va_end (ap);
 
       if (gTestSuite->mock_server_log_buf) {
-         bson_string_append_printf (gTestSuite->mock_server_log_buf, "%s\n", formatted_msg);
+         mcd_string_append_printf (gTestSuite->mock_server_log_buf, "%s\n", formatted_msg);
       } else {
          fprintf (gTestSuite->mock_server_log, "%s\n", formatted_msg);
          fflush (gTestSuite->mock_server_log);

--- a/src/libmongoc/tests/mock_server/mock-rs.c
+++ b/src/libmongoc/tests/mock_server/mock-rs.c
@@ -24,6 +24,7 @@
 #include "sync-queue.h"
 #include "test-libmongoc.h"
 #include "TestSuite.h"
+#include <mcd-string.h>
 
 
 struct _mock_rs_t {
@@ -66,18 +67,18 @@ char *
 hosts (mongoc_array_t *servers)
 {
    const char *host_and_port;
-   bson_string_t *hosts_str = bson_string_new ("");
+   mcd_string_t *hosts_str = mcd_string_new ("");
 
    for (size_t i = 0u; i < servers->len; i++) {
       host_and_port = mock_server_get_host_and_port (get_server (servers, i));
-      bson_string_append_printf (hosts_str, "\"%s\"", host_and_port);
+      mcd_string_append_printf (hosts_str, "\"%s\"", host_and_port);
 
       if (i + 1u < servers->len) {
-         bson_string_append_printf (hosts_str, ", ");
+         mcd_string_append_printf (hosts_str, ", ");
       }
    }
 
-   return bson_string_free (hosts_str, false); /* detach buffer */
+   return mcd_string_free (hosts_str, false); /* detach buffer */
 }
 
 
@@ -85,19 +86,19 @@ mongoc_uri_t *
 make_uri (mongoc_array_t *servers)
 {
    const char *host_and_port;
-   bson_string_t *uri_str = bson_string_new ("mongodb://");
+   mcd_string_t *uri_str = mcd_string_new ("mongodb://");
    mongoc_uri_t *uri;
 
    for (size_t i = 0u; i < servers->len; i++) {
       host_and_port = mock_server_get_host_and_port (get_server (servers, i));
-      bson_string_append_printf (uri_str, "%s", host_and_port);
+      mcd_string_append_printf (uri_str, "%s", host_and_port);
 
       if (i + 1u < servers->len) {
-         bson_string_append_printf (uri_str, ",");
+         mcd_string_append_printf (uri_str, ",");
       }
    }
 
-   bson_string_append_printf (uri_str, "/?replicaSet=rs");
+   mcd_string_append_printf (uri_str, "/?replicaSet=rs");
 
    uri = mongoc_uri_new (uri_str->str);
 
@@ -106,7 +107,7 @@ make_uri (mongoc_array_t *servers)
    mongoc_uri_set_option_as_bool (uri, MONGOC_URI_RETRYREADS, false);
    mongoc_uri_set_option_as_bool (uri, MONGOC_URI_RETRYWRITES, false);
 
-   bson_string_free (uri_str, true);
+   mcd_string_free (uri_str, true);
 
    return uri;
 }

--- a/src/libmongoc/tests/mock_server/mock-server.c
+++ b/src/libmongoc/tests/mock_server/mock-server.c
@@ -28,6 +28,7 @@
 #include "../test-conveniences.h"
 #include "../test-libmongoc.h"
 #include "../TestSuite.h"
+#include <mcd-string.h>
 
 #ifdef BSON_HAVE_STRINGS_H
 #include <strings.h>
@@ -1966,7 +1967,7 @@ static void
 _mock_server_reply_with_stream (mock_server_t *server, reply_t *reply, mongoc_stream_t *client)
 {
    char *doc_json;
-   bson_string_t *docs_json;
+   mcd_string_t *docs_json;
    uint8_t *buf;
    uint8_t *ptr;
    size_t len;
@@ -1991,13 +1992,13 @@ _mock_server_reply_with_stream (mock_server_t *server, reply_t *reply, mongoc_st
       return;
    }
 
-   docs_json = bson_string_new ("");
+   docs_json = mcd_string_new ("");
    for (int i = 0; i < n_docs; i++) {
       doc_json = bson_as_json (&docs[i], NULL);
-      bson_string_append (docs_json, doc_json);
+      mcd_string_append (docs_json, doc_json);
       bson_free (doc_json);
       if (i < n_docs - 1) {
-         bson_string_append (docs_json, ", ");
+         mcd_string_append (docs_json, ", ");
       }
    }
 
@@ -2069,7 +2070,7 @@ _mock_server_reply_with_stream (mock_server_t *server, reply_t *reply, mongoc_st
 
    bson_free (iov);
    mcd_rpc_message_destroy (rpc);
-   bson_string_free (docs_json, true);
+   mcd_string_free (docs_json, true);
    bson_free (buf);
 }
 
@@ -2092,7 +2093,7 @@ void
 rs_response_to_hello (mock_server_t *server, int max_wire_version, bool primary, int has_tags, ...)
 {
    va_list ap;
-   bson_string_t *hosts;
+   mcd_string_t *hosts;
    bool first;
    mock_server_t *host;
 
@@ -2101,7 +2102,7 @@ rs_response_to_hello (mock_server_t *server, int max_wire_version, bool primary,
                     max_wire_version,
                     WIRE_VERSION_MIN);
 
-   hosts = bson_string_new ("");
+   hosts = mcd_string_new ("");
 
    va_start (ap, has_tags);
 
@@ -2110,10 +2111,10 @@ rs_response_to_hello (mock_server_t *server, int max_wire_version, bool primary,
       if (first) {
          first = false;
       } else {
-         bson_string_append (hosts, ",");
+         mcd_string_append (hosts, ",");
       }
 
-      bson_string_append_printf (hosts, "'%s'", mock_server_get_host_and_port (host));
+      mcd_string_append_printf (hosts, "'%s'", mock_server_get_host_and_port (host));
    }
 
    va_end (ap);
@@ -2137,5 +2138,5 @@ rs_response_to_hello (mock_server_t *server, int max_wire_version, bool primary,
                            max_wire_version,
                            hosts->str);
 
-   bson_string_free (hosts, true);
+   mcd_string_free (hosts, true);
 }

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -30,6 +30,7 @@
 #include "TestSuite.h"
 #include "test-conveniences.h"
 #include "test-libmongoc.h"
+#include <mcd-string.h>
 
 #ifdef BSON_HAVE_STRINGS_H
 #include <strings.h>
@@ -368,7 +369,7 @@ char *
 test_framework_get_unix_domain_socket_path_escaped (void)
 {
    char *path = test_framework_get_unix_domain_socket_path (), *c = path;
-   bson_string_t *escaped = bson_string_new (NULL);
+   mcd_string_t *escaped = mcd_string_new (NULL);
 
    /* Connection String Spec: "The host information cannot contain an unescaped
     * slash ("/"), if it does then an exception MUST be thrown informing users
@@ -379,16 +380,16 @@ test_framework_get_unix_domain_socket_path_escaped (void)
     */
    do {
       if (*c == '/') {
-         bson_string_append (escaped, "%2F");
+         mcd_string_append (escaped, "%2F");
       } else {
-         bson_string_append_c (escaped, *c);
+         mcd_string_append_c (escaped, *c);
       }
    } while (*(++c));
 
-   bson_string_append_c (escaped, '\0');
+   mcd_string_append_c (escaped, '\0');
    bson_free (path);
 
-   return bson_string_free (escaped, false /* free_segment */);
+   return mcd_string_free (escaped, false /* free_segment */);
 }
 
 static char *
@@ -927,7 +928,7 @@ set_name (bson_t *hello_response)
 
 
 static bool
-uri_str_has_db (bson_string_t *uri_string)
+uri_str_has_db (mcd_string_t *uri_string)
 {
    BSON_ASSERT_PARAM (uri_string);
 
@@ -949,20 +950,20 @@ uri_str_has_db (bson_string_t *uri_string)
 
 
 static void
-add_option_to_uri_str (bson_string_t *uri_string, const char *option, const char *value)
+add_option_to_uri_str (mcd_string_t *uri_string, const char *option, const char *value)
 {
    if (strchr (uri_string->str, '?')) {
       /* already has some options */
-      bson_string_append_c (uri_string, '&');
+      mcd_string_append_c (uri_string, '&');
    } else if (uri_str_has_db (uri_string)) {
       /* like "mongodb://host/db" */
-      bson_string_append_c (uri_string, '?');
+      mcd_string_append_c (uri_string, '?');
    } else {
       /* like "mongodb://host" */
-      bson_string_append_printf (uri_string, "/?");
+      mcd_string_append_printf (uri_string, "/?");
    }
 
-   bson_string_append_printf (uri_string, "%s=%s", option, value);
+   mcd_string_append_printf (uri_string, "%s=%s", option, value);
 }
 
 
@@ -993,7 +994,7 @@ test_framework_get_uri_str_no_auth (const char *database_name)
 {
    char *env_uri_str;
    bson_t hello_response;
-   bson_string_t *uri_string;
+   mcd_string_t *uri_string;
    char *name;
    bson_iter_t iter;
    bson_iter_t hosts_iter;
@@ -1003,18 +1004,18 @@ test_framework_get_uri_str_no_auth (const char *database_name)
 
    env_uri_str = _uri_str_from_env ();
    if (env_uri_str) {
-      uri_string = bson_string_new (env_uri_str);
+      uri_string = mcd_string_new (env_uri_str);
       if (database_name) {
          if (uri_string->str[uri_string->len - 1] != '/') {
-            bson_string_append (uri_string, "/");
+            mcd_string_append (uri_string, "/");
          }
-         bson_string_append (uri_string, database_name);
+         mcd_string_append (uri_string, database_name);
       }
       bson_free (env_uri_str);
    } else {
       /* construct a direct connection or replica set connection URI */
       call_hello (&hello_response);
-      uri_string = bson_string_new ("mongodb://");
+      uri_string = mcd_string_new ("mongodb://");
 
       if ((name = set_name (&hello_response))) {
          /* make a replica set URI */
@@ -1026,16 +1027,16 @@ test_framework_get_uri_str_no_auth (const char *database_name)
          while (bson_iter_next (&hosts_iter)) {
             BSON_ASSERT (BSON_ITER_HOLDS_UTF8 (&hosts_iter));
             if (!first) {
-               bson_string_append (uri_string, ",");
+               mcd_string_append (uri_string, ",");
             }
 
-            bson_string_append (uri_string, bson_iter_utf8 (&hosts_iter, NULL));
+            mcd_string_append (uri_string, bson_iter_utf8 (&hosts_iter, NULL));
             first = false;
          }
 
-         bson_string_append (uri_string, "/");
+         mcd_string_append (uri_string, "/");
          if (database_name) {
-            bson_string_append (uri_string, database_name);
+            mcd_string_append (uri_string, database_name);
          }
 
          add_option_to_uri_str (uri_string, MONGOC_URI_REPLICASET, name);
@@ -1043,10 +1044,10 @@ test_framework_get_uri_str_no_auth (const char *database_name)
       } else {
          host = test_framework_get_host ();
          port = test_framework_get_port ();
-         bson_string_append_printf (uri_string, "%s:%hu", host, port);
-         bson_string_append (uri_string, "/");
+         mcd_string_append_printf (uri_string, "%s:%hu", host, port);
+         mcd_string_append (uri_string, "/");
          if (database_name) {
-            bson_string_append (uri_string, database_name);
+            mcd_string_append (uri_string, database_name);
          }
 
          bson_free (host);
@@ -1070,7 +1071,7 @@ test_framework_get_uri_str_no_auth (const char *database_name)
    // runner, but make tests a little more resilient to transient errors.
    add_option_to_uri_str (uri_string, MONGOC_URI_SERVERSELECTIONTRYONCE, "false");
 
-   return bson_string_free (uri_string, false);
+   return mcd_string_free (uri_string, false);
 }
 
 /*

--- a/src/libmongoc/tests/test-mcd-azure-imds.c
+++ b/src/libmongoc/tests/test-mcd-azure-imds.c
@@ -3,6 +3,7 @@
 #include <mongoc/mongoc-host-list-private.h>
 
 #include "TestSuite.h"
+#include <mcd-string.h>
 
 #define RAW_STRING(...) #__VA_ARGS__
 
@@ -39,7 +40,7 @@ _test_http_req (void)
    // Test generating an HTTP request for the IMDS server
    mcd_azure_imds_request req;
    mcd_azure_imds_request_init (&req, "example.com", 9879, "");
-   bson_string_t *req_str = _mongoc_http_render_request_head (&req.req);
+   mcd_string_t *req_str = _mongoc_http_render_request_head (&req.req);
    mcd_azure_imds_request_destroy (&req);
    // Assert that we composed exactly the request that we expected
    ASSERT_CMPSTR (req_str->str,
@@ -52,7 +53,7 @@ _test_http_req (void)
                   "Metadata: true\r\n"
                   "Accept: application/json\r\n"
                   "\r\n");
-   bson_string_free (req_str, true);
+   mcd_string_free (req_str, true);
 }
 
 static const char *

--- a/src/libmongoc/tests/test-mongoc-background-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-background-monitoring.c
@@ -26,6 +26,7 @@
 #include "test-conveniences.h"
 #include "test-libmongoc.h"
 #include "TestSuite.h"
+#include <mcd-string.h>
 
 #define LOG_DOMAIN "test_monitoring"
 
@@ -55,7 +56,7 @@ typedef struct {
    tf_observations_t *observations;
    bson_mutex_t mutex;
    mongoc_cond_t cond;
-   bson_string_t *logs;
+   mcd_string_t *logs;
 } test_fixture_t;
 
 void
@@ -101,9 +102,9 @@ void BSON_GNUC_PRINTF (2, 3) tf_log (test_fixture_t *tf, const char *format, ...
    va_start (ap, format);
    str = bson_strdupv_printf (format, ap);
    va_end (ap);
-   bson_string_append (tf->logs, nowstr);
-   bson_string_append (tf->logs, str);
-   bson_string_append_c (tf->logs, '\n');
+   mcd_string_append (tf->logs, nowstr);
+   mcd_string_append (tf->logs, str);
+   mcd_string_append_c (tf->logs, '\n');
    bson_free (str);
 }
 
@@ -238,7 +239,7 @@ tf_new (tf_flags_t flags)
       mock_server_autoresponds (tf->server, auto_respond_polling_hello, NULL, NULL);
    }
    tf->flags = flags;
-   tf->logs = bson_string_new ("");
+   tf->logs = mcd_string_new ("");
    tf->client = mongoc_client_pool_pop (tf->pool);
    return tf;
 }
@@ -249,7 +250,7 @@ tf_destroy (test_fixture_t *tf)
    mock_server_destroy (tf->server);
    mongoc_client_pool_push (tf->pool, tf->client);
    mongoc_client_pool_destroy (tf->pool);
-   bson_string_free (tf->logs, true);
+   mcd_string_free (tf->logs, true);
    bson_mutex_destroy (&tf->mutex);
    mongoc_cond_destroy (&tf->cond);
    bson_free (tf->observations);

--- a/src/libmongoc/tests/test-mongoc-client-pool.c
+++ b/src/libmongoc/tests/test-mongoc-client-pool.c
@@ -2,6 +2,7 @@
 #include "mongoc/mongoc-client-pool-private.h"
 #include <mongoc/mongoc-client-private.h>
 #include "mongoc/mongoc-util-private.h"
+#include <common-macros-private.h> // BEGIN_IGNORE_DEPRECATIONS
 
 
 #include "TestSuite.h"

--- a/src/libmongoc/tests/test-mongoc-client-session.c
+++ b/src/libmongoc/tests/test-mongoc-client-session.c
@@ -10,6 +10,7 @@
 #include "mock_server/mock-server.h"
 #include "mock_server/future-functions.h"
 #include "json-test.h"
+#include <common-macros-private.h> // BEGIN_IGNORE_DEPRECATIONS
 
 #undef MONGOC_LOG_DOMAIN
 #define MONGOC_LOG_DOMAIN "session-test"

--- a/src/libmongoc/tests/test-mongoc-client.c
+++ b/src/libmongoc/tests/test-mongoc-client.c
@@ -23,6 +23,7 @@
 #include "mock_server/future-functions.h"
 #include "mock_server/mock-server.h"
 #include "mock_server/mock-rs.h"
+#include <common-macros-private.h> // BEGIN_IGNORE_DEPRECATIONS
 
 
 #ifdef BSON_HAVE_STRINGS_H

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -15,6 +15,7 @@
 #include "mock_server/future-functions.h"
 #include "mock_server/mock-server.h"
 #include "mock_server/mock-rs.h"
+#include <common-macros-private.h> // BEGIN_IGNORE_DEPRECATIONS
 
 
 BEGIN_IGNORE_DEPRECATIONS

--- a/src/libmongoc/tests/test-mongoc-cursor.c
+++ b/src/libmongoc/tests/test-mongoc-cursor.c
@@ -11,6 +11,7 @@
 #include "mongoc/mongoc-read-concern-private.h"
 #include "mongoc/mongoc-write-concern-private.h"
 #include "test-conveniences.h"
+#include <mcd-string.h>
 
 
 typedef mongoc_cursor_t *(*make_cursor_fn) (mongoc_collection_t *);
@@ -1742,27 +1743,27 @@ typedef struct {
 
 
 static void
-_make_reply_batch (bson_string_t *reply, uint32_t n_docs, bool first_batch, bool finished)
+_make_reply_batch (mcd_string_t *reply, uint32_t n_docs, bool first_batch, bool finished)
 {
    uint32_t j;
 
-   bson_string_append_printf (reply,
-                              "{'ok': 1, 'cursor': {"
-                              "    'id': %d,"
-                              "    'ns': 'db.coll',",
-                              finished ? 0 : 123);
+   mcd_string_append_printf (reply,
+                             "{'ok': 1, 'cursor': {"
+                             "    'id': %d,"
+                             "    'ns': 'db.coll',",
+                             finished ? 0 : 123);
 
    if (first_batch) {
-      bson_string_append (reply, "'firstBatch': [{}");
+      mcd_string_append (reply, "'firstBatch': [{}");
    } else {
-      bson_string_append (reply, "'nextBatch': [{}");
+      mcd_string_append (reply, "'nextBatch': [{}");
    }
 
    for (j = 1; j < n_docs; j++) {
-      bson_string_append (reply, ", {}");
+      mcd_string_append (reply, ", {}");
    }
 
-   bson_string_append (reply, "]}}");
+   mcd_string_append (reply, "]}}");
 }
 
 
@@ -1776,7 +1777,7 @@ _test_cursor_n_return_find_cmd (mongoc_cursor_t *cursor, mock_server_t *server, 
    future_t *future;
    int j;
    int reply_no;
-   bson_string_t *reply;
+   mcd_string_t *reply;
    bool cursor_finished;
 
    BSON_APPEND_UTF8 (&find_cmd, "find", "coll");
@@ -1799,10 +1800,10 @@ _test_cursor_n_return_find_cmd (mongoc_cursor_t *cursor, mock_server_t *server, 
 
    assert_match_bson (request_get_doc (request, 0), &find_cmd, true);
 
-   reply = bson_string_new (NULL);
+   reply = mcd_string_new (NULL);
    _make_reply_batch (reply, (uint32_t) test->reply_length[0], true, false);
    reply_to_request_simple (request, reply->str);
-   bson_string_free (reply, true);
+   mcd_string_free (reply, true);
 
    ASSERT (future_get_bool (future));
    future_destroy (future);
@@ -1828,12 +1829,12 @@ _test_cursor_n_return_find_cmd (mongoc_cursor_t *cursor, mock_server_t *server, 
 
       assert_match_bson (request_get_doc (request, 0), &getmore_cmd, true);
 
-      reply = bson_string_new (NULL);
+      reply = mcd_string_new (NULL);
       cursor_finished = (reply_no == 2);
       _make_reply_batch (reply, (uint32_t) test->reply_length[reply_no], false, cursor_finished);
 
       reply_to_request_simple (request, reply->str);
-      bson_string_free (reply, true);
+      mcd_string_free (reply, true);
 
       ASSERT (future_get_bool (future));
       future_destroy (future);

--- a/src/libmongoc/tests/test-mongoc-database.c
+++ b/src/libmongoc/tests/test-mongoc-database.c
@@ -12,6 +12,7 @@
 #include "mock_server/future-functions.h"
 #include "mock_server/mock-server.h"
 #include "test-conveniences.h"
+#include <common-macros-private.h> // BEGIN_IGNORE_DEPRECATIONS
 
 
 static void

--- a/src/libmongoc/tests/test-mongoc-exhaust.c
+++ b/src/libmongoc/tests/test-mongoc-exhaust.c
@@ -12,6 +12,7 @@
 #include "mock_server/future.h"
 #include "mock_server/future-functions.h"
 #include "mock_server/mock-server.h"
+#include <common-macros-private.h> // BEGIN_IGNORE_DEPRECATIONS
 
 
 #undef MONGOC_LOG_DOMAIN

--- a/src/libmongoc/tests/test-mongoc-gridfs.c
+++ b/src/libmongoc/tests/test-mongoc-gridfs.c
@@ -12,6 +12,7 @@
 #include "mock_server/mock-server.h"
 #include "mock_server/future.h"
 #include "mock_server/future-functions.h"
+#include <mcd-string.h>
 
 
 static mongoc_gridfs_t *
@@ -1504,7 +1505,7 @@ test_reading_multiple_chunks (void)
 
       // Read the entire file.
       {
-         bson_string_t *str = bson_string_new ("");
+         mcd_string_t *str = mcd_string_new ("");
          uint8_t buf[7] = {0};
          mongoc_iovec_t iov = {.iov_base = (void *) buf, .iov_len = sizeof (buf)};
          mongoc_gridfs_file_t *file = mongoc_gridfs_find_one_by_filename (gridfs, "test_file", &error);
@@ -1516,7 +1517,7 @@ test_reading_multiple_chunks (void)
                mongoc_gridfs_file_readv (file, &iov, 1 /* iovcnt */, 1 /* min_bytes */, 0 /* timeout_msec */);
             ASSERT_CMPSSIZE_T (got, >=, 0);
             ASSERT (bson_in_range_int_signed (got));
-            bson_string_append_printf (str, "%.*s", (int) got, (char *) buf);
+            mcd_string_append_printf (str, "%.*s", (int) got, (char *) buf);
             ASSERT_CMPSSIZE_T (got, ==, 4);
          }
 
@@ -1526,12 +1527,12 @@ test_reading_multiple_chunks (void)
                mongoc_gridfs_file_readv (file, &iov, 1 /* iovcnt */, 1 /* min_bytes */, 0 /* timeout_msec */);
             ASSERT_CMPSSIZE_T (got, >=, 0);
             ASSERT (bson_in_range_int_signed (got));
-            bson_string_append_printf (str, "%.*s", (int) got, (char *) buf);
+            mcd_string_append_printf (str, "%.*s", (int) got, (char *) buf);
             ASSERT_CMPSSIZE_T (got, ==, 3);
          }
 
          ASSERT_CMPSTR (str->str, "foobar");
-         bson_string_free (str, true);
+         mcd_string_free (str, true);
          mongoc_gridfs_file_destroy (file);
       }
 

--- a/src/libmongoc/tests/test-mongoc-matcher.c
+++ b/src/libmongoc/tests/test-mongoc-matcher.c
@@ -3,6 +3,7 @@
 #include <mongoc/mongoc.h>
 #include <mongoc/mongoc-matcher-private.h>
 #include <mongoc/mongoc-util-private.h>
+#include <common-macros-private.h> // BEGIN_IGNORE_DEPRECATIONS
 
 #include "TestSuite.h"
 

--- a/src/libmongoc/tests/test-mongoc-read-concern.c
+++ b/src/libmongoc/tests/test-mongoc-read-concern.c
@@ -8,6 +8,7 @@
 #include "mock_server/future.h"
 #include "mock_server/mock-server.h"
 #include "mock_server/future-functions.h"
+#include <common-macros-private.h> // BEGIN_IGNORE_DEPRECATIONS
 
 
 static void

--- a/src/libmongoc/tests/test-mongoc-ssl.c
+++ b/src/libmongoc/tests/test-mongoc-ssl.c
@@ -17,6 +17,7 @@
 #include "TestSuite.h"
 #include "mongoc-config.h"
 #include "test-conveniences.h"
+#include <mcd-string.h>
 
 #ifdef MONGOC_ENABLE_SSL
 #include "mongoc-ssl-private.h"
@@ -140,7 +141,7 @@ test_mongoc_ssl_opts_from_bson (void)
 
    for (test = tests; test->bson != NULL; test++) {
       mongoc_ssl_opt_t ssl_opt = {0};
-      bson_string_t *errmsg = bson_string_new (NULL);
+      mcd_string_t *errmsg = mcd_string_new (NULL);
       bool ok = _mongoc_ssl_opts_from_bson (&ssl_opt, tmp_bson (test->bson), errmsg);
 
       MONGOC_DEBUG ("testcase: %s", test->bson);
@@ -185,7 +186,7 @@ test_mongoc_ssl_opts_from_bson (void)
       ASSERT (!ssl_opt.crl_file);
 
       _mongoc_ssl_opts_cleanup (&ssl_opt, true /* free_internal */);
-      bson_string_free (errmsg, true /* free_segment */);
+      mcd_string_free (errmsg, true /* free_segment */);
    }
 }
 

--- a/src/libmongoc/tests/test-mongoc-transactions.c
+++ b/src/libmongoc/tests/test-mongoc-transactions.c
@@ -12,6 +12,7 @@
 #include "mongoc/mongoc-host-list-private.h"
 #include "mongoc/mongoc-read-concern-private.h"
 #include "mongoc/mongoc-write-concern-private.h"
+#include <common-macros-private.h> // BEGIN_IGNORE_DEPRECATIONS
 
 /* Reset server state by disabling failpoints, killing sessions, and... running
  * a distinct command. */

--- a/src/libmongoc/tests/test-mongoc-uri.c
+++ b/src/libmongoc/tests/test-mongoc-uri.c
@@ -10,6 +10,7 @@
 
 #include "test-libmongoc.h"
 #include "test-conveniences.h"
+#include <mcd-string.h>
 
 static void
 test_mongoc_uri_new (void)
@@ -2240,10 +2241,10 @@ test_parses_long_ipv6 (void)
    // Test the largest permitted IPv6 literal.
    {
       // Construct a string of repeating `:`.
-      bson_string_t *host = bson_string_new (NULL);
+      mcd_string_t *host = mcd_string_new (NULL);
       for (int i = 0; i < BSON_HOST_NAME_MAX - 2; i++) {
          // Max IPv6 literal is two less due to including `[` and `]`.
-         bson_string_append (host, ":");
+         mcd_string_append (host, ":");
       }
 
       char *host_and_port = bson_strdup_printf ("[%s]:27017", host->str);
@@ -2259,15 +2260,15 @@ test_parses_long_ipv6 (void)
       mongoc_uri_destroy (uri);
       bson_free (uri_string);
       bson_free (host_and_port);
-      bson_string_free (host, true /* free_segment */);
+      mcd_string_free (host, true /* free_segment */);
    }
 
    // Test one character more than the largest IPv6 literal.
    {
       // Construct a string of repeating `:`.
-      bson_string_t *host = bson_string_new (NULL);
+      mcd_string_t *host = mcd_string_new (NULL);
       for (int i = 0; i < BSON_HOST_NAME_MAX - 2 + 1; i++) {
-         bson_string_append (host, ":");
+         mcd_string_append (host, ":");
       }
 
       char *host_and_port = bson_strdup_printf ("[%s]:27017", host->str);
@@ -2286,7 +2287,7 @@ test_parses_long_ipv6 (void)
       mongoc_uri_destroy (uri);
       bson_free (uri_string);
       bson_free (host_and_port);
-      bson_string_free (host, true /* free_segment */);
+      mcd_string_free (host, true /* free_segment */);
    }
 }
 

--- a/src/libmongoc/tests/test-mongoc-write-concern.c
+++ b/src/libmongoc/tests/test-mongoc-write-concern.c
@@ -8,6 +8,7 @@
 #include "mock_server/mock-server.h"
 #include "mock_server/future.h"
 #include "mock_server/future-functions.h"
+#include <common-macros-private.h> // BEGIN_IGNORE_DEPRECATIONS
 
 
 static void

--- a/src/libmongoc/tests/test-service-gcp.c
+++ b/src/libmongoc/tests/test-service-gcp.c
@@ -1,6 +1,7 @@
 #include <mongoc/service-gcp.h>
 #include <mongoc/mongoc-host-list-private.h>
 #include "TestSuite.h"
+#include <mcd-string.h>
 
 static void
 _test_gcp_parse (void)
@@ -42,7 +43,7 @@ _test_gcp_http_request (void)
    // Test that we correctly build a http request for the GCP metadata server
    gcp_request req;
    gcp_request_init (&req, "helloworld.com", 1234, NULL);
-   bson_string_t *req_str = _mongoc_http_render_request_head (&req.req);
+   mcd_string_t *req_str = _mongoc_http_render_request_head (&req.req);
    gcp_request_destroy (&req);
    ASSERT_CMPSTR (req_str->str,
                   "GET "
@@ -51,7 +52,7 @@ _test_gcp_http_request (void)
                   "Connection: close\r\n"
                   "Metadata-Flavor: Google\r\n"
                   "\r\n");
-   bson_string_free (req_str, true);
+   mcd_string_free (req_str, true);
 }
 
 static const char *

--- a/src/libmongoc/tests/unified/entity-map.c
+++ b/src/libmongoc/tests/unified/entity-map.c
@@ -32,6 +32,7 @@
  */
 #include "mongoc-client-private.h"
 #include "mongoc-topology-private.h"
+#include <mcd-string.h>
 
 #define REDUCED_HEARTBEAT_FREQUENCY_MS 500
 #define REDUCED_MIN_HEARTBEAT_FREQUENCY_MS 50
@@ -2145,28 +2146,28 @@ entity_map_match (
 char *
 event_list_to_string (event_t *events)
 {
-   bson_string_t *str = NULL;
+   mcd_string_t *str = NULL;
    event_t *eiter = NULL;
 
-   str = bson_string_new ("");
+   str = mcd_string_new ("");
    LL_FOREACH (events, eiter)
    {
-      bson_string_append_printf (str, "- %s:", eiter->type);
+      mcd_string_append_printf (str, "- %s:", eiter->type);
       if (eiter->command_name) {
-         bson_string_append_printf (str, " cmd=%s", eiter->command_name);
+         mcd_string_append_printf (str, " cmd=%s", eiter->command_name);
       }
       if (eiter->database_name) {
-         bson_string_append_printf (str, " db=%s", eiter->database_name);
+         mcd_string_append_printf (str, " db=%s", eiter->database_name);
       }
       if (eiter->command) {
-         bson_string_append_printf (str, " sent %s", tmp_json (eiter->command));
+         mcd_string_append_printf (str, " sent %s", tmp_json (eiter->command));
       }
       if (eiter->reply) {
-         bson_string_append_printf (str, " received %s", tmp_json (eiter->reply));
+         mcd_string_append_printf (str, " received %s", tmp_json (eiter->reply));
       }
-      bson_string_append (str, "\n");
+      mcd_string_append (str, "\n");
    }
-   return bson_string_free (str, false);
+   return mcd_string_free (str, false);
 }
 
 

--- a/src/libmongoc/tests/unified/result.c
+++ b/src/libmongoc/tests/unified/result.c
@@ -23,6 +23,7 @@
 #include "test-conveniences.h"
 #include "util.h"
 #include "TestSuite.h"
+#include <mcd-string.h>
 
 struct _result_t {
    bool ok;
@@ -49,27 +50,27 @@ result_new (void)
 static void
 _result_init (result_t *result, const bson_val_t *value, const bson_t *reply, const bson_error_t *error)
 {
-   bson_string_t *str;
+   mcd_string_t *str;
 
-   str = bson_string_new ("");
+   str = mcd_string_new ("");
 
    if (value) {
       result->value = bson_val_copy (value);
-      bson_string_append_printf (str, "value=%s ", bson_val_to_json (value));
+      mcd_string_append_printf (str, "value=%s ", bson_val_to_json (value));
    }
 
    if (reply) {
       char *reply_str = bson_as_canonical_extended_json (reply, NULL);
 
-      bson_string_append_printf (str, "reply=%s ", reply_str);
+      mcd_string_append_printf (str, "reply=%s ", reply_str);
       result->reply = bson_copy (reply);
       bson_free (reply_str);
    }
 
-   bson_string_append_printf (str, "bson_error=%s", error->message);
+   mcd_string_append_printf (str, "bson_error=%s", error->message);
    memcpy (&result->error, error, sizeof (bson_error_t));
    result->ok = (error->code == 0);
-   result->str = bson_string_free (str, false);
+   result->str = mcd_string_free (str, false);
    result->write_errors = bson_new ();
    result->write_concern_errors = bson_new ();
 }

--- a/src/libmongoc/tests/unified/runner.c
+++ b/src/libmongoc/tests/unified/runner.c
@@ -24,6 +24,7 @@
 #include "test-diagnostics.h"
 #include "utlist.h"
 #include "util.h"
+#include <mcd-string.h>
 
 
 typedef struct {
@@ -762,11 +763,11 @@ check_run_on_requirement (test_runner_t *test_runner,
 static bool
 check_run_on_requirements (test_runner_t *test_runner, bson_t *run_on_requirements, const char **reason)
 {
-   bson_string_t *fail_reasons = NULL;
+   mcd_string_t *fail_reasons = NULL;
    bool requirements_satisfied = false;
    bson_iter_t iter;
 
-   fail_reasons = bson_string_new ("");
+   fail_reasons = mcd_string_new ("");
    BSON_FOREACH (run_on_requirements, iter)
    {
       bson_t run_on_requirement;
@@ -783,7 +784,7 @@ check_run_on_requirements (test_runner_t *test_runner, bson_t *run_on_requiremen
          break;
       }
 
-      bson_string_append_printf (
+      mcd_string_append_printf (
          fail_reasons, "- Requirement %s failed because: %s\n", bson_iter_key (&iter), fail_reason);
       bson_free (fail_reason);
    }
@@ -792,7 +793,7 @@ check_run_on_requirements (test_runner_t *test_runner, bson_t *run_on_requiremen
    if (!requirements_satisfied) {
       (*reason) = tmp_str ("runOnRequirements not satisfied:\n%s", fail_reasons->str);
    }
-   bson_string_free (fail_reasons, true);
+   mcd_string_free (fail_reasons, true);
    return requirements_satisfied;
 }
 

--- a/src/libmongoc/tests/unified/test-diagnostics.c
+++ b/src/libmongoc/tests/unified/test-diagnostics.c
@@ -20,6 +20,7 @@
 #include "TestSuite.h"
 #include "common-thread-private.h"
 #include <signal.h>
+#include <mcd-string.h>
 
 typedef struct _msg_t {
    char *string;
@@ -38,47 +39,47 @@ static char *
 test_diagnostics_error_string (bson_error_t *error)
 {
    msg_t *msg_iter = NULL;
-   bson_string_t *str = NULL;
+   mcd_string_t *str = NULL;
    test_diagnostics_t *td = &diagnostics;
 
    /* Give a large header / footer to make the error easily grep-able */
-   str = bson_string_new ("****************************** BEGIN_MONGOC_ERROR "
-                          "******************************\n");
+   str = mcd_string_new ("****************************** BEGIN_MONGOC_ERROR "
+                         "******************************\n");
 
    bson_mutex_lock (&td->mutex);
    if (td->test_info) {
-      bson_string_append (str, "test info:\n");
+      mcd_string_append (str, "test info:\n");
    }
 
    LL_FOREACH (td->test_info, msg_iter)
    {
-      bson_string_append (str, msg_iter->string);
-      bson_string_append (str, "\n");
+      mcd_string_append (str, msg_iter->string);
+      mcd_string_append (str, "\n");
    }
 
-   bson_string_append (str, "\n");
+   mcd_string_append (str, "\n");
 
    if (td->error_info) {
-      bson_string_append (str, "error context:\n");
+      mcd_string_append (str, "error context:\n");
    }
 
    LL_FOREACH (td->error_info, msg_iter)
    {
-      bson_string_append (str, msg_iter->string);
-      bson_string_append (str, "\n\n");
+      mcd_string_append (str, msg_iter->string);
+      mcd_string_append (str, "\n\n");
    }
 
    bson_mutex_unlock (&td->mutex);
 
    if (error && error->code != 0) {
-      bson_string_append_printf (str, "error: %s\n", error->message);
+      mcd_string_append_printf (str, "error: %s\n", error->message);
    }
 
-   bson_string_append (str,
-                       "******************************* END_MONGOC_ERROR "
-                       "*******************************\n");
+   mcd_string_append (str,
+                      "******************************* END_MONGOC_ERROR "
+                      "*******************************\n");
 
-   return bson_string_free (str, false);
+   return mcd_string_free (str, false);
 }
 
 static void

--- a/src/libmongoc/tests/unified/util.c
+++ b/src/libmongoc/tests/unified/util.c
@@ -53,10 +53,10 @@ bson_copy_and_sort (const bson_t *in)
 typedef struct {
    const char *str;
    bson_type_t type;
-} bson_string_and_type_t;
+} mcd_string_and_type_t;
 
 /* List of aliases: https://www.mongodb.com/docs/manual/reference/bson-types/ */
-bson_string_and_type_t bson_type_map[] = {
+mcd_string_and_type_t bson_type_map[] = {
    {"double", BSON_TYPE_DOUBLE},   {"string", BSON_TYPE_UTF8},
    {"object", BSON_TYPE_DOCUMENT}, {"array", BSON_TYPE_ARRAY},
    {"binData", BSON_TYPE_BINARY},  {"undefined", BSON_TYPE_UNDEFINED},


### PR DESCRIPTION
# Summary
- Deprecate `bson_string_t`.
- Add an internal-only API `mcd_string_t`.

Verified with [this patch build](https://spruce.mongodb.com/version/66fc29e2a87c33000700f204).

# Details

See CDRIVER-5697 for motivation.

`mcd_string_t` is intended to replace internal use of `bson_string_t`. To simplify this change, `mcd_string_t` forwards calls to `bson_string_t` and ignores deprecation warnings:

```c
static BSON_INLINE mcd_string_t *
mcd_string_new (const char *str)
{
   BEGIN_IGNORE_DEPRECATIONS
   return bson_string_new (str);
   END_IGNORE_DEPRECATIONS
}
```

This PR intends to keep the behavior, API, and test coverage of `bson_string_t` unchanged for 1.x. For 2.0, `bson_string_t` can be removed, and the implementation migrated.

The test dependency of libmongocrypt is updated to include changes to remove use of `bson_string_t` (https://github.com/mongodb/libmongocrypt/commit/bca8e7dc1ecb7b1c039132e07de5e0db2703c701) to avoid deprecation warnings when building libmongocrypt.