### PR TITLE
CDRIVER-5708 deprecate `mongoc_<obj>_command`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,12 @@ Platform Support:
 
   * Support for Visual Studio 2013 is dropped.
 
+Deprecated:
+
+  * `mongoc_client_command` is deprecated and planned for removal in a future release. Use `mongoc_client_command_simple` instead.
+  * `mongoc_database_command` is deprecated and planned for removal in a future release. Use `mongoc_database_command_simple` instead.
+  * `mongoc_collection_command` is deprecated and planned for removal in a future release. Use `mongoc_collection_command_simple` instead.
+
 libmongoc 1.28.1
 ================
 

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -1338,6 +1338,11 @@ if (ENABLE_EXAMPLES AND ENABLE_SHARED)
    # examples/tutorial
    mongoc_add_example (executing ${PROJECT_SOURCE_DIR}/examples/tutorial/executing.c)
    mongoc_add_example (appending ${PROJECT_SOURCE_DIR}/examples/tutorial/appending.c)
+   mongoc_add_example (migrating ${PROJECT_SOURCE_DIR}/examples/migrating.c)
+   # Ignore deprecation warnings in migrating examples. Migrating examples deliberately call deprecated API to show how to migrate.
+   target_compile_options (migrating
+      PRIVATE $<$<NOT:$<C_COMPILER_ID:MSVC>>:-Wno-deprecated-declarations>
+   )
 endif ()
 
 if (ENABLE_TESTS AND ENABLE_SHARED AND MONGOC_ENABLE_SSL AND NOT WIN32)

--- a/src/libmongoc/doc/mongoc_client_command.rst
+++ b/src/libmongoc/doc/mongoc_client_command.rst
@@ -25,7 +25,7 @@ Synopsis
                          const mongoc_read_prefs_t *read_prefs)
      BSON_GNUC_WARN_UNUSED_RESULT BSON_GNUC_DEPRECATED_FOR (mongoc_client_command_simple);
 
-This function is superseded by :symbol:`mongoc_client_command_with_opts()`, :symbol:`mongoc_client_read_command_with_opts()`, :symbol:`mongoc_client_write_command_with_opts()`, and :symbol:`mongoc_client_read_write_command_with_opts()`.
+This function is superseded by :symbol:`mongoc_client_command_simple()`.
 
 .. include:: includes/not-retryable-read.txt
 

--- a/src/libmongoc/doc/mongoc_client_command.rst
+++ b/src/libmongoc/doc/mongoc_client_command.rst
@@ -49,6 +49,29 @@ Parameters
 * ``fields``: Unused.
 * ``read_prefs``: An optional :symbol:`mongoc_read_prefs_t`. Otherwise, the command uses mode ``MONGOC_READ_PRIMARY``.
 
+Migrating
+---------
+
+:symbol:`mongoc_client_command` is deprecated.
+
+The following example uses :symbol:`mongoc_client_command`:
+
+.. literalinclude:: ../examples/migrating.c
+   :language: c
+   :dedent: 6
+   :start-after: // mongoc_client_command ... before ... begin
+   :end-before:  // mongoc_client_command ... before ... end
+   :caption: Before
+
+To migrate, use a non-deprecated alternative, like :symbol:`mongoc_client_command_simple`:
+
+.. literalinclude:: ../examples/migrating.c
+   :language: c
+   :dedent: 6
+   :start-after: // mongoc_client_command ... after ... begin
+   :end-before:  // mongoc_client_command ... after ... end
+   :caption: After
+
 Returns
 -------
 

--- a/src/libmongoc/doc/mongoc_client_command.rst
+++ b/src/libmongoc/doc/mongoc_client_command.rst
@@ -61,7 +61,7 @@ The following example uses :symbol:`mongoc_client_command`:
    :end-before:  // mongoc_client_command ... before ... end
    :caption: Before
 
-To migrate, use a non-deprecated alternative, like :symbol:`mongoc_client_command_simple`:
+The above code block may be rewritten to use :symbol:`mongoc_client_command_simple` instead, as shown below:
 
 .. literalinclude:: ../examples/migrating.c
    :language: c

--- a/src/libmongoc/doc/mongoc_client_command.rst
+++ b/src/libmongoc/doc/mongoc_client_command.rst
@@ -7,7 +7,7 @@ mongoc_client_command()
    .. deprecated:: 1.29.0
 
       This function is deprecated and should not be used in new code.
