### PR TITLE
CDRIVER-5745 Enable and address aggressive -Wformat warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,28 +458,6 @@ if (ENABLE_MONGOC)
       message (FATAL_ERROR "ENABLE_TESTS requires ENABLE_STATIC or ENABLE_STATIC_BUILD")
    endif ()
 
-   set (UTF8PROC_SOURCES
-      ${mongo-c-driver_SOURCE_DIR}/src/utf8proc-2.8.0/utf8proc.c
-   )
-
-   set (ZLIB_SOURCES
-      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/adler32.c
-      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/crc32.c
-      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/deflate.c
-      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/infback.c
-      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/inffast.c
-      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/inflate.c
-      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/inftrees.c
-      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/trees.c
-      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/zutil.c
-      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/compress.c
-      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/uncompr.c
-      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/gzclose.c
-      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/gzlib.c
-      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/gzread.c
-      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/gzwrite.c
-   )
-
    set (CPACK_RESOURCE_FILE_LICENSE "${mongo-c-driver_SOURCE_DIR}/COPYING")
 
    include (CPack)
@@ -491,28 +469,6 @@ if (ENABLE_MONGOC)
       # Until CDRIVER-520.
       add_definitions (-Wno-deprecated-declarations)
    endif ()
-
-   set (KMS_MSG_SOURCES
-      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/hexlify.c
-      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_b64.c
-      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_caller_identity_request.c
-      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_crypto_apple.c
-      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_crypto_libcrypto.c
-      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_crypto_none.c
-      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_crypto_windows.c
-      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_decrypt_request.c
-      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_encrypt_request.c
-      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_kmip_response_parser.c
-      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_kv_list.c
-      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_message.c
-      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_port.c
-      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_request.c
-      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_request_opt.c
-      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_request_str.c
-      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_response.c
-      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_response_parser.c
-      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/sort.c
-   )
 
    if (NOT ENABLE_MONGODB_AWS_AUTH MATCHES "ON|OFF|AUTO")
       message (FATAL_ERROR "ENABLE_MONGODB_AWS_AUTH option must be ON, AUTO, or OFF")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,9 +325,6 @@ if(ENABLE_MAINTAINER_FLAGS)
    )
 endif()
 
-# Warnings as errors for our source code.
-add_compile_options (${mongoc-warning-options})
-
 # Link with LLD, if possible
 if (NOT MSVC)
    include (LLDLinker)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,9 +308,6 @@ if(ENABLE_MAINTAINER_FLAGS)
       gnu-like:-Wall
       gnu-like:-Wempty-body
       gnu:not-gcc-lt7:-Wexpansion-to-defined
-      gnu-like:-Wformat
-      gnu-like:-Wformat-nonliteral
-      gnu-like:-Wformat-security
       gnu-like:-Winit-self
       gnu-like:-Wmissing-include-dirs
       gnu-like:-Wredundant-decls

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,6 +325,9 @@ if(ENABLE_MAINTAINER_FLAGS)
    )
 endif()
 
+# Warnings as errors for our source code.
+add_compile_options (${mongoc-warning-options})
+
 # Link with LLD, if possible
 if (NOT MSVC)
    include (LLDLinker)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,31 +458,29 @@ if (ENABLE_MONGOC)
       message (FATAL_ERROR "ENABLE_TESTS requires ENABLE_STATIC or ENABLE_STATIC_BUILD")
    endif ()
 
-   set (SOURCE_DIR "${PROJECT_SOURCE_DIR}/")
-
    set (UTF8PROC_SOURCES
-      ${SOURCE_DIR}/src/utf8proc-2.8.0/utf8proc.c
+      ${mongo-c-driver_SOURCE_DIR}/src/utf8proc-2.8.0/utf8proc.c
    )
 
    set (ZLIB_SOURCES
-      ${SOURCE_DIR}/src/zlib-1.3.1/adler32.c
-      ${SOURCE_DIR}/src/zlib-1.3.1/crc32.c
-      ${SOURCE_DIR}/src/zlib-1.3.1/deflate.c
-      ${SOURCE_DIR}/src/zlib-1.3.1/infback.c
-      ${SOURCE_DIR}/src/zlib-1.3.1/inffast.c
-      ${SOURCE_DIR}/src/zlib-1.3.1/inflate.c
-      ${SOURCE_DIR}/src/zlib-1.3.1/inftrees.c
-      ${SOURCE_DIR}/src/zlib-1.3.1/trees.c
-      ${SOURCE_DIR}/src/zlib-1.3.1/zutil.c
-      ${SOURCE_DIR}/src/zlib-1.3.1/compress.c
-      ${SOURCE_DIR}/src/zlib-1.3.1/uncompr.c
-      ${SOURCE_DIR}/src/zlib-1.3.1/gzclose.c
-      ${SOURCE_DIR}/src/zlib-1.3.1/gzlib.c
-      ${SOURCE_DIR}/src/zlib-1.3.1/gzread.c
-      ${SOURCE_DIR}/src/zlib-1.3.1/gzwrite.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/adler32.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/crc32.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/deflate.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/infback.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/inffast.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/inflate.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/inftrees.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/trees.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/zutil.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/compress.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/uncompr.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/gzclose.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/gzlib.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/gzread.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/gzwrite.c
    )
 
-   set (CPACK_RESOURCE_FILE_LICENSE "${SOURCE_DIR}/COPYING")
+   set (CPACK_RESOURCE_FILE_LICENSE "${mongo-c-driver_SOURCE_DIR}/COPYING")
 
    include (CPack)
 
@@ -495,25 +493,25 @@ if (ENABLE_MONGOC)
    endif ()
 
    set (KMS_MSG_SOURCES
-      ${SOURCE_DIR}/src/kms-message/src/hexlify.c
-      ${SOURCE_DIR}/src/kms-message/src/kms_b64.c
-      ${SOURCE_DIR}/src/kms-message/src/kms_caller_identity_request.c
-      ${SOURCE_DIR}/src/kms-message/src/kms_crypto_apple.c
-      ${SOURCE_DIR}/src/kms-message/src/kms_crypto_libcrypto.c
-      ${SOURCE_DIR}/src/kms-message/src/kms_crypto_none.c
-      ${SOURCE_DIR}/src/kms-message/src/kms_crypto_windows.c
-      ${SOURCE_DIR}/src/kms-message/src/kms_decrypt_request.c
-      ${SOURCE_DIR}/src/kms-message/src/kms_encrypt_request.c
-      ${SOURCE_DIR}/src/kms-message/src/kms_kmip_response_parser.c
-      ${SOURCE_DIR}/src/kms-message/src/kms_kv_list.c
-      ${SOURCE_DIR}/src/kms-message/src/kms_message.c
-      ${SOURCE_DIR}/src/kms-message/src/kms_port.c
-      ${SOURCE_DIR}/src/kms-message/src/kms_request.c
-      ${SOURCE_DIR}/src/kms-message/src/kms_request_opt.c
-      ${SOURCE_DIR}/src/kms-message/src/kms_request_str.c
-      ${SOURCE_DIR}/src/kms-message/src/kms_response.c
-      ${SOURCE_DIR}/src/kms-message/src/kms_response_parser.c
-      ${SOURCE_DIR}/src/kms-message/src/sort.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/hexlify.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_b64.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_caller_identity_request.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_crypto_apple.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_crypto_libcrypto.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_crypto_none.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_crypto_windows.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_decrypt_request.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_encrypt_request.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_kmip_response_parser.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_kv_list.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_message.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_port.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_request.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_request_opt.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_request_str.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_response.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_response_parser.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/sort.c
    )
 
    if (NOT ENABLE_MONGODB_AWS_AUTH MATCHES "ON|OFF|AUTO")

--- a/build/cmake/FindUtf8Proc.cmake
+++ b/build/cmake/FindUtf8Proc.cmake
@@ -1,6 +1,6 @@
 if(USE_BUNDLED_UTF8PROC)
   message (STATUS "Enabling utf8proc (bundled)")
-  add_library (utf8proc_obj OBJECT "${UTF8PROC_SOURCES}")
+  add_library (utf8proc_obj OBJECT "${mongo-c-driver_SOURCE_DIR}/src/utf8proc-2.8.0/utf8proc.c")
   set_property (TARGET utf8proc_obj PROPERTY POSITION_INDEPENDENT_CODE TRUE)
   target_compile_definitions (utf8proc_obj PUBLIC UTF8PROC_STATIC)
 else ()

--- a/build/cmake/MongoC-Warnings.cmake
+++ b/build/cmake/MongoC-Warnings.cmake
@@ -26,6 +26,10 @@ function (mongoc_add_warning_options)
    # "Old" GNU is GCC < 5, which is missing several warning options
    set(cond/gcc-lt5 $<AND:${cond/gnu},$<VERSION_LESS:$<C_COMPILER_VERSION>,5>>)
    set(cond/gcc-lt7 $<AND:${cond/gnu},$<VERSION_LESS:$<C_COMPILER_VERSION>,7>>)
+   set(cond/gcc-lt8 $<AND:${cond/gnu},$<VERSION_LESS:$<C_COMPILER_VERSION>,8>>)
+   set(cond/gcc-lt11 $<AND:${cond/gnu},$<VERSION_LESS:$<C_COMPILER_VERSION>,11>>)
+   set(cond/clang-lt10 $<AND:${cond/clang},$<VERSION_LESS:$<C_COMPILER_VERSION>,10>>)
+   set(cond/clang-lt19 $<AND:${cond/clang},$<VERSION_LESS:$<C_COMPILER_VERSION>,19>>)
    # Process options:
    foreach (opt IN LISTS ARGV)
       # Replace prefixes. Matches right-most first:
@@ -79,6 +83,22 @@ mongoc_add_warning_options (
      msvc:/we4090
      # Definite use of uninitialized value
      gnu-like:-Werror=uninitialized msvc:/we4700
+
+     # Format strings.
+     gnu-like:-Werror=format
+     gnu-like:-Werror=format=2
+     # GCC does not document the full list of warnings enabled by -Wformat.
+     # For assurance, explicitly include those not listed by -Wformat or -Wformat=2.
+     gnu:not-gcc-lt11:-Werror=format-diag
+     gnu:not-gcc-lt8:-Werror=format-overflow=2
+     gnu:not-gcc-lt5:-Werror=format-signedness
+     gnu:not-gcc-lt8:-Werror=format-truncation=2
+     # Clang does not include several flags in `-Wformat` or `-Wformat=2`.
+     # For assurance, explicitly include those not listed by -Wformat or -Wformat=2.
+     clang:-Werror=format-non-iso
+     clang:-Werror=format-pedantic
+     clang:not-clang-lt19:-Werror=format-signedness
+     clang:not-clang-lt10:-Werror=format-type-confusion
 
      # Aside: Disable CRT insecurity warnings
      msvc:/D_CRT_SECURE_NO_WARNINGS

--- a/build/cmake/MongoC-Warnings.cmake
+++ b/build/cmake/MongoC-Warnings.cmake
@@ -1,5 +1,5 @@
 #[[
-   This file sets warning options for the directories in which it is include()'d
+   This file sets warning options in the "mongoc-warning-options" variable when included.
 
    These warnings are intended to be ported to each supported platform, and
    especially for high-value warnings that are very likely to catch latent bugs
@@ -7,11 +7,11 @@
 ]]
 
 #[[
-   Define additional compile options, conditional on the compiler being used.
+   Appends additional compile options to the "mongoc-warning-options" variable, conditioned
+   on the compiler being used.
+
    Each option should be prefixed by `gnu:`, `clang:`, `msvc:`, or `gnu-like:`.
    Those options will be conditionally enabled for GCC, Clang, or MSVC.
-
-   These options are attached to the source directory and its children.
 ]]
 function (mongoc_add_warning_options)
    list(APPEND CMAKE_MESSAGE_CONTEXT ${CMAKE_CURRENT_FUNCTION})
@@ -53,11 +53,14 @@ function (mongoc_add_warning_options)
          set(opt "${before}${opt}")
          message(TRACE "Become: ${opt}")
       endwhile ()
-      add_compile_options("${opt}")
+      list(APPEND mongoc-warning-options "${opt}")
    endforeach ()
+   set(mongoc-warning-options "${mongoc-warning-options}" PARENT_SCOPE)
 endfunction ()
 
 set (is_c_lang "$<COMPILE_LANGUAGE:C>")
+
+set (mongoc-warning-options "")
 
 # These below warnings should always be unconditional hard errors, as the code is
 # almost definitely broken

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 # Copy zconf.h.in to zconf.h, used by zlib
 configure_file (
-   "${SOURCE_DIR}/src/zlib-1.3.1/zconf.h.in"
+   "${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/zconf.h.in"
    "${CMAKE_BINARY_DIR}/src/zlib-1.3.1/zconf.h"
    COPYONLY
 )

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -5,8 +5,6 @@ if (ENABLE_DEBUG_ASSERTIONS)
     set (MONGOC_ENABLE_DEBUG_ASSERTIONS 1)
 endif ()
 
