### PR TITLE
CDRIVER-4602 switch to supported build hosts

### DIFF
--- a/.evergreen/config_generator/components/abi_compliance_check.py
+++ b/.evergreen/config_generator/components/abi_compliance_check.py
@@ -11,6 +11,11 @@ class CheckABICompliance(Function):
     commands = [
         bash_exec(
             command_type=EvgCommandType.SETUP,
+            working_dir='mongoc',
+            script='.evergreen/scripts/abi-compliance-check-setup.sh'
+        ),
+        bash_exec(
+            command_type=EvgCommandType.SETUP,
             add_expansions_to_env=True,
             working_dir='mongoc',
             script='.evergreen/scripts/abi-compliance-check.sh'

--- a/.evergreen/config_generator/components/c_std_compile.py
+++ b/.evergreen/config_generator/components/c_std_compile.py
@@ -19,10 +19,6 @@ TAG = 'std-matrix'
 # fmt: off
 MATRIX = [
     ('debian92',          'clang',     None,   [11,   ]),
-    ('ubuntu1604',        'clang',     'i686', [11,   ]),
-    ('ubuntu1604',        'clang',     None,   [11,   ]),
-    ('ubuntu1804',        'clang',     'i686', [11,   ]),
-    ('ubuntu1804',        'gcc',       None,   [11,   ]),
     ('debian10',          'clang',     None,   [11,   ]),
     ('debian10',          'gcc',       None,   [11, 17]),
     ('debian11',          'clang',     None,   [11,   ]),

--- a/.evergreen/config_generator/components/cse/openssl.py
+++ b/.evergreen/config_generator/components/cse/openssl.py
@@ -35,11 +35,14 @@ TEST_MATRIX = [
     ('windows-vsCurrent', 'vs2017x64', None, 'cyrus', ['auth'], ['server'], ['4.2', '4.4', '5.0', '6.0' ]),
 
     # Test 7.0+ with a replica set since Queryable Encryption does not support the 'server' topology. Queryable Encryption tests require 7.0+.
-    # Test 7.0+ with Ubuntu 20.04+ since MongoDB 7.0 no longer ships binaries for Ubuntu 18.04.
     ('ubuntu2004',        'gcc',       None, 'cyrus', ['auth'], ['server', 'replica'], ['4.4', '5.0', '6.0', '7.0', '8.0', 'latest']),
     ('rhel83-zseries',    'gcc',       None, 'cyrus', ['auth'], ['server', 'replica'], [ '7.0', '8.0', 'latest']),
     ('ubuntu2004-arm64',  'gcc',       None, 'cyrus', ['auth'], ['server', 'replica'], ['4.4', '5.0', '6.0', '7.0', '8.0', 'latest']),
     ('windows-vsCurrent', 'vs2017x64', None, 'cyrus', ['auth'], ['server', 'replica'], [ '7.0', '8.0', 'latest']),
+
+    # Test 4.2 with Debian 10 since 4.2 does not ship on Ubuntu 20.04+.
+    ('debian10',          'gcc',       None, 'cyrus', ['auth'], ['server', 'replica'], ['4.2']),
+    
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/cse/openssl.py
+++ b/.evergreen/config_generator/components/cse/openssl.py
@@ -21,9 +21,7 @@ COMPILE_MATRIX = [
     ('debian92',          'gcc',       None, ['cyrus']),
     ('rhel80',            'gcc',       None, ['cyrus']),
     ('rhel83-zseries',    'gcc',       None, ['cyrus']),
-    ('ubuntu1604',        'clang',     None, ['cyrus']),
-    ('ubuntu1804-arm64',  'gcc',       None, ['cyrus']),
-    ('ubuntu1804',        'gcc',       None, ['cyrus']),
+    ('ubuntu2004',        'clang',       None, ['cyrus']),
     ('ubuntu2004',        'gcc',       None, ['cyrus']),
     ('ubuntu2004-arm64',  'gcc',       None, ['cyrus']),
     ('windows-vsCurrent', 'vs2017x64', None, ['cyrus']),
@@ -33,16 +31,14 @@ COMPILE_MATRIX = [
 TEST_MATRIX = [
     # 4.2 and 4.4 not available on rhel83-zseries.
     ('rhel83-zseries', 'gcc', None, 'cyrus', ['auth'], ['server'], ['5.0']),
-
-    ('ubuntu1804-arm64',  'gcc',       None, 'cyrus', ['auth'], ['server'], ['4.2', '4.4', '5.0', '6.0' ]),
-    ('ubuntu1804',        'gcc',       None, 'cyrus', ['auth'], ['server'], ['4.2', '4.4', '5.0', '6.0' ]),
+    
     ('windows-vsCurrent', 'vs2017x64', None, 'cyrus', ['auth'], ['server'], ['4.2', '4.4', '5.0', '6.0' ]),
 
     # Test 7.0+ with a replica set since Queryable Encryption does not support the 'server' topology. Queryable Encryption tests require 7.0+.
     # Test 7.0+ with Ubuntu 20.04+ since MongoDB 7.0 no longer ships binaries for Ubuntu 18.04.
-    ('ubuntu2004',        'gcc',       None, 'cyrus', ['auth'], ['server', 'replica'], [ '7.0', '8.0', 'latest']),
+    ('ubuntu2004',        'gcc',       None, 'cyrus', ['auth'], ['server', 'replica'], ['4.4', '5.0', '6.0', '7.0', '8.0', 'latest']),
     ('rhel83-zseries',    'gcc',       None, 'cyrus', ['auth'], ['server', 'replica'], [ '7.0', '8.0', 'latest']),
-    ('ubuntu2004-arm64',  'gcc',       None, 'cyrus', ['auth'], ['server', 'replica'], [ '7.0', '8.0', 'latest']),
+    ('ubuntu2004-arm64',  'gcc',       None, 'cyrus', ['auth'], ['server', 'replica'], ['4.4', '5.0', '6.0', '7.0', '8.0', 'latest']),
     ('windows-vsCurrent', 'vs2017x64', None, 'cyrus', ['auth'], ['server', 'replica'], [ '7.0', '8.0', 'latest']),
 ]
 # fmt: on

--- a/.evergreen/config_generator/components/earthly.py
+++ b/.evergreen/config_generator/components/earthly.py
@@ -242,7 +242,6 @@ CONTAINER_RUN_DISTROS = [
     "ubuntu2204-large",
     "ubuntu2004-small",
     "ubuntu2004",
-    "ubuntu1804-medium",
     "debian10",
     "debian11",
     "amazon2",

--- a/.evergreen/config_generator/components/loadbalanced.py
+++ b/.evergreen/config_generator/components/loadbalanced.py
@@ -13,7 +13,7 @@ from config_generator.etc.distros import make_distro_str, find_small_distro, fin
 from config_generator.etc.utils import Task, bash_exec
 
 # Use `rhel8.7` distro. `rhel8.7` distro includes necessary dependency: `haproxy`.
-_DISTRO_NAME = "rhel87"
+_DISTRO_NAME = "rhel89"
 _COMPILER = "gcc"
 
 

--- a/.evergreen/config_generator/components/loadbalanced.py
+++ b/.evergreen/config_generator/components/loadbalanced.py
@@ -12,7 +12,7 @@ from config_generator.components.funcs.upload_build import UploadBuild
 from config_generator.etc.distros import make_distro_str, find_small_distro, find_large_distro
 from config_generator.etc.utils import Task, bash_exec
 
-# Use `rhel8.7` distro. `rhel8.7` distro includes necessary dependency: `haproxy`.
+# Use `rhel8.9` distro. `rhel8.9` distro includes necessary dependency: `haproxy`.
 _DISTRO_NAME = "rhel89"
 _COMPILER = "gcc"
 

--- a/.evergreen/config_generator/components/loadbalanced.py
+++ b/.evergreen/config_generator/components/loadbalanced.py
@@ -13,7 +13,7 @@ from config_generator.etc.distros import make_distro_str, find_small_distro, fin
 from config_generator.etc.utils import Task, bash_exec
 
 # Use `rhel8.9` distro. `rhel8.9` distro includes necessary dependency: `haproxy`.
-_DISTRO_NAME = "rhel89"
+_DISTRO_NAME = "rhel8.9"
 _COMPILER = "gcc"
 
 

--- a/.evergreen/config_generator/components/sanitizers/asan_cse.py
+++ b/.evergreen/config_generator/components/sanitizers/asan_cse.py
@@ -10,16 +10,13 @@ from config_generator.components.sanitizers.asan import TAG
 # pylint: disable=line-too-long
 # fmt: off
 COMPILE_MATRIX = [
-    ('ubuntu1804', 'clang', None, ['cyrus']),
     ('ubuntu2004', 'clang', None, ['cyrus']),
 ]
 
 TEST_MATRIX = [
-    ('ubuntu1804', 'clang', None, 'cyrus', ['auth'], ['server'], ['4.2', '4.4', '5.0', '6.0']),
-
     # Test 7.0+ with a replica set since Queryable Encryption does not support the 'server' topology. Queryable Encryption tests require 7.0+.
     # Test 7.0+ with Ubuntu 20.04+ since MongoDB 7.0 no longer ships binaries for Ubuntu 18.04.
-    ('ubuntu2004', 'clang', None, 'cyrus', ['auth'], ['server', 'replica'], ['7.0', '8.0', 'latest']),
+    ('ubuntu2004', 'clang', None, 'cyrus', ['auth'], ['server', 'replica'], ['4.4', '5.0', '6.0', '7.0', '8.0', 'latest']),
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/sanitizers/asan_cse.py
+++ b/.evergreen/config_generator/components/sanitizers/asan_cse.py
@@ -11,12 +11,15 @@ from config_generator.components.sanitizers.asan import TAG
 # fmt: off
 COMPILE_MATRIX = [
     ('ubuntu2004', 'clang', None, ['cyrus']),
+    ('debian10',   'clang', None, ['cyrus']),
 ]
 
 TEST_MATRIX = [
     # Test 7.0+ with a replica set since Queryable Encryption does not support the 'server' topology. Queryable Encryption tests require 7.0+.
-    # Test 7.0+ with Ubuntu 20.04+ since MongoDB 7.0 no longer ships binaries for Ubuntu 18.04.
     ('ubuntu2004', 'clang', None, 'cyrus', ['auth'], ['server', 'replica'], ['4.4', '5.0', '6.0', '7.0', '8.0', 'latest']),
+
+    # Test 4.2 with Debian 10 since 4.2 does not ship on Ubuntu 20.04+.
+    ('debian10',   'clang', None, 'cyrus', ['auth'], ['server'], ['4.2']), 
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/sanitizers/asan_sasl.py
+++ b/.evergreen/config_generator/components/sanitizers/asan_sasl.py
@@ -11,11 +11,14 @@ from config_generator.components.sanitizers.asan import TAG
 # fmt: off
 COMPILE_MATRIX = [
     ('ubuntu2004', 'clang', None, ['cyrus']),
+    ('debian10',   'clang', None, ['cyrus']),
 ]
 
 TEST_MATRIX = [
-    # Test 7.0+ with Ubuntu 20.04+ since MongoDB 7.0 no longer ships binaries for Ubuntu 18.04.
     ('ubuntu2004', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], ['4.4', '5.0', '6.0', '7.0', '8.0', 'latest']),
+
+    # Test 4.2 with Debian 10 since 4.2 does not ship on Ubuntu 20.04+.
+    ('debian10',   'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], ['4.2']), 
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/sanitizers/asan_sasl.py
+++ b/.evergreen/config_generator/components/sanitizers/asan_sasl.py
@@ -10,16 +10,12 @@ from config_generator.components.sanitizers.asan import TAG
 # pylint: disable=line-too-long
 # fmt: off
 COMPILE_MATRIX = [
-    ('ubuntu1604', 'clang', None, ['cyrus']),
-    ('ubuntu1804', 'clang', None, ['cyrus']),
     ('ubuntu2004', 'clang', None, ['cyrus']),
 ]
 
 TEST_MATRIX = [
-    ('ubuntu1804', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], ['4.0', '4.2', '4.4', '5.0', '6.0']),
-
     # Test 7.0+ with Ubuntu 20.04+ since MongoDB 7.0 no longer ships binaries for Ubuntu 18.04.
-    ('ubuntu2004', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], ['7.0', '8.0', 'latest']),
+    ('ubuntu2004', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], ['4.4', '5.0', '6.0', '7.0', '8.0', 'latest']),
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/sanitizers/tsan_sasl.py
+++ b/.evergreen/config_generator/components/sanitizers/tsan_sasl.py
@@ -10,15 +10,12 @@ from config_generator.components.sanitizers.tsan import TAG
 # pylint: disable=line-too-long
 # fmt: off
 COMPILE_MATRIX = [
-    ('ubuntu1804', 'clang', None, ['cyrus']),
     ('ubuntu2004', 'clang', None, ['cyrus']),
 ]
 
 TEST_OPENSSL_MATRIX = [
-    ('ubuntu1804', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], ['4.0', '4.2', '4.4', '5.0', '6.0']),
-
     # Test 7.0+ with Ubuntu 20.04+ since MongoDB 7.0 no longer ships binaries for Ubuntu 18.04.
-    ('ubuntu2004', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], ['7.0', '8.0', 'latest']),
+    ('ubuntu2004', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], ['4.4', '5.0', '6.0', '7.0', '8.0', 'latest']),
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/sanitizers/tsan_sasl.py
+++ b/.evergreen/config_generator/components/sanitizers/tsan_sasl.py
@@ -11,11 +11,14 @@ from config_generator.components.sanitizers.tsan import TAG
 # fmt: off
 COMPILE_MATRIX = [
     ('ubuntu2004', 'clang', None, ['cyrus']),
+    ('debian10',   'clang', None, ['cyrus']),
 ]
 
 TEST_OPENSSL_MATRIX = [
-    # Test 7.0+ with Ubuntu 20.04+ since MongoDB 7.0 no longer ships binaries for Ubuntu 18.04.
     ('ubuntu2004', 'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], ['4.4', '5.0', '6.0', '7.0', '8.0', 'latest']),
+
+    # Test 4.2 with Debian 10 since 4.2 does not ship on Ubuntu 20.04+.
+    ('debian10',   'clang', None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], ['4.2']), 
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/sasl/nossl.py
+++ b/.evergreen/config_generator/components/sasl/nossl.py
@@ -15,15 +15,12 @@ TAG = f'sasl-matrix-{SSL}'
 # pylint: disable=line-too-long
 # fmt: off
 COMPILE_MATRIX = [
-    ('ubuntu1604',        'gcc',         None,   ['off']),
-    ('ubuntu1804',        'gcc',         None,   ['off']),
     ('ubuntu2004',        'gcc',         None,   ['off']),
     ('windows-vsCurrent', 'vs2017x64',   None,   ['off']),
 ]
 
 TEST_MATRIX = [
-    ('ubuntu1804', 'gcc', None, 'off', ['noauth'], ['server', 'replica', 'sharded'], ['4.0', '4.2', '4.4', '5.0', '6.0',                ]),
-    ('ubuntu2004', 'gcc', None, 'off', ['noauth'], ['server', 'replica', 'sharded'], [                                   '7.0', '8.0', 'latest']),
+    ('ubuntu2004', 'gcc', None, 'off', ['noauth'], ['server', 'replica', 'sharded'], ['4.4', '5.0', '6.0', '7.0', '8.0', 'latest']),
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/sasl/nossl.py
+++ b/.evergreen/config_generator/components/sasl/nossl.py
@@ -17,10 +17,14 @@ TAG = f'sasl-matrix-{SSL}'
 COMPILE_MATRIX = [
     ('ubuntu2004',        'gcc',         None,   ['off']),
     ('windows-vsCurrent', 'vs2017x64',   None,   ['off']),
+    ('debian10',          'gcc',         None,   ['off']),
 ]
 
 TEST_MATRIX = [
     ('ubuntu2004', 'gcc', None, 'off', ['noauth'], ['server', 'replica', 'sharded'], ['4.4', '5.0', '6.0', '7.0', '8.0', 'latest']),
+
+    # Test 4.2 with Debian 10 since 4.2 does not ship on Ubuntu 20.04+.
+    ('debian10',   'gcc', None, 'off', ['noauth'], ['server', 'replica', 'sharded'], ['4.2']), 
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/sasl/openssl.py
+++ b/.evergreen/config_generator/components/sasl/openssl.py
@@ -23,10 +23,7 @@ COMPILE_MATRIX = [
     ('rhel80',            'gcc',        None, ['cyrus']),
     ('rhel81-power8',     'gcc',        None, ['cyrus']),
     ('rhel83-zseries',    'gcc',        None, ['cyrus']),
-    ('ubuntu1604-arm64',  'gcc',        None, ['cyrus']),
-    ('ubuntu1604',        'clang',      None, ['cyrus']),
-    ('ubuntu1804-arm64',  'gcc',        None, ['cyrus']),
-    ('ubuntu1804',        'gcc',        None, ['cyrus']),
+    ('ubuntu2004',        'clang',        None, ['cyrus']),
     ('ubuntu2004-arm64',  'gcc',        None, ['cyrus']),
     ('ubuntu2004',        'gcc',        None, ['cyrus']),
     ('windows-vsCurrent', 'vs2017x64',  None, ['cyrus']),
@@ -35,18 +32,11 @@ COMPILE_MATRIX = [
 TEST_MATRIX = [
     ('rhel81-power8',     'gcc',       None, 'cyrus', ['auth'], ['server',          ], [       '4.2', '4.4', '5.0', '6.0', '7.0', '8.0', 'latest']),
     ('rhel83-zseries',    'gcc',       None, 'cyrus', ['auth'], ['server',          ], [                     '5.0', '6.0', '7.0', '8.0', 'latest']),
-    ('ubuntu1804-arm64',  'gcc',       None, 'cyrus', ['auth'], ['server',          ], [       '4.2', '4.4', '5.0', '6.0',                ]),
-    ('ubuntu1804',        'gcc',       None, 'cyrus', ['auth'], ['server', 'replica'], ['4.0', '4.2', '4.4', '5.0', '6.0',                ]),
 
     # Test 7.0+ with Ubuntu 20.04+ since MongoDB 7.0 no longer ships binaries for Ubuntu 18.04.
-    ('ubuntu2004-arm64',  'gcc',       None, 'cyrus', ['auth'], ['server'], ['7.0', '8.0', 'latest']),
-    ('ubuntu2004',        'gcc',       None, 'cyrus', ['auth'], ['server'], ['7.0', '8.0', 'latest']),
+    ('ubuntu2004-arm64',  'gcc',       None, 'cyrus', ['auth'], ['server'], ['4.4', '5.0', '6.0', '7.0', '8.0', 'latest']),
+    ('ubuntu2004',        'gcc',       None, 'cyrus', ['auth'], ['server'], ['4.4', '5.0', '6.0', '7.0', '8.0', 'latest']),
     ('windows-vsCurrent', 'vs2017x64', None, 'cyrus', ['auth'], ['server'], [       'latest']),
-
-    # Test ARM64 + 4.0 on Ubuntu 16.04, as MongoDB server does not produce
-    # downloads for Ubuntu 18.04 arm64.
-    # See: https://www.mongodb.com/docs/manual/administration/production-notes/
-    ('ubuntu1604-arm64', 'gcc', None, 'cyrus', ['auth'], ['server'], ['4.0']),
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/sasl/openssl.py
+++ b/.evergreen/config_generator/components/sasl/openssl.py
@@ -19,7 +19,6 @@ COMPILE_MATRIX = [
     ('debian11',          'gcc',        None, ['cyrus']),
     ('debian92',          'clang',      None, ['cyrus']),
     ('debian92',          'gcc',        None, ['cyrus']),
-    ('rhel70',            'gcc',        None, ['cyrus']),
     ('rhel80',            'gcc',        None, ['cyrus']),
     ('rhel81-power8',     'gcc',        None, ['cyrus']),
     ('rhel83-zseries',    'gcc',        None, ['cyrus']),

--- a/.evergreen/config_generator/components/sasl/openssl.py
+++ b/.evergreen/config_generator/components/sasl/openssl.py
@@ -32,10 +32,12 @@ TEST_MATRIX = [
     ('rhel81-power8',     'gcc',       None, 'cyrus', ['auth'], ['server',          ], [       '4.2', '4.4', '5.0', '6.0', '7.0', '8.0', 'latest']),
     ('rhel83-zseries',    'gcc',       None, 'cyrus', ['auth'], ['server',          ], [                     '5.0', '6.0', '7.0', '8.0', 'latest']),
 
-    # Test 7.0+ with Ubuntu 20.04+ since MongoDB 7.0 no longer ships binaries for Ubuntu 18.04.
     ('ubuntu2004-arm64',  'gcc',       None, 'cyrus', ['auth'], ['server'], ['4.4', '5.0', '6.0', '7.0', '8.0', 'latest']),
     ('ubuntu2004',        'gcc',       None, 'cyrus', ['auth'], ['server'], ['4.4', '5.0', '6.0', '7.0', '8.0', 'latest']),
     ('windows-vsCurrent', 'vs2017x64', None, 'cyrus', ['auth'], ['server'], [       'latest']),
+
+    # Test 4.2 with Debian 10 since 4.2 does not ship on Ubuntu 20.04+.
+    ('debian10',          'gcc',       None, 'cyrus', ['auth'], ['server', 'replica'], ['4.2']), 
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/scan_build.py
+++ b/.evergreen/config_generator/components/scan_build.py
@@ -20,11 +20,8 @@ TAG = 'scan-build-matrix'
 # fmt: off
 MATRIX = [
     ('macos-1100',       'clang', None  ),
-    ('ubuntu1604-arm64', 'clang', None  ),
-    ('ubuntu1604',       'clang', 'i686'),
-    ('ubuntu1604',       'clang', None  ),
-    ('ubuntu1804-arm64', 'clang', None  ),
-    ('ubuntu1804',       'clang', 'i686'),
+    ('ubuntu2004-arm64', 'clang', None  ),
+    ('ubuntu2004',       'clang', 'i686'),
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -60,10 +60,6 @@ MACOS_ARM64_DISTROS = [
 ]
 
 RHEL_DISTROS = [
-    Distro(name='rhel70-large', os='rhel', os_type='linux', os_ver='7.0', size='large'),
-    Distro(name='rhel70-small', os='rhel', os_type='linux', os_ver='7.0', size='small'),
-    Distro(name='rhel76-large', os='rhel', os_type='linux', os_ver='7.6', size='large'),
-    Distro(name='rhel76-small', os='rhel', os_type='linux', os_ver='7.6', size='small'),
     Distro(name='rhel80-large', os='rhel', os_type='linux', os_ver='8.0', size='large'),
     Distro(name='rhel80-small', os='rhel', os_type='linux', os_ver='8.0', size='small'),
     Distro(name='rhel84-large', os='rhel', os_type='linux', os_ver='8.4', size='large'),
@@ -82,15 +78,11 @@ RHEL_ARM64_DISTROS = [
 ]
 
 RHEL_POWER8_DISTROS = [
-    Distro(name='rhel71-power8-large', os='rhel', os_type='linux', os_ver='7.1', size='large', arch='power8'),
-    Distro(name='rhel71-power8-small', os='rhel', os_type='linux', os_ver='7.1', size='small', arch='power8'),
     Distro(name='rhel81-power8-large', os='rhel', os_type='linux', os_ver='8.1', size='large', arch='power8'),
     Distro(name='rhel81-power8-small', os='rhel', os_type='linux', os_ver='8.1', size='small', arch='power8'),
 ]
 
 RHEL_ZSERIES_DISTROS = [
-    Distro(name='rhel72-zseries-large', os='rhel', os_type='linux', os_ver='7.2', size='large', arch='zseries'),
-    Distro(name='rhel72-zseries-small', os='rhel', os_type='linux', os_ver='7.2', size='small', arch='zseries'),
     Distro(name='rhel83-zseries-large', os='rhel', os_type='linux', os_ver='8.3', size='large', arch='zseries'),
     Distro(name='rhel83-zseries-small', os='rhel', os_type='linux', os_ver='8.3', size='small', arch='zseries'),
 ]

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -96,10 +96,6 @@ RHEL_ZSERIES_DISTROS = [
 ]
 
 UBUNTU_DISTROS = [
-    Distro(name='ubuntu1604-large', os='ubuntu', os_type='linux', os_ver='16.04', size='large'),
-    Distro(name='ubuntu1604-small', os='ubuntu', os_type='linux', os_ver='16.04', size='small'),
-    Distro(name='ubuntu1804-large', os='ubuntu', os_type='linux', os_ver='18.04', size='large'),
-    Distro(name='ubuntu1804-small', os='ubuntu', os_type='linux', os_ver='18.04', size='small'),
     Distro(name='ubuntu2004-large', os='ubuntu', os_type='linux', os_ver='20.04', size='large'),
     Distro(name='ubuntu2004-small', os='ubuntu', os_type='linux', os_ver='20.04', size='small'),
     Distro(name='ubuntu2204-large', os='ubuntu', os_type='linux', os_ver='22.04', size='large'),
@@ -107,10 +103,6 @@ UBUNTU_DISTROS = [
 ]
 
 UBUNTU_ARM64_DISTROS = [
-    Distro(name='ubuntu1604-arm64-large', os='ubuntu', os_type='linux', os_ver='16.04', size='large', arch='arm64'),
-    Distro(name='ubuntu1604-arm64-small', os='ubuntu', os_type='linux', os_ver='16.04', size='small', arch='arm64'),
-    Distro(name='ubuntu1804-arm64-large', os='ubuntu', os_type='linux', os_ver='18.04', size='large', arch='arm64'),
-    Distro(name='ubuntu1804-arm64-small', os='ubuntu', os_type='linux', os_ver='18.04', size='small', arch='arm64'),
     Distro(name='ubuntu2004-arm64-large', os='ubuntu', os_type='linux', os_ver='20.04', size='large', arch='arm64'),
     Distro(name='ubuntu2004-arm64-small', os='ubuntu', os_type='linux', os_ver='20.04', size='small', arch='arm64'),
     Distro(name='ubuntu2204-arm64-large', os='ubuntu', os_type='linux', os_ver='22.04', size='large', arch='arm64'),

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -64,8 +64,8 @@ RHEL_DISTROS = [
     Distro(name='rhel80-small', os='rhel', os_type='linux', os_ver='8.0', size='small'),
     Distro(name='rhel84-large', os='rhel', os_type='linux', os_ver='8.4', size='large'),
     Distro(name='rhel84-small', os='rhel', os_type='linux', os_ver='8.4', size='small'),
-    Distro(name='rhel87-large', os='rhel', os_type='linux', os_ver='8.7', size='large'),
-    Distro(name='rhel87-small', os='rhel', os_type='linux', os_ver='8.7', size='small'),
+    Distro(name='rhel89-large', os='rhel', os_type='linux', os_ver='8.7', size='large'),
+    Distro(name='rhel89-small', os='rhel', os_type='linux', os_ver='8.7', size='small'),
     Distro(name='rhel90-large', os='rhel', os_type='linux', os_ver='9.0', size='large'),
     Distro(name='rhel90-small', os='rhel', os_type='linux', os_ver='9.0', size='small'),
 ]

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -64,8 +64,8 @@ RHEL_DISTROS = [
     Distro(name='rhel80-small', os='rhel', os_type='linux', os_ver='8.0', size='small'),
     Distro(name='rhel84-large', os='rhel', os_type='linux', os_ver='8.4', size='large'),
     Distro(name='rhel84-small', os='rhel', os_type='linux', os_ver='8.4', size='small'),
-    Distro(name='rhel89-large', os='rhel', os_type='linux', os_ver='8.7', size='large'),
-    Distro(name='rhel89-small', os='rhel', os_type='linux', os_ver='8.7', size='small'),
+    Distro(name='rhel8.9-large', os='rhel', os_type='linux', os_ver='8.7', size='large'),
+    Distro(name='rhel8.9-small', os='rhel', os_type='linux', os_ver='8.7', size='small'),
     Distro(name='rhel92-large', os='rhel', os_type='linux', os_ver='9.0', size='large'),
     Distro(name='rhel92-small', os='rhel', os_type='linux', os_ver='9.0', size='small'),
 ]

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -66,15 +66,15 @@ RHEL_DISTROS = [
     Distro(name='rhel84-small', os='rhel', os_type='linux', os_ver='8.4', size='small'),
     Distro(name='rhel89-large', os='rhel', os_type='linux', os_ver='8.7', size='large'),
     Distro(name='rhel89-small', os='rhel', os_type='linux', os_ver='8.7', size='small'),
-    Distro(name='rhel90-large', os='rhel', os_type='linux', os_ver='9.0', size='large'),
-    Distro(name='rhel90-small', os='rhel', os_type='linux', os_ver='9.0', size='small'),
+    Distro(name='rhel92-large', os='rhel', os_type='linux', os_ver='9.0', size='large'),
+    Distro(name='rhel92-small', os='rhel', os_type='linux', os_ver='9.0', size='small'),
 ]
 
 RHEL_ARM64_DISTROS = [
     Distro(name='rhel82-arm64-large', os='rhel', os_type='linux', os_ver='8.2', size='large', arch='arm64'),
     Distro(name='rhel82-arm64-small', os='rhel', os_type='linux', os_ver='8.2', size='small', arch='arm64'),
-    Distro(name='rhel90-arm64-large', os='rhel', os_type='linux', os_ver='9.0', size='large', arch='arm64'),
-    Distro(name='rhel90-arm64-small', os='rhel', os_type='linux', os_ver='9.0', size='small', arch='arm64'),
+    Distro(name='rhel92-arm64-large', os='rhel', os_type='linux', os_ver='9.0', size='large', arch='arm64'),
+    Distro(name='rhel92-arm64-small', os='rhel', os_type='linux', os_ver='9.0', size='small', arch='arm64'),
 ]
 
 RHEL_POWER8_DISTROS = [

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -123,9 +123,6 @@ WINDOWS_DISTROS = [
 
     Distro(name='windows-vsCurrent-large', os='windows', os_type='windows', vs_ver='vsCurrent', size='large'), # Windows Server 2019
     Distro(name='windows-vsCurrent-small', os='windows', os_type='windows', vs_ver='vsCurrent', size='small'), # Windows Server 2019
-
-    Distro(name='windows-vsCurrent2-large', os='windows', os_type='windows', vs_ver='vsCurrent2', size='large'),
-    Distro(name='windows-vsCurrent2-small', os='windows', os_type='windows', vs_ver='vsCurrent2', size='small'),
 ]
 #fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -5,6 +5,14 @@ functions:
       params:
         binary: bash
         working_dir: mongoc
+        args:
+          - -c
+          - .evergreen/scripts/abi-compliance-check-setup.sh
+    - command: subprocess.exec
+      type: setup
+      params:
+        binary: bash
+        working_dir: mongoc
         add_expansions_to_env: true
         args:
           - -c

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -16433,8 +16433,8 @@ buildvariants:
   - debug-compile-sasl-openssl
   - debug-compile-nosasl-openssl
   - .authentication-tests .openssl
-- name: clang60-i686
-  display_name: clang 6.0 (i686) (Ubuntu 20.04)
+- name: clang100-i686
+  display_name: clang 10.0 (i686) (Ubuntu 20.04)
   expansions:
     CC: clang
     MARCH: i686
@@ -16495,8 +16495,8 @@ buildvariants:
   - release-compile
   - debug-compile-nosasl-nossl
   - .latest .nossl
-- name: gcc75-i686
-  display_name: GCC 7.5 (i686) (Ubuntu 20.04)
+- name: gcc94-i686
+  display_name: GCC 9.4 (i686) (Ubuntu 20.04)
   expansions:
     CC: gcc
     MARCH: i686
@@ -16506,8 +16506,8 @@ buildvariants:
   - debug-compile-nosasl-nossl
   - debug-compile-no-align
   - .latest .nossl .nosasl
-- name: gcc75
-  display_name: GCC 7.5 (Ubuntu 20.04)
+- name: gcc94
+  display_name: GCC 9.4 (Ubuntu 20.04)
   expansions:
     CC: gcc
   run_on: ubuntu2004-test
@@ -16656,8 +16656,8 @@ buildvariants:
   - .authentication-tests .openssl
   - .latest .nossl
   batchtime: 1440
-- name: clang60ubuntu
-  display_name: clang 6.0 (Ubuntu 20.04)
+- name: clang100ubuntu
+  display_name: clang 10.0 (Ubuntu 20.04)
   expansions:
     CC: clang
   run_on: ubuntu2004-test

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -16486,15 +16486,6 @@ buildvariants:
   - release-compile
   - debug-compile-nosasl-nossl
   - .latest .nossl
-- name: gcc94
-  display_name: GCC 9.4 (Ubuntu 20.04)
-  expansions:
-    CC: gcc
-  run_on: ubuntu2004-large
-  tasks:
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - .latest .nossl
 - name: gcc94-i686
   display_name: GCC 9.4 (i686) (Ubuntu 20.04)
   expansions:

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -16331,9 +16331,9 @@ buildvariants:
 - name: abi-compliance-check
   display_name: ABI Compliance Check
   run_on:
-  - ubuntu1804-small
-  - ubuntu1804-medium
-  - ubuntu1804-large
+  - ubuntu2004-small
+  - ubuntu2004-medium
+  - ubuntu2004-large
   tasks:
   - abi-compliance-check
 - name: smoke
@@ -16373,7 +16373,7 @@ buildvariants:
     - windows-vsCurrent-large
   - name: link-with-pkg-config
     distros:
-    - ubuntu1804-test
+    - ubuntu2004-test
   - name: link-with-pkg-config-mac
     distros:
     - macos-1100
@@ -16434,38 +16434,17 @@ buildvariants:
   - debug-compile-nosasl-openssl
   - .authentication-tests .openssl
 - name: clang60-i686
-  display_name: clang 6.0 (i686) (Ubuntu 18.04)
+  display_name: clang 6.0 (i686) (Ubuntu 20.04)
   expansions:
     CC: clang
     MARCH: i686
-  run_on: ubuntu1804-test
+  run_on: ubuntu2004-test
   tasks:
   - release-compile
   - debug-compile-nosasl-nossl
   - debug-compile-no-align
   - .debug-compile !.sspi .nossl .nosasl
   - .latest .nossl .nosasl
-- name: clang38-i686
-  display_name: clang 3.8 (i686) (Ubuntu 16.04)
-  expansions:
-    CC: clang
-    MARCH: i686
-  run_on: ubuntu1604-test
-  tasks:
-  - release-compile
-  - debug-compile-no-align
-- name: clang38ubuntu
-  display_name: clang 3.8 (Ubuntu 16.04)
-  expansions:
-    CC: clang
-  run_on: ubuntu1604-test
-  tasks:
-  - .compression !.zstd
-  - release-compile
-  - debug-compile-sasl-openssl
-  - debug-compile-nosasl-openssl
-  - debug-compile-no-align
-  - .authentication-tests .openssl
 - name: gcc82rhel
   display_name: GCC 8.2 (RHEL 8.0)
   expansions:
@@ -16531,21 +16510,21 @@ buildvariants:
   - debug-compile-nosasl-nossl
   - .latest .nossl
 - name: gcc75-i686
-  display_name: GCC 7.5 (i686) (Ubuntu 18.04)
+  display_name: GCC 7.5 (i686) (Ubuntu 20.04)
   expansions:
     CC: gcc
     MARCH: i686
-  run_on: ubuntu1804-test
+  run_on: ubuntu2004-test
   tasks:
   - release-compile
   - debug-compile-nosasl-nossl
   - debug-compile-no-align
   - .latest .nossl .nosasl
 - name: gcc75
-  display_name: GCC 7.5 (Ubuntu 18.04)
+  display_name: GCC 7.5 (Ubuntu 20.04)
   expansions:
     CC: gcc
-  run_on: ubuntu1804-test
+  run_on: ubuntu2004-test
   tasks:
   - .compression !.zstd
   - debug-compile-nosrv
@@ -16562,16 +16541,6 @@ buildvariants:
   - test-dns-openssl
   - test-dns-auth-openssl
   - test-dns-loadbalanced-openssl
-- name: gcc54
-  display_name: GCC 5.4 (Ubuntu 16.04)
-  expansions:
-    CC: gcc
-  run_on: ubuntu1604-test
-  tasks:
-  - .compression !.zstd
-  - debug-compile-nosrv
-  - release-compile
-  - debug-compile-no-align
 - name: darwin
   display_name: '*Darwin, macOS (Apple LLVM)'
   expansions:
@@ -16671,11 +16640,11 @@ buildvariants:
   - .latest .nossl
   - test-dns-openssl
   batchtime: 1440
-- name: arm-ubuntu1804
-  display_name: '*ARM (aarch64) (Ubuntu 18.04)'
+- name: arm-ubuntu2004
+  display_name: '*ARM (aarch64) (Ubuntu 20.04)'
   expansions:
     CC: gcc
-  run_on: ubuntu1804-arm64-large
+  run_on: ubuntu2004-arm64-large
   tasks:
   - .compression !.snappy !.zstd
   - debug-compile-no-align
@@ -16686,16 +16655,6 @@ buildvariants:
   - .authentication-tests .openssl
   - .latest .nossl
   - test-dns-openssl
-  batchtime: 1440
-- name: arm-ubuntu1604
-  display_name: '*ARM (aarch64) (Ubuntu 16.04)'
-  expansions:
-    CC: gcc
-  run_on: ubuntu1604-arm64-large
-  tasks:
-  - .compression !.snappy !.zstd
-  - debug-compile-no-align
-  - release-compile
   batchtime: 1440
 - name: zseries-rhel83
   display_name: '*zSeries'
@@ -16712,10 +16671,10 @@ buildvariants:
   - .latest .nossl
   batchtime: 1440
 - name: clang60ubuntu
-  display_name: clang 6.0 (Ubuntu 18.04)
+  display_name: clang 6.0 (Ubuntu 20.04)
   expansions:
     CC: clang
-  run_on: ubuntu1804-test
+  run_on: ubuntu2004-test
   tasks:
   - debug-compile-sasl-openssl-static
   - .authentication-tests .asan
@@ -16790,20 +16749,14 @@ buildvariants:
     - rhel90-arm64-small
   tags:
   - pr-merge-gate
-- name: versioned-api-ubuntu1804
-  display_name: Versioned API Tests (Ubuntu 18.04)
-  run_on: ubuntu1804-test
-  tasks:
-  - debug-compile-nosasl-openssl
-  - debug-compile-nosasl-nossl
-  - .versioned-api .5.0
-  - .versioned-api .6.0
 - name: versioned-api-ubuntu2004
   display_name: Versioned API Tests (Ubuntu 20.04)
   run_on: ubuntu2004-test
   tasks:
   - debug-compile-nosasl-openssl
   - debug-compile-nosasl-nossl
+  - .versioned-api .5.0
+  - .versioned-api .6.0
   - .versioned-api .7.0
   - .versioned-api .8.0
 - name: testazurekms-variant

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -16459,20 +16459,6 @@ buildvariants:
   - debug-compile-sasl-openssl
   - .authentication-tests .openssl
   - .latest .nossl
-- name: gcc48rhel
-  display_name: GCC 4.8 (RHEL 7.0)
-  expansions:
-    CC: gcc
-  run_on: rhel70
-  tasks:
-  - .hardened
-  - .compression !.snappy
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - debug-compile-sasl-openssl
-  - debug-compile-nosasl-openssl
-  - .authentication-tests .openssl
-  - .latest .nossl
 - name: gcc63
   display_name: GCC 6.3 (Debian 9.2)
   expansions:

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -2695,9 +2695,9 @@ tasks:
   - name: kms-divergence-check
     commands:
       - func: kms-divergence-check
-  - name: loadbalanced-rhel87-gcc-compile
-    run_on: rhel87-large
-    tags: [loadbalanced, rhel87, gcc]
+  - name: loadbalanced-rhel89-gcc-compile
+    run_on: rhel89-large
+    tags: [loadbalanced, rhel89, gcc]
     commands:
       - func: find-cmake-latest
       - command: subprocess.exec
@@ -2714,14 +2714,14 @@ tasks:
             - -c
             - .evergreen/scripts/compile.sh
       - func: upload-build
-  - name: loadbalanced-rhel87-gcc-test-5.0-auth-openssl
-    run_on: rhel87-small
-    tags: [loadbalanced, rhel87, gcc, auth, openssl]
-    depends_on: [{ name: loadbalanced-rhel87-gcc-compile }]
+  - name: loadbalanced-rhel89-gcc-test-5.0-auth-openssl
+    run_on: rhel89-small
+    tags: [loadbalanced, rhel89, gcc, auth, openssl]
+    depends_on: [{ name: loadbalanced-rhel89-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: loadbalanced-rhel87-gcc-compile
+          BUILD_NAME: loadbalanced-rhel89-gcc-compile
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
         vars:
@@ -2740,14 +2740,14 @@ tasks:
           CC: gcc
           LOADBALANCED: loadbalanced
           SSL: openssl
-  - name: loadbalanced-rhel87-gcc-test-5.0-noauth-nossl
-    run_on: rhel87-small
-    tags: [loadbalanced, rhel87, gcc, noauth, nossl]
-    depends_on: [{ name: loadbalanced-rhel87-gcc-compile }]
+  - name: loadbalanced-rhel89-gcc-test-5.0-noauth-nossl
+    run_on: rhel89-small
+    tags: [loadbalanced, rhel89, gcc, noauth, nossl]
+    depends_on: [{ name: loadbalanced-rhel89-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: loadbalanced-rhel87-gcc-compile
+          BUILD_NAME: loadbalanced-rhel89-gcc-compile
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
         vars:
@@ -2766,14 +2766,14 @@ tasks:
           CC: gcc
           LOADBALANCED: loadbalanced
           SSL: nossl
-  - name: loadbalanced-rhel87-gcc-test-6.0-auth-openssl
-    run_on: rhel87-small
-    tags: [loadbalanced, rhel87, gcc, auth, openssl]
-    depends_on: [{ name: loadbalanced-rhel87-gcc-compile }]
+  - name: loadbalanced-rhel89-gcc-test-6.0-auth-openssl
+    run_on: rhel89-small
+    tags: [loadbalanced, rhel89, gcc, auth, openssl]
+    depends_on: [{ name: loadbalanced-rhel89-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: loadbalanced-rhel87-gcc-compile
+          BUILD_NAME: loadbalanced-rhel89-gcc-compile
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
         vars:
@@ -2792,14 +2792,14 @@ tasks:
           CC: gcc
           LOADBALANCED: loadbalanced
           SSL: openssl
-  - name: loadbalanced-rhel87-gcc-test-6.0-noauth-nossl
-    run_on: rhel87-small
-    tags: [loadbalanced, rhel87, gcc, noauth, nossl]
-    depends_on: [{ name: loadbalanced-rhel87-gcc-compile }]
+  - name: loadbalanced-rhel89-gcc-test-6.0-noauth-nossl
+    run_on: rhel89-small
+    tags: [loadbalanced, rhel89, gcc, noauth, nossl]
+    depends_on: [{ name: loadbalanced-rhel89-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: loadbalanced-rhel87-gcc-compile
+          BUILD_NAME: loadbalanced-rhel89-gcc-compile
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
         vars:
@@ -2818,14 +2818,14 @@ tasks:
           CC: gcc
           LOADBALANCED: loadbalanced
           SSL: nossl
-  - name: loadbalanced-rhel87-gcc-test-7.0-auth-openssl
-    run_on: rhel87-small
-    tags: [loadbalanced, rhel87, gcc, auth, openssl]
-    depends_on: [{ name: loadbalanced-rhel87-gcc-compile }]
+  - name: loadbalanced-rhel89-gcc-test-7.0-auth-openssl
+    run_on: rhel89-small
+    tags: [loadbalanced, rhel89, gcc, auth, openssl]
+    depends_on: [{ name: loadbalanced-rhel89-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: loadbalanced-rhel87-gcc-compile
+          BUILD_NAME: loadbalanced-rhel89-gcc-compile
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
         vars:
@@ -2844,14 +2844,14 @@ tasks:
           CC: gcc
           LOADBALANCED: loadbalanced
           SSL: openssl
-  - name: loadbalanced-rhel87-gcc-test-7.0-noauth-nossl
-    run_on: rhel87-small
-    tags: [loadbalanced, rhel87, gcc, noauth, nossl]
-    depends_on: [{ name: loadbalanced-rhel87-gcc-compile }]
+  - name: loadbalanced-rhel89-gcc-test-7.0-noauth-nossl
+    run_on: rhel89-small
+    tags: [loadbalanced, rhel89, gcc, noauth, nossl]
+    depends_on: [{ name: loadbalanced-rhel89-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: loadbalanced-rhel87-gcc-compile
+          BUILD_NAME: loadbalanced-rhel89-gcc-compile
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
         vars:
@@ -2870,14 +2870,14 @@ tasks:
           CC: gcc
           LOADBALANCED: loadbalanced
           SSL: nossl
-  - name: loadbalanced-rhel87-gcc-test-8.0-auth-openssl
-    run_on: rhel87-small
-    tags: [loadbalanced, rhel87, gcc, auth, openssl]
-    depends_on: [{ name: loadbalanced-rhel87-gcc-compile }]
+  - name: loadbalanced-rhel89-gcc-test-8.0-auth-openssl
+    run_on: rhel89-small
+    tags: [loadbalanced, rhel89, gcc, auth, openssl]
+    depends_on: [{ name: loadbalanced-rhel89-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: loadbalanced-rhel87-gcc-compile
+          BUILD_NAME: loadbalanced-rhel89-gcc-compile
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
         vars:
@@ -2896,14 +2896,14 @@ tasks:
           CC: gcc
           LOADBALANCED: loadbalanced
           SSL: openssl
-  - name: loadbalanced-rhel87-gcc-test-8.0-noauth-nossl
-    run_on: rhel87-small
-    tags: [loadbalanced, rhel87, gcc, noauth, nossl]
-    depends_on: [{ name: loadbalanced-rhel87-gcc-compile }]
+  - name: loadbalanced-rhel89-gcc-test-8.0-noauth-nossl
+    run_on: rhel89-small
+    tags: [loadbalanced, rhel89, gcc, noauth, nossl]
+    depends_on: [{ name: loadbalanced-rhel89-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: loadbalanced-rhel87-gcc-compile
+          BUILD_NAME: loadbalanced-rhel89-gcc-compile
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
         vars:
@@ -2922,14 +2922,14 @@ tasks:
           CC: gcc
           LOADBALANCED: loadbalanced
           SSL: nossl
-  - name: loadbalanced-rhel87-gcc-test-latest-auth-openssl
-    run_on: rhel87-small
-    tags: [loadbalanced, rhel87, gcc, auth, openssl]
-    depends_on: [{ name: loadbalanced-rhel87-gcc-compile }]
+  - name: loadbalanced-rhel89-gcc-test-latest-auth-openssl
+    run_on: rhel89-small
+    tags: [loadbalanced, rhel89, gcc, auth, openssl]
+    depends_on: [{ name: loadbalanced-rhel89-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: loadbalanced-rhel87-gcc-compile
+          BUILD_NAME: loadbalanced-rhel89-gcc-compile
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
         vars:
@@ -2948,14 +2948,14 @@ tasks:
           CC: gcc
           LOADBALANCED: loadbalanced
           SSL: openssl
-  - name: loadbalanced-rhel87-gcc-test-latest-noauth-nossl
-    run_on: rhel87-small
-    tags: [loadbalanced, rhel87, gcc, noauth, nossl]
-    depends_on: [{ name: loadbalanced-rhel87-gcc-compile }]
+  - name: loadbalanced-rhel89-gcc-test-latest-noauth-nossl
+    run_on: rhel89-small
+    tags: [loadbalanced, rhel89, gcc, noauth, nossl]
+    depends_on: [{ name: loadbalanced-rhel89-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: loadbalanced-rhel87-gcc-compile
+          BUILD_NAME: loadbalanced-rhel89-gcc-compile
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
         vars:

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -2695,9 +2695,9 @@ tasks:
   - name: kms-divergence-check
     commands:
       - func: kms-divergence-check
-  - name: loadbalanced-rhel89-gcc-compile
-    run_on: rhel89-large
-    tags: [loadbalanced, rhel89, gcc]
+  - name: loadbalanced-rhel8.9-gcc-compile
+    run_on: rhel8.9-large
+    tags: [loadbalanced, rhel8.9, gcc]
     commands:
       - func: find-cmake-latest
       - command: subprocess.exec
@@ -2714,14 +2714,14 @@ tasks:
             - -c
             - .evergreen/scripts/compile.sh
       - func: upload-build
-  - name: loadbalanced-rhel89-gcc-test-5.0-auth-openssl
-    run_on: rhel89-small
-    tags: [loadbalanced, rhel89, gcc, auth, openssl]
-    depends_on: [{ name: loadbalanced-rhel89-gcc-compile }]
+  - name: loadbalanced-rhel8.9-gcc-test-5.0-auth-openssl
+    run_on: rhel8.9-small
+    tags: [loadbalanced, rhel8.9, gcc, auth, openssl]
+    depends_on: [{ name: loadbalanced-rhel8.9-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: loadbalanced-rhel89-gcc-compile
+          BUILD_NAME: loadbalanced-rhel8.9-gcc-compile
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
         vars:
@@ -2740,14 +2740,14 @@ tasks:
           CC: gcc
           LOADBALANCED: loadbalanced
           SSL: openssl
-  - name: loadbalanced-rhel89-gcc-test-5.0-noauth-nossl
-    run_on: rhel89-small
-    tags: [loadbalanced, rhel89, gcc, noauth, nossl]
-    depends_on: [{ name: loadbalanced-rhel89-gcc-compile }]
+  - name: loadbalanced-rhel8.9-gcc-test-5.0-noauth-nossl
+    run_on: rhel8.9-small
+    tags: [loadbalanced, rhel8.9, gcc, noauth, nossl]
+    depends_on: [{ name: loadbalanced-rhel8.9-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: loadbalanced-rhel89-gcc-compile
+          BUILD_NAME: loadbalanced-rhel8.9-gcc-compile
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
         vars:
@@ -2766,14 +2766,14 @@ tasks:
           CC: gcc
           LOADBALANCED: loadbalanced
           SSL: nossl
-  - name: loadbalanced-rhel89-gcc-test-6.0-auth-openssl
-    run_on: rhel89-small
-    tags: [loadbalanced, rhel89, gcc, auth, openssl]
-    depends_on: [{ name: loadbalanced-rhel89-gcc-compile }]
+  - name: loadbalanced-rhel8.9-gcc-test-6.0-auth-openssl
+    run_on: rhel8.9-small
+    tags: [loadbalanced, rhel8.9, gcc, auth, openssl]
+    depends_on: [{ name: loadbalanced-rhel8.9-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: loadbalanced-rhel89-gcc-compile
+          BUILD_NAME: loadbalanced-rhel8.9-gcc-compile
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
         vars:
@@ -2792,14 +2792,14 @@ tasks:
           CC: gcc
           LOADBALANCED: loadbalanced
           SSL: openssl
-  - name: loadbalanced-rhel89-gcc-test-6.0-noauth-nossl
-    run_on: rhel89-small
-    tags: [loadbalanced, rhel89, gcc, noauth, nossl]
-    depends_on: [{ name: loadbalanced-rhel89-gcc-compile }]
+  - name: loadbalanced-rhel8.9-gcc-test-6.0-noauth-nossl
+    run_on: rhel8.9-small
+    tags: [loadbalanced, rhel8.9, gcc, noauth, nossl]
+    depends_on: [{ name: loadbalanced-rhel8.9-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: loadbalanced-rhel89-gcc-compile
+          BUILD_NAME: loadbalanced-rhel8.9-gcc-compile
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
         vars:
@@ -2818,14 +2818,14 @@ tasks:
           CC: gcc
           LOADBALANCED: loadbalanced
           SSL: nossl
-  - name: loadbalanced-rhel89-gcc-test-7.0-auth-openssl
-    run_on: rhel89-small
-    tags: [loadbalanced, rhel89, gcc, auth, openssl]
-    depends_on: [{ name: loadbalanced-rhel89-gcc-compile }]
+  - name: loadbalanced-rhel8.9-gcc-test-7.0-auth-openssl
+    run_on: rhel8.9-small
+    tags: [loadbalanced, rhel8.9, gcc, auth, openssl]
+    depends_on: [{ name: loadbalanced-rhel8.9-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: loadbalanced-rhel89-gcc-compile
+          BUILD_NAME: loadbalanced-rhel8.9-gcc-compile
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
         vars:
@@ -2844,14 +2844,14 @@ tasks:
           CC: gcc
           LOADBALANCED: loadbalanced
           SSL: openssl
-  - name: loadbalanced-rhel89-gcc-test-7.0-noauth-nossl
-    run_on: rhel89-small
-    tags: [loadbalanced, rhel89, gcc, noauth, nossl]
-    depends_on: [{ name: loadbalanced-rhel89-gcc-compile }]
+  - name: loadbalanced-rhel8.9-gcc-test-7.0-noauth-nossl
+    run_on: rhel8.9-small
+    tags: [loadbalanced, rhel8.9, gcc, noauth, nossl]
+    depends_on: [{ name: loadbalanced-rhel8.9-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: loadbalanced-rhel89-gcc-compile
+          BUILD_NAME: loadbalanced-rhel8.9-gcc-compile
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
         vars:
@@ -2870,14 +2870,14 @@ tasks:
           CC: gcc
           LOADBALANCED: loadbalanced
           SSL: nossl
-  - name: loadbalanced-rhel89-gcc-test-8.0-auth-openssl
-    run_on: rhel89-small
-    tags: [loadbalanced, rhel89, gcc, auth, openssl]
-    depends_on: [{ name: loadbalanced-rhel89-gcc-compile }]
+  - name: loadbalanced-rhel8.9-gcc-test-8.0-auth-openssl
+    run_on: rhel8.9-small
+    tags: [loadbalanced, rhel8.9, gcc, auth, openssl]
+    depends_on: [{ name: loadbalanced-rhel8.9-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: loadbalanced-rhel89-gcc-compile
+          BUILD_NAME: loadbalanced-rhel8.9-gcc-compile
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
         vars:
@@ -2896,14 +2896,14 @@ tasks:
           CC: gcc
           LOADBALANCED: loadbalanced
           SSL: openssl
-  - name: loadbalanced-rhel89-gcc-test-8.0-noauth-nossl
-    run_on: rhel89-small
-    tags: [loadbalanced, rhel89, gcc, noauth, nossl]
-    depends_on: [{ name: loadbalanced-rhel89-gcc-compile }]
+  - name: loadbalanced-rhel8.9-gcc-test-8.0-noauth-nossl
+    run_on: rhel8.9-small
+    tags: [loadbalanced, rhel8.9, gcc, noauth, nossl]
+    depends_on: [{ name: loadbalanced-rhel8.9-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: loadbalanced-rhel89-gcc-compile
+          BUILD_NAME: loadbalanced-rhel8.9-gcc-compile
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
         vars:
@@ -2922,14 +2922,14 @@ tasks:
           CC: gcc
           LOADBALANCED: loadbalanced
           SSL: nossl
-  - name: loadbalanced-rhel89-gcc-test-latest-auth-openssl
-    run_on: rhel89-small
-    tags: [loadbalanced, rhel89, gcc, auth, openssl]
-    depends_on: [{ name: loadbalanced-rhel89-gcc-compile }]
+  - name: loadbalanced-rhel8.9-gcc-test-latest-auth-openssl
+    run_on: rhel8.9-small
+    tags: [loadbalanced, rhel8.9, gcc, auth, openssl]
+    depends_on: [{ name: loadbalanced-rhel8.9-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: loadbalanced-rhel89-gcc-compile
+          BUILD_NAME: loadbalanced-rhel8.9-gcc-compile
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
         vars:
@@ -2948,14 +2948,14 @@ tasks:
           CC: gcc
           LOADBALANCED: loadbalanced
           SSL: openssl
-  - name: loadbalanced-rhel89-gcc-test-latest-noauth-nossl
-    run_on: rhel89-small
-    tags: [loadbalanced, rhel89, gcc, noauth, nossl]
-    depends_on: [{ name: loadbalanced-rhel89-gcc-compile }]
+  - name: loadbalanced-rhel8.9-gcc-test-latest-noauth-nossl
+    run_on: rhel8.9-small
+    tags: [loadbalanced, rhel8.9, gcc, noauth, nossl]
+    depends_on: [{ name: loadbalanced-rhel8.9-gcc-compile }]
     commands:
       - func: fetch-build
         vars:
-          BUILD_NAME: loadbalanced-rhel89-gcc-compile
+          BUILD_NAME: loadbalanced-rhel8.9-gcc-compile
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
         vars:

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -2,6 +2,60 @@ tasks:
   - name: abi-compliance-check
     commands:
       - func: abi-compliance-check
+  - name: asan-cse-sasl-cyrus-openssl-debian10-clang-compile
+    run_on: debian10-large
+    tags: [sanitizers-matrix-asan, compile, debian10, clang, cse, asan, sasl-cyrus]
+    commands:
+      - func: find-cmake-latest
+      - func: cse-sasl-cyrus-openssl-compile
+        vars:
+          CC: clang
+      - func: upload-build
+  - name: asan-cse-sasl-cyrus-openssl-debian10-clang-test-4.2-server-auth
+    run_on: debian10-small
+    tags: [sanitizers-matrix-asan, test, debian10, clang, sasl-cyrus, cse, asan, auth, server, "4.2", openssl]
+    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-debian10-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-cse-sasl-cyrus-openssl-debian10-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.2" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+            - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: asan-cse-sasl-cyrus-openssl-debian10-clang-test-4.2-server-auth-with-mongocrypt
+    run_on: debian10-small
+    tags: [sanitizers-matrix-asan, test, debian10, clang, sasl-cyrus, cse, asan, auth, server, "4.2", with-mongocrypt, openssl]
+    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-debian10-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-cse-sasl-cyrus-openssl-debian10-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.2" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+            - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
+            - { key: SKIP_CRYPT_SHARED_LIB, value: "on" }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-mock-kms-servers
+      - func: run-tests
   - name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile
     run_on: ubuntu2004-large
     tags: [sanitizers-matrix-asan, compile, ubuntu2004, clang, cse, asan, sasl-cyrus]
@@ -550,6 +604,75 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-mock-kms-servers
+      - func: run-tests
+  - name: asan-sasl-cyrus-openssl-debian10-clang-compile
+    run_on: debian10-large
+    tags: [sanitizers-matrix-asan, compile, debian10, clang, asan, sasl-cyrus]
+    commands:
+      - func: find-cmake-latest
+      - func: sasl-cyrus-openssl-compile
+        vars:
+          CC: clang
+      - func: upload-build
+  - name: asan-sasl-cyrus-openssl-debian10-clang-test-4.2-replica-auth
+    run_on: debian10-small
+    tags: [sanitizers-matrix-asan, test, debian10, clang, sasl-cyrus, asan, auth, replica, "4.2", openssl]
+    depends_on: [{ name: asan-sasl-cyrus-openssl-debian10-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-sasl-cyrus-openssl-debian10-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.2" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: asan-sasl-cyrus-openssl-debian10-clang-test-4.2-server-auth
+    run_on: debian10-small
+    tags: [sanitizers-matrix-asan, test, debian10, clang, sasl-cyrus, asan, auth, server, "4.2", openssl]
+    depends_on: [{ name: asan-sasl-cyrus-openssl-debian10-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-sasl-cyrus-openssl-debian10-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.2" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: asan-sasl-cyrus-openssl-debian10-clang-test-4.2-sharded-auth
+    run_on: debian10-small
+    tags: [sanitizers-matrix-asan, test, debian10, clang, sasl-cyrus, asan, auth, sharded, "4.2", openssl]
+    depends_on: [{ name: asan-sasl-cyrus-openssl-debian10-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-sasl-cyrus-openssl-debian10-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.2" }
+            - { key: TOPOLOGY, value: sharded_cluster }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
       - func: run-tests
   - name: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile
     run_on: ubuntu2004-large
@@ -1573,6 +1696,46 @@ tasks:
         vars:
           CC: gcc
       - func: upload-build
+  - name: cse-sasl-cyrus-openssl-debian10-gcc-test-4.2-replica-auth
+    run_on: debian10-small
+    tags: [cse-matrix-openssl, test, debian10, gcc, sasl-cyrus, cse, auth, replica, "4.2", openssl]
+    depends_on: [{ name: cse-sasl-cyrus-openssl-debian10-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: cse-sasl-cyrus-openssl-debian10-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.2" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: cse-sasl-cyrus-openssl-debian10-gcc-test-4.2-server-auth
+    run_on: debian10-small
+    tags: [cse-matrix-openssl, test, debian10, gcc, sasl-cyrus, cse, auth, server, "4.2", openssl]
+    depends_on: [{ name: cse-sasl-cyrus-openssl-debian10-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: cse-sasl-cyrus-openssl-debian10-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.2" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-mock-kms-servers
+      - func: run-tests
   - name: cse-sasl-cyrus-openssl-debian11-gcc-compile
     run_on: debian11-large
     tags: [cse-matrix-openssl, compile, debian11, gcc, cse, sasl-cyrus]
@@ -3222,6 +3385,46 @@ tasks:
         vars:
           CC: gcc
       - func: upload-build
+  - name: sasl-cyrus-openssl-debian10-gcc-test-4.2-replica-auth
+    run_on: debian10-small
+    tags: [sasl-matrix-openssl, test, debian10, gcc, sasl-cyrus, auth, replica, "4.2", openssl]
+    depends_on: [{ name: sasl-cyrus-openssl-debian10-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: sasl-cyrus-openssl-debian10-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.2" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: sasl-cyrus-openssl-debian10-gcc-test-4.2-server-auth
+    run_on: debian10-small
+    tags: [sasl-matrix-openssl, test, debian10, gcc, sasl-cyrus, auth, server, "4.2", openssl]
+    depends_on: [{ name: sasl-cyrus-openssl-debian10-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: sasl-cyrus-openssl-debian10-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.2" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
   - name: sasl-cyrus-openssl-debian11-gcc-compile
     run_on: debian11-large
     tags: [sasl-matrix-openssl, compile, debian11, gcc, sasl-cyrus]
@@ -3990,6 +4193,75 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
+  - name: sasl-off-nossl-debian10-gcc-compile
+    run_on: debian10-large
+    tags: [sasl-matrix-nossl, compile, debian10, gcc, sasl-off]
+    commands:
+      - func: find-cmake-latest
+      - func: sasl-off-nossl-compile
+        vars:
+          CC: gcc
+      - func: upload-build
+  - name: sasl-off-nossl-debian10-gcc-test-4.2-replica-noauth
+    run_on: debian10-small
+    tags: [sasl-matrix-nossl, test, debian10, gcc, sasl-off, noauth, replica, "4.2"]
+    depends_on: [{ name: sasl-off-nossl-debian10-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: sasl-off-nossl-debian10-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: noauth }
+            - { key: MONGODB_VERSION, value: "4.2" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: nossl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: sasl-off-nossl-debian10-gcc-test-4.2-server-noauth
+    run_on: debian10-small
+    tags: [sasl-matrix-nossl, test, debian10, gcc, sasl-off, noauth, server, "4.2"]
+    depends_on: [{ name: sasl-off-nossl-debian10-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: sasl-off-nossl-debian10-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: noauth }
+            - { key: MONGODB_VERSION, value: "4.2" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: nossl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: sasl-off-nossl-debian10-gcc-test-4.2-sharded-noauth
+    run_on: debian10-small
+    tags: [sasl-matrix-nossl, test, debian10, gcc, sasl-off, noauth, sharded, "4.2"]
+    depends_on: [{ name: sasl-off-nossl-debian10-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: sasl-off-nossl-debian10-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: noauth }
+            - { key: MONGODB_VERSION, value: "4.2" }
+            - { key: TOPOLOGY, value: sharded_cluster }
+            - { key: SSL, value: nossl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
   - name: sasl-off-nossl-ubuntu2004-gcc-compile
     run_on: ubuntu2004-large
     tags: [sasl-matrix-nossl, compile, ubuntu2004, gcc, sasl-off]
@@ -4669,6 +4941,75 @@ tasks:
         vars:
           CC: Visual Studio 15 2017 Win64
           C_STD_VERSION: 17
+  - name: tsan-sasl-cyrus-openssl-debian10-clang-compile
+    run_on: debian10-large
+    tags: [sanitizers-matrix-tsan, compile, debian10, clang, tsan, sasl-cyrus]
+    commands:
+      - func: find-cmake-latest
+      - func: sasl-cyrus-openssl-compile
+        vars:
+          CC: clang
+      - func: upload-build
+  - name: tsan-sasl-cyrus-openssl-debian10-clang-test-4.2-replica-auth
+    run_on: debian10-small
+    tags: [sanitizers-matrix-tsan, test, debian10, clang, sasl-cyrus, tsan, auth, replica, "4.2", openssl]
+    depends_on: [{ name: tsan-sasl-cyrus-openssl-debian10-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: tsan-sasl-cyrus-openssl-debian10-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.2" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: tsan-sasl-cyrus-openssl-debian10-clang-test-4.2-server-auth
+    run_on: debian10-small
+    tags: [sanitizers-matrix-tsan, test, debian10, clang, sasl-cyrus, tsan, auth, server, "4.2", openssl]
+    depends_on: [{ name: tsan-sasl-cyrus-openssl-debian10-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: tsan-sasl-cyrus-openssl-debian10-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.2" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: tsan-sasl-cyrus-openssl-debian10-clang-test-4.2-sharded-auth
+    run_on: debian10-small
+    tags: [sanitizers-matrix-tsan, test, debian10, clang, sasl-cyrus, tsan, auth, sharded, "4.2", openssl]
+    depends_on: [{ name: tsan-sasl-cyrus-openssl-debian10-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: tsan-sasl-cyrus-openssl-debian10-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.2" }
+            - { key: TOPOLOGY, value: sharded_cluster }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
   - name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile
     run_on: ubuntu2004-large
     tags: [sanitizers-matrix-tsan, compile, ubuntu2004, clang, tsan, sasl-cyrus]

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -995,6 +995,42 @@ tasks:
             - --test_mongocxx_ref=r3.9.0
             - --env=${MONGOC_EARTHLY_ENV}
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
+  - name: "check:sasl=Cyrus\_\u2022\_tls=OpenSSL\_\u2022\_test_mongocxx_ref=none"
+    run_on:
+      - ubuntu2204-small
+      - ubuntu2204-large
+      - ubuntu2004-small
+      - ubuntu2004
+      - debian10
+      - debian11
+      - amazon2
+    tags: [earthly, pr-merge-gate, u16-clang, u16-gcc]
+    commands:
+      - command: subprocess.exec
+        type: setup
+        params:
+          binary: ./tools/earthly.sh
+          working_dir: mongoc
+          args:
+            - +env-warmup
+            - --sasl=Cyrus
+            - --tls=OpenSSL
+            - --test_mongocxx_ref=none
+            - --env=${MONGOC_EARTHLY_ENV}
+            - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
+      - command: subprocess.exec
+        type: test
+        params:
+          binary: ./tools/earthly.sh
+          working_dir: mongoc
+          args:
+            - +run
+            - --targets=test-example
+            - --sasl=Cyrus
+            - --tls=OpenSSL
+            - --test_mongocxx_ref=none
+            - --env=${MONGOC_EARTHLY_ENV}
+            - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
   - name: "check:sasl=Cyrus\_\u2022\_tls=OpenSSL\_\u2022\_test_mongocxx_ref=r3.8.0"
     run_on:
       - ubuntu2204-small
@@ -1065,6 +1101,42 @@ tasks:
             - --sasl=Cyrus
             - --tls=OpenSSL
             - --test_mongocxx_ref=r3.9.0
+            - --env=${MONGOC_EARTHLY_ENV}
+            - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
+  - name: "check:sasl=Cyrus\_\u2022\_tls=off\_\u2022\_test_mongocxx_ref=none"
+    run_on:
+      - ubuntu2204-small
+      - ubuntu2204-large
+      - ubuntu2004-small
+      - ubuntu2004
+      - debian10
+      - debian11
+      - amazon2
+    tags: [earthly, pr-merge-gate, u16-clang, u16-gcc]
+    commands:
+      - command: subprocess.exec
+        type: setup
+        params:
+          binary: ./tools/earthly.sh
+          working_dir: mongoc
+          args:
+            - +env-warmup
+            - --sasl=Cyrus
+            - --tls=off
+            - --test_mongocxx_ref=none
+            - --env=${MONGOC_EARTHLY_ENV}
+            - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
+      - command: subprocess.exec
+        type: test
+        params:
+          binary: ./tools/earthly.sh
+          working_dir: mongoc
+          args:
+            - +run
+            - --targets=test-example
+            - --sasl=Cyrus
+            - --tls=off
+            - --test_mongocxx_ref=none
             - --env=${MONGOC_EARTHLY_ENV}
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
   - name: "check:sasl=Cyrus\_\u2022\_tls=off\_\u2022\_test_mongocxx_ref=r3.8.0"

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -1004,7 +1004,7 @@ tasks:
       - debian10
       - debian11
       - amazon2
-    tags: [earthly, pr-merge-gate, u16-clang, u16-gcc]
+    tags: [earthly, pr-merge-gate, centos7-clang, centos7-gcc, u16-clang, u16-gcc]
     commands:
       - command: subprocess.exec
         type: setup
@@ -1112,7 +1112,7 @@ tasks:
       - debian10
       - debian11
       - amazon2
-    tags: [earthly, pr-merge-gate, u16-clang, u16-gcc]
+    tags: [earthly, pr-merge-gate, centos7-clang, centos7-gcc, u16-clang, u16-gcc]
     commands:
       - command: subprocess.exec
         type: setup

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -2,195 +2,6 @@ tasks:
   - name: abi-compliance-check
     commands:
       - func: abi-compliance-check
-  - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile
-    run_on: ubuntu1804-large
-    tags: [sanitizers-matrix-asan, compile, ubuntu1804, clang, cse, asan, sasl-cyrus]
-    commands:
-      - func: find-cmake-latest
-      - func: cse-sasl-cyrus-openssl-compile
-        vars:
-          CC: clang
-      - func: upload-build
-  - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-4.2-server-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, cse, asan, auth, server, "4.2", openssl]
-    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.2" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-            - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-mock-kms-servers
-      - func: run-tests
-  - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-4.2-server-auth-with-mongocrypt
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, cse, asan, auth, server, "4.2", with-mongocrypt, openssl]
-    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.2" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-            - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
-            - { key: SKIP_CRYPT_SHARED_LIB, value: "on" }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-mock-kms-servers
-      - func: run-tests
-  - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-4.4-server-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, cse, asan, auth, server, "4.4", openssl]
-    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.4" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-            - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-mock-kms-servers
-      - func: run-tests
-  - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-4.4-server-auth-with-mongocrypt
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, cse, asan, auth, server, "4.4", with-mongocrypt, openssl]
-    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.4" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-            - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
-            - { key: SKIP_CRYPT_SHARED_LIB, value: "on" }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-mock-kms-servers
-      - func: run-tests
-  - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-5.0-server-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, cse, asan, auth, server, "5.0", openssl]
-    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "5.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-            - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-mock-kms-servers
-      - func: run-tests
-  - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-5.0-server-auth-with-mongocrypt
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, cse, asan, auth, server, "5.0", with-mongocrypt, openssl]
-    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "5.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-            - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
-            - { key: SKIP_CRYPT_SHARED_LIB, value: "on" }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-mock-kms-servers
-      - func: run-tests
-  - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-6.0-server-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, cse, asan, auth, server, "6.0", openssl]
-    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "6.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-            - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-mock-kms-servers
-      - func: run-tests
-  - name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-test-6.0-server-auth-with-mongocrypt
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, cse, asan, auth, server, "6.0", with-mongocrypt, openssl]
-    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "6.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-            - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
-            - { key: SKIP_CRYPT_SHARED_LIB, value: "on" }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-mock-kms-servers
-      - func: run-tests
   - name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile
     run_on: ubuntu2004-large
     tags: [sanitizers-matrix-asan, compile, ubuntu2004, clang, cse, asan, sasl-cyrus]
@@ -200,6 +11,276 @@ tasks:
         vars:
           CC: clang
       - func: upload-build
+  - name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-test-4.4-replica-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, cse, asan, auth, replica, "4.4", openssl]
+    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.4" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: openssl }
+            - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-test-4.4-replica-auth-with-mongocrypt
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, cse, asan, auth, replica, "4.4", with-mongocrypt, openssl]
+    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.4" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: openssl }
+            - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
+            - { key: SKIP_CRYPT_SHARED_LIB, value: "on" }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-test-4.4-server-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, cse, asan, auth, server, "4.4", openssl]
+    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.4" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+            - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-test-4.4-server-auth-with-mongocrypt
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, cse, asan, auth, server, "4.4", with-mongocrypt, openssl]
+    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.4" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+            - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
+            - { key: SKIP_CRYPT_SHARED_LIB, value: "on" }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-test-5.0-replica-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, cse, asan, auth, replica, "5.0", openssl]
+    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "5.0" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: openssl }
+            - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-test-5.0-replica-auth-with-mongocrypt
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, cse, asan, auth, replica, "5.0", with-mongocrypt, openssl]
+    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "5.0" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: openssl }
+            - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
+            - { key: SKIP_CRYPT_SHARED_LIB, value: "on" }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-test-5.0-server-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, cse, asan, auth, server, "5.0", openssl]
+    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "5.0" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+            - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-test-5.0-server-auth-with-mongocrypt
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, cse, asan, auth, server, "5.0", with-mongocrypt, openssl]
+    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "5.0" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+            - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
+            - { key: SKIP_CRYPT_SHARED_LIB, value: "on" }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-test-6.0-replica-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, cse, asan, auth, replica, "6.0", openssl]
+    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "6.0" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: openssl }
+            - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-test-6.0-replica-auth-with-mongocrypt
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, cse, asan, auth, replica, "6.0", with-mongocrypt, openssl]
+    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "6.0" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: openssl }
+            - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
+            - { key: SKIP_CRYPT_SHARED_LIB, value: "on" }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-test-6.0-server-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, cse, asan, auth, server, "6.0", openssl]
+    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "6.0" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+            - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-test-6.0-server-auth-with-mongocrypt
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, cse, asan, auth, server, "6.0", with-mongocrypt, openssl]
+    depends_on: [{ name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "6.0" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+            - { key: CLIENT_SIDE_ENCRYPTION, value: "on" }
+            - { key: SKIP_CRYPT_SHARED_LIB, value: "on" }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-mock-kms-servers
+      - func: run-tests
   - name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-test-7.0-replica-auth
     run_on: ubuntu2004-small
     tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, cse, asan, auth, replica, "7.0", openssl]
@@ -470,324 +551,6 @@ tasks:
       - func: run-simple-http-server
       - func: run-mock-kms-servers
       - func: run-tests
-  - name: asan-sasl-cyrus-openssl-ubuntu1604-clang-compile
-    run_on: ubuntu1604-large
-    tags: [sanitizers-matrix-asan, compile, ubuntu1604, clang, asan, sasl-cyrus]
-    commands:
-      - func: find-cmake-latest
-      - func: sasl-cyrus-openssl-compile
-        vars:
-          CC: clang
-      - func: upload-build
-  - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-    run_on: ubuntu1804-large
-    tags: [sanitizers-matrix-asan, compile, ubuntu1804, clang, asan, sasl-cyrus]
-    commands:
-      - func: find-cmake-latest
-      - func: sasl-cyrus-openssl-compile
-        vars:
-          CC: clang
-      - func: upload-build
-  - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.0-replica-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, asan, auth, replica, "4.0", openssl]
-    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.0" }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.0-server-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, asan, auth, server, "4.0", openssl]
-    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.0-sharded-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, asan, auth, sharded, "4.0", openssl]
-    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.0" }
-            - { key: TOPOLOGY, value: sharded_cluster }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.2-replica-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, asan, auth, replica, "4.2", openssl]
-    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.2" }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.2-server-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, asan, auth, server, "4.2", openssl]
-    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.2" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.2-sharded-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, asan, auth, sharded, "4.2", openssl]
-    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.2" }
-            - { key: TOPOLOGY, value: sharded_cluster }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.4-replica-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, asan, auth, replica, "4.4", openssl]
-    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.4" }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.4-server-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, asan, auth, server, "4.4", openssl]
-    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.4" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.4-sharded-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, asan, auth, sharded, "4.4", openssl]
-    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.4" }
-            - { key: TOPOLOGY, value: sharded_cluster }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-5.0-replica-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, asan, auth, replica, "5.0", openssl]
-    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "5.0" }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-5.0-server-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, asan, auth, server, "5.0", openssl]
-    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "5.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-5.0-sharded-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, asan, auth, sharded, "5.0", openssl]
-    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "5.0" }
-            - { key: TOPOLOGY, value: sharded_cluster }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-6.0-replica-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, asan, auth, replica, "6.0", openssl]
-    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "6.0" }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-6.0-server-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, asan, auth, server, "6.0", openssl]
-    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "6.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: asan-sasl-cyrus-openssl-ubuntu1804-clang-test-6.0-sharded-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-asan, test, ubuntu1804, clang, sasl-cyrus, asan, auth, sharded, "6.0", openssl]
-    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "6.0" }
-            - { key: TOPOLOGY, value: sharded_cluster }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
   - name: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile
     run_on: ubuntu2004-large
     tags: [sanitizers-matrix-asan, compile, ubuntu2004, clang, asan, sasl-cyrus]
@@ -797,6 +560,186 @@ tasks:
         vars:
           CC: clang
       - func: upload-build
+  - name: asan-sasl-cyrus-openssl-ubuntu2004-clang-test-4.4-replica-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, asan, auth, replica, "4.4", openssl]
+    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.4" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: asan-sasl-cyrus-openssl-ubuntu2004-clang-test-4.4-server-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, asan, auth, server, "4.4", openssl]
+    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.4" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: asan-sasl-cyrus-openssl-ubuntu2004-clang-test-4.4-sharded-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, asan, auth, sharded, "4.4", openssl]
+    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.4" }
+            - { key: TOPOLOGY, value: sharded_cluster }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: asan-sasl-cyrus-openssl-ubuntu2004-clang-test-5.0-replica-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, asan, auth, replica, "5.0", openssl]
+    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "5.0" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: asan-sasl-cyrus-openssl-ubuntu2004-clang-test-5.0-server-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, asan, auth, server, "5.0", openssl]
+    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "5.0" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: asan-sasl-cyrus-openssl-ubuntu2004-clang-test-5.0-sharded-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, asan, auth, sharded, "5.0", openssl]
+    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "5.0" }
+            - { key: TOPOLOGY, value: sharded_cluster }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: asan-sasl-cyrus-openssl-ubuntu2004-clang-test-6.0-replica-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, asan, auth, replica, "6.0", openssl]
+    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "6.0" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: asan-sasl-cyrus-openssl-ubuntu2004-clang-test-6.0-server-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, asan, auth, server, "6.0", openssl]
+    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "6.0" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: asan-sasl-cyrus-openssl-ubuntu2004-clang-test-6.0-sharded-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, asan, auth, sharded, "6.0", openssl]
+    depends_on: [{ name: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: asan-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "6.0" }
+            - { key: TOPOLOGY, value: sharded_cluster }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
   - name: asan-sasl-cyrus-openssl-ubuntu2004-clang-test-7.0-replica-auth
     run_on: ubuntu2004-small
     tags: [sanitizers-matrix-asan, test, ubuntu2004, clang, sasl-cyrus, asan, auth, replica, "7.0", openssl]
@@ -986,7 +929,6 @@ tasks:
       - ubuntu2204-large
       - ubuntu2004-small
       - ubuntu2004
-      - ubuntu1804-medium
       - debian10
       - debian11
       - amazon2
@@ -1023,7 +965,6 @@ tasks:
       - ubuntu2204-large
       - ubuntu2004-small
       - ubuntu2004
-      - ubuntu1804-medium
       - debian10
       - debian11
       - amazon2
@@ -1060,7 +1001,6 @@ tasks:
       - ubuntu2204-large
       - ubuntu2004-small
       - ubuntu2004
-      - ubuntu1804-medium
       - debian10
       - debian11
       - amazon2
@@ -1097,7 +1037,6 @@ tasks:
       - ubuntu2204-large
       - ubuntu2004-small
       - ubuntu2004
-      - ubuntu1804-medium
       - debian10
       - debian11
       - amazon2
@@ -1134,7 +1073,6 @@ tasks:
       - ubuntu2204-large
       - ubuntu2004-small
       - ubuntu2004
-      - ubuntu1804-medium
       - debian10
       - debian11
       - amazon2
@@ -1171,7 +1109,6 @@ tasks:
       - ubuntu2204-large
       - ubuntu2004-small
       - ubuntu2004
-      - ubuntu1804-medium
       - debian10
       - debian11
       - amazon2
@@ -1208,7 +1145,6 @@ tasks:
       - ubuntu2204-large
       - ubuntu2004-small
       - ubuntu2004
-      - ubuntu1804-medium
       - debian10
       - debian11
       - amazon2
@@ -1249,7 +1185,6 @@ tasks:
       - ubuntu2204-large
       - ubuntu2004-small
       - ubuntu2004
-      - ubuntu1804-medium
       - debian10
       - debian11
       - amazon2
@@ -1751,193 +1686,6 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-mock-kms-servers
       - func: run-tests
-  - name: cse-sasl-cyrus-openssl-ubuntu1604-clang-compile
-    run_on: ubuntu1604-large
-    tags: [cse-matrix-openssl, compile, ubuntu1604, clang, cse, sasl-cyrus]
-    commands:
-      - func: find-cmake-latest
-      - func: cse-sasl-cyrus-openssl-compile
-        vars:
-          CC: clang
-      - func: upload-build
-  - name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile
-    run_on: ubuntu1804-arm64-large
-    tags: [cse-matrix-openssl, compile, ubuntu1804-arm64, gcc, cse, sasl-cyrus]
-    commands:
-      - func: find-cmake-latest
-      - func: cse-sasl-cyrus-openssl-compile
-        vars:
-          CC: gcc
-      - func: upload-build
-  - name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-4.2-server-auth
-    run_on: ubuntu1804-arm64-small
-    tags: [cse-matrix-openssl, test, ubuntu1804-arm64, gcc, sasl-cyrus, cse, auth, server, "4.2", openssl]
-    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.2" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-mock-kms-servers
-      - func: run-tests
-  - name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-4.4-server-auth
-    run_on: ubuntu1804-arm64-small
-    tags: [cse-matrix-openssl, test, ubuntu1804-arm64, gcc, sasl-cyrus, cse, auth, server, "4.4", openssl]
-    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.4" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-mock-kms-servers
-      - func: run-tests
-  - name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-5.0-server-auth
-    run_on: ubuntu1804-arm64-small
-    tags: [cse-matrix-openssl, test, ubuntu1804-arm64, gcc, sasl-cyrus, cse, auth, server, "5.0", openssl]
-    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "5.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-mock-kms-servers
-      - func: run-tests
-  - name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-6.0-server-auth
-    run_on: ubuntu1804-arm64-small
-    tags: [cse-matrix-openssl, test, ubuntu1804-arm64, gcc, sasl-cyrus, cse, auth, server, "6.0", openssl]
-    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "6.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-mock-kms-servers
-      - func: run-tests
-  - name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-compile
-    run_on: ubuntu1804-large
-    tags: [cse-matrix-openssl, compile, ubuntu1804, gcc, cse, sasl-cyrus]
-    commands:
-      - func: find-cmake-latest
-      - func: cse-sasl-cyrus-openssl-compile
-        vars:
-          CC: gcc
-      - func: upload-build
-  - name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-test-4.2-server-auth
-    run_on: ubuntu1804-small
-    tags: [cse-matrix-openssl, test, ubuntu1804, gcc, sasl-cyrus, cse, auth, server, "4.2", openssl]
-    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.2" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-mock-kms-servers
-      - func: run-tests
-  - name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-test-4.4-server-auth
-    run_on: ubuntu1804-small
-    tags: [cse-matrix-openssl, test, ubuntu1804, gcc, sasl-cyrus, cse, auth, server, "4.4", openssl]
-    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.4" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-mock-kms-servers
-      - func: run-tests
-  - name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-test-5.0-server-auth
-    run_on: ubuntu1804-small
-    tags: [cse-matrix-openssl, test, ubuntu1804, gcc, sasl-cyrus, cse, auth, server, "5.0", openssl]
-    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "5.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-mock-kms-servers
-      - func: run-tests
-  - name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-test-6.0-server-auth
-    run_on: ubuntu1804-small
-    tags: [cse-matrix-openssl, test, ubuntu1804, gcc, sasl-cyrus, cse, auth, server, "6.0", openssl]
-    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "6.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-mock-kms-servers
-      - func: run-tests
   - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
     run_on: ubuntu2004-arm64-large
     tags: [cse-matrix-openssl, compile, ubuntu2004-arm64, gcc, cse, sasl-cyrus]
@@ -1947,6 +1695,126 @@ tasks:
         vars:
           CC: gcc
       - func: upload-build
+  - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-4.4-replica-auth
+    run_on: ubuntu2004-arm64-small
+    tags: [cse-matrix-openssl, test, ubuntu2004-arm64, gcc, sasl-cyrus, cse, auth, replica, "4.4", openssl]
+    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.4" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-4.4-server-auth
+    run_on: ubuntu2004-arm64-small
+    tags: [cse-matrix-openssl, test, ubuntu2004-arm64, gcc, sasl-cyrus, cse, auth, server, "4.4", openssl]
+    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.4" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-5.0-replica-auth
+    run_on: ubuntu2004-arm64-small
+    tags: [cse-matrix-openssl, test, ubuntu2004-arm64, gcc, sasl-cyrus, cse, auth, replica, "5.0", openssl]
+    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "5.0" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-5.0-server-auth
+    run_on: ubuntu2004-arm64-small
+    tags: [cse-matrix-openssl, test, ubuntu2004-arm64, gcc, sasl-cyrus, cse, auth, server, "5.0", openssl]
+    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "5.0" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-6.0-replica-auth
+    run_on: ubuntu2004-arm64-small
+    tags: [cse-matrix-openssl, test, ubuntu2004-arm64, gcc, sasl-cyrus, cse, auth, replica, "6.0", openssl]
+    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "6.0" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-6.0-server-auth
+    run_on: ubuntu2004-arm64-small
+    tags: [cse-matrix-openssl, test, ubuntu2004-arm64, gcc, sasl-cyrus, cse, auth, server, "6.0", openssl]
+    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "6.0" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-mock-kms-servers
+      - func: run-tests
   - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-7.0-replica-auth
     run_on: ubuntu2004-arm64-small
     tags: [cse-matrix-openssl, test, ubuntu2004-arm64, gcc, sasl-cyrus, cse, auth, replica, "7.0", openssl]
@@ -2076,6 +1944,126 @@ tasks:
         vars:
           CC: gcc
       - func: upload-build
+  - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-4.4-replica-auth
+    run_on: ubuntu2004-small
+    tags: [cse-matrix-openssl, test, ubuntu2004, gcc, sasl-cyrus, cse, auth, replica, "4.4", openssl]
+    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu2004-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.4" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-4.4-server-auth
+    run_on: ubuntu2004-small
+    tags: [cse-matrix-openssl, test, ubuntu2004, gcc, sasl-cyrus, cse, auth, server, "4.4", openssl]
+    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu2004-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.4" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-5.0-replica-auth
+    run_on: ubuntu2004-small
+    tags: [cse-matrix-openssl, test, ubuntu2004, gcc, sasl-cyrus, cse, auth, replica, "5.0", openssl]
+    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu2004-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "5.0" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-5.0-server-auth
+    run_on: ubuntu2004-small
+    tags: [cse-matrix-openssl, test, ubuntu2004, gcc, sasl-cyrus, cse, auth, server, "5.0", openssl]
+    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu2004-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "5.0" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-6.0-replica-auth
+    run_on: ubuntu2004-small
+    tags: [cse-matrix-openssl, test, ubuntu2004, gcc, sasl-cyrus, cse, auth, replica, "6.0", openssl]
+    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu2004-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "6.0" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-mock-kms-servers
+      - func: run-tests
+  - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-6.0-server-auth
+    run_on: ubuntu2004-small
+    tags: [cse-matrix-openssl, test, ubuntu2004, gcc, sasl-cyrus, cse, auth, server, "6.0", openssl]
+    depends_on: [{ name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: cse-sasl-cyrus-openssl-ubuntu2004-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "6.0" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-mock-kms-servers
+      - func: run-tests
   - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-7.0-replica-auth
     run_on: ubuntu2004-small
     tags: [cse-matrix-openssl, test, ubuntu2004, gcc, sasl-cyrus, cse, auth, replica, "7.0", openssl]
@@ -3456,342 +3444,6 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: sasl-cyrus-openssl-ubuntu1604-arm64-gcc-compile
-    run_on: ubuntu1604-arm64-large
-    tags: [sasl-matrix-openssl, compile, ubuntu1604-arm64, gcc, sasl-cyrus]
-    commands:
-      - func: find-cmake-latest
-      - func: sasl-cyrus-openssl-compile
-        vars:
-          CC: gcc
-      - func: upload-build
-  - name: sasl-cyrus-openssl-ubuntu1604-arm64-gcc-test-4.0-server-auth
-    run_on: ubuntu1604-arm64-small
-    tags: [sasl-matrix-openssl, test, ubuntu1604-arm64, gcc, sasl-cyrus, auth, server, "4.0", openssl]
-    depends_on: [{ name: sasl-cyrus-openssl-ubuntu1604-arm64-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-cyrus-openssl-ubuntu1604-arm64-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-cyrus-openssl-ubuntu1604-clang-compile
-    run_on: ubuntu1604-large
-    tags: [sasl-matrix-openssl, compile, ubuntu1604, clang, sasl-cyrus]
-    commands:
-      - func: find-cmake-latest
-      - func: sasl-cyrus-openssl-compile
-        vars:
-          CC: clang
-      - func: upload-build
-  - name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile
-    run_on: ubuntu1804-arm64-large
-    tags: [sasl-matrix-openssl, compile, ubuntu1804-arm64, gcc, sasl-cyrus]
-    commands:
-      - func: find-cmake-latest
-      - func: sasl-cyrus-openssl-compile
-        vars:
-          CC: gcc
-      - func: upload-build
-  - name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-4.2-server-auth
-    run_on: ubuntu1804-arm64-small
-    tags: [sasl-matrix-openssl, test, ubuntu1804-arm64, gcc, sasl-cyrus, auth, server, "4.2", openssl]
-    depends_on: [{ name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.2" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-4.4-server-auth
-    run_on: ubuntu1804-arm64-small
-    tags: [sasl-matrix-openssl, test, ubuntu1804-arm64, gcc, sasl-cyrus, auth, server, "4.4", openssl]
-    depends_on: [{ name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.4" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-5.0-server-auth
-    run_on: ubuntu1804-arm64-small
-    tags: [sasl-matrix-openssl, test, ubuntu1804-arm64, gcc, sasl-cyrus, auth, server, "5.0", openssl]
-    depends_on: [{ name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "5.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-6.0-server-auth
-    run_on: ubuntu1804-arm64-small
-    tags: [sasl-matrix-openssl, test, ubuntu1804-arm64, gcc, sasl-cyrus, auth, server, "6.0", openssl]
-    depends_on: [{ name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "6.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-cyrus-openssl-ubuntu1804-gcc-compile
-    run_on: ubuntu1804-large
-    tags: [sasl-matrix-openssl, compile, ubuntu1804, gcc, sasl-cyrus]
-    commands:
-      - func: find-cmake-latest
-      - func: sasl-cyrus-openssl-compile
-        vars:
-          CC: gcc
-      - func: upload-build
-  - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-4.0-replica-auth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-openssl, test, ubuntu1804, gcc, sasl-cyrus, auth, replica, "4.0", openssl]
-    depends_on: [{ name: sasl-cyrus-openssl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-cyrus-openssl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.0" }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-4.0-server-auth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-openssl, test, ubuntu1804, gcc, sasl-cyrus, auth, server, "4.0", openssl]
-    depends_on: [{ name: sasl-cyrus-openssl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-cyrus-openssl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-4.2-replica-auth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-openssl, test, ubuntu1804, gcc, sasl-cyrus, auth, replica, "4.2", openssl]
-    depends_on: [{ name: sasl-cyrus-openssl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-cyrus-openssl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.2" }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-4.2-server-auth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-openssl, test, ubuntu1804, gcc, sasl-cyrus, auth, server, "4.2", openssl]
-    depends_on: [{ name: sasl-cyrus-openssl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-cyrus-openssl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.2" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-4.4-replica-auth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-openssl, test, ubuntu1804, gcc, sasl-cyrus, auth, replica, "4.4", openssl]
-    depends_on: [{ name: sasl-cyrus-openssl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-cyrus-openssl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.4" }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-4.4-server-auth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-openssl, test, ubuntu1804, gcc, sasl-cyrus, auth, server, "4.4", openssl]
-    depends_on: [{ name: sasl-cyrus-openssl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-cyrus-openssl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.4" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-5.0-replica-auth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-openssl, test, ubuntu1804, gcc, sasl-cyrus, auth, replica, "5.0", openssl]
-    depends_on: [{ name: sasl-cyrus-openssl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-cyrus-openssl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "5.0" }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-5.0-server-auth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-openssl, test, ubuntu1804, gcc, sasl-cyrus, auth, server, "5.0", openssl]
-    depends_on: [{ name: sasl-cyrus-openssl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-cyrus-openssl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "5.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-6.0-replica-auth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-openssl, test, ubuntu1804, gcc, sasl-cyrus, auth, replica, "6.0", openssl]
-    depends_on: [{ name: sasl-cyrus-openssl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-cyrus-openssl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "6.0" }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-6.0-server-auth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-openssl, test, ubuntu1804, gcc, sasl-cyrus, auth, server, "6.0", openssl]
-    depends_on: [{ name: sasl-cyrus-openssl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-cyrus-openssl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "6.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
   - name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
     run_on: ubuntu2004-arm64-large
     tags: [sasl-matrix-openssl, compile, ubuntu2004-arm64, gcc, sasl-cyrus]
@@ -3801,6 +3453,66 @@ tasks:
         vars:
           CC: gcc
       - func: upload-build
+  - name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-4.4-server-auth
+    run_on: ubuntu2004-arm64-small
+    tags: [sasl-matrix-openssl, test, ubuntu2004-arm64, gcc, sasl-cyrus, auth, server, "4.4", openssl]
+    depends_on: [{ name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.4" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-5.0-server-auth
+    run_on: ubuntu2004-arm64-small
+    tags: [sasl-matrix-openssl, test, ubuntu2004-arm64, gcc, sasl-cyrus, auth, server, "5.0", openssl]
+    depends_on: [{ name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "5.0" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-6.0-server-auth
+    run_on: ubuntu2004-arm64-small
+    tags: [sasl-matrix-openssl, test, ubuntu2004-arm64, gcc, sasl-cyrus, auth, server, "6.0", openssl]
+    depends_on: [{ name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "6.0" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
   - name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-7.0-server-auth
     run_on: ubuntu2004-arm64-small
     tags: [sasl-matrix-openssl, test, ubuntu2004-arm64, gcc, sasl-cyrus, auth, server, "7.0", openssl]
@@ -3870,6 +3582,66 @@ tasks:
         vars:
           CC: gcc
       - func: upload-build
+  - name: sasl-cyrus-openssl-ubuntu2004-gcc-test-4.4-server-auth
+    run_on: ubuntu2004-small
+    tags: [sasl-matrix-openssl, test, ubuntu2004, gcc, sasl-cyrus, auth, server, "4.4", openssl]
+    depends_on: [{ name: sasl-cyrus-openssl-ubuntu2004-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: sasl-cyrus-openssl-ubuntu2004-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.4" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: sasl-cyrus-openssl-ubuntu2004-gcc-test-5.0-server-auth
+    run_on: ubuntu2004-small
+    tags: [sasl-matrix-openssl, test, ubuntu2004, gcc, sasl-cyrus, auth, server, "5.0", openssl]
+    depends_on: [{ name: sasl-cyrus-openssl-ubuntu2004-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: sasl-cyrus-openssl-ubuntu2004-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "5.0" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: sasl-cyrus-openssl-ubuntu2004-gcc-test-6.0-server-auth
+    run_on: ubuntu2004-small
+    tags: [sasl-matrix-openssl, test, ubuntu2004, gcc, sasl-cyrus, auth, server, "6.0", openssl]
+    depends_on: [{ name: sasl-cyrus-openssl-ubuntu2004-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: sasl-cyrus-openssl-ubuntu2004-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "6.0" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
   - name: sasl-cyrus-openssl-ubuntu2004-gcc-test-7.0-server-auth
     run_on: ubuntu2004-small
     tags: [sasl-matrix-openssl, test, ubuntu2004, gcc, sasl-cyrus, auth, server, "7.0", openssl]
@@ -4137,324 +3909,6 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: sasl-off-nossl-ubuntu1604-gcc-compile
-    run_on: ubuntu1604-large
-    tags: [sasl-matrix-nossl, compile, ubuntu1604, gcc, sasl-off]
-    commands:
-      - func: find-cmake-latest
-      - func: sasl-off-nossl-compile
-        vars:
-          CC: gcc
-      - func: upload-build
-  - name: sasl-off-nossl-ubuntu1804-gcc-compile
-    run_on: ubuntu1804-large
-    tags: [sasl-matrix-nossl, compile, ubuntu1804, gcc, sasl-off]
-    commands:
-      - func: find-cmake-latest
-      - func: sasl-off-nossl-compile
-        vars:
-          CC: gcc
-      - func: upload-build
-  - name: sasl-off-nossl-ubuntu1804-gcc-test-4.0-replica-noauth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-nossl, test, ubuntu1804, gcc, sasl-off, noauth, replica, "4.0"]
-    depends_on: [{ name: sasl-off-nossl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-off-nossl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: noauth }
-            - { key: MONGODB_VERSION, value: "4.0" }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: nossl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-off-nossl-ubuntu1804-gcc-test-4.0-server-noauth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-nossl, test, ubuntu1804, gcc, sasl-off, noauth, server, "4.0"]
-    depends_on: [{ name: sasl-off-nossl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-off-nossl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: noauth }
-            - { key: MONGODB_VERSION, value: "4.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: nossl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-off-nossl-ubuntu1804-gcc-test-4.0-sharded-noauth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-nossl, test, ubuntu1804, gcc, sasl-off, noauth, sharded, "4.0"]
-    depends_on: [{ name: sasl-off-nossl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-off-nossl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: noauth }
-            - { key: MONGODB_VERSION, value: "4.0" }
-            - { key: TOPOLOGY, value: sharded_cluster }
-            - { key: SSL, value: nossl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-off-nossl-ubuntu1804-gcc-test-4.2-replica-noauth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-nossl, test, ubuntu1804, gcc, sasl-off, noauth, replica, "4.2"]
-    depends_on: [{ name: sasl-off-nossl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-off-nossl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: noauth }
-            - { key: MONGODB_VERSION, value: "4.2" }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: nossl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-off-nossl-ubuntu1804-gcc-test-4.2-server-noauth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-nossl, test, ubuntu1804, gcc, sasl-off, noauth, server, "4.2"]
-    depends_on: [{ name: sasl-off-nossl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-off-nossl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: noauth }
-            - { key: MONGODB_VERSION, value: "4.2" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: nossl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-off-nossl-ubuntu1804-gcc-test-4.2-sharded-noauth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-nossl, test, ubuntu1804, gcc, sasl-off, noauth, sharded, "4.2"]
-    depends_on: [{ name: sasl-off-nossl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-off-nossl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: noauth }
-            - { key: MONGODB_VERSION, value: "4.2" }
-            - { key: TOPOLOGY, value: sharded_cluster }
-            - { key: SSL, value: nossl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-off-nossl-ubuntu1804-gcc-test-4.4-replica-noauth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-nossl, test, ubuntu1804, gcc, sasl-off, noauth, replica, "4.4"]
-    depends_on: [{ name: sasl-off-nossl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-off-nossl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: noauth }
-            - { key: MONGODB_VERSION, value: "4.4" }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: nossl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-off-nossl-ubuntu1804-gcc-test-4.4-server-noauth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-nossl, test, ubuntu1804, gcc, sasl-off, noauth, server, "4.4"]
-    depends_on: [{ name: sasl-off-nossl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-off-nossl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: noauth }
-            - { key: MONGODB_VERSION, value: "4.4" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: nossl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-off-nossl-ubuntu1804-gcc-test-4.4-sharded-noauth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-nossl, test, ubuntu1804, gcc, sasl-off, noauth, sharded, "4.4"]
-    depends_on: [{ name: sasl-off-nossl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-off-nossl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: noauth }
-            - { key: MONGODB_VERSION, value: "4.4" }
-            - { key: TOPOLOGY, value: sharded_cluster }
-            - { key: SSL, value: nossl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-off-nossl-ubuntu1804-gcc-test-5.0-replica-noauth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-nossl, test, ubuntu1804, gcc, sasl-off, noauth, replica, "5.0"]
-    depends_on: [{ name: sasl-off-nossl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-off-nossl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: noauth }
-            - { key: MONGODB_VERSION, value: "5.0" }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: nossl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-off-nossl-ubuntu1804-gcc-test-5.0-server-noauth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-nossl, test, ubuntu1804, gcc, sasl-off, noauth, server, "5.0"]
-    depends_on: [{ name: sasl-off-nossl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-off-nossl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: noauth }
-            - { key: MONGODB_VERSION, value: "5.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: nossl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-off-nossl-ubuntu1804-gcc-test-5.0-sharded-noauth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-nossl, test, ubuntu1804, gcc, sasl-off, noauth, sharded, "5.0"]
-    depends_on: [{ name: sasl-off-nossl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-off-nossl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: noauth }
-            - { key: MONGODB_VERSION, value: "5.0" }
-            - { key: TOPOLOGY, value: sharded_cluster }
-            - { key: SSL, value: nossl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-off-nossl-ubuntu1804-gcc-test-6.0-replica-noauth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-nossl, test, ubuntu1804, gcc, sasl-off, noauth, replica, "6.0"]
-    depends_on: [{ name: sasl-off-nossl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-off-nossl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: noauth }
-            - { key: MONGODB_VERSION, value: "6.0" }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: nossl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-off-nossl-ubuntu1804-gcc-test-6.0-server-noauth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-nossl, test, ubuntu1804, gcc, sasl-off, noauth, server, "6.0"]
-    depends_on: [{ name: sasl-off-nossl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-off-nossl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: noauth }
-            - { key: MONGODB_VERSION, value: "6.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: nossl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-off-nossl-ubuntu1804-gcc-test-6.0-sharded-noauth
-    run_on: ubuntu1804-small
-    tags: [sasl-matrix-nossl, test, ubuntu1804, gcc, sasl-off, noauth, sharded, "6.0"]
-    depends_on: [{ name: sasl-off-nossl-ubuntu1804-gcc-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-off-nossl-ubuntu1804-gcc-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: gcc }
-            - { key: AUTH, value: noauth }
-            - { key: MONGODB_VERSION, value: "6.0" }
-            - { key: TOPOLOGY, value: sharded_cluster }
-            - { key: SSL, value: nossl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
   - name: sasl-off-nossl-ubuntu2004-gcc-compile
     run_on: ubuntu2004-large
     tags: [sasl-matrix-nossl, compile, ubuntu2004, gcc, sasl-off]
@@ -4464,6 +3918,186 @@ tasks:
         vars:
           CC: gcc
       - func: upload-build
+  - name: sasl-off-nossl-ubuntu2004-gcc-test-4.4-replica-noauth
+    run_on: ubuntu2004-small
+    tags: [sasl-matrix-nossl, test, ubuntu2004, gcc, sasl-off, noauth, replica, "4.4"]
+    depends_on: [{ name: sasl-off-nossl-ubuntu2004-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: sasl-off-nossl-ubuntu2004-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: noauth }
+            - { key: MONGODB_VERSION, value: "4.4" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: nossl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: sasl-off-nossl-ubuntu2004-gcc-test-4.4-server-noauth
+    run_on: ubuntu2004-small
+    tags: [sasl-matrix-nossl, test, ubuntu2004, gcc, sasl-off, noauth, server, "4.4"]
+    depends_on: [{ name: sasl-off-nossl-ubuntu2004-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: sasl-off-nossl-ubuntu2004-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: noauth }
+            - { key: MONGODB_VERSION, value: "4.4" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: nossl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: sasl-off-nossl-ubuntu2004-gcc-test-4.4-sharded-noauth
+    run_on: ubuntu2004-small
+    tags: [sasl-matrix-nossl, test, ubuntu2004, gcc, sasl-off, noauth, sharded, "4.4"]
+    depends_on: [{ name: sasl-off-nossl-ubuntu2004-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: sasl-off-nossl-ubuntu2004-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: noauth }
+            - { key: MONGODB_VERSION, value: "4.4" }
+            - { key: TOPOLOGY, value: sharded_cluster }
+            - { key: SSL, value: nossl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: sasl-off-nossl-ubuntu2004-gcc-test-5.0-replica-noauth
+    run_on: ubuntu2004-small
+    tags: [sasl-matrix-nossl, test, ubuntu2004, gcc, sasl-off, noauth, replica, "5.0"]
+    depends_on: [{ name: sasl-off-nossl-ubuntu2004-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: sasl-off-nossl-ubuntu2004-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: noauth }
+            - { key: MONGODB_VERSION, value: "5.0" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: nossl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: sasl-off-nossl-ubuntu2004-gcc-test-5.0-server-noauth
+    run_on: ubuntu2004-small
+    tags: [sasl-matrix-nossl, test, ubuntu2004, gcc, sasl-off, noauth, server, "5.0"]
+    depends_on: [{ name: sasl-off-nossl-ubuntu2004-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: sasl-off-nossl-ubuntu2004-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: noauth }
+            - { key: MONGODB_VERSION, value: "5.0" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: nossl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: sasl-off-nossl-ubuntu2004-gcc-test-5.0-sharded-noauth
+    run_on: ubuntu2004-small
+    tags: [sasl-matrix-nossl, test, ubuntu2004, gcc, sasl-off, noauth, sharded, "5.0"]
+    depends_on: [{ name: sasl-off-nossl-ubuntu2004-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: sasl-off-nossl-ubuntu2004-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: noauth }
+            - { key: MONGODB_VERSION, value: "5.0" }
+            - { key: TOPOLOGY, value: sharded_cluster }
+            - { key: SSL, value: nossl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: sasl-off-nossl-ubuntu2004-gcc-test-6.0-replica-noauth
+    run_on: ubuntu2004-small
+    tags: [sasl-matrix-nossl, test, ubuntu2004, gcc, sasl-off, noauth, replica, "6.0"]
+    depends_on: [{ name: sasl-off-nossl-ubuntu2004-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: sasl-off-nossl-ubuntu2004-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: noauth }
+            - { key: MONGODB_VERSION, value: "6.0" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: nossl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: sasl-off-nossl-ubuntu2004-gcc-test-6.0-server-noauth
+    run_on: ubuntu2004-small
+    tags: [sasl-matrix-nossl, test, ubuntu2004, gcc, sasl-off, noauth, server, "6.0"]
+    depends_on: [{ name: sasl-off-nossl-ubuntu2004-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: sasl-off-nossl-ubuntu2004-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: noauth }
+            - { key: MONGODB_VERSION, value: "6.0" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: nossl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: sasl-off-nossl-ubuntu2004-gcc-test-6.0-sharded-noauth
+    run_on: ubuntu2004-small
+    tags: [sasl-matrix-nossl, test, ubuntu2004, gcc, sasl-off, noauth, sharded, "6.0"]
+    depends_on: [{ name: sasl-off-nossl-ubuntu2004-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: sasl-off-nossl-ubuntu2004-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: AUTH, value: noauth }
+            - { key: MONGODB_VERSION, value: "6.0" }
+            - { key: TOPOLOGY, value: sharded_cluster }
+            - { key: SSL, value: nossl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
   - name: sasl-off-nossl-ubuntu2004-gcc-test-7.0-replica-noauth
     run_on: ubuntu2004-small
     tags: [sasl-matrix-nossl, test, ubuntu2004, gcc, sasl-off, noauth, replica, "7.0"]
@@ -4836,46 +4470,18 @@ tasks:
         vars:
           CC: clang
       - func: upload scan artifacts
-  - name: scan-build-ubuntu1604-arm64-clang
-    run_on: ubuntu1604-arm64-large
-    tags: [scan-build-matrix, ubuntu1604-arm64, clang]
+  - name: scan-build-ubuntu2004-arm64-clang
+    run_on: ubuntu2004-arm64-large
+    tags: [scan-build-matrix, ubuntu2004-arm64, clang]
     commands:
       - func: find-cmake-latest
       - func: scan-build
         vars:
           CC: clang
       - func: upload scan artifacts
-  - name: scan-build-ubuntu1604-clang
-    run_on: ubuntu1604-large
-    tags: [scan-build-matrix, ubuntu1604, clang]
-    commands:
-      - func: find-cmake-latest
-      - func: scan-build
-        vars:
-          CC: clang
-      - func: upload scan artifacts
-  - name: scan-build-ubuntu1604-clang-i686
-    run_on: ubuntu1604-large
-    tags: [scan-build-matrix, ubuntu1604, clang, i686]
-    commands:
-      - func: find-cmake-latest
-      - func: scan-build
-        vars:
-          CC: clang
-          MARCH: i686
-      - func: upload scan artifacts
-  - name: scan-build-ubuntu1804-arm64-clang
-    run_on: ubuntu1804-arm64-large
-    tags: [scan-build-matrix, ubuntu1804-arm64, clang]
-    commands:
-      - func: find-cmake-latest
-      - func: scan-build
-        vars:
-          CC: clang
-      - func: upload scan artifacts
-  - name: scan-build-ubuntu1804-clang-i686
-    run_on: ubuntu1804-large
-    tags: [scan-build-matrix, ubuntu1804, clang, i686]
+  - name: scan-build-ubuntu2004-clang-i686
+    run_on: ubuntu2004-large
+    tags: [scan-build-matrix, ubuntu2004, clang, i686]
     commands:
       - func: find-cmake-latest
       - func: scan-build
@@ -4927,44 +4533,6 @@ tasks:
       - func: std-compile
         vars:
           CC: clang
-          C_STD_VERSION: 11
-  - name: std-c11-ubuntu1604-clang-compile
-    run_on: ubuntu1604-large
-    tags: [std-matrix, ubuntu1604, clang, compile, std-c11]
-    commands:
-      - func: find-cmake-latest
-      - func: std-compile
-        vars:
-          CC: clang
-          C_STD_VERSION: 11
-  - name: std-c11-ubuntu1604-clang-i686-compile
-    run_on: ubuntu1604-large
-    tags: [std-matrix, ubuntu1604, clang, compile, i686, std-c11]
-    commands:
-      - func: find-cmake-latest
-      - func: std-compile
-        vars:
-          CC: clang
-          C_STD_VERSION: 11
-          MARCH: i686
-  - name: std-c11-ubuntu1804-clang-i686-compile
-    run_on: ubuntu1804-large
-    tags: [std-matrix, ubuntu1804, clang, compile, i686, std-c11]
-    commands:
-      - func: find-cmake-latest
-      - func: std-compile
-        vars:
-          CC: clang
-          C_STD_VERSION: 11
-          MARCH: i686
-  - name: std-c11-ubuntu1804-gcc-compile
-    run_on: ubuntu1804-large
-    tags: [std-matrix, ubuntu1804, gcc, compile, std-c11]
-    commands:
-      - func: find-cmake-latest
-      - func: std-compile
-        vars:
-          CC: gcc
           C_STD_VERSION: 11
   - name: std-c11-ubuntu2004-clang-compile
     run_on: ubuntu2004-large
@@ -5020,315 +4588,6 @@ tasks:
         vars:
           CC: Visual Studio 15 2017 Win64
           C_STD_VERSION: 17
-  - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-    run_on: ubuntu1804-large
-    tags: [sanitizers-matrix-tsan, compile, ubuntu1804, clang, tsan, sasl-cyrus]
-    commands:
-      - func: find-cmake-latest
-      - func: sasl-cyrus-openssl-compile
-        vars:
-          CC: clang
-      - func: upload-build
-  - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.0-replica-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-tsan, test, ubuntu1804, clang, sasl-cyrus, tsan, auth, replica, "4.0", openssl]
-    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.0" }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.0-server-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-tsan, test, ubuntu1804, clang, sasl-cyrus, tsan, auth, server, "4.0", openssl]
-    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.0-sharded-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-tsan, test, ubuntu1804, clang, sasl-cyrus, tsan, auth, sharded, "4.0", openssl]
-    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.0" }
-            - { key: TOPOLOGY, value: sharded_cluster }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.2-replica-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-tsan, test, ubuntu1804, clang, sasl-cyrus, tsan, auth, replica, "4.2", openssl]
-    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.2" }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.2-server-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-tsan, test, ubuntu1804, clang, sasl-cyrus, tsan, auth, server, "4.2", openssl]
-    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.2" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.2-sharded-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-tsan, test, ubuntu1804, clang, sasl-cyrus, tsan, auth, sharded, "4.2", openssl]
-    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.2" }
-            - { key: TOPOLOGY, value: sharded_cluster }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.4-replica-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-tsan, test, ubuntu1804, clang, sasl-cyrus, tsan, auth, replica, "4.4", openssl]
-    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.4" }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.4-server-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-tsan, test, ubuntu1804, clang, sasl-cyrus, tsan, auth, server, "4.4", openssl]
-    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.4" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-4.4-sharded-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-tsan, test, ubuntu1804, clang, sasl-cyrus, tsan, auth, sharded, "4.4", openssl]
-    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.4" }
-            - { key: TOPOLOGY, value: sharded_cluster }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-5.0-replica-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-tsan, test, ubuntu1804, clang, sasl-cyrus, tsan, auth, replica, "5.0", openssl]
-    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "5.0" }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-5.0-server-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-tsan, test, ubuntu1804, clang, sasl-cyrus, tsan, auth, server, "5.0", openssl]
-    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "5.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-5.0-sharded-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-tsan, test, ubuntu1804, clang, sasl-cyrus, tsan, auth, sharded, "5.0", openssl]
-    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "5.0" }
-            - { key: TOPOLOGY, value: sharded_cluster }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-6.0-replica-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-tsan, test, ubuntu1804, clang, sasl-cyrus, tsan, auth, replica, "6.0", openssl]
-    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "6.0" }
-            - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-6.0-server-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-tsan, test, ubuntu1804, clang, sasl-cyrus, tsan, auth, server, "6.0", openssl]
-    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "6.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-test-6.0-sharded-auth
-    run_on: ubuntu1804-small
-    tags: [sanitizers-matrix-tsan, test, ubuntu1804, clang, sasl-cyrus, tsan, auth, sharded, "6.0", openssl]
-    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu1804-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "6.0" }
-            - { key: TOPOLOGY, value: sharded_cluster }
-            - { key: SSL, value: openssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
   - name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile
     run_on: ubuntu2004-large
     tags: [sanitizers-matrix-tsan, compile, ubuntu2004, clang, tsan, sasl-cyrus]
@@ -5338,6 +4597,186 @@ tasks:
         vars:
           CC: clang
       - func: upload-build
+  - name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-test-4.4-replica-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-tsan, test, ubuntu2004, clang, sasl-cyrus, tsan, auth, replica, "4.4", openssl]
+    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.4" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-test-4.4-server-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-tsan, test, ubuntu2004, clang, sasl-cyrus, tsan, auth, server, "4.4", openssl]
+    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.4" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-test-4.4-sharded-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-tsan, test, ubuntu2004, clang, sasl-cyrus, tsan, auth, sharded, "4.4", openssl]
+    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "4.4" }
+            - { key: TOPOLOGY, value: sharded_cluster }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-test-5.0-replica-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-tsan, test, ubuntu2004, clang, sasl-cyrus, tsan, auth, replica, "5.0", openssl]
+    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "5.0" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-test-5.0-server-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-tsan, test, ubuntu2004, clang, sasl-cyrus, tsan, auth, server, "5.0", openssl]
+    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "5.0" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-test-5.0-sharded-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-tsan, test, ubuntu2004, clang, sasl-cyrus, tsan, auth, sharded, "5.0", openssl]
+    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "5.0" }
+            - { key: TOPOLOGY, value: sharded_cluster }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-test-6.0-replica-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-tsan, test, ubuntu2004, clang, sasl-cyrus, tsan, auth, replica, "6.0", openssl]
+    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "6.0" }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-test-6.0-server-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-tsan, test, ubuntu2004, clang, sasl-cyrus, tsan, auth, server, "6.0", openssl]
+    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "6.0" }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-test-6.0-sharded-auth
+    run_on: ubuntu2004-small
+    tags: [sanitizers-matrix-tsan, test, ubuntu2004, clang, sasl-cyrus, tsan, auth, sharded, "6.0", openssl]
+    depends_on: [{ name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: tsan-sasl-cyrus-openssl-ubuntu2004-clang-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: clang }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: "6.0" }
+            - { key: TOPOLOGY, value: sharded_cluster }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
   - name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-test-7.0-replica-auth
     run_on: ubuntu2004-small
     tags: [sanitizers-matrix-tsan, test, ubuntu2004, clang, sasl-cyrus, tsan, auth, replica, "7.0", openssl]

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -1935,6 +1935,15 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-mock-kms-servers
       - func: run-tests
+  - name: cse-sasl-cyrus-openssl-ubuntu2004-clang-compile
+    run_on: ubuntu2004-large
+    tags: [cse-matrix-openssl, compile, ubuntu2004, clang, cse, sasl-cyrus]
+    commands:
+      - func: find-cmake-latest
+      - func: cse-sasl-cyrus-openssl-compile
+        vars:
+          CC: clang
+      - func: upload-build
   - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-compile
     run_on: ubuntu2004-large
     tags: [cse-matrix-openssl, compile, ubuntu2004, gcc, cse, sasl-cyrus]
@@ -3168,15 +3177,6 @@ tasks:
         vars:
           CC: gcc
       - func: upload-build
-  - name: sasl-cyrus-openssl-rhel70-gcc-compile
-    run_on: rhel70-large
-    tags: [sasl-matrix-openssl, compile, rhel70, gcc, sasl-cyrus]
-    commands:
-      - func: find-cmake-latest
-      - func: sasl-cyrus-openssl-compile
-        vars:
-          CC: gcc
-      - func: upload-build
   - name: sasl-cyrus-openssl-rhel80-gcc-compile
     run_on: rhel80-large
     tags: [sasl-matrix-openssl, compile, rhel80, gcc, sasl-cyrus]
@@ -3573,6 +3573,15 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
+  - name: sasl-cyrus-openssl-ubuntu2004-clang-compile
+    run_on: ubuntu2004-large
+    tags: [sasl-matrix-openssl, compile, ubuntu2004, clang, sasl-cyrus]
+    commands:
+      - func: find-cmake-latest
+      - func: sasl-cyrus-openssl-compile
+        vars:
+          CC: clang
+      - func: upload-build
   - name: sasl-cyrus-openssl-ubuntu2004-gcc-compile
     run_on: ubuntu2004-large
     tags: [sasl-matrix-openssl, compile, ubuntu2004, gcc, sasl-cyrus]

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -163,6 +163,20 @@ buildvariants:
     display_name: std-matrix
     tasks:
       - name: .std-matrix
+  - name: u16-clang
+    display_name: Ubuntu 16.04 (LLVM/Clang)
+    expansions:
+      MONGOC_EARTHLY_C_COMPILER: clang
+      MONGOC_EARTHLY_ENV: u16
+    tasks:
+      - name: .u16-clang
+  - name: u16-gcc
+    display_name: Ubuntu 16.04 (GCC)
+    expansions:
+      MONGOC_EARTHLY_C_COMPILER: gcc
+      MONGOC_EARTHLY_ENV: u16
+    tasks:
+      - name: .u16-gcc
   - name: u18-clang
     display_name: Ubuntu 18.04 (LLVM/Clang)
     expansions:

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -69,6 +69,20 @@ buildvariants:
       MONGOC_EARTHLY_ENV: archlinux
     tasks:
       - name: .archlinux-gcc
+  - name: centos7-clang
+    display_name: CentOS 7.0 (LLVM/Clang)
+    expansions:
+      MONGOC_EARTHLY_C_COMPILER: clang
+      MONGOC_EARTHLY_ENV: centos7
+    tasks:
+      - name: .centos7-clang
+  - name: centos7-gcc
+    display_name: CentOS 7.0 (GCC)
+    expansions:
+      MONGOC_EARTHLY_C_COMPILER: gcc
+      MONGOC_EARTHLY_ENV: centos7
+    tasks:
+      - name: .centos7-gcc
   - name: clang-format
     display_name: clang-format
     run_on:

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -165,13 +165,6 @@ all_variants = [
         {"CC": "gcc"},
     ),
     Variant(
-        "gcc94",
-        "GCC 9.4 (Ubuntu 20.04)",
-        "ubuntu2004-large",
-        ["release-compile", "debug-compile-nosasl-nossl", ".latest .nossl"],
-        {"CC": "gcc"},
-    ),
-    Variant(
         "gcc94-i686",
         "GCC 9.4 (i686) (Ubuntu 20.04)",
         "ubuntu2004-test",

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -144,24 +144,6 @@ all_variants = [
         {"CC": "gcc"},
     ),
     Variant(
-        "gcc48rhel",
-        "GCC 4.8 (RHEL 7.0)",
-        "rhel70",
-        # Skip client-side-encryption tests on RHEL 7.0 due to OCSP errors
-        # with Azure. See CDRIVER-3620 and CDRIVER-3814.
-        [
-            ".hardened",
-            ".compression !.snappy",
-            "release-compile",
-            "debug-compile-nosasl-nossl",
-            "debug-compile-sasl-openssl",
-            "debug-compile-nosasl-openssl",
-            ".authentication-tests .openssl",
-            ".latest .nossl",
-        ],
-        {"CC": "gcc"},
-    ),
-    Variant(
         "gcc63",
         "GCC 6.3 (Debian 9.2)",
         "debian92-test",

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -34,7 +34,7 @@ all_variants = [
     Variant(
         "abi-compliance-check",
         "ABI Compliance Check",
-        ["ubuntu1804-small", "ubuntu1804-medium", "ubuntu1804-large"],
+        ["ubuntu2004-small", "ubuntu2004-medium", "ubuntu2004-large"],
         ["abi-compliance-check"],
     ),
     Variant(
@@ -59,7 +59,7 @@ all_variants = [
             OD([("name", "link-with-cmake-windows-ssl"), ("distros", ["windows-vsCurrent-large"])]),
             OD([("name", "link-with-cmake-windows-snappy"), ("distros", ["windows-vsCurrent-large"])]),
             OD([("name", "link-with-cmake-mingw"), ("distros", ["windows-vsCurrent-large"])]),
-            OD([("name", "link-with-pkg-config"), ("distros", ["ubuntu1804-test"])]),
+            OD([("name", "link-with-pkg-config"), ("distros", ["ubuntu2004-test"])]),
             OD([("name", "link-with-pkg-config-mac"), ("distros", ["macos-1100"])]),
             "link-with-pkg-config-ssl",
             "link-with-bson",
@@ -116,8 +116,8 @@ all_variants = [
     ),
     Variant(
         "clang60-i686",
-        "clang 6.0 (i686) (Ubuntu 18.04)",
-        "ubuntu1804-test",
+        "clang 6.0 (i686) (Ubuntu 20.04)",
+        "ubuntu2004-test",
         [
             "release-compile",
             "debug-compile-nosasl-nossl",
@@ -126,27 +126,6 @@ all_variants = [
             ".latest .nossl .nosasl",
         ],
         {"CC": "clang", "MARCH": "i686"},
-    ),
-    Variant(
-        "clang38-i686",
-        "clang 3.8 (i686) (Ubuntu 16.04)",
-        "ubuntu1604-test",
-        ["release-compile", "debug-compile-no-align"],
-        {"CC": "clang", "MARCH": "i686"},
-    ),
-    Variant(
-        "clang38ubuntu",
-        "clang 3.8 (Ubuntu 16.04)",
-        "ubuntu1604-test",
-        [
-            ".compression !.zstd",
-            "release-compile",
-            "debug-compile-sasl-openssl",
-            "debug-compile-nosasl-openssl",
-            "debug-compile-no-align",
-            ".authentication-tests .openssl",
-        ],
-        {"CC": "clang"},
     ),
     Variant(
         "gcc82rhel",
@@ -212,15 +191,15 @@ all_variants = [
     ),
     Variant(
         "gcc75-i686",
-        "GCC 7.5 (i686) (Ubuntu 18.04)",
-        "ubuntu1804-test",
+        "GCC 7.5 (i686) (Ubuntu 20.04)",
+        "ubuntu2004-test",
         ["release-compile", "debug-compile-nosasl-nossl", "debug-compile-no-align", ".latest .nossl .nosasl"],
         {"CC": "gcc", "MARCH": "i686"},
     ),
     Variant(
         "gcc75",
-        "GCC 7.5 (Ubuntu 18.04)",
-        "ubuntu1804-test",
+        "GCC 7.5 (Ubuntu 20.04)",
+        "ubuntu2004-test",
         [
             ".compression !.zstd",
             "debug-compile-nosrv",
@@ -238,13 +217,6 @@ all_variants = [
             "test-dns-auth-openssl",
             "test-dns-loadbalanced-openssl",
         ],
-        {"CC": "gcc"},
-    ),
-    Variant(
-        "gcc54",
-        "GCC 5.4 (Ubuntu 16.04)",
-        "ubuntu1604-test",
-        [".compression !.zstd", "debug-compile-nosrv", "release-compile", "debug-compile-no-align"],
         {"CC": "gcc"},
     ),
     Variant(
@@ -351,9 +323,9 @@ all_variants = [
         batchtime=days(1),
     ),
     Variant(
-        "arm-ubuntu1804",
-        "*ARM (aarch64) (Ubuntu 18.04)",
-        "ubuntu1804-arm64-large",
+        "arm-ubuntu2004",
+        "*ARM (aarch64) (Ubuntu 20.04)",
+        "ubuntu2004-arm64-large",
         [
             ".compression !.snappy !.zstd",
             "debug-compile-no-align",
@@ -365,14 +337,6 @@ all_variants = [
             ".latest .nossl",
             "test-dns-openssl",
         ],
-        {"CC": "gcc"},
-        batchtime=days(1),
-    ),
-    Variant(
-        "arm-ubuntu1604",
-        "*ARM (aarch64) (Ubuntu 16.04)",
-        "ubuntu1604-arm64-large",
-        [".compression !.snappy !.zstd", "debug-compile-no-align", "release-compile"],
         {"CC": "gcc"},
         batchtime=days(1),
     ),
@@ -395,8 +359,8 @@ all_variants = [
     ),
     Variant(
         "clang60ubuntu",
-        "clang 6.0 (Ubuntu 18.04)",
-        "ubuntu1804-test",
+        "clang 6.0 (Ubuntu 20.04)",
+        "ubuntu2004-test",
         [
             "debug-compile-sasl-openssl-static",
             ".authentication-tests .asan",
@@ -476,18 +440,6 @@ all_variants = [
         {},
         tags=["pr-merge-gate"],
     ),
-    Variant(
-        "versioned-api-ubuntu1804",
-        "Versioned API Tests (Ubuntu 18.04)",
-        "ubuntu1804-test",
-        [
-            "debug-compile-nosasl-openssl",
-            "debug-compile-nosasl-nossl",
-            ".versioned-api .5.0",
-            ".versioned-api .6.0",
-        ],
-        {},
-    ),
     # Test 7.0+ with Ubuntu 20.04+ since MongoDB 7.0 no longer ships binaries for Ubuntu 18.04.
     Variant(
         "versioned-api-ubuntu2004",
@@ -496,6 +448,8 @@ all_variants = [
         [
             "debug-compile-nosasl-openssl",
             "debug-compile-nosasl-nossl",
+            ".versioned-api .5.0",
+            ".versioned-api .6.0",
             ".versioned-api .7.0",
             ".versioned-api .8.0"
         ],

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -115,8 +115,8 @@ all_variants = [
         {"CC": "clang"},
     ),
     Variant(
-        "clang60-i686",
-        "clang 6.0 (i686) (Ubuntu 20.04)",
+        "clang100-i686",
+        "clang 10.0 (i686) (Ubuntu 20.04)",
         "ubuntu2004-test",
         [
             "release-compile",
@@ -172,15 +172,15 @@ all_variants = [
         {"CC": "gcc"},
     ),
     Variant(
-        "gcc75-i686",
-        "GCC 7.5 (i686) (Ubuntu 20.04)",
+        "gcc94-i686",
+        "GCC 9.4 (i686) (Ubuntu 20.04)",
         "ubuntu2004-test",
         ["release-compile", "debug-compile-nosasl-nossl", "debug-compile-no-align", ".latest .nossl .nosasl"],
         {"CC": "gcc", "MARCH": "i686"},
     ),
     Variant(
-        "gcc75",
-        "GCC 7.5 (Ubuntu 20.04)",
+        "gcc94",
+        "GCC 9.4 (Ubuntu 20.04)",
         "ubuntu2004-test",
         [
             ".compression !.zstd",
@@ -340,8 +340,8 @@ all_variants = [
         batchtime=days(1),
     ),
     Variant(
-        "clang60ubuntu",
-        "clang 6.0 (Ubuntu 20.04)",
+        "clang100ubuntu",
+        "clang 10.0 (Ubuntu 20.04)",
         "ubuntu2004-test",
         [
             "debug-compile-sasl-openssl-static",

--- a/.evergreen/scripts/abi-compliance-check-setup.sh
+++ b/.evergreen/scripts/abi-compliance-check-setup.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+
+declare working_dir
+working_dir="$(pwd)"
+
+export PATH
+PATH="${working_dir:?}/install/bin:${PATH:-}"
+
+# Install prefix to use for ABI compatibility scripts.
+if [[ ! -d "${working_dir}/install" ]]; then
+  echo "Creating install directory at ${working_dir}/install"
+  mkdir -p "${working_dir}/install"
+fi
+
+declare parallel_level
+parallel_level="$(("$(nproc)" + 1))"
+
+# Obtain abi-compliance-checker.
+echo "Fetching abi-compliance-checker..."
+[[ -d checker ]] || {
+  git clone -b "2.3" --depth 1 https://github.com/lvc/abi-compliance-checker.git checker
+  pushd checker
+  make -j "${parallel_level:?}" --no-print-directory install prefix="${working_dir:?}/install"
+  popd # checker
+} >/dev/null
+echo "Fetching abi-compliance-checker... done."
+
+# Obtain ctags.
+echo "Fetching ctags..."
+[[ -d ctags ]] || {
+  git clone -b "v6.0.0" --depth 1 https://github.com/universal-ctags/ctags.git ctags
+  pushd ctags
+  ./autogen.sh
+  ./configure --prefix="${working_dir}/install"
+  make -j "${parallel_level:?}"
+  make install
+  popd # ctags
+} >/dev/null
+echo "Fetching ctags... done."
+
+command -V abi-compliance-checker

--- a/.evergreen/scripts/abi-compliance-check.sh
+++ b/.evergreen/scripts/abi-compliance-check.sh
@@ -15,6 +15,12 @@ declare newest current
 newest="$(cat VERSION_RELEASED)"
 current="$(cat VERSION_CURRENT)"
 
+declare working_dir
+working_dir="$(pwd)"
+
+export PATH
+PATH="${working_dir:?}/install/bin:${PATH:-}"
+
 # build the current changes
 env \
   CFLAGS="-g -Og" \

--- a/Earthfile
+++ b/Earthfile
@@ -461,6 +461,9 @@ run:
 # 88.     88  V888  `8bd8'    .88.   88 `88. `8b  d8' 88  V888 88  88  88 88.     88  V888    88    db   8D
 # Y88888P VP   V8P    YP    Y888888P 88   YD  `Y88P'  VP   V8P YP  YP  YP Y88888P VP   V8P    YP    `8888Y'
 
+env.u16:
+    DO --pass-args +UBUNTU_ENV --version=16.04
+
 env.u18:
     DO --pass-args +UBUNTU_ENV --version=18.04
 


### PR DESCRIPTION
# Description
This PR removes unsupported Evergreen platforms and adds two new environments to build on in Earthly.

# Background
See [CDRIVER-4602](https://jira.mongodb.org/browse/CDRIVER-4602). Along with the two platforms explicitly mentioned in the ticket, other unsupported variants were also removed/upgraded from our CI according to [this](https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=116563465) wiki page.

# Earthly
Ubuntu <= 18.04 and RHEL <= 7.2 were both removed from our CI pipeline in this PR. However, these are both platforms [supported](https://www.mongodb.com/docs/languages/c/c-driver/current/libmongoc/ref/platforms/) by the C driver, so it was necessary to continue to check that the driver can be built successfully. To achieve this, Earthly was used to spawn the older versions of these OSes (CentOS used for RHEL) and confirm that things still run smoothly. 

Due to GCC and Clang issues on Ubuntu 16.04 and CentOS 7, the C++ driver is not compiled with the C driver in Earthly as part of the test. The Clang and GCC versions in those environment are too old to support library features used in the C++ driver such as `string_view`.

# `abi-compliance-check`
The `abi-compliance-check` task previously ran on an unsupported Ubuntu 18.04 platform. A simple upgrade was made for the task to now run on Ubuntu 20.04. However, this Evergreen variant did not have the `abi-compliance-checker` tool installed on the system. To fix this, a [routine](https://github.com/mongodb/mongo-cxx-driver/blob/338c7666f2f46afd52c98f359a0f6eea2ab46c30/.evergreen/abi-compliance-check-setup.sh#L18) was pulled from the C++ driver to install the tool before running the task.

# Windows Distros
All of the `windows-64-*` distros are technically unsupported by Evergreen. I chose to not remove them from our CI in this PR as I was worried about not being able to get those environments working in Earthly in a timely manner (different compiler could cause issues?). It might be a good idea to move this task to a separate ticket.

# What's New
- Removed/updated distros in various `config_generator` files and `distros.py`
- Regenerated Evergreen config files
- Script to download `abi-compliance-checker` prior to correlated task
- CentOS 7 and Ubuntu 16.04 support in Earthly