### PR TITLE
Use Artifactory to obtain Docker images

### DIFF
--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -1048,15 +1048,19 @@ tasks:
       - func: check-headers
   - name: "check:sasl=Cyrus\_\u2022\_tls=LibreSSL\_\u2022\_test_mongocxx_ref=r3.8.0"
     run_on:
-      - ubuntu2204-small
       - ubuntu2204-large
-      - ubuntu2004-small
-      - ubuntu2004
-      - debian10
-      - debian11
+      - debian10-large
+      - debian11-large
       - amazon2
     tags: [earthly, pr-merge-gate, alpine3.16-clang, alpine3.16-gcc, alpine3.17-clang, alpine3.17-gcc, alpine3.18-clang, alpine3.18-gcc, alpine3.19-clang, alpine3.19-gcc, archlinux-clang, archlinux-gcc]
     commands:
+      - command: subprocess.exec
+        type: setup
+        params:
+          binary: bash
+          args:
+            - -c
+            - docker login -u "${artifactory_username}" --password-stdin artifactory.corp.mongodb.com <<<"${artifactory_password}"
       - command: subprocess.exec
         type: setup
         params:
@@ -1084,15 +1088,19 @@ tasks:
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
   - name: "check:sasl=Cyrus\_\u2022\_tls=LibreSSL\_\u2022\_test_mongocxx_ref=r3.9.0"
     run_on:
-      - ubuntu2204-small
       - ubuntu2204-large
-      - ubuntu2004-small
-      - ubuntu2004
-      - debian10
-      - debian11
+      - debian10-large
+      - debian11-large
       - amazon2
     tags: [earthly, pr-merge-gate, alpine3.16-clang, alpine3.16-gcc, alpine3.17-clang, alpine3.17-gcc, alpine3.18-clang, alpine3.18-gcc, alpine3.19-clang, alpine3.19-gcc, archlinux-clang, archlinux-gcc]
     commands:
+      - command: subprocess.exec
+        type: setup
+        params:
+          binary: bash
+          args:
+            - -c
+            - docker login -u "${artifactory_username}" --password-stdin artifactory.corp.mongodb.com <<<"${artifactory_password}"
       - command: subprocess.exec
         type: setup
         params:
@@ -1120,15 +1128,19 @@ tasks:
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
   - name: "check:sasl=Cyrus\_\u2022\_tls=OpenSSL\_\u2022\_test_mongocxx_ref=none"
     run_on:
-      - ubuntu2204-small
       - ubuntu2204-large
-      - ubuntu2004-small
-      - ubuntu2004
-      - debian10
-      - debian11
+      - debian10-large
+      - debian11-large
       - amazon2
     tags: [earthly, pr-merge-gate, centos7-clang, centos7-gcc, u16-clang, u16-gcc]
     commands:
+      - command: subprocess.exec
+        type: setup
+        params:
+          binary: bash
+          args:
+            - -c
+            - docker login -u "${artifactory_username}" --password-stdin artifactory.corp.mongodb.com <<<"${artifactory_password}"
       - command: subprocess.exec
         type: setup
         params:
@@ -1156,15 +1168,19 @@ tasks:
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
   - name: "check:sasl=Cyrus\_\u2022\_tls=OpenSSL\_\u2022\_test_mongocxx_ref=r3.8.0"
     run_on:
-      - ubuntu2204-small
       - ubuntu2204-large
-      - ubuntu2004-small
-      - ubuntu2004
-      - debian10
-      - debian11
+      - debian10-large
+      - debian11-large
       - amazon2
     tags: [earthly, pr-merge-gate, alpine3.16-clang, alpine3.16-gcc, alpine3.17-clang, alpine3.17-gcc, alpine3.18-clang, alpine3.18-gcc, alpine3.19-clang, alpine3.19-gcc, archlinux-clang, archlinux-gcc, u18-clang, u20-clang, u20-gcc, u22-clang, u22-gcc]
     commands:
