### PR TITLE
CDRIVER-5741 remove duplicate declaration

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-bulkwrite.c
+++ b/src/libmongoc/src/mongoc/mongoc-bulkwrite.c
@@ -1514,8 +1514,6 @@ mongoc_bulkwrite_execute (mongoc_bulkwrite_t *self, const mongoc_bulkwriteopts_t
       }
    }
 
-   bool is_ordered =
-      mongoc_optional_is_set (&opts->ordered) ? mongoc_optional_value (&opts->ordered) : true; // default.
    bool verboseresults =
       mongoc_optional_is_set (&opts->verboseresults) ? mongoc_optional_value (&opts->verboseresults) : false;
    ret.res->verboseresults = verboseresults;


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/mongo-c-driver/pull/1752. Changes were not rebased on https://github.com/mongodb/mongo-c-driver/pull/1749 and resulted in duplicate declaration of `is_ordered`.