### PR TITLE
Remove compiler attributes from docs

### DIFF
--- a/src/libbson/doc/bson_array_as_json.rst
+++ b/src/libbson/doc/bson_array_as_json.rst
@@ -14,7 +14,7 @@ Synopsis
 .. code-block:: c
 
   char *
-  bson_array_as_json (const bson_t *bson, size_t *length) BSON_GNUC_DEPRECATED_FOR (bson_array_as_legacy_extended_json);
+  bson_array_as_json (const bson_t *bson, size_t *length);
 
 Parameters
 ----------

--- a/src/libbson/doc/bson_array_as_json.rst
+++ b/src/libbson/doc/bson_array_as_json.rst
@@ -6,11 +6,9 @@ bson_array_as_json()
 .. warning::
    .. deprecated:: 1.29.0
 
-      This function is deprecated and should not be used in new code.
+      Use :symbol:`bson_array_as_canonical_extended_json()` and :symbol:`bson_array_as_relaxed_extended_json()` instead, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
 
-      Prefer :symbol:`bson_array_as_canonical_extended_json()` and :symbol:`bson_array_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
-
-      To continue producing Legacy Extended JSON, :symbol:`bson_array_as_legacy_extended_json()` may be used.
+      To continue producing Legacy Extended JSON, use :symbol:`bson_array_as_legacy_extended_json()`.
 
 Synopsis
 --------

--- a/src/libbson/doc/bson_array_as_json.rst
+++ b/src/libbson/doc/bson_array_as_json.rst
@@ -8,6 +8,10 @@ bson_array_as_json()
 
       This function is deprecated and should not be used in new code.
 
+      This function is superseded by :symbol:`bson_array_as_canonical_extended_json()` and :symbol:`bson_array_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
+
+      To continue producing Legacy Extended JSON, :symbol:`bson_array_as_legacy_extended_json()` may be used.
+
 Synopsis
 --------
 
@@ -27,8 +31,6 @@ Description
 
 :symbol:`bson_array_as_json()` encodes ``bson`` as a UTF-8 string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`.
 The outermost element is encoded as a JSON array (``[ ... ]``), rather than a JSON document (``{ ... }``).
-This function is superseded by :symbol:`bson_array_as_canonical_extended_json()` and :symbol:`bson_array_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
-To continue producing Legacy Extended JSON, :symbol:`bson_array_as_legacy_extended_json()` may be used.
 
 The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 

--- a/src/libbson/doc/bson_array_as_json.rst
+++ b/src/libbson/doc/bson_array_as_json.rst
@@ -8,7 +8,7 @@ bson_array_as_json()
 
       This function is deprecated and should not be used in new code.
 
-      This function is superseded by :symbol:`bson_array_as_canonical_extended_json()` and :symbol:`bson_array_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
+      Prefer :symbol:`bson_array_as_canonical_extended_json()` and :symbol:`bson_array_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
 
       To continue producing Legacy Extended JSON, :symbol:`bson_array_as_legacy_extended_json()` may be used.
 

--- a/src/libbson/doc/bson_array_builder_t.rst
+++ b/src/libbson/doc/bson_array_builder_t.rst
@@ -46,7 +46,7 @@ Creating a top-level array
     bool
     bson_array_builder_build (bson_array_builder_t *bab, bson_t *out);
 
-    BSON_EXPORT (void)
+    void
     bson_array_builder_destroy (bson_array_builder_t *bab);
 
 ``bson_array_builder_new`` and ``bson_array_builder_build`` may be used to build a top-level BSON array. ``bson_array_builder_build`` initializes and moves BSON data to ``out``. The ``bson_array_builder_t`` may be reused and will start appending a new array at index "0":

--- a/src/libbson/doc/bson_as_json.rst
+++ b/src/libbson/doc/bson_as_json.rst
@@ -8,7 +8,7 @@ bson_as_json()
 
       This function is deprecated and should not be used in new code.
 
-      This function is superseded by :symbol:`bson_as_canonical_extended_json()` and :symbol:`bson_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
+      Prefer :symbol:`bson_as_canonical_extended_json()` and :symbol:`bson_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
 
       To continue producing Legacy Extended JSON, :symbol:`bson_as_legacy_extended_json()` may be used.
 

--- a/src/libbson/doc/bson_as_json.rst
+++ b/src/libbson/doc/bson_as_json.rst
@@ -14,7 +14,7 @@ Synopsis
 .. code-block:: c
 
   char *
-  bson_as_json (const bson_t *bson, size_t *length) BSON_GNUC_DEPRECATED_FOR (bson_as_legacy_extended_json);
+  bson_as_json (const bson_t *bson, size_t *length);
 
 Parameters
 ----------

--- a/src/libbson/doc/bson_as_json.rst
+++ b/src/libbson/doc/bson_as_json.rst
@@ -8,6 +8,10 @@ bson_as_json()
 
       This function is deprecated and should not be used in new code.
 
+      This function is superseded by :symbol:`bson_as_canonical_extended_json()` and :symbol:`bson_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
+
+      To continue producing Legacy Extended JSON, :symbol:`bson_as_legacy_extended_json()` may be used.
+
 Synopsis
 --------
 
@@ -26,8 +30,6 @@ Description
 -----------
 
 :symbol:`bson_as_json()` encodes ``bson`` as a UTF-8 string using :doc:`libbson's Legacy Extended JSON <legacy_extended_json>`.
