### PR TITLE
evg: set patchable and batchtime for Power8 and zSeries tasks

### DIFF
--- a/.evergreen/config_generator/components/cse/openssl.py
+++ b/.evergreen/config_generator/components/cse/openssl.py
@@ -73,11 +73,14 @@ def tasks():
 
     MORE_TAGS = ['cse']
 
-    res += generate_compile_tasks(
-        SSL, TAG, SASL_TO_FUNC, COMPILE_MATRIX, MORE_TAGS
-    )
-
+    res += generate_compile_tasks(SSL, TAG, SASL_TO_FUNC, COMPILE_MATRIX, MORE_TAGS)
     res += generate_test_tasks(SSL, TAG, TEST_MATRIX)
+
+    # PowerPC and zSeries are limited resources.
+    for task in res:
+        if any(pattern in task.run_on for pattern in ["power8", "zseries"]):
+            task.patchable = False
+            task.batchtime = 1440  # 1 day
 
     return res
 

--- a/.evergreen/config_generator/components/sasl/openssl.py
+++ b/.evergreen/config_generator/components/sasl/openssl.py
@@ -77,6 +77,12 @@ def tasks():
     res += generate_compile_tasks(SSL, TAG, SASL_TO_FUNC, COMPILE_MATRIX)
     res += generate_test_tasks(SSL, TAG, TEST_MATRIX)
 
+    # PowerPC and zSeries are limited resources.
+    for task in res:
+        if any(pattern in task.run_on for pattern in ["power8", "zseries"]):
+            task.patchable = False
+            task.batchtime = 1440  # 1 day
+
     return res
 
 

--- a/.evergreen/config_generator/etc/utils.py
+++ b/.evergreen/config_generator/etc/utils.py
@@ -25,6 +25,7 @@ class Task(EvgTask):
 
     disable: bool = False
     run_on: str | Sequence[str] | None = None
+    batchtime: int | None = None
 
 
 # Automatically formats the provided script and invokes it in Bash.

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -16670,6 +16670,7 @@ buildvariants:
   - debug-compile-sasl-openssl
   - .latest .nossl
   - test-dns-openssl
+  patchable: false
   batchtime: 1440
 - name: arm-ubuntu1804
   display_name: '*ARM (aarch64) (Ubuntu 18.04)'
@@ -16710,6 +16711,7 @@ buildvariants:
   - debug-compile-sasl-openssl
   - .authentication-tests .openssl
   - .latest .nossl
+  patchable: false
   batchtime: 1440
 - name: clang60ubuntu
   display_name: clang 6.0 (Ubuntu 18.04)

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -1605,6 +1605,8 @@ tasks:
   - name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-compile
     run_on: rhel83-zseries-large
     tags: [cse-matrix-openssl, compile, rhel83-zseries, gcc, cse, sasl-cyrus]
+    batchtime: 1440
+    patchable: false
     commands:
       - func: find-cmake-latest
       - func: cse-sasl-cyrus-openssl-compile
@@ -1615,6 +1617,8 @@ tasks:
     run_on: rhel83-zseries-small
     tags: [cse-matrix-openssl, test, rhel83-zseries, gcc, sasl-cyrus, cse, auth, server, "5.0", openssl]
     depends_on: [{ name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-compile }]
+    batchtime: 1440
+    patchable: false
     commands:
       - func: fetch-build
         vars:
@@ -1635,6 +1639,8 @@ tasks:
     run_on: rhel83-zseries-small
     tags: [cse-matrix-openssl, test, rhel83-zseries, gcc, sasl-cyrus, cse, auth, replica, "7.0", openssl]
     depends_on: [{ name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-compile }]
+    batchtime: 1440
+    patchable: false
     commands:
       - func: fetch-build
         vars:
@@ -1655,6 +1661,8 @@ tasks:
     run_on: rhel83-zseries-small
     tags: [cse-matrix-openssl, test, rhel83-zseries, gcc, sasl-cyrus, cse, auth, server, "7.0", openssl]
     depends_on: [{ name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-compile }]
+    batchtime: 1440
+    patchable: false
     commands:
       - func: fetch-build
         vars:
@@ -1675,6 +1683,8 @@ tasks:
     run_on: rhel83-zseries-small
     tags: [cse-matrix-openssl, test, rhel83-zseries, gcc, sasl-cyrus, cse, auth, replica, "8.0", openssl]
     depends_on: [{ name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-compile }]
+    batchtime: 1440
+    patchable: false
     commands:
       - func: fetch-build
         vars:
@@ -1695,6 +1705,8 @@ tasks:
     run_on: rhel83-zseries-small
     tags: [cse-matrix-openssl, test, rhel83-zseries, gcc, sasl-cyrus, cse, auth, server, "8.0", openssl]
     depends_on: [{ name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-compile }]
+    batchtime: 1440
+    patchable: false
     commands:
       - func: fetch-build
         vars:
@@ -1715,6 +1727,8 @@ tasks:
     run_on: rhel83-zseries-small
     tags: [cse-matrix-openssl, test, rhel83-zseries, gcc, sasl-cyrus, cse, auth, replica, latest, openssl]
     depends_on: [{ name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-compile }]
+    batchtime: 1440
+    patchable: false
     commands:
       - func: fetch-build
         vars:
@@ -1735,6 +1749,8 @@ tasks:
     run_on: rhel83-zseries-small
     tags: [cse-matrix-openssl, test, rhel83-zseries, gcc, sasl-cyrus, cse, auth, server, latest, openssl]
     depends_on: [{ name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-compile }]
+    batchtime: 1440
+    patchable: false
     commands:
       - func: fetch-build
         vars:
@@ -3201,6 +3217,8 @@ tasks:
   - name: sasl-cyrus-openssl-rhel81-power8-gcc-compile
     run_on: rhel81-power8-large
     tags: [sasl-matrix-openssl, compile, rhel81-power8, gcc, sasl-cyrus]
+    batchtime: 1440
+    patchable: false
     commands:
       - func: find-cmake-latest
       - func: sasl-cyrus-openssl-compile
@@ -3211,6 +3229,8 @@ tasks:
     run_on: rhel81-power8-small
     tags: [sasl-matrix-openssl, test, rhel81-power8, gcc, sasl-cyrus, auth, server, "4.2", openssl]
     depends_on: [{ name: sasl-cyrus-openssl-rhel81-power8-gcc-compile }]
+    batchtime: 1440
+    patchable: false
     commands:
       - func: fetch-build
         vars:
@@ -3231,6 +3251,8 @@ tasks:
     run_on: rhel81-power8-small
     tags: [sasl-matrix-openssl, test, rhel81-power8, gcc, sasl-cyrus, auth, server, "4.4", openssl]
     depends_on: [{ name: sasl-cyrus-openssl-rhel81-power8-gcc-compile }]
+    batchtime: 1440
+    patchable: false
     commands:
       - func: fetch-build
         vars:
@@ -3251,6 +3273,8 @@ tasks:
     run_on: rhel81-power8-small
     tags: [sasl-matrix-openssl, test, rhel81-power8, gcc, sasl-cyrus, auth, server, "5.0", openssl]
     depends_on: [{ name: sasl-cyrus-openssl-rhel81-power8-gcc-compile }]
+    batchtime: 1440
+    patchable: false
     commands:
       - func: fetch-build
         vars:
@@ -3271,6 +3295,8 @@ tasks:
     run_on: rhel81-power8-small
     tags: [sasl-matrix-openssl, test, rhel81-power8, gcc, sasl-cyrus, auth, server, "6.0", openssl]
     depends_on: [{ name: sasl-cyrus-openssl-rhel81-power8-gcc-compile }]
+    batchtime: 1440
+    patchable: false
     commands:
       - func: fetch-build
         vars:
@@ -3291,6 +3317,8 @@ tasks:
     run_on: rhel81-power8-small
     tags: [sasl-matrix-openssl, test, rhel81-power8, gcc, sasl-cyrus, auth, server, "7.0", openssl]
     depends_on: [{ name: sasl-cyrus-openssl-rhel81-power8-gcc-compile }]
+    batchtime: 1440
+    patchable: false
     commands:
       - func: fetch-build
         vars:
@@ -3311,6 +3339,8 @@ tasks:
     run_on: rhel81-power8-small
     tags: [sasl-matrix-openssl, test, rhel81-power8, gcc, sasl-cyrus, auth, server, "8.0", openssl]
     depends_on: [{ name: sasl-cyrus-openssl-rhel81-power8-gcc-compile }]
+    batchtime: 1440
+    patchable: false
     commands:
       - func: fetch-build
         vars:
@@ -3331,6 +3361,8 @@ tasks:
     run_on: rhel81-power8-small
     tags: [sasl-matrix-openssl, test, rhel81-power8, gcc, sasl-cyrus, auth, server, latest, openssl]
     depends_on: [{ name: sasl-cyrus-openssl-rhel81-power8-gcc-compile }]
+    batchtime: 1440
+    patchable: false
     commands:
       - func: fetch-build
         vars:
@@ -3350,6 +3382,8 @@ tasks:
   - name: sasl-cyrus-openssl-rhel83-zseries-gcc-compile
     run_on: rhel83-zseries-large
     tags: [sasl-matrix-openssl, compile, rhel83-zseries, gcc, sasl-cyrus]
+    batchtime: 1440
+    patchable: false
     commands:
       - func: find-cmake-latest
       - func: sasl-cyrus-openssl-compile
@@ -3360,6 +3394,8 @@ tasks:
     run_on: rhel83-zseries-small
     tags: [sasl-matrix-openssl, test, rhel83-zseries, gcc, sasl-cyrus, auth, server, "5.0", openssl]
     depends_on: [{ name: sasl-cyrus-openssl-rhel83-zseries-gcc-compile }]
