### PR TITLE
CDRIVER-5824 remove EXPORT macros from source files

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-bulkwrite.c
+++ b/src/libmongoc/src/mongoc/mongoc-bulkwrite.c
@@ -1438,7 +1438,7 @@ _bulkwritereturn_apply_result (mongoc_bulkwritereturn_t *self,
    return true;
 }
 
-BSON_EXPORT (void)
+void
 mongoc_bulkwrite_set_session (mongoc_bulkwrite_t *self, mongoc_client_session_t *session)
 {
    BSON_ASSERT_PARAM (self);

--- a/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
@@ -911,7 +911,7 @@ mongoc_client_encryption_get_key_by_alt_name (mongoc_client_encryption_t *client
 }
 
 
-MONGOC_EXPORT (mongoc_client_encryption_t *)
+mongoc_client_encryption_t *
 mongoc_client_encryption_new (mongoc_client_encryption_opts_t *opts, bson_error_t *error)
 {
    BSON_UNUSED (opts);


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-5824

@kevinAlbs: This dates back to the initial release in 1.28.0, but I'm not sure whether it warrants a patch release. I figured it easier to fix in master and then you can backport as desired.