### PR TITLE
Fix and update references to Markdown MongoDB specifications

### DIFF
--- a/.evergreen/config_generator/components/loadbalanced.py
+++ b/.evergreen/config_generator/components/loadbalanced.py
@@ -94,7 +94,7 @@ def tasks():
     )
 
     # Satisfy requirements specified in
-    # https://github.com/mongodb/specifications/blob/14916f76fd92b2686d8e3d1f0e4c2d2ef88ca5a7/source/load-balancers/tests/README.rst#testing-requirements
+    # https://github.com/mongodb/specifications/blob/master/source/load-balancers/tests/README.md#testing-requirements
     #
     # > For each server version that supports load balanced clusters, drivers
     # > MUST add two Evergreen tasks: one with a sharded cluster with both

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Documentation / Support / Feedback
 
 The documentation is available at `MongoDB C Driver Docs <https://www.mongodb.com/docs/drivers/c/>`_ and https://www.mongoc.org.
 For issues with, questions about, or feedback for libmongoc, please look into
-our `support channels <http://www.mongodb.org/about/support>`_. Please
+our `support channels <https://www.mongodb.org/about/support>`_. Please
 do not email any of the libmongoc developers directly with issues or
 questions - you're more likely to get an answer on the `MongoDB Community Forums`_ or `StackOverflow <https://stackoverflow.com/questions/tagged/mongodb+c>`_.
 

--- a/src/kms-message/README.md
+++ b/src/kms-message/README.md
@@ -11,7 +11,7 @@ implements the request format.
 - `test_kms_azure_online` makes live requests, and has additional requirements (must have working credentials).
 
 ### Requirements
