### PR TITLE
CDRIVER-5742 Update ref to kms-message with spec link fixes

### DIFF
--- a/.evergreen/scripts/kms-divergence-check.sh
+++ b/.evergreen/scripts/kms-divergence-check.sh
@@ -13,7 +13,7 @@ LIBMONGOCRYPT_DIR="$MONGOC_DIR/libmongocrypt-for-kms-divergence-check"
 
 # LIBMONGOCRYPT_GITREF is expected to refer to the version of libmongocrypt
 # where kms-message was last copied.
-LIBMONGOCRYPT_GITREF="f44b2973a07dec80f194014a122689b0800d8413"
+LIBMONGOCRYPT_GITREF="a650d171ed3b552446095817ae2c5c4f7cec43a2"
 
 cleanup() {
     if [ -d "$LIBMONGOCRYPT_DIR" ]; then

--- a/src/kms-message/src/kms_kmip_request.c
+++ b/src/kms-message/src/kms_kmip_request.c
@@ -182,7 +182,7 @@ kms_kmip_request_activate_new (void *reserved, const char *unique_identifer)
    kmip_writer_close_struct (writer); /* KMIP_TAG_RequestHeader */
 
    kmip_writer_begin_struct (writer, KMIP_TAG_BatchItem);
-   /* 0x0A == Get */
+   /* 0x12 == Activate */
    kmip_writer_write_enumeration (writer, KMIP_TAG_Operation, 0x12);
    kmip_writer_begin_struct (writer, KMIP_TAG_RequestPayload);
    kmip_writer_write_string (writer,

--- a/src/kms-message/src/kms_message/kms_response_parser.h
+++ b/src/kms-message/src/kms_message/kms_response_parser.h
@@ -57,6 +57,9 @@ kms_response_parser_error (kms_response_parser_t *parser);
 KMS_MSG_EXPORT (void)
 kms_response_parser_destroy (kms_response_parser_t *parser);
 
+KMS_MSG_EXPORT (void)
+kms_response_parser_reset (kms_response_parser_t *parser);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/src/kms-message/src/kms_response_parser.c
+++ b/src/kms-message/src/kms_response_parser.c
@@ -38,6 +38,14 @@ _parser_init (kms_response_parser_t *parser)
    parser->kmip = NULL;
 }
 
+void
+kms_response_parser_reset (kms_response_parser_t *parser)
+{
+   KMS_ASSERT(!parser->kmip); // KMIP is not-yet supported.  
+   _parser_destroy(parser);  
+   _parser_init(parser);  
+}
+
 kms_response_parser_t *
 kms_response_parser_new (void)
 {


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1746 and https://github.com/mongodb/libmongocrypt/pull/888. Verified by [this patch](https://spruce.mongodb.com/version/6704369750c69f00078a9cb7).

Overlooked a required update to `LIBMONGOCRYPT_GITREF` to point to https://github.com/mongodb/libmongocrypt/commit/a650d171ed3b552446095817ae2c5c4f7cec43a2 which contains the kms-message sources with updated spec links. Synced the kms-message sources accordingly.