### PR TITLE
CDRIVER-5829 Increase spawn wait time in TestFixtures

### DIFF
--- a/build/cmake/TestFixtures.cmake
+++ b/build/cmake/TestFixtures.cmake
@@ -41,7 +41,7 @@ endfunction ()
 # Create a fixture that runs a fake Azure IMDS server
 mongo_define_subprocess_fixture(
     mongoc/fixtures/fake_imds
-    SPAWN_WAIT 0.2
+    SPAWN_WAIT 1
     COMMAND
         "$<TARGET_FILE:Python3::Interpreter>" -u --
         "${_MONGOC_BUILD_SCRIPT_DIR}/bottle.py" fake_kms_provider_server:kms_provider


### PR DESCRIPTION
While building mongo-c-driver 1.29.0 on Arch Linux on TH1520, the test `mongoc/fixtures/fake_imds/start` fails.

TH1520 is a low performance chip. The 0.2s waiting time in proc-ctl.py to wait for spawn is not enough: https://github.com/mongodb/mongo-c-driver/blob/028b987d77c92d879cd844c2fb7b20e09ab1d66f/build/cmake/TestFixtures.cmake#L44
Increase it to 1s make the build to success.

Reported-by: https://archriscv.felixc.at/.status/log.htm?url=logs/mongo-c-driver/mongo-c-driver-1.29.0-1.log
Link: https://github.com/felixonmars/archriscv-packages/pull/4329