### PR TITLE
CDRIVER-5840 remove unnecessary include

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-bulkwrite.c
+++ b/src/libmongoc/src/mongoc/mongoc-bulkwrite.c
@@ -24,7 +24,6 @@
 #include <mongoc/mongoc-client-private.h>
 #include <mongoc/mongoc-client-side-encryption-private.h>
 #include <mongoc/mongoc-error.h>
-#include <mongoc/mongoc-error-private.h> // _mongoc_write_error_handle_labels
 #include <mongoc/mongoc-server-stream-private.h>
 #include <mongoc/mongoc-util-private.h> // _mongoc_iter_document_as_bson
 #include <mongoc/mongoc-optional.h>


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/mongo-c-driver/pull/1590. Removes an unnecessary include of `mongoc-error-private.h`.