### PR TITLE
Added pragma for Advapi32.lib

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-socket.c
+++ b/src/libmongoc/src/mongoc/mongoc-socket.c
@@ -27,6 +27,7 @@
 #ifdef _WIN32
 #include <Mstcpip.h>
 #include <process.h>
+#pragma comment(lib, "Advapi32.lib")
 #endif
 #include <common-cmp-private.h>
 


### PR DESCRIPTION
Without adding Advapi32.lib, the code won't link on Windows 64-bit ARM for me when building with clang. The #pragma is a simple way to tell linker to include the library later.