### PR TITLE
Move batchtime from task definitions to task refs

### DIFF
--- a/.evergreen/config_generator/components/cse/openssl.py
+++ b/.evergreen/config_generator/components/cse/openssl.py
@@ -1,8 +1,8 @@
 from shrub.v3.evg_build_variant import BuildVariant
-from shrub.v3.evg_task import EvgTaskRef
 
 from config_generator.etc.compile import generate_compile_tasks
 from config_generator.etc.function import merge_defns
+from config_generator.etc.utils import TaskRef
 
 from config_generator.etc.cse.compile import CompileCommon
 from config_generator.etc.cse.test import generate_test_tasks
@@ -64,23 +64,25 @@ def functions():
     )
 
 
+SASL_TO_FUNC = {
+    'cyrus': SaslCyrusOpenSSLCompile,
+}
+
+MORE_TAGS = ['cse']
+
+TASKS = [
+    *generate_compile_tasks(SSL, TAG, SASL_TO_FUNC, COMPILE_MATRIX, MORE_TAGS),
+    *generate_test_tasks(SSL, TAG, TEST_MATRIX),
+]
+
+
 def tasks():
-    res = []
-
-    SASL_TO_FUNC = {
-        'cyrus': SaslCyrusOpenSSLCompile,
-    }
-
-    MORE_TAGS = ['cse']
-
-    res += generate_compile_tasks(SSL, TAG, SASL_TO_FUNC, COMPILE_MATRIX, MORE_TAGS)
-    res += generate_test_tasks(SSL, TAG, TEST_MATRIX)
+    res = TASKS.copy()
 
     # PowerPC and zSeries are limited resources.
     for task in res:
         if any(pattern in task.run_on for pattern in ["power8", "zseries"]):
             task.patchable = False
-            task.batchtime = 1440  # 1 day
 
     return res
 
@@ -90,11 +92,25 @@ def variants():
         'CLIENT_SIDE_ENCRYPTION': 'on',
     }
 
+    tasks = []
+
+    # PowerPC and zSeries are limited resources.
+    for task in TASKS:
+        if any(pattern in task.run_on for pattern in ["power8", "zseries"]):
+            tasks.append(
+                TaskRef(
+                    name=task.name,
+                    batchtime=1440,   # 1 day
+                )
+            )
+        else:
+            tasks.append(task.get_task_ref())
+
     return [
         BuildVariant(
             name=TAG,
             display_name=TAG,
-            tasks=[EvgTaskRef(name=f'.{TAG}')],
+            tasks=tasks,
             expansions=expansions,
         ),
     ]

--- a/.evergreen/config_generator/components/sasl/openssl.py
+++ b/.evergreen/config_generator/components/sasl/openssl.py
@@ -1,6 +1,8 @@
-from shrub.v3.evg_build_variant import BuildVariant
-from shrub.v3.evg_task import EvgTaskRef
+from typing import List
 
+from shrub.v3.evg_build_variant import BuildVariant
+
+from config_generator.etc.utils import TaskRef
 from config_generator.etc.function import merge_defns
 from config_generator.etc.compile import generate_compile_tasks
 
@@ -67,21 +69,23 @@ def functions():
     )
 
 
+SASL_TO_FUNC = {
+    'cyrus': SaslCyrusOpenSSLCompile,
+}
+
+TASKS = [
+    *generate_compile_tasks(SSL, TAG, SASL_TO_FUNC, COMPILE_MATRIX),
+    *generate_test_tasks(SSL, TAG, TEST_MATRIX),
+]
+
+
 def tasks():
-    res = []
-
-    SASL_TO_FUNC = {
-        'cyrus': SaslCyrusOpenSSLCompile,
-    }
-
-    res += generate_compile_tasks(SSL, TAG, SASL_TO_FUNC, COMPILE_MATRIX)
-    res += generate_test_tasks(SSL, TAG, TEST_MATRIX)
+    res = TASKS.copy()
 
     # PowerPC and zSeries are limited resources.
     for task in res:
         if any(pattern in task.run_on for pattern in ["power8", "zseries"]):
             task.patchable = False
-            task.batchtime = 1440  # 1 day
 
     return res
 
@@ -89,11 +93,25 @@ def tasks():
 def variants():
     expansions = {}
 