+      - command: subprocess.exec
+        type: setup
+        params:
+          binary: bash
+          args:
+            - -c
+            - docker login -u "${artifactory_username}" --password-stdin artifactory.corp.mongodb.com <<<"${artifactory_password}"
       - command: subprocess.exec
         type: setup
         params:
@@ -1192,15 +1208,19 @@ tasks:
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
   - name: "check:sasl=Cyrus\_\u2022\_tls=OpenSSL\_\u2022\_test_mongocxx_ref=r3.9.0"
     run_on:
-      - ubuntu2204-small
       - ubuntu2204-large
-      - ubuntu2004-small
-      - ubuntu2004
-      - debian10
-      - debian11
+      - debian10-large
+      - debian11-large
       - amazon2
     tags: [earthly, pr-merge-gate, alpine3.16-clang, alpine3.16-gcc, alpine3.17-clang, alpine3.17-gcc, alpine3.18-clang, alpine3.18-gcc, alpine3.19-clang, alpine3.19-gcc, archlinux-clang, archlinux-gcc, u18-clang, u18-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
     commands:
+      - command: subprocess.exec
+        type: setup
+        params:
+          binary: bash
+          args:
+            - -c
+            - docker login -u "${artifactory_username}" --password-stdin artifactory.corp.mongodb.com <<<"${artifactory_password}"
       - command: subprocess.exec
         type: setup
         params:
@@ -1228,15 +1248,19 @@ tasks:
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
   - name: "check:sasl=Cyrus\_\u2022\_tls=off\_\u2022\_test_mongocxx_ref=none"
     run_on:
-      - ubuntu2204-small
       - ubuntu2204-large
-      - ubuntu2004-small
-      - ubuntu2004
-      - debian10
-      - debian11
+      - debian10-large
+      - debian11-large
       - amazon2
     tags: [earthly, pr-merge-gate, centos7-clang, centos7-gcc, u16-clang, u16-gcc]
     commands:
+      - command: subprocess.exec
+        type: setup
+        params:
+          binary: bash
+          args:
+            - -c
+            - docker login -u "${artifactory_username}" --password-stdin artifactory.corp.mongodb.com <<<"${artifactory_password}"
       - command: subprocess.exec
         type: setup
         params:
@@ -1264,15 +1288,19 @@ tasks:
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
   - name: "check:sasl=Cyrus\_\u2022\_tls=off\_\u2022\_test_mongocxx_ref=r3.8.0"
     run_on:
-      - ubuntu2204-small
       - ubuntu2204-large
-      - ubuntu2004-small
-      - ubuntu2004
-      - debian10
-      - debian11
+      - debian10-large
+      - debian11-large
       - amazon2
     tags: [earthly, pr-merge-gate, alpine3.16-clang, alpine3.16-gcc, alpine3.17-clang, alpine3.17-gcc, alpine3.18-clang, alpine3.18-gcc, alpine3.19-clang, alpine3.19-gcc, archlinux-clang, archlinux-gcc, u18-clang, u20-clang, u20-gcc, u22-clang, u22-gcc]
     commands:
+      - command: subprocess.exec
+        type: setup
+        params:
+          binary: bash
+          args:
+            - -c
+            - docker login -u "${artifactory_username}" --password-stdin artifactory.corp.mongodb.com <<<"${artifactory_password}"
       - command: subprocess.exec
         type: setup
         params:
@@ -1300,15 +1328,19 @@ tasks:
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
   - name: "check:sasl=Cyrus\_\u2022\_tls=off\_\u2022\_test_mongocxx_ref=r3.9.0"
     run_on:
-      - ubuntu2204-small
       - ubuntu2204-large
-      - ubuntu2004-small
-      - ubuntu2004
-      - debian10
-      - debian11
+      - debian10-large
+      - debian11-large
       - amazon2
     tags: [earthly, pr-merge-gate, alpine3.16-clang, alpine3.16-gcc, alpine3.17-clang, alpine3.17-gcc, alpine3.18-clang, alpine3.18-gcc, alpine3.19-clang, alpine3.19-gcc, archlinux-clang, archlinux-gcc, u18-clang, u18-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
     commands:
+      - command: subprocess.exec
+        type: setup
+        params:
+          binary: bash
+          args:
+            - -c
+            - docker login -u "${artifactory_username}" --password-stdin artifactory.corp.mongodb.com <<<"${artifactory_password}"
       - command: subprocess.exec
         type: setup
         params:
@@ -1336,15 +1368,19 @@ tasks:
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
   - name: "check:sasl=off\_\u2022\_tls=OpenSSL\_\u2022\_test_mongocxx_ref=r3.8.0"
     run_on:
-      - ubuntu2204-small
       - ubuntu2204-large
-      - ubuntu2004-small
-      - ubuntu2004
-      - debian10
-      - debian11
+      - debian10-large
+      - debian11-large
       - amazon2
     tags: [earthly, pr-merge-gate, u22-gcc]
     commands:
+      - command: subprocess.exec
+        type: setup
+        params:
+          binary: bash
+          args:
+            - -c
+            - docker login -u "${artifactory_username}" --password-stdin artifactory.corp.mongodb.com <<<"${artifactory_password}"
       - command: subprocess.exec
         type: setup
         params:
@@ -1376,12 +1412,9 @@ tasks:
       - func: clang-format
   - name: create-silk-asset-group
     run_on:
-      - ubuntu2204-small
       - ubuntu2204-large
-      - ubuntu2004-small
-      - ubuntu2004
-      - debian10
-      - debian11
+      - debian10-large
+      - debian11-large
       - amazon2
     tags: [misc, pr-merge-gate]
     commands:

--- a/Earthfile
+++ b/Earthfile
@@ -119,7 +119,7 @@ test-cxx-driver:
 #   Create the VERSION_CURRENT file using Git. This file is exported as an artifact at /
 version-current:
     # Run on Alpine, which does this work the fastest
-    FROM alpine:3.18
+    FROM artifactory.corp.mongodb.com/dockerhub/library/alpine:3.18
     # Install Python and Git, the only things required for this job:
     RUN apk add git python3
     # Copy only the .git/ directory and calc_release_version, which are enough to get the VERSION_CURRENT
@@ -174,7 +174,7 @@ multibuild:
 # release-archive :
 #   Create a release archive of the source tree. (Refer to dev docs)
 release-archive:
-    FROM alpine:3.20
+    FROM artifactory.corp.mongodb.com/dockerhub/library/alpine:3.20
     RUN apk add git bash
     ARG --required sbom_branch
     ARG --required prefix
@@ -218,7 +218,7 @@ release-archive:
 
 # Obtain the signing public key. Exported as an artifact /c-driver.pub
 signing-pubkey:
-    FROM alpine:3.20
+    FROM artifactory.corp.mongodb.com/dockerhub/library/alpine:3.20
     RUN apk add curl
     RUN curl --location --silent --fail "https://pgp.mongodb.com/c-driver.pub" -o /c-driver.pub
     SAVE ARTIFACT /c-driver.pub
@@ -248,7 +248,7 @@ sign-file:
 #   Generate a signed release artifact. Refer to the "Earthly" page of our dev docs for more information.
 #   (Refer to dev docs)
 signed-release:
-    FROM alpine:3.20
+    FROM artifactory.corp.mongodb.com/dockerhub/library/alpine:3.20
     RUN apk add git
     # We need to know which branch to get the SBOM from
     ARG --required sbom_branch
@@ -308,7 +308,7 @@ sbom-generate:
 #
 # Requires credentials for silk access.
 sbom-download:
-    FROM alpine:3.20
+    FROM artifactory.corp.mongodb.com/dockerhub/library/alpine:3.20
     ARG --required branch
     # Run the SilkBomb tool to download the artifact that matches the requested branch
     FROM +silkbomb
@@ -331,14 +331,14 @@ sbom-download:
 create-silk-asset-group:
     ARG branch
     # Get a default value for $branch
-    FROM alpine:3.19
+    FROM artifactory.corp.mongodb.com/dockerhub/library/alpine:3.19
     IF test "${branch}" = ""
         LOCALLY
         LET branch=$(git rev-parse --abbrev-ref HEAD)
         RUN --no-cache echo "Inferred asset-group name from Git HEAD to be “${branch}”"
     END
     # Reset to alpine from the LOCALLY above
-    FROM alpine:3.19
+    FROM artifactory.corp.mongodb.com/dockerhub/library/alpine:3.19
     RUN apk add python3
     # Copy in the script
     COPY tools/create-silk-asset-group.py /opt/
@@ -355,7 +355,7 @@ create-silk-asset-group:
 
 
 snyk:
-    FROM --platform=linux/amd64 ubuntu:24.04
+    FROM --platform=linux/amd64 artifactory.corp.mongodb.com/dockerhub/library/ubuntu:24.04
     RUN apt-get update && apt-get -y install curl
     RUN curl --location https://github.com/snyk/cli/releases/download/v1.1291.1/snyk-linux -o /usr/local/bin/snyk
     RUN chmod a+x /usr/local/bin/snyk
@@ -427,7 +427,7 @@ test-vcpkg-manifest-mode:
         make test-manifest-mode
 
 vcpkg-base:
-    FROM alpine:3.18
+    FROM artifactory.corp.mongodb.com/dockerhub/library/alpine:3.18
     RUN apk add cmake curl gcc g++ musl-dev ninja-is-really-ninja zip unzip tar \
                 build-base git pkgconf perl bash linux-headers
     ENV VCPKG_ROOT=/opt/vcpkg-git
@@ -486,7 +486,7 @@ env.alpine3.19:
     DO --pass-args +ALPINE_ENV --version=3.19
 
 env.archlinux:
-    FROM --pass-args tools+init-env --from archlinux
+    FROM --pass-args tools+init-env --from artifactory.corp.mongodb.com/dockerhub/library/archlinux
     RUN pacman-key --init
     ARG --required purpose
 
@@ -507,7 +507,7 @@ env.centos7:
 ALPINE_ENV:
     COMMAND
     ARG --required version
-    FROM --pass-args tools+init-env --from alpine:$version
+    FROM --pass-args tools+init-env --from artifactory.corp.mongodb.com/dockerhub/library/alpine:$version
     # XXX: On Alpine, we just use the system's CMake. At time of writing, it is
     # very up-to-date and much faster than building our own from source (since
     # Kitware does not (yet) provide libmuslc builds of CMake)
@@ -529,7 +529,7 @@ ALPINE_ENV:
 UBUNTU_ENV:
     COMMAND
     ARG --required version
-    FROM --pass-args tools+init-env --from ubuntu:$version
+    FROM --pass-args tools+init-env --from artifactory.corp.mongodb.com/dockerhub/library/ubuntu:$version
     RUN __install curl build-essential
     ARG --required purpose
 
@@ -547,7 +547,7 @@ UBUNTU_ENV:
 CENTOS_ENV:
     COMMAND
     ARG --required version
-    FROM --pass-args tools+init-env --from centos:$version
+    FROM --pass-args tools+init-env --from artifactory.corp.mongodb.com/dockerhub/library/centos:$version
     # Update repositories to use vault.centos.org
     RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
         sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*

--- a/tools/earthly.sh
+++ b/tools/earthly.sh
@@ -36,7 +36,7 @@ if ! is-file "$EARTHLY_EXE"; then
 fi
 
 run-earthly() {
-    "$EARTHLY_EXE" "$@"
+    "$EARTHLY_EXE" --buildkit-image artifactory.corp.mongodb.com/dockerhub/earthly/buildkitd:v${EARTHLY_VERSION} "$@"
 }
 
 if is-main; then


### PR DESCRIPTION
Verified by [this patch](https://spruce.mongodb.com/version/673b77880014770007fff149).

Appends a `docker login` command prior to Earthly/Docker commands and uses the custom Earthly buildkit image in `tools/earthly.sh` as done in https://github.com/mongodb/libmongocrypt/pull/911.

The Ubuntu 20.04 distro is dropped from the list due to the following obtuse error:

```
Error saving credentials: error storing credentials - err: exit status 1, out: `not implemented`
```