### PR TITLE
CDRIVER-5736 do not assert

### DIFF
--- a/src/libmongoc/tests/test-mongoc-ssl.c
+++ b/src/libmongoc/tests/test-mongoc-ssl.c
@@ -205,7 +205,7 @@ static void
 test_non_existant_cafile (void)
 {
    mongoc_client_t *client = mongoc_client_new ("mongodb://localhost:27017/?tls=true&tlsCAFile=/nonexistant/ca.pem");
-   ASSERT (!mongoc_client_command_simple (client, "admin", tmp_bson ("{'ping': 1}"), NULL, NULL, NULL));
+   mongoc_client_command_simple (client, "admin", tmp_bson ("{'ping': 1}"), NULL, NULL, NULL);
    mongoc_client_destroy (client);
 }
 

--- a/src/libmongoc/tests/test-mongoc-ssl.c
+++ b/src/libmongoc/tests/test-mongoc-ssl.c
@@ -205,6 +205,7 @@ static void
 test_non_existant_cafile (void)
 {
    mongoc_client_t *client = mongoc_client_new ("mongodb://localhost:27017/?tls=true&tlsCAFile=/nonexistant/ca.pem");
+   // Ignore return. May return true on Windows hosts. See CDRIVER-5747.
    mongoc_client_command_simple (client, "admin", tmp_bson ("{'ping': 1}"), NULL, NULL, NULL);
    mongoc_client_destroy (client);
 }


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/mongo-c-driver/pull/1750 to fix failing Windows tasks.

The Windows hosts appear to have the expected CA file installed:

```
PS C:\Users\Administrator> Get-ChildItem -Recurse Cert:
(...)
Subject      : C=US, S=New York, L=New York City, O=MongoDB, OU=Drivers, CN=Drivers Testing CA
```

So no error is returned for the test.

Verified with this [patch build](https://spruce.mongodb.com/version/670586e5dac49200074a5795).