-include (MongoC-Warnings)
-
 configure_file (
         "${PROJECT_SOURCE_DIR}/src/common/common-config.h.in"
         "${PROJECT_BINARY_DIR}/src/common/common-config.h"

--- a/src/libbson/CMakeLists.txt
+++ b/src/libbson/CMakeLists.txt
@@ -223,6 +223,9 @@ mongo_target_requirements(
          MCOMMON_NAME_PREFIX=_bson_mcommon
    COMPILE_OPTIONS
       PRIVATE
+         # Enable unconditional warnings-as-errors for our source code.
+         ${mongoc-warning-options}
+
          # Macro constant INFINITY triggers constant arithmetic overflow warnings in
          # VS 2013, but VS 2013 doesn't support inline warning suppression.
          # Remove once support for VS 2013 is dropped.
@@ -266,6 +269,9 @@ if (ENABLE_EXAMPLES)
    function (add_example bin src)
       add_executable (${bin} EXCLUDE_FROM_ALL ${src})
       add_dependencies (mongo_c_driver_examples ${bin})
+
+      # Enable unconditional warnings-as-errors for our source code.
+      target_compile_options (${bin} PRIVATE ${mongoc-warning-options})
 
       # Link against the shared lib like normal apps
       if(TARGET bson_shared)

--- a/src/libbson/examples/bson-validate.c
+++ b/src/libbson/examples/bson-validate.c
@@ -73,7 +73,7 @@ main (int argc, char *argv[])
       while ((b = bson_reader_read (reader, NULL))) {
          docnum++;
          if (!bson_validate (b, (BSON_VALIDATE_UTF8 | BSON_VALIDATE_UTF8_ALLOW_NULL), &offset)) {
-            fprintf (stderr, "Document %u in \"%s\" is invalid at offset %u.\n", docnum, filename, (int) offset);
+            fprintf (stderr, "Document %d in \"%s\" is invalid at offset %zu.\n", docnum, filename, offset);
             bson_reader_destroy (reader);
             return 1;
          }

--- a/src/libbson/src/bson/bson-macros.h
+++ b/src/libbson/src/bson/bson-macros.h
@@ -190,24 +190,25 @@
 #define BSON_FUNC __func__
 #endif
 
-#define BSON_ASSERT(test)                                                                                 \
-   do {                                                                                                   \
-      if (!(BSON_LIKELY (test))) {                                                                        \
-         fprintf (stderr, "%s:%d %s(): precondition failed: %s\n", __FILE__, __LINE__, BSON_FUNC, #test); \
-         abort ();                                                                                        \
-      }                                                                                                   \
+#define BSON_ASSERT(test)                                                                                         \
+   do {                                                                                                           \
+      if (!(BSON_LIKELY (test))) {                                                                                \
+         fprintf (stderr, "%s:%d %s(): precondition failed: %s\n", __FILE__, (int) (__LINE__), BSON_FUNC, #test); \
+         abort ();                                                                                                \
+      }                                                                                                           \
    } while (0)
 
 /**
  * @brief Assert the expression `Assertion`, and evaluates to `Value` on
  * success.
  */
-#define BSON_ASSERT_INLINE(Assertion, Value)                                                                         \
-   ((void) ((Assertion)                                                                                              \
-               ? (0)                                                                                                 \
-               : ((fprintf (stderr, "%s:%d %s(): Assertion '%s' failed", __FILE__, __LINE__, BSON_FUNC, #Assertion), \
-                   abort ()),                                                                                        \
-                  0)),                                                                                               \
+#define BSON_ASSERT_INLINE(Assertion, Value)                                                                           \
+   ((void) ((Assertion)                                                                                                \
+               ? (0)                                                                                                   \
+               : ((fprintf (                                                                                           \
+                      stderr, "%s:%d %s(): Assertion '%s' failed", __FILE__, (int) (__LINE__), BSON_FUNC, #Assertion), \
+                   abort ()),                                                                                          \
+                  0)),                                                                                                 \
     Value)
 
 /**
@@ -349,10 +350,10 @@
  * @param What A string to include in the error message if this point is ever
  * executed.
  */
-#define BSON_UNREACHABLE(What)                                                                             \
-   do {                                                                                                    \
-      fprintf (stderr, "%s:%d %s(): Unreachable code reached: %s\n", __FILE__, __LINE__, BSON_FUNC, What); \
-      abort ();                                                                                            \
+#define BSON_UNREACHABLE(What)                                                                                     \
+   do {                                                                                                            \
+      fprintf (stderr, "%s:%d %s(): Unreachable code reached: %s\n", __FILE__, (int) (__LINE__), BSON_FUNC, What); \
+      abort ();                                                                                                    \
    } while (0)
 
 /**

--- a/src/libbson/tests/test-bson-corpus.c
+++ b/src/libbson/tests/test-bson-corpus.c
@@ -4,6 +4,8 @@
 #include "corpus-test.h"
 #include <mcd-string.h>
 
+#include <inttypes.h>
+
 
 #define IS_NAN(dec) (dec).high == 0x7c00000000000000ull
 
@@ -47,15 +49,16 @@ compare_data (const uint8_t *a, uint32_t a_len, const uint8_t *b, uint32_t b_len
    if (a_len != b_len || memcmp (a, b, (size_t) a_len)) {
       a_str = mcd_string_new (NULL);
       for (i = 0; i < a_len; i++) {
-         mcd_string_append_printf (a_str, "%02X", (int) a[i]);
+         mcd_string_append_printf (a_str, "%02" PRIx8, a[i]);
       }
 
       b_str = mcd_string_new (NULL);
       for (i = 0; i < b_len; i++) {
-         mcd_string_append_printf (b_str, "%02X", (int) b[i]);
+         mcd_string_append_printf (b_str, "%02" PRIx8, b[i]);
       }
 
-      fprintf (stderr, "unequal data of length %d and %d:\n%s\n%s\n", a_len, b_len, a_str->str, b_str->str);
+      fprintf (
+         stderr, "unequal data of length %" PRIu32 " and %" PRIu32 ":\n%s\n%s\n", a_len, b_len, a_str->str, b_str->str);
 
       abort ();
    }

--- a/src/libbson/tests/test-bson-error.c
+++ b/src/libbson/tests/test-bson-error.c
@@ -24,10 +24,10 @@ test_bson_error_basic (void)
 {
    bson_error_t error;
 
-   bson_set_error (&error, 123, 456, "%s %u", "localhost", 27017);
+   bson_set_error (&error, 123, 456, "%s %d", "localhost", 27017);
    BSON_ASSERT (!strcmp (error.message, "localhost 27017"));
-   ASSERT_CMPINT (error.domain, ==, 123);
-   ASSERT_CMPINT (error.code, ==, 456);
+   ASSERT_CMPUINT32 (error.domain, ==, 123u);
+   ASSERT_CMPUINT32 (error.code, ==, 456u);
 }
 
 

--- a/src/libbson/tests/test-bson.c
+++ b/src/libbson/tests/test-bson.c
@@ -1129,7 +1129,7 @@ test_bson_validate (void)
    bson_error_t error;
 
    for (i = 1; i <= 38; i++) {
-      bson_snprintf (filename, sizeof filename, "test%u.bson", i);
+      bson_snprintf (filename, sizeof filename, "test%d.bson", i);
       b = get_bson (filename);
       BSON_ASSERT (bson_validate (b, BSON_VALIDATE_NONE, &offset));
       bson_destroy (b);
@@ -2218,10 +2218,9 @@ test_bson_iter_key_len (void)
    BSON_ASSERT (bson_iter_init (&iter, bson));
    while (bson_iter_next (&iter)) {
       ASSERT_WITH_MSG (strlen (bson_iter_key (&iter)) == bson_iter_key_len (&iter),
-                       "iter_key_len differs from real key length. got %d but "
-                       "expected %d for key %s\n",
+                       "iter_key_len differs from real key length. got %" PRIu32 " but expected %zu for key %s\n",
                        bson_iter_key_len (&iter),
-                       (int) strlen (bson_iter_key (&iter)),
+                       strlen (bson_iter_key (&iter)),
                        bson_iter_key (&iter));
    }
 }
@@ -2250,8 +2249,8 @@ test_bson_iter_init_from_data_at_offset (void)
          for (i = 0; i < 2; i++) {
             fprintf (stderr, "iter %d: ", i);
             fprintf (stderr,
-                     "len=%d, off=%d, type=%d, key=%d, d1=%d, d2=%d, "
-                     "d3=%d, d4=%d, next_off=%d, err_off=%d\n",
+                     "len=%" PRIu32 ", off=%" PRIu32 ", type=%" PRIu32 ", key=%" PRIu32 ", d1=%" PRIu32 ", d2=%" PRIu32
+                     ", d3=%" PRIu32 ", d4=%" PRIu32 ", next_off=%" PRIu32 ", err_off=%" PRIu32 "\n",
                      iters[i]->len,
                      iters[i]->off,
                      iters[i]->type,

--- a/src/libbson/tests/test-string.c
+++ b/src/libbson/tests/test-string.c
@@ -131,7 +131,7 @@ test_bson_strdup_printf (void)
 {
    char *s;
 
-   s = bson_strdup_printf ("%s:%u", "localhost", 27017);
+   s = bson_strdup_printf ("%s:%d", "localhost", 27017);
    BSON_ASSERT (!strcmp (s, "localhost:27017"));
    bson_free (s);
 }

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -70,7 +70,23 @@ endif ()
 if ( (ENABLE_ZLIB STREQUAL "BUNDLED")
    OR (ENABLE_ZLIB STREQUAL "AUTO" AND NOT ZLIB_FOUND) )
    message (STATUS "Enabling zlib compression (bundled)")
-   add_library (zlib_obj OBJECT "${ZLIB_SOURCES}")
+   add_library (zlib_obj OBJECT
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/adler32.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/crc32.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/deflate.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/infback.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/inffast.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/inflate.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/inftrees.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/trees.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/zutil.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/compress.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/uncompr.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/gzclose.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/gzlib.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/gzread.c
+      ${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1/gzwrite.c
+   )
    set_property (TARGET zlib_obj PROPERTY POSITION_INDEPENDENT_CODE TRUE)
    # This tells the bundled zlib where to find its generated headers
    target_include_directories (zlib_obj
@@ -799,6 +815,28 @@ if(ENABLE_SRV)
 endif()
 
 if (MONGOC_ENABLE_MONGODB_AWS_AUTH)
+   set (KMS_MSG_SOURCES
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/hexlify.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_b64.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_caller_identity_request.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_crypto_apple.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_crypto_libcrypto.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_crypto_none.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_crypto_windows.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_decrypt_request.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_encrypt_request.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_kmip_response_parser.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_kv_list.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_message.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_port.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_request.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_request_opt.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_request_str.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_response.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/kms_response_parser.c
+      ${mongo-c-driver_SOURCE_DIR}/src/kms-message/src/sort.c
+   )
+
    # Disable warnings on bundled kms_message source files.
    set_source_files_properties (${KMS_MSG_SOURCES} PROPERTIES COMPILE_FLAGS -w)
    set (SOURCES ${SOURCES} ${KMS_MSG_SOURCES})

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -75,7 +75,7 @@ if ( (ENABLE_ZLIB STREQUAL "BUNDLED")
    # This tells the bundled zlib where to find its generated headers
    target_include_directories (zlib_obj
       BEFORE PUBLIC
-      "${SOURCE_DIR}/src/zlib-1.3.1"
+      "${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1"
       "${CMAKE_BINARY_DIR}/src/zlib-1.3.1"
    )
    # Disable all warnings for compiling Zlib
@@ -84,7 +84,7 @@ if ( (ENABLE_ZLIB STREQUAL "BUNDLED")
    # This tells mongoc_shared/mongoc_static where to find generated zlib headers
    set (
       ZLIB_INCLUDE_DIRS
-      "${SOURCE_DIR}/src/zlib-1.3.1"
+      "${mongo-c-driver_SOURCE_DIR}/src/zlib-1.3.1"
       "${CMAKE_BINARY_DIR}/src/zlib-1.3.1"
    )
 endif ()
@@ -644,9 +644,9 @@ set (SOURCES ${SOURCES}
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-write-command.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-write-concern.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/service-gcp.c
-   ${PROJECT_SOURCE_DIR}/../../src/common/common-b64.c
-   ${PROJECT_SOURCE_DIR}/../../src/common/common-md5.c
-   ${PROJECT_SOURCE_DIR}/../../src/common/common-thread.c
+   ${mongo-c-driver_SOURCE_DIR}/src/common/common-b64.c
+   ${mongo-c-driver_SOURCE_DIR}/src/common/common-md5.c
+   ${mongo-c-driver_SOURCE_DIR}/src/common/common-thread.c
 
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-crypto.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-scram.c
@@ -783,7 +783,7 @@ set(UTF8PROC_INCLUDE_DIRS, "")
 if (USE_BUNDLED_UTF8PROC)
    set (
       UTF8PROC_INCLUDE_DIRS
-      "${SOURCE_DIR}/src/utf8proc-2.8.0"
+      "${mongo-c-driver_SOURCE_DIR}/src/utf8proc-2.8.0"
    )
    list(APPEND SOURCES $<TARGET_OBJECTS:utf8proc_obj>)
 else()
@@ -842,7 +842,7 @@ set_property(
 
 set (
    UTHASH_INCLUDE_DIR
-   "${SOURCE_DIR}/src/uthash"
+   "${mongo-c-driver_SOURCE_DIR}/src/uthash"
 )
 
 if (ENABLE_SHARED)
@@ -859,11 +859,11 @@ if (ENABLE_SHARED)
    target_include_directories (mongoc_shared PRIVATE ${LIBMONGOCRYPT_INCLUDE_DIRECTORIES})
    target_include_directories (mongoc_shared PRIVATE ${UTHASH_INCLUDE_DIR})
    if (MONGOC_ENABLE_MONGODB_AWS_AUTH)
-      target_include_directories (mongoc_shared PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../kms-message/src")
+      target_include_directories (mongoc_shared PRIVATE "${mongo-c-driver_SOURCE_DIR}/src/kms-message/src")
       if (APPLE)
-         set_target_properties (mongoc_shared PROPERTIES LINK_FLAGS "-Wl,-unexported_symbols_list,\"${CMAKE_CURRENT_SOURCE_DIR}/../../build/cmake/libmongoc-hidden-symbols.txt\"")
+         set_target_properties (mongoc_shared PROPERTIES LINK_FLAGS "-Wl,-unexported_symbols_list,\"${mongo-c-driver_SOURCE_DIR}/build/cmake/libmongoc-hidden-symbols.txt\"")
       elseif (UNIX)
-         set_target_properties (mongoc_shared PROPERTIES LINK_FLAGS "-Wl,--version-script=\"${CMAKE_CURRENT_SOURCE_DIR}/../../build/cmake/libmongoc-hidden-symbols.map\"")
+         set_target_properties (mongoc_shared PROPERTIES LINK_FLAGS "-Wl,--version-script=\"${mongo-c-driver_SOURCE_DIR}/build/cmake/libmongoc-hidden-symbols.map\"")
       endif ()
 
    endif ()
@@ -887,9 +887,9 @@ if (ENABLE_SHARED)
          $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src/mongoc>
          $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
          $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/mongoc>
-         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/../../src/common>
-         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/../../src>
-         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/../../src/common>
+         $<BUILD_INTERFACE:${mongo-c-driver_SOURCE_DIR}/src/common>
+         $<BUILD_INTERFACE:${mongo-c-driver_BINARY_DIR}/src>
+         $<BUILD_INTERFACE:${mongo-c-driver_BINARY_DIR}/src/common>
    )
 
    set_target_properties (mongoc_shared PROPERTIES
@@ -911,7 +911,7 @@ if (ENABLE_SHARED)
       )
    endif () # ENABLE_APPLE_FRAMEWORK
 
-   add_executable (mongoc-stat ${PROJECT_SOURCE_DIR}/../../src/tools/mongoc-stat.c)
+   add_executable (mongoc-stat ${mongo-c-driver_SOURCE_DIR}/src/tools/mongoc-stat.c)
    target_link_libraries (mongoc-stat mongoc_shared ${LIBRARIES})
 
    # mongoc-stat works if shared memory performance counters are enabled.
@@ -944,7 +944,7 @@ if (MONGOC_ENABLE_STATIC_BUILD)
    target_include_directories (mongoc_static PRIVATE ${LIBMONGOCRYPT_INCLUDE_DIRECTORIES})
    target_include_directories (mongoc_static PRIVATE ${UTHASH_INCLUDE_DIR})
    if (MONGOC_ENABLE_MONGODB_AWS_AUTH)
-      target_include_directories (mongoc_static PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../kms-message/src")
+      target_include_directories (mongoc_static PRIVATE "${mongo-c-driver_SOURCE_DIR}/src/kms-message/src")
    endif ()
    target_compile_definitions (mongoc_static
       PUBLIC
@@ -967,9 +967,9 @@ if (MONGOC_ENABLE_STATIC_BUILD)
          $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src/mongoc>
          $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
          $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/mongoc>
-         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/../../src/common>
-         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/../../src>
-         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/../../src/common>
+         $<BUILD_INTERFACE:${mongo-c-driver_SOURCE_DIR}/src/common>
+         $<BUILD_INTERFACE:${mongo-c-driver_BINARY_DIR}/src>
+         $<BUILD_INTERFACE:${mongo-c-driver_BINARY_DIR}/src/common>
    )
    set_target_properties (mongoc_static PROPERTIES
       VERSION 0.0.0
@@ -983,30 +983,30 @@ endif ()
 
 
 set (test-libmongoc-sources
-   ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/corpus-test.c
-   ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/corpus-test.h
-   ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/test-atomic.c
-   ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/test-b64.c
-   ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/test-bson.c
-   ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/test-bcon-basic.c
-   ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/test-bcon-extract.c
-   ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/test-bson-cmp.c
-   ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/test-bson-corpus.c
-   ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/test-bson-error.c
-   ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/test-bson-version.c
-   ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/test-bson.c
-   ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/test-clock.c
-   ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/test-decimal128.c
-   ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/test-endian.c
-   ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/test-iso8601.c
-   ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/test-iter.c
-   ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/test-json.c
-   ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/test-oid.c
-   ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/test-reader.c
-   ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/test-string.c
-   ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/test-utf8.c
-   ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/test-value.c
-   ${PROJECT_SOURCE_DIR}/../../src/libbson/tests/test-writer.c
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/corpus-test.c
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/corpus-test.h
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-atomic.c
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-b64.c
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-bson.c
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-bcon-basic.c
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-bcon-extract.c
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-bson-cmp.c
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-bson-corpus.c
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-bson-error.c
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-bson-version.c
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-bson.c
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-clock.c
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-decimal128.c
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-endian.c
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-iso8601.c
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-iter.c
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-json.c
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-oid.c
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-reader.c
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-string.c
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-utf8.c
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-value.c
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-writer.c
    ${PROJECT_SOURCE_DIR}/tests/bsonutil/bson-match.c
    ${PROJECT_SOURCE_DIR}/tests/bsonutil/bson-parser.c
    ${PROJECT_SOURCE_DIR}/tests/bsonutil/bson-val.c

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -565,7 +565,7 @@ else ()
 endif ()
 
 
-set (SOURCES ${SOURCES}
+set (MONGOC_SOURCES
    ${PROJECT_SOURCE_DIR}/src/mongoc/mcd-azure.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mcd-nsinfo.c
    ${PROJECT_SOURCE_DIR}/src/mongoc/mcd-rpc.c
@@ -693,6 +693,26 @@ set (SOURCES ${SOURCES}
    ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-bulkwrite.c
 )
 
+if (MONGOC_ENABLE_SASL)
+   list (APPEND MONGOC_SOURCES ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-sasl.c)
+   if (MONGOC_ENABLE_SASL_CYRUS)
+      message (STATUS "Compiling against Cyrus SASL")
+      list (APPEND MONGOC_SOURCES ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-cluster-cyrus.c)
+      list (APPEND MONGOC_SOURCES ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-cyrus.c)
+   elseif (MONGOC_ENABLE_SASL_SSPI)
+      message (STATUS "Compiling against Windows SSPI")
+      list (APPEND MONGOC_SOURCES ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-cluster-sspi.c)
+      list (APPEND MONGOC_SOURCES ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-sspi.c)
+   endif ()
+else ()
+   message (STATUS "SASL disabled")
+endif ()
+
+# Enable unconditional warnings-as-errors for our source code.
+set_property(SOURCE ${MONGOC_SOURCES} APPEND PROPERTY COMPILE_OPTIONS ${mongoc-warning-options})
+
+list (APPEND SOURCES ${MONGOC_SOURCES})
+
 set (HEADERS
    ${PROJECT_BINARY_DIR}/src/mongoc/mongoc-config.h
    ${PROJECT_BINARY_DIR}/src/mongoc/mongoc-version.h
@@ -769,21 +789,6 @@ if (ENABLE_APPLE_FRAMEWORK)
       "${PROJECT_SOURCE_DIR}/src/mongoc/modules/module.modulemap.in"
       "${PROJECT_BINARY_DIR}/src/mongoc/modules/module.modulemap"
    )
-endif ()
-
-if (MONGOC_ENABLE_SASL)
-   set (SOURCES ${SOURCES} ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-sasl.c)
-   if (MONGOC_ENABLE_SASL_CYRUS)
-      message (STATUS "Compiling against Cyrus SASL")
-      set (SOURCES ${SOURCES} ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-cluster-cyrus.c)
-      set (SOURCES ${SOURCES} ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-cyrus.c)
-   elseif (MONGOC_ENABLE_SASL_SSPI)
-      message (STATUS "Compiling against Windows SSPI")
-      set (SOURCES ${SOURCES} ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-cluster-sspi.c)
-      set (SOURCES ${SOURCES} ${PROJECT_SOURCE_DIR}/src/mongoc/mongoc-sspi.c)
-   endif ()
-else ()
-   message (STATUS "SASL disabled")
 endif ()
 
 set (LIBRARIES
@@ -950,6 +955,7 @@ if (ENABLE_SHARED)
    endif () # ENABLE_APPLE_FRAMEWORK
 
    add_executable (mongoc-stat ${mongo-c-driver_SOURCE_DIR}/src/tools/mongoc-stat.c)
+   target_compile_options (mongoc-stat PRIVATE ${mongoc-warning-options})
    target_link_libraries (mongoc-stat mongoc_shared ${LIBRARIES})
 
    # mongoc-stat works if shared memory performance counters are enabled.
@@ -1191,6 +1197,8 @@ if (ENABLE_TESTS)
    target_compile_options (test-libmongoc-lib
       PRIVATE $<$<NOT:$<C_COMPILER_ID:MSVC>>:-Wno-deprecated-declarations>
    )
+   # Enable unconditional warnings-as-errors for our source code.
+   target_compile_options (test-libmongoc-lib PRIVATE ${mongoc-warning-options})
    target_include_directories (test-libmongoc-lib
       PRIVATE
          ${PROJECT_SOURCE_DIR}/tests
@@ -1217,6 +1225,8 @@ if (ENABLE_TESTS)
       target_compile_options (${test}
          PRIVATE $<$<NOT:$<C_COMPILER_ID:MSVC>>:-Wno-deprecated-declarations>
       )
+      # Enable unconditional warnings-as-errors for our source code.
+      target_compile_options (${test} PRIVATE ${mongoc-warning-options})
       target_include_directories (${test}
          PRIVATE
             ${PROJECT_SOURCE_DIR}/tests
@@ -1253,6 +1263,9 @@ if (ENABLE_EXAMPLES AND ENABLE_SHARED)
    function (mongoc_add_example example)
       add_executable (${example} EXCLUDE_FROM_ALL ${ARGN})
       add_dependencies (mongo_c_driver_examples ${example})
+
+      # Enable unconditional warnings-as-errors for our source code.
+      target_compile_options (${example} PRIVATE ${mongoc-warning-options})
 
       target_link_libraries (${example} mongoc_shared ${LIBRARIES})
       if (WIN32)
@@ -1327,6 +1340,7 @@ if (ENABLE_TESTS AND ENABLE_SHARED AND MONGOC_ENABLE_SSL AND NOT WIN32)
    # Add benchmarks to measure opening many TLS connections.
    # Benchmarks require SSL, and do not build on Windows.
    add_executable (benchmark-tls-pooled ${PROJECT_SOURCE_DIR}/tests/benchmark-tls-pooled.c)
+   target_compile_options (benchmark-tls-pooled PRIVATE ${mongoc-warning-options})
    target_link_libraries (benchmark-tls-pooled mongoc_shared ${LIBRARIES})
 endif ()
 

--- a/src/libmongoc/examples/example-manage-collection-indexes.c
+++ b/src/libmongoc/examples/example-manage-collection-indexes.c
@@ -4,13 +4,13 @@
 #include <mongoc/mongoc.h>
 #include <stdlib.h> // abort
 
-#define HANDLE_ERROR(...)                                         \
-   if (1) {                                                       \
-      fprintf (stderr, "Failure at %s:%d\n", __FILE__, __LINE__); \
-      fprintf (stderr, __VA_ARGS__);                              \
-      fprintf (stderr, "\n");                                     \
-      goto fail;                                                  \
-   } else                                                         \
+#define HANDLE_ERROR(...)                                                 \
+   if (1) {                                                               \
+      fprintf (stderr, "Failure at %s:%d\n", __FILE__, (int) (__LINE__)); \
+      fprintf (stderr, __VA_ARGS__);                                      \
+      fprintf (stderr, "\n");                                             \
+      goto fail;                                                          \
+   } else                                                                 \
       (void) 0
 
 int

--- a/src/libmongoc/examples/example-manage-search-indexes.c
+++ b/src/libmongoc/examples/example-manage-search-indexes.c
@@ -13,11 +13,11 @@
    } else                            \
       (void) 0
 
-#define ASSERT(stmt)                                                                      \
-   if (!stmt) {                                                                           \
-      fprintf (stderr, "assertion failed on line: %d, statement: %s\n", __LINE__, #stmt); \
-      abort ();                                                                           \
-   } else                                                                                 \
+#define ASSERT(stmt)                                                                              \
+   if (!stmt) {                                                                                   \
+      fprintf (stderr, "assertion failed on line: %d, statement: %s\n", (int) (__LINE__), #stmt); \
+      abort ();                                                                                   \
+   } else                                                                                         \
       (void) 0
 
 int

--- a/src/libmongoc/examples/find_and_modify_with_opts/fam.c
+++ b/src/libmongoc/examples/find_and_modify_with_opts/fam.c
@@ -35,7 +35,7 @@ fam_bypass (mongoc_collection_t *collection)
       printf ("%s\n", str);
       bson_free (str);
    } else {
-      fprintf (stderr, "Got error: \"%s\" on line %d\n", error.message, __LINE__);
+      fprintf (stderr, "Got error: \"%s\" on line %d\n", error.message, (int) (__LINE__));
    }
 
    bson_destroy (&reply);
@@ -83,7 +83,7 @@ fam_flags (mongoc_collection_t *collection)
       printf ("%s\n", str);
       bson_free (str);
    } else {
-      fprintf (stderr, "Got error: \"%s\" on line %d\n", error.message, __LINE__);
+      fprintf (stderr, "Got error: \"%s\" on line %d\n", error.message, (int) (__LINE__));
    }
 
    bson_destroy (&reply);
@@ -129,7 +129,7 @@ fam_update (mongoc_collection_t *collection)
       printf ("%s\n", str);
       bson_free (str);
    } else {
-      fprintf (stderr, "Got error: \"%s\" on line %d\n", error.message, __LINE__);
+      fprintf (stderr, "Got error: \"%s\" on line %d\n", error.message, (int) (__LINE__));
    }
 
    bson_destroy (&reply);
@@ -177,7 +177,7 @@ fam_fields (mongoc_collection_t *collection)
       printf ("%s\n", str);
       bson_free (str);
    } else {
-      fprintf (stderr, "Got error: \"%s\" on line %d\n", error.message, __LINE__);
+      fprintf (stderr, "Got error: \"%s\" on line %d\n", error.message, (int) (__LINE__));
    }
 
    bson_destroy (&reply);
@@ -235,7 +235,7 @@ fam_opts (mongoc_collection_t *collection)
       printf ("%s\n", str);
       bson_free (str);
    } else {
-      fprintf (stderr, "Got error: \"%s\" on line %d\n", error.message, __LINE__);
+      fprintf (stderr, "Got error: \"%s\" on line %d\n", error.message, (int) (__LINE__));
    }
 
    bson_destroy (&reply);
@@ -282,7 +282,7 @@ fam_sort (mongoc_collection_t *collection)
       printf ("%s\n", str);
       bson_free (str);
    } else {
-      fprintf (stderr, "Got error: \"%s\" on line %d\n", error.message, __LINE__);
+      fprintf (stderr, "Got error: \"%s\" on line %d\n", error.message, (int) (__LINE__));
    }
 
    bson_destroy (&reply);
@@ -340,7 +340,7 @@ main (void)
 
    collection = mongoc_database_create_collection (database, "collectionName", options, &error);
    if (!collection) {
-      fprintf (stderr, "Got error: \"%s\" on line %d\n", error.message, __LINE__);
+      fprintf (stderr, "Got error: \"%s\" on line %d\n", error.message, (int) (__LINE__));
       return EXIT_FAILURE;
    }
 

--- a/src/libmongoc/src/mongoc/mcd-azure.c
+++ b/src/libmongoc/src/mongoc/mcd-azure.c
@@ -126,7 +126,7 @@ mcd_azure_access_token_try_init_from_json_str (mcd_azure_access_token *out,
                          MONGOC_ERROR_AZURE,
                          MONGOC_ERROR_KMS_SERVER_BAD_JSON,
                          "Invalid 'expires_in' string \"%.*s\" from IMDS server",
-                         expires_in_len,
+                         bson_in_range_unsigned (int, expires_in_len) ? (int) expires_in_len : INT_MAX,
                          expires_in_str);
       } else {
          out->expires_in = mcd_seconds (s);

--- a/src/libmongoc/src/mongoc/mongoc-bulkwrite.c
+++ b/src/libmongoc/src/mongoc/mongoc-bulkwrite.c
@@ -241,12 +241,12 @@ mongoc_bulkwrite_append_insertone (mongoc_bulkwrite_t *self,
    uint32_t persisted_id_offset = 0;
    {
       // Refer: bsonspec.org for BSON format.
-      persisted_id_offset += 4;                       // Document length.
-      persisted_id_offset += 1;                       // BSON type for int32.
-      persisted_id_offset += strlen ("insert") + 1;   // Key + 1 for NULL byte.
-      persisted_id_offset += 4;                       // int32 value.
-      persisted_id_offset += 1;                       // BSON type for document.
-      persisted_id_offset += strlen ("document") + 1; // Key + 1 for NULL byte.
+      persisted_id_offset += 4;                                   // Document length.
+      persisted_id_offset += 1;                                   // BSON type for int32.
+      persisted_id_offset += (uint32_t) strlen ("insert") + 1u;   // Key + 1 for NULL byte.
+      persisted_id_offset += 4;                                   // int32 value.
+      persisted_id_offset += 1;                                   // BSON type for document.
+      persisted_id_offset += (uint32_t) strlen ("document") + 1u; // Key + 1 for NULL byte.
    }
 
    // If `document` does not contain `_id`, add one in the beginning.

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -72,6 +72,8 @@
 
 #include <mcd-string.h>
 
+#include <inttypes.h>
+
 #undef MONGOC_LOG_DOMAIN
 #define MONGOC_LOG_DOMAIN "client"
 
@@ -784,8 +786,11 @@ mongoc_client_connect (bool buffered,
       base_stream = mongoc_client_connect_unix (host, error);
       break;
    default:
-      bson_set_error (
-         error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_INVALID_TYPE, "Invalid address family: 0x%02x", host->family);
+      bson_set_error (error,
+                      MONGOC_ERROR_STREAM,
+                      MONGOC_ERROR_STREAM_INVALID_TYPE,
+                      "Invalid address family: 0x%02x",
+                      (unsigned int) host->family);
       break;
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -2271,8 +2271,11 @@ _cluster_fetch_stream_single (mongoc_cluster_t *cluster,
    scanner_node = mongoc_topology_scanner_get_node (cluster->client->topology->scanner, server_id);
    /* This could happen if a user explicitly passes a bad server id. */
    if (!scanner_node) {
-      bson_set_error (
-         error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "Could not find server with id: %d", server_id);
+      bson_set_error (error,
+                      MONGOC_ERROR_COMMAND,
+                      MONGOC_ERROR_COMMAND_INVALID_ARG,
+                      "Could not find server with id: %" PRIu32,
+                      server_id);
       return NULL;
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-counters.c
+++ b/src/libmongoc/src/mongoc/mongoc-counters.c
@@ -137,7 +137,7 @@ _mongoc_counters_cleanup (void)
 
       pid = getpid ();
       // Truncation is OK.
-      int req = bson_snprintf (name, sizeof name, "/mongoc-%u", pid);
+      int req = bson_snprintf (name, sizeof name, "/mongoc-%d", pid);
       BSON_ASSERT (req > 0);
       shm_unlink (name);
 #endif
@@ -171,7 +171,7 @@ mongoc_counters_alloc (size_t size)
 
    pid = getpid ();
    // Truncation is OK.
-   int req = bson_snprintf (name, sizeof name, "/mongoc-%u", pid);
+   int req = bson_snprintf (name, sizeof name, "/mongoc-%d", pid);
    BSON_ASSERT (req > 0);
 
 #ifndef O_NOFOLLOW

--- a/src/libmongoc/src/mongoc/mongoc-gridfs-bucket-file.c
+++ b/src/libmongoc/src/mongoc/mongoc-gridfs-bucket-file.c
@@ -23,6 +23,8 @@
 #include "mongoc-collection-private.h"
 #include "mongoc-util-private.h"
 
+#include <inttypes.h>
+
 /* Returns the minimum of two numbers */
 static size_t
 _mongoc_min (const size_t a, const size_t b)
@@ -283,7 +285,7 @@ _mongoc_gridfs_bucket_read_chunk (mongoc_gridfs_bucket_file_t *file)
       bson_set_error (&file->err,
                       MONGOC_ERROR_GRIDFS,
                       MONGOC_ERROR_GRIDFS_CORRUPT,
-                      "Chunk %d expected to have size %" PRId64 " but is size %d.",
+                      "Chunk %d expected to have size %" PRId64 " but is size %" PRIu32 ".",
                       file->curr_chunk,
                       expected_size,
                       data_len);

--- a/src/libmongoc/src/mongoc/mongoc-matcher-op.c
+++ b/src/libmongoc/src/mongoc/mongoc-matcher-op.c
@@ -19,6 +19,8 @@
 #include "mongoc-matcher-op-private.h"
 #include "mongoc-util-private.h"
 
+#include <inttypes.h>
+
 /*
  *--------------------------------------------------------------------------
  *
@@ -600,7 +602,8 @@ _mongoc_matcher_op_gt_match (mongoc_matcher_op_compare_t *compare, /* IN */
       return _GT_COMPARE (_int64, _int64);
 
    default:
-      MONGOC_WARNING ("Implement for (Type(%d) > Type(%d))", bson_iter_type (compare_iter), bson_iter_type (iter));
+      MONGOC_WARNING (
+         "Implement for (Type(%d) > Type(%d))", (int) bson_iter_type (compare_iter), (int) bson_iter_type (iter));
       break;
    }
 
@@ -669,7 +672,8 @@ _mongoc_matcher_op_gte_match (mongoc_matcher_op_compare_t *compare, /* IN */
       return _GTE_COMPARE (_int64, _int64);
 
    default:
-      MONGOC_WARNING ("Implement for (Type(%d) >= Type(%d))", bson_iter_type (compare_iter), bson_iter_type (iter));
+      MONGOC_WARNING (
+         "Implement for (Type(%d) >= Type(%d))", (int) bson_iter_type (compare_iter), (int) bson_iter_type (iter));
       break;
    }
 
@@ -777,7 +781,8 @@ _mongoc_matcher_op_lt_match (mongoc_matcher_op_compare_t *compare, /* IN */
       return _LT_COMPARE (_int64, _int64);
 
    default:
-      MONGOC_WARNING ("Implement for (Type(%d) < Type(%d))", bson_iter_type (compare_iter), bson_iter_type (iter));
+      MONGOC_WARNING (
+         "Implement for (Type(%d) < Type(%d))", (int) bson_iter_type (compare_iter), (int) bson_iter_type (iter));
       break;
    }
 
@@ -846,7 +851,8 @@ _mongoc_matcher_op_lte_match (mongoc_matcher_op_compare_t *compare, /* IN */
       return _LTE_COMPARE (_int64, _int64);
 
    default:
-      MONGOC_WARNING ("Implement for (Type(%d) <= Type(%d))", bson_iter_type (compare_iter), bson_iter_type (iter));
+      MONGOC_WARNING (
+         "Implement for (Type(%d) <= Type(%d))", (int) bson_iter_type (compare_iter), (int) bson_iter_type (iter));
       break;
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -431,7 +431,7 @@ mongoc_secure_channel_read (mongoc_stream_tls_t *tls, void *data, size_t data_le
    }
 
    errno = 0;
-   TRACE ("Wanting to read: %zu, timeout is %" PRIu64, data_length, tls->timeout_msec);
+   TRACE ("Wanting to read: %zu, timeout is %" PRId64, data_length, tls->timeout_msec);
    /* 4th argument is minimum bytes, while the data_length is the
     * size of the buffer. We are totally fine with just one TLS record (few
     *bytes)

--- a/src/libmongoc/src/mongoc/mongoc-server-monitor.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-monitor.c
@@ -27,6 +27,8 @@
 #include "mongoc/mongoc-topology-private.h"
 #include "mongoc/mongoc-trace-private.h"
 
+#include <inttypes.h>
+
 #undef MONGOC_LOG_DOMAIN
 #define MONGOC_LOG_DOMAIN "monitor"
 
@@ -541,7 +543,7 @@ _server_monitor_poll_with_interrupt (mongoc_server_monitor_t *server_monitor,
       ssize_t ret;
       mongoc_stream_poll_t poller[1];
 
-      MONITOR_LOG (server_monitor, "_server_monitor_poll_with_interrupt expires in: %" PRIu64 "ms", timeleft_ms);
+      MONITOR_LOG (server_monitor, "_server_monitor_poll_with_interrupt expires in: %" PRId64 "ms", timeleft_ms);
       poller[0].stream = server_monitor->stream;
       poller[0].events = POLLIN; /* POLLERR and POLLHUP are added in mongoc_socket_poll. */
       poller[0].revents = 0;

--- a/src/libmongoc/src/mongoc/mongoc-socket.c
+++ b/src/libmongoc/src/mongoc/mongoc-socket.c
@@ -29,6 +29,8 @@
 #include <process.h>
 #endif
 
+#include <inttypes.h>
+
 #undef MONGOC_LOG_DOMAIN
 #define MONGOC_LOG_DOMAIN "socket"
 
@@ -1258,7 +1260,7 @@ _mongoc_socket_try_sendv (mongoc_socket_t *sock, /* IN */
 #ifdef _WIN32
    BSON_ASSERT (bson_in_range_unsigned (unsigned_long, iovcnt));
    ret = WSASend (sock->sd, (LPWSABUF) iov, (DWORD) iovcnt, &dwNumberofBytesSent, 0, NULL, NULL);
-   TRACE ("WSASend sent: %ld (out of: %zu), ret: %d", dwNumberofBytesSent, iov->iov_len, ret);
+   TRACE ("WSASend sent: %lu (out of: %zu), ret: %d", dwNumberofBytesSent, iov->iov_len, ret);
 #else
    memset (&msg, 0, sizeof msg);
    msg.msg_iov = iov;
@@ -1270,7 +1272,7 @@ _mongoc_socket_try_sendv (mongoc_socket_t *sock, /* IN */
 #else
                   0);
 #endif
-   TRACE ("Send %zu out of %zu bytes", ret, iov->iov_len);
+   TRACE ("Send %zd out of %zu bytes", ret, iov->iov_len);
 #endif
 
 

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl.c
@@ -43,6 +43,8 @@
 
 #include <common-macros-private.h>
 
+#include <inttypes.h>
+
 
 #undef MONGOC_LOG_DOMAIN
 #define MONGOC_LOG_DOMAIN "stream-tls-openssl"
@@ -332,12 +334,12 @@ _mongoc_stream_tls_openssl_writev (mongoc_stream_t *stream, mongoc_iovec_t *iov,
 
             child_ret = _mongoc_stream_tls_openssl_write (tls, to_write, to_write_len);
             if (bson_cmp_not_equal_su (child_ret, to_write_len)) {
-               TRACE ("Got child_ret: %zu while to_write_len is: %zu", child_ret, to_write_len);
+               TRACE ("Got child_ret: %zd while to_write_len is: %zu", child_ret, to_write_len);
             }
 
             if (child_ret < 0) {
-               TRACE ("Returning what I had (%zu) as apposed to the error "
-                      "(%zu, errno:%d)",
+               TRACE ("Returning what I had (%zd) as apposed to the error "
+                      "(%zd, errno:%d)",
                       ret,
                       child_ret,
                       errno);

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
@@ -245,7 +245,7 @@ _mongoc_stream_tls_secure_channel_write (mongoc_stream_t *stream, char *buf, siz
          &secure_channel->ctxt->ctxt_handle, SECPKG_ATTR_STREAM_SIZES, &secure_channel->stream_sizes);
 
       if (sspi_status != SEC_E_OK) {
-         TRACE ("failing here: %d", __LINE__);
+         TRACE ("failing here: %d", (int) (__LINE__));
          return -1;
       }
    }

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
@@ -752,7 +752,9 @@ mongoc_stream_tls_secure_channel_handshake (mongoc_stream_t *stream, const char 
       error->code = 0;
    }
 
-   TRACE ("Getting ready for state: %d, timeout is %" PRId64, secure_channel->connecting_state + 1, tls->timeout_msec);
+   TRACE ("Getting ready for state: %d, timeout is %" PRId64,
+          (int) secure_channel->connecting_state + 1,
+          tls->timeout_msec);
 
    switch (secure_channel->connecting_state) {
    case ssl_connect_1:

--- a/src/libmongoc/src/mongoc/mongoc-topology-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description.c
@@ -2325,7 +2325,7 @@ mongoc_topology_description_type (const mongoc_topology_description_t *td)
       return "LoadBalanced";
    case MONGOC_TOPOLOGY_DESCRIPTION_TYPES:
    default:
-      fprintf (stderr, "ERROR: Unknown topology type %d\n", td->type);
+      fprintf (stderr, "ERROR: Unknown topology type %d\n", (int) td->type);
       BSON_ASSERT (0);
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
@@ -45,6 +45,8 @@
 #include "mongoc-util-private.h"
 #include <mcd-string.h>
 
+#include <inttypes.h>
+
 #undef MONGOC_LOG_DOMAIN
 #define MONGOC_LOG_DOMAIN "topology_scanner"
 
@@ -778,7 +780,7 @@ _async_handler (mongoc_async_cmd_t *acmd,
       return;
    case MONGOC_ASYNC_CMD_IN_PROGRESS:
    default:
-      fprintf (stderr, "unexpected async status: %d\n", async_status);
+      fprintf (stderr, "unexpected async status: %d\n", (int) async_status);
       BSON_ASSERT (false);
       return;
    }

--- a/src/libmongoc/src/mongoc/mongoc-trace-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-trace-private.h
@@ -34,53 +34,44 @@ BSON_BEGIN_DECLS
 // `gLogTrace` determines if tracing is enabled at runtime.
 extern bool gLogTrace;
 
-#define TRACE(msg, ...)                                                                                          \
-   do {                                                                                                          \
-      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                                   \
-         mongoc_log (                                                                                            \
-            MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, "TRACE: %s():%d " msg, BSON_FUNC, __LINE__, __VA_ARGS__); \
-      }                                                                                                          \
+#define TRACE(msg, ...)                        \
+   do {                                        \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) { \
+         mongoc_log (MONGOC_LOG_LEVEL_TRACE,   \
+                     MONGOC_LOG_DOMAIN,        \
+                     "TRACE: %s():%d " msg,    \
+                     BSON_FUNC,                \
+                     (int) (__LINE__),         \
+                     __VA_ARGS__);             \
+      }                                        \
    } while (0)
-#define ENTRY                                                                                           \
-   do {                                                                                                 \
-      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                          \
-         mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, "ENTRY: %s():%d", BSON_FUNC, __LINE__); \
-      }                                                                                                 \
+#define ENTRY                                                                                                   \
+   do {                                                                                                         \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                                  \
+         mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, "ENTRY: %s():%d", BSON_FUNC, (int) (__LINE__)); \
+      }                                                                                                         \
    } while (0)
-#define EXIT                                                                                            \
-   do {                                                                                                 \
-      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                          \
-         mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, " EXIT: %s():%d", BSON_FUNC, __LINE__); \
-      }                                                                                                 \
-      return;                                                                                           \
+#define EXIT                                                                                                    \
+   do {                                                                                                         \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                                  \
+         mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, " EXIT: %s():%d", BSON_FUNC, (int) (__LINE__)); \
+      }                                                                                                         \
+      return;                                                                                                   \
    } while (0)
-#define RETURN(ret)                                                                                     \
-   do {                                                                                                 \
-      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                          \
-         mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, " EXIT: %s():%d", BSON_FUNC, __LINE__); \
-      }                                                                                                 \
-      return ret;                                                                                       \
+#define RETURN(ret)                                                                                             \
+   do {                                                                                                         \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                                  \
+         mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, " EXIT: %s():%d", BSON_FUNC, (int) (__LINE__)); \
+      }                                                                                                         \
+      return ret;                                                                                               \
    } while (0)
-#define GOTO(label)                                                                                                \
-   do {                                                                                                            \
-      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                                     \
-         mongoc_log (MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, " GOTO: %s():%d %s", BSON_FUNC, __LINE__, #label); \
-      }                                                                                                            \
-      goto label;                                                                                                  \
-   } while (0)
-#define DUMP_BYTES(_n, _b, _l)                               \
-   do {                                                      \
-      if (MONGOC_TRACE_ENABLED && gLogTrace) {               \
-         mongoc_log (MONGOC_LOG_LEVEL_TRACE,                 \
-                     MONGOC_LOG_DOMAIN,                      \
-                     "TRACE: %s():%d %s = %p [%d]",          \
-                     BSON_FUNC,                              \
-                     __LINE__,                               \
-                     #_n,                                    \
-                     _b,                                     \
-                     (int) _l);                              \
-         mongoc_log_trace_bytes (MONGOC_LOG_DOMAIN, _b, _l); \
-      }                                                      \
+#define GOTO(label)                                                                                               \
+   do {                                                                                                           \
+      if (MONGOC_TRACE_ENABLED && gLogTrace) {                                                                    \
+         mongoc_log (                                                                                             \
+            MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, " GOTO: %s():%d %s", BSON_FUNC, (int) (__LINE__), #label); \
+      }                                                                                                           \
+      goto label;                                                                                                 \
    } while (0)
 #define DUMP_BSON(_bson)                                               \
    do {                                                                \
@@ -95,7 +86,7 @@ extern bool gLogTrace;
                      MONGOC_LOG_DOMAIN,                                \
                      "TRACE: %s():%d %s = %s",                         \
                      BSON_FUNC,                                        \
-                     __LINE__,                                         \
+                     (int) (__LINE__),                                 \
                      #_bson,                                           \
                      _bson_str);                                       \
          bson_free (_bson_str);                                        \
@@ -108,7 +99,7 @@ extern bool gLogTrace;
                      MONGOC_LOG_DOMAIN,                             \
                      "TRACE: %s():%d %s = %p [%d]",                 \
                      BSON_FUNC,                                     \
-                     __LINE__,                                      \
+                     (int) (__LINE__),                              \
                      #_n,                                           \
                      (void *) _iov,                                 \
                      (int) _iovcnt);                                \

--- a/src/libmongoc/src/mongoc/mongoc-write-command.c
+++ b/src/libmongoc/src/mongoc/mongoc-write-command.c
@@ -28,6 +28,7 @@
 #include "mongoc-opts-private.h"
 #include <mcd-string.h>
 
+#include <inttypes.h>
 
 /* indexed by MONGOC_WRITE_COMMAND_DELETE, INSERT, UPDATE */
 static const char *gCommandNames[] = {"delete", "insert", "update"};
@@ -382,8 +383,8 @@ _mongoc_write_command_too_large_error (bson_error_t *error, int32_t idx, int32_t
    bson_set_error (error,
                    MONGOC_ERROR_BSON,
                    MONGOC_ERROR_BSON_INVALID,
-                   "Document %u is too large for the cluster. "
-                   "Document is %u bytes, max is %d.",
+                   "Document %" PRId32 " is too large for the cluster. "
+                   "Document is %" PRId32 " bytes, max is %" PRId32 ".",
                    idx,
                    len,
                    max_bson_size);

--- a/src/libmongoc/tests/TestSuite.c
+++ b/src/libmongoc/tests/TestSuite.c
@@ -428,7 +428,7 @@ TestSuite_RunFuncInChild (TestSuite *suite, /* IN */
                        NULL,  /* Use parent's starting directory */
                        &si,
                        &pi)) {
-      test_error ("CreateProcess failed (%ld).", GetLastError ());
+      test_error ("CreateProcess failed (%lu).", GetLastError ());
       bson_free (cmdline);
 
       return -1;
@@ -736,19 +736,18 @@ TestSuite_PrintJsonSystemHeader (FILE *stream)
    fprintf (stream,
             "  \"host\": {\n"
             "    \"sysname\": \"Windows\",\n"
-            "    \"release\": \"%ld.%ld (%ld)\",\n"
-            "    \"machine\": \"%ld\",\n"
+            "    \"release\": \"%lu.%lu (%lu)\",\n"
+            "    \"machine\": \"%lu\",\n"
             "    \"memory\": {\n"
-            "      \"pagesize\": %ld,\n"
-            "      \"npages\": %d\n"
+            "      \"pagesize\": %lu,\n"
+            "      \"npages\": 0\n"
             "    }\n"
             "  },\n",
             major_version,
             minor_version,
             build,
             si.dwProcessorType,
-            si.dwPageSize,
-            0);
+            si.dwPageSize);
 #else
    struct utsname u;
    uint64_t pagesize;
@@ -826,7 +825,7 @@ TestSuite_PrintJsonHeader (TestSuite *suite, /* IN */
             "  \"framework\": {\n"
             "    \"monitoringVerbose\": %s,\n"
             "    \"mockServerLog\": \"%s\",\n"
-            "    \"futureTimeoutMS\": %" PRIu64 ",\n"
+            "    \"futureTimeoutMS\": %" PRId64 ",\n"
             "    \"majorityReadConcern\": %s,\n"
             "    \"skipLiveTests\": %s,\n"
             "  },\n"

--- a/src/libmongoc/tests/TestSuite.h
+++ b/src/libmongoc/tests/TestSuite.h
@@ -23,6 +23,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <stdlib.h>
+#include <inttypes.h>
 
 #include "mongoc/mongoc-array-private.h"
 #include "mongoc/mongoc-util-private.h"
@@ -160,7 +161,7 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
          if (off == -1) {                                                                                       \
             off = BSON_MAX ((expected)->len, (bson)->len) - 1;                                                  \
          }                                                                                                      \
-         MONGOC_STDERR_PRINTF ("bson objects unequal (byte %u):\n(%s)\n(%s)\n", off, bson_json, expected_json); \
+         MONGOC_STDERR_PRINTF ("bson objects unequal (byte %d):\n(%s)\n(%s)\n", off, bson_json, expected_json); \
          {                                                                                                      \
             int fd1 = bson_open ("failure.bad.bson", O_RDWR | O_CREAT, 0640);                                   \
             int fd2 = bson_open ("failure.expected.bson", O_RDWR | O_CREAT, 0640);                              \
@@ -393,31 +394,33 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
       }                                                                                              \
    } while (0)
 
-#define ASSERT_ERROR_CONTAINS(error, _domain, _code, _message)                           \
-   do {                                                                                  \
-      if (error.domain != _domain) {                                                     \
-         MONGOC_STDERR_PRINTF ("%s:%d %s(): error domain %d doesn't match expected %d\n" \
-                               "error: \"%s\"",                                          \
-                               __FILE__,                                                 \
-                               __LINE__,                                                 \
-                               BSON_FUNC,                                                \
-                               error.domain,                                             \
-                               _domain,                                                  \
-                               error.message);                                           \
-         abort ();                                                                       \
-      };                                                                                 \
-      if (error.code != _code) {                                                         \
-         MONGOC_STDERR_PRINTF ("%s:%d %s(): error code %d doesn't match expected %d\n"   \
-                               "error: \"%s\"",                                          \
-                               __FILE__,                                                 \
-                               __LINE__,                                                 \
-                               BSON_FUNC,                                                \
-                               error.code,                                               \
-                               _code,                                                    \
-                               error.message);                                           \
-         abort ();                                                                       \
-      };                                                                                 \
-      ASSERT_CONTAINS (error.message, _message);                                         \
+#define ASSERT_ERROR_CONTAINS(error, _domain, _code, _message)                                             \
+   do {                                                                                                    \
+      uint32_t _domain_ = (_domain);                                                                       \
+      uint32_t _code_ = (_code);                                                                           \
+      if (error.domain != _domain_) {                                                                      \
+         MONGOC_STDERR_PRINTF ("%s:%d %s(): error domain %" PRIu32 " doesn't match expected %" PRIu32 "\n" \
+                               "error: \"%s\"",                                                            \
+                               __FILE__,                                                                   \
+                               __LINE__,                                                                   \
+                               BSON_FUNC,                                                                  \
+                               error.domain,                                                               \
+                               _domain_,                                                                   \
+                               error.message);                                                             \
+         abort ();                                                                                         \
+      };                                                                                                   \
+      if (error.code != _code_) {                                                                          \
+         MONGOC_STDERR_PRINTF ("%s:%d %s(): error code %" PRIu32 " doesn't match expected %" PRIu32 "\n"   \
+                               "error: \"%s\"",                                                            \
+                               __FILE__,                                                                   \
+                               __LINE__,                                                                   \
+                               BSON_FUNC,                                                                  \
+                               error.code,                                                                 \
+                               _code_,                                                                     \
+                               error.message);                                                             \
+         abort ();                                                                                         \
+      };                                                                                                   \
+      ASSERT_CONTAINS (error.message, _message);                                                           \
    } while (0)
 
 #define ASSERT_CAPTURED_LOG(_info, _level, _msg)                                                       \

--- a/src/libmongoc/tests/TestSuite.h
+++ b/src/libmongoc/tests/TestSuite.h
@@ -118,25 +118,25 @@ bson_open (const char *filename, int flags, ...)
    } else                                    \
       ((void) 0)
 
-#define ASSERT(Cond)                                                                                         \
-   do {                                                                                                      \
-      if (!(Cond)) {                                                                                         \
-         MONGOC_STDERR_PRINTF (                                                                              \
-            "FAIL:%s:%d  %s()\n  Condition '%s' failed.\n", __FILE__, __LINE__, BSON_FUNC, BSON_STR (Cond)); \
-         abort ();                                                                                           \
-      }                                                                                                      \
+#define ASSERT(Cond)                                                                                                 \
+   do {                                                                                                              \
+      if (!(Cond)) {                                                                                                 \
+         MONGOC_STDERR_PRINTF (                                                                                      \
+            "FAIL:%s:%d  %s()\n  Condition '%s' failed.\n", __FILE__, (int) (__LINE__), BSON_FUNC, BSON_STR (Cond)); \
+         abort ();                                                                                                   \
+      }                                                                                                              \
    } while (0)
 
 
 void
 _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
 
-#define test_error(...)                                                                    \
-   if (1) {                                                                                \
-      MONGOC_STDERR_PRINTF ("test error in: %s %d:%s()\n", __FILE__, __LINE__, BSON_FUNC); \
-      _test_error (__VA_ARGS__);                                                           \
-      abort (); /* suppress missing return errors in non-void functions */                 \
-   } else                                                                                  \
+#define test_error(...)                                                                            \
+   if (1) {                                                                                        \
+      MONGOC_STDERR_PRINTF ("test error in: %s %d:%s()\n", __FILE__, (int) (__LINE__), BSON_FUNC); \
+      _test_error (__VA_ARGS__);                                                                   \
+      abort (); /* suppress missing return errors in non-void functions */                         \
+   } else                                                                                          \
       ((void) 0)
 
 #define bson_eq_bson(bson, expected)                                                                            \
@@ -181,41 +181,47 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
 #undef ASSERT_OR_PRINT
 #endif
 
-#define ASSERT_OR_PRINT(_statement, _err)                                                                            \
-   do {                                                                                                              \
-      if (!(_statement)) {                                                                                           \
-         MONGOC_STDERR_PRINTF (                                                                                      \
-            "FAIL:%s:%d  %s()\n  %s\n  %s\n\n", __FILE__, __LINE__, BSON_FUNC, BSON_STR (_statement), _err.message); \
-         abort ();                                                                                                   \
-      }                                                                                                              \
+#define ASSERT_OR_PRINT(_statement, _err)                          \
+   do {                                                            \
+      if (!(_statement)) {                                         \
+         MONGOC_STDERR_PRINTF ("FAIL:%s:%d  %s()\n  %s\n  %s\n\n", \
+                               __FILE__,                           \
+                               (int) (__LINE__),                   \
+                               BSON_FUNC,                          \
+                               BSON_STR (_statement),              \
+                               _err.message);                      \
+         abort ();                                                 \
+      }                                                            \
    } while (0)
 
-#define ASSERT_CURSOR_NEXT(_cursor, _doc)                                                                       \
-   do {                                                                                                         \
-      bson_error_t _err;                                                                                        \
-      if (!mongoc_cursor_next ((_cursor), (_doc))) {                                                            \
-         if (mongoc_cursor_error ((_cursor), &_err)) {                                                          \
-            MONGOC_STDERR_PRINTF ("FAIL:%s:%d  %s()\n  %s\n\n", __FILE__, __LINE__, BSON_FUNC, _err.message);   \
-         } else {                                                                                               \
-            MONGOC_STDERR_PRINTF ("FAIL:%s:%d  %s()\n  %s\n\n", __FILE__, __LINE__, BSON_FUNC, "empty cursor"); \
-         }                                                                                                      \
-         abort ();                                                                                              \
-      }                                                                                                         \
+#define ASSERT_CURSOR_NEXT(_cursor, _doc)                                                                             \
+   do {                                                                                                               \
+      bson_error_t _err;                                                                                              \
+      if (!mongoc_cursor_next ((_cursor), (_doc))) {                                                                  \
+         if (mongoc_cursor_error ((_cursor), &_err)) {                                                                \
+            MONGOC_STDERR_PRINTF ("FAIL:%s:%d  %s()\n  %s\n\n", __FILE__, (int) (__LINE__), BSON_FUNC, _err.message); \
+         } else {                                                                                                     \
+            MONGOC_STDERR_PRINTF (                                                                                    \
+               "FAIL:%s:%d  %s()\n  %s\n\n", __FILE__, (int) (__LINE__), BSON_FUNC, "empty cursor");                  \
+         }                                                                                                            \
+         abort ();                                                                                                    \
+      }                                                                                                               \
    } while (0)
 
 
-#define ASSERT_CURSOR_DONE(_cursor)                                                                              \
-   do {                                                                                                          \
-      bson_error_t _err;                                                                                         \
-      const bson_t *_doc;                                                                                        \
-      if (mongoc_cursor_next ((_cursor), &_doc)) {                                                               \
-         MONGOC_STDERR_PRINTF ("FAIL:%s:%d  %s()\n  %s\n\n", __FILE__, __LINE__, BSON_FUNC, "non-empty cursor"); \
-         abort ();                                                                                               \
-      }                                                                                                          \
-      if (mongoc_cursor_error ((_cursor), &_err)) {                                                              \
-         MONGOC_STDERR_PRINTF ("FAIL:%s:%d  %s()\n  %s\n\n", __FILE__, __LINE__, BSON_FUNC, _err.message);       \
-         abort ();                                                                                               \
-      }                                                                                                          \
+#define ASSERT_CURSOR_DONE(_cursor)                                                                                \
+   do {                                                                                                            \
+      bson_error_t _err;                                                                                           \
+      const bson_t *_doc;                                                                                          \
+      if (mongoc_cursor_next ((_cursor), &_doc)) {                                                                 \
+         MONGOC_STDERR_PRINTF (                                                                                    \
+            "FAIL:%s:%d  %s()\n  %s\n\n", __FILE__, (int) (__LINE__), BSON_FUNC, "non-empty cursor");              \
+         abort ();                                                                                                 \
+      }                                                                                                            \
+      if (mongoc_cursor_error ((_cursor), &_err)) {                                                                \
+         MONGOC_STDERR_PRINTF ("FAIL:%s:%d  %s()\n  %s\n\n", __FILE__, (int) (__LINE__), BSON_FUNC, _err.message); \
+         abort ();                                                                                                 \
+      }                                                                                                            \
    } while (0)
 
 
@@ -231,7 +237,7 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
                                BSON_STR (eq),                                   \
                                _b,                                              \
                                __FILE__,                                        \
-                               __LINE__,                                        \
+                               (int) (__LINE__),                                \
                                BSON_FUNC);                                      \
          abort ();                                                              \
       }                                                                         \
@@ -275,7 +281,7 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
                                _a,                                                                    \
                                _b,                                                                    \
                                __FILE__,                                                              \
-                               __LINE__,                                                              \
+                               (int) (__LINE__),                                                      \
                                BSON_FUNC);                                                            \
          abort ();                                                                                    \
       }                                                                                               \
@@ -294,7 +300,7 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
                                (double) a,                                          \
                                (double) b,                                          \
                                __FILE__,                                            \
-                               __LINE__,                                            \
+                               (int) (__LINE__),                                    \
                                BSON_FUNC);                                          \
          abort ();                                                                  \
       }                                                                             \
@@ -312,7 +318,7 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
                                _a ? _a : "(null)",                                          \
                                _b ? _b : "(null)",                                          \
                                __FILE__,                                                    \
-                               __LINE__,                                                    \
+                               (int) (__LINE__),                                            \
                                BSON_FUNC);                                                  \
          abort ();                                                                          \
       }                                                                                     \
@@ -343,7 +349,7 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
                                __aa,                                        \
                                __bb,                                        \
                                __FILE__,                                    \
-                               __LINE__,                                    \
+                               (int) (__LINE__),                            \
                                BSON_FUNC);                                  \
          abort ();                                                          \
       }                                                                     \
