### PR TITLE
CDRIVER-5835 Rename `set_error` to `kms_set_error`

### DIFF
--- a/.evergreen/scripts/kms-divergence-check.sh
+++ b/.evergreen/scripts/kms-divergence-check.sh
@@ -13,7 +13,7 @@ LIBMONGOCRYPT_DIR="$MONGOC_DIR/libmongocrypt-for-kms-divergence-check"
 
 # LIBMONGOCRYPT_GITREF is expected to refer to the version of libmongocrypt
 # where kms-message was last copied.
-LIBMONGOCRYPT_GITREF="a650d171ed3b552446095817ae2c5c4f7cec43a2"
+LIBMONGOCRYPT_GITREF="ea8af831bf067cc7eed7417ff4aef3c14cf1e67a"
 
 cleanup() {
     if [ -d "$LIBMONGOCRYPT_DIR" ]; then

--- a/src/kms-message/src/kms_message.c
+++ b/src/kms-message/src/kms_message.c
@@ -24,7 +24,7 @@
 #include <stdio.h>
 
 void
-set_error (char *error, size_t size, const char *fmt, ...)
+kms_set_error (char *error, size_t size, const char *fmt, ...)
 {
    va_list va;
 

--- a/src/kms-message/src/kms_message_private.h
+++ b/src/kms-message/src/kms_message_private.h
@@ -125,12 +125,12 @@ struct _kms_response_parser_t {
    } while (0)
 
 void
-set_error (char *error, size_t size, const char *fmt, ...);
+kms_set_error (char *error, size_t size, const char *fmt, ...);
 
 #define KMS_ERROR(obj, ...)                                     \
    do {                                                         \
       obj->failed = true;                                       \
-      set_error (obj->error, sizeof (obj->error), __VA_ARGS__); \
+      kms_set_error (obj->error, sizeof (obj->error), __VA_ARGS__); \
    } while (0)
 
 #define KMS_ASSERT(stmt)                      \


### PR DESCRIPTION
set_error is an awful generic name for a global function.

Sadly this easily conflicts with other libraries if you statically link this into an application.

please have us rename set_error to kms_set_error to avoid link errors with libraries/applications that also have set_error as function.