-This function is superseded by :symbol:`bson_as_canonical_extended_json()` and :symbol:`bson_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
-To continue producing Legacy Extended JSON, :symbol:`bson_as_legacy_extended_json()` may be used.
 
 The caller is responsible for freeing the resulting UTF-8 encoded string by calling :symbol:`bson_free()` with the result.
 

--- a/src/libbson/doc/bson_as_json.rst
+++ b/src/libbson/doc/bson_as_json.rst
@@ -6,11 +6,9 @@ bson_as_json()
 .. warning::
    .. deprecated:: 1.29.0
 
-      This function is deprecated and should not be used in new code.
+      Use :symbol:`bson_as_canonical_extended_json()` and :symbol:`bson_as_relaxed_extended_json()` instead, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
 
-      Prefer :symbol:`bson_as_canonical_extended_json()` and :symbol:`bson_as_relaxed_extended_json()`, which use the same `MongoDB Extended JSON format`_ as all other MongoDB drivers.
-
-      To continue producing Legacy Extended JSON, :symbol:`bson_as_legacy_extended_json()` may be used.
+      To continue producing Legacy Extended JSON, use :symbol:`bson_as_legacy_extended_json()`.
 
 Synopsis
 --------

--- a/src/libbson/doc/bson_context_t.rst
+++ b/src/libbson/doc/bson_context_t.rst
@@ -20,7 +20,7 @@ Synopsis
   typedef struct _bson_context_t bson_context_t;
 
   bson_context_t *
-  bson_context_get_default (void) BSON_GNUC_CONST;
+  bson_context_get_default (void);
   bson_context_t *
   bson_context_new (bson_context_flags_t flags);
   void

--- a/src/libbson/doc/bson_copy_to_excluding.rst
+++ b/src/libbson/doc/bson_copy_to_excluding.rst
@@ -6,9 +6,7 @@ bson_copy_to_excluding()
 .. warning::
    .. deprecated:: 1.1.0
 
-      This function is deprecated and should not be used in new code.
-
-      Please use :symbol:`bson_copy_to_excluding_noinit()` in new code.
+      Use :symbol:`bson_copy_to_excluding_noinit()` instead.
 
 Synopsis
 --------

--- a/src/libbson/doc/bson_copy_to_excluding.rst
+++ b/src/libbson/doc/bson_copy_to_excluding.rst
@@ -19,7 +19,7 @@ Synopsis
   bson_copy_to_excluding (const bson_t *src,
                           bson_t *dst,
                           const char *first_exclude,
-                          ...) BSON_GNUC_NULL_TERMINATED
+                          ...)
      BSON_GNUC_DEPRECATED_FOR (bson_copy_to_excluding_noinit);
 
 Parameters

--- a/src/libbson/doc/bson_copy_to_excluding.rst
+++ b/src/libbson/doc/bson_copy_to_excluding.rst
@@ -19,8 +19,7 @@ Synopsis
   bson_copy_to_excluding (const bson_t *src,
                           bson_t *dst,
                           const char *first_exclude,
-                          ...)
-     BSON_GNUC_DEPRECATED_FOR (bson_copy_to_excluding_noinit);
+                          ...);
 
 Parameters
 ----------

--- a/src/libbson/doc/bson_copy_to_excluding_noinit.rst
+++ b/src/libbson/doc/bson_copy_to_excluding_noinit.rst
@@ -12,7 +12,7 @@ Synopsis
   bson_copy_to_excluding_noinit (const bson_t *src,
                                  bson_t *dst,
                                  const char *first_exclude,
-                                 ...) BSON_GNUC_NULL_TERMINATED;
+                                 ...);
 
 Parameters
 ----------

--- a/src/libbson/doc/bson_oid_init_sequence.rst
+++ b/src/libbson/doc/bson_oid_init_sequence.rst
@@ -16,8 +16,7 @@ Synopsis
 .. code-block:: c
 
   void
-  bson_oid_init_sequence (bson_oid_t *oid, bson_context_t *context)
-    BSON_GNUC_DEPRECATED_FOR (bson_oid_init);
+  bson_oid_init_sequence (bson_oid_t *oid, bson_context_t *context);
 
 Parameters
 ----------

--- a/src/libbson/doc/bson_oid_init_sequence.rst
+++ b/src/libbson/doc/bson_oid_init_sequence.rst
@@ -6,9 +6,7 @@ bson_oid_init_sequence()
 .. warning::
    .. deprecated:: 1.14.0
 
-      This function is deprecated and should not be used in new code.
-
-      Please use :symbol:`bson_oid_init()` in new code.
+      Use :symbol:`bson_oid_init()` instead.
 
 Synopsis
 --------

--- a/src/libbson/doc/bson_set_error.rst
+++ b/src/libbson/doc/bson_set_error.rst
@@ -10,8 +10,7 @@ Synopsis
 
   void
   bson_set_error (
-     bson_error_t *error, uint32_t domain, uint32_t code, const char *format, ...)
-     BSON_GNUC_PRINTF (4, 5);
+     bson_error_t *error, uint32_t domain, uint32_t code, const char *format, ...);
 
 Parameters
 ----------

--- a/src/libbson/doc/bson_snprintf.rst
+++ b/src/libbson/doc/bson_snprintf.rst
@@ -9,8 +9,7 @@ Synopsis
 .. code-block:: c
 
   int
-  bson_snprintf (char *str, size_t size, const char *format, ...)
-     BSON_GNUC_PRINTF (3, 4);
+  bson_snprintf (char *str, size_t size, const char *format, ...);
 
 Parameters
 ----------

--- a/src/libbson/doc/bson_strdup_printf.rst
+++ b/src/libbson/doc/bson_strdup_printf.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   char *
-  bson_strdup_printf (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
+  bson_strdup_printf (const char *format, ...);
 
 Parameters
 ----------

--- a/src/libbson/doc/bson_strdupv_printf.rst
+++ b/src/libbson/doc/bson_strdupv_printf.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   char *
-  bson_strdupv_printf (const char *format, va_list args) BSON_GNUC_PRINTF (1, 0);
+  bson_strdupv_printf (const char *format, va_list args);
 
 Parameters
 ----------

--- a/src/libbson/doc/bson_string_append.rst
+++ b/src/libbson/doc/bson_string_append.rst
@@ -6,8 +6,6 @@ bson_string_append()
 .. warning::
    .. deprecated:: 1.29.0
 
-      This function is deprecated and should not be used in new code.
-
 Synopsis
 --------
 

--- a/src/libbson/doc/bson_string_append_c.rst
+++ b/src/libbson/doc/bson_string_append_c.rst
@@ -6,8 +6,6 @@ bson_string_append_c()
 .. warning::
    .. deprecated:: 1.29.0
 
-      This function is deprecated and should not be used in new code.
-
 Synopsis
 --------
 

--- a/src/libbson/doc/bson_string_append_printf.rst
+++ b/src/libbson/doc/bson_string_append_printf.rst
@@ -14,8 +14,7 @@ Synopsis
 .. code-block:: c
 
   void
-  bson_string_append_printf (bson_string_t *string, const char *format, ...)
-     BSON_GNUC_PRINTF (2, 3);
+  bson_string_append_printf (bson_string_t *string, const char *format, ...);
 
 Parameters
 ----------

--- a/src/libbson/doc/bson_string_append_printf.rst
+++ b/src/libbson/doc/bson_string_append_printf.rst
@@ -6,8 +6,6 @@ bson_string_append_printf()
 .. warning::
    .. deprecated:: 1.29.0
 
-      This function is deprecated and should not be used in new code.
-
 Synopsis
 --------
 

--- a/src/libbson/doc/bson_string_append_unichar.rst
+++ b/src/libbson/doc/bson_string_append_unichar.rst
@@ -6,8 +6,6 @@ bson_string_append_unichar()
 .. warning::
    .. deprecated:: 1.29.0
 
-      This function is deprecated and should not be used in new code.
-
 Synopsis
 --------
 

--- a/src/libbson/doc/bson_string_free.rst
+++ b/src/libbson/doc/bson_string_free.rst
@@ -6,8 +6,6 @@ bson_string_free()
 .. warning::
    .. deprecated:: 1.29.0
 
-      This function is deprecated and should not be used in new code.
-
 Synopsis
 --------
 

--- a/src/libbson/doc/bson_string_new.rst
+++ b/src/libbson/doc/bson_string_new.rst
@@ -6,8 +6,6 @@ bson_string_new()
 .. warning::
    .. deprecated:: 1.29.0
 
-      This function is deprecated and should not be used in new code.
-
 Synopsis
 --------
 

--- a/src/libbson/doc/bson_string_t.rst
+++ b/src/libbson/doc/bson_string_t.rst
@@ -6,7 +6,6 @@ bson_string_t
 .. warning::
    .. deprecated:: 1.29.0
 
-      This struct is deprecated and should not be used in new code.
 
 String Building Abstraction
 

--- a/src/libbson/doc/bson_string_truncate.rst
+++ b/src/libbson/doc/bson_string_truncate.rst
@@ -6,7 +6,6 @@ bson_string_truncate()
 .. warning::
    .. deprecated:: 1.29.0
 
-      This function is deprecated and should not be used in new code.
 
 Synopsis
 --------

--- a/src/libbson/doc/bson_vsnprintf.rst
+++ b/src/libbson/doc/bson_vsnprintf.rst
@@ -9,8 +9,7 @@ Synopsis
 .. code-block:: c
 
   int
-  bson_vsnprintf (char *str, size_t size, const char *format, va_list ap)
-     BSON_GNUC_PRINTF (3, 0);
+  bson_vsnprintf (char *str, size_t size, const char *format, va_list ap);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/logging.rst
+++ b/src/libmongoc/doc/logging.rst
@@ -38,7 +38,7 @@ Synopsis
   mongoc_log (mongoc_log_level_t log_level,
               const char *log_domain,
               const char *format,
-              ...) BSON_GNUC_PRINTF (3, 4);
+              ...);
   const char *
   mongoc_log_level_str (mongoc_log_level_t log_level);
   void

--- a/src/libmongoc/doc/mongoc_apm_callbacks_new.rst
+++ b/src/libmongoc/doc/mongoc_apm_callbacks_new.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_apm_callbacks_t *
-  mongoc_apm_callbacks_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_apm_callbacks_new (void);
 
 Create a struct to hold event-notification callbacks.
 

--- a/src/libmongoc/doc/mongoc_apm_command_failed_get_server_connection_id.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_failed_get_server_connection_id.rst
@@ -6,9 +6,7 @@ mongoc_apm_command_failed_get_server_connection_id()
 .. warning::
    .. deprecated:: 1.24.0
 
-      This function is deprecated and should not be used in new code.
-
-      Please use :symbol:`mongoc_apm_command_failed_get_server_connection_id_int64()` in new code.
+      Use :symbol:`mongoc_apm_command_failed_get_server_connection_id_int64()` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_apm_command_failed_get_server_connection_id.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_failed_get_server_connection_id.rst
@@ -17,9 +17,7 @@ Synopsis
 
   int32_t
   mongoc_apm_command_failed_get_server_connection_id (
-    const mongoc_apm_command_failed_t *event)
-    BSON_GNUC_DEPRECATED_FOR (
-        "mongoc_apm_command_failed_get_server_connection_id_int64");
+    const mongoc_apm_command_failed_t *event);
 
 Returns this event's context.
 

--- a/src/libmongoc/doc/mongoc_apm_command_started_get_server_connection_id.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_started_get_server_connection_id.rst
@@ -17,9 +17,7 @@ Synopsis
 
   int32_t
   mongoc_apm_command_started_get_server_connection_id (
-    const mongoc_apm_command_started_t *event)
-    BSON_GNUC_DEPRECATED_FOR (
-        "mongoc_apm_command_started_get_server_connection_id_int64");
+    const mongoc_apm_command_started_t *event);
 
 Returns the server connection ID for the command. The server connection ID is
 distinct from the server ID (:symbol:`mongoc_apm_command_started_get_server_id`)

--- a/src/libmongoc/doc/mongoc_apm_command_started_get_server_connection_id.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_started_get_server_connection_id.rst
@@ -6,9 +6,7 @@ mongoc_apm_command_started_get_server_connection_id()
 .. warning::
    .. deprecated:: 1.24.0
 
-      This function is deprecated and should not be used in new code.
-   
-      Please use :symbol:`mongoc_apm_command_started_get_server_connection_id_int64()` in new code.
+      Use :symbol:`mongoc_apm_command_started_get_server_connection_id_int64()` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_apm_command_succeeded_get_server_connection_id.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_succeeded_get_server_connection_id.rst
@@ -17,9 +17,7 @@ Synopsis
 
   int32_t
   mongoc_apm_command_succeeded_get_server_connection_id (
-    const mongoc_apm_command_succeeded_t *event)
-    BSON_GNUC_DEPRECATED_FOR (
-        "mongoc_apm_command_succeeded_get_server_connection_id_int64");
+    const mongoc_apm_command_succeeded_t *event);
 
 Returns the server connection ID for the command. The server connection ID is
 distinct from the server ID

--- a/src/libmongoc/doc/mongoc_apm_command_succeeded_get_server_connection_id.rst
+++ b/src/libmongoc/doc/mongoc_apm_command_succeeded_get_server_connection_id.rst
@@ -6,9 +6,7 @@ mongoc_apm_command_succeeded_get_server_connection_id()
 .. warning::
    .. deprecated:: 1.24.0
 
-      This function is deprecated and should not be used in new code.
-
-      Please use :symbol:`mongoc_apm_command_succeeded_get_server_connection_id_int64()` in new code.
+      Use :symbol:`mongoc_apm_command_succeeded_get_server_connection_id_int64()` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_auto_encryption_opts_new.rst
+++ b/src/libmongoc/doc/mongoc_auto_encryption_opts_new.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_auto_encryption_opts_t *
-  mongoc_auto_encryption_opts_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_auto_encryption_opts_new (void);
 
 
 Create a new :symbol:`mongoc_auto_encryption_opts_t`.

--- a/src/libmongoc/doc/mongoc_bulk_operation_delete.rst
+++ b/src/libmongoc/doc/mongoc_bulk_operation_delete.rst
@@ -6,9 +6,7 @@ mongoc_bulk_operation_delete()
 .. warning::
    .. deprecated:: 0.96.0
 
-   This function is deprecated and should not be used in new code.
-
-   Please use :symbol:`mongoc_bulk_operation_remove()` in new code.
+   Use :symbol:`mongoc_bulk_operation_remove()` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_bulk_operation_delete.rst
+++ b/src/libmongoc/doc/mongoc_bulk_operation_delete.rst
@@ -17,8 +17,7 @@ Synopsis
 
   void
   mongoc_bulk_operation_delete (mongoc_bulk_operation_t *bulk,
-                                const bson_t *selector)
-    BSON_GNUC_DEPRECATED_FOR (mongoc_bulk_operation_remove);
+                                const bson_t *selector);
 
 Deletes documents as part of a bulk operation. This only queues the operation. To execute it, call :symbol:`mongoc_bulk_operation_execute()`.
 

--- a/src/libmongoc/doc/mongoc_bulk_operation_delete_one.rst
+++ b/src/libmongoc/doc/mongoc_bulk_operation_delete_one.rst
@@ -17,8 +17,7 @@ Synopsis
 
   void
   mongoc_bulk_operation_delete_one (mongoc_bulk_operation_t *bulk,
-                                    const bson_t *selector)
-    BSON_GNUC_DEPRECATED_FOR (mongoc_bulk_operation_remove_one);
+                                    const bson_t *selector);
 
 Delete a single document as part of a bulk operation. This only queues the operation. To execute it, call :symbol:`mongoc_bulk_operation_execute()`.
 

--- a/src/libmongoc/doc/mongoc_bulk_operation_delete_one.rst
+++ b/src/libmongoc/doc/mongoc_bulk_operation_delete_one.rst
@@ -6,9 +6,7 @@ mongoc_bulk_operation_delete_one()
 .. warning::
    .. deprecated:: 0.96.0
 
-      This function is deprecated and should not be used in new code.
-
-      Please use :symbol:`mongoc_bulk_operation_remove_one()` in new code.
+      Use :symbol:`mongoc_bulk_operation_remove_one()` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_bulk_operation_get_hint.rst
+++ b/src/libmongoc/doc/mongoc_bulk_operation_get_hint.rst
@@ -16,8 +16,7 @@ Synopsis
 .. code-block:: c
 
   uint32_t
-  mongoc_bulk_operation_get_hint (const mongoc_bulk_operation_t *bulk)
-    BSON_GNUC_DEPRECATED_FOR (mongoc_bulk_operation_get_server_id);
+  mongoc_bulk_operation_get_hint (const mongoc_bulk_operation_t *bulk);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_bulk_operation_get_hint.rst
+++ b/src/libmongoc/doc/mongoc_bulk_operation_get_hint.rst
@@ -6,9 +6,7 @@ mongoc_bulk_operation_get_hint()
 .. warning::
    .. deprecated:: 1.28.0
 
-      This function is deprecated and should not be used in new code.
-
-      Please use :symbol:`mongoc_bulk_operation_get_server_id()` in new code.
+      Use :symbol:`mongoc_bulk_operation_get_server_id()` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_bulk_operation_set_hint.rst
+++ b/src/libmongoc/doc/mongoc_bulk_operation_set_hint.rst
@@ -6,9 +6,7 @@ mongoc_bulk_operation_set_hint()
 .. warning::
    .. deprecated:: 1.28.0
 
-      This function is deprecated and should not be used in new code.
-
-      Please use :symbol:`mongoc_bulk_operation_set_server_id()` in new code.
+      Use :symbol:`mongoc_bulk_operation_set_server_id()` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_bulk_operation_set_hint.rst
+++ b/src/libmongoc/doc/mongoc_bulk_operation_set_hint.rst
@@ -16,8 +16,7 @@ Synopsis
 .. code-block:: c
 
   void
-  mongoc_bulk_operation_set_hint (mongoc_bulk_operation_t *bulk, uint32_t server_id)
-    BSON_GNUC_DEPRECATED_FOR (mongoc_bulk_operation_set_server_id);
+  mongoc_bulk_operation_set_hint (mongoc_bulk_operation_t *bulk, uint32_t server_id);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_client_command.rst
+++ b/src/libmongoc/doc/mongoc_client_command.rst
@@ -17,8 +17,7 @@ Synopsis
                          uint32_t batch_size,
                          const bson_t *query,
                          const bson_t *fields,
-                         const mongoc_read_prefs_t *read_prefs)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+                         const mongoc_read_prefs_t *read_prefs);
 
 This function is superseded by :symbol:`mongoc_client_command_with_opts()`, :symbol:`mongoc_client_read_command_with_opts()`, :symbol:`mongoc_client_write_command_with_opts()`, and :symbol:`mongoc_client_read_write_command_with_opts()`.
 

--- a/src/libmongoc/doc/mongoc_client_encryption_create_encrypted_collection.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_create_encrypted_collection.rst
@@ -17,8 +17,7 @@ Synopsis
         bson_t *out_options,
         const char *kms_provider,
         const bson_t *opt_masterKey,
-        bson_error_t *error)
-    BSON_GNUC_WARN_UNUSED_RESULT;
+        bson_error_t *error);
 
 Create a new collection with `Queryable Encryption <queryable-encryption_>`_
 enabled. Requires a valid :symbol:`mongoc_client_encryption_t` object to

--- a/src/libmongoc/doc/mongoc_client_encryption_datakey_opts_new.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_datakey_opts_new.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_client_encryption_datakey_opts_t *
-  mongoc_client_encryption_datakey_opts_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_client_encryption_datakey_opts_new (void);
 
 Returns
 -------

--- a/src/libmongoc/doc/mongoc_client_encryption_encrypt_opts_new.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_encrypt_opts_new.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_client_encryption_encrypt_opts_t *
-  mongoc_client_encryption_encrypt_opts_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_client_encryption_encrypt_opts_new (void);
 
 Returns
 -------

--- a/src/libmongoc/doc/mongoc_client_encryption_encrypt_opts_set_query_type.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_encrypt_opts_set_query_type.rst
@@ -11,9 +11,8 @@ Synopsis
    #define MONGOC_ENCRYPT_QUERY_TYPE_EQUALITY "equality"
    #define MONGOC_ENCRYPT_QUERY_TYPE_RANGE "range"
 
-   MONGOC_EXPORT (void)
-    mongoc_client_encryption_encrypt_opts_set_query_type (
-        mongoc_client_encryption_encrypt_opts_t *opts, const char* query_type);
+   void mongoc_client_encryption_encrypt_opts_set_query_type (
+      mongoc_client_encryption_encrypt_opts_t *opts, const char* query_type);
 
 .. versionadded:: 1.22.0
 

--- a/src/libmongoc/doc/mongoc_client_encryption_get_crypt_shared_version.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_get_crypt_shared_version.rst
@@ -9,8 +9,7 @@ Synopsis
 .. code-block:: c
 
   const char*
-  mongoc_client_encryption_get_crypt_shared_version (mongoc_client_encryption_t const *enc)
-      BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_client_encryption_get_crypt_shared_version (mongoc_client_encryption_t const *enc);
 
 Obtain the version string of the crypt_shared_ that is loaded for the given
 explicit encryption object. If no crypt_shared_ library is loaded, the returned

--- a/src/libmongoc/doc/mongoc_client_encryption_new.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_new.rst
@@ -10,7 +10,7 @@ Synopsis
 
   mongoc_client_encryption_t *
   mongoc_client_encryption_new (mongoc_client_encryption_opts_t *opts,
-                                bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT;
+                                bson_error_t *error);
 
 Create a new :symbol:`mongoc_client_encryption_t`.
 

--- a/src/libmongoc/doc/mongoc_client_encryption_opts_new.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_opts_new.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_client_encryption_opts_t *
-  mongoc_client_encryption_opts_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_client_encryption_opts_new (void);
 
 Returns
 -------

--- a/src/libmongoc/doc/mongoc_client_encryption_rewrap_many_datakey_result_get_bulk_write_result.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_rewrap_many_datakey_result_get_bulk_write_result.rst
@@ -10,8 +10,7 @@ Synopsis
 
    const bson_t *
    mongoc_client_encryption_rewrap_many_datakey_result_get_bulk_write_result (
-      mongoc_client_encryption_rewrap_many_datakey_result_t *result)
-      BSON_GNUC_WARN_UNUSED_RESULT;
+      mongoc_client_encryption_rewrap_many_datakey_result_t *result);
 
 Get the bulk write result set by a successful call to :symbol:`mongoc_client_encryption_rewrap_many_datakey()`.
 

--- a/src/libmongoc/doc/mongoc_client_encryption_rewrap_many_datakey_result_new.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_rewrap_many_datakey_result_new.rst
@@ -9,8 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_client_encryption_rewrap_many_datakey_result_t *
-  mongoc_client_encryption_rewrap_many_datakey_result_new (void)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_client_encryption_rewrap_many_datakey_result_new (void);
 
 Returns
 -------

--- a/src/libmongoc/doc/mongoc_client_find_databases_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_client_find_databases_with_opts.rst
@@ -10,7 +10,7 @@ Synopsis
 
   mongoc_cursor_t *
   mongoc_client_find_databases_with_opts (
-     mongoc_client_t *client, const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
+     mongoc_client_t *client, const bson_t *opts);
 
 Fetches a cursor containing documents, each corresponding to a database on this MongoDB server.
 

--- a/src/libmongoc/doc/mongoc_client_get_collection.rst
+++ b/src/libmongoc/doc/mongoc_client_get_collection.rst
@@ -11,8 +11,7 @@ Synopsis
   mongoc_collection_t *
   mongoc_client_get_collection (mongoc_client_t *client,
                                 const char *db,
-                                const char *collection)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+                                const char *collection);
 
 Get a newly allocated :symbol:`mongoc_collection_t` for the collection named ``collection`` in the database named ``db``.
 

--- a/src/libmongoc/doc/mongoc_client_get_crypt_shared_version.rst
+++ b/src/libmongoc/doc/mongoc_client_get_crypt_shared_version.rst
@@ -9,8 +9,7 @@ Synopsis
 .. code-block:: c
 
   const char *
-  mongoc_client_get_crypt_shared_version (const mongoc_client_t *client)
-    BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_client_get_crypt_shared_version (const mongoc_client_t *client);
 
 Obtain the version string of the crypt_shared_ that is loaded for
 auto-encryption on the given ``client``. If no crypt_shared_ library is loaded,

--- a/src/libmongoc/doc/mongoc_client_get_database.rst
+++ b/src/libmongoc/doc/mongoc_client_get_database.rst
@@ -10,7 +10,7 @@ Synopsis
 
   mongoc_database_t *
   mongoc_client_get_database (mongoc_client_t *client,
-                              const char *name) BSON_GNUC_WARN_UNUSED_RESULT;
+                              const char *name);
 
 Get a newly allocated :symbol:`mongoc_database_t` for the database named ``name``.
 

--- a/src/libmongoc/doc/mongoc_client_get_database_names.rst
+++ b/src/libmongoc/doc/mongoc_client_get_database_names.rst
@@ -17,8 +17,7 @@ Synopsis
 
   char **
   mongoc_client_get_database_names (mongoc_client_t *client, bson_error_t *error)
-     BSON_GNUC_WARN_UNUSED_RESULT
-     BSON_GNUC_DEPRECATED_FOR (mongoc_client_get_database_names_with_opts);
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Description
 -----------

--- a/src/libmongoc/doc/mongoc_client_get_database_names.rst
+++ b/src/libmongoc/doc/mongoc_client_get_database_names.rst
@@ -16,8 +16,7 @@ Synopsis
 .. code-block:: c
 
   char **
-  mongoc_client_get_database_names (mongoc_client_t *client, bson_error_t *error)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_client_get_database_names (mongoc_client_t *client, bson_error_t *error);
 
 Description
 -----------

--- a/src/libmongoc/doc/mongoc_client_get_database_names.rst
+++ b/src/libmongoc/doc/mongoc_client_get_database_names.rst
@@ -6,9 +6,7 @@ mongoc_client_get_database_names()
 .. warning::
    .. deprecated:: 1.9.0
 
-      This function is deprecated and should not be used in new code.
-
-      Please use :symbol:`mongoc_client_get_database_names_with_opts()` in new code.
+      Use :symbol:`mongoc_client_get_database_names_with_opts()` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_client_get_database_names_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_client_get_database_names_with_opts.rst
@@ -11,8 +11,7 @@ Synopsis
   char **
   mongoc_client_get_database_names_with_opts (mongoc_client_t *client,
                                               const bson_t *opts,
-                                              bson_error_t *error)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+                                              bson_error_t *error);
 
 This function queries the MongoDB server for a list of known databases.
 

--- a/src/libmongoc/doc/mongoc_client_get_default_database.rst
+++ b/src/libmongoc/doc/mongoc_client_get_default_database.rst
@@ -9,8 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_database_t *
-  mongoc_client_get_default_database (mongoc_client_t *client)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_client_get_default_database (mongoc_client_t *client);
 
 Get the database named in the MongoDB connection URI, or ``NULL`` if the URI specifies none.
 

--- a/src/libmongoc/doc/mongoc_client_get_gridfs.rst
+++ b/src/libmongoc/doc/mongoc_client_get_gridfs.rst
@@ -12,7 +12,7 @@ Synopsis
   mongoc_client_get_gridfs (mongoc_client_t *client,
                             const char *db,
                             const char *prefix,
-                            bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT;
+                            bson_error_t *error);
 
 The ``mongoc_client_get_gridfs()`` function shall create a new :symbol:`mongoc_gridfs_t`. The ``db`` parameter is the name of the database which the gridfs instance should exist in. The ``prefix`` parameter corresponds to the gridfs collection namespacing; its default is "fs", thus the default GridFS collection names are "fs.files" and "fs.chunks".
 

--- a/src/libmongoc/doc/mongoc_client_get_handshake_description.rst
+++ b/src/libmongoc/doc/mongoc_client_get_handshake_description.rst
@@ -12,8 +12,7 @@ Synopsis
   mongoc_client_get_handshake_description (mongoc_client_t *client,
                                            uint32_t server_id,
                                            bson_t *opts,
-                                           bson_error_t *error)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+                                           bson_error_t *error);
 
 Returns a description constructed from the initial handshake response to a server.
 

--- a/src/libmongoc/doc/mongoc_client_get_server_description.rst
+++ b/src/libmongoc/doc/mongoc_client_get_server_description.rst
@@ -10,7 +10,7 @@ Synopsis
 
   mongoc_server_description_t *
   mongoc_client_get_server_description (
-     mongoc_client_t *client, uint32_t server_id) BSON_GNUC_WARN_UNUSED_RESULT;
+     mongoc_client_t *client, uint32_t server_id);
 
 Get information about the server specified by ``server_id``.
 

--- a/src/libmongoc/doc/mongoc_client_get_server_descriptions.rst
+++ b/src/libmongoc/doc/mongoc_client_get_server_descriptions.rst
@@ -10,7 +10,7 @@ Synopsis
 
   mongoc_server_description_t **
   mongoc_client_get_server_descriptions (const mongoc_client_t *client,
-                                         size_t *n) BSON_GNUC_WARN_UNUSED_RESULT;
+                                         size_t *n);
 
 Fetches an array of :symbol:`mongoc_server_description_t` structs for all known servers in the topology. Returns no servers until the client connects. Returns a single server if the client is directly connected, or all members of a replica set if the client's MongoDB URI includes a "replicaSet" option, or all known mongos servers if the MongoDB URI includes a list of them.
 

--- a/src/libmongoc/doc/mongoc_client_get_server_status.rst
+++ b/src/libmongoc/doc/mongoc_client_get_server_status.rst
@@ -6,8 +6,6 @@ mongoc_client_get_server_status()
 .. warning::
    .. deprecated:: 1.10.0
 
-      This function is deprecated and should not be used in new code.
-
       Run the `serverStatus <https://www.mongodb.com/docs/manual/reference/command/serverStatus/>`_ command directly with :symbol:`mongoc_client_read_command_with_opts()` instead.
 
 Synopsis

