### PR TITLE
CDRIVER-3436 Document "ssl" APIs use TLS protocols

### DIFF
--- a/src/libmongoc/doc/conf.py
+++ b/src/libmongoc/doc/conf.py
@@ -223,6 +223,9 @@ rst_prolog = rf"""
 
 .. _bson_lifetimes: https://www.mongodb.com/docs/languages/c/c-driver/current/libbson/guides/lifetimes/
 
+.. |ssl:naming| replace::
+    Though some API names include the term "ssl", the C driver only support TLS protocols, which supersede SSL.
+
 """
 
 

--- a/src/libmongoc/doc/mongoc_client_pool_set_ssl_opts.rst
+++ b/src/libmongoc/doc/mongoc_client_pool_set_ssl_opts.rst
@@ -14,6 +14,9 @@ Synopsis
                                    const mongoc_ssl_opt_t *opts);
   #endif
 
+.. note::
+   |ssl:naming|
+
 This function is identical to :symbol:`mongoc_client_set_ssl_opts()` except for
 client pools. It ensures that all clients retrieved from
 :symbol:`mongoc_client_pool_pop()` or :symbol:`mongoc_client_pool_try_pop()`

--- a/src/libmongoc/doc/mongoc_client_pool_set_ssl_opts.rst
+++ b/src/libmongoc/doc/mongoc_client_pool_set_ssl_opts.rst
@@ -22,13 +22,13 @@ client pools. It ensures that all clients retrieved from
 :symbol:`mongoc_client_pool_pop()` or :symbol:`mongoc_client_pool_try_pop()`
 are configured with the same TLS settings.
 
-The ``mongoc_ssl_opt_t`` struct is copied by the pool along with the strings
+The :symbol:`mongoc_ssl_opt_t` struct is copied by the pool along with the strings
 it points to (``pem_file``, ``pem_pwd``, ``ca_file``, ``ca_dir``, and
 ``crl_file``) so they don't have to remain valid after the call to
-``mongoc_client_pool_set_ssl_opts``.
+:symbol:`mongoc_client_pool_set_ssl_opts`.
 
-A call to ``mongoc_client_pool_set_ssl_opts`` overrides all TLS options set
-through the connection string with which the ``mongoc_client_pool_t`` was
+A call to :symbol:`mongoc_client_pool_set_ssl_opts` overrides all TLS options set
+through the connection string with which the :symbol:`mongoc_client_pool_t` was
 constructed.
 
 Parameters

--- a/src/libmongoc/doc/mongoc_client_pool_set_ssl_opts.rst
+++ b/src/libmongoc/doc/mongoc_client_pool_set_ssl_opts.rst
@@ -17,7 +17,7 @@ Synopsis
 This function is identical to :symbol:`mongoc_client_set_ssl_opts()` except for
 client pools. It ensures that all clients retrieved from
 :symbol:`mongoc_client_pool_pop()` or :symbol:`mongoc_client_pool_try_pop()`
-are configured with the same SSL settings.
+are configured with the same TLS settings.
 
 The ``mongoc_ssl_opt_t`` struct is copied by the pool along with the strings
 it points to (``pem_file``, ``pem_pwd``, ``ca_file``, ``ca_dir``, and

--- a/src/libmongoc/doc/mongoc_client_set_ssl_opts.rst
+++ b/src/libmongoc/doc/mongoc_client_set_ssl_opts.rst
@@ -19,13 +19,13 @@ Synopsis
 
 Sets the TLS (SSL) options to use when connecting to TLS enabled MongoDB servers.
 
-The ``mongoc_ssl_opt_t`` struct is copied by the client along with the strings
+The :symbol:`mongoc_ssl_opt_t` struct is copied by the client along with the strings
 it points to (``pem_file``, ``pem_pwd``, ``ca_file``, ``ca_dir``, and
 ``crl_file``) so they don't have to remain valid after the call to
-``mongoc_client_set_ssl_opts``.
+:symbol:`mongoc_client_set_ssl_opts`.
 
-A call to ``mongoc_client_set_ssl_opts`` overrides all TLS options set through
-the connection string with which the ``mongoc_client_t`` was constructed.
+A call to :symbol:`mongoc_client_set_ssl_opts` overrides all TLS options set through
+the connection string with which the :symbol:`mongoc_client_t` was constructed.
 
 It is a programming error to call this function on a client from a
 :symbol:`mongoc_client_pool_t`. Instead, call

--- a/src/libmongoc/doc/mongoc_client_set_ssl_opts.rst
+++ b/src/libmongoc/doc/mongoc_client_set_ssl_opts.rst
@@ -14,6 +14,9 @@ Synopsis
                               const mongoc_ssl_opt_t *opts);
   #endif
 
