### PR TITLE
CDRIVER-4602 regenerate build variants config

### DIFF
--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -108,29 +108,25 @@ buildvariants:
       - name: cse-sasl-cyrus-openssl-rhel80-gcc-compile
       - name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-compile
         batchtime: 1440
-      - name: cse-sasl-cyrus-openssl-ubuntu1604-clang-compile
-      - name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile
-      - name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-compile
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-clang-compile
       - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-compile
       - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
       - name: cse-sasl-cyrus-openssl-windows-2019-vs2017-x64-compile
       - name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-test-5.0-server-auth
         batchtime: 1440
-      - name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-4.2-server-auth
-      - name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-4.4-server-auth
-      - name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-5.0-server-auth
-      - name: cse-sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-6.0-server-auth
-      - name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-test-4.2-server-auth
-      - name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-test-4.4-server-auth
-      - name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-test-5.0-server-auth
-      - name: cse-sasl-cyrus-openssl-ubuntu1804-gcc-test-6.0-server-auth
       - name: cse-sasl-cyrus-openssl-windows-2019-vs2017-x64-test-4.2-server-auth
       - name: cse-sasl-cyrus-openssl-windows-2019-vs2017-x64-test-4.4-server-auth
       - name: cse-sasl-cyrus-openssl-windows-2019-vs2017-x64-test-5.0-server-auth
       - name: cse-sasl-cyrus-openssl-windows-2019-vs2017-x64-test-6.0-server-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-4.4-server-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-5.0-server-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-6.0-server-auth
       - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-7.0-server-auth
       - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-8.0-server-auth
       - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-latest-server-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-4.4-replica-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-5.0-replica-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-6.0-replica-auth
       - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-7.0-replica-auth
       - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-8.0-replica-auth
       - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-latest-replica-auth
@@ -146,9 +142,15 @@ buildvariants:
         batchtime: 1440
       - name: cse-sasl-cyrus-openssl-rhel83-zseries-gcc-test-latest-replica-auth
         batchtime: 1440
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-4.4-server-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-5.0-server-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-6.0-server-auth
       - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-7.0-server-auth
       - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-8.0-server-auth
       - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-latest-server-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-4.4-replica-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-5.0-replica-auth
+      - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-6.0-replica-auth
       - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-7.0-replica-auth
       - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-8.0-replica-auth
       - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-latest-replica-auth
@@ -158,6 +160,8 @@ buildvariants:
       - name: cse-sasl-cyrus-openssl-windows-2019-vs2017-x64-test-7.0-replica-auth
       - name: cse-sasl-cyrus-openssl-windows-2019-vs2017-x64-test-8.0-replica-auth
       - name: cse-sasl-cyrus-openssl-windows-2019-vs2017-x64-test-latest-replica-auth
+      - name: cse-sasl-cyrus-openssl-debian10-gcc-test-4.2-server-auth
+      - name: cse-sasl-cyrus-openssl-debian10-gcc-test-4.2-replica-auth
   - name: cse-matrix-winssl
     display_name: cse-matrix-winssl
     expansions:
@@ -223,16 +227,12 @@ buildvariants:
       - name: sasl-cyrus-openssl-debian11-gcc-compile
       - name: sasl-cyrus-openssl-debian92-clang-compile
       - name: sasl-cyrus-openssl-debian92-gcc-compile
-      - name: sasl-cyrus-openssl-rhel70-gcc-compile
       - name: sasl-cyrus-openssl-rhel80-gcc-compile
       - name: sasl-cyrus-openssl-rhel81-power8-gcc-compile
         batchtime: 1440
       - name: sasl-cyrus-openssl-rhel83-zseries-gcc-compile
         batchtime: 1440
-      - name: sasl-cyrus-openssl-ubuntu1604-arm64-gcc-compile
-      - name: sasl-cyrus-openssl-ubuntu1604-clang-compile
-      - name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-compile
-      - name: sasl-cyrus-openssl-ubuntu1804-gcc-compile
+      - name: sasl-cyrus-openssl-ubuntu2004-clang-compile
       - name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
       - name: sasl-cyrus-openssl-ubuntu2004-gcc-compile
       - name: sasl-cyrus-openssl-windows-2019-vs2017-x64-compile
@@ -260,28 +260,21 @@ buildvariants:
         batchtime: 1440
       - name: sasl-cyrus-openssl-rhel83-zseries-gcc-test-latest-server-auth
         batchtime: 1440
-      - name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-4.2-server-auth
-      - name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-4.4-server-auth
-      - name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-5.0-server-auth
-      - name: sasl-cyrus-openssl-ubuntu1804-arm64-gcc-test-6.0-server-auth
-      - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-4.0-server-auth
-      - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-4.2-server-auth
-      - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-4.4-server-auth
-      - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-5.0-server-auth
-      - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-6.0-server-auth
-      - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-4.0-replica-auth
-      - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-4.2-replica-auth
-      - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-4.4-replica-auth
-      - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-5.0-replica-auth
-      - name: sasl-cyrus-openssl-ubuntu1804-gcc-test-6.0-replica-auth
+      - name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-4.4-server-auth
+      - name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-5.0-server-auth
+      - name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-6.0-server-auth
       - name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-7.0-server-auth
       - name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-8.0-server-auth
       - name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-latest-server-auth
+      - name: sasl-cyrus-openssl-ubuntu2004-gcc-test-4.4-server-auth
+      - name: sasl-cyrus-openssl-ubuntu2004-gcc-test-5.0-server-auth
+      - name: sasl-cyrus-openssl-ubuntu2004-gcc-test-6.0-server-auth
       - name: sasl-cyrus-openssl-ubuntu2004-gcc-test-7.0-server-auth
       - name: sasl-cyrus-openssl-ubuntu2004-gcc-test-8.0-server-auth
       - name: sasl-cyrus-openssl-ubuntu2004-gcc-test-latest-server-auth
       - name: sasl-cyrus-openssl-windows-2019-vs2017-x64-test-latest-server-auth
-      - name: sasl-cyrus-openssl-ubuntu1604-arm64-gcc-test-4.0-server-auth
+      - name: sasl-cyrus-openssl-debian10-gcc-test-4.2-server-auth
+      - name: sasl-cyrus-openssl-debian10-gcc-test-4.2-replica-auth
   - name: sasl-matrix-winssl
     display_name: sasl-matrix-winssl
     expansions: {}


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1760. Addresses the warnings observed in EVG build pages:

![image](https://github.com/user-attachments/assets/a2463655-5da2-475f-b426-94d445fef692)

Regenerates build variants config YAML file, which appears to have only been partially updated in https://github.com/mongodb/mongo-c-driver/pull/1760.