--- a/src/libmongoc/doc/mongoc_client_get_server_status.rst
+++ b/src/libmongoc/doc/mongoc_client_get_server_status.rst
@@ -19,7 +19,7 @@ Synopsis
   mongoc_client_get_server_status (mongoc_client_t *client,
                                    mongoc_read_prefs_t *read_prefs,
                                    bson_t *reply,
-                                   bson_error_t *error) BSON_GNUC_DEPRECATED;
+                                   bson_error_t *error);
 
 Queries the server for the current server status. The result is stored in ``reply``.
 

--- a/src/libmongoc/doc/mongoc_client_new.rst
+++ b/src/libmongoc/doc/mongoc_client_new.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_client_t *
-  mongoc_client_new (const char *uri_string) BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_client_new (const char *uri_string);
 
 Creates a new :symbol:`mongoc_client_t` using the URI string provided.
 

--- a/src/libmongoc/doc/mongoc_client_new_from_uri.rst
+++ b/src/libmongoc/doc/mongoc_client_new_from_uri.rst
@@ -9,8 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_client_t *
-  mongoc_client_new_from_uri (const mongoc_uri_t *uri)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_client_new_from_uri (const mongoc_uri_t *uri);
 
 Creates a new :symbol:`mongoc_client_t` using the :symbol:`mongoc_uri_t` provided.
 