+    batchtime: 1440
+    patchable: false
     commands:
       - func: fetch-build
         vars:
@@ -3380,6 +3416,8 @@ tasks:
     run_on: rhel83-zseries-small
     tags: [sasl-matrix-openssl, test, rhel83-zseries, gcc, sasl-cyrus, auth, server, "6.0", openssl]
     depends_on: [{ name: sasl-cyrus-openssl-rhel83-zseries-gcc-compile }]
+    batchtime: 1440
+    patchable: false
     commands:
       - func: fetch-build
         vars:
@@ -3400,6 +3438,8 @@ tasks:
     run_on: rhel83-zseries-small
     tags: [sasl-matrix-openssl, test, rhel83-zseries, gcc, sasl-cyrus, auth, server, "7.0", openssl]
     depends_on: [{ name: sasl-cyrus-openssl-rhel83-zseries-gcc-compile }]
+    batchtime: 1440
+    patchable: false
     commands:
       - func: fetch-build
         vars:
@@ -3420,6 +3460,8 @@ tasks:
     run_on: rhel83-zseries-small
     tags: [sasl-matrix-openssl, test, rhel83-zseries, gcc, sasl-cyrus, auth, server, "8.0", openssl]
     depends_on: [{ name: sasl-cyrus-openssl-rhel83-zseries-gcc-compile }]
+    batchtime: 1440
+    patchable: false
     commands:
       - func: fetch-build
         vars:
@@ -3440,6 +3482,8 @@ tasks:
     run_on: rhel83-zseries-small
     tags: [sasl-matrix-openssl, test, rhel83-zseries, gcc, sasl-cyrus, auth, server, latest, openssl]
     depends_on: [{ name: sasl-cyrus-openssl-rhel83-zseries-gcc-compile }]
+    batchtime: 1440
+    patchable: false
     commands:
       - func: fetch-build
         vars:

--- a/.evergreen/legacy_config_generator/evergreen_config_generator/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_generator/variants.py
@@ -26,7 +26,8 @@ class Variant(ConfigObject):
         run_on: list[str] | str,
         tasks: Iterable[str | ValueMapping],
         expansions: Mapping[str, str] | None = None,
-        tags: Iterable[str] = (),
+        tags: Iterable[str] | None = None,
+        patchable: bool | None = None,
         batchtime: int | None = None,
         display_tasks: Iterable[ValueMapping] = None,
     ):
@@ -36,7 +37,8 @@ class Variant(ConfigObject):
         self.run_on = run_on
         self.tasks = tasks
         self.expansions = expansions
-        self.tags = list(tags)
+        self.tags = tags
+        self.patchable = patchable
         self.batchtime = batchtime
         self.display_tasks = display_tasks
 
@@ -46,7 +48,12 @@ class Variant(ConfigObject):
 
     def to_dict(self):
         v = super(Variant, self).to_dict()
-        for i in "display_name", "expansions", "run_on", "tasks", "batchtime", "tags", "display_tasks":
-            if getattr(self, i):
-                v[i] = getattr(self, i)
+        for i in "display_name", "expansions", "run_on", "tasks", "patchable", "batchtime", "tags", "display_tasks":
+            attr = getattr(self, i)
+
+            # Allow `False`, but ignore empty lists and dicts.
+            if isinstance(attr, None | list | dict) and not attr:
+                continue
+
+            v[i] = attr
         return v

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -348,6 +348,7 @@ all_variants = [
             "test-dns-openssl",
         ],
         {"CC": "gcc"},
+        patchable=False,
         batchtime=days(1),
     ),
     Variant(
@@ -391,6 +392,7 @@ all_variants = [
             ".latest .nossl",
         ],
         {"CC": "gcc"},
+        patchable=False,
         batchtime=days(1),
     ),
     Variant(
@@ -403,7 +405,8 @@ all_variants = [
         ],
         {"CC": "clang"},
     ),
-    # Run AWS tests for MongoDB 4.4 and 5.0 on Ubuntu 20.04. AWS setup scripts expect Ubuntu 20.04+. MongoDB 4.4 and 5.0 are not available on 22.04.
+    # Run AWS tests for MongoDB 4.4 and 5.0 on Ubuntu 20.04. AWS setup scripts
+    # expect Ubuntu 20.04+. MongoDB 4.4 and 5.0 are not available on 22.04.
     Variant(
         "aws-ubuntu2004",
         "AWS Tests (Ubuntu 20.04)",


### PR DESCRIPTION
[EVG Distro Guidelines](https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=116563465) states:

> zseries and ppc (power8) hosts are very resource constrained [...] use a very long batch time on mainline commits, and avoid patch building on them.

Applies a batchtime of 1 day already used by the legacy config generator to new config generator components running tasks on Power8 and zSeries distros (overlooked by https://github.com/mongodb/mongo-c-driver/issues/1201). Additionally sets `patchable: false` to avoid their execution in patch builds.