+    tasks = []
+
+    # PowerPC and zSeries are limited resources.
+    for task in TASKS:
+        if any(pattern in task.run_on for pattern in ["power8", "zseries"]):
+            tasks.append(
+                TaskRef(
+                    name=task.name,
+                    batchtime=1440,   # 1 day
+                )
+            )
+        else:
+            tasks.append(task.get_task_ref())
+
     return [
         BuildVariant(
             name=TAG,
             display_name=TAG,
-            tasks=[EvgTaskRef(name=f'.{TAG}')],
+            tasks=tasks,
             expansions=expansions,
         ),
     ]

--- a/.evergreen/config_generator/etc/utils.py
+++ b/.evergreen/config_generator/etc/utils.py
@@ -10,9 +10,21 @@ import yaml
 from shrub.v3.evg_command import EvgCommandType, subprocess_exec
 from shrub.v3.evg_project import EvgProject
 from shrub.v3.shrub_service import ConfigDumper
+from shrub.v3.evg_task import EvgTaskRef
 from typing_extensions import get_args, get_origin, get_type_hints
 
 T = TypeVar('T')
+
+
+# Equivalent to EvgTaskRef but defines additional properties.
+class TaskRef(EvgTaskRef):
+    """
+    An evergreen task reference model that also includes additional properties.
+
+    (The shrub.py model is missing some properties)
+    """
+
+    batchtime: int | None = None
 
 
 # Automatically formats the provided script and invokes it in Bash.

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -1605,7 +1605,6 @@ tasks:
   - name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-compile
     run_on: rhel83-zseries-large
     tags: [cse-matrix-openssl, compile, rhel83-zseries, gcc, cse, sasl-cyrus]
-    batchtime: 1440
     patchable: false
     commands:
       - func: find-cmake-latest
@@ -1617,7 +1616,6 @@ tasks:
     run_on: rhel83-zseries-small
     tags: [cse-matrix-openssl, test, rhel83-zseries, gcc, sasl-cyrus, cse, auth, server, "5.0", openssl]
     depends_on: [{ name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-compile }]
-    batchtime: 1440
     patchable: false
     commands:
       - func: fetch-build
@@ -1639,7 +1637,6 @@ tasks:
     run_on: rhel83-zseries-small
     tags: [cse-matrix-openssl, test, rhel83-zseries, gcc, sasl-cyrus, cse, auth, replica, "7.0", openssl]
     depends_on: [{ name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-compile }]
-    batchtime: 1440
     patchable: false
     commands:
       - func: fetch-build
@@ -1661,7 +1658,6 @@ tasks:
     run_on: rhel83-zseries-small
     tags: [cse-matrix-openssl, test, rhel83-zseries, gcc, sasl-cyrus, cse, auth, server, "7.0", openssl]
     depends_on: [{ name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-compile }]
-    batchtime: 1440
     patchable: false
     commands:
       - func: fetch-build
@@ -1683,7 +1679,6 @@ tasks:
     run_on: rhel83-zseries-small
     tags: [cse-matrix-openssl, test, rhel83-zseries, gcc, sasl-cyrus, cse, auth, replica, "8.0", openssl]
     depends_on: [{ name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-compile }]
-    batchtime: 1440
     patchable: false
     commands:
       - func: fetch-build
@@ -1705,7 +1700,6 @@ tasks:
     run_on: rhel83-zseries-small
     tags: [cse-matrix-openssl, test, rhel83-zseries, gcc, sasl-cyrus, cse, auth, server, "8.0", openssl]
     depends_on: [{ name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-compile }]
-    batchtime: 1440
     patchable: false
     commands:
       - func: fetch-build
@@ -1727,7 +1721,6 @@ tasks:
     run_on: rhel83-zseries-small
     tags: [cse-matrix-openssl, test, rhel83-zseries, gcc, sasl-cyrus, cse, auth, replica, latest, openssl]
     depends_on: [{ name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-compile }]
-    batchtime: 1440
     patchable: false
     commands:
       - func: fetch-build
@@ -1749,7 +1742,6 @@ tasks:
     run_on: rhel83-zseries-small
     tags: [cse-matrix-openssl, test, rhel83-zseries, gcc, sasl-cyrus, cse, auth, server, latest, openssl]
     depends_on: [{ name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-compile }]
-    batchtime: 1440
     patchable: false
     commands:
       - func: fetch-build
@@ -3217,7 +3209,6 @@ tasks:
   - name: sasl-cyrus-openssl-rhel81-power8-gcc-compile
     run_on: rhel81-power8-large
     tags: [sasl-matrix-openssl, compile, rhel81-power8, gcc, sasl-cyrus]