--- a/src/libmongoc/doc/mongoc_client_new_from_uri_with_error.rst
+++ b/src/libmongoc/doc/mongoc_client_new_from_uri_with_error.rst
@@ -10,8 +10,7 @@ Synopsis
 
   mongoc_client_t *
   mongoc_client_new_from_uri_with_error (const mongoc_uri_t *uri,
-                                         bson_error_t *error)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+                                         bson_error_t *error);
 
 Creates a new :symbol:`mongoc_client_t` using the :symbol:`mongoc_uri_t` provided.
 

--- a/src/libmongoc/doc/mongoc_client_pool_min_size.rst
+++ b/src/libmongoc/doc/mongoc_client_pool_min_size.rst
@@ -17,8 +17,7 @@ Synopsis
 
   void
   mongoc_client_pool_min_size (mongoc_client_pool_t *pool,
-                               uint32_t min_pool_size)
-     BSON_GNUC_DEPRECATED;
+                               uint32_t min_pool_size);
 
 This function sets the *maximum* number of idle clients to be kept in the pool. Any idle clients in excess of the maximum are destroyed.
 

--- a/src/libmongoc/doc/mongoc_client_pool_new.rst
+++ b/src/libmongoc/doc/mongoc_client_pool_new.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_client_pool_t *
-  mongoc_client_pool_new (const mongoc_uri_t *uri) BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_client_pool_new (const mongoc_uri_t *uri);
 
 This function creates a new :symbol:`mongoc_client_pool_t` using the :symbol:`mongoc_uri_t` provided.
 

--- a/src/libmongoc/doc/mongoc_client_pool_new_with_error.rst
+++ b/src/libmongoc/doc/mongoc_client_pool_new_with_error.rst
@@ -10,8 +10,7 @@ Synopsis
 
   mongoc_client_pool_t *
   mongoc_client_pool_new_with_error (const mongoc_uri_t *uri,
-                                     bson_error_t *error)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+                                     bson_error_t *error);
 
 This function creates a new :symbol:`mongoc_client_pool_t` using the :symbol:`mongoc_uri_t` provided.
 

--- a/src/libmongoc/doc/mongoc_client_pool_pop.rst
+++ b/src/libmongoc/doc/mongoc_client_pool_pop.rst
@@ -9,8 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_client_t *
-  mongoc_client_pool_pop (mongoc_client_pool_t *pool)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_client_pool_pop (mongoc_client_pool_t *pool);
 
 Retrieve a :symbol:`mongoc_client_t` from the client pool, or create one. The total number of clients that can be created from this pool is limited by the URI option "maxPoolSize", default 100. If this number of clients has been created and all are in use, ``mongoc_client_pool_pop`` blocks until another thread returns a client with :symbol:`mongoc_client_pool_push()`. If the "waitQueueTimeoutMS" URI option was specified with a positive value, then ``mongoc_client_pool_pop`` will return ``NULL`` when the timeout expires.
 

--- a/src/libmongoc/doc/mongoc_client_pool_try_pop.rst
+++ b/src/libmongoc/doc/mongoc_client_pool_try_pop.rst
@@ -9,8 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_client_t *
-  mongoc_client_pool_try_pop (mongoc_client_pool_t *pool)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_client_pool_try_pop (mongoc_client_pool_t *pool);
 
 This function is identical to :symbol:`mongoc_client_pool_pop()` except it will return ``NULL`` instead of blocking for a client to become available.
 

--- a/src/libmongoc/doc/mongoc_client_select_server.rst
+++ b/src/libmongoc/doc/mongoc_client_select_server.rst
@@ -12,7 +12,7 @@ Synopsis
   mongoc_client_select_server (mongoc_client_t *client,
                                bool for_writes,
                                const mongoc_read_prefs_t *prefs,
-                               bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT;
+                               bson_error_t *error);
 
 Choose a server for an operation, according to the logic described in the Server Selection Spec.
 

--- a/src/libmongoc/doc/mongoc_client_watch.rst
+++ b/src/libmongoc/doc/mongoc_client_watch.rst
@@ -11,7 +11,7 @@ Synopsis
   mongoc_change_stream_t*
   mongoc_client_watch (mongoc_client_t *client,
                        const bson_t *pipeline,
-                       const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
+                       const bson_t *opts);
 
 A helper function to create a change stream. It is preferred to call this
 function over using a raw aggregation to create a change stream.

--- a/src/libmongoc/doc/mongoc_collection_aggregate.rst
+++ b/src/libmongoc/doc/mongoc_collection_aggregate.rst
@@ -13,8 +13,7 @@ Synopsis
                                mongoc_query_flags_t flags,
                                const bson_t *pipeline,
                                const bson_t *opts,
-                               const mongoc_read_prefs_t *read_prefs)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+                               const mongoc_read_prefs_t *read_prefs);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_collection_command.rst
+++ b/src/libmongoc/doc/mongoc_collection_command.rst
@@ -16,8 +16,7 @@ Synopsis
                              uint32_t batch_size,
                              const bson_t *command,
                              const bson_t *fields,
-                             const mongoc_read_prefs_t *read_prefs)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+                             const mongoc_read_prefs_t *read_prefs);
 
 This function is superseded by :symbol:`mongoc_collection_command_with_opts()`, :symbol:`mongoc_collection_read_command_with_opts()`, :symbol:`mongoc_collection_write_command_with_opts()`, and :symbol:`mongoc_collection_read_write_command_with_opts()`.
 

--- a/src/libmongoc/doc/mongoc_collection_copy.rst
+++ b/src/libmongoc/doc/mongoc_collection_copy.rst
@@ -9,8 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_collection_t *
-  mongoc_collection_copy (mongoc_collection_t *collection)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_collection_copy (mongoc_collection_t *collection);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_collection_count.rst
+++ b/src/libmongoc/doc/mongoc_collection_count.rst
@@ -6,7 +6,6 @@ mongoc_collection_count()
 .. warning::
    .. deprecated:: 1.11.0
 
-      This function is deprecated and should not be used in new code.
       Use :symbol:`mongoc_collection_count_documents` or :symbol:`mongoc_collection_estimated_document_count` instead.
 
       :symbol:`mongoc_collection_count_documents` has similar performance to calling :symbol:`mongoc_collection_count` with a non-NULL ``query``, and is guaranteed to retrieve an accurate collection count. See :ref:`migrating from deprecated count functions <migrating-from-deprecated-count>` for details.

--- a/src/libmongoc/doc/mongoc_collection_count.rst
+++ b/src/libmongoc/doc/mongoc_collection_count.rst
@@ -27,9 +27,7 @@ Synopsis
                            int64_t skip,
                            int64_t limit,
                            const mongoc_read_prefs_t *read_prefs,
-                           bson_error_t *error)
-   BSON_GNUC_DEPRECATED_FOR (mongoc_collection_count_documents or
-                             mongoc_collection_estimated_document_count);
+                           bson_error_t *error);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_collection_count_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_collection_count_with_opts.rst
@@ -26,9 +26,7 @@ Synopsis
                                      int64_t limit,
                                      const bson_t *opts,
                                      const mongoc_read_prefs_t *read_prefs,
-                                     bson_error_t *error)
-   BSON_GNUC_DEPRECATED_FOR (mongoc_collection_count_documents or
-                             mongoc_collection_estimated_document_count);
+                                     bson_error_t *error);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_collection_count_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_collection_count_with_opts.rst
@@ -6,7 +6,6 @@ mongoc_collection_count_with_opts()
 .. warning::
    .. deprecated:: 1.11.0
 
-      This function is deprecated and should not be used in new code.
       Use :symbol:`mongoc_collection_count_documents` or :symbol:`mongoc_collection_estimated_document_count` instead.
 
       :symbol:`mongoc_collection_count_documents` has similar performance to calling :symbol:`mongoc_collection_count` with a non-NULL ``query``, and is guaranteed to retrieve an accurate collection count. See :ref:`migrating from deprecated count functions <migrating-from-deprecated-count>` for details.

--- a/src/libmongoc/doc/mongoc_collection_create_bulk_operation.rst
+++ b/src/libmongoc/doc/mongoc_collection_create_bulk_operation.rst
@@ -6,9 +6,7 @@ mongoc_collection_create_bulk_operation()
 .. warning::
    .. deprecated:: 1.9.0
 
