### PR TITLE
CDRIVER-5844 fix macOS format specifier

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-secure-transport.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-transport.c
@@ -309,6 +309,27 @@ _mongoc_secure_transport_extract_subject (const char *filename, const char *pass
    return retval;
 }
 
+static const char *
+SecExternalItemType_to_string (SecExternalItemType value)
+{
+   switch (value) {
+   case kSecItemTypeUnknown:
+      return "kSecItemTypeUnknown";
+   case kSecItemTypePrivateKey:
+      return "kSecItemTypePrivateKey";
+   case kSecItemTypePublicKey:
+      return "kSecItemTypePublicKey";
+   case kSecItemTypeSessionKey:
+      return "kSecItemTypeSessionKey";
+   case kSecItemTypeCertificate:
+      return "kSecItemTypeCertificate";
+   case kSecItemTypeAggregate:
+      return "kSecItemTypeAggregate";
+   default:
+      return "Unknown";
+   }
+}
+
 bool
 mongoc_secure_transport_setup_certificate (mongoc_stream_tls_secure_transport_t *secure_transport,
                                            mongoc_ssl_opt_t *opt)
@@ -332,7 +353,9 @@ mongoc_secure_transport_setup_certificate (mongoc_stream_tls_secure_transport_t 
    }
 
    if (type != kSecItemTypeAggregate) {
-      MONGOC_ERROR ("Cannot work with keys of type \"%" PRIu32 "\". Please file a JIRA", type);
+      MONGOC_ERROR ("Cannot work with keys of type %s (%" PRIu32 "). Please file a JIRA",
+                    SecExternalItemType_to_string (type),
+                    type);
       CFRelease (items);
       return false;
    }

--- a/src/libmongoc/src/mongoc/mongoc-secure-transport.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-transport.c
@@ -353,7 +353,7 @@ mongoc_secure_transport_setup_certificate (mongoc_stream_tls_secure_transport_t 
    }
 
    if (type != kSecItemTypeAggregate) {
-      MONGOC_ERROR ("Cannot work with keys of type %s (%" PRIu32 "). Please file a JIRA",
+      MONGOC_ERROR ("Cannot work with keys of type %s (%" PRIu32 "). Type is not supported",
                     SecExternalItemType_to_string (type),
                     type);
       CFRelease (items);

--- a/src/libmongoc/src/mongoc/mongoc-secure-transport.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-transport.c
@@ -332,7 +332,7 @@ mongoc_secure_transport_setup_certificate (mongoc_stream_tls_secure_transport_t 
    }
 
    if (type != kSecItemTypeAggregate) {
-      MONGOC_ERROR ("Cannot work with keys of type \"%d\". Please file a JIRA", type);
+      MONGOC_ERROR ("Cannot work with keys of type \"%" PRIu32 "\". Please file a JIRA", type);
       CFRelease (items);
       return false;
    }


### PR DESCRIPTION
Fixes a build error observed after upgrading from macOS 12 to macOS 13.7.2:

```
mongoc-secure-transport.c:335:81: error: format specifies type 'int' but the argument has type 'SecExternalItemType' (aka 'unsigned int') [-Werror,-Wformat]
  335 |       MONGOC_ERROR ("Cannot work with keys of type \"%d\". Please file a JIRA", type);
      |                                                      ~~                         ^~~~
      |                                                      %u
```

`SecExternalItemType` is [represented as `uint32_t`](https://github.com/apple-oss-distributions/Security/blob/3dab46a11f45f2ffdbd70e2127cc5a8ce4a1f222/keychain/headers/SecImportExport.h#L98). I expect the error is triggered by a local upgrade to clang.

Added improvements:
- A string representation of the enum value is added to the error.
- "Please file a JIRA" is replaced with "Type is not supported" for consistency (it was the only error message referencing JIRA).

Verified with [this patch build](https://spruce.mongodb.com/version/6776faf5169c87000724c3ed).