### PR TITLE
CDRIVER-5735 Improve validation of uncompressedSize for OP_COMPRESSED

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -3597,7 +3597,19 @@ mcd_rpc_message_decompress (mcd_rpc_message *rpc, void **data, size_t *data_len)
    // msgHeader consists of four int32 fields.
    const size_t message_header_length = 4u * sizeof (int32_t);
 
-   const size_t uncompressed_size = (size_t) mcd_rpc_op_compressed_get_uncompressed_size (rpc);
+   const int32_t uncompressed_size_raw = mcd_rpc_op_compressed_get_uncompressed_size (rpc);
+
+   // Malformed message: invalid uncompressedSize.
+   if (BSON_UNLIKELY (uncompressed_size_raw < 0)) {
+      return false;
+   }
+
+   const size_t uncompressed_size = (size_t) uncompressed_size_raw;
+
+   // Malformed message: original message length is not representable.
+   if (BSON_UNLIKELY (uncompressed_size > SIZE_MAX - message_header_length)) {
+      return false;
+   }
 
    // uncompressedSize does not include msgHeader fields.
    const size_t original_message_length = message_header_length + uncompressed_size;
@@ -3643,7 +3655,11 @@ mcd_rpc_message_decompress (mcd_rpc_message *rpc, void **data, size_t *data_len)
       return false;
    }
 
-   BSON_ASSERT (uncompressed_size == actual_uncompressed_size);
+   // Malformed message: size inconsistency.
+   if (BSON_UNLIKELY (uncompressed_size != actual_uncompressed_size)) {
+      bson_free (ptr);
+      return false;
+   }
 
    *data_len = original_message_length;
    *data = ptr; // Ownership transfer.


### PR DESCRIPTION
Resolves CDRIVER-5735. Verified by [this patch](https://spruce.mongodb.com/version/66fda3bdea5e9d00077abc3e). See ticket for details.