-      This function is superseded by :symbol:`mongoc_client_command_simple()`.
+      Use :symbol:`mongoc_client_command_simple()` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_client_command.rst
+++ b/src/libmongoc/doc/mongoc_client_command.rst
@@ -3,6 +3,11 @@
 mongoc_client_command()
 =======================
 
+.. warning::
+   .. deprecated:: 1.29.0
+
+      This function is deprecated and should not be used in new code.
+
 Synopsis
 --------
 
@@ -18,7 +23,7 @@ Synopsis
                          const bson_t *query,
                          const bson_t *fields,
                          const mongoc_read_prefs_t *read_prefs)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+     BSON_GNUC_WARN_UNUSED_RESULT BSON_GNUC_DEPRECATED_FOR (mongoc_client_command_simple);
 
 This function is superseded by :symbol:`mongoc_client_command_with_opts()`, :symbol:`mongoc_client_read_command_with_opts()`, :symbol:`mongoc_client_write_command_with_opts()`, and :symbol:`mongoc_client_read_write_command_with_opts()`.
 

--- a/src/libmongoc/doc/mongoc_client_command.rst
+++ b/src/libmongoc/doc/mongoc_client_command.rst
@@ -7,6 +7,7 @@ mongoc_client_command()
    .. deprecated:: 1.29.0
 
       This function is deprecated and should not be used in new code.
+      This function is superseded by :symbol:`mongoc_client_command_simple()`.
 
 Synopsis
 --------
@@ -23,8 +24,6 @@ Synopsis
                          const bson_t *query,
                          const bson_t *fields,
                          const mongoc_read_prefs_t *read_prefs);
-
-This function is superseded by :symbol:`mongoc_client_command_simple()`.
 
 .. include:: includes/not-retryable-read.txt
 

--- a/src/libmongoc/doc/mongoc_client_command.rst
+++ b/src/libmongoc/doc/mongoc_client_command.rst
@@ -22,8 +22,7 @@ Synopsis
                          uint32_t batch_size,
                          const bson_t *query,
                          const bson_t *fields,
-                         const mongoc_read_prefs_t *read_prefs)
-     BSON_GNUC_WARN_UNUSED_RESULT BSON_GNUC_DEPRECATED_FOR (mongoc_client_command_simple);
+                         const mongoc_read_prefs_t *read_prefs);
 
 This function is superseded by :symbol:`mongoc_client_command_simple()`.
 

--- a/src/libmongoc/doc/mongoc_collection_command.rst
+++ b/src/libmongoc/doc/mongoc_collection_command.rst
@@ -24,7 +24,7 @@ Synopsis
                              const mongoc_read_prefs_t *read_prefs)
      BSON_GNUC_WARN_UNUSED_RESULT BSON_GNUC_DEPRECATED_FOR (mongoc_collection_command_simple);
 
-This function is superseded by :symbol:`mongoc_collection_command_with_opts()`, :symbol:`mongoc_collection_read_command_with_opts()`, :symbol:`mongoc_collection_write_command_with_opts()`, and :symbol:`mongoc_collection_read_write_command_with_opts()`.
+This function is superseded by :symbol:`mongoc_collection_command_simple()`.
 
 .. include:: includes/not-retryable-read.txt
 

--- a/src/libmongoc/doc/mongoc_collection_command.rst
+++ b/src/libmongoc/doc/mongoc_collection_command.rst
@@ -7,6 +7,7 @@ mongoc_collection_command()
    .. deprecated:: 1.29.0
 
       This function is deprecated and should not be used in new code.
+      This function is superseded by :symbol:`mongoc_collection_command_simple()`.
 
 Synopsis
 --------
@@ -22,8 +23,6 @@ Synopsis
                              const bson_t *command,
                              const bson_t *fields,
                              const mongoc_read_prefs_t *read_prefs);
-
-This function is superseded by :symbol:`mongoc_collection_command_simple()`.
 
 .. include:: includes/not-retryable-read.txt
 

--- a/src/libmongoc/doc/mongoc_collection_command.rst
+++ b/src/libmongoc/doc/mongoc_collection_command.rst
@@ -21,8 +21,7 @@ Synopsis
                              uint32_t batch_size,
                              const bson_t *command,
                              const bson_t *fields,