-      This function is deprecated and should not be used in new code.
-
-      Please use :symbol:`mongoc_collection_create_bulk_operation_with_opts()` in new code.
+      Use :symbol:`mongoc_collection_create_bulk_operation_with_opts()` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_collection_create_bulk_operation.rst
+++ b/src/libmongoc/doc/mongoc_collection_create_bulk_operation.rst
@@ -19,7 +19,7 @@ Synopsis
   mongoc_collection_create_bulk_operation (
      mongoc_collection_t *collection,
      bool ordered,
-     const mongoc_write_concern_t *write_concern) BSON_GNUC_WARN_UNUSED_RESULT;
+     const mongoc_write_concern_t *write_concern);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_collection_create_bulk_operation.rst
+++ b/src/libmongoc/doc/mongoc_collection_create_bulk_operation.rst
@@ -19,8 +19,7 @@ Synopsis
   mongoc_collection_create_bulk_operation (
      mongoc_collection_t *collection,
      bool ordered,
-     const mongoc_write_concern_t *write_concern) BSON_GNUC_WARN_UNUSED_RESULT
-     BSON_GNUC_DEPRECATED_FOR (mongoc_collection_create_bulk_operation_with_opts);
+     const mongoc_write_concern_t *write_concern) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_collection_create_bulk_operation_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_collection_create_bulk_operation_with_opts.rst
@@ -11,7 +11,7 @@ Synopsis
   mongoc_bulk_operation_t *
   mongoc_collection_create_bulk_operation_with_opts (
      mongoc_collection_t *collection,
-     const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
+     const bson_t *opts);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_collection_create_index.rst
+++ b/src/libmongoc/doc/mongoc_collection_create_index.rst
@@ -17,7 +17,7 @@ Synopsis
   mongoc_collection_create_index (mongoc_collection_t *collection,
                                   const bson_t *keys,
                                   const mongoc_index_opt_t *opt,
-                                  bson_error_t *error) BSON_GNUC_DEPRECATED;
+                                  bson_error_t *error);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_collection_create_index.rst
+++ b/src/libmongoc/doc/mongoc_collection_create_index.rst
@@ -6,7 +6,7 @@ mongoc_collection_create_index()
 .. warning::
    .. deprecated:: 1.8.0
 
-      This function is deprecated and should not be used in new code. See `Manage Collection Indexes <manage-collection-indexes_>`_.
+      See `Manage Collection Indexes <manage-collection-indexes_>`_ for alternatives.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_collection_create_index_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_collection_create_index_with_opts.rst
@@ -6,7 +6,7 @@ mongoc_collection_create_index_with_opts()
 .. warning::
    .. deprecated:: 1.8.0
 
-      This function is deprecated and should not be used in new code. See `Manage Collection Indexes <manage-collection-indexes_>`_.
+      See `Manage Collection Indexes <manage-collection-indexes_>`_ for alternatives.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_collection_create_index_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_collection_create_index_with_opts.rst
@@ -19,8 +19,7 @@ Synopsis
                                             const mongoc_index_opt_t *index_opts,
                                             const bson_t *command_opts,
                                             bson_t *reply,
-                                            bson_error_t *error)
-     BSON_GNUC_DEPRECATED; 
+                                            bson_error_t *error); 
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_collection_delete.rst
+++ b/src/libmongoc/doc/mongoc_collection_delete.rst
@@ -6,9 +6,7 @@ mongoc_collection_delete()
 .. warning::
    .. deprecated:: 1.9.0
 
-      This function is deprecated and should not be used in new code.
-
-      Please use :symbol:`mongoc_collection_delete_one()` or :symbol:`mongoc_collection_delete_many()` in new code.
+      Use :symbol:`mongoc_collection_delete_one()` or :symbol:`mongoc_collection_delete_many()` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_collection_delete.rst
+++ b/src/libmongoc/doc/mongoc_collection_delete.rst
@@ -20,9 +20,7 @@ Synopsis
                             mongoc_delete_flags_t flags,
                             const bson_t *selector,
                             const mongoc_write_concern_t *write_concern,
-                            bson_error_t *error)
-     BSON_GNUC_DEPRECATED_FOR (mongoc_collection_delete_one or
-                               mongoc_collection_delete_many);
+                            bson_error_t *error);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_collection_ensure_index.rst
+++ b/src/libmongoc/doc/mongoc_collection_ensure_index.rst
@@ -6,7 +6,7 @@ mongoc_collection_ensure_index()
 .. warning::
    .. deprecated:: 1.8.0
 
-      This function is deprecated and should not be used in new code. See `Manage Collection Indexes <manage-collection-indexes_>`_.
+      See `Manage Collection Indexes <manage-collection-indexes_>`_ for alternatives.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_collection_ensure_index.rst
+++ b/src/libmongoc/doc/mongoc_collection_ensure_index.rst
@@ -17,8 +17,7 @@ Synopsis
   mongoc_collection_ensure_index (mongoc_collection_t *collection,
                                   const bson_t *keys,
                                   const mongoc_index_opt_t *opt,
-                                  bson_error_t *error)
-     BSON_GNUC_DEPRECATED;
+                                  bson_error_t *error);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_collection_find.rst
+++ b/src/libmongoc/doc/mongoc_collection_find.rst
@@ -24,7 +24,6 @@ Synopsis
                           const bson_t *query,
                           const bson_t *fields,
                           const mongoc_read_prefs_t *read_prefs)
-     BSON_GNUC_DEPRECATED_FOR (mongoc_collection_find_with_opts)
         BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters

--- a/src/libmongoc/doc/mongoc_collection_find.rst
+++ b/src/libmongoc/doc/mongoc_collection_find.rst
@@ -6,9 +6,7 @@ mongoc_collection_find()
 .. warning::
    .. deprecated:: 1.5.0
 
-      This function is deprecated and should not be used in new code.
-
-Use the more convenient :symbol:`mongoc_collection_find_with_opts` instead.
+      Use :symbol:`mongoc_collection_find_with_opts` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_collection_find.rst
+++ b/src/libmongoc/doc/mongoc_collection_find.rst
@@ -23,8 +23,7 @@ Synopsis
                           uint32_t batch_size,
                           const bson_t *query,
                           const bson_t *fields,
-                          const mongoc_read_prefs_t *read_prefs)
-        BSON_GNUC_WARN_UNUSED_RESULT;
+                          const mongoc_read_prefs_t *read_prefs);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_collection_find_indexes.rst
+++ b/src/libmongoc/doc/mongoc_collection_find_indexes.rst
@@ -6,9 +6,7 @@ mongoc_collection_find_indexes()
 .. warning::
    .. deprecated:: 1.9.0
 
-      This function is deprecated and should not be used in new code.
-
-      Please use :symbol:`mongoc_collection_find_indexes_with_opts()` in new code.
+      Use :symbol:`mongoc_collection_find_indexes_with_opts()` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_collection_find_indexes.rst
+++ b/src/libmongoc/doc/mongoc_collection_find_indexes.rst
@@ -17,9 +17,8 @@ Synopsis
 
   mongoc_cursor_t *
   mongoc_collection_find_indexes (mongoc_collection_t *collection,
-                                  bson_error_t *error);
-     BSON_GNUC_WARN_UNUSED_RESULT
-     BSON_GNUC_DEPRECATED_FOR (mongoc_collection_find_indexes_with_opts);
+                                  bson_error_t *error)
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Fetches a cursor containing documents, each corresponding to an index on this collection.
 

--- a/src/libmongoc/doc/mongoc_collection_find_indexes.rst
+++ b/src/libmongoc/doc/mongoc_collection_find_indexes.rst
@@ -17,8 +17,7 @@ Synopsis
 
   mongoc_cursor_t *
   mongoc_collection_find_indexes (mongoc_collection_t *collection,
-                                  bson_error_t *error)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+                                  bson_error_t *error);
 
 Fetches a cursor containing documents, each corresponding to an index on this collection.
 

--- a/src/libmongoc/doc/mongoc_collection_find_indexes_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_collection_find_indexes_with_opts.rst
@@ -10,8 +10,7 @@ Synopsis
 
   mongoc_cursor_t *
   mongoc_collection_find_indexes_with_opts (mongoc_collection_t *collection,
-                                            const bson_t *opts)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+                                            const bson_t *opts);
 
 Fetches a cursor containing documents, each corresponding to an index on this collection.
 

--- a/src/libmongoc/doc/mongoc_collection_find_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_collection_find_with_opts.rst
@@ -12,8 +12,7 @@ Synopsis
   mongoc_collection_find_with_opts (mongoc_collection_t *collection,
                                     const bson_t *filter,
                                     const bson_t *opts,
-                                    const mongoc_read_prefs_t *read_prefs)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+                                    const mongoc_read_prefs_t *read_prefs);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_collection_insert_bulk.rst
+++ b/src/libmongoc/doc/mongoc_collection_insert_bulk.rst
@@ -6,9 +6,7 @@ mongoc_collection_insert_bulk()
 .. warning::
    .. deprecated:: 1.9.0
 
-     This function is deprecated and should not be used in new code.
-
-     Please use :symbol:`mongoc_collection_insert_many()` in new code.
+    Use :symbol:`mongoc_collection_insert_many()` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_collection_insert_bulk.rst
+++ b/src/libmongoc/doc/mongoc_collection_insert_bulk.rst
@@ -21,8 +21,7 @@ Synopsis
                                  const bson_t **documents,
                                  uint32_t n_documents,
                                  const mongoc_write_concern_t *write_concern,
-                                 bson_error_t *error)
-     BSON_GNUC_DEPRECATED_FOR (mongoc_collection_insert_many);
+                                 bson_error_t *error);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_collection_keys_to_index_string.rst
+++ b/src/libmongoc/doc/mongoc_collection_keys_to_index_string.rst
@@ -9,8 +9,7 @@ Synopsis
 .. code-block:: c
 
   char *
-  mongoc_collection_keys_to_index_string (const bson_t *keys)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_collection_keys_to_index_string (const bson_t *keys);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_collection_save.rst
+++ b/src/libmongoc/doc/mongoc_collection_save.rst
@@ -20,9 +20,7 @@ Synopsis
   mongoc_collection_save (mongoc_collection_t *collection,
                           const bson_t *document,
                           const mongoc_write_concern_t *write_concern,
-                          bson_error_t *error)
-     BSON_GNUC_DEPRECATED_FOR (mongoc_collection_insert_one or
-                               mongoc_collection_replace_one);
+                          bson_error_t *error);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_collection_save.rst
+++ b/src/libmongoc/doc/mongoc_collection_save.rst
@@ -6,10 +6,7 @@ mongoc_collection_save()
 .. warning::
    .. deprecated:: 1.9.0
 
-      This function is deprecated and should not be used in new code.
-
-      Please use :symbol:`mongoc_collection_insert_one()` or
-      :symbol:`mongoc_collection_replace_one()` with "upsert" instead.
+      Use :symbol:`mongoc_collection_insert_one()` or :symbol:`mongoc_collection_replace_one()` with "upsert" instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_collection_stats.rst
+++ b/src/libmongoc/doc/mongoc_collection_stats.rst
@@ -6,7 +6,7 @@ mongoc_collection_stats()
 .. warning::
    .. deprecated:: 1.10.0
 
