### PR TITLE
CDRIVER-5754 always write output on error in bson_validate_with_error_and_offset

### DIFF
--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -3385,16 +3385,17 @@ bson_validate_with_error_and_offset (const bson_t *bson,
    state.flags = flags;
    _bson_validate_internal (bson, &state);
 
-   if (state.err_offset > 0) {
+   if (state.err_offset >= 0) {
       if (offset) {
          *offset = (size_t) state.err_offset;
       }
       if (error) {
          memcpy (error, &state.error, sizeof *error);
       }
+      return false;
    }
 
-   return state.err_offset < 0;
+   return true;
 }
 
 

--- a/src/libbson/tests/test-bson.c
+++ b/src/libbson/tests/test-bson.c
@@ -1120,6 +1120,18 @@ test_bson_validate_dbpointer (void)
 
 
 static void
+test_bson_validate_with_error_and_offset (void)
+{
+   size_t err_offset = 12345;
+   bson_error_t err = { 67890 };
+   bson_t bson = { 0 };
+   ASSERT (!bson_validate_with_error_and_offset (&bson, BSON_VALIDATE_NONE, &err_offset, &err));
+   ASSERT (err_offset == 0);
+   ASSERT (err.domain != 67890);
+}
+
+
+static void
 test_bson_validate (void)
 {
    char filename[64];
@@ -3227,6 +3239,7 @@ test_bson_install (TestSuite *suite)
    TestSuite_Add (suite, "/bson/validate/dbref", test_bson_validate_dbref);
    TestSuite_Add (suite, "/bson/validate/bool", test_bson_validate_bool);
    TestSuite_Add (suite, "/bson/validate/dbpointer", test_bson_validate_dbpointer);
+   TestSuite_Add (suite, "/bson/validate/with_error_and_offset", test_bson_validate_with_error_and_offset);
    TestSuite_Add (suite, "/bson/new_1mm", test_bson_new_1mm);
    TestSuite_Add (suite, "/bson/init_1mm", test_bson_init_1mm);
    TestSuite_Add (suite, "/bson/build_child", test_bson_build_child);

--- a/src/libbson/tests/test-bson.c
+++ b/src/libbson/tests/test-bson.c
@@ -1126,8 +1126,8 @@ test_bson_validate_with_error_and_offset (void)
    bson_error_t err = {67890};
    bson_t bson = {0};
    ASSERT (!bson_validate_with_error_and_offset (&bson, BSON_VALIDATE_NONE, &err_offset, &err));
-   ASSERT (err_offset == 0);
-   ASSERT (err.domain != 67890);
+   ASSERT_CMPSIZE_T (err_offset, ==, 0);
+   ASSERT_CMPUINT32 (err.domain, !=, 67890); // domain is overwritten.
 }
 
 

--- a/src/libbson/tests/test-bson.c
+++ b/src/libbson/tests/test-bson.c
@@ -1123,8 +1123,8 @@ static void
 test_bson_validate_with_error_and_offset (void)
 {
    size_t err_offset = 12345;
-   bson_error_t err = { 67890 };
-   bson_t bson = { 0 };
+   bson_error_t err = {67890};
+   bson_t bson = {0};
    ASSERT (!bson_validate_with_error_and_offset (&bson, BSON_VALIDATE_NONE, &err_offset, &err));
    ASSERT (err_offset == 0);
    ASSERT (err.domain != 67890);


### PR DESCRIPTION
This fixes an edge case in `bson_validate_with_error_and_offset` that would cause unexpectedly uninitialized output parameters when a failure occurs at offset zero.

Includes the test case from CDRIVER-5754, now passing.
