### PR TITLE
CDRIVER-3054 fix docs and test `mongoc_collection_get_last_error`

### DIFF
--- a/src/libmongoc/doc/mongoc_collection_get_last_error.rst
+++ b/src/libmongoc/doc/mongoc_collection_get_last_error.rst
@@ -3,6 +3,9 @@
 mongoc_collection_get_last_error()
 ==================================
 
+.. warning::
+   .. deprecated:: 1.9.0
+
 Synopsis
 --------
 

--- a/src/libmongoc/doc/mongoc_collection_get_last_error.rst
+++ b/src/libmongoc/doc/mongoc_collection_get_last_error.rst
@@ -33,5 +33,6 @@ Description
 Returns
 -------
 
-A :symbol:`bson:bson_t` that should not be modified or ``NULL``.
+A :symbol:`bson:bson_t` that should not be modified or ``NULL``. The returned :symbol:`bson:bson_t` is may be
+invalidated by the next operation on ``collection``.
 

--- a/src/libmongoc/doc/mongoc_collection_get_last_error.rst
+++ b/src/libmongoc/doc/mongoc_collection_get_last_error.rst
@@ -6,6 +6,18 @@ mongoc_collection_get_last_error()
 .. warning::
    .. deprecated:: 1.9.0
 
+    To get write results from write operations, instead use:
+    
+    - :symbol:`mongoc_collection_update_one`
+    - :symbol:`mongoc_collection_update_many`
+    - :symbol:`mongoc_collection_delete_one`
+    - :symbol:`mongoc_collection_delete_many`
+    - :symbol:`mongoc_collection_insert_one`
+    - :symbol:`mongoc_collection_insert_many`
+    - :symbol:`mongoc_bulkwrite_t`
+    - :symbol:`mongoc_bulk_operation_t`
+
+
 Synopsis
 --------
 

--- a/src/libmongoc/doc/mongoc_collection_get_last_error.rst
+++ b/src/libmongoc/doc/mongoc_collection_get_last_error.rst
@@ -22,9 +22,13 @@ Parameters
 Description
 -----------
 
-The mongoc_collection_get_last_error() function returns a bulk result. See `Bulk Write Operations <bulk_>`_ for examples of bulk results.
+:symbol:`mongoc_collection_get_last_error` returns write results from some operations:
 
-A write_concern must be at least ``MONGOC_WRITE_CONCERN_W_DEFAULT`` in last command execution for this to be available.
+- :symbol:`mongoc_collection_update`
+- :symbol:`mongoc_collection_remove`
+- :symbol:`mongoc_collection_delete`
+- :symbol:`mongoc_collection_insert_bulk`
+- :symbol:`mongoc_collection_insert`
 
 Returns
 -------

--- a/src/libmongoc/doc/mongoc_collection_get_last_error.rst
+++ b/src/libmongoc/doc/mongoc_collection_get_last_error.rst
@@ -7,9 +7,10 @@ mongoc_collection_get_last_error()
    .. deprecated:: 1.9.0
 
     To get write results from write operations, instead use:
-    
+
     - :symbol:`mongoc_collection_update_one`
     - :symbol:`mongoc_collection_update_many`
+    - :symbol:`mongoc_collection_replace_one`
     - :symbol:`mongoc_collection_delete_one`
     - :symbol:`mongoc_collection_delete_many`
     - :symbol:`mongoc_collection_insert_one`


### PR DESCRIPTION
Fix documentation and add tests for `mongoc_collection_get_last_error`.

This PR is related to, but does not resolve CDRIVER-3054.

Verified by this [patch build](https://spruce.mongodb.com/version/6724e5487840f40007eec0d0).

# Background

`mongoc_collection_get_last_error` may be used to obtain results from `mongoc_collection_(remove|insert|update)`. 

`mongoc_collection_get_last_error` has been marked deprecated with `BSON_GNUC_DEPRECATED` since 1.9.0 (CDRIVER-2243) but public docs were not updated.


