### PR TITLE
CDRIVER-5644 increase `wait` time

### DIFF
--- a/src/libmongoc/doc/mongoc_auto_encryption_opts_set_key_expiration.rst
+++ b/src/libmongoc/doc/mongoc_auto_encryption_opts_set_key_expiration.rst
@@ -17,7 +17,7 @@ Parameters
 ----------
 
 * ``opts``: The :symbol:`mongoc_auto_encryption_opts_t`
-* ``cache_expiration_ms``: The data encryption key cache expiration time in milliseconds.
+* ``cache_expiration_ms``: The data encryption key cache expiration time in milliseconds. 0 means "never expire".
 
 .. seealso::
 

--- a/src/libmongoc/doc/mongoc_auto_encryption_opts_set_key_expiration.rst
+++ b/src/libmongoc/doc/mongoc_auto_encryption_opts_set_key_expiration.rst
@@ -17,7 +17,7 @@ Parameters
 ----------
 
 * ``opts``: The :symbol:`mongoc_auto_encryption_opts_t`
-* ``cache_expiration_ms``: The data encryption key cache expiration time in milliseconds. 0 means "never expire".
+* ``cache_expiration_ms``: The data encryption key cache expiration time in milliseconds. Defaults to 60,000. 0 means "never expire".
 
 .. seealso::
 

--- a/src/libmongoc/doc/mongoc_client_encryption_opts_set_key_expiration.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_opts_set_key_expiration.rst
@@ -17,7 +17,7 @@ Parameters
 ----------
 
 * ``opts``: The :symbol:`mongoc_client_encryption_opts_t`
-* ``cache_expiration_ms``: The data encryption key cache expiration time in milliseconds.
+* ``cache_expiration_ms``: The data encryption key cache expiration time in milliseconds. 0 means "never expire".
 
 .. seealso::
 

--- a/src/libmongoc/doc/mongoc_client_encryption_opts_set_key_expiration.rst
+++ b/src/libmongoc/doc/mongoc_client_encryption_opts_set_key_expiration.rst
@@ -17,7 +17,7 @@ Parameters
 ----------
 
 * ``opts``: The :symbol:`mongoc_client_encryption_opts_t`
-* ``cache_expiration_ms``: The data encryption key cache expiration time in milliseconds. 0 means "never expire".
+* ``cache_expiration_ms``: The data encryption key cache expiration time in milliseconds. Defaults to 60,000. 0 means "never expire".
 
 .. seealso::
 

--- a/src/libmongoc/tests/json/client_side_encryption/legacy/keyCache.json
+++ b/src/libmongoc/tests/json/client_side_encryption/legacy/keyCache.json
@@ -122,7 +122,7 @@
           "name": "wait",
           "object": "testRunner",
           "arguments": {
-            "ms": 2
+            "ms": 50
           }
         },
         {

--- a/src/libmongoc/tests/json/client_side_encryption/unified/keyCache.json
+++ b/src/libmongoc/tests/json/client_side_encryption/unified/keyCache.json
@@ -105,7 +105,7 @@
           "name": "wait",
           "object": "testRunner",
           "arguments": {
-            "ms": 2
+            "ms": 50
           }
         },
         {


### PR DESCRIPTION
# Summary
Follow-up to https://github.com/mongodb/mongo-c-driver/pull/1779:

- Increase the `wait` time to fix DEK cache tests on Windows.
- Document expiration time of 0 means "never expire".

Verified with this [patch build](https://spruce.mongodb.com/version/675066dec4dc3c0006a3e9b3).

# Background & Motivation

Tests failures were observed on Windows ([example](https://spruce.mongodb.com/task/mongo_c_driver_cse_matrix_winssl_cse_sasl_cyrus_winssl_windows_2019_vs2017_x64_test_latest_server_auth_8eba3f6f52bff67389124eef36fe120dc6fef15f_24_12_03_21_36_43/logs?execution=0)):

```
running test: decrypt, wait, and decrypt again
[...]
error: expected: 2 events but got 1
```

The test configures a 1ms expiration time. The failure suggests the DEK was not considered expired after the 2ms wait. This appears to be due to the coarse resolution of `bson_get_monotonic_time` on Windows: CDRIVER-4526. `bson_get_montonic_time` is used to [check the current time](https://github.com/mongodb/libmongocrypt/blob/9262d91c40d28c4ebc8cc50c475b4435afc94529/src/mongocrypt-cache.c#L28). Pending resolution of CDRIVER-4526, the test is updated to increase the `wait` time.

