### PR TITLE
sync RPM spec file from downstream

### DIFF
--- a/.evergreen/etc/mongo-c-driver.spec
+++ b/.evergreen/etc/mongo-c-driver.spec
@@ -10,7 +10,7 @@
 %global gh_project   mongo-c-driver
 %global libname      libmongoc
 %global libver       1.0
-%global up_version   1.28.0
+%global up_version   1.28.1
 #global up_prever    rc0
 # disabled as require a MongoDB server
 %bcond_with          tests
@@ -27,7 +27,7 @@
 Name:      mongo-c-driver
 Summary:   Client library written in C for MongoDB
 Version:   %{up_version}%{?up_prever:~%{up_prever}}
-Release:   2%{?dist}
+Release:   1%{?dist}
 # See THIRD_PARTY_NOTICES
 License:   Apache-2.0 AND ISC AND MIT AND Zlib
 URL:       https://github.com/%{gh_owner}/%{gh_project}
@@ -258,6 +258,9 @@ exit $ret
 
 
 %changelog
+* Thu Oct 10 2024 Remi Collet <remi@remirepo.net> - 1.28.1-1
+- update to 1.28.1
+
 * Mon Oct  7 2024 Remi Collet <remi@remirepo.net> - 1.28.0-2
 - rebuild for utf8proc #2316935
 

--- a/.evergreen/etc/spec.patch
+++ b/.evergreen/etc/spec.patch
@@ -4,7 +4,7 @@
  %global gh_project   mongo-c-driver
  %global libname      libmongoc
  %global libver       1.0
--%global up_version   1.28.0
+-%global up_version   1.28.1
 +%global up_version   1.29.0
  #global up_prever    rc0
  # disabled as require a MongoDB server
@@ -15,6 +15,6 @@
  Summary:   Client library written in C for MongoDB
 -Version:   %{up_version}%{?up_prever:~%{up_prever}}
 +Version:   %{up_version}%{?up_prever}
- Release:   2%{?dist}
+ Release:   1%{?dist}
  # See THIRD_PARTY_NOTICES
  License:   Apache-2.0 AND ISC AND MIT AND Zlib


### PR DESCRIPTION
Evergreen patch build: https://spruce.mongodb.com/version/67093e350f6cad0007e951d2/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Note that this task is failing because changes introduced in d934cd5de55af65220816e4fd01ce3f9c0ef1cd4 raise the required version of libmongocrypt to 1.12.0. It will continue to fail until 1.12.0 becomes available in Fedora.