### PR TITLE
Remove skip for loading crypt_shared on Windows

### DIFF
--- a/.evergreen/scripts/run-tests.sh
+++ b/.evergreen/scripts/run-tests.sh
@@ -207,9 +207,6 @@ if [[ "${CLIENT_SIDE_ENCRYPTION}" == "on" ]]; then
   # Check if tests should use the crypt_shared library.
   if [[ "${SKIP_CRYPT_SHARED_LIB}" == "on" ]]; then
     echo "crypt_shared library is skipped due to SKIP_CRYPT_SHARED_LIB=on"
-  elif [[ -d /cygdrive/c ]]; then
-    # We have trouble with this test on Windows. only set cryptSharedLibPath on other platforms
-    echo "crypt_shared library is skipped due to running on Windows"
   else
     export MONGOC_TEST_CRYPT_SHARED_LIB_PATH="${CRYPT_SHARED_LIB_PATH}"
     echo "crypt_shared library will be loaded with cryptSharedLibPath: [${MONGOC_TEST_CRYPT_SHARED_LIB_PATH}]"


### PR DESCRIPTION
When investigating a reported Windows crash unloading crypt shared ([JAVA-5648](https://jira.mongodb.org/browse/JAVA-5648)), I rediscovered that testing with the crypt shared library was skipped on Windows. The skip was added in https://github.com/mongodb/mongo-c-driver/pull/968. I am not sure what motivated the skip. Removing the skips appears to pass. The logs of the [patch build](https://spruce.mongodb.com/version/6733524718af6a0007318507/) include:

```
crypt_shared library will be loaded with cryptSharedLibPath: [C:/data/mci/5c60da88b4d482d9f4943604b2d9b92a/mongoc/mongo_crypt_v1.dll]
```