### PR TITLE
CDRIVER-5826 Fix result of `bson_strerror_r` on macOS

### DIFF
--- a/src/libbson/src/bson/bson-error.c
+++ b/src/libbson/src/bson/bson-error.c
@@ -130,6 +130,7 @@ bson_strerror_r (int err_code,                    /* IN */
    // required) by the POSIX spec (see:
    // https://pubs.opengroup.org/onlinepubs/9699919799/functions/strerror.html#tag_16_574_08).
    (void) strerror_r (err_code, buf, buflen);
+   ret = buf;
 #elif defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 700
    // The behavior (of `strerror_l`) is undefined if the locale argument to
    // `strerror_l()` is the special locale object LC_GLOBAL_LOCALE or is not a

--- a/src/libbson/tests/test-bson-error.c
+++ b/src/libbson/tests/test-bson-error.c
@@ -30,9 +30,20 @@ test_bson_error_basic (void)
    ASSERT_CMPUINT32 (error.code, ==, 456u);
 }
 
+static void
+test_bson_strerror_r (void)
+{
+   FILE *f = fopen ("file-that-does-not-exist", "r");
+   ASSERT (!f);
+   char errmsg_buf[BSON_ERROR_BUFFER_SIZE];
+   char *errmsg = bson_strerror_r (errno, errmsg_buf, sizeof errmsg_buf);
+   // Check a message is returned. Do not check platform-dependent contents:
+   ASSERT (errmsg);
+}
 
 void
 test_bson_error_install (TestSuite *suite)
 {
    TestSuite_Add (suite, "/bson/error/basic", test_bson_error_basic);
+   TestSuite_Add (suite, "/bson/strerror_r", test_bson_strerror_r);
 }


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/mongo-c-driver/pull/1370/files. On macOS `bson_strerror_r` always returned NULL and set the output buffer to "Unknown error message". This PR adds a missing `ret = buf;` assignment to fix.

Verified with [this patch build](https://spruce.mongodb.com/version/675320d2c9816e0007e9dca3).