-    batchtime: 1440
     patchable: false
     commands:
       - func: find-cmake-latest
@@ -3229,7 +3220,6 @@ tasks:
     run_on: rhel81-power8-small
     tags: [sasl-matrix-openssl, test, rhel81-power8, gcc, sasl-cyrus, auth, server, "4.2", openssl]
     depends_on: [{ name: sasl-cyrus-openssl-rhel81-power8-gcc-compile }]
-    batchtime: 1440
     patchable: false
     commands:
       - func: fetch-build
@@ -3251,7 +3241,6 @@ tasks:
     run_on: rhel81-power8-small
     tags: [sasl-matrix-openssl, test, rhel81-power8, gcc, sasl-cyrus, auth, server, "4.4", openssl]
     depends_on: [{ name: sasl-cyrus-openssl-rhel81-power8-gcc-compile }]
-    batchtime: 1440
     patchable: false
     commands:
       - func: fetch-build
@@ -3273,7 +3262,6 @@ tasks:
     run_on: rhel81-power8-small
     tags: [sasl-matrix-openssl, test, rhel81-power8, gcc, sasl-cyrus, auth, server, "5.0", openssl]
     depends_on: [{ name: sasl-cyrus-openssl-rhel81-power8-gcc-compile }]
-    batchtime: 1440
     patchable: false
     commands:
       - func: fetch-build
@@ -3295,7 +3283,6 @@ tasks:
     run_on: rhel81-power8-small
     tags: [sasl-matrix-openssl, test, rhel81-power8, gcc, sasl-cyrus, auth, server, "6.0", openssl]
     depends_on: [{ name: sasl-cyrus-openssl-rhel81-power8-gcc-compile }]
-    batchtime: 1440
     patchable: false
     commands:
       - func: fetch-build
@@ -3317,7 +3304,6 @@ tasks:
     run_on: rhel81-power8-small
     tags: [sasl-matrix-openssl, test, rhel81-power8, gcc, sasl-cyrus, auth, server, "7.0", openssl]
     depends_on: [{ name: sasl-cyrus-openssl-rhel81-power8-gcc-compile }]
-    batchtime: 1440
     patchable: false
     commands:
       - func: fetch-build
@@ -3339,7 +3325,6 @@ tasks:
     run_on: rhel81-power8-small
     tags: [sasl-matrix-openssl, test, rhel81-power8, gcc, sasl-cyrus, auth, server, "8.0", openssl]
     depends_on: [{ name: sasl-cyrus-openssl-rhel81-power8-gcc-compile }]
-    batchtime: 1440
     patchable: false
     commands:
       - func: fetch-build
@@ -3361,7 +3346,6 @@ tasks:
     run_on: rhel81-power8-small
     tags: [sasl-matrix-openssl, test, rhel81-power8, gcc, sasl-cyrus, auth, server, latest, openssl]
     depends_on: [{ name: sasl-cyrus-openssl-rhel81-power8-gcc-compile }]
-    batchtime: 1440
     patchable: false
     commands:
       - func: fetch-build
@@ -3382,7 +3366,6 @@ tasks:
   - name: sasl-cyrus-openssl-rhel83-zseries-gcc-compile
     run_on: rhel83-zseries-large
     tags: [sasl-matrix-openssl, compile, rhel83-zseries, gcc, sasl-cyrus]
-    batchtime: 1440
     patchable: false
     commands:
       - func: find-cmake-latest
@@ -3394,7 +3377,6 @@ tasks:
     run_on: rhel83-zseries-small
     tags: [sasl-matrix-openssl, test, rhel83-zseries, gcc, sasl-cyrus, auth, server, "5.0", openssl]
     depends_on: [{ name: sasl-cyrus-openssl-rhel83-zseries-gcc-compile }]
-    batchtime: 1440
     patchable: false
     commands:
       - func: fetch-build
@@ -3416,7 +3398,6 @@ tasks:
     run_on: rhel83-zseries-small
     tags: [sasl-matrix-openssl, test, rhel83-zseries, gcc, sasl-cyrus, auth, server, "6.0", openssl]
     depends_on: [{ name: sasl-cyrus-openssl-rhel83-zseries-gcc-compile }]
-    batchtime: 1440
     patchable: false
     commands:
       - func: fetch-build
