### PR TITLE
CDRIVER-4220 redefine bson_sync_synchronize using bson_atomic_thread_fence

### DIFF
--- a/src/libbson/src/bson/bson-atomic.h
+++ b/src/libbson/src/bson/bson-atomic.h
@@ -641,6 +641,12 @@ bson_atomic_thread_fence (void)
    BSON_IF_GNU_LEGACY_ATOMICS (__sync_synchronize ();)
 }
 
+static BSON_INLINE void BSON_GNUC_DEPRECATED
+bson_sync_synchronize (void)
+{
+   bson_atomic_thread_fence ();
+}
+
 #ifdef BSON_USE_LEGACY_GCC_ATOMICS
 #undef BSON_IF_GNU_LIKE
 #define BSON_IF_GNU_LIKE(...) __VA_ARGS__

--- a/src/libbson/src/bson/bson-compat.h
+++ b/src/libbson/src/bson/bson-compat.h
@@ -203,13 +203,6 @@ typedef signed char bool;
 #define BSON_IF_POSIX(...) __VA_ARGS__
 #endif
 
-static BSON_INLINE void BSON_GNUC_DEPRECATED
-bson_sync_synchronize (void)
-{
-   BSON_IF_MSVC (MemoryBarrier ();)
-   BSON_IF_GNU_LIKE (__sync_synchronize ();)
-}
-
 
 BSON_END_DECLS
 


### PR DESCRIPTION
Previously, change 71475dfc58d0a35fe9e3a4941a2c997a50eab4ef redefined bson_sync_synchronize in terms of __sync_synchronize, avoiding obsolete conditionals and inline asm. This change fails on the "public-header-warnings" build target when CC=clang, because all warnings are enabled including -Watomic-implicit-seq-cst.

This change uses bson_atomic_thread_fence instead, which is both the simpler solution and it already includes an exception for the compiler warning. The previous patch was written in an attempt to avoid moving the public bson_sync_synchronize entry point from bson-compat to bson-atomic, but now I know the BSON_INSIDE include guard makes this distinction unnecessary.