@@ -368,30 +374,31 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
    } while (0)
 
 
-#define ASSERT_CONTAINS(a, b)                                                                                    \
-   do {                                                                                                          \
-      char *_a_lower = bson_strdup (a);                                                                          \
-      char *_b_lower = bson_strdup (b);                                                                          \
-      mongoc_lowercase (_a_lower, _a_lower);                                                                     \
-      mongoc_lowercase (_b_lower, _b_lower);                                                                     \
-      if (NULL == strstr ((_a_lower), (_b_lower))) {                                                             \
-         MONGOC_STDERR_PRINTF ("%s:%d %s(): [%s] does not contain [%s]\n", __FILE__, __LINE__, BSON_FUNC, a, b); \
-         abort ();                                                                                               \
-      }                                                                                                          \
-      bson_free (_a_lower);                                                                                      \
-      bson_free (_b_lower);                                                                                      \
+#define ASSERT_CONTAINS(a, b)                                                                         \
+   do {                                                                                               \
+      char *_a_lower = bson_strdup (a);                                                               \
+      char *_b_lower = bson_strdup (b);                                                               \
+      mongoc_lowercase (_a_lower, _a_lower);                                                          \
+      mongoc_lowercase (_b_lower, _b_lower);                                                          \
+      if (NULL == strstr ((_a_lower), (_b_lower))) {                                                  \
+         MONGOC_STDERR_PRINTF (                                                                       \
+            "%s:%d %s(): [%s] does not contain [%s]\n", __FILE__, (int) (__LINE__), BSON_FUNC, a, b); \
+         abort ();                                                                                    \
+      }                                                                                               \
+      bson_free (_a_lower);                                                                           \
+      bson_free (_b_lower);                                                                           \
    } while (0)
 
-#define ASSERT_STARTSWITH(a, b)                                                                      \
-   do {                                                                                              \
-      /* evaluate once */                                                                            \
-      const char *_a = a;                                                                            \
-      const char *_b = b;                                                                            \
-      if ((_a) != strstr ((_a), (_b))) {                                                             \
-         MONGOC_STDERR_PRINTF (                                                                      \
-            "%s:%d %s(): : [%s] does not start with [%s]\n", __FILE__, __LINE__, BSON_FUNC, _a, _b); \
-         abort ();                                                                                   \
-      }                                                                                              \
+#define ASSERT_STARTSWITH(a, b)                                                                              \
+   do {                                                                                                      \
+      /* evaluate once */                                                                                    \
+      const char *_a = a;                                                                                    \
+      const char *_b = b;                                                                                    \
+      if ((_a) != strstr ((_a), (_b))) {                                                                     \
+         MONGOC_STDERR_PRINTF (                                                                              \
+            "%s:%d %s(): : [%s] does not start with [%s]\n", __FILE__, (int) (__LINE__), BSON_FUNC, _a, _b); \
+         abort ();                                                                                           \
+      }                                                                                                      \
    } while (0)
 
 #define ASSERT_ERROR_CONTAINS(error, _domain, _code, _message)                                             \
@@ -402,7 +409,7 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
          MONGOC_STDERR_PRINTF ("%s:%d %s(): error domain %" PRIu32 " doesn't match expected %" PRIu32 "\n" \
                                "error: \"%s\"",                                                            \
                                __FILE__,                                                                   \
-                               __LINE__,                                                                   \
+                               (int) (__LINE__),                                                           \
                                BSON_FUNC,                                                                  \
                                error.domain,                                                               \
                                _domain_,                                                                   \
@@ -413,7 +420,7 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
          MONGOC_STDERR_PRINTF ("%s:%d %s(): error code %" PRIu32 " doesn't match expected %" PRIu32 "\n"   \
                                "error: \"%s\"",                                                            \
                                __FILE__,                                                                   \
-                               __LINE__,                                                                   \
+                               (int) (__LINE__),                                                           \
                                BSON_FUNC,                                                                  \
                                error.code,                                                                 \
                                _code_,                                                                     \
@@ -423,24 +430,24 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
       ASSERT_CONTAINS (error.message, _message);                                                           \
    } while (0)
 
-#define ASSERT_CAPTURED_LOG(_info, _level, _msg)                                                       \
-   do {                                                                                                \
-      if (!has_captured_log (_level, _msg)) {                                                          \
-         MONGOC_STDERR_PRINTF (                                                                        \
-            "%s:%d %s(): testing %s didn't log \"%s\"\n", __FILE__, __LINE__, BSON_FUNC, _info, _msg); \
-         print_captured_logs ("\t");                                                                   \
-         abort ();                                                                                     \
-      }                                                                                                \
+#define ASSERT_CAPTURED_LOG(_info, _level, _msg)                                                               \
+   do {                                                                                                        \
+      if (!has_captured_log (_level, _msg)) {                                                                  \
+         MONGOC_STDERR_PRINTF (                                                                                \
+            "%s:%d %s(): testing %s didn't log \"%s\"\n", __FILE__, (int) (__LINE__), BSON_FUNC, _info, _msg); \
+         print_captured_logs ("\t");                                                                           \
+         abort ();                                                                                             \
+      }                                                                                                        \
    } while (0)
 
-#define ASSERT_NO_CAPTURED_LOGS(_info)                                                                \
-   do {                                                                                               \
-      if (has_captured_logs ()) {                                                                     \
-         MONGOC_STDERR_PRINTF (                                                                       \
-            "%s:%d %s(): testing %s shouldn't have logged:\n", __FILE__, __LINE__, BSON_FUNC, _info); \
-         print_captured_logs ("\t");                                                                  \
-         abort ();                                                                                    \
-      }                                                                                               \
+#define ASSERT_NO_CAPTURED_LOGS(_info)                                                                        \
+   do {                                                                                                       \
+      if (has_captured_logs ()) {                                                                             \
+         MONGOC_STDERR_PRINTF (                                                                               \
+            "%s:%d %s(): testing %s shouldn't have logged:\n", __FILE__, (int) (__LINE__), BSON_FUNC, _info); \
+         print_captured_logs ("\t");                                                                          \
+         abort ();                                                                                            \
+      }                                                                                                       \
    } while (0)
 
 #define ASSERT_HAS_FIELD(_bson, _field)                                               \
@@ -488,7 +495,7 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
       if (!(_statement)) {                                                                      \
          MONGOC_STDERR_PRINTF ("FAIL:%s:%d  %s()\n  %s\n  Failed with error code: %d (%s)\n\n", \
                                __FILE__,                                                        \
-                               __LINE__,                                                        \
+                               (int) (__LINE__),                                                \
                                BSON_FUNC,                                                       \
                                BSON_STR (_statement),                                           \
                                _errcode,                                                        \
@@ -507,7 +514,7 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
                                count,                                                                            \
                                n,                                                                                \
                                __FILE__,                                                                         \
-                               __LINE__,                                                                         \
+                               (int) (__LINE__),                                                                 \
                                BSON_FUNC);                                                                       \
          abort ();                                                                                               \
       }                                                                                                          \
@@ -526,7 +533,7 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
                                _count,                                                \
                                _n,                                                    \
                                __FILE__,                                              \
-                               __LINE__,                                              \
+                               (int) (__LINE__),                                      \
                                BSON_FUNC);                                            \
          abort ();                                                                    \
       }                                                                               \
@@ -541,7 +548,7 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
                                   "   %s:%d  %s()\n",                  \
                                   BSON_STR (_pred),                    \
                                   __FILE__,                            \
-                                  __LINE__,                            \
+                                  (int) (__LINE__),                    \
                                   BSON_FUNC);                          \
             abort ();                                                  \
          }                                                             \
@@ -549,15 +556,16 @@ _test_error (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
       }                                                                \
    } while (0)
 