-                             const mongoc_read_prefs_t *read_prefs)
-     BSON_GNUC_WARN_UNUSED_RESULT BSON_GNUC_DEPRECATED_FOR (mongoc_collection_command_simple);
+                             const mongoc_read_prefs_t *read_prefs);
 
 This function is superseded by :symbol:`mongoc_collection_command_simple()`.
 

--- a/src/libmongoc/doc/mongoc_collection_command.rst
+++ b/src/libmongoc/doc/mongoc_collection_command.rst
@@ -7,7 +7,7 @@ mongoc_collection_command()
    .. deprecated:: 1.29.0
 
       This function is deprecated and should not be used in new code.
-      This function is superseded by :symbol:`mongoc_collection_command_simple()`.
+      Use :symbol:`mongoc_collection_command_simple()` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_collection_command.rst
+++ b/src/libmongoc/doc/mongoc_collection_command.rst
@@ -52,7 +52,7 @@ The following example uses :symbol:`mongoc_collection_command`:
    :end-before:  // mongoc_collection_command ... before ... end
    :caption: Before
 
-To migrate, use a non-deprecated alternative, like :symbol:`mongoc_collection_command_simple`:
+The above code block may be rewritten to use :symbol:`mongoc_collection_command_simple` instead, as shown below:
 
 .. literalinclude:: ../examples/migrating.c
    :language: c

--- a/src/libmongoc/doc/mongoc_collection_command.rst
+++ b/src/libmongoc/doc/mongoc_collection_command.rst
@@ -40,6 +40,29 @@ Parameters
 * ``fields``: Unused.
 * ``read_prefs``: An optional :symbol:`mongoc_read_prefs_t`. Otherwise, the command uses mode ``MONGOC_READ_PRIMARY``.
 
+Migrating
+---------
+
+:symbol:`mongoc_collection_command` is deprecated.
+
+The following example uses :symbol:`mongoc_collection_command`:
+
+.. literalinclude:: ../examples/migrating.c
+   :language: c
+   :dedent: 6
+   :start-after: // mongoc_collection_command ... before ... begin
+   :end-before:  // mongoc_collection_command ... before ... end
+   :caption: Before
+
+To migrate, use a non-deprecated alternative, like :symbol:`mongoc_collection_command_simple`:
+
+.. literalinclude:: ../examples/migrating.c
+   :language: c
+   :dedent: 6
+   :start-after: // mongoc_collection_command ... after ... begin
+   :end-before:  // mongoc_collection_command ... after ... end
+   :caption: After
+
 Returns
 -------
 

--- a/src/libmongoc/doc/mongoc_collection_command.rst
+++ b/src/libmongoc/doc/mongoc_collection_command.rst
@@ -3,6 +3,11 @@
 mongoc_collection_command()
 ===========================
 
+.. warning::
+   .. deprecated:: 1.29.0
+
+      This function is deprecated and should not be used in new code.
+
 Synopsis
 --------
 
@@ -17,7 +22,7 @@ Synopsis
                              const bson_t *command,
                              const bson_t *fields,
                              const mongoc_read_prefs_t *read_prefs)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+     BSON_GNUC_WARN_UNUSED_RESULT BSON_GNUC_DEPRECATED_FOR (mongoc_collection_command_simple);
 
 This function is superseded by :symbol:`mongoc_collection_command_with_opts()`, :symbol:`mongoc_collection_read_command_with_opts()`, :symbol:`mongoc_collection_write_command_with_opts()`, and :symbol:`mongoc_collection_read_write_command_with_opts()`.
 

--- a/src/libmongoc/doc/mongoc_collection_command.rst
+++ b/src/libmongoc/doc/mongoc_collection_command.rst
@@ -32,12 +32,12 @@ Parameters
 ----------
 
 * ``collection``: A :symbol:`mongoc_collection_t`.
-* ``flags``: A :symbol:`mongoc_query_flags_t`.
-* ``skip``: A uint32_t with the number of documents to skip or zero.
-* ``limit``: A uint32_t with the max number of documents to return or zero.
-* ``batch_size``: A uint32_t with the number of documents in each batch or zero. Default is 100.
+* ``flags``: Unused.
+* ``skip``: Unused.
+* ``limit``: Unused.
+* ``batch_size``: Unused.
 * ``command``: A :symbol:`bson:bson_t` containing the command to execute.
-* ``fields``: A :symbol:`bson:bson_t` containing the fields to return or ``NULL``. Not all commands support this option.
+* ``fields``: Unused.
 * ``read_prefs``: An optional :symbol:`mongoc_read_prefs_t`. Otherwise, the command uses mode ``MONGOC_READ_PRIMARY``.
 
 Returns