-- A complete installation of the C driver. (libbson is needed for parsing JSON, and libmongoc is used for creating TLS streams). See http://mongoc.org/libmongoc/current/installing.html for installation instructions. For macOS, `brew install mongo-c-driver` will suffice.
+- A complete installation of the C driver. (libbson is needed for parsing JSON, and libmongoc is used for creating TLS streams). See the [C Driver Manual](https://www.mongodb.com/docs/languages/c/c-driver/current/libmongoc/tutorials/obtaining-libraries/) for installation instructions. For macOS, `brew install mongo-c-driver` will suffice.
 - An Azure key vault, and a service principal with an access policy allowing encrypt / decrypt key operations. The following environment variables must be set:
     - AZURE_TENANT_ID
     - AZURE_CLIENT_ID

--- a/src/libbson/doc/bson_array_as_canonical_extended_json.rst
+++ b/src/libbson/doc/bson_array_as_canonical_extended_json.rst
@@ -67,4 +67,4 @@ Example
 
   .. include:: includes/seealso/bson-as-json.txt
 
-.. _MongoDB Extended JSON format: https://github.com/mongodb/specifications/blob/master/source/extended-json.rst
+.. _MongoDB Extended JSON format: https://github.com/mongodb/specifications/blob/master/source/extended-json/extended-json.md

--- a/src/libbson/doc/bson_array_as_json.rst
+++ b/src/libbson/doc/bson_array_as_json.rst
@@ -72,4 +72,4 @@ Example
 
   .. include:: includes/seealso/bson-as-json.txt
 
-.. _MongoDB Extended JSON format: https://github.com/mongodb/specifications/blob/master/source/extended-json.rst
+.. _MongoDB Extended JSON format: https://github.com/mongodb/specifications/blob/master/source/extended-json/extended-json.md

--- a/src/libbson/doc/bson_array_as_relaxed_extended_json.rst
+++ b/src/libbson/doc/bson_array_as_relaxed_extended_json.rst
@@ -67,4 +67,4 @@ Example
 
   .. include:: includes/seealso/bson-as-json.txt
 
-.. _MongoDB Extended JSON format: https://github.com/mongodb/specifications/blob/master/source/extended-json.rst
+.. _MongoDB Extended JSON format: https://github.com/mongodb/specifications/blob/master/source/extended-json/extended-json.md

--- a/src/libbson/doc/bson_as_canonical_extended_json.rst
+++ b/src/libbson/doc/bson_as_canonical_extended_json.rst
@@ -47,4 +47,4 @@ Example
 
   .. include:: includes/seealso/bson-as-json.txt
 
-.. _MongoDB Extended JSON format: https://github.com/mongodb/specifications/blob/master/source/extended-json.rst
+.. _MongoDB Extended JSON format: https://github.com/mongodb/specifications/blob/master/source/extended-json/extended-json.md

--- a/src/libbson/doc/bson_as_json.rst
+++ b/src/libbson/doc/bson_as_json.rst
@@ -63,5 +63,4 @@ Example
 
   .. include:: includes/seealso/bson-as-json.txt
 
-.. _MongoDB Extended JSON format: https://github.com/mongodb/specifications/blob/master/source/extended-json.rst
-
+.. _MongoDB Extended JSON format: https://github.com/mongodb/specifications/blob/master/source/extended-json/extended-json.md

--- a/src/libbson/doc/bson_as_json_with_opts.rst
+++ b/src/libbson/doc/bson_as_json_with_opts.rst
@@ -52,4 +52,4 @@ Example
 
   .. include:: includes/seealso/bson-as-json.txt
 
-.. _MongoDB Extended JSON format: https://github.com/mongodb/specifications/blob/master/source/extended-json.rst
+.. _MongoDB Extended JSON format: https://github.com/mongodb/specifications/blob/master/source/extended-json/extended-json.md

--- a/src/libbson/doc/bson_as_relaxed_extended_json.rst
+++ b/src/libbson/doc/bson_as_relaxed_extended_json.rst
@@ -47,4 +47,4 @@ Example
 
   .. include:: includes/seealso/bson-as-json.txt
 
-.. _MongoDB Extended JSON format: https://github.com/mongodb/specifications/blob/master/source/extended-json.rst
+.. _MongoDB Extended JSON format: https://github.com/mongodb/specifications/blob/master/source/extended-json/extended-json.md

--- a/src/libbson/doc/bson_decimal128_from_string.rst
+++ b/src/libbson/doc/bson_decimal128_from_string.rst
@@ -22,7 +22,7 @@ Description
 
 Parses the string containing ascii encoded Decimal128 and initialize the bytes
 in ``dec``. See the `Decimal128 specification
-<https://github.com/mongodb/specifications/blob/master/source/bson-decimal128/decimal128.rst>`_
+<https://github.com/mongodb/specifications/blob/master/source/bson-decimal128/decimal128.md>`_
 for the exact string format.
 
 Returns
@@ -38,4 +38,3 @@ Example
 
   bson_decimal128_t dec;
   bson_decimal128_from_string ("1.00", &dec);
-

--- a/src/libbson/doc/bson_decimal128_from_string_w_len.rst
+++ b/src/libbson/doc/bson_decimal128_from_string_w_len.rst
@@ -25,7 +25,7 @@ Description
 
 Parses the string containing ascii encoded Decimal128 and initialize the bytes
 in ``dec``. See the `Decimal128 specification
-<https://github.com/mongodb/specifications/blob/master/source/bson-decimal128/decimal128.rst>`_
+<https://github.com/mongodb/specifications/blob/master/source/bson-decimal128/decimal128.md>`_
 for the exact string format.
 
 Returns

--- a/src/libbson/doc/bson_json_mode_t.rst
+++ b/src/libbson/doc/bson_json_mode_t.rst
@@ -27,4 +27,4 @@ The :symbol:`bson_json_mode_t` enumeration contains all available modes for enco
 
   | :symbol:`bson_as_json_with_opts()`
 
-.. _MongoDB Extended JSON: https://github.com/mongodb/specifications/blob/master/source/extended-json.rst
+.. _MongoDB Extended JSON: https://github.com/mongodb/specifications/blob/master/source/extended-json/extended-json.md

--- a/src/libbson/doc/bson_json_opts_t.rst
+++ b/src/libbson/doc/bson_json_opts_t.rst
@@ -34,7 +34,7 @@ The ``max_len`` member holds a maximum length for the resulting JSON string. Enc
 
   | :symbol:`bson_as_json_with_opts()`
 
-.. _MongoDB Extended JSON: https://github.com/mongodb/specifications/blob/master/source/extended-json.rst
+.. _MongoDB Extended JSON: https://github.com/mongodb/specifications/blob/master/source/extended-json/extended-json.md
 
 
 .. only:: html

--- a/src/libbson/doc/index.rst
+++ b/src/libbson/doc/index.rst
@@ -8,7 +8,7 @@ This site documents the API. For tutorials, guides, and explainers, see `MongoDB
 Introduction
 ------------
 
-libbson builds, parses, and iterates `BSON <http://bsonspec.org>`_ documents, the native data format of MongoDB. It also converts BSON to and from JSON, and provides a platform compatibility layer for `the MongoDB C Driver <https://www.mongoc.org/>`_.
+libbson builds, parses, and iterates `BSON <https://bsonspec.org>`_ documents, the native data format of MongoDB. It also converts BSON to and from JSON, and provides a platform compatibility layer for `the MongoDB C Driver <https://www.mongoc.org/>`_.
 
 
 .. toctree::

--- a/src/libmongoc/doc/application-performance-monitoring.rst
+++ b/src/libmongoc/doc/application-performance-monitoring.rst
@@ -5,8 +5,8 @@ Application Performance Monitoring (APM)
 
 The MongoDB C Driver allows you to monitor all the MongoDB operations the driver executes. This event-notification system conforms to two MongoDB driver specs:
 
-* `Command Logging and Monitoring <https://github.com/mongodb/specifications/blob/master/source/command-logging-and-monitoring/command-logging-and-monitoring.rst>`_: events related to all application operations.
-* `SDAM Monitoring <https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring-monitoring.rst>`_: events related to the driver's Server Discovery And Monitoring logic.
+* `Command Logging and Monitoring <https://github.com/mongodb/specifications/blob/master/source/command-logging-and-monitoring/command-logging-and-monitoring.md>`_: events related to all application operations.
+* `SDAM Monitoring <https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md>`_: events related to the driver's Server Discovery And Monitoring logic.
 
 To receive notifications, create a ``mongoc_apm_callbacks_t`` with :symbol:`mongoc_apm_callbacks_new`, set callbacks on it, then pass it to :symbol:`mongoc_client_set_apm_callbacks` or :symbol:`mongoc_client_pool_set_apm_callbacks`.
 

--- a/src/libmongoc/doc/gridfs.rst
+++ b/src/libmongoc/doc/gridfs.rst
@@ -3,8 +3,8 @@ GridFS
 
 The C driver includes two APIs for GridFS.
 
-The older API consists of :symbol:`mongoc_gridfs_t` and its derivatives. It contains deprecated API, does not support read preferences, and is not recommended in new applications. It does not conform to the `MongoDB GridFS specification <https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.rst>`_.
+The older API consists of :symbol:`mongoc_gridfs_t` and its derivatives. It contains deprecated API, does not support read preferences, and is not recommended in new applications. It does not conform to the `MongoDB GridFS specification <https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.md>`_.
 
-The newer API consists of :symbol:`mongoc_gridfs_bucket_t` and allows uploading/downloading through derived :symbol:`mongoc_stream_t` objects. It conforms to the `MongoDB GridFS specification <https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.rst>`_.
+The newer API consists of :symbol:`mongoc_gridfs_bucket_t` and allows uploading/downloading through derived :symbol:`mongoc_stream_t` objects. It conforms to the `MongoDB GridFS specification <https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.md>`_.
 
 There is not always a straightforward upgrade path from an application built with :symbol:`mongoc_gridfs_t` to :symbol:`mongoc_gridfs_bucket_t` (e.g. a :symbol:`mongoc_gridfs_file_t` provides functions to seek but :symbol:`mongoc_stream_t` does not). But users are encouraged to upgrade when possible.

--- a/src/libmongoc/doc/mongoc_client_encryption_rewrap_many_datakey.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_rewrap_many_datakey.rst
@@ -29,7 +29,7 @@ provider and master key.
 If ``provider`` is not ``NULL``, rewraps matching data keys with the new KMS
 provider as described by ``master_key``. The ``master_key`` document must
 conform to the `Client Side Encryption specification
-<https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst#masterkey>`_.
+<https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.md#masterkey>`_.
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_client_session_get_dirty.rst
+++ b/src/libmongoc/doc/mongoc_client_session_get_dirty.rst
@@ -11,7 +11,7 @@ Synopsis
   bool
   mongoc_client_session_get_dirty (const mongoc_client_session_t *session);
 
-Indicates whether ``session`` has been marked "dirty" as defined in the `driver sessions specification <https://github.com/mongodb/specifications/blob/master/source/sessions/driver-sessions.rst>`_.
+Indicates whether ``session`` has been marked "dirty" as defined in the `driver sessions specification <https://github.com/mongodb/specifications/blob/master/source/sessions/driver-sessions.md>`_.
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_gridfs_bucket_t.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_bucket_t.rst
@@ -59,7 +59,6 @@ Example
 
 .. seealso::
 
-  | The `MongoDB GridFS specification <https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.rst>`_.
+  | The `MongoDB GridFS specification <https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.md>`_.
 
   | The non spec-compliant :symbol:`mongoc_gridfs_t`.
-

--- a/src/libmongoc/doc/mongoc_gridfs_t.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_t.rst
@@ -5,7 +5,7 @@ mongoc_gridfs_t
 
 .. warning::
 
-  This GridFS implementation does not conform to the `MongoDB GridFS specification <https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.rst>`_. For a spec compliant implementation, use :symbol:`mongoc_gridfs_bucket_t`.
+  This GridFS implementation does not conform to the `MongoDB GridFS specification <https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.md>`_. For a spec compliant implementation, use :symbol:`mongoc_gridfs_bucket_t`.
 
 Synopsis
 --------
@@ -48,7 +48,7 @@ Example
 
 .. seealso::
 
-  | The `MongoDB GridFS specification <https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.rst>`_.
+  | The `MongoDB GridFS specification <https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.md>`_.
 
   | The spec-compliant :symbol:`mongoc_gridfs_bucket_t`.
 
@@ -73,4 +73,3 @@ Example
     mongoc_gridfs_get_chunks
     mongoc_gridfs_get_files
     mongoc_gridfs_remove_by_filename
-

--- a/src/libmongoc/doc/mongoc_topology_description_t.rst
+++ b/src/libmongoc/doc/mongoc_topology_description_t.rst
@@ -13,7 +13,7 @@ Synopsis
   typedef struct _mongoc_topology_description_t mongoc_topology_description_t;
 
 ``mongoc_topology_description_t`` is an opaque type representing the driver's knowledge of the MongoDB server or servers it is connected to.
-Its API conforms to the `SDAM Monitoring Specification <https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring-monitoring.rst>`_.
+Its API conforms to the `SDAM Monitoring Specification <https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md>`_.
 
 Applications receive a temporary reference to a ``mongoc_topology_description_t`` as a parameter to an SDAM Monitoring callback that must not be destroyed. See :doc:`Introduction to Application Performance Monitoring <application-performance-monitoring>`.
 
@@ -32,4 +32,3 @@ Applications receive a temporary reference to a ``mongoc_topology_description_t`
     mongoc_topology_description_has_writable_server
     mongoc_topology_description_new_copy
     mongoc_topology_description_type
-

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -3597,19 +3597,7 @@ mcd_rpc_message_decompress (mcd_rpc_message *rpc, void **data, size_t *data_len)
    // msgHeader consists of four int32 fields.
    const size_t message_header_length = 4u * sizeof (int32_t);
 
-   const int32_t uncompressed_size_raw = mcd_rpc_op_compressed_get_uncompressed_size (rpc);
-
-   // Malformed message: invalid uncompressedSize.
-   if (BSON_UNLIKELY (uncompressed_size_raw < 0)) {
-      return false;
-   }
-
-   const size_t uncompressed_size = (size_t) uncompressed_size_raw;
-
-   // Malformed message: original message length is not representable.
-   if (uncompressed_size > SIZE_MAX - message_header_length) {
-      return false;
-   }
+   const size_t uncompressed_size = (size_t) mcd_rpc_op_compressed_get_uncompressed_size (rpc);
 
    // uncompressedSize does not include msgHeader fields.
    const size_t original_message_length = message_header_length + uncompressed_size;
@@ -3655,11 +3643,7 @@ mcd_rpc_message_decompress (mcd_rpc_message *rpc, void **data, size_t *data_len)
       return false;
    }
 
-   // Malformed message: size inconsistency.
-   if (BSON_UNLIKELY (uncompressed_size != actual_uncompressed_size)) {
-      bson_free (ptr);
-      return false;
-   }
+   BSON_ASSERT (uncompressed_size == actual_uncompressed_size);
 
    *data_len = original_message_length;
    *data = ptr; // Ownership transfer.

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -546,7 +546,7 @@ mongoc_cluster_run_command_monitored (mongoc_cluster_t *cluster, mongoc_cmd_t *c
       /*
        * Unacknowledged writes must provide a CommandSucceededEvent with an
        * {ok: 1} reply.
-       * https://github.com/mongodb/specifications/blob/master/source/command-logging-and-monitoring/command-logging-and-monitoring.rst#unacknowledged-acknowledged-writes
+       * https://github.com/mongodb/specifications/blob/master/source/command-logging-and-monitoring/command-logging-and-monitoring.md#unacknowledgedacknowledged-writes
        */
       if (!cmd->is_acknowledged) {
          bson_append_int32 (&fake_reply, "ok", 2, 1);
@@ -3597,7 +3597,19 @@ mcd_rpc_message_decompress (mcd_rpc_message *rpc, void **data, size_t *data_len)
    // msgHeader consists of four int32 fields.
    const size_t message_header_length = 4u * sizeof (int32_t);
 
-   const size_t uncompressed_size = (size_t) mcd_rpc_op_compressed_get_uncompressed_size (rpc);
+   const int32_t uncompressed_size_raw = mcd_rpc_op_compressed_get_uncompressed_size (rpc);
+
+   // Malformed message: invalid uncompressedSize.
+   if (BSON_UNLIKELY (uncompressed_size_raw < 0)) {
+      return false;
+   }
+
+   const size_t uncompressed_size = (size_t) uncompressed_size_raw;
+
+   // Malformed message: original message length is not representable.
+   if (uncompressed_size > SIZE_MAX - message_header_length) {
+      return false;
+   }
 
    // uncompressedSize does not include msgHeader fields.
    const size_t original_message_length = message_header_length + uncompressed_size;
@@ -3643,7 +3655,11 @@ mcd_rpc_message_decompress (mcd_rpc_message *rpc, void **data, size_t *data_len)
       return false;
    }
 
-   BSON_ASSERT (uncompressed_size == actual_uncompressed_size);
+   // Malformed message: size inconsistency.
+   if (BSON_UNLIKELY (uncompressed_size != actual_uncompressed_size)) {
+      bson_free (ptr);
+      return false;
+   }
 
    *data_len = original_message_length;
    *data = ptr; // Ownership transfer.

--- a/src/libmongoc/src/mongoc/mongoc-collection.c
+++ b/src/libmongoc/src/mongoc/mongoc-collection.c
@@ -1616,7 +1616,7 @@ mongoc_collection_find_indexes_with_opts (mongoc_collection_t *collection, const
 
    if (mongoc_cursor_error (cursor, &error) && error.code == MONGOC_ERROR_COLLECTION_DOES_NOT_EXIST) {
       /* collection does not exist. from spec: return no documents but no err:
-       * https://github.com/mongodb/specifications/blob/master/source/enumerate-indexes.rst#enumeration-getting-index-information
+       * https://github.com/mongodb/specifications/blob/master/source/enumerate-collections/enumerate-collections.md#getting-full-collection-information
        */
       _mongoc_cursor_set_empty (cursor);
    }

--- a/src/libmongoc/src/mongoc/mongoc-compression.c
+++ b/src/libmongoc/src/mongoc/mongoc-compression.c
@@ -137,6 +137,9 @@ mongoc_compressor_name_to_id (const char *compressor)
    return -1;
 }
 
+// To support unchecked casts from `unsigned long` to `size_t`.
+BSON_STATIC_ASSERT2 (size_t_gte_ulong, SIZE_MAX >= ULONG_MAX);
+
 bool
 mongoc_uncompress (int32_t compressor_id,
                    const uint8_t *compressed,
@@ -144,11 +147,29 @@ mongoc_uncompress (int32_t compressor_id,
                    uint8_t *uncompressed,
                    size_t *uncompressed_len)
 {
+   BSON_ASSERT_PARAM (compressed);
+   BSON_ASSERT_PARAM (uncompressed);
+   BSON_ASSERT_PARAM (uncompressed_len);
+
    TRACE ("Uncompressing with '%s' (%d)", mongoc_compressor_id_to_name (compressor_id), compressor_id);
 
    switch (compressor_id) {
    case MONGOC_COMPRESSOR_SNAPPY_ID: {
 #ifdef MONGOC_ENABLE_COMPRESSION_SNAPPY
+      size_t actual_uncompressed_len;
+
+      // Malformed message: inconsistent lengths.
+      if (BSON_UNLIKELY (!snappy_uncompressed_length (compressed, compressed_len, &actual_uncompressed_len))) {
+         return false;
+      }
+
+      // Malformed message: destination is not large enough.
+      if (actual_uncompressed_len > *uncompressed_len) {
+         return false;
+      }
+
+      *uncompressed_len = actual_uncompressed_len;
+
       snappy_status status;
       status = snappy_uncompress ((const char *) compressed, compressed_len, (char *) uncompressed, uncompressed_len);
 
@@ -162,11 +183,27 @@ mongoc_uncompress (int32_t compressor_id,
 
    case MONGOC_COMPRESSOR_ZLIB_ID: {
 #ifdef MONGOC_ENABLE_COMPRESSION_ZLIB
-      BSON_ASSERT (bson_in_range_unsigned (unsigned_long, compressed_len));
-      const int ok =
-         uncompress (uncompressed, (unsigned long *) uncompressed_len, compressed, (unsigned long) compressed_len);
+      // Malformed message: unrepresentable.
+      if (BSON_UNLIKELY (!bson_in_range_unsigned (unsigned_long, compressed_len))) {
+         return false;
+      }
 
-      return ok == Z_OK;
+      // Malformed message: unrepresentable.
+      if (BSON_UNLIKELY (!bson_in_range_unsigned (unsigned_long, *uncompressed_len))) {
+         return false;
+      }
+
+      uLong actual_uncompressed_len = (uLong) *uncompressed_len;
+
+      const bool ok = uncompress (uncompressed, &actual_uncompressed_len, compressed, (uLong) compressed_len) == Z_OK;
+
+      if (BSON_UNLIKELY (!ok)) {
+         return false;
+      }
+
+      *uncompressed_len = (size_t) actual_uncompressed_len;
+
+      return true;
 #else
       MONGOC_WARNING ("Received zlib compressed opcode, but zlib "
                       "compression is not compiled in");

--- a/src/libmongoc/src/mongoc/mongoc-cursor.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor.c
@@ -112,7 +112,7 @@ _mongoc_n_return (mongoc_cursor_t *cursor)
    int64_t n_return;
 
    /* calculate numberToReturn according to:
-    * https://github.com/mongodb/specifications/blob/master/source/crud/crud.rst#combining-limit-and-batch-size-for-the-wire-protocol
+    * https://github.com/mongodb/specifications/blob/master/source/crud/crud.md#combining-limit-and-batch-size-for-the-wire-protocol
     */
    limit = mongoc_cursor_get_limit (cursor);
    batch_size = mongoc_cursor_get_batch_size (cursor);

--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -907,7 +907,7 @@ mongoc_server_description_filter_stale (const mongoc_server_description_t **sds,
  * Given a set of server descriptions, set to NULL any that don't
  * match the read preference's tag sets.
  *
- * https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.rst#tag-set
+ * https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.md#tag_sets
  *
  *-------------------------------------------------------------------------
  */

--- a/src/libmongoc/src/mongoc/mongoc-topology-description-apm-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description-apm-private.h
@@ -25,7 +25,7 @@
 /* Application Performance Monitoring for topology events, complies with the
  * SDAM Monitoring Spec:
 
-https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring-monitoring.rst
+https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md
 
  */
 

--- a/src/libmongoc/src/mongoc/mongoc-topology-description-apm.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description-apm.c
@@ -20,7 +20,7 @@
 /* Application Performance Monitoring for topology events, complies with the
  * SDAM Monitoring Spec:
 
-https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring-monitoring.rst
+https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md
 
  */
 

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -1579,7 +1579,7 @@ _mongoc_topology_push_server_session (mongoc_topology_t *topology, mongoc_server
    /**
     * ! note:
     * At time of writing, this diverges from the spec:
-    * https://github.com/mongodb/specifications/blob/df6be82f865e9b72444488fd62ae1eb5fca18569/source/sessions/driver-sessions.rst#algorithm-to-return-a-serversession-instance-to-the-server-session-pool
+    * https://github.com/mongodb/specifications/blob/master/source/sessions/driver-sessions.md#algorithm-to-return-a-serversession-instance-to-the-server-session-pool
     *
     * The spec notes that before returning a session, we should first inspect
     * the back of the pool for expired items and delete them. In this case, we

--- a/src/libmongoc/src/mongoc/mongoc-uri.c
+++ b/src/libmongoc/src/mongoc/mongoc-uri.c
@@ -1155,7 +1155,7 @@ mongoc_uri_apply_options (mongoc_uri_t *uri, const bson_t *options, bool from_dn
           * Keys that aren't supported by a driver MUST be ignored.
           *
           * A WARN level logging message MUST be issued
-          * https://github.com/mongodb/specifications/blob/master/source/connection-string/connection-string-spec.rst#keys
+          * https://github.com/mongodb/specifications/blob/master/source/connection-string/connection-string-spec.md#keys
           */
          MONGOC_WARNING ("Unsupported URI option \"%s\"", key);
       }

--- a/src/libmongoc/src/mongoc/mongoc-util.c
+++ b/src/libmongoc/src/mongoc/mongoc-util.c
@@ -264,7 +264,7 @@ _mongoc_bson_type_to_str (bson_type_t t)
 
 
 /* Refer to:
- * https://github.com/mongodb/specifications/blob/master/source/wireversion-featurelist.rst
+ * https://github.com/mongodb/specifications/blob/master/source/wireversion-featurelist/wireversion-featurelist.md
  * and:
  * https://github.com/mongodb/mongo/blob/master/src/mongo/db/wire_version.h#L57
  */


### PR DESCRIPTION
Discovered dead links while reviewing https://github.com/mongodb/docs-c/pull/63.

Sweeps URLs in documentation and source files and updates references to `.rst` -> `.md`, `http://` -> `https://`, and various links to renamed/relocated pages.