-#define ASSERT_WITH_MSG(_statement, ...)                                                                            \
-   do {                                                                                                             \
-      if (!(_statement)) {                                                                                          \
-         MONGOC_STDERR_PRINTF ("FAIL:%s:%d  %s()\n  %s\n\n", __FILE__, __LINE__, BSON_FUNC, BSON_STR (_statement)); \
-         fprintf (stderr, __VA_ARGS__);                                                                             \
-         fprintf (stderr, "\n");                                                                                    \
-         fflush (stderr);                                                                                           \
-         abort ();                                                                                                  \
-      }                                                                                                             \
+#define ASSERT_WITH_MSG(_statement, ...)                                                                 \
+   do {                                                                                                  \
+      if (!(_statement)) {                                                                               \
+         MONGOC_STDERR_PRINTF (                                                                          \
+            "FAIL:%s:%d  %s()\n  %s\n\n", __FILE__, (int) (__LINE__), BSON_FUNC, BSON_STR (_statement)); \
+         fprintf (stderr, __VA_ARGS__);                                                                  \
+         fprintf (stderr, "\n");                                                                         \
+         fflush (stderr);                                                                                \
+         abort ();                                                                                       \
+      }                                                                                                  \
    } while (0)
 
 // bson_value_to_str returns a string representation of a BSON value.

--- a/src/libmongoc/tests/json-test-operations.c
+++ b/src/libmongoc/tests/json-test-operations.c
@@ -34,6 +34,8 @@
 #include "test-libmongoc.h"
 #include "TestSuite.h"
 
+#include <inttypes.h>
+
 
 mongoc_client_session_t *
 session_from_name (json_test_ctx_t *ctx, const char *session_name)
@@ -474,7 +476,10 @@ check_error_code_name (const bson_t *operation, const bson_error_t *error)
    code_name = bson_lookup_utf8 (operation, "errorCodeName");
    expected_error_code = error_code_from_name (code_name);
    if (error->code != expected_error_code) {
-      test_error ("Expected error code %d : %s but got error code %d\n", expected_error_code, code_name, error->code);
+      test_error ("Expected error code %" PRIu32 " : %s but got error code %" PRIu32 "\n",
+                  expected_error_code,
+                  code_name,
+                  error->code);
    }
 }
 

