### PR TITLE
CDRIVER-5834 Do not compare uninitialized bytes in _mongoc_server_description_equal

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -1151,8 +1151,8 @@ _mongoc_server_description_equal (mongoc_server_description_t *sd1, mongoc_serve
       return false;
    }
 
-   /* error may have uninitialized bytes after terminating '\0' */
-   if (0 != strncmp (&sd1->error, &sd2->error, sizeof (bson_error_t))) {
+   if (sd1->error.domain != sd2->error.domain || sd1->error.code != sd2->error.code ||
+       0 != strncmp (sd1->error.message, sd2->error.message, BSON_ERROR_BUFFER_SIZE)) {
       return false;
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -1151,7 +1151,8 @@ _mongoc_server_description_equal (mongoc_server_description_t *sd1, mongoc_serve
       return false;
    }
 
-   if (0 != memcmp (&sd1->error, &sd2->error, sizeof (bson_error_t))) {
+   /* error may have uninitialized bytes after terminating '\0' */
+   if (0 != strncmp (&sd1->error, &sd2->error, sizeof (bson_error_t))) {
       return false;
    }
 


### PR DESCRIPTION
In `mongoc_cluster_check_interval` function the `bson_error_t error;` is constructed on the stack, its error message is **not** zero initialised https://github.com/mongodb/mongo-c-driver/blob/db54ccf2fe10f6577cf17feae46f9448cd21f3a4/src/libmongoc/src/mongoc/mongoc-cluster.c#L2771. In case of an error in `mongoc_cluster_run_command_parts` function, a short error message is written to `error`, leaving some of the bytes uninitialized. That `error` is then passed to `mongoc_topology_description_invalidate_server` https://github.com/mongodb/mongo-c-driver/blob/db54ccf2fe10f6577cf17feae46f9448cd21f3a4/src/libmongoc/src/mongoc/mongoc-cluster.c#L2840 , which in turn copies the whole error message buffer into `sd` in `mongoc_server_description_handle_hello` https://github.com/mongodb/mongo-c-driver/blob/db54ccf2fe10f6577cf17feae46f9448cd21f3a4/src/libmongoc/src/mongoc/mongoc-topology-description.c#L2168, including uninitialized bytes https://github.com/mongodb/mongo-c-driver/blob/db54ccf2fe10f6577cf17feae46f9448cd21f3a4/src/libmongoc/src/mongoc/mongoc-server-description.c#L741

After that, attempt to call `_mongoc_server_description_equal` https://github.com/mongodb/mongo-c-driver/blob/db54ccf2fe10f6577cf17feae46f9448cd21f3a4/src/libmongoc/src/mongoc/mongoc-topology-description.c#L2204 results in comparison of uninitilized bytes of std->error at https://github.com/mongodb/mongo-c-driver/blob/db54ccf2fe10f6577cf17feae46f9448cd21f3a4/src/libmongoc/src/mongoc/mongoc-server-description.c#L1154

Resulting in sanitizer error:
```
Uninitialized bytes in MemcmpInterceptorCommon at offset 109 inside [0x71d0000200f8, 512)
==366158==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x9ac794 in bcmp /-S/contrib/libs/clang18-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc:859:10
    #1 0x1dc3136 in _mongoc_server_description_equal /-S/contrib/libs/mongo-c-driver/libmongoc/src/mongoc/mongoc-server-description.c:1154:13
    #2 0x1de1ea0 in mongoc_topology_description_handle_hello /-S/contrib/libs/mongo-c-driver/libmongoc/src/mongoc/mongoc-topology-description.c:2204:21
    #3 0x1d867d7 in _mongoc_topology_update_no_lock /-S/contrib/libs/mongo-c-driver/libmongoc/src/mongoc/mongoc-topology.c:101:4
    #4 0x1d867d7 in _mongoc_topology_scanner_cb /-S/contrib/libs/mongo-c-driver/libmongoc/src/mongoc/mongoc-topology.c:188:7
    #5 0x1d9349d in _async_error_or_timeout /-S/contrib/libs/mongo-c-driver/libmongoc/src/mongoc/mongoc-topology-scanner.c:742:7
    #6 0x1d99b7d in mongoc_async_run /-S/contrib/libs/mongo-c-driver/libmongoc/src/mongoc/mongoc-async.c
```