-      This helper function is deprecated and should not be used in new code. Use the `$collStats aggregation pipeline stage <https://www.mongodb.com/docs/manual/reference/operator/aggregation/collStats/>`_ with :symbol:`mongoc_collection_aggregate()` instead.
+      Use the `$collStats aggregation pipeline stage <https://www.mongodb.com/docs/manual/reference/operator/aggregation/collStats/>`_ with :symbol:`mongoc_collection_aggregate()` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_collection_stats.rst
+++ b/src/libmongoc/doc/mongoc_collection_stats.rst
@@ -17,7 +17,7 @@ Synopsis
   mongoc_collection_stats (mongoc_collection_t *collection,
                            const bson_t *options,
                            bson_t *reply,
-                           bson_error_t *error) BSON_GNUC_DEPRECATED;
+                           bson_error_t *error);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_collection_validate.rst
+++ b/src/libmongoc/doc/mongoc_collection_validate.rst
@@ -17,7 +17,7 @@ Synopsis
   mongoc_collection_validate (mongoc_collection_t *collection,
                               const bson_t *options,
                               bson_t *reply,
-                              bson_error_t *error) BSON_GNUC_DEPRECATED;
+                              bson_error_t *error);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_collection_validate.rst
+++ b/src/libmongoc/doc/mongoc_collection_validate.rst
@@ -6,7 +6,7 @@ mongoc_collection_validate()
 .. warning::
    .. deprecated:: 1.10.0
 
-      This helper function is deprecated and should not be used in new code. Run the `validate <https://www.mongodb.com/docs/manual/reference/command/validate/>`_ command directly with :symbol:`mongoc_client_read_command_with_opts()` instead.
+      Run the `validate <https://www.mongodb.com/docs/manual/reference/command/validate/>`_ command directly with :symbol:`mongoc_client_read_command_with_opts()` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_collection_watch.rst
+++ b/src/libmongoc/doc/mongoc_collection_watch.rst
@@ -11,7 +11,7 @@ Synopsis
   mongoc_change_stream_t*
   mongoc_collection_watch (const mongoc_collection_t *coll,
                            const bson_t *pipeline,
-                           const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
+                           const bson_t *opts);
 
 A helper function to create a change stream. It is preferred to call this
 function over using a raw aggregation to create a change stream.

--- a/src/libmongoc/doc/mongoc_cursor_clone.rst
+++ b/src/libmongoc/doc/mongoc_cursor_clone.rst
@@ -9,8 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_cursor_t *
-  mongoc_cursor_clone (const mongoc_cursor_t *cursor)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_cursor_clone (const mongoc_cursor_t *cursor);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_cursor_get_hint.rst
+++ b/src/libmongoc/doc/mongoc_cursor_get_hint.rst
@@ -6,9 +6,7 @@ mongoc_cursor_get_hint()
 .. warning::
    .. deprecated:: 1.28.0
 
-      This function is deprecated and should not be used in new code.
-
-      Please use :symbol:`mongoc_cursor_get_server_id()` in new code.
+      Use :symbol:`mongoc_cursor_get_server_id()` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_cursor_get_hint.rst
+++ b/src/libmongoc/doc/mongoc_cursor_get_hint.rst
@@ -16,7 +16,7 @@ Synopsis
 .. code-block:: c
 
   uint32_t
-  mongoc_cursor_get_hint (const mongoc_cursor_t *cursor) BSON_GNUC_DEPRECATED_FOR (mongoc_cursor_get_server_id);
+  mongoc_cursor_get_hint (const mongoc_cursor_t *cursor);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_cursor_is_alive.rst
+++ b/src/libmongoc/doc/mongoc_cursor_is_alive.rst
@@ -17,8 +17,7 @@ Synopsis
 .. code-block:: c
 
   bool
-  mongoc_cursor_is_alive (const mongoc_cursor_t *cursor)
-     BSON_GNUC_DEPRECATED_FOR (mongoc_cursor_more);
+  mongoc_cursor_is_alive (const mongoc_cursor_t *cursor);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_cursor_is_alive.rst
+++ b/src/libmongoc/doc/mongoc_cursor_is_alive.rst
@@ -6,9 +6,7 @@ mongoc_cursor_is_alive()
 .. warning::
    .. deprecated:: 1.10.0
 
-      This function is deprecated and should not be used in new code.
-
-      Please use :symbol:`mongoc_cursor_more()` in new code.
+      Use :symbol:`mongoc_cursor_more()` instead.
 
 
 Synopsis

--- a/src/libmongoc/doc/mongoc_cursor_new_from_command_reply.rst
+++ b/src/libmongoc/doc/mongoc_cursor_new_from_command_reply.rst
@@ -6,9 +6,7 @@ mongoc_cursor_new_from_command_reply()
 .. warning::
    .. deprecated:: 1.11.0
 
-      This function is deprecated and should not be used in new code.
-
-      Please use :symbol:`mongoc_cursor_new_from_command_reply_with_opts()` in new code.
+      Use :symbol:`mongoc_cursor_new_from_command_reply_with_opts()` instead.
 
       When migrating from the deprecated :symbol:`mongoc_cursor_new_from_command_reply()` to :symbol:`mongoc_cursor_new_from_command_reply_with_opts()`,
       note that options previously passed to the ``reply`` argument (e.g. "batchSize") must instead be provided in the ``opts`` argument.

--- a/src/libmongoc/doc/mongoc_cursor_new_from_command_reply.rst
+++ b/src/libmongoc/doc/mongoc_cursor_new_from_command_reply.rst
@@ -22,7 +22,6 @@ Synopsis
   mongoc_cursor_new_from_command_reply (mongoc_client_t *client,
                                         bson_t *reply,
                                         uint32_t server_id);
-     BSON_GNUC_DEPRECATED_FOR (mongoc_cursor_new_from_command_reply_with_opts);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_cursor_set_hint.rst
+++ b/src/libmongoc/doc/mongoc_cursor_set_hint.rst
@@ -6,9 +6,7 @@ mongoc_cursor_set_hint()
 .. warning::
    .. deprecated:: 1.28.0
 
-      This function is deprecated and should not be used in new code.
-
-      Please use :symbol:`mongoc_cursor_set_server_id()` in new code.
+      Use :symbol:`mongoc_cursor_set_server_id()` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_cursor_set_hint.rst
+++ b/src/libmongoc/doc/mongoc_cursor_set_hint.rst
@@ -16,8 +16,7 @@ Synopsis
 .. code-block:: c
 
   bool
-  mongoc_cursor_set_hint (mongoc_cursor_t *cursor, uint32_t server_id)
-    BSON_GNUC_DEPRECATED_FOR (mongoc_cursor_set_server_id);
+  mongoc_cursor_set_hint (mongoc_cursor_t *cursor, uint32_t server_id);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_database_aggregate.rst
+++ b/src/libmongoc/doc/mongoc_database_aggregate.rst
@@ -12,8 +12,7 @@ Synopsis
   mongoc_database_aggregate (mongoc_database_t *database,
                              const bson_t *pipeline,
                              const bson_t *opts,
-                             const mongoc_read_prefs_t *read_prefs)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+                             const mongoc_read_prefs_t *read_prefs);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_database_command.rst
+++ b/src/libmongoc/doc/mongoc_database_command.rst
@@ -16,8 +16,7 @@ Synopsis
                            uint32_t batch_size,
                            const bson_t *command,
                            const bson_t *fields,
-                           const mongoc_read_prefs_t *read_prefs)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+                           const mongoc_read_prefs_t *read_prefs);
 
 This function is superseded by :symbol:`mongoc_database_command_with_opts()`, :symbol:`mongoc_database_read_command_with_opts()`, :symbol:`mongoc_database_write_command_with_opts()`, and :symbol:`mongoc_database_read_write_command_with_opts()`.
 

--- a/src/libmongoc/doc/mongoc_database_copy.rst
+++ b/src/libmongoc/doc/mongoc_database_copy.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_database_t *
-  mongoc_database_copy (mongoc_database_t *database) BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_database_copy (mongoc_database_t *database);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_database_create_collection.rst
+++ b/src/libmongoc/doc/mongoc_database_create_collection.rst
@@ -12,8 +12,7 @@ Synopsis
   mongoc_database_create_collection (mongoc_database_t *database,
                                      const char *name,
                                      const bson_t *opts,
-                                     bson_error_t *error)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+                                     bson_error_t *error);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_database_find_collections.rst
+++ b/src/libmongoc/doc/mongoc_database_find_collections.rst
@@ -18,8 +18,7 @@ Synopsis
   mongoc_cursor_t *
   mongoc_database_find_collections (mongoc_database_t *database,
                                     const bson_t *filter,
-                                    bson_error_t *error)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+                                    bson_error_t *error);
 
 Description
 -----------

--- a/src/libmongoc/doc/mongoc_database_find_collections.rst
+++ b/src/libmongoc/doc/mongoc_database_find_collections.rst
@@ -6,9 +6,7 @@ mongoc_database_find_collections()
 .. warning::
    .. deprecated:: 1.9.0
 
-      This function is deprecated and should not be used in new code.
-
-      Please use :symbol:`mongoc_database_find_collections_with_opts()` in new code.
+      Use :symbol:`mongoc_database_find_collections_with_opts()` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_database_find_collections.rst
+++ b/src/libmongoc/doc/mongoc_database_find_collections.rst
@@ -19,8 +19,7 @@ Synopsis
   mongoc_database_find_collections (mongoc_database_t *database,
                                     const bson_t *filter,
                                     bson_error_t *error)
-     BSON_GNUC_WARN_UNUSED_RESULT
-     BSON_GNUC_DEPRECATED_FOR (mongoc_database_find_collections_with_opts);
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Description
 -----------

--- a/src/libmongoc/doc/mongoc_database_find_collections_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_database_find_collections_with_opts.rst
@@ -10,8 +10,7 @@ Synopsis
 
   mongoc_cursor_t *
   mongoc_database_find_collections_with_opts (mongoc_database_t *database,
-                                              const bson_t *opts)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+                                              const bson_t *opts);
 
 Fetches a cursor containing documents, each corresponding to a collection on this database.
 

--- a/src/libmongoc/doc/mongoc_database_get_collection.rst
+++ b/src/libmongoc/doc/mongoc_database_get_collection.rst
@@ -10,7 +10,7 @@ Synopsis
 
   mongoc_collection_t *
   mongoc_database_get_collection (mongoc_database_t *database,
-                                  const char *name) BSON_GNUC_WARN_UNUSED_RESULT;
+                                  const char *name);
 
 Allocates a new :symbol:`mongoc_collection_t` structure for the collection named ``name`` in ``database``.
 

--- a/src/libmongoc/doc/mongoc_database_get_collection_names.rst
+++ b/src/libmongoc/doc/mongoc_database_get_collection_names.rst
@@ -17,8 +17,7 @@ Synopsis
 
   char **
   mongoc_database_get_collection_names (mongoc_database_t *database,
-                                        bson_error_t *error)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+                                        bson_error_t *error);
 
 Description
 -----------

--- a/src/libmongoc/doc/mongoc_database_get_collection_names.rst
+++ b/src/libmongoc/doc/mongoc_database_get_collection_names.rst
@@ -18,8 +18,7 @@ Synopsis
   char **
   mongoc_database_get_collection_names (mongoc_database_t *database,
                                         bson_error_t *error)
-     BSON_GNUC_WARN_UNUSED_RESULT
-     BSON_GNUC_DEPRECATED_FOR (mongoc_database_get_collection_names_with_opts);
+     BSON_GNUC_WARN_UNUSED_RESULT;
 
 Description
 -----------