--- a/src/libmongoc/tests/json-test.c
+++ b/src/libmongoc/tests/json-test.c
@@ -1325,7 +1325,7 @@ set_uri_opts_from_bson (mongoc_uri_t *uri, const bson_t *opts)
          } else if (BSON_ITER_HOLDS_INT (&iter)) {
             mongoc_write_concern_set_w (wc, (int32_t) bson_iter_as_int64 (&iter));
          } else {
-            test_error ("Unrecognized type for 'w': %d", bson_iter_type (&iter));
+            test_error ("Unrecognized type for 'w': %d", (int) bson_iter_type (&iter));
          }
 
          mongoc_uri_set_write_concern (uri, wc);

--- a/src/libmongoc/tests/mock_server/mock-server.c
+++ b/src/libmongoc/tests/mock_server/mock-server.c
@@ -1852,7 +1852,7 @@ again:
       }
 
       if (_mongoc_buffer_fill (&buffer, client_stream, (size_t) msg_len, -1, &error) == -1) {
-         MONGOC_WARNING ("%s():%d: %s", BSON_FUNC, __LINE__, error.message);
+         MONGOC_WARNING ("%s():%d: %s", BSON_FUNC, (int) (__LINE__), error.message);
          GOTO (failure);
       }
 

--- a/src/libmongoc/tests/ssl-test.c
+++ b/src/libmongoc/tests/ssl-test.c
@@ -88,7 +88,7 @@ static BSON_THREAD_FUN (ssl_test_server, ptr)
       data->server_result->ssl_err = err;
       data->server_result->result = SSL_TEST_SSL_INIT;
 #ifdef MONGOC_ENABLE_SSL_OPENSSL
