### PR TITLE
CDRIVER-5700 deprecate `bson_as_json` and `bson_array_as_json`

### DIFF
--- a/.evergreen/scripts/compile-libmongocrypt.sh
+++ b/.evergreen/scripts/compile-libmongocrypt.sh
@@ -10,12 +10,13 @@ compile_libmongocrypt() {
   # `.evergreen/scripts/kms-divergence-check.sh` to ensure that there is no
   # divergence in the copied files.
 
-  # TODO: once 1.12.0 is released (containing MONGOCRYPT-599) replace the following with:
+  # TODO: once 1.12.0 is released replace the following with:
   # git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.12.0 || return
   {
-    git clone -q https://github.com/mongodb/libmongocrypt || return
-    # Check out commit containing MONGOCRYPT-599
-    git -C libmongocrypt checkout 7aeaec4ae1369c7d3c5b3aea6f1da35c5e9478b0
+    # TODO: update once https://github.com/mongodb/libmongocrypt/pull/895 is merged.
+    git clone -q https://github.com/kevinAlbs/libmongocrypt || return
+    # Check out commit removing use of (the now deprecated) bson_as_json
+    git -C libmongocrypt checkout --branch CDRIVER-5700
   }
 
   declare -a crypt_cmake_flags=(

--- a/.evergreen/scripts/compile-libmongocrypt.sh
+++ b/.evergreen/scripts/compile-libmongocrypt.sh
@@ -10,13 +10,11 @@ compile_libmongocrypt() {
   # `.evergreen/scripts/kms-divergence-check.sh` to ensure that there is no
   # divergence in the copied files.
 
-  # TODO: once 1.12.0 is released replace the following with:
+  # TODO: once 1.12.0 is released (containing de69cc91e1574e8861cd0ceb4bb866cc02a53d6b) replace the following with:
   # git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.12.0 || return
   {
-    # TODO: update once https://github.com/mongodb/libmongocrypt/pull/895 is merged.
-    git clone -q https://github.com/kevinAlbs/libmongocrypt || return
-    # Check out commit removing use of (the now deprecated) bson_as_json
-    git -C libmongocrypt checkout --branch CDRIVER-5700
+    git clone -q https://github.com/mongodb/libmongocrypt || return
+    git -C libmongocrypt checkout de69cc91e1574e8861cd0ceb4bb866cc02a53d6b
   }
 
   declare -a crypt_cmake_flags=(

--- a/src/libbson/CMakeLists.txt
+++ b/src/libbson/CMakeLists.txt
@@ -295,6 +295,7 @@ if (ENABLE_EXAMPLES)
    add_example (json-to-bson examples/json-to-bson.c)
    add_example (bson-check-depth examples/bson-check-depth.c)
    add_example (creating examples/creating.c)
+   add_example (extended-json examples/extended-json.c)
 endif () # ENABLE_EXAMPLES
 
 

--- a/src/libbson/NEWS
+++ b/src/libbson/NEWS
@@ -7,6 +7,7 @@ Deprecated:
   * Compiling with `BSON_MEMCHECK` defined is deprecated.
   * `bson_in_range_*` and `bson_cmp_*` functions.
   * `bson_atomic_*` and `bson_thrd_yield` functions.
+  * `bson_as_json` and `bson_array_as_json` are deprecated due to producing non-portable Legacy Extended JSON. Prefer Canonical Extended JSON or Relaxed Extended JSON for portability. To continue using Legacy Extended JSON, use `bson_as_legacy_extended_json` and `bson_array_as_legacy_extended_json`.
 
 libbson 1.28.1
 ==============

--- a/src/libbson/doc/api.rst
+++ b/src/libbson/doc/api.rst
@@ -26,3 +26,4 @@ API Reference
   bson_get_monotonic_time
   bson_memory
   version
+  legacy_extended_json

--- a/src/libbson/doc/bson_array_as_canonical_extended_json.rst
+++ b/src/libbson/doc/bson_array_as_canonical_extended_json.rst
@@ -20,7 +20,9 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_array_as_canonical_extended_json()` encodes ``bson`` as a UTF-8 string in Canonical Extended JSON. See `MongoDB Extended JSON format`_ for a description of Extended JSON formats. The outermost element is encoded as a JSON array, rather than a JSON document.
+The :symbol:`bson_array_as_canonical_extended_json()` encodes ``bson`` as a UTF-8 string in Canonical Extended JSON.
+See `MongoDB Extended JSON format`_ for a description of Extended JSON formats.
+The outermost element is encoded as a JSON array, rather than a JSON document.
 
 The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 

--- a/src/libbson/doc/bson_array_as_canonical_extended_json.rst
+++ b/src/libbson/doc/bson_array_as_canonical_extended_json.rst
@@ -21,8 +21,8 @@ Description
 -----------
 
 The :symbol:`bson_array_as_canonical_extended_json()` encodes ``bson`` as a UTF-8 string in Canonical Extended JSON.
+The outermost element is encoded as a JSON array (``[ ... ]``), rather than a JSON document (``{ ... }``).
 See `MongoDB Extended JSON format`_ for a description of Extended JSON formats.
-The outermost element is encoded as a JSON array, rather than a JSON document.
 
 The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 

--- a/src/libbson/doc/bson_array_as_canonical_extended_json.rst
+++ b/src/libbson/doc/bson_array_as_canonical_extended_json.rst
@@ -20,7 +20,7 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_array_as_canonical_extended_json()` encodes ``bson`` as a UTF-8 string in Canonical Extended JSON.
+:symbol:`bson_array_as_canonical_extended_json()` encodes ``bson`` as a UTF-8 string in Canonical Extended JSON.
 The outermost element is encoded as a JSON array (``[ ... ]``), rather than a JSON document (``{ ... }``).
 See `MongoDB Extended JSON format`_ for a description of Extended JSON formats.
 

--- a/src/libbson/doc/bson_array_as_canonical_extended_json.rst
+++ b/src/libbson/doc/bson_array_as_canonical_extended_json.rst
@@ -20,7 +20,7 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_array_as_canonical_extended_json()` encodes ``bson`` as a UTF-8 string in the canonical `MongoDB Extended JSON format`_, except the outermost element is encoded as a JSON array, rather than a JSON document.
+The :symbol:`bson_array_as_canonical_extended_json()` encodes ``bson`` as a UTF-8 string in Canonical Extended JSON. See `MongoDB Extended JSON format`_ for a description of Extended JSON formats. The outermost element is encoded as a JSON array, rather than a JSON document.
 
 The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 

--- a/src/libbson/doc/bson_array_as_canonical_extended_json.rst
+++ b/src/libbson/doc/bson_array_as_canonical_extended_json.rst
@@ -38,31 +38,11 @@ Upon failure, NULL is returned.
 Example
 -------
 
-.. code-block:: c
-
-  #include <bson/bson.h>
-
-  int main ()
-  {
-     bson_t bson;
-     char *str;
-
-     bson_init (&bson);
-     /* BSON array is a normal BSON document with integer values for the keys,
-      * starting with 0 and continuing sequentially
-      */
-     BSON_APPEND_INT32 (&bson, "0", 1);
-     BSON_APPEND_UTF8 (&bson, "1", "bar");
-
-     str = bson_array_as_canonical_extended_json (&bson, NULL);
-     /* Prints
-      * [ { "$numberInt" : 1 }, "bar" ]
-      */
-     printf ("%s\n", str);
-     bson_free (str);
-
-     bson_destroy (&bson);
-  }
+.. literalinclude:: ../examples/extended-json.c
+   :language: c
+   :start-after: // bson_array_as_canonical_extended_json ... begin
+   :end-before: // bson_array_as_canonical_extended_json ... end
+   :dedent: 6
 
 
 .. only:: html

--- a/src/libbson/doc/bson_array_as_json.rst
+++ b/src/libbson/doc/bson_array_as_json.rst
@@ -26,7 +26,7 @@ Description
 -----------
 
 The :symbol:`bson_array_as_json()` function shall encode ``bson`` as a UTF-8
-string using libbson's Legacy Extended JSON format, except the outermost element is
+string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`, except the outermost element is
 encoded as a JSON array, rather than a JSON document. This function is
 superseded by :symbol:`bson_array_as_canonical_extended_json()` and
 :symbol:`bson_array_as_relaxed_extended_json()`, which use the same 

--- a/src/libbson/doc/bson_array_as_json.rst
+++ b/src/libbson/doc/bson_array_as_json.rst
@@ -3,13 +3,18 @@
 bson_array_as_json()
 ====================
 
+.. warning::
+   .. deprecated:: 1.29.0
+
+      This function is deprecated and should not be used in new code.
+
 Synopsis
 --------
 
 .. code-block:: c
 
   char *
-  bson_array_as_json (const bson_t *bson, size_t *length);
+  bson_array_as_json (const bson_t *bson, size_t *length) BSON_GNUC_DEPRECATED_FOR (bson_array_as_legacy_extended_json);
 
 Parameters
 ----------
@@ -26,6 +31,7 @@ encoded as a JSON array, rather than a JSON document. This function is
 superseded by :symbol:`bson_array_as_canonical_extended_json()` and
 :symbol:`bson_array_as_relaxed_extended_json()`, which use the same 
 `MongoDB Extended JSON format`_ as all other MongoDB drivers.
+To continue producing Legacy Extended JSON, :symbol:`bson_array_as_legacy_extended_json()` may be used.
 The caller is responsible for freeing the resulting UTF-8 encoded string by
 calling :symbol:`bson_free()` with the result.
 

--- a/src/libbson/doc/bson_array_as_json.rst
+++ b/src/libbson/doc/bson_array_as_json.rst
@@ -25,9 +25,11 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_array_as_json()` function shall encode ``bson`` as a UTF-8 string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`, except the outermost element is encoded as a JSON array, rather than a JSON document.
+The :symbol:`bson_array_as_json()` function shall encode ``bson`` as a UTF-8 string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`.
+The outermost element is encoded as a JSON array (``[ ... ]``), rather than a JSON document (``{ ... }``).
 This function is superseded by :symbol:`bson_array_as_canonical_extended_json()` and :symbol:`bson_array_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
 To continue producing Legacy Extended JSON, :symbol:`bson_array_as_legacy_extended_json()` may be used.
+
 The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 
 If non-NULL, ``length`` will be set to the length of the result in bytes.

--- a/src/libbson/doc/bson_array_as_json.rst
+++ b/src/libbson/doc/bson_array_as_json.rst
@@ -26,7 +26,7 @@ Description
 -----------
 
 The :symbol:`bson_array_as_json()` function shall encode ``bson`` as a UTF-8
-string using libbson's legacy JSON format, except the outermost element is
+string using libbson's Legacy Extended JSON format, except the outermost element is
 encoded as a JSON array, rather than a JSON document. This function is
 superseded by :symbol:`bson_array_as_canonical_extended_json()` and
 :symbol:`bson_array_as_relaxed_extended_json()`, which use the same 

--- a/src/libbson/doc/bson_array_as_json.rst
+++ b/src/libbson/doc/bson_array_as_json.rst
@@ -25,7 +25,7 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_array_as_json()` function shall encode ``bson`` as a UTF-8 string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`.
+:symbol:`bson_array_as_json()` encodes ``bson`` as a UTF-8 string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`.
 The outermost element is encoded as a JSON array (``[ ... ]``), rather than a JSON document (``{ ... }``).
 This function is superseded by :symbol:`bson_array_as_canonical_extended_json()` and :symbol:`bson_array_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
 To continue producing Legacy Extended JSON, :symbol:`bson_array_as_legacy_extended_json()` may be used.

--- a/src/libbson/doc/bson_array_as_json.rst
+++ b/src/libbson/doc/bson_array_as_json.rst
@@ -41,36 +41,6 @@ If successful, a newly allocated UTF-8 encoded string and ``length`` is set.
 
 Upon failure, NULL is returned.
 
-Example
--------
-
-.. code-block:: c
-
-  #include <bson/bson.h>
-
-  int main ()
-  {
-     bson_t bson;
-     char *str;
-
-     bson_init (&bson);
-     /* BSON array is a normal BSON document with integer values for the keys,
-      * starting with 0 and continuing sequentially
-      */
-     BSON_APPEND_UTF8 (&bson, "0", "foo");
-     BSON_APPEND_UTF8 (&bson, "1", "bar");
-
-     str = bson_array_as_json (&bson, NULL);
-     /* Prints
-      * [ "foo", "bar" ]
-      */
-     printf ("%s\n", str);
-     bson_free (str);
-
-     bson_destroy (&bson);
-  }
-
-
 .. only:: html
 
   .. include:: includes/seealso/bson-as-json.txt

--- a/src/libbson/doc/bson_array_as_json.rst
+++ b/src/libbson/doc/bson_array_as_json.rst
@@ -25,15 +25,10 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_array_as_json()` function shall encode ``bson`` as a UTF-8
-string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`, except the outermost element is
-encoded as a JSON array, rather than a JSON document. This function is
-superseded by :symbol:`bson_array_as_canonical_extended_json()` and
-:symbol:`bson_array_as_relaxed_extended_json()`, which use the same 
-`MongoDB Extended JSON format`_ as all other MongoDB drivers.
+The :symbol:`bson_array_as_json()` function shall encode ``bson`` as a UTF-8 string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`, except the outermost element is encoded as a JSON array, rather than a JSON document.
+This function is superseded by :symbol:`bson_array_as_canonical_extended_json()` and :symbol:`bson_array_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
 To continue producing Legacy Extended JSON, :symbol:`bson_array_as_legacy_extended_json()` may be used.
-The caller is responsible for freeing the resulting UTF-8 encoded string by
-calling :symbol:`bson_free()` with the result.
+The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 
 If non-NULL, ``length`` will be set to the length of the result in bytes.
 

--- a/src/libbson/doc/bson_array_as_legacy_extended_json.rst
+++ b/src/libbson/doc/bson_array_as_legacy_extended_json.rst
@@ -20,14 +20,9 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_array_as_legacy_extended_json()` function shall encode ``bson`` as a UTF-8
-string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`, except the outermost element is
-encoded as a JSON array, rather than a JSON document. This function is
-superseded by :symbol:`bson_array_as_canonical_extended_json()` and
-:symbol:`bson_array_as_relaxed_extended_json()`, which use the same 
-`MongoDB Extended JSON format`_ as all other MongoDB drivers.
-The caller is responsible for freeing the resulting UTF-8 encoded string by
-calling :symbol:`bson_free()` with the result.
+The :symbol:`bson_array_as_legacy_extended_json()` function shall encode ``bson`` as a UTF-8 string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`, except the outermost element is encoded as a JSON array, rather than a JSON document.
+This function is superseded by :symbol:`bson_array_as_canonical_extended_json()` and :symbol:`bson_array_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
+The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 
 If non-NULL, ``length`` will be set to the length of the result in bytes.
 

--- a/src/libbson/doc/bson_array_as_legacy_extended_json.rst
+++ b/src/libbson/doc/bson_array_as_legacy_extended_json.rst
@@ -20,8 +20,10 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_array_as_legacy_extended_json()` function shall encode ``bson`` as a UTF-8 string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`, except the outermost element is encoded as a JSON array, rather than a JSON document.
+The :symbol:`bson_array_as_legacy_extended_json()` function shall encode ``bson`` as a UTF-8 string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`.
+The outermost element is encoded as a JSON array (``[ ... ]``), rather than a JSON document (``{ ... }``).
 This function is superseded by :symbol:`bson_array_as_canonical_extended_json()` and :symbol:`bson_array_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
+
 The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 
 If non-NULL, ``length`` will be set to the length of the result in bytes.

--- a/src/libbson/doc/bson_array_as_legacy_extended_json.rst
+++ b/src/libbson/doc/bson_array_as_legacy_extended_json.rst
@@ -20,7 +20,7 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_array_as_legacy_extended_json()` function shall encode ``bson`` as a UTF-8 string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`.
+:symbol:`bson_array_as_legacy_extended_json()` encodes ``bson`` as a UTF-8 string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`.
 The outermost element is encoded as a JSON array (``[ ... ]``), rather than a JSON document (``{ ... }``).
 This function is superseded by :symbol:`bson_array_as_canonical_extended_json()` and :symbol:`bson_array_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
 

--- a/src/libbson/doc/bson_array_as_legacy_extended_json.rst
+++ b/src/libbson/doc/bson_array_as_legacy_extended_json.rst
@@ -38,32 +38,11 @@ Upon failure, NULL is returned.
 Example
 -------
 
-.. code-block:: c
-
-  #include <bson/bson.h>
-
-  int main ()
-  {
-     bson_t bson;
-     char *str;
-
-     bson_init (&bson);
-     /* BSON array is a normal BSON document with integer values for the keys,
-      * starting with 0 and continuing sequentially
-      */
-     BSON_APPEND_UTF8 (&bson, "0", "foo");
-     BSON_APPEND_UTF8 (&bson, "1", "bar");
-
-     str = bson_array_as_legacy_extended_json (&bson, NULL);
-     /* Prints
-      * [ "foo", "bar" ]
-      */
-     printf ("%s\n", str);
-     bson_free (str);
-
-     bson_destroy (&bson);
-  }
-
+.. literalinclude:: ../examples/extended-json.c
+   :language: c
+   :start-after: // bson_array_as_legacy_extended_json ... begin
+   :end-before: // bson_array_as_legacy_extended_json ... end
+   :dedent: 6
 
 .. only:: html
 

--- a/src/libbson/doc/bson_array_as_legacy_extended_json.rst
+++ b/src/libbson/doc/bson_array_as_legacy_extended_json.rst
@@ -21,7 +21,7 @@ Description
 -----------
 
 The :symbol:`bson_array_as_legacy_extended_json()` function shall encode ``bson`` as a UTF-8
-string using libbson's Legacy Extended JSON format, except the outermost element is
+string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`, except the outermost element is
 encoded as a JSON array, rather than a JSON document. This function is
 superseded by :symbol:`bson_array_as_canonical_extended_json()` and
 :symbol:`bson_array_as_relaxed_extended_json()`, which use the same 

--- a/src/libbson/doc/bson_array_as_legacy_extended_json.rst
+++ b/src/libbson/doc/bson_array_as_legacy_extended_json.rst
@@ -1,0 +1,75 @@
+:man_page: bson_array_as_legacy_extended_json
+
+bson_array_as_legacy_extended_json()
+====================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  char *
+  bson_array_as_legacy_extended_json (const bson_t *bson, size_t *length)
+
+Parameters
+----------
+
+* ``bson``: A :symbol:`bson_t`.
+* ``length``: An optional location for the length of the resulting string.
+
+Description
+-----------
+
+The :symbol:`bson_array_as_legacy_extended_json()` function shall encode ``bson`` as a UTF-8
+string using libbson's Legacy Extended JSON format, except the outermost element is
+encoded as a JSON array, rather than a JSON document. This function is
+superseded by :symbol:`bson_array_as_canonical_extended_json()` and
+:symbol:`bson_array_as_relaxed_extended_json()`, which use the same 
+`MongoDB Extended JSON format`_ as all other MongoDB drivers.
+The caller is responsible for freeing the resulting UTF-8 encoded string by
+calling :symbol:`bson_free()` with the result.
+
+If non-NULL, ``length`` will be set to the length of the result in bytes.
+
+Returns
+-------
+
+If successful, a newly allocated UTF-8 encoded string and ``length`` is set.
+
+Upon failure, NULL is returned.
+
+Example
+-------
+
+.. code-block:: c
+
+  #include <bson/bson.h>
+
+  int main ()
+  {
+     bson_t bson;
+     char *str;
+
+     bson_init (&bson);
+     /* BSON array is a normal BSON document with integer values for the keys,
+      * starting with 0 and continuing sequentially
+      */
+     BSON_APPEND_UTF8 (&bson, "0", "foo");
+     BSON_APPEND_UTF8 (&bson, "1", "bar");
+
+     str = bson_array_as_legacy_extended_json (&bson, NULL);
+     /* Prints
+      * [ "foo", "bar" ]
+      */
+     printf ("%s\n", str);
+     bson_free (str);
+
+     bson_destroy (&bson);
+  }
+
+
+.. only:: html
+
+  .. include:: includes/seealso/bson-as-json.txt
+
+.. _MongoDB Extended JSON format: https://github.com/mongodb/specifications/blob/master/source/extended-json/extended-json.md

--- a/src/libbson/doc/bson_array_as_relaxed_extended_json.rst
+++ b/src/libbson/doc/bson_array_as_relaxed_extended_json.rst
@@ -38,31 +38,11 @@ Upon failure, NULL is returned.
 Example
 -------
 
-.. code-block:: c
-
-  #include <bson/bson.h>
-
-  int main ()
-  {
-     bson_t bson;
-     char *str;
-
-     bson_init (&bson);
-     /* BSON array is a normal BSON document with integer values for the keys,
-      * starting with 0 and continuing sequentially
-      */
-     BSON_APPEND_DOUBLE (&bson, "0", 3.14);
-     BSON_APPEND_UTF8 (&bson, "1", "bar");
-
-     str = bson_array_as_relaxed_extended_json (&bson, NULL);
-     /* Prints
-      * [ 3.14, "bar" ]
-      */
-     printf ("%s\n", str);
-     bson_free (str);
-
-     bson_destroy (&bson);
-  }
+.. literalinclude:: ../examples/extended-json.c
+   :language: c
+   :start-after: // bson_array_as_relaxed_extended_json ... begin
+   :end-before: // bson_array_as_relaxed_extended_json ... end
+   :dedent: 6
 
 
 .. only:: html

--- a/src/libbson/doc/bson_array_as_relaxed_extended_json.rst
+++ b/src/libbson/doc/bson_array_as_relaxed_extended_json.rst
@@ -20,7 +20,9 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_as_relaxed_extended_json()` encodes ``bson`` as a UTF-8 string in the Relaxed Extended JSON. See `MongoDB Extended JSON format`_ for a description of Extended JSON formats. The outermost element is encoded as a JSON array, rather than a JSON document.
+The :symbol:`bson_as_relaxed_extended_json()` encodes ``bson`` as a UTF-8 string in the Relaxed Extended JSON.
+See `MongoDB Extended JSON format`_ for a description of Extended JSON formats.
+The outermost element is encoded as a JSON array, rather than a JSON document.
 
 The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 

--- a/src/libbson/doc/bson_array_as_relaxed_extended_json.rst
+++ b/src/libbson/doc/bson_array_as_relaxed_extended_json.rst
@@ -20,7 +20,7 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_as_relaxed_extended_json()` encodes ``bson`` as a UTF-8 string in the Relaxed Extended JSON.
+:symbol:`bson_as_relaxed_extended_json()` encodes ``bson`` as a UTF-8 string in the Relaxed Extended JSON.
 The outermost element is encoded as a JSON array (``[ ... ]``), rather than a JSON document (``{ ... }``).
 See `MongoDB Extended JSON format`_ for a description of Extended JSON formats.
 

--- a/src/libbson/doc/bson_array_as_relaxed_extended_json.rst
+++ b/src/libbson/doc/bson_array_as_relaxed_extended_json.rst
@@ -21,8 +21,8 @@ Description
 -----------
 
 The :symbol:`bson_as_relaxed_extended_json()` encodes ``bson`` as a UTF-8 string in the Relaxed Extended JSON.
+The outermost element is encoded as a JSON array (``[ ... ]``), rather than a JSON document (``{ ... }``).
 See `MongoDB Extended JSON format`_ for a description of Extended JSON formats.
-The outermost element is encoded as a JSON array, rather than a JSON document.
 
 The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 

--- a/src/libbson/doc/bson_array_as_relaxed_extended_json.rst
+++ b/src/libbson/doc/bson_array_as_relaxed_extended_json.rst
@@ -20,7 +20,7 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_as_relaxed_extended_json()` encodes ``bson`` as a UTF-8 string in the relaxed `MongoDB Extended JSON format`_, except the outermost element is encoded as a JSON array, rather than a JSON document.
+The :symbol:`bson_as_relaxed_extended_json()` encodes ``bson`` as a UTF-8 string in the Relaxed Extended JSON. See `MongoDB Extended JSON format`_ for a description of Extended JSON formats. The outermost element is encoded as a JSON array, rather than a JSON document.
 
 The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 

--- a/src/libbson/doc/bson_as_canonical_extended_json.rst
+++ b/src/libbson/doc/bson_as_canonical_extended_json.rst
@@ -20,7 +20,8 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_as_canonical_extended_json()` encodes ``bson`` as a UTF-8 string in the Canonical Extended JSON. See `MongoDB Extended JSON format`_ for a description of Extended JSON formats.
+The :symbol:`bson_as_canonical_extended_json()` encodes ``bson`` as a UTF-8 string in the Canonical Extended JSON.
+See `MongoDB Extended JSON format`_ for a description of Extended JSON formats.
 
 The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 

--- a/src/libbson/doc/bson_as_canonical_extended_json.rst
+++ b/src/libbson/doc/bson_as_canonical_extended_json.rst
@@ -20,7 +20,7 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_as_canonical_extended_json()` encodes ``bson`` as a UTF-8 string in the canonical `MongoDB Extended JSON format`_.
+The :symbol:`bson_as_canonical_extended_json()` encodes ``bson`` as a UTF-8 string in the Canonical Extended JSON. See `MongoDB Extended JSON format`_ for a description of Extended JSON formats.
 
 The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 

--- a/src/libbson/doc/bson_as_canonical_extended_json.rst
+++ b/src/libbson/doc/bson_as_canonical_extended_json.rst
@@ -20,7 +20,7 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_as_canonical_extended_json()` encodes ``bson`` as a UTF-8 string in the Canonical Extended JSON.
+:symbol:`bson_as_canonical_extended_json()` encodes ``bson`` as a UTF-8 string in the Canonical Extended JSON.
 See `MongoDB Extended JSON format`_ for a description of Extended JSON formats.
 
 The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.

--- a/src/libbson/doc/bson_as_canonical_extended_json.rst
+++ b/src/libbson/doc/bson_as_canonical_extended_json.rst
@@ -37,11 +37,11 @@ Upon failure, NULL is returned.
 Example
 -------
 
-.. code-block:: c
-
-  char *str = bson_as_canonical_extended_json (doc, NULL);
-  printf ("%s\n", str);
-  bson_free (str);
+.. literalinclude:: ../examples/extended-json.c
+   :language: c
+   :start-after: // bson_as_canonical_extended_json ... begin
+   :end-before: // bson_as_canonical_extended_json ... end
+   :dedent: 6
 
 
 .. only:: html

--- a/src/libbson/doc/bson_as_json.rst
+++ b/src/libbson/doc/bson_as_json.rst
@@ -25,7 +25,7 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_as_json()` function shall encode ``bson`` as a UTF-8 string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`.
+:symbol:`bson_as_json()` encodes ``bson`` as a UTF-8 string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`.
 This function is superseded by :symbol:`bson_as_canonical_extended_json()` and :symbol:`bson_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
 To continue producing Legacy Extended JSON, :symbol:`bson_as_legacy_extended_json()` may be used.
 

--- a/src/libbson/doc/bson_as_json.rst
+++ b/src/libbson/doc/bson_as_json.rst
@@ -40,32 +40,6 @@ If successful, a newly allocated UTF-8 encoded string and ``length`` is set.
 
 Upon failure, NULL is returned.
 
-Example
--------
-
-.. code-block:: c
-
-  #include <bson/bson.h>
-
-  int main ()
-  {
-     bson_t bson;
-     char *str;
-
-     bson_init (&bson);
-     BSON_APPEND_UTF8 (&bson, "0", "foo");
-     BSON_APPEND_UTF8 (&bson, "1", "bar");
-
-     str = bson_as_json (&bson, NULL);
-     /* Prints
-      * { "0" : "foo", "1" : "bar" }
-      */
-     printf ("%s\n", str);
-     bson_free (str);
-
-     bson_destroy (&bson);
-  }
-
 .. only:: html
 
   .. include:: includes/seealso/bson-as-json.txt

--- a/src/libbson/doc/bson_as_json.rst
+++ b/src/libbson/doc/bson_as_json.rst
@@ -3,13 +3,18 @@
 bson_as_json()
 ==============
 
+.. warning::
+   .. deprecated:: 1.29.0
+
+      This function is deprecated and should not be used in new code.
+
 Synopsis
 --------
 
 .. code-block:: c
 
   char *
-  bson_as_json (const bson_t *bson, size_t *length);
+  bson_as_json (const bson_t *bson, size_t *length) BSON_GNUC_DEPRECATED_FOR (bson_as_legacy_extended_json);
 
 Parameters
 ----------
@@ -20,7 +25,7 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_as_json()` function shall encode ``bson`` as a UTF-8 string using libbson's legacy JSON format. This function is superseded by :symbol:`bson_as_canonical_extended_json()` and :symbol:`bson_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
+The :symbol:`bson_as_json()` function shall encode ``bson`` as a UTF-8 string using libbson's legacy JSON format. This function is superseded by :symbol:`bson_as_canonical_extended_json()` and :symbol:`bson_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers. To continue producing Legacy Extended JSON, :symbol:`bson_as_legacy_extended_json()` may be used.
 
 The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 

--- a/src/libbson/doc/bson_as_json.rst
+++ b/src/libbson/doc/bson_as_json.rst
@@ -25,7 +25,9 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_as_json()` function shall encode ``bson`` as a UTF-8 string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`. This function is superseded by :symbol:`bson_as_canonical_extended_json()` and :symbol:`bson_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers. To continue producing Legacy Extended JSON, :symbol:`bson_as_legacy_extended_json()` may be used.
+The :symbol:`bson_as_json()` function shall encode ``bson`` as a UTF-8 string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`.
+This function is superseded by :symbol:`bson_as_canonical_extended_json()` and :symbol:`bson_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
+To continue producing Legacy Extended JSON, :symbol:`bson_as_legacy_extended_json()` may be used.
 
 The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 

--- a/src/libbson/doc/bson_as_json.rst
+++ b/src/libbson/doc/bson_as_json.rst
@@ -25,7 +25,7 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_as_json()` function shall encode ``bson`` as a UTF-8 string using libbson's legacy JSON format. This function is superseded by :symbol:`bson_as_canonical_extended_json()` and :symbol:`bson_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers. To continue producing Legacy Extended JSON, :symbol:`bson_as_legacy_extended_json()` may be used.
+The :symbol:`bson_as_json()` function shall encode ``bson`` as a UTF-8 string using libbson's Legacy Extended JSON format. This function is superseded by :symbol:`bson_as_canonical_extended_json()` and :symbol:`bson_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers. To continue producing Legacy Extended JSON, :symbol:`bson_as_legacy_extended_json()` may be used.
 
 The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 

--- a/src/libbson/doc/bson_as_json.rst
+++ b/src/libbson/doc/bson_as_json.rst
@@ -25,7 +25,7 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_as_json()` function shall encode ``bson`` as a UTF-8 string using libbson's Legacy Extended JSON format. This function is superseded by :symbol:`bson_as_canonical_extended_json()` and :symbol:`bson_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers. To continue producing Legacy Extended JSON, :symbol:`bson_as_legacy_extended_json()` may be used.
+The :symbol:`bson_as_json()` function shall encode ``bson`` as a UTF-8 string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`. This function is superseded by :symbol:`bson_as_canonical_extended_json()` and :symbol:`bson_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers. To continue producing Legacy Extended JSON, :symbol:`bson_as_legacy_extended_json()` may be used.
 
 The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 

--- a/src/libbson/doc/bson_as_json_with_opts.rst
+++ b/src/libbson/doc/bson_as_json_with_opts.rst
@@ -21,7 +21,7 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_as_json_with_opts()` encodes ``bson`` as a UTF-8 string in the `MongoDB Extended JSON format`_ or :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`.
+:symbol:`bson_as_json_with_opts()` encodes ``bson`` as a UTF-8 string in the `MongoDB Extended JSON format`_ or :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`.
 
 The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 

--- a/src/libbson/doc/bson_as_json_with_opts.rst
+++ b/src/libbson/doc/bson_as_json_with_opts.rst
@@ -21,7 +21,7 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_as_json_with_opts()` encodes ``bson`` as a UTF-8 string in the `MongoDB Extended JSON format`_.
+The :symbol:`bson_as_json_with_opts()` encodes ``bson`` as a UTF-8 string in the `MongoDB Extended JSON format`_ or :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`.
 
 The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 

--- a/src/libbson/doc/bson_as_json_with_opts.rst
+++ b/src/libbson/doc/bson_as_json_with_opts.rst
@@ -39,13 +39,11 @@ Upon failure, NULL is returned.
 Example
 -------
 
-.. code-block:: c
-
-  bson_json_opts_t *opts = bson_json_opts_new (BSON_JSON_MODE_CANONICAL, BSON_MAX_LEN_UNLIMITED);
-  char *str = bson_as_json_with_opts (doc, NULL, opts);
-  printf ("%s\n", str);
-  bson_free (str);
-  bson_json_opts_destroy (opts);
+.. literalinclude:: ../examples/extended-json.c
+   :language: c
+   :start-after: // bson_as_json_with_opts ... begin
+   :end-before: // bson_as_json_with_opts ... end
+   :dedent: 6
 
 
 .. only:: html

--- a/src/libbson/doc/bson_as_legacy_extended_json.rst
+++ b/src/libbson/doc/bson_as_legacy_extended_json.rst
@@ -1,0 +1,66 @@
+:man_page: bson_as_legacy_extended_json
+
+bson_as_legacy_extended_json()
+==============================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  char *
+  bson_as_legacy_extended_json (const bson_t *bson, size_t *length)
+
+Parameters
+----------
+
+* ``bson``: A :symbol:`bson_t`.
+* ``length``: An optional location for the length of the resulting string.
+
+Description
+-----------
+
+The :symbol:`bson_as_legacy_extended_json()` function shall encode ``bson`` as a UTF-8 string using libbson's Legacy Extended JSON format. This function is superseded by :symbol:`bson_as_canonical_extended_json()` and :symbol:`bson_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
+
+The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
+
+If non-NULL, ``length`` will be set to the length of the result in bytes.
+
+Returns
+-------
+
+If successful, a newly allocated UTF-8 encoded string and ``length`` is set.
+
+Upon failure, NULL is returned.
+
+Example
+-------
+
+.. code-block:: c
+
+  #include <bson/bson.h>
+
+  int main ()
+  {
+     bson_t bson;
+     char *str;
+
+     bson_init (&bson);
+     BSON_APPEND_UTF8 (&bson, "0", "foo");
+     BSON_APPEND_UTF8 (&bson, "1", "bar");
+
+     str = bson_as_legacy_extended_json (&bson, NULL);
+     /* Prints
+      * { "0" : "foo", "1" : "bar" }
+      */
+     printf ("%s\n", str);
+     bson_free (str);
+
+     bson_destroy (&bson);
+  }
+
+.. only:: html
+
+  .. include:: includes/seealso/bson-as-json.txt
+
+.. _MongoDB Extended JSON format: https://github.com/mongodb/specifications/blob/master/source/extended-json/extended-json.md

--- a/src/libbson/doc/bson_as_legacy_extended_json.rst
+++ b/src/libbson/doc/bson_as_legacy_extended_json.rst
@@ -20,7 +20,7 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_as_legacy_extended_json()` function shall encode ``bson`` as a UTF-8 string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`.
+:symbol:`bson_as_legacy_extended_json()` encodes ``bson`` as a UTF-8 string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`.
 This function is superseded by :symbol:`bson_as_canonical_extended_json()` and :symbol:`bson_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
 
 The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.

--- a/src/libbson/doc/bson_as_legacy_extended_json.rst
+++ b/src/libbson/doc/bson_as_legacy_extended_json.rst
@@ -20,7 +20,7 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_as_legacy_extended_json()` function shall encode ``bson`` as a UTF-8 string using libbson's Legacy Extended JSON format. This function is superseded by :symbol:`bson_as_canonical_extended_json()` and :symbol:`bson_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
+The :symbol:`bson_as_legacy_extended_json()` function shall encode ``bson`` as a UTF-8 string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`. This function is superseded by :symbol:`bson_as_canonical_extended_json()` and :symbol:`bson_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
 
 The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 

--- a/src/libbson/doc/bson_as_legacy_extended_json.rst
+++ b/src/libbson/doc/bson_as_legacy_extended_json.rst
@@ -20,7 +20,8 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_as_legacy_extended_json()` function shall encode ``bson`` as a UTF-8 string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`. This function is superseded by :symbol:`bson_as_canonical_extended_json()` and :symbol:`bson_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
+The :symbol:`bson_as_legacy_extended_json()` function shall encode ``bson`` as a UTF-8 string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`.
+This function is superseded by :symbol:`bson_as_canonical_extended_json()` and :symbol:`bson_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
 
 The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 

--- a/src/libbson/doc/bson_as_legacy_extended_json.rst
+++ b/src/libbson/doc/bson_as_legacy_extended_json.rst
@@ -37,28 +37,11 @@ Upon failure, NULL is returned.
 Example
 -------
 
-.. code-block:: c
-
-  #include <bson/bson.h>
-
-  int main ()
-  {
-     bson_t bson;
-     char *str;
-
-     bson_init (&bson);
-     BSON_APPEND_UTF8 (&bson, "0", "foo");
-     BSON_APPEND_UTF8 (&bson, "1", "bar");
-
-     str = bson_as_legacy_extended_json (&bson, NULL);
-     /* Prints
-      * { "0" : "foo", "1" : "bar" }
-      */
-     printf ("%s\n", str);
-     bson_free (str);
-
-     bson_destroy (&bson);
-  }
+.. literalinclude:: ../examples/extended-json.c
+   :language: c
+   :start-after: // bson_as_legacy_extended_json ... begin
+   :end-before: // bson_as_legacy_extended_json ... end
+   :dedent: 6
 
 .. only:: html
 

--- a/src/libbson/doc/bson_as_relaxed_extended_json.rst
+++ b/src/libbson/doc/bson_as_relaxed_extended_json.rst
@@ -20,7 +20,7 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_as_relaxed_extended_json()` encodes ``bson`` as a UTF-8 string in the relaxed `MongoDB Extended JSON format`_.
+The :symbol:`bson_as_relaxed_extended_json()` encodes ``bson`` as a UTF-8 string in Relaxed Extended JSON. See `MongoDB Extended JSON format`_ for a description of Extended JSON formats.
 
 The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 

--- a/src/libbson/doc/bson_as_relaxed_extended_json.rst
+++ b/src/libbson/doc/bson_as_relaxed_extended_json.rst
@@ -20,7 +20,8 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_as_relaxed_extended_json()` encodes ``bson`` as a UTF-8 string in Relaxed Extended JSON. See `MongoDB Extended JSON format`_ for a description of Extended JSON formats.
+The :symbol:`bson_as_relaxed_extended_json()` encodes ``bson`` as a UTF-8 string in Relaxed Extended JSON.
+See `MongoDB Extended JSON format`_ for a description of Extended JSON formats.
 
 The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 

--- a/src/libbson/doc/bson_as_relaxed_extended_json.rst
+++ b/src/libbson/doc/bson_as_relaxed_extended_json.rst
@@ -37,12 +37,11 @@ Upon failure, NULL is returned.
 Example
 -------
 
-.. code-block:: c
-
-  char *str = bson_as_relaxed_extended_json (doc, NULL);
-  printf ("%s\n", str);
-  bson_free (str);
-
+.. literalinclude:: ../examples/extended-json.c
+   :language: c
+   :start-after: // bson_as_relaxed_extended_json ... begin
+   :end-before: // bson_as_relaxed_extended_json ... end
+   :dedent: 6
 
 .. only:: html
 

--- a/src/libbson/doc/bson_as_relaxed_extended_json.rst
+++ b/src/libbson/doc/bson_as_relaxed_extended_json.rst
@@ -20,7 +20,7 @@ Parameters
 Description
 -----------
 
-The :symbol:`bson_as_relaxed_extended_json()` encodes ``bson`` as a UTF-8 string in Relaxed Extended JSON.
+:symbol:`bson_as_relaxed_extended_json()` encodes ``bson`` as a UTF-8 string in Relaxed Extended JSON.
 See `MongoDB Extended JSON format`_ for a description of Extended JSON formats.
 
 The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.

--- a/src/libbson/doc/bson_copy_to_excluding_noinit.rst
+++ b/src/libbson/doc/bson_copy_to_excluding_noinit.rst
@@ -56,7 +56,7 @@ Example
      bson_init (&bson2);
      bson_copy_to_excluding_noinit (&bson, &bson2, "b", NULL);
 
-     str = bson_as_json (&bson2, NULL);
+     str = bson_as_relaxed_extended_json (&bson2, NULL);
      /* Prints
       * { "a" : 1, "c" : 2 }
       */

--- a/src/libbson/doc/bson_t.rst
+++ b/src/libbson/doc/bson_t.rst
@@ -192,10 +192,12 @@ BSON document contains duplicate keys.
     bson_append_value
     bson_array_as_canonical_extended_json
     bson_array_as_json
+    bson_array_as_legacy_extended_json
     bson_array_as_relaxed_extended_json
     bson_as_canonical_extended_json
     bson_as_json
     bson_as_json_with_opts
+    bson_as_legacy_extended_json
     bson_as_relaxed_extended_json
     bson_compare
     bson_concat

--- a/src/libbson/doc/includes/seealso/bson-as-json.txt
+++ b/src/libbson/doc/includes/seealso/bson-as-json.txt
@@ -1,14 +1,19 @@
 .. seealso::
-  | :symbol:`bson_array_as_canonical_extended_json()`
-
-  | :symbol:`bson_array_as_json()`
-
-  | :symbol:`bson_array_as_relaxed_extended_json()`
-
   | :symbol:`bson_as_canonical_extended_json()`
 
-  | :symbol:`bson_as_json()`
+  | :symbol:`bson_as_relaxed_extended_json()`
+
+  | :symbol:`bson_as_legacy_extended_json()`
+
+  | :symbol:`bson_as_json()` (Deprecated)
 
   | :symbol:`bson_as_json_with_opts()`
 
-  | :symbol:`bson_as_relaxed_extended_json()`
+  | :symbol:`bson_array_as_canonical_extended_json()`
+
+  | :symbol:`bson_array_as_relaxed_extended_json()`
+
+  | :symbol:`bson_array_as_legacy_extended_json()`
+
+  | :symbol:`bson_array_as_json()` (Deprecated)
+

--- a/src/libbson/doc/includes/seealso/bson-as-json.txt
+++ b/src/libbson/doc/includes/seealso/bson-as-json.txt
@@ -1,9 +1,9 @@
 .. seealso::
-  | :symbol: `bson_array_as_canonical_extended_json()`
+  | :symbol:`bson_array_as_canonical_extended_json()`
 
   | :symbol:`bson_array_as_json()`
 
-  | :symbol: `bson_array_as_relaxed_extended_json()`
+  | :symbol:`bson_array_as_relaxed_extended_json()`
 
   | :symbol:`bson_as_canonical_extended_json()`
 

--- a/src/libbson/doc/legacy_extended_json.rst
+++ b/src/libbson/doc/legacy_extended_json.rst
@@ -1,0 +1,58 @@
+:man_page: libbson_legacy_extended_json
+
+Libbson Legacy Extended JSON
+============================
+
+libbson can produce a non-portable Legacy Extended JSON format.
+
+.. warning::
+   
+   Use of the Legacy Extended JSON format is discouraged. Prefer Canonical Extended JSON or Relaxed Extended JSON for portability.
+
+`MongoDB Extended JSON (v2)`_ describes the preferred Relaxed Extended JSON format and Canonical Extended Formats
+
+libbson's Legacy Extended JSON format matches Relaxed Extended JSON with the following exceptions. Notation is borrowed from `MongoDB Extended JSON (v2)`_:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Type
+     - Legacy Extended JSON
+
+   * - Binary
+     - .. code:: json
+         
+          { "$binary": "<payload>", "$type": "<t>" }
+
+   * - Date
+     - .. code:: json
+
+          { "$date" : "<millis>" }
+
+   * - Regular Expression
+     - .. code:: json
+
+          { "$regex" : "<regexPattern>", "$options" : "<options>" }
+
+   * - DBPointer (deprecated)
+     - .. code:: json
+
+          { "$ref" : "<collection namespace>", "$id" : "<ObjectId bytes>" }
+
+   * - Symbol (deprecated)
+     - .. code:: json
+
+          "<string>"
+
+   * - Double infinity
+     - ``infinity`` or ``inf`` without quotes. Implementation defined. Produces invalid JSON. 
+
+   * - Double NaN
+     - ``nan`` or ``nan(n-char-sequence)``. Implementation defined. Produces invalid JSON.
+
+.. _BSON: https://bsonspec.org/
+.. _MongoDB Extended JSON (v2): https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/
+
+.. only:: html
+
+  .. include:: includes/seealso/bson-as-json.txt

--- a/src/libbson/examples/extended-json.c
+++ b/src/libbson/examples/extended-json.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2009-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// extended-json.c shows examples of producing Extended JSON.
+
+#include <bson/bson.h>
+#include <stdio.h>
+
+int
+main (int argc, char *argv[])
+{
+   {
+      // bson_as_canonical_extended_json ... begin
+      bson_t *b = BCON_NEW ("foo", BCON_INT32 (123));
+      char *str = bson_as_canonical_extended_json (b, NULL);
+      printf ("Canonical Extended JSON: %s\n", str);
+      // Prints:
+      // Canonical Extended JSON: { "foo" : { "$numberInt" : "123" } }
+      bson_free (str);
+      bson_destroy (b);
+      // bson_as_canonical_extended_json ... end
+   }
+   {
+      // bson_as_relaxed_extended_json ... begin
+      bson_t *b = BCON_NEW ("foo", BCON_INT32 (123));
+      char *str = bson_as_relaxed_extended_json (b, NULL);
+      printf ("Relaxed Extended JSON: %s\n", str);
+      // Prints:
+      // Relaxed Extended JSON: { "foo" : 123 }
+      bson_free (str);
+      bson_destroy (b);
+      // bson_as_relaxed_extended_json ... end
+   }
+   {
+      // bson_as_legacy_extended_json ... begin
+      bson_t *b = BCON_NEW ("foo", BCON_INT32 (123));
+      char *str = bson_as_legacy_extended_json (b, NULL);
+      printf ("Legacy Extended JSON: %s\n", str);
+      // Prints:
+      // Legacy Extended JSON: { "foo" : 123 }
+      bson_free (str);
+      bson_destroy (b);
+      // bson_as_legacy_extended_json ... end
+   }
+   {
+      // bson_array_as_canonical_extended_json ... begin
+      bson_t *b = BCON_NEW ("0", BCON_INT32 (1), "1", BCON_UTF8 ("bar"));
+      // The document for an array is a normal BSON document with integer values for the keys, starting with 0 and
+      // continuing sequentially.
+      char *str = bson_array_as_canonical_extended_json (b, NULL);
+      printf ("Canonical Extended JSON array: %s\n", str);
+      // Prints:
+      // Canonical Extended JSON array: [ { "$numberInt" : "1" }, "bar" ]
+      bson_free (str);
+      bson_destroy (b);
+      // bson_array_as_canonical_extended_json ... end
+   }
+   {
+      // bson_array_as_relaxed_extended_json ... begin
+      bson_t *b = BCON_NEW ("0", BCON_INT32 (1), "1", BCON_UTF8 ("bar"));
+      // The document for an array is a normal BSON document with integer values for the keys, starting with 0 and
+      // continuing sequentially.
+      char *str = bson_array_as_relaxed_extended_json (b, NULL);
+      printf ("Relaxed Extended JSON array: %s\n", str);
+      // Prints:
+      // Relaxed Extended JSON array: [ 1, "bar" ]
+      bson_free (str);
+      bson_destroy (b);
+      // bson_array_as_relaxed_extended_json ... end
+   }
+   {
+      // bson_array_as_legacy_extended_json ... begin
+      bson_t *b = BCON_NEW ("0", BCON_INT32 (1), "1", BCON_UTF8 ("bar"));
+      // The document for an array is a normal BSON document with integer values for the keys, starting with 0 and
+      // continuing sequentially.
+      char *str = bson_array_as_legacy_extended_json (b, NULL);
+      printf ("Legacy Extended JSON array: %s\n", str);
+      // Prints:
+      // Legacy Extended JSON array: [ 1, "bar" ]
+      bson_free (str);
+      bson_destroy (b);
+      // bson_array_as_legacy_extended_json ... end
+   }
+   {
+      // bson_as_json_with_opts ... begin
+      bson_t *b = BCON_NEW ("foo", BCON_INT32 (123));
+      bson_json_opts_t *opts = bson_json_opts_new (BSON_JSON_MODE_CANONICAL, BSON_MAX_LEN_UNLIMITED);
+      char *str = bson_as_json_with_opts (b, NULL, opts);
+      printf ("Canonical Extended JSON: %s\n", str);
+      // Prints:
+      // Canonical Extended JSON: { "foo" : { "$numberInt" : "123" } }
+      bson_free (str);
+      bson_json_opts_destroy (opts);
+      bson_destroy (b);
+      // bson_as_json_with_opts ... end
+   }
+}

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -3141,6 +3141,13 @@ bson_as_json (const bson_t *bson, size_t *length)
    return bson_as_json_with_opts (bson, length, &opts);
 }
 
+char *
+bson_as_legacy_extended_json (const bson_t *bson, size_t *length)
+{
+   const bson_json_opts_t opts = {BSON_JSON_MODE_LEGACY, BSON_MAX_LEN_UNLIMITED, false};
+   return bson_as_json_with_opts (bson, length, &opts);
+}
+
 
 char *
 bson_as_relaxed_extended_json (const bson_t *bson, size_t *length)
@@ -3152,6 +3159,13 @@ bson_as_relaxed_extended_json (const bson_t *bson, size_t *length)
 
 char *
 bson_array_as_json (const bson_t *bson, size_t *length)
+{
+   const bson_json_opts_t opts = {BSON_JSON_MODE_LEGACY, BSON_MAX_LEN_UNLIMITED, true};
+   return bson_as_json_with_opts (bson, length, &opts);
+}
+
+char *
+bson_array_as_legacy_extended_json (const bson_t *bson, size_t *length)
 {
    const bson_json_opts_t opts = {BSON_JSON_MODE_LEGACY, BSON_MAX_LEN_UNLIMITED, true};
    return bson_as_json_with_opts (bson, length, &opts);

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -3137,8 +3137,7 @@ bson_as_canonical_extended_json (const bson_t *bson, size_t *length)
 char *
 bson_as_json (const bson_t *bson, size_t *length)
 {
-   const bson_json_opts_t opts = {BSON_JSON_MODE_LEGACY, BSON_MAX_LEN_UNLIMITED, false};
-   return bson_as_json_with_opts (bson, length, &opts);
+   return bson_as_legacy_extended_json (bson, length);
 }
 
 char *
@@ -3160,8 +3159,7 @@ bson_as_relaxed_extended_json (const bson_t *bson, size_t *length)
 char *
 bson_array_as_json (const bson_t *bson, size_t *length)
 {
-   const bson_json_opts_t opts = {BSON_JSON_MODE_LEGACY, BSON_MAX_LEN_UNLIMITED, true};
-   return bson_as_json_with_opts (bson, length, &opts);
+   return bson_array_as_legacy_extended_json (bson, length);
 }
 
 char *

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -3122,6 +3122,9 @@ _bson_as_json_visit_all (
 char *
 bson_as_json_with_opts (const bson_t *bson, size_t *length, const bson_json_opts_t *opts)
 {
+   BSON_ASSERT_PARAM (bson);
+   BSON_OPTIONAL_PARAM (length);
+   BSON_ASSERT_PARAM (opts);
    return _bson_as_json_visit_all (bson, length, opts->mode, opts->max_len, opts->is_outermost_array);
 }
 

--- a/src/libbson/src/bson/bson.h
+++ b/src/libbson/src/bson/bson.h
@@ -534,6 +534,10 @@ bson_as_canonical_extended_json (const bson_t *bson, size_t *length);
 BSON_EXPORT (char *)
 bson_as_json (const bson_t *bson, size_t *length);
 
+// `bson_as_legacy_extended_json` is a non-deprecated form of `bson_as_json`.
+BSON_EXPORT (char *)
+bson_as_legacy_extended_json (const bson_t *bson, size_t *length);
+
 
 /**
  * bson_as_relaxed_extended_json:
@@ -559,6 +563,10 @@ bson_as_relaxed_extended_json (const bson_t *bson, size_t *length);
 
 /* like bson_as_json() but for outermost arrays. */
 BSON_EXPORT (char *) bson_array_as_json (const bson_t *bson, size_t *length);
+
+// `bson_array_as_legacy_extended_json` is a non-deprecated form of `bson_array_as_json`.
+BSON_EXPORT (char *)
+bson_array_as_legacy_extended_json (const bson_t *bson, size_t *length);
 
 
 /* like bson_as_relaxed_extended_json() but for outermost arrays. */

--- a/src/libbson/src/bson/bson.h
+++ b/src/libbson/src/bson/bson.h
@@ -532,7 +532,7 @@ bson_as_canonical_extended_json (const bson_t *bson, size_t *length);
  * Returns: A newly allocated string that should be freed with bson_free().
  */
 BSON_EXPORT (char *)
-bson_as_json (const bson_t *bson, size_t *length);
+bson_as_json (const bson_t *bson, size_t *length) BSON_GNUC_DEPRECATED_FOR (bson_as_legacy_extended_json);
 
 // `bson_as_legacy_extended_json` is a non-deprecated form of `bson_as_json`.
 BSON_EXPORT (char *)
@@ -562,7 +562,8 @@ bson_as_relaxed_extended_json (const bson_t *bson, size_t *length);
 
 
 /* like bson_as_json() but for outermost arrays. */
-BSON_EXPORT (char *) bson_array_as_json (const bson_t *bson, size_t *length);
+BSON_EXPORT (char *)
+bson_array_as_json (const bson_t *bson, size_t *length) BSON_GNUC_DEPRECATED_FOR (bson_array_as_legacy_extended_json);
 
 // `bson_array_as_legacy_extended_json` is a non-deprecated form of `bson_array_as_json`.
 BSON_EXPORT (char *)

--- a/src/libbson/tests/test-json.c
+++ b/src/libbson/tests/test-json.c
@@ -123,7 +123,7 @@ test_bson_as_json_x1000 (void)
    }
 
    for (i = 0; i < 1000; i++) {
-      str = bson_as_json (b, &len);
+      str = bson_as_legacy_extended_json (b, &len);
       bson_free (str);
    }
 
@@ -227,7 +227,7 @@ test_bson_as_json_multi (void)
       BSON_ASSERT (bson_append_decimal128 (b, "Decimal128", -1, &decimal128));
    }
 
-   str = bson_as_json (b, &len);
+   str = bson_as_legacy_extended_json (b, &len);
 
    /* Based on multi-type-deprecated.json from BSON Corpus Tests. */
    ASSERT_CMPSTR (str,
@@ -278,7 +278,7 @@ test_bson_as_json_string (void)
 
    b = bson_new ();
    BSON_ASSERT (bson_append_utf8 (b, "foo", -1, "bar", -1));
-   str = bson_as_json (b, &len);
+   str = bson_as_legacy_extended_json (b, &len);
    BSON_ASSERT (len == 17);
    BSON_ASSERT (!strcmp ("{ \"foo\" : \"bar\" }", str));
    bson_free (str);
@@ -295,7 +295,7 @@ test_bson_as_json_int32 (void)
 
    b = bson_new ();
    BSON_ASSERT (bson_append_int32 (b, "foo", -1, 1234));
-   str = bson_as_json (b, &len);
+   str = bson_as_legacy_extended_json (b, &len);
    BSON_ASSERT (len == 16);
    BSON_ASSERT (!strcmp ("{ \"foo\" : 1234 }", str));
    bson_free (str);
@@ -312,7 +312,7 @@ test_bson_as_json_int64 (void)
 
    b = bson_new ();
    BSON_ASSERT (bson_append_int64 (b, "foo", -1, 341234123412341234ULL));
-   str = bson_as_json (b, &len);
+   str = bson_as_legacy_extended_json (b, &len);
    BSON_ASSERT (len == 30);
    BSON_ASSERT (!strcmp ("{ \"foo\" : 341234123412341234 }", str));
    bson_free (str);
@@ -334,7 +334,7 @@ test_bson_as_json_double (void)
    BSON_ASSERT (bson_append_double (b, "baz", -1, -1));
    BSON_ASSERT (bson_append_double (b, "quux", -1, 0.03125));
    BSON_ASSERT (bson_append_double (b, "huge", -1, 1e99));
-   str = bson_as_json (b, &len);
+   str = bson_as_legacy_extended_json (b, &len);
 
    expected = bson_strdup_printf ("{"
                                   " \"foo\" : 123.5,"
@@ -367,7 +367,7 @@ test_bson_as_json_double_nonfinite (void)
    BSON_ASSERT (bson_append_double (b, "nan", -1, NAN));
    BSON_ASSERT (bson_append_double (b, "pos_inf", -1, pos_inf));
    BSON_ASSERT (bson_append_double (b, "neg_inf", -1, neg_inf));
-   str = bson_as_json (b, &len);
+   str = bson_as_legacy_extended_json (b, &len);
 
    expected = bson_strdup_printf ("{"
                                   " \"nan\" : %.20g,"
@@ -397,7 +397,7 @@ test_bson_as_json_decimal128 (void)
 
    b = bson_new ();
    BSON_ASSERT (bson_append_decimal128 (b, "decimal128", -1, &decimal128));
-   str = bson_as_json (b, &len);
+   str = bson_as_legacy_extended_json (b, &len);
    ASSERT_CMPSTR (str,
                   "{ "
                   "\"decimal128\" : { \"$numberDecimal\" : \"11\" }"
@@ -416,7 +416,7 @@ test_bson_as_json_code (void)
    char *str;
 
    BSON_ASSERT (bson_append_code (&code, "c", -1, "function () {}"));
-   str = bson_as_json (&code, NULL);
+   str = bson_as_legacy_extended_json (&code, NULL);
    ASSERT_CMPSTR (str, "{ \"c\" : { \"$code\" : \"function () {}\" } }");
 
    bson_free (str);
@@ -424,7 +424,7 @@ test_bson_as_json_code (void)
 
    /* empty scope */
    BSON_ASSERT (BSON_APPEND_CODE_WITH_SCOPE (&code, "c", "function () {}", &scope));
-   str = bson_as_json (&code, NULL);
+   str = bson_as_legacy_extended_json (&code, NULL);
    ASSERT_CMPSTR (str, "{ \"c\" : { \"$code\" : \"function () {}\", \"$scope\" : { } } }");
 
    bson_free (str);
@@ -432,7 +432,7 @@ test_bson_as_json_code (void)
 
    BSON_APPEND_INT32 (&scope, "x", 1);
    BSON_ASSERT (BSON_APPEND_CODE_WITH_SCOPE (&code, "c", "function () {}", &scope));
-   str = bson_as_json (&code, NULL);
+   str = bson_as_legacy_extended_json (&code, NULL);
    ASSERT_CMPSTR (str,
                   "{ \"c\" : { \"$code\" : \"function () {}\", \"$scope\" "
                   ": { \"x\" : 1 } } }");
@@ -442,7 +442,7 @@ test_bson_as_json_code (void)
 
    /* test that embedded quotes are backslash-escaped */
    BSON_ASSERT (BSON_APPEND_CODE (&code, "c", "return \"a\""));
-   str = bson_as_json (&code, NULL);
+   str = bson_as_legacy_extended_json (&code, NULL);
 
    /* hard to read, this is { "c" : { "$code" : "return \"a\"" } } */
    ASSERT_CMPSTR (str, "{ \"c\" : { \"$code\" : \"return \\\"a\\\"\" } }");
@@ -464,7 +464,7 @@ test_bson_as_json_date_time (void)
    BSON_ASSERT (bson_append_date_time (b, "epoch", -1, 0));
    BSON_ASSERT (bson_append_date_time (b, "negative", -1, -123456000));
    BSON_ASSERT (bson_append_date_time (b, "positive", -1, 123456000));
-   str = bson_as_json (b, &len);
+   str = bson_as_legacy_extended_json (b, &len);
 
    ASSERT_CMPSTR (str,
                   "{"
@@ -491,7 +491,7 @@ test_bson_as_json_regex (void)
    BSON_ASSERT (bson_append_regex (b, "unordered", -1, "^abcd", "xusmli"));
    BSON_ASSERT (bson_append_regex (b, "duplicate", -1, "^abcd", "mmiii"));
    BSON_ASSERT (bson_append_regex (b, "unsupported", -1, "^abcd", "jkmlvz"));
-   str = bson_as_json (b, &len);
+   str = bson_as_legacy_extended_json (b, &len);
 
    ASSERT_CMPSTR (str,
                   "{"
@@ -523,7 +523,7 @@ test_bson_as_json_symbol (void)
    b = bson_new ();
    BSON_ASSERT (bson_append_symbol (b, "symbol", -1, "foo", -1));
    BSON_ASSERT (bson_append_symbol (b, "escaping", -1, "\"bar\"", -1));
-   str = bson_as_json (b, &len);
+   str = bson_as_legacy_extended_json (b, &len);
 
    ASSERT_CMPSTR (str,
                   "{"
@@ -547,7 +547,7 @@ test_bson_as_json_utf8 (void)
 
    b = bson_new ();
    BSON_ASSERT (bson_append_utf8 (b, FIVE_EUROS, -1, FIVE_EUROS, -1));
-   str = bson_as_json (b, &len);
+   str = bson_as_legacy_extended_json (b, &len);
    BSON_ASSERT (!strcmp (str, "{ \"" FIVE_EUROS "\" : \"" FIVE_EUROS "\" }"));
    bson_free (str);
    bson_destroy (b);
@@ -567,7 +567,7 @@ test_bson_as_json_dbpointer (void)
    b = bson_new ();
    BSON_ASSERT (bson_append_dbpointer (b, "dbpointer", -1, "collection", &oid));
    BSON_ASSERT (bson_append_dbpointer (b, "escaping", -1, "\"coll\"", &oid));
-   str = bson_as_json (b, &len);
+   str = bson_as_legacy_extended_json (b, &len);
 
    ASSERT_CMPSTR (str,
                   "{"
@@ -623,7 +623,7 @@ test_bson_as_json_stack_overflow (void)
    r = bson_init_static (&b, buf, 16777220);
    BSON_ASSERT (r);
 
-   str = bson_as_json (&b, NULL);
+   str = bson_as_legacy_extended_json (&b, NULL);
    BSON_ASSERT (str);
 
    r = !!strstr (str, "...");
@@ -656,7 +656,7 @@ test_bson_corrupt (void)
    r = bson_init_static (&b, buf, (uint32_t) r);
    BSON_ASSERT (r);
 
-   str = bson_as_json (&b, NULL);
+   str = bson_as_legacy_extended_json (&b, NULL);
    BSON_ASSERT (!str);
 
    bson_destroy (&b);
@@ -684,7 +684,7 @@ test_bson_corrupt_utf8 (void)
    r = bson_init_static (&b, buf, (uint32_t) r);
    BSON_ASSERT (r);
 
-   str = bson_as_json (&b, NULL);
+   str = bson_as_legacy_extended_json (&b, NULL);
    BSON_ASSERT (!str);
 
    bson_destroy (&b);
@@ -712,7 +712,7 @@ test_bson_corrupt_binary (void)
    r = bson_init_static (&b, buf, (uint32_t) r);
    BSON_ASSERT (r);
 
-   str = bson_as_json (&b, NULL);
+   str = bson_as_legacy_extended_json (&b, NULL);
    BSON_ASSERT (!str);
 
    bson_destroy (&b);
@@ -786,7 +786,7 @@ test_bson_json_read_buffering (void)
             }
 
             /* append the BSON document's JSON representation to "json" */
-            json_tmp = bson_as_json (bsons[docs_idx], NULL);
+            json_tmp = bson_as_legacy_extended_json (bsons[docs_idx], NULL);
             BSON_ASSERT (json_tmp);
             mcommon_string_append (json, json_tmp);
             bson_free (json_tmp);
@@ -952,9 +952,9 @@ test_bson_json_read_corrupt_document (void)
 
    bson_t bson;
    BSON_ASSERT (bson_init_static (&bson, (uint8_t *) bad_doc, sizeof (bad_doc)));
-   BSON_ASSERT (!bson_as_json (&bson, NULL));
+   BSON_ASSERT (!bson_as_legacy_extended_json (&bson, NULL));
    BSON_ASSERT (bson_init_static (&bson, (uint8_t *) bad_array, sizeof (bad_array)));
-   BSON_ASSERT (!bson_as_json (&bson, NULL));
+   BSON_ASSERT (!bson_as_legacy_extended_json (&bson, NULL));
 }
 
 
@@ -2534,13 +2534,13 @@ test_bson_as_json_spacing (void)
    size_t len;
    char *str;
 
-   str = bson_as_json (&d, &len);
+   str = bson_as_legacy_extended_json (&d, &len);
    BSON_ASSERT (0 == strcmp (str, "{ }"));
    BSON_ASSERT (len == 3);
    bson_free (str);
 
    BSON_APPEND_INT32 (&d, "a", 1);
-   str = bson_as_json (&d, &len);
+   str = bson_as_legacy_extended_json (&d, &len);
    BSON_ASSERT (0 == strcmp (str, "{ \"a\" : 1 }"));
    BSON_ASSERT (len == 11);
    bson_free (str);
@@ -2583,7 +2583,7 @@ test_bson_integer_width (void)
    bson_error_t err;
    bson_t *bs = bson_new_from_json ((const uint8_t *) sd, strlen (sd), &err);
 
-   match = bson_as_json (bs, 0);
+   match = bson_as_legacy_extended_json (bs, 0);
    ASSERT_CMPSTR (match, "{ \"v\" : -1234567890123, \"x\" : 12345678901234 }");
 
    bson_free (match);

--- a/src/libbson/tests/test-json.c
+++ b/src/libbson/tests/test-json.c
@@ -2453,20 +2453,20 @@ test_bson_array_as_legacy_json (void)
    size_t len;
    char *str;
 
-   str = bson_array_as_json (&d, &len);
+   str = bson_array_as_legacy_extended_json (&d, &len);
    ASSERT_CMPSTR (str, "[ ]");
    ASSERT_CMPSIZE_T (len, ==, 3u);
    bson_free (str);
 
    BSON_APPEND_INT32 (&d, "0", 1);
-   str = bson_array_as_json (&d, &len);
+   str = bson_array_as_legacy_extended_json (&d, &len);
    ASSERT_CMPSTR (str, "[ 1 ]");
    ASSERT_CMPSIZE_T (len, ==, 5u);
    bson_free (str);
 
    /* test corrupted bson */
    BSON_APPEND_UTF8 (&d, "1", "\x80"); /* bad UTF-8 */
-   str = bson_array_as_json (&d, &len);
+   str = bson_array_as_legacy_extended_json (&d, &len);
    BSON_ASSERT (!str);
    BSON_ASSERT (!len);
 

--- a/src/libbson/tests/test-json.c
+++ b/src/libbson/tests/test-json.c
@@ -2641,8 +2641,8 @@ _test_json_produces_multiple (const char *json_in, int err_expected, ...)
          abort ();
       }
       if (bson_compare (&bson_in, bson_expected) != 0) {
-         char *expect = bson_as_json (bson_expected, NULL);
-         char *in = bson_as_json (&bson_in, NULL);
+         char *expect = bson_as_relaxed_extended_json (bson_expected, NULL);
+         char *in = bson_as_relaxed_extended_json (&bson_in, NULL);
          fprintf (stderr, "Got %s, but expected %s for input %s\n", expect, in, json);
          bson_free (expect);
          bson_free (in);

--- a/src/libbson/tests/test-json.c
+++ b/src/libbson/tests/test-json.c
@@ -3622,8 +3622,9 @@ test_bson_as_json_all_formats (void)
          {
             char *as_legacy = bson_as_legacy_extended_json (b, NULL);
             char *ptr = as_legacy;
-            ASSERT_STARTSWITH (ptr, "{ \"double_nan\" : ");
-            ptr += strlen ("{ \"double_nan\" : ");
+            const char *expected_prefix = "{ \"double_nan\" : ";
+            ASSERT_STARTSWITH (ptr, expected_prefix);
+            ptr += strlen (expected_prefix);
             if (ptr[0] == '-') {
                ptr += 1;
             }

--- a/src/libmongoc/doc/mongoc_cursor_error_document.rst
+++ b/src/libmongoc/doc/mongoc_cursor_error_document.rst
@@ -75,7 +75,7 @@ On the other hand, if the client connects to the server successfully and attempt
      }
 
      if (mongoc_cursor_error_document (cursor, &error, &reply)) {
-        str = bson_as_json (reply, NULL);
+        str = bson_as_relaxed_extended_json (reply, NULL);
         fprintf (stderr, "Cursor Failure: %s\nReply: %s\n", error.message, str);
         bson_free (str);
      }

--- a/src/libmongoc/examples/example-session.c
+++ b/src/libmongoc/examples/example-session.c
@@ -92,7 +92,7 @@ main (int argc, char *argv[])
    cursor = mongoc_collection_find_with_opts (collection, selector, find_opts, secondary);
 
    while (mongoc_cursor_next (cursor, &doc)) {
-      str = bson_as_json (doc, NULL);
+      str = bson_as_relaxed_extended_json (doc, NULL);
       fprintf (stdout, "%s\n", str);
       bson_free (str);
    }

--- a/src/libmongoc/examples/example-transaction.c
+++ b/src/libmongoc/examples/example-transaction.c
@@ -128,7 +128,7 @@ retry_transaction:
          goto done;
       }
 
-      reply_json = bson_as_json (&reply, NULL);
+      reply_json = bson_as_relaxed_extended_json (&reply, NULL);
       printf ("%s\n", reply_json);
       bson_free (reply_json);
    }

--- a/src/libmongoc/examples/example-with-transaction-cb.c
+++ b/src/libmongoc/examples/example-with-transaction-cb.c
@@ -159,7 +159,7 @@ main (int argc, char *argv[])
       goto done;
    }
 
-   str = bson_as_json (&reply, NULL);
+   str = bson_as_relaxed_extended_json (&reply, NULL);
    printf ("%s\n", str);
 
    exit_code = EXIT_SUCCESS;

--- a/src/libmongoc/examples/hello_mongoc.c
+++ b/src/libmongoc/examples/hello_mongoc.c
@@ -88,7 +88,7 @@ main (int argc, char *argv[])
       return EXIT_FAILURE;
    }
 
-   str = bson_as_json (&reply, NULL);
+   str = bson_as_relaxed_extended_json (&reply, NULL);
    printf ("%s\n", str);
 
    insert = BCON_NEW ("hello", BCON_UTF8 ("world"));

--- a/src/libmongoc/src/mongoc/mongoc-client-session.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-session.c
@@ -569,7 +569,7 @@ _mongoc_parse_cluster_time (const bson_t *cluster_time, uint32_t *timestamp, uin
 
    if (!cluster_time || !bson_iter_init_find (&iter, cluster_time, "clusterTime") ||
        !BSON_ITER_HOLDS_TIMESTAMP (&iter)) {
-      s = bson_as_json (cluster_time, NULL);
+      s = bson_as_relaxed_extended_json (cluster_time, NULL);
       MONGOC_ERROR ("Cannot parse cluster time from %s\n", s);
       bson_free (s);
       return false;

--- a/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
@@ -552,7 +552,7 @@ _obtain_creds_from_assumerolewithwebidentity (_mongoc_aws_credentials_t *creds, 
       if (!_mongoc_iter_document_as_bson (&Error_iter, &Error_bson, error)) {
          goto fail;
       }
-      char *Error_json = bson_as_json (&Error_bson, NULL);
+      char *Error_json = bson_as_relaxed_extended_json (&Error_bson, NULL);
       bson_set_error (error,
                       MONGOC_ERROR_CLIENT,
                       MONGOC_ERROR_CLIENT_AUTHENTICATE,

--- a/src/libmongoc/tests/json-test-monitoring.c
+++ b/src/libmongoc/tests/json-test-monitoring.c
@@ -417,7 +417,7 @@ apm_match_visitor (match_ctx_t *ctx, bson_iter_t *pattern_iter, bson_iter_t *doc
       }
 
       if (fail) {
-         char *str = bson_as_json (&lsid, NULL);
+         char *str = bson_as_relaxed_extended_json (&lsid, NULL);
          match_err (ctx, "expected %s, but used session: %s", session_name, str);
          bson_free (str);
          return MATCH_ACTION_ABORT;

--- a/src/libmongoc/tests/json-test-operations.c
+++ b/src/libmongoc/tests/json-test-operations.c
@@ -266,7 +266,7 @@ value_to_str (const bson_value_t *value)
 
    if (value->value_type == BSON_TYPE_DOCUMENT || value->value_type == BSON_TYPE_ARRAY) {
       bson_init_from_value (&doc, value);
-      return bson_as_json (&doc, NULL);
+      return bson_as_relaxed_extended_json (&doc, NULL);
    } else {
       return bson_strdup_printf ("%" PRId64, bson_value_as_int64 (value));
    }
@@ -420,7 +420,7 @@ get_result (const bson_t *test, const bson_t *operation, bson_value_t *value)
 static void
 check_success_expected (const bson_t *operation, bool succeeded, bool expected, const bson_error_t *error)
 {
-   char *json = bson_as_json (operation, NULL);
+   char *json = bson_as_relaxed_extended_json (operation, NULL);
 
    if (!succeeded && expected) {
       test_error ("Expected success, got error \"%s\":\n%s", error->message, json);
@@ -525,7 +525,8 @@ check_error_labels_contain (const bson_t *operation, const bson_value_t *result)
    while (bson_iter_next (&expected_label)) {
       expected_label_str = bson_iter_utf8 (&expected_label, NULL);
       if (!mongoc_error_has_label (&reply, expected_label_str)) {
-         test_error ("Expected label \"%s\" not found in %s", expected_label_str, bson_as_json (&reply, NULL));
+         test_error (
+            "Expected label \"%s\" not found in %s", expected_label_str, bson_as_relaxed_extended_json (&reply, NULL));
       }
    }
 }
@@ -1076,7 +1077,7 @@ insert_many (mongoc_collection_t *collection,
       doc_ptrs[n] = bson_copy (&document);
       n++;
       if (n >= 100) {
-         test_error ("Too many documents: %s", bson_as_json (operation, NULL));
+         test_error ("Too many documents: %s", bson_as_relaxed_extended_json (operation, NULL));
       }
    }
 
@@ -2423,7 +2424,7 @@ json_test_operation (json_test_ctx_t *ctx,
          bson_destroy (reply);
          res = command (admin_db, test, operation, session, read_prefs, reply);
          if (!res) {
-            test_error ("admin command failed: %s", bson_as_json (reply, NULL));
+            test_error ("admin command failed: %s", bson_as_relaxed_extended_json (reply, NULL));
          }
          mongoc_database_destroy (admin_db);
          mongoc_client_destroy (client);
@@ -2506,7 +2507,7 @@ one_operation (json_test_ctx_t *ctx, const bson_t *test, const bson_t *operation
    if (ctx->verbose) {
       char *op_str;
 
-      op_str = bson_as_json (operation, NULL);
+      op_str = bson_as_relaxed_extended_json (operation, NULL);
       MONGOC_DEBUG ("     running operation %s : %s\n", op_name, op_str);
       bson_free (op_str);
    }

--- a/src/libmongoc/tests/json-test.c
+++ b/src/libmongoc/tests/json-test.c
@@ -1352,7 +1352,7 @@ set_uri_opts_from_bson (mongoc_uri_t *uri, const bson_t *opts)
       } else if (mongoc_uri_option_is_utf8 (key)) {
          mongoc_uri_set_option_as_utf8 (uri, key, bson_iter_utf8 (&iter, NULL));
       } else {
-         test_error ("Unsupported clientOptions field \"%s\" in %s", key, bson_as_json (opts, NULL));
+         test_error ("Unsupported clientOptions field \"%s\" in %s", key, bson_as_relaxed_extended_json (opts, NULL));
       }
    }
 }

--- a/src/libmongoc/tests/mock_server/mock-rs.c
+++ b/src/libmongoc/tests/mock_server/mock-rs.c
@@ -133,7 +133,7 @@ hello_json (mock_rs_t *rs, mongoc_server_description_type_t type, const bson_t *
    if (bson_empty0 (tags)) {
       tags_json = bson_strdup ("{}");
    } else {
-      tags_json = bson_as_json (tags, NULL);
+      tags_json = bson_as_relaxed_extended_json (tags, NULL);
    }
 
    hosts_str = hosts (&rs->servers);

--- a/src/libmongoc/tests/mock_server/mock-server.c
+++ b/src/libmongoc/tests/mock_server/mock-server.c
@@ -546,7 +546,7 @@ auto_hello (request_t *request, void *data)
       BSON_APPEND_INT32 (&response, "maxWireVersion", WIRE_VERSION_MAX);
    }
 
-   response_json = bson_as_json (&response, 0);
+   response_json = bson_as_relaxed_extended_json (&response, 0);
 
    if (mock_server_get_rand_delay (request->server)) {
       _mongoc_usleep ((int64_t) (rand () % 10) * 1000);
@@ -1995,7 +1995,7 @@ _mock_server_reply_with_stream (mock_server_t *server, reply_t *reply, mongoc_st
 
    docs_json = mcommon_string_new ("");
    for (int i = 0; i < n_docs; i++) {
-      doc_json = bson_as_json (&docs[i], NULL);
+      doc_json = bson_as_relaxed_extended_json (&docs[i], NULL);
       mcommon_string_append (docs_json, doc_json);
       bson_free (doc_json);
       if (i < n_docs - 1) {

--- a/src/libmongoc/tests/mock_server/request.c
+++ b/src/libmongoc/tests/mock_server/request.c
@@ -155,7 +155,7 @@ request_matches_query (const request_t *request,
 
    if (request->docs.len) {
       doc = request_get_doc (request, 0);
-      doc_as_json = bson_as_json (doc, NULL);
+      doc_as_json = bson_as_relaxed_extended_json (doc, NULL);
    } else {
       doc = NULL;
       doc_as_json = NULL;
@@ -560,7 +560,7 @@ request_from_query (request_t *request)
          }
       }
 
-      str = bson_as_json (query, NULL);
+      str = bson_as_relaxed_extended_json (query, NULL);
       mcommon_string_append (query_as_str, str);
       bson_free (str);
    }
@@ -571,7 +571,7 @@ request_from_query (request_t *request)
       BSON_ASSERT (fields);
       _mongoc_array_append_val (&request->docs, fields);
 
-      str = bson_as_json (fields, NULL);
+      str = bson_as_relaxed_extended_json (fields, NULL);
       mcommon_string_append (query_as_str, " fields=");
       mcommon_string_append (query_as_str, str);
       bson_free (str);
@@ -629,7 +629,7 @@ parse_op_msg_doc (request_t *request, const uint8_t *data, size_t data_len, mcom
       BSON_ASSERT (doc);
       _mongoc_array_append_val (&request->docs, doc);
 
-      char *const str = bson_as_json (doc, NULL);
+      char *const str = bson_as_relaxed_extended_json (doc, NULL);
       mcommon_string_append (msg_as_str, str);
       bson_free (str);
 

--- a/src/libmongoc/tests/test-conveniences.c
+++ b/src/libmongoc/tests/test-conveniences.c
@@ -1585,7 +1585,8 @@ assert_no_duplicate_keys (const bson_t *doc)
 
    while (bson_iter_next (&iter)) {
       if (mongoc_set_find_item (keys, find_key, (void *) bson_iter_key (&iter))) {
-         test_error ("Duplicate key \"%s\" in document:\n%s", bson_iter_key (&iter), bson_as_json (doc, NULL));
+         test_error (
+            "Duplicate key \"%s\" in document:\n%s", bson_iter_key (&iter), bson_as_relaxed_extended_json (doc, NULL));
       }
 
       mongoc_set_add (keys, 0 /* index */, (void *) bson_iter_key (&iter));

--- a/src/libmongoc/tests/test-mongoc-client-session.c
+++ b/src/libmongoc/tests/test-mongoc-client-session.c
@@ -1000,7 +1000,7 @@ started (const mongoc_apm_command_started_t *event)
    ctx.strict_numeric_types = false;
 
    if (test->verbose) {
-      char *s = bson_as_json (cmd, NULL);
+      char *s = bson_as_relaxed_extended_json (cmd, NULL);
       printf ("%s\n", s);
       bson_free (s);
    }
@@ -1071,7 +1071,7 @@ succeeded (const mongoc_apm_command_succeeded_t *event)
    session_test_t *test = (session_test_t *) mongoc_apm_command_succeeded_get_context (event);
 
    if (test->verbose) {
-      char *s = bson_as_json (reply, NULL);
+      char *s = bson_as_relaxed_extended_json (reply, NULL);
       printf ("<--  %s\n", s);
       bson_free (s);
    }
@@ -1226,7 +1226,7 @@ check_session_returned (session_test_t *test, const bson_t *lsid)
     * been used. It is expected behavior for found to be false if
     * ss->last_used_usec == SESSION_NEVER_USED */
    if (!check_state.found) {
-      test_error ("server session %s not returned to pool", bson_as_json (lsid, NULL));
+      test_error ("server session %s not returned to pool", bson_as_relaxed_extended_json (lsid, NULL));
    }
 }
 
@@ -1553,7 +1553,7 @@ _test_causal_consistency (session_test_fn_t test_fn, bool allow_read_concern)
       for (i = 0; i < test->cmds.len; i++) {
          cmd = _mongoc_array_index (&test->cmds, bson_t *, i);
          if (bson_has_field (cmd, "readConcern")) {
-            test_error ("Command should not have included readConcern: %s", bson_as_json (cmd, NULL));
+            test_error ("Command should not have included readConcern: %s", bson_as_relaxed_extended_json (cmd, NULL));
          }
       }
    }

--- a/src/libmongoc/tests/test-mongoc-cluster.c
+++ b/src/libmongoc/tests/test-mongoc-cluster.c
@@ -435,8 +435,8 @@ test_cluster_time_cmd_started_cb (const mongoc_apm_command_started_t *event)
          bson_iter_bson (&iter, &client_cluster_time);
          if (!bson_equal (test->cluster_time, &client_cluster_time)) {
             test_error ("Unequal clusterTimes.\nServer sent %s\nClient sent %s",
-                        bson_as_json (test->cluster_time, NULL),
-                        bson_as_json (&client_cluster_time, NULL));
+                        bson_as_relaxed_extended_json (test->cluster_time, NULL),
+                        bson_as_relaxed_extended_json (&client_cluster_time, NULL));
          }
 
          bson_destroy (&client_cluster_time);

--- a/src/libmongoc/tests/test-mongoc-dns.c
+++ b/src/libmongoc/tests/test-mongoc-dns.c
@@ -50,8 +50,8 @@ _assert_options_match (const bson_t *test, mongoc_uri_t *uri)
                      "expected: %s\n"
                      "actual: %s",
                      opt_name,
-                     bson_as_json (&opts_from_test, NULL),
-                     bson_as_json (opts_or_creds, NULL));
+                     bson_as_relaxed_extended_json (&opts_from_test, NULL),
+                     bson_as_relaxed_extended_json (opts_or_creds, NULL));
       }
 
       test_value = bson_iter_value (&test_opts_iter);
@@ -62,8 +62,8 @@ _assert_options_match (const bson_t *test, mongoc_uri_t *uri)
                      "actual: %s",
                      opt_name,
                      ctx.errmsg,
-                     bson_as_json (&opts_from_test, NULL),
-                     bson_as_json (opts_from_uri, NULL));
+                     bson_as_relaxed_extended_json (&opts_from_test, NULL),
+                     bson_as_relaxed_extended_json (opts_from_uri, NULL));
       }
    }
 }

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -3169,7 +3169,7 @@ test_sample_causal_consistency (mongoc_client_t *client)
 					      read_prefs);
 
    while (mongoc_cursor_next (cursor, &result)) {
-      json = bson_as_json (result, NULL);
+      json = bson_as_relaxed_extended_json (result, NULL);
       fprintf (stdout, "Document: %s\n", json);
       bson_free (json);
    }
@@ -4316,7 +4316,7 @@ _test_sample_versioned_api_example_5_6_7_8 (void)
    /* This block not evaluated, but is inserted into documentation to represent the above reply.
     * Don't delete me! */
    /* Start Versioned API Example 6 */
-   char *str = bson_as_json (&reply, NULL /* length */);
+   char *str = bson_as_relaxed_extended_json (&reply, NULL /* length */);
    printf ("%s", str);
    /* Prints the server reply:
     * { "ok" : 0, "errmsg" : "Provided apiStrict:true, but the command count is not in API Version 1", "code" : 323, "codeName" : "APIStrictError" } */

--- a/src/libmongoc/tests/test-mongoc-transactions.c
+++ b/src/libmongoc/tests/test-mongoc-transactions.c
@@ -441,7 +441,7 @@ _test_transient_txn_err (bool hangup)
       if (!mongoc_error_has_label ((_b), "TransientTransactionError")) { \
          test_error ("Reply lacks TransientTransactionError label: %s\n" \
                      "Running %s",                                       \
-                     bson_as_json ((_b), NULL),                          \
+                     bson_as_relaxed_extended_json ((_b), NULL),         \
                      #_expr);                                            \
       }                                                                  \
    } while (0)
@@ -584,11 +584,12 @@ test_unknown_commit_result (void)
    BSON_ASSERT (!r);
 
    if (!mongoc_error_has_label (&reply, "UnknownTransactionCommitResult")) {
-      test_error ("Reply lacks UnknownTransactionCommitResult label: %s", bson_as_json (&reply, NULL));
+      test_error ("Reply lacks UnknownTransactionCommitResult label: %s", bson_as_relaxed_extended_json (&reply, NULL));
    }
 
    if (mongoc_error_has_label (&reply, "TransientTransactionError")) {
-      test_error ("Reply shouldn't have TransientTransactionError label: %s", bson_as_json (&reply, NULL));
+      test_error ("Reply shouldn't have TransientTransactionError label: %s",
+                  bson_as_relaxed_extended_json (&reply, NULL));
    }
 
    bson_destroy (&reply);

--- a/src/libmongoc/tests/unified/result.c
+++ b/src/libmongoc/tests/unified/result.c
@@ -561,7 +561,7 @@ result_check (result_t *result, entity_map_t *em, bson_val_t *expect_result, bso
          if (!bson_match (error_response, val_to_match, result->array_of_root_docs, error)) {
             test_diagnostics_error_info ("error.errorResponse mismatch:\nExpected: %s\nActual: %s\n",
                                          bson_val_to_json (error_response),
-                                         bson_as_json (result->reply, NULL));
+                                         bson_as_relaxed_extended_json (result->reply, NULL));
             bson_val_destroy (val_to_match);
             bson_destroy (&doc_to_match);
             goto done;

--- a/src/libmongoc/tests/unified/runner.c
+++ b/src/libmongoc/tests/unified/runner.c
@@ -1409,8 +1409,8 @@ test_generate_atlas_results (test_t *test, bson_error_t *error)
 
    size_t events_json_len = 0u;
    size_t results_json_len = 0u;
-   char *const events_json = bson_as_json (&events_doc, &events_json_len);
-   char *const results_json = bson_as_json (&results_doc, &results_json_len);
+   char *const events_json = bson_as_relaxed_extended_json (&events_doc, &events_json_len);
+   char *const results_json = bson_as_relaxed_extended_json (&results_doc, &results_json_len);
 
    ASSERT_WITH_MSG (events_json, "failed to convert events BSON document to JSON");
    ASSERT_WITH_MSG (results_json, "failed to convert results BSON document to JSON");


### PR DESCRIPTION
# Summary

- Deprecate `bson_as_json` for newly added `bson_as_legacy_extended_json`.
- Deprecate `bson_array_as_json` for newly added `bson_array_as_legacy_extended_json`.
- Document libbson's Legacy Extended JSON format.
- Test side-by-side comparison of Canonical, Relaxed, and Legacy Extended JSON.

Verified with this [patch build](https://spruce.mongodb.com/version/6716a86d6f27b60007428eeb).

# Background & Motivation

Deprecating intends to better inform users that `bson_as_json` and `bson_array_as_json` use Legacy Extended JSON. `bson_as_legacy_extended_json` and `bson_array_as_legacy_extended_json` are added as non-deprecated alternatives to ease migration. Users wanting to continue using Legacy Extended JSON can find+replace to the non-deprecated alternatives.

Significant existing use of `bson_as_json` is expected (see [scope](https://docs.google.com/document/d/13-pxZ9LPpIcoYSxkkQ7IfDhKCaw_cxyjIZfcVrC5J3g/edit#heading=h.i81lzqug228b)). Deprecation of encoding Legacy Extended JSON can be considered for future releases. 

Documenting the libbson's Legacy Extended JSON format is intended to inform users wanting to migrate to non-Legacy formats.

Example code snippets in docs have been moved to a new `extended-json.c` source file to ease modifying and ensure they compile.

Examples are updated to use `bson_as_relaxed_extended_json` to encourage use of non-Legacy formats.

libmongoc tests are updated to use `bson_as_relaxed_extended_json`.

libbson tests intending to test encoding are updated to use `bson_as_legacy_extended_json` to clarify Legacy Extended JSON is intended.

## Testing

A new test is added to compare encoding of Canonical, Relaxed, and Legacy Extended JSON. This led to the discovery of CDRIVER-5759.

Notably, libbson's Legacy Extended JSON encoding of double Infinity and NaN is implementation defined. libbson's Legacy Extended JSON uses `"%.20g"` to encode all double values:

```c
bson_t *b = BCON_NEW ("double_inf", BCON_DOUBLE (INFINITY));
char *as_legacy = bson_as_json (b, NULL);
printf ("%s\n", as_legacy);
// Prints either:
// { "double_inf" : inf }
// { "double_inf" : infinity }
```

Quoting [C99](https://port70.net/~nsz/c/c99/n1256.html#7.19.6):

> A double argument representing an infinity is converted in one of the styles [-]inf or [-]infinity -- which style is implementation-defined. A double argument representing a NaN is converted in one of the styles [-]nan or [-]nan(n-char-sequence) -- which style, and the meaning of any n-char-sequence, is implementation-defined.

Preserving this encoding seems somewhat deliberate. Quoting https://github.com/mongodb/libbson/commit/6929d34e7af2ccdc1ce283daf72b4d4dff952849

> Maintain legacy bson_as_json() output for non-finite values. Note that legacy mode will produce "nan" and "inf" literals, which are not valid JSON.

This PR does not propose changing this encoding to preserve backward compatibility. Instead, this behavior is documented to inform users.