### PR TITLE
CDRIVER-5718 fix logic for returning bulk write result on error

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,13 @@ Platform Support:
 
   * Support for Visual Studio 2013 is dropped.
 
+libmongoc 1.28.1 (unreleased)
+=============================
+
+Fixed:
+
+  * Do not return result in `mongoc_bulkwritereturn_t` if there are no known successful writes.
+
 libmongoc 1.28.0
 ================
 

--- a/src/libmongoc/doc/mongoc_bulkwritereturn_t.rst
+++ b/src/libmongoc/doc/mongoc_bulkwritereturn_t.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
    typedef struct {
-     mongoc_bulkwriteresult_t *res;    // NULL if write was unacknowledged.
+     mongoc_bulkwriteresult_t *res;    // NULL if no known successful writes or write was unacknowledged.
      mongoc_bulkwriteexception_t *exc; // NULL if no error.
    } mongoc_bulkwritereturn_t;
 
@@ -20,7 +20,7 @@ Description
 
 ``res`` or ``exc`` may outlive the :symbol:`mongoc_bulkwrite_t` that was executed.
 
-``res`` is NULL if the :symbol:`mongoc_bulkwrite_t` was executed with an unacknowledged write concern.
+``res`` is NULL if the :symbol:`mongoc_bulkwrite_t` has no known successful writes or was executed with an unacknowledged write concern.
 
 ``res`` must be freed with :symbol:`mongoc_bulkwriteresult_destroy`.
 