--- a/src/libmongoc/doc/mongoc_database_get_collection_names.rst
+++ b/src/libmongoc/doc/mongoc_database_get_collection_names.rst
@@ -6,9 +6,7 @@ mongoc_database_get_collection_names()
 .. warning::
    .. deprecated:: 1.9.0
 
-      This function is deprecated and should not be used in new code.
-
-      Please use :symbol:`mongoc_database_get_collection_names_with_opts()` in new code.
+      Use :symbol:`mongoc_database_get_collection_names_with_opts()` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_database_get_collection_names_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_database_get_collection_names_with_opts.rst
@@ -11,8 +11,7 @@ Synopsis
   char **
   mongoc_database_get_collection_names_with_opts (mongoc_database_t *database,
                                                   const bson_t *opts,
-                                                  bson_error_t *error)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+                                                  bson_error_t *error);
 
 Fetches a ``NULL`` terminated array of ``NULL-byte`` terminated ``char*`` strings containing the names of all of the collections in ``database``.
 

--- a/src/libmongoc/doc/mongoc_database_watch.rst
+++ b/src/libmongoc/doc/mongoc_database_watch.rst
@@ -11,7 +11,7 @@ Synopsis
   mongoc_change_stream_t*
   mongoc_database_watch (const mongoc_database_t *db,
                          const bson_t *pipeline,
-                         const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
+                         const bson_t *opts);
 
 A helper function to create a change stream. It is preferred to call this
 function over using a raw aggregation to create a change stream.

--- a/src/libmongoc/doc/mongoc_delete_flags_t.rst
+++ b/src/libmongoc/doc/mongoc_delete_flags_t.rst
@@ -6,9 +6,7 @@ mongoc_delete_flags_t
 .. warning::
    .. deprecated:: 1.9.0
 
-      These flags are deprecated and should not be used in new code.
-
-      Please use :symbol:`mongoc_collection_delete_one()` or :symbol:`mongoc_collection_delete_many()` in new code.
+      Use :symbol:`mongoc_collection_delete_one()` or :symbol:`mongoc_collection_delete_many()` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_find_and_modify_opts_new.rst
+++ b/src/libmongoc/doc/mongoc_find_and_modify_opts_new.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_find_and_modify_opts_t *
-  mongoc_find_and_modify_opts_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_find_and_modify_opts_new (void);
 
 Returns
 -------

--- a/src/libmongoc/doc/mongoc_gridfs_bucket_find.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_bucket_find.rst
@@ -11,7 +11,7 @@ Synopsis
   mongoc_cursor_t *
   mongoc_gridfs_bucket_find (mongoc_gridfs_bucket_t *bucket,
                              const bson_t *filter,
-                             const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
+                             const bson_t *opts);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_gridfs_bucket_new.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_bucket_new.rst
@@ -12,7 +12,7 @@ Synopsis
   mongoc_gridfs_bucket_new (mongoc_database_t *db,
                             const bson_t *opts,
                             const mongoc_read_prefs_t *read_prefs,
-                            bson_error_t* error) BSON_GNUC_WARN_UNUSED_RESULT;
+                            bson_error_t* error);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_gridfs_bucket_open_download_stream.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_bucket_open_download_stream.rst
@@ -11,8 +11,7 @@ Synopsis
   mongoc_stream_t *
   mongoc_gridfs_bucket_open_download_stream (mongoc_gridfs_bucket_t *bucket,
                                              const bson_value_t *file_id,
-                                             bson_error_t *error)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+                                             bson_error_t *error);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_gridfs_bucket_open_upload_stream.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_bucket_open_upload_stream.rst
@@ -13,8 +13,7 @@ Synopsis
                                             const char *filename,
                                             const bson_t *opts,
                                             bson_value_t *file_id,
-                                            bson_error_t *error)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+                                            bson_error_t *error);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_gridfs_bucket_open_upload_stream_with_id.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_bucket_open_upload_stream_with_id.rst
@@ -13,8 +13,7 @@ Synopsis
                                                    const bson_value_t *file_id,
                                                    const char *filename,
                                                    const bson_t *opts,
-                                                   bson_error_t *error)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+                                                   bson_error_t *error);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_gridfs_create_file.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_create_file.rst
@@ -10,8 +10,7 @@ Synopsis
 
   mongoc_gridfs_file_t *
   mongoc_gridfs_create_file (mongoc_gridfs_t *gridfs,
-                             mongoc_gridfs_file_opt_t *opt)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+                             mongoc_gridfs_file_opt_t *opt);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_gridfs_create_file_from_stream.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_create_file_from_stream.rst
@@ -11,8 +11,7 @@ Synopsis
   mongoc_gridfs_file_t *
   mongoc_gridfs_create_file_from_stream (mongoc_gridfs_t *gridfs,
                                          mongoc_stream_t *stream,
-                                         mongoc_gridfs_file_opt_t *opt)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+                                         mongoc_gridfs_file_opt_t *opt);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_gridfs_file_list_next.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_file_list_next.rst
@@ -9,8 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_gridfs_file_t *
-  mongoc_gridfs_file_list_next (mongoc_gridfs_file_list_t *list)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_gridfs_file_list_next (mongoc_gridfs_file_list_t *list);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_gridfs_find.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_find.rst
@@ -15,7 +15,7 @@ Synopsis
 
   mongoc_gridfs_file_list_t *
   mongoc_gridfs_find (mongoc_gridfs_t *gridfs,
-                      const bson_t *query) BSON_GNUC_WARN_UNUSED_RESULT;
+                      const bson_t *query);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_gridfs_find.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_find.rst
@@ -15,8 +15,7 @@ Synopsis
 
   mongoc_gridfs_file_list_t *
   mongoc_gridfs_find (mongoc_gridfs_t *gridfs,
-                      const bson_t *query) BSON_GNUC_WARN_UNUSED_RESULT
-     BSON_GNUC_DEPRECATED_FOR (mongoc_gridfs_find_with_opts);
+                      const bson_t *query) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_gridfs_find_one.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_find_one.rst
@@ -16,8 +16,7 @@ Synopsis
   mongoc_gridfs_file_t *
   mongoc_gridfs_find_one (mongoc_gridfs_t *gridfs,
                           const bson_t *query,
-                          bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT
-     BSON_GNUC_DEPRECATED_FOR (mongoc_gridfs_find_one_with_opts);
+                          bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT;
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_gridfs_find_one.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_find_one.rst
@@ -16,7 +16,7 @@ Synopsis
   mongoc_gridfs_file_t *
   mongoc_gridfs_find_one (mongoc_gridfs_t *gridfs,
                           const bson_t *query,
-                          bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT;
+                          bson_error_t *error);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_gridfs_find_one_by_filename.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_find_one_by_filename.rst
@@ -11,8 +11,7 @@ Synopsis
   mongoc_gridfs_file_t *
   mongoc_gridfs_find_one_by_filename (mongoc_gridfs_t *gridfs,
                                       const char *filename,
-                                      bson_error_t *error)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+                                      bson_error_t *error);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_gridfs_find_one_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_find_one_with_opts.rst
@@ -12,8 +12,7 @@ Synopsis
   mongoc_gridfs_find_one_with_opts (mongoc_gridfs_t *gridfs,
                                     const bson_t *filter,
                                     const bson_t *opts,
-                                    bson_error_t *error)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+                                    bson_error_t *error);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_gridfs_find_with_opts.rst
+++ b/src/libmongoc/doc/mongoc_gridfs_find_with_opts.rst
@@ -11,7 +11,7 @@ Synopsis
   mongoc_gridfs_file_list_t *
   mongoc_gridfs_find_with_opts (mongoc_gridfs_t *gridfs,
                                 const bson_t *filter,
-                                const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
+                                const bson_t *opts);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_index_opt_geo_get_default.rst
+++ b/src/libmongoc/doc/mongoc_index_opt_geo_get_default.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   const mongoc_index_opt_geo_t *
-  mongoc_index_opt_geo_get_default (void) BSON_GNUC_PURE;
+  mongoc_index_opt_geo_get_default (void);
 
 Returns
 -------

--- a/src/libmongoc/doc/mongoc_index_opt_get_default.rst
+++ b/src/libmongoc/doc/mongoc_index_opt_get_default.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   const mongoc_index_opt_t *
-  mongoc_index_opt_get_default (void) BSON_GNUC_PURE;
+  mongoc_index_opt_get_default (void);
 
 Returns
 -------

--- a/src/libmongoc/doc/mongoc_index_opt_t.rst
+++ b/src/libmongoc/doc/mongoc_index_opt_t.rst
@@ -6,7 +6,7 @@ mongoc_index_opt_t
 .. warning::
    .. deprecated:: 1.8.0
 
-      This structure is deprecated and should not be used in new code. See `Manage Collection Indexes <manage-collection-indexes_>`_.
+      See `Manage Collection Indexes <manage-collection-indexes_>`_ for alternatives.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_index_opt_wt_get_default.rst
+++ b/src/libmongoc/doc/mongoc_index_opt_wt_get_default.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   const mongoc_index_opt_wt_t *
-  mongoc_index_opt_wt_get_default (void) BSON_GNUC_PURE;
+  mongoc_index_opt_wt_get_default (void);
 
 Returns
 -------

--- a/src/libmongoc/doc/mongoc_read_concern_copy.rst
+++ b/src/libmongoc/doc/mongoc_read_concern_copy.rst
@@ -9,8 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_read_concern_t *
-  mongoc_read_concern_copy (const mongoc_read_concern_t *read_concern)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_read_concern_copy (const mongoc_read_concern_t *read_concern);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_read_concern_new.rst
+++ b/src/libmongoc/doc/mongoc_read_concern_new.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_read_concern_t *
-  mongoc_read_concern_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_read_concern_new (void);
 
 Returns
 -------

--- a/src/libmongoc/doc/mongoc_read_prefs_copy.rst
+++ b/src/libmongoc/doc/mongoc_read_prefs_copy.rst
@@ -9,8 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_read_prefs_t *
-  mongoc_read_prefs_copy (const mongoc_read_prefs_t *read_prefs)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_read_prefs_copy (const mongoc_read_prefs_t *read_prefs);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_read_prefs_new.rst
+++ b/src/libmongoc/doc/mongoc_read_prefs_new.rst
@@ -9,8 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_read_prefs_t *
-  mongoc_read_prefs_new (mongoc_read_mode_t read_mode)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_read_prefs_new (mongoc_read_mode_t read_mode);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_server_api_copy.rst
+++ b/src/libmongoc/doc/mongoc_server_api_copy.rst
@@ -9,8 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_server_api_t *
-  mongoc_server_api_copy (const mongoc_server_api_t *api)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_server_api_copy (const mongoc_server_api_t *api);
 
 Creates a deep copy of ``api``.
 

--- a/src/libmongoc/doc/mongoc_server_api_new.rst
+++ b/src/libmongoc/doc/mongoc_server_api_new.rst
@@ -9,8 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_server_api_t *
-  mongoc_server_api_new (mongoc_server_api_version_t version)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_server_api_new (mongoc_server_api_version_t version);
 
 Create a struct to hold server API preferences.
 

--- a/src/libmongoc/doc/mongoc_server_description_ismaster.rst
+++ b/src/libmongoc/doc/mongoc_server_description_ismaster.rst
@@ -6,9 +6,7 @@ mongoc_server_description_ismaster()
 .. warning::
    .. deprecated:: 1.18.0
 