--- a/src/libmongoc/doc/mongoc_database_command.rst
+++ b/src/libmongoc/doc/mongoc_database_command.rst
@@ -24,7 +24,7 @@ Synopsis
                            const mongoc_read_prefs_t *read_prefs)
      BSON_GNUC_WARN_UNUSED_RESULT BSON_GNUC_DEPRECATED_FOR (mongoc_database_command_simple);
 
-This function is superseded by :symbol:`mongoc_database_command_with_opts()`, :symbol:`mongoc_database_read_command_with_opts()`, :symbol:`mongoc_database_write_command_with_opts()`, and :symbol:`mongoc_database_read_write_command_with_opts()`.
+This function is superseded by :symbol:`mongoc_database_command_simple()`.
 
 Description
 -----------

--- a/src/libmongoc/doc/mongoc_database_command.rst
+++ b/src/libmongoc/doc/mongoc_database_command.rst
@@ -7,6 +7,7 @@ mongoc_database_command()
    .. deprecated:: 1.29.0
 
       This function is deprecated and should not be used in new code.
+      This function is superseded by :symbol:`mongoc_database_command_simple()`.
 
 Synopsis
 --------
@@ -22,8 +23,6 @@ Synopsis
                            const bson_t *command,
                            const bson_t *fields,
                            const mongoc_read_prefs_t *read_prefs);
-
-This function is superseded by :symbol:`mongoc_database_command_simple()`.
 
 Description
 -----------

--- a/src/libmongoc/doc/mongoc_database_command.rst
+++ b/src/libmongoc/doc/mongoc_database_command.rst
@@ -21,8 +21,7 @@ Synopsis
                            uint32_t batch_size,
                            const bson_t *command,
                            const bson_t *fields,
-                           const mongoc_read_prefs_t *read_prefs)
-     BSON_GNUC_WARN_UNUSED_RESULT BSON_GNUC_DEPRECATED_FOR (mongoc_database_command_simple);
+                           const mongoc_read_prefs_t *read_prefs);
 
 This function is superseded by :symbol:`mongoc_database_command_simple()`.
 

--- a/src/libmongoc/doc/mongoc_database_command.rst
+++ b/src/libmongoc/doc/mongoc_database_command.rst
@@ -3,6 +3,11 @@
 mongoc_database_command()
 =========================
 
+.. warning::
+   .. deprecated:: 1.29.0
+
+      This function is deprecated and should not be used in new code.
+
 Synopsis
 --------
 
@@ -17,7 +22,7 @@ Synopsis
                            const bson_t *command,
                            const bson_t *fields,
                            const mongoc_read_prefs_t *read_prefs)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+     BSON_GNUC_WARN_UNUSED_RESULT BSON_GNUC_DEPRECATED_FOR (mongoc_database_command_simple);
 
 This function is superseded by :symbol:`mongoc_database_command_with_opts()`, :symbol:`mongoc_database_read_command_with_opts()`, :symbol:`mongoc_database_write_command_with_opts()`, and :symbol:`mongoc_database_read_write_command_with_opts()`.
 

--- a/src/libmongoc/doc/mongoc_database_command.rst
+++ b/src/libmongoc/doc/mongoc_database_command.rst
@@ -45,6 +45,29 @@ Parameters
 * ``fields``: Unused.
 * ``read_prefs``: An optional :symbol:`mongoc_read_prefs_t`. Otherwise, the command uses mode ``MONGOC_READ_PRIMARY``.
 
+Migrating
+---------
+
+:symbol:`mongoc_database_command` is deprecated.
+
+The following example uses :symbol:`mongoc_database_command`:
+
+.. literalinclude:: ../examples/migrating.c
+   :language: c
+   :dedent: 6
+   :start-after: // mongoc_database_command ... before ... begin
+   :end-before:  // mongoc_database_command ... before ... end
+   :caption: Before
+
+To migrate, use a non-deprecated alternative, like :symbol:`mongoc_database_command_simple`:
+
+.. literalinclude:: ../examples/migrating.c
+   :language: c
+   :dedent: 6
+   :start-after: // mongoc_database_command ... after ... begin
+   :end-before:  // mongoc_database_command ... after ... end
+   :caption: After
+
 Returns
 -------
 