-      MONGOC_ERROR ("ERRORED (line: %d): %s\n", __LINE__, ERR_error_string (ERR_get_error (), NULL));
+      MONGOC_ERROR ("ERRORED (line: %d): %s\n", (int) (__LINE__), ERR_error_string (ERR_get_error (), NULL));
 #endif
       mongoc_stream_destroy (sock_stream);
       mongoc_socket_destroy (listen_sock);
@@ -102,7 +102,7 @@ static BSON_THREAD_FUN (ssl_test_server, ptr)
    if (!r) {
       unsigned long err = 43;
 
-      MONGOC_ERROR ("ERRORED (line: %d): %s\n", __LINE__, error.message);
+      MONGOC_ERROR ("ERRORED (line: %d): %s\n", (int) (__LINE__), error.message);
 #ifdef MONGOC_ENABLE_SSL_OPENSSL
       MONGOC_ERROR ("msg: %s\n", ERR_error_string (ERR_get_error (), NULL));
 #endif
@@ -119,7 +119,7 @@ static BSON_THREAD_FUN (ssl_test_server, ptr)
    if (r < 0) {
       data->server_result->err = errno;
       data->server_result->result = SSL_TEST_TIMEOUT;
-      MONGOC_ERROR ("ERRORED (line: %d): %s\n", __LINE__, "mongoc_stream_readv failed.");
+      MONGOC_ERROR ("ERRORED (line: %d): %s\n", (int) (__LINE__), "mongoc_stream_readv failed.");
 
       mongoc_stream_destroy (ssl_stream);
       mongoc_socket_destroy (listen_sock);
@@ -207,7 +207,7 @@ static BSON_THREAD_FUN (ssl_test_client, ptr)
 
       data->client_result->ssl_err = err;
       data->client_result->result = SSL_TEST_SSL_INIT;
-      MONGOC_ERROR ("ERRORED (line: %d): %s\n", __LINE__, "mongoc_stream_tls_new_with_hostname failed.");
+      MONGOC_ERROR ("ERRORED (line: %d): %s\n", (int) (__LINE__), "mongoc_stream_tls_new_with_hostname failed.");
 
       mongoc_stream_destroy (sock_stream);
 
@@ -222,7 +222,7 @@ static BSON_THREAD_FUN (ssl_test_client, ptr)
 
       data->client_result->ssl_err = err;
       data->client_result->result = SSL_TEST_SSL_HANDSHAKE;
-      MONGOC_ERROR ("ERRORED (line: %d): %s\n", __LINE__, error.message);
+      MONGOC_ERROR ("ERRORED (line: %d): %s\n", (int) (__LINE__), error.message);
 
       mongoc_stream_destroy (ssl_stream);
       BSON_THREAD_RETURN;

--- a/src/libmongoc/tests/test-awsauth.c
+++ b/src/libmongoc/tests/test-awsauth.c
@@ -32,34 +32,34 @@
    } else                                    \
       ((void) 0)
 
-#define ASSERT(Cond)                                                                                         \
-   if (1) {                                                                                                  \
-      if (!(Cond)) {                                                                                         \
-         MONGOC_STDERR_PRINTF (                                                                              \
-            "FAIL:%s:%d  %s()\n  Condition '%s' failed.\n", __FILE__, __LINE__, BSON_FUNC, BSON_STR (Cond)); \
-         abort ();                                                                                           \
-      }                                                                                                      \
-   } else                                                                                                    \
+#define ASSERT(Cond)                                                                                                 \
+   if (1) {                                                                                                          \
+      if (!(Cond)) {                                                                                                 \
+         MONGOC_STDERR_PRINTF (                                                                                      \
+            "FAIL:%s:%d  %s()\n  Condition '%s' failed.\n", __FILE__, (int) (__LINE__), BSON_FUNC, BSON_STR (Cond)); \
+         abort ();                                                                                                   \
+      }                                                                                                              \
+   } else                                                                                                            \
       ((void) 0)
 
-#define ASSERTF(Cond, Fmt, ...)                                                                              \
-   if (1) {                                                                                                  \
-      if (!(Cond)) {                                                                                         \
-         MONGOC_STDERR_PRINTF (                                                                              \
-            "FAIL:%s:%d  %s()\n  Condition '%s' failed.\n", __FILE__, __LINE__, BSON_FUNC, BSON_STR (Cond)); \
-         MONGOC_STDERR_PRINTF ("MESSAGE: " Fmt "\n", __VA_ARGS__);                                           \
-         abort ();                                                                                           \
-      }                                                                                                      \
-   } else                                                                                                    \
+#define ASSERTF(Cond, Fmt, ...)                                                                                      \
+   if (1) {                                                                                                          \
+      if (!(Cond)) {                                                                                                 \
+         MONGOC_STDERR_PRINTF (                                                                                      \
+            "FAIL:%s:%d  %s()\n  Condition '%s' failed.\n", __FILE__, (int) (__LINE__), BSON_FUNC, BSON_STR (Cond)); \
+         MONGOC_STDERR_PRINTF ("MESSAGE: " Fmt "\n", __VA_ARGS__);                                                   \
+         abort ();                                                                                                   \
+      }                                                                                                              \
+   } else                                                                                                            \
       ((void) 0)
 
-#define FAILF(Fmt, ...)                                                                                   \
-   if (1) {                                                                                               \
-      MONGOC_STDERR_PRINTF (                                                                              \
-         "FAIL:%s:%d  %s()\n  Condition '%s' failed.\n", __FILE__, __LINE__, BSON_FUNC, BSON_STR (Cond)); \
-      MONGOC_STDERR_PRINTF ("MESSAGE: " Fmt "\n", __VA_ARGS__);                                           \
-      abort ();                                                                                           \
-   } else                                                                                                 \
+#define FAILF(Fmt, ...)                                                                                           \
+   if (1) {                                                                                                       \
+      MONGOC_STDERR_PRINTF (                                                                                      \
+         "FAIL:%s:%d  %s()\n  Condition '%s' failed.\n", __FILE__, (int) (__LINE__), BSON_FUNC, BSON_STR (Cond)); \
+      MONGOC_STDERR_PRINTF ("MESSAGE: " Fmt "\n", __VA_ARGS__);                                                   \
+      abort ();                                                                                                   \
+   } else                                                                                                         \
       ((void) 0)
 
 static void

--- a/src/libmongoc/tests/test-conveniences.c
+++ b/src/libmongoc/tests/test-conveniences.c
@@ -35,6 +35,8 @@
 #include <strings.h>
 #endif
 
+#include <inttypes.h>
+
 
 static bool gConveniencesInitialized = false;
 static mongoc_array_t gTmpBsonArray;
@@ -1273,7 +1275,7 @@ bson_value_as_int64 (const bson_value_t *value)
    } else if (value->value_type == BSON_TYPE_INT64) {
       return value->value.v_int64;
    } else {
-      test_error ("bson_value_as_int64 called on value of type %d", value->value_type);
+      test_error ("bson_value_as_int64 called on value of type %d", (int) value->value_type);
    }
 }
 