@@ -3438,7 +3419,6 @@ tasks:
     run_on: rhel83-zseries-small
     tags: [sasl-matrix-openssl, test, rhel83-zseries, gcc, sasl-cyrus, auth, server, "7.0", openssl]
     depends_on: [{ name: sasl-cyrus-openssl-rhel83-zseries-gcc-compile }]
-    batchtime: 1440
     patchable: false
     commands:
       - func: fetch-build
@@ -3460,7 +3440,6 @@ tasks:
     run_on: rhel83-zseries-small
     tags: [sasl-matrix-openssl, test, rhel83-zseries, gcc, sasl-cyrus, auth, server, "8.0", openssl]
     depends_on: [{ name: sasl-cyrus-openssl-rhel83-zseries-gcc-compile }]
-    batchtime: 1440
     patchable: false
     commands:
       - func: fetch-build
@@ -3482,7 +3461,6 @@ tasks:
     run_on: rhel83-zseries-small
     tags: [sasl-matrix-openssl, test, rhel83-zseries, gcc, sasl-cyrus, auth, server, latest, openssl]
     depends_on: [{ name: sasl-cyrus-openssl-rhel83-zseries-gcc-compile }]
-    batchtime: 1440
     patchable: false
     commands:
       - func: fetch-build

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -87,7 +87,63 @@ buildvariants:
     expansions:
       CLIENT_SIDE_ENCRYPTION: "on"
     tasks:
-      - name: .cse-matrix-openssl
+      - name: cse-sasl-cyrus-openssl-debian10-gcc-compile
+      - name: cse-sasl-cyrus-openssl-debian11-gcc-compile
+      - name: cse-sasl-cyrus-openssl-debian92-clang-compile
+      - name: cse-sasl-cyrus-openssl-debian92-gcc-compile
+      - name: cse-sasl-cyrus-openssl-rhel80-gcc-compile
+      - name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-compile
+        batchtime: 1440
+      - name: cse-sasl-cyrus-openssl-ubuntu1604-clang-compile
+      - name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile
+      - name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-compile
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-compile
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
+      - name: cse-sasl-cyrus-openssl-windows-2019-vs2017-x64-compile
+      - name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-test-5.0-server-auth
+        batchtime: 1440
+      - name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-4.2-server-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-4.4-server-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-5.0-server-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-6.0-server-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-test-4.2-server-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-test-4.4-server-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-test-5.0-server-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-test-6.0-server-auth
+      - name: cse-sasl-cyrus-openssl-windows-2019-vs2017-x64-test-4.2-server-auth
+      - name: cse-sasl-cyrus-openssl-windows-2019-vs2017-x64-test-4.4-server-auth
+      - name: cse-sasl-cyrus-openssl-windows-2019-vs2017-x64-test-5.0-server-auth
+      - name: cse-sasl-cyrus-openssl-windows-2019-vs2017-x64-test-6.0-server-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-7.0-server-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-8.0-server-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-latest-server-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-7.0-replica-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-8.0-replica-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-latest-replica-auth
+      - name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-test-7.0-server-auth
+        batchtime: 1440
+      - name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-test-8.0-server-auth
+        batchtime: 1440
+      - name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-test-latest-server-auth
+        batchtime: 1440
+      - name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-test-7.0-replica-auth
+        batchtime: 1440
+      - name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-test-8.0-replica-auth
+        batchtime: 1440
+      - name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-test-latest-replica-auth
+        batchtime: 1440
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-7.0-server-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-8.0-server-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-latest-server-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-7.0-replica-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-8.0-replica-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-latest-replica-auth
+      - name: cse-sasl-cyrus-openssl-windows-2019-vs2017-x64-test-7.0-server-auth
+      - name: cse-sasl-cyrus-openssl-windows-2019-vs2017-x64-test-8.0-server-auth
+      - name: cse-sasl-cyrus-openssl-windows-2019-vs2017-x64-test-latest-server-auth
+      - name: cse-sasl-cyrus-openssl-windows-2019-vs2017-x64-test-7.0-replica-auth
+      - name: cse-sasl-cyrus-openssl-windows-2019-vs2017-x64-test-8.0-replica-auth
+      - name: cse-sasl-cyrus-openssl-windows-2019-vs2017-x64-test-latest-replica-auth
   - name: cse-matrix-winssl
     display_name: cse-matrix-winssl
     expansions:
@@ -149,7 +205,69 @@ buildvariants:
     display_name: sasl-matrix-openssl
     expansions: {}
     tasks:
-      - name: .sasl-matrix-openssl
+      - name: sasl-cyrus-openssl-debian10-gcc-compile
+      - name: sasl-cyrus-openssl-debian11-gcc-compile
+      - name: sasl-cyrus-openssl-debian92-clang-compile
+      - name: sasl-cyrus-openssl-debian92-gcc-compile
+      - name: sasl-cyrus-openssl-rhel70-gcc-compile
+      - name: sasl-cyrus-openssl-rhel80-gcc-compile
+      - name: sasl-cyrus-openssl-rhel81-power8-gcc-compile
+        batchtime: 1440
+      - name: sasl-cyrus-openssl-rhel83-zseries-gcc-compile
+        batchtime: 1440
+      - name: sasl-cyrus-openssl-ubuntu1604-arm64-gcc-compile
+      - name: sasl-cyrus-openssl-ubuntu1604-clang-compile
+      - name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile
+      - name: sasl-cyrus-openssl-ubuntu1804-gcc-compile
+      - name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
+      - name: sasl-cyrus-openssl-ubuntu2004-gcc-compile
+      - name: sasl-cyrus-openssl-windows-2019-vs2017-x64-compile
+      - name: sasl-cyrus-openssl-rhel81-power8-gcc-test-4.2-server-auth
+        batchtime: 1440
+      - name: sasl-cyrus-openssl-rhel81-power8-gcc-test-4.4-server-auth
+        batchtime: 1440
+      - name: sasl-cyrus-openssl-rhel81-power8-gcc-test-5.0-server-auth
+        batchtime: 1440
+      - name: sasl-cyrus-openssl-rhel81-power8-gcc-test-6.0-server-auth
+        batchtime: 1440
+      - name: sasl-cyrus-openssl-rhel81-power8-gcc-test-7.0-server-auth
+        batchtime: 1440
+      - name: sasl-cyrus-openssl-rhel81-power8-gcc-test-8.0-server-auth
+        batchtime: 1440
+      - name: sasl-cyrus-openssl-rhel81-power8-gcc-test-latest-server-auth
+        batchtime: 1440
+      - name: sasl-cyrus-openssl-rhel83-zseries-gcc-test-5.0-server-auth
+        batchtime: 1440
+      - name: sasl-cyrus-openssl-rhel83-zseries-gcc-test-6.0-server-auth
+        batchtime: 1440
+      - name: sasl-cyrus-openssl-rhel83-zseries-gcc-test-7.0-server-auth
+        batchtime: 1440
+      - name: sasl-cyrus-openssl-rhel83-zseries-gcc-test-8.0-server-auth
+        batchtime: 1440
+      - name: sasl-cyrus-openssl-rhel83-zseries-gcc-test-latest-server-auth
+        batchtime: 1440
+      - name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-4.2-server-auth
+      - name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-4.4-server-auth
+      - name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-5.0-server-auth
+      - name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-6.0-server-auth
+      - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-4.0-server-auth
+      - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-4.2-server-auth
+      - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-4.4-server-auth
+      - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-5.0-server-auth
+      - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-6.0-server-auth
+      - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-4.0-replica-auth
+      - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-4.2-replica-auth
+      - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-4.4-replica-auth
+      - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-5.0-replica-auth
+      - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-6.0-replica-auth
+      - name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-7.0-server-auth
+      - name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-8.0-server-auth
+      - name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-latest-server-auth
+      - name: sasl-cyrus-openssl-ubuntu2004-gcc-test-7.0-server-auth
+      - name: sasl-cyrus-openssl-ubuntu2004-gcc-test-8.0-server-auth
+      - name: sasl-cyrus-openssl-ubuntu2004-gcc-test-latest-server-auth
+      - name: sasl-cyrus-openssl-windows-2019-vs2017-x64-test-latest-server-auth
+      - name: sasl-cyrus-openssl-ubuntu1604-arm64-gcc-test-4.0-server-auth
   - name: sasl-matrix-winssl
     display_name: sasl-matrix-winssl
     expansions: {}


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1761.

Evergreen validation errors initially thought to be [false-positives](https://jira.mongodb.org/browse/DEVPROD-11988) turns out to have been accurate: batchtime is [not yet supported](https://jira.mongodb.org/browse/DEVPROD-12032) in standalone task definitions.

Moves the `batchtime` field for Power8 and zSeries tasks to the build variant definition as required until DEVPROD-12032 is resolved. To avoid task definition conflict errors (due to multiple references to a task in a build variant), the convenient component tag in the build variant definition is replaced with an explicit, full list of task references.