### PR TITLE
add release instruction to update webhook

### DIFF
--- a/docs/dev/releasing.rst
+++ b/docs/dev/releasing.rst
@@ -45,6 +45,7 @@ process.
        - [ ] Announce the Release on the Community Forums
        - [ ] Copy the Release Updates to the ``master`` Branch
        - [ ] Close the Jira Release
+       - [ ] Update the GitHub Webhook
        - [ ] Comment on the Generated DOCSP Ticket
        - [ ] Update the EVG Project
        - [ ] Stop the Release Stopwatch (end time: HH:MM)
@@ -488,6 +489,20 @@ Return to the `Jira releases`_ page and open the release for the release
 version. Close the *Release x.y.z* ticket that corresponds to the release and
 "Release" that version in Jira, ensuring that the release date is correct. (Do
 not use the "Build and Release" option)
+
+
+Update GitHub Webhook
+*********************
+
+For a non-patch release, update the `Github Webhook <https://wiki.corp.mongodb.com/display/INTX/Githook>`_
+to include the new branch.
+
+Navigate to the `Webhook Settings <https://github.com/mongodb/mongo-c-driver/settings/hooks>`_.
+
+Click ``Edit`` on the hook for ``https://githook.mongodb.com/``.
+
+Add the new release branch to the ``Payload URL``. Remove unmaintained
+release branches.
 
 
 Comment on the Generated DOCSP Ticket


### PR DESCRIPTION
Applies similar changes from https://github.com/mongodb/mongo-cxx-driver/pull/1282: Add release process step to update the GitHub Webhook.

**Background**

Updating the `debian/unstable` branch may result in Jira ticket comments for commits added to the branch ([example](https://jira.mongodb.org/browse/CDRIVER-4618?focusedCommentId=6703357&focusedId=6703357&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-6703357)). I expect this is not helpful, and results in unnecessary emails.

The [webhook](https://github.com/mongodb/mongo-c-driver/settings/hooks) is now updated to limit updates to `master` and `r1.29`:

```
https://githook.mongodb.com?branches=master..r1.29
```

Consequently, the webhook must be updated when new release branches are created.