@@ -1468,7 +1470,7 @@ match_bson_value (const bson_value_t *doc, const bson_value_t *pattern, match_ct
       }
       break;
    default:
-      test_error ("unexpected value type %d: %s", doc->value_type, _mongoc_bson_type_to_str (doc->value_type));
+      test_error ("unexpected value type %d: %s", (int) doc->value_type, _mongoc_bson_type_to_str (doc->value_type));
    }
 
    if (!ret) {

--- a/src/libmongoc/tests/test-mcd-rpc.c
+++ b/src/libmongoc/tests/test-mcd-rpc.c
@@ -1775,7 +1775,9 @@ test_rpc_message_from_data_op_kill_cursors_invalid (void)
    } else                                                                                                              \
       (void) 0
 
-#define ASSERT_IOVEC_UINT8(index, expected) ASSERT_IOVEC_VALUE (index, expected, uint8_t, uint8_t, (uint8_t), PRIu8)
+// Use `%d` for uint8_t to avoid -Wformat warnings due to integer promotion rules conflicting with definition of `PRIu8`
+// as `%u` by GCC on certain platforms (only in release mode...?).
+#define ASSERT_IOVEC_UINT8(index, expected) ASSERT_IOVEC_VALUE (index, expected, uint8_t, uint8_t, (uint8_t), "d")
 #define ASSERT_IOVEC_INT32(index, expected) \
    ASSERT_IOVEC_VALUE (index, expected, int32_t, uint32_t, BSON_UINT32_FROM_LE, PRId32)
 #define ASSERT_IOVEC_UINT32(index, expected) \
@@ -1818,7 +1820,7 @@ test_rpc_message_to_iovecs_op_compressed (void)
    ASSERT_IOVEC_INT32 (3, 2012);     // opCode
    ASSERT_IOVEC_INT32 (4, 2013);     // originalOpcode
    ASSERT_IOVEC_INT32 (5, 20);       // uncompressedSize
-   ASSERT_IOVEC_UINT8 (6, 0u);       // compressorId
+   ASSERT_IOVEC_UINT8 (6, 0);        // compressorId
    ASSERT_IOVEC_BYTES (7, 25u, 20u); // compressedMessage
 
    bson_free (iovecs);

--- a/src/libmongoc/tests/test-mongoc-background-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-background-monitoring.c
@@ -28,6 +28,8 @@
 #include "TestSuite.h"
 #include <mcd-string.h>
 
