### PR TITLE
CDRIVER-5813 remove misplaced define `BSON_IF_MSVC`

### DIFF
--- a/src/common/src/common-atomic-private.h
+++ b/src/common/src/common-atomic-private.h
@@ -57,7 +57,6 @@ enum mcommon_memory_order {
 #ifdef MCOMMON_USE_LEGACY_GCC_ATOMICS
 #undef BSON_IF_GNU_LIKE
 #define BSON_IF_GNU_LIKE(...)
-#define BSON_IF_MSVC(...)
 #define MCOMMON_IF_GNU_LEGACY_ATOMICS(...) __VA_ARGS__
 #else
 #define MCOMMON_IF_GNU_LEGACY_ATOMICS(...)

--- a/src/libbson/src/bson/bson-atomic.h
+++ b/src/libbson/src/bson/bson-atomic.h
@@ -78,7 +78,6 @@ enum BSON_GNUC_DEPRECATED bson_memory_order {
 #ifdef BSON_USE_LEGACY_GCC_ATOMICS
 #undef BSON_IF_GNU_LIKE
 #define BSON_IF_GNU_LIKE(...)
-#define BSON_IF_MSVC(...)
 #define BSON_IF_GNU_LEGACY_ATOMICS(...) __VA_ARGS__
 #else
 #define BSON_IF_GNU_LEGACY_ATOMICS(...)

--- a/src/libbson/src/bson/bson-compat.h
+++ b/src/libbson/src/bson/bson-compat.h
@@ -189,6 +189,10 @@ typedef signed char bool;
 #define BSON_IF_MSVC(...)
 /** Expands the arguments if compiling with GCC or Clang, otherwise empty */
 #define BSON_IF_GNU_LIKE(...) __VA_ARGS__
+#else
+/** Unsupported compiler. **/
+#define BSON_IF_MSVC(...)
+#define BSON_IF_GNU_LIKE(...)
 #endif
 
 #ifdef BSON_OS_WIN32


### PR DESCRIPTION
https://github.com/mongodb/mongo-c-driver/pull/1096 added a conditional `#define BSON_IF_MSVC(...)` to `bson-atomic.h` without later undefining.

This PR assumes the `#define BSON_IF_MSVC(...)` was motivated by `BSON_IF_MSVC` not being defined on xlC.

`BSON_IF_MSVC` is conditionally defined in [in bson-compat.h](https://github.com/mongodb/mongo-c-driver/blob/4ccd9db9c48be5755af83d7a62b61bd141cc9644/src/libbson/src/bson/bson-compat.h#L182-L192). xlC (not xlclang) appears [not to define `__clang__`, `__GNUC__`, or `_MSC_VER`](https://www.ibm.com/docs/en/xl-c-and-cpp-aix/16.1?topic=macros-identify-xl-cc-compiler). I expect this caused `BSON_IF_MSVC` to not be defined.

This PR changes bson-compat.h to define `BSON_IF_MSVC` (and `BSON_IF_GNU_LIKE`) to be empty on unsupported compilers. Though xLC is not tested or officially supported, this PR makes a best effort to preserve building.