--- a/src/libmongoc/src/mongoc/mongoc-bulkwrite.h
+++ b/src/libmongoc/src/mongoc/mongoc-bulkwrite.h
@@ -235,7 +235,7 @@ mongoc_bulkwrite_append_deletemany (mongoc_bulkwrite_t *self,
 
 // `mongoc_bulkwritereturn_t` may outlive `mongoc_bulkwrite_t`.
 typedef struct {
-   mongoc_bulkwriteresult_t *res;    // NULL if write was unacknowledged.
+   mongoc_bulkwriteresult_t *res;    // NULL if no known successful writes or write was unacknowledged.
    mongoc_bulkwriteexception_t *exc; // NULL if no error.
 } mongoc_bulkwritereturn_t;
 

--- a/src/libmongoc/tests/json/crud/unified/client-bulkWrite-partialResults.json
+++ b/src/libmongoc/tests/json/crud/unified/client-bulkWrite-partialResults.json
@@ -1,0 +1,540 @@
+{
+  "description": "client bulkWrite partial results",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        }
+      ]
+    }
+  ],
+  "_yamlAnchors": {
+    "namespace": "crud-tests.coll0",
+    "newDocument": {
+      "_id": 2,
+      "x": 22
+    }
+  },
+  "tests": [
+    {
+      "description": "partialResult is unset when first operation fails during an ordered bulk write (verbose)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              }
+            ],
+            "ordered": true,
+            "verboseResults": true
+          },
+          "expectError": {
+            "expectResult": {
+              "$$unsetOrMatches": {
+                "insertedCount": {
+                  "$$exists": false
+                },
+                "upsertedCount": {
+                  "$$exists": false
+                },
+                "matchedCount": {
+                  "$$exists": false
+                },
+                "modifiedCount": {
+                  "$$exists": false
+                },
+                "deletedCount": {
+                  "$$exists": false
+                },
+                "insertResults": {
+                  "$$exists": false
+                },
+                "updateResults": {
+                  "$$exists": false
+                },
+                "deleteResults": {
+                  "$$exists": false
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is unset when first operation fails during an ordered bulk write (summary)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              }
+            ],
+            "ordered": true,
+            "verboseResults": false
+          },
+          "expectError": {
+            "expectResult": {
+              "$$unsetOrMatches": {
+                "insertedCount": {
+                  "$$exists": false
+                },
+                "upsertedCount": {
+                  "$$exists": false
+                },
+                "matchedCount": {
+                  "$$exists": false
+                },
+                "modifiedCount": {
+                  "$$exists": false
+                },
+                "deletedCount": {
+                  "$$exists": false
+                },
+                "insertResults": {
+                  "$$exists": false
+                },
+                "updateResults": {
+                  "$$exists": false
+                },
+                "deleteResults": {
+                  "$$exists": false
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is set when second operation fails during an ordered bulk write (verbose)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              }
+            ],
+            "ordered": true,
+            "verboseResults": true
+          },
+          "expectError": {
+            "expectResult": {
+              "insertedCount": 1,
+              "upsertedCount": 0,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "deletedCount": 0,
+              "insertResults": {
+                "0": {
+                  "insertedId": 2
+                }
+              },
+              "updateResults": {},
+              "deleteResults": {}
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is set when second operation fails during an ordered bulk write (summary)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              }
+            ],
+            "ordered": true,
+            "verboseResults": false
+          },
+          "expectError": {
+            "expectResult": {
+              "insertedCount": 1,
+              "upsertedCount": 0,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "deletedCount": 0,
+              "insertResults": {
+                "$$unsetOrMatches": {}
+              },
+              "updateResults": {
+                "$$unsetOrMatches": {}
+              },
+              "deleteResults": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is unset when all operations fail during an unordered bulk write",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              }
+            ],
+            "ordered": false
+          },
+          "expectError": {
+            "expectResult": {
+              "$$unsetOrMatches": {
+                "insertedCount": {
+                  "$$exists": false
+                },
+                "upsertedCount": {
+                  "$$exists": false
+                },
+                "matchedCount": {
+                  "$$exists": false
+                },
+                "modifiedCount": {
+                  "$$exists": false
+                },
+                "deletedCount": {
+                  "$$exists": false
+                },
+                "insertResults": {
+                  "$$exists": false
+                },
+                "updateResults": {
+                  "$$exists": false
+                },
+                "deleteResults": {
+                  "$$exists": false
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is set when first operation fails during an unordered bulk write (verbose)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              }
+            ],
+            "ordered": false,
+            "verboseResults": true
+          },
+          "expectError": {
+            "expectResult": {
+              "insertedCount": 1,
+              "upsertedCount": 0,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "deletedCount": 0,
+              "insertResults": {
+                "1": {
+                  "insertedId": 2
+                }
+              },
+              "updateResults": {},
+              "deleteResults": {}
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is set when first operation fails during an unordered bulk write (summary)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              }
+            ],
+            "ordered": false,
+            "verboseResults": false
+          },
+          "expectError": {
+            "expectResult": {
+              "insertedCount": 1,
+              "upsertedCount": 0,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "deletedCount": 0,
+              "insertResults": {
+                "$$unsetOrMatches": {}
+              },
+              "updateResults": {
+                "$$unsetOrMatches": {}
+              },
+              "deleteResults": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is set when second operation fails during an unordered bulk write (verbose)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              }
+            ],
+            "ordered": false,
+            "verboseResults": true
+          },
+          "expectError": {
+            "expectResult": {
+              "insertedCount": 1,
+              "upsertedCount": 0,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "deletedCount": 0,
+              "insertResults": {
+                "0": {
+                  "insertedId": 2
+                }
+              },
+              "updateResults": {},
+              "deleteResults": {}
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is set when first operation fails during an unordered bulk write (summary)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              }
+            ],
+            "ordered": false,
+            "verboseResults": false
+          },
+          "expectError": {
+            "expectResult": {
+              "insertedCount": 1,
+              "upsertedCount": 0,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "deletedCount": 0,
+              "insertResults": {
+                "$$unsetOrMatches": {}
+              },
+              "updateResults": {
+                "$$unsetOrMatches": {}
+              },
+              "deleteResults": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

Do not return `mongoc_bulkwriteresult_t` if no known successful writes.

Verified by this patch build: https://spruce.mongodb.com/version/66fd6c9083cb7e000745405a

# Background & Motivation

The C driver models `BulkWriteException.partialResult` as a top-level field `res` within `mongoc_bulkwritereturn_t`.

The specification requires only setting `partialResult` if there were known successful writes:

> Drivers MUST NOT populate the `partialResult` field in `BulkWriteException` if no operations were successful.

This was missed in CDRIVER-4363. The C driver incorrectly always set `res` for acknowledged writes. This PR changes to conditionally set `res`.

The specification was updated in DRIVERS-2975 to fix the check. This PR includes the updated spec change and test.