-      This function is deprecated and should not be used in new code.
-
-      Please use :doc:`mongoc_server_description_hello_response() <mongoc_server_description_hello_response>` in new code.
+      Use :doc:`mongoc_server_description_hello_response() <mongoc_server_description_hello_response>` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_server_description_new_copy.rst
+++ b/src/libmongoc/doc/mongoc_server_description_new_copy.rst
@@ -10,7 +10,7 @@ Synopsis
 
   mongoc_server_description_t *
   mongoc_server_description_new_copy (
-     const mongoc_server_description_t *description) BSON_GNUC_WARN_UNUSED_RESULT;
+     const mongoc_server_description_t *description);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_session_opts_clone.rst
+++ b/src/libmongoc/doc/mongoc_session_opts_clone.rst
@@ -9,8 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_session_opt_t *
-  mongoc_session_opts_clone (const mongoc_session_opt_t *opts)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_session_opts_clone (const mongoc_session_opt_t *opts);
 
 Create a copy of a session options struct.
 

--- a/src/libmongoc/doc/mongoc_session_opts_get_transaction_opts.rst
+++ b/src/libmongoc/doc/mongoc_session_opts_get_transaction_opts.rst
@@ -10,7 +10,7 @@ Synopsis
 
   mongoc_transaction_opt_t *
   mongoc_session_opts_get_transaction_opts (
-     const mongoc_client_session_t *session) BSON_GNUC_WARN_UNUSED_RESULT;
+     const mongoc_client_session_t *session);
 
 The options for the current transaction started with this session.
 

--- a/src/libmongoc/doc/mongoc_socket_accept.rst
+++ b/src/libmongoc/doc/mongoc_socket_accept.rst
@@ -10,7 +10,7 @@ Synopsis
 
   mongoc_socket_t *
   mongoc_socket_accept (mongoc_socket_t *sock,
-                        int64_t expire_at) BSON_GNUC_WARN_UNUSED_RESULT;
+                        int64_t expire_at);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_socket_getnameinfo.rst
+++ b/src/libmongoc/doc/mongoc_socket_getnameinfo.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   char *
-  mongoc_socket_getnameinfo (mongoc_socket_t *sock) BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_socket_getnameinfo (mongoc_socket_t *sock);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_socket_new.rst
+++ b/src/libmongoc/doc/mongoc_socket_new.rst
@@ -11,7 +11,7 @@ Synopsis
   mongoc_socket_t *
   mongoc_socket_new (int domain,
                      int type,
-                     int protocol) BSON_GNUC_WARN_UNUSED_RESULT;
+                     int protocol);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_ssl_opt_get_default.rst
+++ b/src/libmongoc/doc/mongoc_ssl_opt_get_default.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   const mongoc_ssl_opt_t *
-  mongoc_ssl_opt_get_default (void) BSON_GNUC_PURE;
+  mongoc_ssl_opt_get_default (void);
 
 Returns
 -------

--- a/src/libmongoc/doc/mongoc_stream_buffered_new.rst
+++ b/src/libmongoc/doc/mongoc_stream_buffered_new.rst
@@ -10,7 +10,7 @@ Synopsis
 
   mongoc_stream_t *
   mongoc_stream_buffered_new (mongoc_stream_t *base_stream,
-                          size_t buffer_size) BSON_GNUC_WARN_UNUSED_RESULT;
+                          size_t buffer_size);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_stream_file_new.rst
+++ b/src/libmongoc/doc/mongoc_stream_file_new.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_stream_t *
-  mongoc_stream_file_new (int fd) BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_stream_file_new (int fd);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_stream_file_new_for_path.rst
+++ b/src/libmongoc/doc/mongoc_stream_file_new_for_path.rst
@@ -11,7 +11,7 @@ Synopsis
   mongoc_stream_t *
   mongoc_stream_file_new_for_path (const char *path,
                                    int flags,
-                                   int mode) BSON_GNUC_WARN_UNUSED_RESULT;
+                                   int mode);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_stream_gridfs_new.rst
+++ b/src/libmongoc/doc/mongoc_stream_gridfs_new.rst
@@ -9,8 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_stream_t *
-  mongoc_stream_gridfs_new (mongoc_gridfs_file_t *file)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_stream_gridfs_new (mongoc_gridfs_file_t *file);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_stream_socket_new.rst
+++ b/src/libmongoc/doc/mongoc_stream_socket_new.rst
@@ -9,8 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_stream_t *
-  mongoc_stream_socket_new (mongoc_socket_t *socket)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_stream_socket_new (mongoc_socket_t *socket);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_topology_description_get_servers.rst
+++ b/src/libmongoc/doc/mongoc_topology_description_get_servers.rst
@@ -11,7 +11,7 @@ Synopsis
   mongoc_server_description_t **
   mongoc_topology_description_get_servers (
      const mongoc_topology_description_t *td,
-     size_t *n) BSON_GNUC_WARN_UNUSED_RESULT;
+     size_t *n);
 
 Fetches an array of :symbol:`mongoc_server_description_t` structs for all known servers in the topology.
 

--- a/src/libmongoc/doc/mongoc_topology_description_new_copy.rst
+++ b/src/libmongoc/doc/mongoc_topology_description_new_copy.rst
@@ -10,8 +10,7 @@ Synopsis
 
   mongoc_topology_description_t *
   mongoc_topology_description_new_copy (
-     const mongoc_topology_description_t *description)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+     const mongoc_topology_description_t *description);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_transaction_opts_clone.rst
+++ b/src/libmongoc/doc/mongoc_transaction_opts_clone.rst
@@ -9,8 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_transaction_opt_t *
-  mongoc_transaction_opts_clone (const mongoc_transaction_opt_t *opts)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_transaction_opts_clone (const mongoc_transaction_opt_t *opts);
 
 Create a copy of a transaction options struct.
 

--- a/src/libmongoc/doc/mongoc_uri_copy.rst
+++ b/src/libmongoc/doc/mongoc_uri_copy.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_uri_t *
-  mongoc_uri_copy (const mongoc_uri_t *uri) BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_uri_copy (const mongoc_uri_t *uri);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_uri_get_read_prefs.rst
+++ b/src/libmongoc/doc/mongoc_uri_get_read_prefs.rst
@@ -6,9 +6,7 @@ mongoc_uri_get_read_prefs()
 .. warning::
    .. deprecated:: 1.2.0
 
-      This function is deprecated and should not be used in new code.
-
-      Please use :doc:`mongoc_uri_get_read_prefs_t() <mongoc_uri_get_read_prefs_t>` in new code.
+      Use :doc:`mongoc_uri_get_read_prefs_t() <mongoc_uri_get_read_prefs_t>` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_uri_get_service.rst
+++ b/src/libmongoc/doc/mongoc_uri_get_service.rst
@@ -6,9 +6,7 @@ mongoc_uri_get_service()
 .. warning::
    .. deprecated:: 1.21.0
 
-      This function is deprecated and should not be used in new code.
-
-      Please use :symbol:`mongoc_uri_get_srv_hostname()` in new code.
+      Use :symbol:`mongoc_uri_get_srv_hostname()` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_uri_get_service.rst
+++ b/src/libmongoc/doc/mongoc_uri_get_service.rst
@@ -16,8 +16,7 @@ Synopsis
 .. code-block:: c
 
   const char *
-  mongoc_uri_get_service (const mongoc_uri_t *uri)
-     BSON_GNUC_DEPRECATED_FOR (mongoc_uri_get_srv_hostname);
+  mongoc_uri_get_service (const mongoc_uri_t *uri);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_uri_get_ssl.rst
+++ b/src/libmongoc/doc/mongoc_uri_get_ssl.rst
@@ -19,8 +19,7 @@ Synopsis
 .. code-block:: c
 
   bool
-  mongoc_uri_get_ssl (const mongoc_uri_t *uri)
-     BSON_GNUC_DEPRECATED_FOR (mongoc_uri_get_tls);
+  mongoc_uri_get_ssl (const mongoc_uri_t *uri);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_uri_get_ssl.rst
+++ b/src/libmongoc/doc/mongoc_uri_get_ssl.rst
@@ -6,12 +6,8 @@ mongoc_uri_get_ssl()
 .. warning::
    .. deprecated:: 1.15.0
 
-      This function is deprecated and should not be used in new code. See `Manage Collection Indexes <manage-collection-indexes_>`_.
+      Use :doc:`mongoc_uri_get_tls() <mongoc_uri_get_tls>` instead.
 
-
-This function is deprecated and should not be used in new code.
-
-Please use :doc:`mongoc_uri_get_tls() <mongoc_uri_get_tls>` in new code.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_uri_new.rst
+++ b/src/libmongoc/doc/mongoc_uri_new.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_uri_t *
-  mongoc_uri_new (const char *uri_string) BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_uri_new (const char *uri_string);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_uri_new_with_error.rst
+++ b/src/libmongoc/doc/mongoc_uri_new_with_error.rst
@@ -10,7 +10,7 @@ Synopsis
 
   mongoc_uri_t *
   mongoc_uri_new_with_error (const char *uri_string,
-                             bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT;
+                             bson_error_t *error);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_uri_unescape.rst
+++ b/src/libmongoc/doc/mongoc_uri_unescape.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   char *
-  mongoc_uri_unescape (const char *escaped_string) BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_uri_unescape (const char *escaped_string);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_write_concern_copy.rst
+++ b/src/libmongoc/doc/mongoc_write_concern_copy.rst
@@ -9,8 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_write_concern_t *
-  mongoc_write_concern_copy (const mongoc_write_concern_t *write_concern)
-     BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_write_concern_copy (const mongoc_write_concern_t *write_concern);
 
 Parameters
 ----------

--- a/src/libmongoc/doc/mongoc_write_concern_get_fsync.rst
+++ b/src/libmongoc/doc/mongoc_write_concern_get_fsync.rst
@@ -6,9 +6,7 @@ mongoc_write_concern_get_fsync()
 .. warning::
    .. deprecated:: 1.4.0
 
-      This function is deprecated and should not be used in new code.
-
-      Please use :symbol:`mongoc_write_concern_get_journal()` in new code.
+      Use :symbol:`mongoc_write_concern_get_journal()` instead.
 
 Synopsis
 --------

--- a/src/libmongoc/doc/mongoc_write_concern_new.rst
+++ b/src/libmongoc/doc/mongoc_write_concern_new.rst
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_write_concern_t *
-  mongoc_write_concern_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
+  mongoc_write_concern_new (void);
 
 Returns
 -------

--- a/src/libmongoc/doc/mongoc_write_concern_set_fsync.rst
+++ b/src/libmongoc/doc/mongoc_write_concern_set_fsync.rst
@@ -6,9 +6,7 @@ mongoc_write_concern_set_fsync()
 .. warning::
    .. deprecated:: 1.4.0
 
-      This function is deprecated and should not be used in new code.
-
-      Please use :symbol:`mongoc_write_concern_set_journal()` in new code.
+      Use :symbol:`mongoc_write_concern_set_journal()` instead.
 
 Synopsis
 --------


### PR DESCRIPTION
# Summary

- Remove compiler attributes from `.rst` docs.
- Relocate "superseded" notes to deprecation warnings for `bson_as_json` and `bson_array_as_json` (follow-up to https://github.com/mongodb/mongo-c-driver/pull/1776)

# Background & Motivation

Motivated by https://github.com/mongodb/mongo-c-driver/pull/1778#discussion_r1813683302. The compiler attributes are inconsistently documented and more intended for compilers rather than for users to read.