### PR TITLE
update NEWS for 1.29.2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,24 @@
+libmongoc 1.29.2
+================
+
+Fixes:
+  * Rename `set_error` function to avoid symbol conflicts.
+  * Fix Windows ARM 64 build.
+  * Fix comparison of uninitialized bytes.
+  * Fix format specifier on macOS.
+
+Notes:
+  * Windows ARM 64 is not-yet officially tested or supported. Support is community driven.
+
+Thanks to everyone who contributed to the development of this release.
+
+  * Adrian Dole
+  * Christian Schmitz
+  * Antony Polukhin
+  * Kevin Albertson
+
+
+
 libmongoc 1.29.1
 ================
 

--- a/docs/dev/releasing.rst
+++ b/docs/dev/releasing.rst
@@ -96,7 +96,7 @@ Check that the `etc/purls.txt` file is up-to-date with the set of
 updated, refer to `sbom-lite-updating`.
 
 Create a New Clone of ``mongo-c-driver``
-****************************************
+########################################
 
 To prevent publishing unwanted changes and to preserve local changes, create a
 fresh clone of the C driver. We will clone into a new arbitrary directory which

--- a/docs/dev/releasing.rst
+++ b/docs/dev/releasing.rst
@@ -27,6 +27,7 @@ process.
 
    - [ ] Check Static Analysis
    - [ ] Check that Tests Are Passing
+   - [ ] Create a new **mongo-c-driver** clone
    - [ ] Check and Update the SBOM Lite
    - [ ] Start Snyk Monitoring
    - [ ] Address and Report Vulnerabilities
@@ -35,7 +36,6 @@ process.
    - [ ] Do the Release:
        - [ ] Start a Release Stopwatch (start time: HH:MM)
        - [ ] Clone the Driver Tools
-       - [ ] Create a new **mongo-c-driver** clone
        - [ ] If patch release: Check consistency with [the Jira release](https://jira.mongodb.org/projects/CDRIVER/versions/XXXXXX)
        - [ ] Run the Release Script
        - [ ] Fixup the `NEWS` Pages

--- a/src/libbson/NEWS
+++ b/src/libbson/NEWS
@@ -1,3 +1,10 @@
+libbson 1.29.2
+==============
+
+No changes since 1.29.1. Version incremented to match the libmongoc version.
+
+
+
 libbson 1.29.1
 ==============
 
@@ -35,7 +42,7 @@ Improvements:
 Thanks to everyone who contributed to the development of this release.
 
   * Kevin Albertson
-  * Micah Scott
+  * Micah Scott @ MongoDB
   * Ezra Chung
   * Joshua Siegel
 


### PR DESCRIPTION
- update NEWS for 1.29.2
- fix release docs rendering of "Create a New Clone [...]" to prevent rendering as a sub-step.
- fix release docs checklist ordering.