### PR TITLE
Move scan-build task from macos-14 to macos-14-arm64

### DIFF
--- a/.evergreen/config_generator/components/scan_build.py
+++ b/.evergreen/config_generator/components/scan_build.py
@@ -18,7 +18,7 @@ TAG = 'scan-build-matrix'
 # pylint: disable=line-too-long
 # fmt: off
 MATRIX = [
-    ('macos-14',         'clang', None  ),
+    ('macos-14-arm64',   'clang', None  ),
     ('ubuntu2004-arm64', 'clang', None  ),
     ('ubuntu2004',       'clang', 'i686'),
 ]

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -4916,9 +4916,9 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: scan-build-macos-14-clang
-    run_on: macos-14
-    tags: [scan-build-matrix, macos-14, clang]
+  - name: scan-build-macos-14-arm64-clang
+    run_on: macos-14-arm64
+    tags: [scan-build-matrix, macos-14-arm64, clang]
     commands:
       - func: find-cmake-latest
       - func: scan-build

--- a/.evergreen/scripts/compile-scan-build.sh
+++ b/.evergreen/scripts/compile-scan-build.sh
@@ -126,7 +126,7 @@ if [[ -d /usr/local/Cellar/llvm ]]; then
   done
 fi
 
-if command -v scan-build && clmmand -v clang && command -v clang++; then
+if command -v scan-build && command -v clang && command -v clang++; then
   scan_build_binary="scan-build"
   CC="clang"
   CXX="clang++"


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1791. Moves the MacOS scan-build task from `macos-14` to `macos-14-arm64` per distro recommendations following resolution of [DEVPROD-12817](https://jira.mongodb.org/browse/DEVPROD-12817).