+.. note::
+   |ssl:naming|
+
 Sets the TLS (SSL) options to use when connecting to TLS enabled MongoDB servers.
 
 The ``mongoc_ssl_opt_t`` struct is copied by the client along with the strings

--- a/src/libmongoc/doc/mongoc_ssl_opt_get_default.rst
+++ b/src/libmongoc/doc/mongoc_ssl_opt_get_default.rst
@@ -11,6 +11,9 @@ Synopsis
   const mongoc_ssl_opt_t *
   mongoc_ssl_opt_get_default (void);
 
+.. note::
+   |ssl:naming|
+
 Returns
 -------
 

--- a/src/libmongoc/doc/mongoc_ssl_opt_get_default.rst
+++ b/src/libmongoc/doc/mongoc_ssl_opt_get_default.rst
@@ -14,5 +14,5 @@ Synopsis
 Returns
 -------
 
-Returns the default SSL options for the process. This should not be modified or freed.
+Returns the default TLS options for the process. This should not be modified or freed.
 

--- a/src/libmongoc/doc/mongoc_ssl_opt_t.rst
+++ b/src/libmongoc/doc/mongoc_ssl_opt_t.rst
@@ -20,6 +20,9 @@ Synopsis
      void *padding[6];
   } mongoc_ssl_opt_t;
 
+.. note::
+   |ssl:naming|
+
 Description
 -----------
 


### PR DESCRIPTION
# Summary

Document "ssl" APIs use TLS protocols

# Background & Motivation

CDRIVER-3436 originally proposed deprecating `mongoc_ssl_opt_t`. This PR does not deprecate to avoid unnecessary extra migration effort for users.

The motivation for deprecating `mongoc_ssl_opt_t` refers to the MongoDB URI options [preferring "tls" over "ssl" as a prefix](https://github.com/mongodb/specifications/blob/fc7996db26d0ea92091a5034c6acb287ef7282fe/source/uri-options/uri-options.md#why-use-tls-as-the-prefix-instead-of-ssl-for-related-options).

Deprecating "ssl" termed API was done on [this branch](https://github.com/mongodb/mongo-c-driver/compare/master...kevinAlbs:mongo-c-driver:deprecate-ssl.C3436?expand=1) but was abandoned. Though the migration is simple (find+replace), I think it is an unnecessary effort for users with little value gained. I expect there is significant existing use of `mongoc_ssl_opt_t`. [GitHub code search](https://github.com/search?q=mongoc_ssl_opt_t+path%3A*.c+-repo%3Amongodb%2Fmongo-c-driver+NOT+is%3Afork+NOT+path%3A%2Fmongoc%5C-.*%5C.c%2F+NOT+path%3A%2Fbson%5C-.*%5C.c%2F+NOT+path%3Abson.c++NOT+path%3A%2Fmongocrypt%5C-.*%5C.c%2F+NOT+path%3A%2F.*test.*%2F&type=code&ref=advsearch) shows 7 unique looking non-MongoDB uses.

There is precedent among drivers for "ssl" named APIs: Java's [SslSettings](https://mongodb.github.io/mongo-java-driver/5.2/apidocs/mongodb-driver-core/com/mongodb/connection/SslSettings.html) and C#'s [SslSettings](https://mongodb.github.io/mongo-csharp-driver/3.0.0/api/MongoDB.Driver/MongoDB.Driver.SslSettings.html).