### PR TITLE
Update NEWS and release step after 1.29.0 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,9 @@
-libmongoc 1.29.0 (unreleased)
-=============================
+libmongoc 1.29.0
+================
 
+Improvements:
+
+  * Retry KMS requests on transient errors.
 
 Platform Support:
 
@@ -15,6 +18,16 @@ Deprecated:
 Notes:
 
   * Raise required version of libmongocrypt to 1.12.0 to support In-Use Encryption (corresponds to the CMake option: `ENABLE_CLIENT_SIDE_ENCRYPTION`).
+  * A future minor release will raise the minimum supported MongoDB Server version from 4.0 to 4.2. This is in accordance with [MongoDB Software Lifecycle Schedules](https://www.mongodb.com/legal/support-policy/lifecycles). **Support for MongoDB Server 4.0 will be dropped in a future release!**
+
+Thanks to everyone who contributed to the development of this release.
+
+  * Kevin Albertson
+  * Ezra Chung
+  * Micah Scott
+  * Adrian Dole
+  * Andreas Braun
+  * Joshua Siegel
 
 libmongoc 1.28.1
 ================

--- a/docs/dev/releasing.rst
+++ b/docs/dev/releasing.rst
@@ -396,8 +396,9 @@ required for it to succeed:
 Once these prerequesites are met, creating the release archive can be done using
 the :any:`+signed-release` target.::
 
-   $ ./tools/earthly.sh --artifact +signed-release/dist dist --sbom_branch=$RELEASE_BRANCH --version=$NEW_VERSION
+   $ ./tools/earthly.sh --artifact +signed-release/dist dist --sbom_branch=$SBOM_BRANCH --version=$NEW_VERSION
 
+.. note:: `$SBOM_BRANCH` must be ``master`` for a minor release, or ``$RELEASE_BRANCH`` for a patch release.
 .. note:: `$NEW_VERSION` must correspond to the Git tag created by the release.
 
 The above command will create a `dist/` directory in the working directory that

--- a/src/libbson/NEWS
+++ b/src/libbson/NEWS
@@ -1,5 +1,5 @@
-libbson 1.29.0 (Unreleased)
-===========================
+libbson 1.29.0
+==============
 
 Deprecated:
 
@@ -8,6 +8,21 @@ Deprecated:
   * `bson_in_range_*` and `bson_cmp_*` functions.
   * `bson_atomic_*` and `bson_thrd_yield` functions.
   * `bson_as_json` and `bson_array_as_json` are deprecated due to producing non-portable Legacy Extended JSON. Prefer Canonical Extended JSON or Relaxed Extended JSON for portability. To continue using Legacy Extended JSON, use `bson_as_legacy_extended_json` and `bson_array_as_legacy_extended_json`.
+
+Fixes:
+
+  * Fix Relaxed Extended JSON encoding of dates after year 9999.
+
+Improvements:
+
+  * Improve performance of bson_utf8_escape_for_json
+
+Thanks to everyone who contributed to the development of this release.
+
+  * Kevin Albertson
+  * Micah Scott
+  * Ezra Chung
+  * Joshua Siegel
 
 libbson 1.28.1
 ==============


### PR DESCRIPTION
Includes a follow-up fix to https://github.com/mongodb/mongo-c-driver/pull/1715. Fixes the referenced `--sbom_branch` in the release step to be `master` for a minor release.

During the 1.29.0 release, running the `+signed-release/dist` target with `--sbom_branch=r1.29` resulted in an HTTP 404:

```
+sbom-download | 2024-11-06T19:46:57.028494Z [error    ] Message get_asset_group failed [silk_api] content=b'{"detail":"The manual ingested asset with id `mongo-c-driver-r1.29` was not found"}' filename=silk_api.py func_name=_check_response headers=Headers({'date': 'Wed, 06 Nov 2024 19:46:56 GMT', 'content-type': 'application/json', 'content-length': '83', 'connection': 'keep-alive', 'server': 'uvicorn', 'x-cid': 'e9eb4d70-5cac-4d19-9b8d-08a0945e02a8', 'x-ratelimit-limit': '10', 'x-ratelimit-remaining': '9', 'x-ratelimit-reset': '1730922418', 'x-ratelimit-retryafter': '0'}) lineno=142 module=silk_api parsed=None status_code=<HTTPStatus.NOT_FOUND: 404>
```

This reminded me that the Silk asset group for a branch is expected to be [created in Evergreen](https://github.com/mongodb/mongo-c-driver/blob/3b0078e8d9150f193da2cb47f6904057cfcf3854/docs/dev/deps.rst#silk-asset-groups).