+#include <inttypes.h>
+
 #define LOG_DOMAIN "test_monitoring"
 
 typedef struct {
@@ -64,11 +66,11 @@ tf_dump (test_fixture_t *tf)
 {
    printf ("== Begin dump ==\n");
    printf ("-- Current observations --\n");
-   printf ("n_heartbeat_started=%d\n", tf->observations->n_heartbeat_started);
-   printf ("n_heartbeat_succeeded=%d\n", tf->observations->n_heartbeat_succeeded);
-   printf ("n_heartbeat_failed=%d\n", tf->observations->n_heartbeat_failed);
-   printf ("n_server_changed=%d\n", tf->observations->n_server_changed);
-   printf ("sd_type=%d\n", tf->observations->sd_type);
+   printf ("n_heartbeat_started=%" PRIu32 "\n", tf->observations->n_heartbeat_started);
+   printf ("n_heartbeat_succeeded=%" PRIu32 "\n", tf->observations->n_heartbeat_succeeded);
+   printf ("n_heartbeat_failed=%" PRIu32 "\n", tf->observations->n_heartbeat_failed);
+   printf ("n_server_changed=%" PRIu32 "\n", tf->observations->n_server_changed);
+   printf ("sd_type=%d\n", (int) tf->observations->sd_type);
 
    printf ("-- Test fixture logs --\n");
    printf ("%s", tf->logs->str);

--- a/src/libmongoc/tests/test-mongoc-client-session.c
+++ b/src/libmongoc/tests/test-mongoc-client-session.c
@@ -12,6 +12,8 @@
 #include "json-test.h"
 #include <common-macros-private.h> // BEGIN_IGNORE_DEPRECATIONS
 
+#include <inttypes.h>
+
 #undef MONGOC_LOG_DOMAIN
 #define MONGOC_LOG_DOMAIN "session-test"
 
@@ -1494,10 +1496,14 @@ parse_reply_time (const bson_t *reply, op_time_t *op_time)
 }
 
 
-#define ASSERT_OP_TIMES_EQUAL(_a, _b)                                                               \
-   if ((_a).t != (_b).t || (_a).i != (_b).i) {                                                      \
-      test_error (#_a " (%d, %d) does not match " #_b " (%d, %d)", (_a).t, (_a).i, (_b).t, (_b).i); \
-   } else                                                                                           \
+#define ASSERT_OP_TIMES_EQUAL(_a, _b)                                                                  \
+   if ((_a).t != (_b).t || (_a).i != (_b).i) {                                                         \
+      test_error (#_a " (%" PRIu32 ", %" PRIu32 ") does not match " #_b " (%" PRIu32 ", %" PRIu32 ")", \
+                  (_a).t,                                                                              \
+                  (_a).i,                                                                              \
+                  (_b).t,                                                                              \
+                  (_b).i);                                                                             \
+   } else                                                                                              \
       ((void) 0)
 
 

--- a/src/libmongoc/tests/test-mongoc-cluster.c
+++ b/src/libmongoc/tests/test-mongoc-cluster.c
@@ -13,6 +13,8 @@
 #include "test-libmongoc.h"
 #include "test-conveniences.h"
 
+#include <inttypes.h>
+
 
 #undef MONGOC_LOG_DOMAIN
 #define MONGOC_LOG_DOMAIN "cluster-test"
@@ -785,7 +787,11 @@ receives_with_cluster_time (mock_server_t *server, uint32_t timestamp, uint32_t 
    BSON_ASSERT (BSON_ITER_HOLDS_TIMESTAMP (&cluster_time));
    bson_iter_timestamp (&cluster_time, &t, &i);
    if (t != timestamp || i != increment) {
-      test_error ("Expected Timestamp(%d, %d), got Timestamp(%d, %d)", timestamp, increment, t, i);
+      test_error ("Expected Timestamp(%" PRIu32 ", %" PRIu32 "), got Timestamp(%" PRIu32 ", %" PRIu32 ")",
+                  timestamp,
+                  increment,
+                  t,
+                  i);
    }
 
    return request;

--- a/src/libmongoc/tests/test-mongoc-collection-find.c
+++ b/src/libmongoc/tests/test-mongoc-collection-find.c
@@ -9,6 +9,8 @@
 #include "mock_server/future.h"
 #include "mock_server/future-functions.h"
 
+#include <inttypes.h>
+
 
 typedef struct {
    /* if do_live is true (the default), actually query the server using the
@@ -82,7 +84,7 @@ _check_cursor (mongoc_cursor_t *cursor, test_collection_find_t *test_data)
    ASSERT_OR_PRINT (!mongoc_cursor_error (cursor, &error), error);
 
    if (i != test_data->n_results) {
-      test_error ("expect %d results, got %d", test_data->n_results, i);
+      test_error ("expect %" PRIu32 " results, got %" PRIu32 "", test_data->n_results, i);
    }
 
    ASSERT (match_json (&actual_result,
@@ -243,7 +245,7 @@ _test_collection_find_command (test_collection_find_t *test_data)
    }
 
    if (i != test_data->n_results) {
-      test_error ("Expected %d results, got %d\n", test_data->n_results, i);
+      test_error ("Expected %" PRIu32 " results, got %" PRIu32 "\n", test_data->n_results, i);
    }
 
    ASSERT (match_json (&actual_result,

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -17,6 +17,8 @@
 #include "mock_server/mock-rs.h"
 #include <common-macros-private.h> // BEGIN_IGNORE_DEPRECATIONS
 
+#include <inttypes.h>
+
 
 BEGIN_IGNORE_DEPRECATIONS
 
@@ -2591,7 +2593,7 @@ again:
       for (j = 0; j < 2; j++) {
          r = mongoc_cursor_next (cursor, &doc);
          if (mongoc_cursor_error (cursor, &error)) {
-            test_error ("[%d.%d] %s", error.domain, error.code, error.message);
+            test_error ("[%" PRIu32 ".%" PRIu32 "] %s", error.domain, error.code, error.message);
          }
 
          ASSERT (r);

--- a/src/libmongoc/tests/test-mongoc-error.c
+++ b/src/libmongoc/tests/test-mongoc-error.c
@@ -8,6 +8,8 @@
 #include "mock_server/mock-server.h"
 #include "mongoc/mongoc-error-private.h"
 
+#include <inttypes.h>
+
 
 #undef MONGOC_LOG_DOMAIN
 #define MONGOC_LOG_DOMAIN "error-test"
@@ -140,7 +142,7 @@ test_state_change_helper (uint32_t domain, bool expect_error)
                                            MONGOC_SERVER_ERR_SHUTDOWNINPROGRESS};
    int i;
 
-   MONGOC_DEBUG ("Checking domain = %d", domain);
+   MONGOC_DEBUG ("Checking domain = %" PRIu32, domain);
 
    memset (&error, 0, sizeof (bson_error_t));
    error.domain = domain;

--- a/src/libmongoc/tests/test-mongoc-gridfs.c
+++ b/src/libmongoc/tests/test-mongoc-gridfs.c
@@ -222,7 +222,7 @@ test_remove (void)
 
    mongoc_gridfs_drop (gridfs, &error);
 
-   bson_snprintf (name, sizeof name, "test-remove.%u", rand ());
+   bson_snprintf (name, sizeof name, "test-remove.%d", rand ());
    opts.filename = name;
 
    file = mongoc_gridfs_create_file (gridfs, &opts);

--- a/src/libmongoc/tests/unified/test-diagnostics.h
+++ b/src/libmongoc/tests/unified/test-diagnostics.h
@@ -23,12 +23,12 @@ void
 _test_diagnostics_add (bool fail, const char *fmt, ...) BSON_GNUC_PRINTF (2, 3);
 
 #define test_diagnostics_test_info(fmt, ...) \
-   _test_diagnostics_add (false, "[%s:%d %s()]\n" fmt, __FILE__, __LINE__, BSON_FUNC, __VA_ARGS__)
+   _test_diagnostics_add (false, "[%s:%d %s()]\n" fmt, __FILE__, (int) (__LINE__), BSON_FUNC, __VA_ARGS__)
 
 /* Append additional information to an error after it has occurred (similar to
  * backtrace). */
 #define test_diagnostics_error_info(fmt, ...) \
-   _test_diagnostics_add (true, "[%s:%d %s()]\n" fmt, __FILE__, __LINE__, BSON_FUNC, __VA_ARGS__)
+   _test_diagnostics_add (true, "[%s:%d %s()]\n" fmt, __FILE__, (int) (__LINE__), BSON_FUNC, __VA_ARGS__)
 
 void
 test_diagnostics_init (void);

--- a/src/tools/mongoc-stat.c
+++ b/src/tools/mongoc-stat.c
@@ -111,7 +111,7 @@ mongoc_counters_new_from_pid (unsigned pid)
    size = len;
 
    if (MAP_FAILED == (mem = mmap (NULL, size, PROT_READ, MAP_SHARED, fd, 0))) {
-      fprintf (stderr, "Failed to mmap shared memory segment of size: %u", (unsigned) size);
+      fprintf (stderr, "Failed to mmap shared memory segment of size: %zu", size);
       close (fd);
       return NULL;
    }
@@ -198,9 +198,9 @@ main (int argc, char *argv[])
       return 1;
    }
 
-   pid = strtol (argv[1], NULL, 10);
+   pid = (int) strtol (argv[1], NULL, 10);
    if (!(counters = mongoc_counters_new_from_pid (pid))) {
-      fprintf (stderr, "Failed to load shared memory for pid %u.\n", pid);
+      fprintf (stderr, "Failed to load shared memory for pid %d.\n", pid);
       return EXIT_FAILURE;
    }
 

--- a/src/tools/mongoc-stat.c
+++ b/src/tools/mongoc-stat.c
@@ -41,8 +41,7 @@ typedef struct {
 #pragma pack()
 
 
-BSON_STATIC_ASSERT2 (sizeof_counter_info_t,
-                     sizeof (mongoc_counter_info_t) == 128);
+BSON_STATIC_ASSERT2 (sizeof_counter_info_t, sizeof (mongoc_counter_info_t) == 128);
 
 
 #pragma pack(1)
@@ -65,8 +64,7 @@ typedef struct {
 } mongoc_counter_slots_t;
 
 
-BSON_STATIC_ASSERT2 (sizeof_counter_slots,
-                     sizeof (mongoc_counter_slots_t) == 64);
+BSON_STATIC_ASSERT2 (sizeof_counter_slots, sizeof (mongoc_counter_slots_t) == 64);
 
 
 typedef struct {
@@ -113,9 +111,7 @@ mongoc_counters_new_from_pid (unsigned pid)
    size = len;
 
    if (MAP_FAILED == (mem = mmap (NULL, size, PROT_READ, MAP_SHARED, fd, 0))) {
-      fprintf (stderr,
-               "Failed to mmap shared memory segment of size: %u",
-               (unsigned) size);
+      fprintf (stderr, "Failed to mmap shared memory segment of size: %u", (unsigned) size);
       close (fd);
       return NULL;
    }
@@ -150,9 +146,7 @@ mongoc_counters_get_infos (mongoc_counters_t *counters, uint32_t *n_infos)
 
 
 static int64_t
-mongoc_counters_get_value (mongoc_counters_t *counters,
-                           mongoc_counter_info_t *info,
-                           mongoc_counter_t *counter)
+mongoc_counters_get_value (mongoc_counters_t *counters, mongoc_counter_info_t *info, mongoc_counter_t *counter)
 {
    int64_t value = 0;
    unsigned i;
@@ -166,9 +160,7 @@ mongoc_counters_get_value (mongoc_counters_t *counters,
 
 
 static void
-mongoc_counters_print_info (mongoc_counters_t *counters,
-                            mongoc_counter_info_t *info,
-                            FILE *file)
+mongoc_counters_print_info (mongoc_counters_t *counters, mongoc_counter_info_t *info, FILE *file)
 {
    mongoc_counter_t ctr;
    int64_t value;
@@ -188,12 +180,7 @@ mongoc_counters_print_info (mongoc_counters_t *counters,
 
    value = mongoc_counters_get_value (counters, info, &ctr);
 
-   fprintf (file,
-            "%24s : %-24s : %-50s : %lld\n",
-            info->category,
-            info->name,
-            info->description,
-            (long long) value);
+   fprintf (file, "%24s : %-24s : %-50s : %lld\n", info->category, info->name, info->description, (long long) value);
 }
 
 


### PR DESCRIPTION
## Summary

Resolves CDRIVER-5745. Verified by [this patch](https://spruce.mongodb.com/version/670549aca9b10b0007419c7d) (excluding the addition of `--verbose` for debugging).

Addresses 1007 (550 unique) `-Wformat` warnings in library, test, and example code.

## Scope of mongoc Warnings

The `MongoC-Warnings` module applied warning flags to all targets defined in the current directory and below using `add_compile_options()`. Unfortunately, this included external library sources such as kms-message and bundled zlib. This led to `-Wformat` warnings triggering build failures due to zlib sources:

```
src/zlib-1.3.1/gzwrite.c:407:40: error: format string is not a string literal [-Werror,-Wformat-nonliteral]
    len = vsnprintf(next, state->size, format, va);
                                       ^~~~~~
```

To avoid applying our warning flags to external library sources, the `MongoC-Warnings` module is refactored to set a `${mongoc-warning-options}` variable instead of using `add_compile_options()`. The `${mongoc-warning-options}` variable is used to apply the warning options to _only_ our sources and targets.

For libbson, the options are added to target library properties via `mongo_target_requirements()`. (This helper function should probably be reused by/extended to libmongoc someday).

For libmongoc, due to the libraries being built with sources included both directly (as source files, a la kms-message) and indirectly (as object files, a la bundled zlib), the options are added as source file properties (specifically for `${MONGOC_SOURCES}`) instead of library target properties.

> [!NOTE]
> Directory properties would apply warning options to the zlib object library target (currently defined in the `src/libmongoc` directory). Target properties would apply warning options to the kms-message sources (included as source files by `${SOURCE}`). Therefore, warning options are applied to `${MONGOC_SOURCES}` only. In the future, a refactor may enable setting warning options at the directory level, but a source-based/target-based approach is likely still preferable as done here.

For test and example targets, the options are added as target properties.

## -Wformat Options

Investigation revealed that neither `-Wformat` (currently as a maintainer flag) nor `-Wformat=2` (a subset of which is currently partially enabled as maintainer flags) are sufficient to fully enable all format warning options across GCC and Clang. For GCC, refer to [Warning Options](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html). For Clang, refer to [Diagnostic Flags in Clang](https://clang.llvm.org/docs/DiagnosticsReference.html).

To ensure full and proper format warning coverage, all format flags which are not explicitly documented as being included by `-Wformat` or `-Wformat=2` are explicitly specified. This required the addition of several compiler version checks for compatibility to avoid "unrecognized option" errors. The redundancy of some flags is deliberate (no harm).

> [!NOTE]
> `-Wformat-signedness` not being enabled by `-Wformat` appears to be a major reason behind the lack of valuable format warnings enforcement in the current EVG config despite maintainer flags being enabled.

## -Wformat Fixes

Most changes required a simple fix of either the specifier to match the provided argument. Enumerators are cast to `int` to avoid implementation-defined underlying type compatibility issues. As a special case, saturation is used for `expires_in_len` in `mcd_azure_access_token_try_init_from_json_str` to print as much of the string as possible (although this is probably very unlikely to happen).

The implementation-defined type of `__LINE__` was exposed by MinGW builds, where `unsigned int` (`DWORD`) is used to represent `__LINE__` instead of `int` as expected by format strings:

```
error: format '%ld' expects argument of type 'long int', but argument has type 'DWORD' {aka 'long unsigned int'} [-Werror=format=]
```

Therefore, all cases of `__LINE__` being passed directly as an argument to a format string (rather than to a function parameter or variable of type `int`) are now explicitly cast to `int`. I do not expect we will ever need to support a source file that exceeds `int` representability.

A workaround was required for the formatting of `uint8_t` due to `PRIu8` on some platforms/build configurations (specifically release builds with GCC...?) conflicting with `-Wformat` due to implicit integer promotion rules:

```
error: format '%u' expects argument of type 'unsigned int', but argument has type 'int' [-Werror=format=]
  [...]
/usr/include/inttypes.h:102:18: note: format string is defined here
  102 | # define PRIu8  "u"
```

It is not entirely clear whether the stdlib implementation (should it be using `%hhu`...?) or the compiler (all `uint8_t` is representable by `int`; `uint8_t` -> `int` -> `unsigned int` should be perfectly fine...?) is to blame, but nevertheless, `%d` is used instead of `PRIu8` to address this (false-positive?) warning. (Relevant discussion: https://sourceware.org/bugzilla/show_bug.cgi?id=5747.)

> [!NOTE]
> Investigating this issue revealed a possibly obsolete definition of [__USE_MINGW_ANSI_STDIO](https://github.com/mongodb/mongo-c-driver/blob/58c3836e2c03361a49a914fbe82e67212d54a41a/src/libbson/src/bson/bson-compat.h#L27) which should now be handled by our defining `_XOPEN_SOURCE=700` + `_DEFAULT_SOURCE` in the CMake config. This is left untouched for now.

This PR also applies a drive-by fix for a new `-Wconversion` warning in mongoc-bulkwrite.c introduced by https://github.com/mongodb/mongo-c-driver/commit/84728bdb4e7def11a792e3bcb1b94811feff7b62.

Additionally, as a drive-by improvement and part of reducing the scope of mongoc warning options, `${mongo-c-driver_SOURCE_DIR}` is used in place of `*_SOURCES` variables (defined at root level) and `../`-relative paths when specifying source files for bundled external library sources.