--- a/src/libmongoc/doc/mongoc_database_command.rst
+++ b/src/libmongoc/doc/mongoc_database_command.rst
@@ -57,7 +57,7 @@ The following example uses :symbol:`mongoc_database_command`:
    :end-before:  // mongoc_database_command ... before ... end
    :caption: Before
 
-To migrate, use a non-deprecated alternative, like :symbol:`mongoc_database_command_simple`:
+The above code block may be rewritten to use :symbol:`mongoc_database_command_simple` instead, as shown below:
 
 .. literalinclude:: ../examples/migrating.c
    :language: c

--- a/src/libmongoc/doc/mongoc_database_command.rst
+++ b/src/libmongoc/doc/mongoc_database_command.rst
@@ -7,7 +7,7 @@ mongoc_database_command()
    .. deprecated:: 1.29.0
 
       This function is deprecated and should not be used in new code.
-      This function is superseded by :symbol:`mongoc_database_command_simple()`.
+      Use :symbol:`mongoc_database_command_simple()` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_database_command.rst
+++ b/src/libmongoc/doc/mongoc_database_command.rst
@@ -37,12 +37,12 @@ Parameters
 ----------
 
 * ``database``: A :symbol:`mongoc_database_t`.
-* ``flags``: A :symbol:`mongoc_query_flags_t`.
-* ``skip``: The number of documents to skip on the server.
-* ``limit``: The maximum number of documents to return from the cursor.
-* ``batch_size``: Attempt to batch results from the server in groups of ``batch_size`` documents.
+* ``flags``: Unused.
+* ``skip``: Unused.
+* ``limit``: Unused.
+* ``batch_size``: Unused.
 * ``command``: A :symbol:`bson:bson_t` containing the command.
-* ``fields``: An optional :symbol:`bson:bson_t` containing the fields to return. ``NULL`` for all fields.
+* ``fields``: Unused.
 * ``read_prefs``: An optional :symbol:`mongoc_read_prefs_t`. Otherwise, the command uses mode ``MONGOC_READ_PRIMARY``.
 
 Returns

--- a/src/libmongoc/examples/basic_aggregation/map-reduce-advanced.c
+++ b/src/libmongoc/examples/basic_aggregation/map-reduce-advanced.c
@@ -4,9 +4,8 @@ map_reduce_advanced (mongoc_database_t *database)
    bson_t *command;
    bson_error_t error;
    bool res = true;
-   mongoc_cursor_t *cursor;
    mongoc_read_prefs_t *read_pref;
-   const bson_t *doc;
+   bson_t doc;
 
    /* Construct the mapReduce command */
    /* Other arguments can also be specified here, like "query" or "limit"
@@ -26,21 +25,16 @@ map_reduce_advanced (mongoc_database_t *database)
                        "}");
 
    read_pref = mongoc_read_prefs_new (MONGOC_READ_SECONDARY);
-   cursor = mongoc_database_command (database, MONGOC_QUERY_NONE, 0, 0, 0, command, NULL, read_pref);
-
-   /* Do something with the results */
-   while (mongoc_cursor_next (cursor, &doc)) {
-      print_res (doc);
-   }
-
-   if (mongoc_cursor_error (cursor, &error)) {
+   if (mongoc_database_command_simple (database, command, read_pref, &doc, &error)) {
+      print_res (&doc);
+   } else {
       fprintf (stderr, "ERROR: %s\n", error.message);
       res = false;
    }
 
-   mongoc_cursor_destroy (cursor);
    mongoc_read_prefs_destroy (read_pref);
    bson_destroy (command);
+   bson_destroy (&doc);
 
    return res;
 }

--- a/src/libmongoc/examples/basic_aggregation/map-reduce-advanced.c
+++ b/src/libmongoc/examples/basic_aggregation/map-reduce-advanced.c
@@ -21,7 +21,7 @@ map_reduce_advanced (mongoc_database_t *database)
                        "out",
                        "{",
                        "inline",
-                       "1",
+                       BCON_INT32 (1),
                        "}");
 
    read_pref = mongoc_read_prefs_new (MONGOC_READ_SECONDARY);

--- a/src/libmongoc/examples/migrating.c
+++ b/src/libmongoc/examples/migrating.c
@@ -82,8 +82,7 @@ main (void)
       bson_t reply;
       bson_error_t error;
       bson_t *cmd = BCON_NEW ("find", "foo", "filter", "{", "}");
