### PR TITLE
CDRIVER-5841 add missing return on failure to parse `errInfo`

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-bulkwrite.c
+++ b/src/libmongoc/src/mongoc/mongoc-bulkwrite.c
@@ -1326,6 +1326,7 @@ _bulkwritereturn_apply_reply (mongoc_bulkwritereturn_t *self, const bson_t *cmd_
          if (!_mongoc_iter_document_as_bson (&wce_iter, &errInfo, &error)) {
             _bulkwriteexception_set_error (self->exc, &error);
             _bulkwriteexception_set_error_reply (self->exc, cmd_reply);
+            return false;
          }
       }
 


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/mongo-c-driver/pull/1590. Add a missing return failure to parse `writeConcernError.errInfo` in a `bulkWrite` reply. Fixes a possible ignored error.