### PR TITLE
CDRIVER-5759 fix relaxed encoding of date after year 9999

### DIFF
--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -2619,7 +2619,10 @@ _bson_as_json_visit_date_time (const bson_iter_t *iter, const char *key, int64_t
    BSON_UNUSED (iter);
    BSON_UNUSED (key);
 
-   if (state->mode == BSON_JSON_MODE_CANONICAL || (state->mode == BSON_JSON_MODE_RELAXED && msec_since_epoch < 0)) {
+   const int64_t msec_since_Y10K = 253402300800000; // Milliseconds since 10000-01-01T00:00:00Z.
+
+   if (state->mode == BSON_JSON_MODE_CANONICAL ||
+       (state->mode == BSON_JSON_MODE_RELAXED && (msec_since_epoch < 0 || msec_since_epoch >= msec_since_Y10K))) {
       mcommon_string_append (state->str, "{ \"$date\" : { \"$numberLong\" : \"");
       mcommon_string_append_printf (state->str, "%" PRId64, msec_since_epoch);
       mcommon_string_append (state->str, "\" } }");

--- a/src/libbson/tests/json/bson_corpus/datetime.json
+++ b/src/libbson/tests/json/bson_corpus/datetime.json
@@ -24,6 +24,7 @@
         {
             "description" : "Y10K",
             "canonical_bson" : "1000000009610000DC1FD277E6000000",
+            "relaxed_extjson" : "{\"a\":{\"$date\":{\"$numberLong\":\"253402300800000\"}}}",
             "canonical_extjson" : "{\"a\":{\"$date\":{\"$numberLong\":\"253402300800000\"}}}"
         },
         {


### PR DESCRIPTION
Fix encoding of date after year 9999 to agree with the Extended JSON specification.

Verified with [this patch build](https://spruce.mongodb.com/version/67117b1eb138970007cc034b).

## Background & Motivation

The extended JSON spec notes:

> | **BSON 1.1 Type or Convention**                                                            | **Canonical Extended JSON Format**                                                                                                                                                                                                                                                                                                                                                                                         | **Relaxed Extended JSON Format**                                                                                                            |
> | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
> ...
> | Datetime \[year before 1970 or after 9999\]                                                | {"$date": {"$numberLong": \<64-bit signed integer giving millisecs relative to the epoch, as a _string_>}}                                                                                                                                                                                                                                                                                                                 | \<Same as Canonical Extended JSON\>        

Includes a regression test from https://github.com/mongodb/specifications/pull/1676.