-      bool ok = mongoc_client_command_simple (client, "db", cmd, NULL /* read prefs */, &reply, &error);
-      if (!ok) {
+      if (!mongoc_client_command_simple (client, "db", cmd, NULL /* read prefs */, &reply, &error)) {
          FAIL ("Expected no error, got: %s\n", error.message);
       }
 
@@ -132,8 +131,7 @@ main (void)
       bson_t reply;
       bson_error_t error;
       bson_t *cmd = BCON_NEW ("find", "foo", "filter", "{", "}");
-      bool ok = mongoc_database_command_simple (db, cmd, NULL /* read prefs */, &reply, &error);
-      if (!ok) {
+      if (!mongoc_database_command_simple (db, cmd, NULL /* read prefs */, &reply, &error)) {
          FAIL ("Expected no error, got: %s\n", error.message);
       }
 
@@ -182,8 +180,7 @@ main (void)
       bson_t reply;
       bson_error_t error;
       bson_t *cmd = BCON_NEW ("find", "foo", "filter", "{", "}");
-      bool ok = mongoc_collection_command_simple (coll, cmd, NULL /* read prefs */, &reply, &error);
-      if (!ok) {
+      if (!mongoc_collection_command_simple (coll, cmd, NULL /* read prefs */, &reply, &error)) {
          FAIL ("Expected no error, got: %s\n", error.message);
       }
 

--- a/src/libmongoc/examples/migrating.c
+++ b/src/libmongoc/examples/migrating.c
@@ -37,7 +37,7 @@
       (void) 0
 
 int
-main (int argc, char *argv[])
+main (void)
 {
    mongoc_init ();
 

--- a/src/libmongoc/examples/migrating.c
+++ b/src/libmongoc/examples/migrating.c
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2009-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <mongoc/mongoc.h>
+
+// `migrating.c` shows examples of migrating from deprecated API to alternatives.
+
+#define FAIL(...)                                                       \
+   if (1) {                                                             \
+      fprintf (stderr, "[%s:%d] failed: ", __FILE__, (int) (__LINE__)); \
+      fprintf (stderr, __VA_ARGS__);                                    \
+      fprintf (stderr, "\n");                                           \
+      abort ();                                                         \
+   } else                                                               \
+      (void) 0
+
+
+#define EXPECT(Cond)                           \
+   if (1) {                                    \
+      if (!(Cond)) {                           \
+         FAIL ("condition failed: %s", #Cond); \
+      }                                        \
+   } else                                      \
+      (void) 0
+
+int
+main (int argc, char *argv[])
+{
+   mongoc_init ();
+
+   mongoc_client_t *client = mongoc_client_new ("mongodb://localhost:27017");
+   mongoc_database_t *db = mongoc_client_get_database (client, "db");
+   mongoc_collection_t *coll = mongoc_database_get_collection (db, "coll");
+
+   {
+      // mongoc_client_command ... before ... begin
+      const bson_t *reply;
+      bson_t *cmd = BCON_NEW ("find", "foo", "filter", "{", "}");
+      mongoc_cursor_t *cursor = mongoc_client_command (client,
+                                                       "db",
+                                                       MONGOC_QUERY_NONE /* unused */,
+                                                       0 /* unused */,
+                                                       0 /* unused */,
+                                                       0 /* unused */,
+                                                       cmd,
+                                                       NULL /* unused */,
+                                                       NULL /* read prefs */);
+      // Expect cursor to return exactly one document for the command reply.
+      EXPECT (mongoc_cursor_next (cursor, &reply));
+
+      bson_error_t error;
+      if (mongoc_cursor_error (cursor, &error)) {
+         FAIL ("Expected no error, got: %s\n", error.message);
+      }
+
+      // Expect successful reply to contain "ok": 1
+      bson_iter_t iter;
+      EXPECT (bson_iter_init_find (&iter, reply, "ok") && bson_iter_as_int64 (&iter) == 1);
+
+      // Expect cursor to return no other documents.
+      EXPECT (!mongoc_cursor_next (cursor, &reply));
+      mongoc_cursor_destroy (cursor);
+      bson_destroy (cmd);
+      // mongoc_client_command ... before ... end
+   }
+
+   {
+      // mongoc_client_command ... after ... begin
+      bson_t reply;
+      bson_error_t error;
+      bson_t *cmd = BCON_NEW ("find", "foo", "filter", "{", "}");
+      bool ok = mongoc_client_command_simple (client, "db", cmd, NULL /* read prefs */, &reply, &error);
+      if (!ok) {
+         FAIL ("Expected no error, got: %s\n", error.message);
+      }
+
+      // Expect successful reply to contain "ok": 1
+      bson_iter_t iter;
+      EXPECT (bson_iter_init_find (&iter, &reply, "ok") && bson_iter_as_int64 (&iter) == 1);
+
+      bson_destroy (&reply);
+      bson_destroy (cmd);
+      // mongoc_client_command ... after ... end
+   }
+
+   {
+      // mongoc_database_command ... before ... begin
+      const bson_t *reply;
+      bson_t *cmd = BCON_NEW ("find", "foo", "filter", "{", "}");
+      mongoc_cursor_t *cursor = mongoc_database_command (db,
+                                                         MONGOC_QUERY_NONE /* unused */,
+                                                         0 /* unused */,
+                                                         0 /* unused */,
+                                                         0 /* unused */,
+                                                         cmd,
+                                                         NULL /* unused */,
+                                                         NULL /* read prefs */);
+      // Expect cursor to return exactly one document for the command reply.
+      EXPECT (mongoc_cursor_next (cursor, &reply));
+
+      bson_error_t error;
+      if (mongoc_cursor_error (cursor, &error)) {
+         FAIL ("Expected no error, got: %s\n", error.message);
+      }
+
+      // Expect successful reply to contain "ok": 1
+      bson_iter_t iter;
+      EXPECT (bson_iter_init_find (&iter, reply, "ok") && bson_iter_as_int64 (&iter) == 1);
+
+      // Expect cursor to return no other documents.
+      EXPECT (!mongoc_cursor_next (cursor, &reply));
+      mongoc_cursor_destroy (cursor);
+      bson_destroy (cmd);
+      // mongoc_database_command ... before ... end
+   }
+
+   {
+      // mongoc_database_command ... after ... begin
+      bson_t reply;
+      bson_error_t error;
+      bson_t *cmd = BCON_NEW ("find", "foo", "filter", "{", "}");
+      bool ok = mongoc_database_command_simple (db, cmd, NULL /* read prefs */, &reply, &error);
+      if (!ok) {
+         FAIL ("Expected no error, got: %s\n", error.message);
+      }
+
+      // Expect successful reply to contain "ok": 1
+      bson_iter_t iter;
+      EXPECT (bson_iter_init_find (&iter, &reply, "ok") && bson_iter_as_int64 (&iter) == 1);
+
+      bson_destroy (&reply);
+      bson_destroy (cmd);
+      // mongoc_database_command ... after ... end
+   }
+
+   {
+      // mongoc_collection_command ... before ... begin
+      const bson_t *reply;
+      bson_t *cmd = BCON_NEW ("find", "foo", "filter", "{", "}");
+      mongoc_cursor_t *cursor = mongoc_collection_command (coll,
+                                                           MONGOC_QUERY_NONE /* unused */,
+                                                           0 /* unused */,
+                                                           0 /* unused */,
+                                                           0 /* unused */,
+                                                           cmd,
+                                                           NULL /* unused */,
+                                                           NULL /* read prefs */);
+      // Expect cursor to return exactly one document for the command reply.
+      EXPECT (mongoc_cursor_next (cursor, &reply));
+
+      bson_error_t error;
+      if (mongoc_cursor_error (cursor, &error)) {
+         FAIL ("Expected no error, got: %s\n", error.message);
+      }
+
+      // Expect successful reply to contain "ok": 1
+      bson_iter_t iter;
+      EXPECT (bson_iter_init_find (&iter, reply, "ok") && bson_iter_as_int64 (&iter) == 1);
+
+      // Expect cursor to return no other documents.
+      EXPECT (!mongoc_cursor_next (cursor, &reply));
+      mongoc_cursor_destroy (cursor);
+      bson_destroy (cmd);
+      // mongoc_collection_command ... before ... end
+   }
+
+   {
+      // mongoc_collection_command ... after ... begin
+      bson_t reply;
+      bson_error_t error;
+      bson_t *cmd = BCON_NEW ("find", "foo", "filter", "{", "}");
+      bool ok = mongoc_collection_command_simple (coll, cmd, NULL /* read prefs */, &reply, &error);
+      if (!ok) {
+         FAIL ("Expected no error, got: %s\n", error.message);
+      }
+
+      // Expect successful reply to contain "ok": 1
+      bson_iter_t iter;
+      EXPECT (bson_iter_init_find (&iter, &reply, "ok") && bson_iter_as_int64 (&iter) == 1);
+
+      bson_destroy (&reply);
+      bson_destroy (cmd);
+      // mongoc_collection_command ... after ... end
+   }
+
+   mongoc_collection_destroy (coll);
+   mongoc_database_destroy (db);
+   mongoc_client_destroy (client);
+
+   mongoc_cleanup ();
+}

--- a/src/libmongoc/src/mongoc/mongoc-client.h
+++ b/src/libmongoc/src/mongoc/mongoc-client.h
@@ -122,7 +122,8 @@ mongoc_client_command (mongoc_client_t *client,
                        uint32_t batch_size,
                        const bson_t *query,
                        const bson_t *fields,
-                       const mongoc_read_prefs_t *read_prefs) BSON_GNUC_WARN_UNUSED_RESULT;
+                       const mongoc_read_prefs_t *read_prefs) BSON_GNUC_WARN_UNUSED_RESULT
+   BSON_GNUC_DEPRECATED_FOR (mongoc_client_command_simple);
 MONGOC_EXPORT (void)
 mongoc_client_kill_cursor (mongoc_client_t *client, int64_t cursor_id) BSON_GNUC_DEPRECATED;
 MONGOC_EXPORT (bool)

--- a/src/libmongoc/src/mongoc/mongoc-collection.h
+++ b/src/libmongoc/src/mongoc/mongoc-collection.h
@@ -55,7 +55,8 @@ mongoc_collection_command (mongoc_collection_t *collection,
                            uint32_t batch_size,
                            const bson_t *command,
                            const bson_t *fields,
-                           const mongoc_read_prefs_t *read_prefs) BSON_GNUC_WARN_UNUSED_RESULT;
+                           const mongoc_read_prefs_t *read_prefs) BSON_GNUC_WARN_UNUSED_RESULT
+   BSON_GNUC_DEPRECATED_FOR (mongoc_collection_command_simple);
 MONGOC_EXPORT (bool)
 mongoc_collection_read_command_with_opts (mongoc_collection_t *collection,
                                           const bson_t *command,

--- a/src/libmongoc/src/mongoc/mongoc-database.h
+++ b/src/libmongoc/src/mongoc/mongoc-database.h
@@ -64,7 +64,8 @@ mongoc_database_command (mongoc_database_t *database,
                          uint32_t batch_size,
                          const bson_t *command,
                          const bson_t *fields,
-                         const mongoc_read_prefs_t *read_prefs) BSON_GNUC_WARN_UNUSED_RESULT;
+                         const mongoc_read_prefs_t *read_prefs) BSON_GNUC_WARN_UNUSED_RESULT
+   BSON_GNUC_DEPRECATED_FOR (mongoc_database_command_simple);
 MONGOC_EXPORT (bool)
 mongoc_database_read_command_with_opts (mongoc_database_t *database,
                                         const bson_t *command,


### PR DESCRIPTION
# Summary

Deprecate `mongoc_<obj>_command`.

Document migrating to corresponding `mongoc_<obj>_command_simple`.

Verified by [this patch build](https://spruce.mongodb.com/version/671951525bedf30007bc2545).

# Background & Motivation

See CDRIVER-5708 for motivation for deprecating.

Previous documentation [noted]((https://mongoc.org/libmongoc/1.28.0/mongoc_client_command.html)) the `mongoc_<obj>_command` functions were "superseded" by `mongoc_<obj>_command_with_opts`, `mongoc_<obj>_read_command_with_opts`, `mongoc_<obj>_write_command_with_opts`, and `mongoc_client_read_write_<obj>_with_opts`.

Documentation has been updated to recommend migrating to `mongoc_<obj>_command_simple` for simplicity. Though the underlying call to `_mongoc_cursor_run_command` [indicates a read command](https://github.com/mongodb/mongo-c-driver/blob/9e42ae331ff079fc3ea2a8bad3d69063ddb7207f/src/libmongoc/src/mongoc/mongoc-cursor.c#L890), none of the read-specific behavior appears to apply. `mongoc_<obj>_command` [prohibits retry](https://github.com/mongodb/mongo-c-driver/blob/9e42ae331ff079fc3ea2a8bad3d69063ddb7207f/src/libmongoc/tests/test-mongoc-retryable-reads.c#L173-L174). Options are not supported, so a session cannot be passed. The read concern is not inherited from the client.
