### PR TITLE
CDRIVER-5736 do not assert on failure to create OpenSSL context

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl.c
@@ -882,7 +882,10 @@ mongoc_stream_t *
 mongoc_stream_tls_openssl_new_with_context (
    mongoc_stream_t *base_stream, const char *host, mongoc_ssl_opt_t *opt, int client, SSL_CTX *ssl_ctx)
 {
-   BSON_ASSERT_PARAM (ssl_ctx);
+   // `ssl_ctx` may be NULL if creating the context failed. Return NULL to signal failure.
+   if (!ssl_ctx) {
+      return NULL;
+   }
    SSL_CTX_up_ref (ssl_ctx);
 
    return create_stream_with_ctx (base_stream, host, opt, client, ssl_ctx);

--- a/src/libmongoc/tests/test-mongoc-ssl.c
+++ b/src/libmongoc/tests/test-mongoc-ssl.c
@@ -199,6 +199,15 @@ test_mongoc_ssl_opts_cleanup_zero (void)
    _mongoc_ssl_opts_cleanup (&ssl_opt, false /* free_internal */);
 }
 
+// `test_non_existant_cafile` is a regression test for CDRIVER-5736.
+static void
+test_non_existant_cafile (void)
+{
+   mongoc_client_t *client = mongoc_client_new ("mongodb://localhost:27017/?tls=true&tlsCAFile=/nonexistant/ca.pem");
+   ASSERT (!mongoc_client_command_simple (client, "admin", tmp_bson ("{'ping': 1}"), NULL, NULL, NULL));
+   mongoc_client_destroy (client);
+}
+
 #endif /* MONGOC_ENABLE_SSL */
 
 void
@@ -207,5 +216,6 @@ test_ssl_install (TestSuite *suite)
 #ifdef MONGOC_ENABLE_SSL
    TestSuite_Add (suite, "/ssl_opt/from_bson", test_mongoc_ssl_opts_from_bson);
    TestSuite_Add (suite, "/ssl_opt/cleanup", test_mongoc_ssl_opts_cleanup_zero);
+   TestSuite_Add (suite, "/ssl_opt/non-existant-cafile", test_non_existant_cafile);
 #endif /* MONGOC_ENABLE_SSL */
 }


### PR DESCRIPTION
Changes in [CDRIVER-4656](https://github.com/mongodb/mongo-c-driver/pull/1673) resulted in a regression. Failure to create an OpenSSL context resulted in an abort, rather than an expected failure.

This PR updates `mongoc_stream_tls_openssl_new_with_context` to return NULL if the passed context is NULL to signal failure.

The context is created in `mongoc_client_pool_set_ssl_opts` and `mongoc_client_set_ssl_opts`. Neither have a way to return an error.