### PR TITLE
CDRIVER-5850 prefix all error messages with source information

### DIFF
--- a/build/opts_templates/mongoc-opts.c.template
+++ b/build/opts_templates/mongoc-opts.c.template
@@ -1,6 +1,7 @@
 #include "mongoc-opts-helpers-private.h"
 #include "mongoc-opts-private.h"
 #include "mongoc-error.h"
+#include "mongoc-error-private.h"
 #include "mongoc-util-private.h"
 #include "mongoc-client-private.h"
 
@@ -54,10 +55,10 @@ _{{ struct_name }}_parse (
    }
 
    if (!bson_iter_init (&iter, opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_BSON,
-                      MONGOC_ERROR_BSON_INVALID,
-                      "Invalid 'opts' parameter.");
+      _mongoc_set_error (error,
+                        MONGOC_ERROR_BSON,
+                        MONGOC_ERROR_BSON_INVALID,
+                        "Invalid 'opts' parameter.");
       return false;
    }
 
@@ -100,18 +101,18 @@ _{{ struct_name }}_parse (
                &{{ struct_name }}->extra,
                bson_iter_key (&iter),
                bson_iter_value (&iter))) {
-            bson_set_error (error,
-                            MONGOC_ERROR_BSON,
-                            MONGOC_ERROR_BSON_INVALID,
-                            "Invalid 'opts' parameter.");
+            _mongoc_set_error (error,
+                              MONGOC_ERROR_BSON,
+                              MONGOC_ERROR_BSON_INVALID,
+                              "Invalid 'opts' parameter.");
             return false;
          }
 {% else %}
-         bson_set_error (error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Invalid option '%s'",
-                         bson_iter_key (&iter));
+         _mongoc_set_error (error,
+                           MONGOC_ERROR_COMMAND,
+                           MONGOC_ERROR_COMMAND_INVALID_ARG,
+                           "Invalid option '%s'",
+                           bson_iter_key (&iter));
          return false;
 {% endif %}
       }

--- a/src/libbson/src/bson/bson-iso8601.c
+++ b/src/libbson/src/bson/bson-iso8601.c
@@ -126,9 +126,9 @@ _bson_iso8601_date_parse (const char *str, int32_t len, int64_t *out, bson_error
 
    struct bson_tm posix_date = {0};
 
-#define DATE_PARSE_ERR(msg)                                                                                     \
-   bson_set_error (                                                                                             \
-      error, BSON_ERROR_JSON, BSON_JSON_ERROR_READ_INVALID_PARAM, "Could not parse \"%s\" as date: " msg, str); \
+#define DATE_PARSE_ERR(msg)                                                                                           \
+   bson_set_error (                                                                                                   \
+      error, BSON_ERROR_JSON, BSON_JSON_ERROR_READ_INVALID_PARAM, "bson: Could not parse \"%s\" as date: " msg, str); \
    return false
 
 #define DEFAULT_DATE_PARSE_ERR                                                 \

--- a/src/libbson/src/bson/bson-reader.c
+++ b/src/libbson/src/bson/bson-reader.c
@@ -788,7 +788,7 @@ bson_reader_new_from_file (const char *path,    /* IN */
 
    if (fd == -1) {
       errmsg = bson_strerror_r (errno, errmsg_buf, sizeof errmsg_buf);
-      bson_set_error (error, BSON_ERROR_READER, BSON_ERROR_READER_BADFD, "%s", errmsg);
+      bson_set_error (error, BSON_ERROR_READER, BSON_ERROR_READER_BADFD, "bson: %s", errmsg);
       return NULL;
    }
 

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -3189,7 +3189,8 @@ bson_array_as_canonical_extended_json (const bson_t *bson, size_t *length)
 }
 
 
-#define VALIDATION_ERR(_flag, _msg, ...) bson_set_error (&state->error, BSON_ERROR_INVALID, _flag, _msg, __VA_ARGS__)
+#define VALIDATION_ERR(_flag, _msg, ...) \
+   bson_set_error (&state->error, BSON_ERROR_INVALID, _flag, "bson: " _msg, __VA_ARGS__)
 
 static bool
 _bson_iter_validate_utf8 (const bson_iter_t *iter, const char *key, size_t v_utf8_len, const char *v_utf8, void *data)

--- a/src/libmongoc/src/mongoc/mcd-azure.c
+++ b/src/libmongoc/src/mongoc/mcd-azure.c
@@ -17,6 +17,7 @@
 #include "./mcd-azure.h"
 
 #include "mongoc-util-private.h"
+#include "mongoc-error-private.h"
 #include <common-cmp-private.h>
 
 #define AZURE_API_VERSION "2018-02-01"
@@ -103,12 +104,12 @@ mcd_azure_access_token_try_init_from_json_str (mcd_azure_access_token *out,
    const char *const expires_in_str = !found ? NULL : bson_iter_utf8 (&iter, &expires_in_len);
 
    if (!(access_token && resource && token_type && expires_in_str)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_AZURE,
-                      MONGOC_ERROR_KMS_SERVER_BAD_JSON,
-                      "One or more required JSON properties are missing/invalid: data: %.*s",
-                      len,
-                      json);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_AZURE,
+                         MONGOC_ERROR_KMS_SERVER_BAD_JSON,
+                         "One or more required JSON properties are missing/invalid: data: %.*s",
+                         len,
+                         json);
    } else {
       // Set the output, duplicate each string
       *out = (mcd_azure_access_token){
@@ -123,12 +124,12 @@ mcd_azure_access_token_try_init_from_json_str (mcd_azure_access_token *out,
       long long s = strtoll (expires_in_str, &parse_end, 0);
       if (parse_end != expires_in_str + expires_in_len) {
          // Did not parse the entire string. Bad
-         bson_set_error (error,
-                         MONGOC_ERROR_AZURE,
-                         MONGOC_ERROR_KMS_SERVER_BAD_JSON,
-                         "Invalid 'expires_in' string \"%.*s\" from IMDS server",
-                         mcommon_in_range_unsigned (int, expires_in_len) ? (int) expires_in_len : INT_MAX,
-                         expires_in_str);
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_AZURE,
+                            MONGOC_ERROR_KMS_SERVER_BAD_JSON,
+                            "Invalid 'expires_in' string \"%.*s\" from IMDS server",
+                            mcommon_in_range_unsigned (int, expires_in_len) ? (int) expires_in_len : INT_MAX,
+                            expires_in_str);
       } else {
          out->expires_in = mcd_seconds (s);
          okay = true;
@@ -178,13 +179,13 @@ mcd_azure_access_token_from_imds (mcd_azure_access_token *const out,
 
    // We only accept an HTTP 200 as a success
    if (resp.status != 200) {
-      bson_set_error (error,
-                      MONGOC_ERROR_AZURE,
-                      MONGOC_ERROR_KMS_SERVER_HTTP,
-                      "Error from Azure IMDS server while looking for "
-                      "Managed Identity access token: %.*s",
-                      resp.body_len,
-                      resp.body);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_AZURE,
+                         MONGOC_ERROR_KMS_SERVER_HTTP,
+                         "Error from Azure IMDS server while looking for "
+                         "Managed Identity access token: %.*s",
+                         resp.body_len,
+                         resp.body);
       goto fail;
    }
 

--- a/src/libmongoc/src/mongoc/mcd-nsinfo.c
+++ b/src/libmongoc/src/mongoc/mcd-nsinfo.c
@@ -18,6 +18,7 @@
 
 #include <mongoc/mongoc-buffer-private.h>
 #include <mongoc/mongoc-error.h>
+#include <mongoc/mongoc-error-private.h>
 #include <mongoc/uthash.h>
 
 typedef struct {
@@ -67,11 +68,11 @@ mcd_nsinfo_append (mcd_nsinfo_t *self, const char *ns, bson_error_t *error)
 
    const int32_t ns_index = self->count;
    if (self->count == INT32_MAX) {
-      bson_set_error (error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "Only %" PRId32 " distinct collections may be used",
-                      INT32_MAX);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "Only %" PRId32 " distinct collections may be used",
+                         INT32_MAX);
       return -1;
    }
    self->count++;

--- a/src/libmongoc/src/mongoc/mongoc-aggregate.c
+++ b/src/libmongoc/src/mongoc/mongoc-aggregate.c
@@ -18,6 +18,7 @@
 #include "mongoc-aggregate-private.h"
 #include "mongoc-client-private.h"
 #include "mongoc-cursor-private.h"
+#include "mongoc-error-private.h"
 #include "mongoc-read-prefs-private.h"
 #include "mongoc-server-stream-private.h"
 #include "mongoc-trace-private.h"
@@ -158,12 +159,12 @@ _make_agg_cmd (
    return true;
 
 fail:
-   bson_set_error (err,
-                   MONGOC_ERROR_COMMAND,
-                   MONGOC_ERROR_COMMAND_INVALID_ARG,
-                   "Error while building aggregate command [%s]: %s",
-                   error_hint,
-                   error);
+   _mongoc_set_error (err,
+                      MONGOC_ERROR_COMMAND,
+                      MONGOC_ERROR_COMMAND_INVALID_ARG,
+                      "Error while building aggregate command [%s]: %s",
+                      error_hint,
+                      error);
    return false;
 }
 
@@ -284,7 +285,7 @@ _mongoc_aggregate (mongoc_client_t *client,
       has_write_key = _has_write_key (&ar);
    } else {
       if (!bson_iter_init (&iter, pipeline)) {
-         bson_set_error (&cursor->error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, "Pipeline is invalid BSON");
+         _mongoc_set_error (&cursor->error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, "Pipeline is invalid BSON");
          GOTO (done);
       }
       has_write_key = _has_write_key (&iter);

--- a/src/libmongoc/src/mongoc/mongoc-async-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-async-cmd.c
@@ -22,6 +22,7 @@
 #include "mongoc-async-private.h"
 #include "mongoc-cluster-private.h"
 #include "mongoc-error.h"
+#include "mongoc-error-private.h"
 #include "mongoc-opcode.h"
 #include "mongoc-rpc-private.h"
 #include "mongoc-stream-private.h"
@@ -345,7 +346,7 @@ _mongoc_async_cmd_phase_send (mongoc_async_cmd_t *acmd)
    }
 
    if (bytes < 0) {
-      bson_set_error (&acmd->error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Failed to write rpc bytes.");
+      _mongoc_set_error (&acmd->error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Failed to write rpc bytes.");
       return MONGOC_ASYNC_CMD_ERROR;
    }
 
@@ -375,13 +376,13 @@ _mongoc_async_cmd_phase_recv_len (mongoc_async_cmd_t *acmd)
    }
 
    if (bytes < 0) {
-      bson_set_error (
+      _mongoc_set_error (
          &acmd->error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Failed to receive length header from server.");
       return MONGOC_ASYNC_CMD_ERROR;
    }
 
    if (bytes == 0) {
-      bson_set_error (&acmd->error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Server closed connection.");
+      _mongoc_set_error (&acmd->error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Server closed connection.");
       return MONGOC_ASYNC_CMD_ERROR;
    }
 
@@ -392,7 +393,7 @@ _mongoc_async_cmd_phase_recv_len (mongoc_async_cmd_t *acmd)
       msg_len = BSON_UINT32_FROM_LE (msg_len);
 
       if (msg_len < 16 || msg_len > MONGOC_DEFAULT_MAX_MSG_SIZE || msg_len < acmd->buffer.len) {
-         bson_set_error (
+         _mongoc_set_error (
             &acmd->error, MONGOC_ERROR_PROTOCOL, MONGOC_ERROR_PROTOCOL_INVALID_REPLY, "Invalid reply from server.");
          return MONGOC_ASYNC_CMD_ERROR;
       }
@@ -416,13 +417,13 @@ _mongoc_async_cmd_phase_recv_rpc (mongoc_async_cmd_t *acmd)
    }
 
    if (bytes < 0) {
-      bson_set_error (
+      _mongoc_set_error (
          &acmd->error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Failed to receive rpc bytes from server.");
       return MONGOC_ASYNC_CMD_ERROR;
    }
 
    if (bytes == 0) {
-      bson_set_error (&acmd->error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Server closed connection.");
+      _mongoc_set_error (&acmd->error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Server closed connection.");
       return MONGOC_ASYNC_CMD_ERROR;
    }
 
@@ -431,7 +432,7 @@ _mongoc_async_cmd_phase_recv_rpc (mongoc_async_cmd_t *acmd)
    if (!acmd->bytes_to_read) {
       mcd_rpc_message_reset (acmd->rpc);
       if (!mcd_rpc_message_from_data_in_place (acmd->rpc, acmd->buffer.data, acmd->buffer.len, NULL)) {
-         bson_set_error (
+         _mongoc_set_error (
             &acmd->error, MONGOC_ERROR_PROTOCOL, MONGOC_ERROR_PROTOCOL_INVALID_REPLY, "Invalid reply from server.");
          return MONGOC_ASYNC_CMD_ERROR;
       }
@@ -441,10 +442,10 @@ _mongoc_async_cmd_phase_recv_rpc (mongoc_async_cmd_t *acmd)
       size_t decompressed_data_len;
 
       if (!mcd_rpc_message_decompress_if_necessary (acmd->rpc, &decompressed_data, &decompressed_data_len)) {
-         bson_set_error (&acmd->error,
-                         MONGOC_ERROR_PROTOCOL,
-                         MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
-                         "Could not decompress server reply");
+         _mongoc_set_error (&acmd->error,
+                            MONGOC_ERROR_PROTOCOL,
+                            MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
+                            "Could not decompress server reply");
          return MONGOC_ASYNC_CMD_ERROR;
       }
 
@@ -454,7 +455,7 @@ _mongoc_async_cmd_phase_recv_rpc (mongoc_async_cmd_t *acmd)
       }
 
       if (!mcd_rpc_message_get_body (acmd->rpc, &acmd->reply)) {
-         bson_set_error (
+         _mongoc_set_error (
             &acmd->error, MONGOC_ERROR_PROTOCOL, MONGOC_ERROR_PROTOCOL_INVALID_REPLY, "Invalid reply from server");
          return MONGOC_ASYNC_CMD_ERROR;
       }

--- a/src/libmongoc/src/mongoc/mongoc-async.c
+++ b/src/libmongoc/src/mongoc/mongoc-async.c
@@ -21,6 +21,7 @@
 #include "mongoc-async-cmd-private.h"
 #include "utlist.h"
 #include "mongoc.h"
+#include "mongoc-error-private.h"
 #include "mongoc-socket-private.h"
 #include "mongoc-util-private.h"
 
@@ -134,15 +135,15 @@ mongoc_async_run (mongoc_async_t *async)
             if (poller[i].revents & (POLLERR | POLLHUP)) {
                int hup = poller[i].revents & POLLHUP;
                if (iter->state == MONGOC_ASYNC_CMD_SEND) {
-                  bson_set_error (&iter->error,
-                                  MONGOC_ERROR_STREAM,
-                                  MONGOC_ERROR_STREAM_CONNECT,
-                                  hup ? "connection refused" : "unknown connection error");
+                  _mongoc_set_error (&iter->error,
+                                     MONGOC_ERROR_STREAM,
+                                     MONGOC_ERROR_STREAM_CONNECT,
+                                     hup ? "connection refused" : "unknown connection error");
                } else {
-                  bson_set_error (&iter->error,
-                                  MONGOC_ERROR_STREAM,
-                                  MONGOC_ERROR_STREAM_SOCKET,
-                                  hup ? "connection closed" : "unknown socket error");
+                  _mongoc_set_error (&iter->error,
+                                     MONGOC_ERROR_STREAM,
+                                     MONGOC_ERROR_STREAM_SOCKET,
+                                     hup ? "connection closed" : "unknown socket error");
                }
 
                iter->state = MONGOC_ASYNC_CMD_ERROR_STATE;
@@ -163,10 +164,10 @@ mongoc_async_run (mongoc_async_t *async)
       {
          /* check if an initiated cmd has passed the connection timeout.  */
          if (acmd->state != MONGOC_ASYNC_CMD_INITIATE && now > acmd->connect_started + acmd->timeout_msec * 1000) {
-            bson_set_error (&acmd->error,
-                            MONGOC_ERROR_STREAM,
-                            MONGOC_ERROR_STREAM_CONNECT,
-                            acmd->state == MONGOC_ASYNC_CMD_SEND ? "connection timeout" : "socket timeout");
+            _mongoc_set_error (&acmd->error,
+                               MONGOC_ERROR_STREAM,
+                               MONGOC_ERROR_STREAM_CONNECT,
+                               acmd->state == MONGOC_ASYNC_CMD_SEND ? "connection timeout" : "socket timeout");
 
             acmd->cb (acmd, MONGOC_ASYNC_CMD_TIMEOUT, NULL, (now - acmd->connect_started) / 1000);
 

--- a/src/libmongoc/src/mongoc/mongoc-buffer.c
+++ b/src/libmongoc/src/mongoc/mongoc-buffer.c
@@ -19,6 +19,7 @@
 #include <stdarg.h>
 
 #include "mongoc-error.h"
+#include "mongoc-error-private.h"
 #include "mongoc-buffer-private.h"
 #include "mongoc-trace-private.h"
 #include <common-cmp-private.h>
@@ -188,21 +189,21 @@ _mongoc_buffer_append_from_stream (
 
    if (BSON_UNLIKELY (!mcommon_in_range_signed (int32_t, timeout_msec))) {
       // CDRIVER-4589
-      bson_set_error (error,
-                      MONGOC_ERROR_STREAM,
-                      MONGOC_ERROR_STREAM_SOCKET,
-                      "timeout_msec value %" PRId64 " exceeds supported 32-bit range",
-                      timeout_msec);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_STREAM,
+                         MONGOC_ERROR_STREAM_SOCKET,
+                         "timeout_msec value %" PRId64 " exceeds supported 32-bit range",
+                         timeout_msec);
       RETURN (false);
    }
 
    ret = mongoc_stream_read (stream, buf, size, size, (int32_t) timeout_msec);
    if (mcommon_cmp_not_equal_su (ret, size)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_STREAM,
-                      MONGOC_ERROR_STREAM_SOCKET,
-                      "Failed to read %zu bytes: socket error or timeout",
-                      size);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_STREAM,
+                         MONGOC_ERROR_STREAM_SOCKET,
+                         "Failed to read %zu bytes: socket error or timeout",
+                         size);
       RETURN (false);
    }
 
@@ -251,30 +252,31 @@ _mongoc_buffer_fill (
 
    if (BSON_UNLIKELY (!mcommon_in_range_signed (int32_t, timeout_msec))) {
       // CDRIVER-4589
-      bson_set_error (error,
-                      MONGOC_ERROR_STREAM,
-                      MONGOC_ERROR_STREAM_SOCKET,
-                      "timeout_msec value %" PRId64 " exceeds supported 32-bit range",
-                      timeout_msec);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_STREAM,
+                         MONGOC_ERROR_STREAM_SOCKET,
+                         "timeout_msec value %" PRId64 " exceeds supported 32-bit range",
+                         timeout_msec);
       RETURN (false);
    }
 
    ret = mongoc_stream_read (stream, &buffer->data[buffer->len], avail_bytes, min_bytes, (int32_t) timeout_msec);
 
    if (ret < 0) {
-      bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Failed to buffer %zu bytes", min_bytes);
+      _mongoc_set_error (
+         error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Failed to buffer %zu bytes", min_bytes);
       RETURN (-1);
    }
 
    buffer->len += (size_t) ret;
 
    if (buffer->len < min_bytes) {
-      bson_set_error (error,
-                      MONGOC_ERROR_STREAM,
-                      MONGOC_ERROR_STREAM_SOCKET,
-                      "Could only buffer %zu of %zu bytes",
-                      buffer->len,
-                      min_bytes);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_STREAM,
+                         MONGOC_ERROR_STREAM_SOCKET,
+                         "Could only buffer %zu of %zu bytes",
+                         buffer->len,
+                         min_bytes);
       RETURN (-1);
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-bulk-operation.c
+++ b/src/libmongoc/src/mongoc/mongoc-bulk-operation.c
@@ -18,6 +18,7 @@
 #include "mongoc-bulk-operation.h"
 #include "mongoc-bulk-operation-private.h"
 #include "mongoc-client-private.h"
+#include "mongoc-error-private.h"
 #include "mongoc-trace-private.h"
 #include "mongoc-write-concern-private.h"
 #include "mongoc-util-private.h"
@@ -121,18 +122,18 @@ mongoc_bulk_operation_destroy (mongoc_bulk_operation_t *bulk) /* IN */
       }                                \
    } while (0)
 
-#define BULK_RETURN_IF_PRIOR_ERROR                                            \
-   do {                                                                       \
-      if (bulk->result.error.domain) {                                        \
-         if (error != &bulk->result.error) {                                  \
-            bson_set_error (error,                                            \
-                            MONGOC_ERROR_COMMAND,                             \
-                            MONGOC_ERROR_COMMAND_INVALID_ARG,                 \
-                            "Bulk operation is invalid from prior error: %s", \
-                            bulk->result.error.message);                      \
-         };                                                                   \
-         return false;                                                        \
-      };                                                                      \
+#define BULK_RETURN_IF_PRIOR_ERROR                                               \
+   do {                                                                          \
+      if (bulk->result.error.domain) {                                           \
+         if (error != &bulk->result.error) {                                     \
+            _mongoc_set_error (error,                                            \
+                               MONGOC_ERROR_COMMAND,                             \
+                               MONGOC_ERROR_COMMAND_INVALID_ARG,                 \
+                               "Bulk operation is invalid from prior error: %s", \
+                               bulk->result.error.message);                      \
+         };                                                                      \
+         return false;                                                           \
+      };                                                                         \
    } while (0)
 
 
@@ -160,13 +161,13 @@ _mongoc_bulk_operation_remove_with_opts (mongoc_bulk_operation_t *bulk,
 
    /* allow "limit" in opts, but it must be the correct limit */
    if (remove_opts->limit != limit) {
-      bson_set_error (error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "Invalid \"limit\" in opts: %" PRId32 "."
-                      " The value must be %" PRId32 ", or omitted.",
-                      remove_opts->limit,
-                      limit);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "Invalid \"limit\" in opts: %" PRId32 "."
+                         " The value must be %" PRId32 ", or omitted.",
+                         remove_opts->limit,
+                         limit);
       GOTO (done);
    }
 
@@ -503,13 +504,13 @@ _mongoc_bulk_operation_update_with_opts (mongoc_bulk_operation_t *bulk,
 
    /* allow "multi" in opts, but it must be the correct multi */
    if (update_opts->multi != multi) {
-      bson_set_error (error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "Invalid \"multi\" in opts: %s."
-                      " The value must be %s, or omitted.",
-                      update_opts->multi ? "true" : "false",
-                      multi ? "true" : "false");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "Invalid \"multi\" in opts: %s."
+                         " The value must be %s, or omitted.",
+                         update_opts->multi ? "true" : "false",
+                         multi ? "true" : "false");
       RETURN (false);
    }
 
@@ -673,12 +674,12 @@ mongoc_bulk_operation_replace_one_with_opts (mongoc_bulk_operation_t *bulk,
 
    /* allow "multi" in opts, but it must be the correct multi */
    if (update_opts->multi) {
-      bson_set_error (error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "Invalid \"multi\": true in opts for"
-                      " mongoc_bulk_operation_replace_one_with_opts."
-                      " The value must be true, or omitted.");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "Invalid \"multi\": true in opts for"
+                         " mongoc_bulk_operation_replace_one_with_opts."
+                         " The value must be true, or omitted.");
       GOTO (done);
    }
 
@@ -729,11 +730,11 @@ mongoc_bulk_operation_execute (mongoc_bulk_operation_t *bulk, /* IN */
    BSON_ASSERT_PARAM (bulk);
 
    if (!bulk->client) {
-      bson_set_error (error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "mongoc_bulk_operation_execute() requires a client "
-                      "and one has not been set.");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "mongoc_bulk_operation_execute() requires a client "
+                         "and one has not been set.");
       GOTO (err);
    }
    cluster = &bulk->client->cluster;
@@ -746,18 +747,18 @@ mongoc_bulk_operation_execute (mongoc_bulk_operation_t *bulk, /* IN */
    bulk->executed = true;
 
    if (!bulk->database) {
-      bson_set_error (error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "mongoc_bulk_operation_execute() requires a database "
-                      "and one has not been set.");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "mongoc_bulk_operation_execute() requires a database "
+                         "and one has not been set.");
       GOTO (err);
    } else if (!bulk->collection) {
-      bson_set_error (error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "mongoc_bulk_operation_execute() requires a collection "
-                      "and one has not been set.");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "mongoc_bulk_operation_execute() requires a collection "
+                         "and one has not been set.");
       GOTO (err);
    }
 
@@ -772,7 +773,8 @@ mongoc_bulk_operation_execute (mongoc_bulk_operation_t *bulk, /* IN */
    }
 
    if (!bulk->commands.len) {
-      bson_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "Cannot do an empty bulk write");
+      _mongoc_set_error (
+         error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "Cannot do an empty bulk write");
       GOTO (err);
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-bulkwrite.c
+++ b/src/libmongoc/src/mongoc/mongoc-bulkwrite.c
@@ -24,6 +24,7 @@
 #include <mongoc/mongoc-client-private.h>
 #include <mongoc/mongoc-client-side-encryption-private.h>
 #include <mongoc/mongoc-error.h>
+#include <mongoc/mongoc-error-private.h>
 #include <mongoc/mongoc-server-stream-private.h>
 #include <mongoc/mongoc-util-private.h> // _mongoc_iter_document_as_bson
 #include <mongoc/mongoc-optional.h>
@@ -218,11 +219,12 @@ mongoc_bulkwrite_insertoneopts_destroy (mongoc_bulkwrite_insertoneopts_t *self)
    bson_free (self);
 }
 
-#define ERROR_IF_EXECUTED                                                                                            \
-   if (self->executed) {                                                                                             \
-      bson_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "bulk write already executed"); \
-      return false;                                                                                                  \
-   } else                                                                                                            \
+#define ERROR_IF_EXECUTED                                                                               \
+   if (self->executed) {                                                                                \
+      _mongoc_set_error (                                                                               \
+         error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "bulk write already executed"); \
+      return false;                                                                                     \
+   } else                                                                                               \
       (void) 0
 
 bool
@@ -314,12 +316,12 @@ validate_update (const bson_t *update, bool *is_pipeline, bson_error_t *error)
    if (bson_iter_next (&iter)) {
       const char *key = bson_iter_key (&iter);
       if (key[0] != '$') {
-         bson_set_error (error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Invalid key '%s': update only works with $ operators"
-                         " and pipelines",
-                         key);
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_COMMAND,
+                            MONGOC_ERROR_COMMAND_INVALID_ARG,
+                            "Invalid key '%s': update only works with $ operators"
+                            " and pipelines",
+                            key);
 
          return false;
       }
@@ -514,11 +516,11 @@ validate_replace (const bson_t *doc, bson_error_t *error)
    if (bson_iter_next (&iter)) {
       const char *key = bson_iter_key (&iter);
       if (key[0] == '$') {
-         bson_set_error (error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Invalid key '%s': replace prohibits $ operators",
-                         key);
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_COMMAND,
+                            MONGOC_ERROR_COMMAND_INVALID_ARG,
+                            "Invalid key '%s': replace prohibits $ operators",
+                            key);
 
          return false;
       }
@@ -1163,18 +1165,18 @@ lookup_int32 (const bson_t *bson, const char *key, int32_t *out, const char *sou
    }
    bson_error_t error;
    if (source) {
-      bson_set_error (&error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "expected to find int32 `%s` in %s, but did not",
-                      key,
-                      source);
+      _mongoc_set_error (&error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "expected to find int32 `%s` in %s, but did not",
+                         key,
+                         source);
    } else {
-      bson_set_error (&error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "expected to find int32 `%s`, but did not",
-                      key);
+      _mongoc_set_error (&error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "expected to find int32 `%s`, but did not",
+                         key);
    }
    _bulkwriteexception_set_error (exc, &error);
    return false;
@@ -1198,18 +1200,18 @@ lookup_as_int64 (
    }
    bson_error_t error;
    if (source) {
-      bson_set_error (&error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "expected to find int32, int64, or double `%s` in %s, but did not",
-                      key,
-                      source);
+      _mongoc_set_error (&error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "expected to find int32, int64, or double `%s` in %s, but did not",
+                         key,
+                         source);
    } else {
-      bson_set_error (&error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "expected to find int32, int64, or double `%s`, but did not",
-                      key);
+      _mongoc_set_error (&error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "expected to find int32, int64, or double `%s`, but did not",
+                         key);
    }
    _bulkwriteexception_set_error (exc, &error);
    return false;
@@ -1232,18 +1234,18 @@ lookup_string (
    }
    bson_error_t error;
    if (source) {
-      bson_set_error (&error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "expected to find string `%s` in %s, but did not",
-                      key,
-                      source);
+      _mongoc_set_error (&error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "expected to find string `%s` in %s, but did not",
+                         key,
+                         source);
    } else {
-      bson_set_error (&error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "expected to find string `%s`, but did not",
-                      key);
+      _mongoc_set_error (&error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "expected to find string `%s`, but did not",
+                         key);
    }
    _bulkwriteexception_set_error (exc, &error);
    return false;
@@ -1360,11 +1362,11 @@ _bulkwritereturn_apply_result (mongoc_bulkwritereturn_t *self,
          return false;
       }
       if (idx < 0) {
-         bson_set_error (&error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "expected to find non-negative int64 `idx` in "
-                         "result, but did not");
+         _mongoc_set_error (&error,
+                            MONGOC_ERROR_COMMAND,
+                            MONGOC_ERROR_COMMAND_INVALID_ARG,
+                            "expected to find non-negative int64 `idx` in "
+                            "result, but did not");
          _bulkwriteexception_set_error (self->exc, &error);
          return false;
       }
@@ -1432,11 +1434,11 @@ _bulkwritereturn_apply_result (mongoc_bulkwritereturn_t *self,
          if (bson_iter_init_find (&result_iter, result, "upserted")) {
             BSON_ASSERT (bson_iter_init (&result_iter, result));
             if (!bson_iter_find_descendant (&result_iter, "upserted._id", &id_iter)) {
-               bson_set_error (&error,
-                               MONGOC_ERROR_COMMAND,
-                               MONGOC_ERROR_COMMAND_INVALID_ARG,
-                               "expected `upserted` to be a document "
-                               "containing `_id`, but did not find `_id`");
+               _mongoc_set_error (&error,
+                                  MONGOC_ERROR_COMMAND,
+                                  MONGOC_ERROR_COMMAND_INVALID_ARG,
+                                  "expected `upserted` to be a document "
+                                  "containing `_id`, but did not find `_id`");
                _bulkwriteexception_set_error (self->exc, &error);
                return false;
             }
@@ -1526,33 +1528,33 @@ mongoc_bulkwrite_execute (mongoc_bulkwrite_t *self, const mongoc_bulkwriteopts_t
    ret.exc = _bulkwriteexception_new ();
 
    if (!self->client) {
-      bson_set_error (&error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "bulk write requires a client and one has not been set");
+      _mongoc_set_error (&error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "bulk write requires a client and one has not been set");
       _bulkwriteexception_set_error (ret.exc, &error);
       goto fail;
    }
 
    if (self->executed) {
-      bson_set_error (&error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "bulk write already executed");
+      _mongoc_set_error (&error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "bulk write already executed");
       _bulkwriteexception_set_error (ret.exc, &error);
       goto fail;
    }
    self->executed = true;
 
    if (self->n_ops == 0) {
-      bson_set_error (
+      _mongoc_set_error (
          &error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "cannot do `bulkWrite` with no models");
       _bulkwriteexception_set_error (ret.exc, &error);
       goto fail;
    }
 
    if (_mongoc_cse_is_enabled (self->client)) {
-      bson_set_error (&error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "bulkWrite does not currently support automatic encryption");
+      _mongoc_set_error (&error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "bulkWrite does not currently support automatic encryption");
       _bulkwriteexception_set_error (ret.exc, &error);
       goto fail;
    }
@@ -1628,10 +1630,10 @@ mongoc_bulkwrite_execute (mongoc_bulkwrite_t *self, const mongoc_bulkwriteopts_t
          const mongoc_write_concern_t *wc = self->client->write_concern; // Default to client.
          if (opts->writeconcern) {
             if (_mongoc_client_session_in_txn (self->session)) {
-               bson_set_error (&error,
-                               MONGOC_ERROR_COMMAND,
-                               MONGOC_ERROR_COMMAND_INVALID_ARG,
-                               "Cannot set write concern after starting a transaction.");
+               _mongoc_set_error (&error,
+                                  MONGOC_ERROR_COMMAND,
+                                  MONGOC_ERROR_COMMAND_INVALID_ARG,
+                                  "Cannot set write concern after starting a transaction.");
                _bulkwriteexception_set_error (ret.exc, &error);
                goto fail;
             }
@@ -1643,13 +1645,13 @@ mongoc_bulkwrite_execute (mongoc_bulkwrite_t *self, const mongoc_bulkwriteopts_t
          }
          if (!mongoc_write_concern_is_acknowledged (wc) &&
              mcommon_cmp_greater_us (self->max_insert_len, maxBsonObjectSize)) {
-            bson_set_error (&error,
-                            MONGOC_ERROR_COMMAND,
-                            MONGOC_ERROR_COMMAND_INVALID_ARG,
-                            "Unacknowledged `bulkWrite` includes insert of size: %" PRIu32
-                            ", exceeding maxBsonObjectSize: %" PRId32,
-                            self->max_insert_len,
-                            maxBsonObjectSize);
+            _mongoc_set_error (&error,
+                               MONGOC_ERROR_COMMAND,
+                               MONGOC_ERROR_COMMAND_INVALID_ARG,
+                               "Unacknowledged `bulkWrite` includes insert of size: %" PRIu32
+                               ", exceeding maxBsonObjectSize: %" PRId32,
+                               self->max_insert_len,
+                               maxBsonObjectSize);
             _bulkwriteexception_set_error (ret.exc, &error);
             goto fail;
          }
@@ -1657,19 +1659,19 @@ mongoc_bulkwrite_execute (mongoc_bulkwrite_t *self, const mongoc_bulkwriteopts_t
       }
 
       if (verboseresults && !is_acknowledged) {
-         bson_set_error (&error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Cannot request unacknowledged write concern and verbose results.");
+         _mongoc_set_error (&error,
+                            MONGOC_ERROR_COMMAND,
+                            MONGOC_ERROR_COMMAND_INVALID_ARG,
+                            "Cannot request unacknowledged write concern and verbose results.");
          _bulkwriteexception_set_error (ret.exc, &error);
          goto fail;
       }
 
       if (is_ordered && !is_acknowledged) {
-         bson_set_error (&error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Cannot request unacknowledged write concern and ordered writes.");
+         _mongoc_set_error (&error,
+                            MONGOC_ERROR_COMMAND,
+                            MONGOC_ERROR_COMMAND_INVALID_ARG,
+                            "Cannot request unacknowledged write concern and ordered writes.");
          _bulkwriteexception_set_error (ret.exc, &error);
          goto fail;
       }
@@ -1745,13 +1747,13 @@ mongoc_bulkwrite_execute (mongoc_bulkwrite_t *self, const mongoc_bulkwriteopts_t
          if (opmsg_overhead + ops_byte_len + doc_len + nsinfo_bson_size > maxMessageSizeBytes) {
             if (ops_byte_len == 0) {
                // Could not even fit one document within an OP_MSG.
-               bson_set_error (&error,
-                               MONGOC_ERROR_COMMAND,
-                               MONGOC_ERROR_COMMAND_INVALID_ARG,
-                               "unable to send document at index %zu. Sending "
-                               "would exceed maxMessageSizeBytes=%" PRId32,
-                               ops_doc_len,
-                               maxMessageSizeBytes);
+               _mongoc_set_error (&error,
+                                  MONGOC_ERROR_COMMAND,
+                                  MONGOC_ERROR_COMMAND_INVALID_ARG,
+                                  "unable to send document at index %zu. Sending "
+                                  "would exceed maxMessageSizeBytes=%" PRId32,
+                                  ops_doc_len,
+                                  maxMessageSizeBytes);
                _bulkwriteexception_set_error (ret.exc, &error);
                goto batch_fail;
             }

--- a/src/libmongoc/src/mongoc/mongoc-change-stream.c
+++ b/src/libmongoc/src/mongoc/mongoc-change-stream.c
@@ -26,7 +26,7 @@
 #include "mongoc-error-private.h"
 
 #define CHANGE_STREAM_ERR(_str) \
-   bson_set_error (&stream->err, MONGOC_ERROR_CURSOR, MONGOC_ERROR_BSON, "Could not set " _str)
+   _mongoc_set_error (&stream->err, MONGOC_ERROR_CURSOR, MONGOC_ERROR_BSON, "Could not set " _str)
 
 /* the caller knows either a client or server error has occurred.
  * `reply` contains the server reply or an empty document. */
@@ -530,11 +530,11 @@ mongoc_change_stream_next (mongoc_change_stream_t *stream, const bson_t **bson)
    stream->has_returned_results = true;
 
    if (!bson_iter_init_find (&iter, *bson, "_id") || !BSON_ITER_HOLDS_DOCUMENT (&iter)) {
-      bson_set_error (&stream->err,
-                      MONGOC_ERROR_CURSOR,
-                      MONGOC_ERROR_CHANGE_STREAM_NO_RESUME_TOKEN,
-                      "Cannot provide resume functionality when the resume "
-                      "token is missing");
+      _mongoc_set_error (&stream->err,
+                         MONGOC_ERROR_CURSOR,
+                         MONGOC_ERROR_CHANGE_STREAM_NO_RESUME_TOKEN,
+                         "Cannot provide resume functionality when the resume "
+                         "token is missing");
       goto end;
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-client-pool.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-pool.c
@@ -23,6 +23,7 @@
 #include "mongoc-client-pool.h"
 #include "mongoc-client-private.h"
 #include "mongoc-client-side-encryption-private.h"
+#include "mongoc-error-private.h"
 #include "mongoc-queue-private.h"
 #include "mongoc-thread-private.h"
 #include "mongoc-topology-private.h"
@@ -139,11 +140,11 @@ mongoc_client_pool_new_with_error (const mongoc_uri_t *uri, bson_error_t *error)
 
 #ifndef MONGOC_ENABLE_SSL
    if (mongoc_uri_get_tls (uri)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "Can't create SSL client pool, SSL not enabled in this "
-                      "build.");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "Can't create SSL client pool, SSL not enabled in this "
+                         "build.");
       return NULL;
    }
 #endif
@@ -683,16 +684,16 @@ mongoc_client_pool_set_server_api (mongoc_client_pool_t *pool, const mongoc_serv
    BSON_ASSERT_PARAM (api);
 
    if (pool->api) {
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_POOL, MONGOC_ERROR_POOL_API_ALREADY_SET, "Cannot set server api more than once per pool");
       return false;
    }
 
    if (pool->client_initialized) {
-      bson_set_error (error,
-                      MONGOC_ERROR_POOL,
-                      MONGOC_ERROR_POOL_API_TOO_LATE,
-                      "Cannot set server api after a client has been created");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_POOL,
+                         MONGOC_ERROR_POOL_API_TOO_LATE,
+                         "Cannot set server api after a client has been created");
       return false;
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-client-session.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-session.c
@@ -19,6 +19,7 @@
 #include "mongoc-cluster-private.h"
 #include "mongoc-trace-private.h"
 #include "mongoc-client-private.h"
+#include "mongoc-error-private.h"
 #include "mongoc-rand-private.h"
 #include "mongoc-util-private.h"
 #include "mongoc-read-concern-private.h"
@@ -99,10 +100,10 @@ txn_abort (mongoc_client_session_t *session, bson_t *reply, bson_error_t *error)
 
    if (session->txn.opts.write_concern) {
       if (!mongoc_write_concern_append (session->txn.opts.write_concern, &opts)) {
-         bson_set_error (err_ptr,
-                         MONGOC_ERROR_TRANSACTION,
-                         MONGOC_ERROR_TRANSACTION_INVALID_STATE,
-                         "Invalid transaction write concern");
+         _mongoc_set_error (err_ptr,
+                            MONGOC_ERROR_TRANSACTION,
+                            MONGOC_ERROR_TRANSACTION_INVALID_STATE,
+                            "Invalid transaction write concern");
          GOTO (done);
       }
    }
@@ -191,7 +192,7 @@ retry:
 
    if (session->txn.opts.max_commit_time_ms != DEFAULT_MAX_COMMIT_TIME_MS) {
       if (!bson_append_int64 (&opts, "maxTimeMS", -1, session->txn.opts.max_commit_time_ms)) {
-         bson_set_error (err_ptr, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, "error appending maxCommitTimeMS");
+         _mongoc_set_error (err_ptr, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, "error appending maxCommitTimeMS");
          GOTO (done);
       }
    }
@@ -207,10 +208,10 @@ retry:
 
    if (retry_wc || session->txn.opts.write_concern) {
       if (!mongoc_write_concern_append (retry_wc ? retry_wc : session->txn.opts.write_concern, &opts)) {
-         bson_set_error (err_ptr,
-                         MONGOC_ERROR_TRANSACTION,
-                         MONGOC_ERROR_TRANSACTION_INVALID_STATE,
-                         "Invalid transaction write concern");
+         _mongoc_set_error (err_ptr,
+                            MONGOC_ERROR_TRANSACTION,
+                            MONGOC_ERROR_TRANSACTION_INVALID_STATE,
+                            "Invalid transaction write concern");
          GOTO (done);
       }
    }
@@ -535,10 +536,10 @@ _mongoc_server_session_uuid (uint8_t *data /* OUT */, bson_error_t *error)
     */
 
    if (!_mongoc_rand_bytes (data, 16)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_CLIENT,
-                      MONGOC_ERROR_CLIENT_SESSION_FAILURE,
-                      "Could not generate UUID for logical session id");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_CLIENT,
+                         MONGOC_ERROR_CLIENT_SESSION_FAILURE,
+                         "Could not generate UUID for logical session id");
 
       return false;
    }
@@ -549,12 +550,12 @@ _mongoc_server_session_uuid (uint8_t *data /* OUT */, bson_error_t *error)
    return true;
 #else
    /* no _mongoc_rand_bytes without a crypto library */
-   bson_set_error (error,
-                   MONGOC_ERROR_CLIENT,
-                   MONGOC_ERROR_CLIENT_SESSION_FAILURE,
-                   "Could not generate UUID for logical session id, we need a"
-                   " cryptography library like libcrypto, Common Crypto, or"
-                   " CNG");
+   _mongoc_set_error (error,
+                      MONGOC_ERROR_CLIENT,
+                      MONGOC_ERROR_CLIENT_SESSION_FAILURE,
+                      "Could not generate UUID for logical session id, we need a"
+                      " cryptography library like libcrypto, Common Crypto, or"
+                      " CNG");
 
    return false;
 #endif
@@ -1044,21 +1045,21 @@ mongoc_client_session_start_transaction (mongoc_client_session_t *session,
    }
 
    if (mongoc_session_opts_get_snapshot (&session->opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_TRANSACTION,
-                      MONGOC_ERROR_TRANSACTION_INVALID_STATE,
-                      "Transactions are not supported in snapshot sessions");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_TRANSACTION,
+                         MONGOC_ERROR_TRANSACTION_INVALID_STATE,
+                         "Transactions are not supported in snapshot sessions");
       ret = false;
       GOTO (done);
    }
 
    if (server_stream->sd->max_wire_version < 7 ||
        (server_stream->sd->max_wire_version < 8 && server_stream->sd->type == MONGOC_SERVER_MONGOS)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_TRANSACTION,
-                      MONGOC_ERROR_TRANSACTION_INVALID_STATE,
-                      "Multi-document transactions are not supported by this "
-                      "server version");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_TRANSACTION,
+                         MONGOC_ERROR_TRANSACTION_INVALID_STATE,
+                         "Multi-document transactions are not supported by this "
+                         "server version");
       ret = false;
       GOTO (done);
    }
@@ -1067,7 +1068,7 @@ mongoc_client_session_start_transaction (mongoc_client_session_t *session,
    switch (session->txn.state) {
    case MONGOC_INTERNAL_TRANSACTION_STARTING:
    case MONGOC_INTERNAL_TRANSACTION_IN_PROGRESS:
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_TRANSACTION, MONGOC_ERROR_TRANSACTION_INVALID_STATE, "Transaction already in progress");
       ret = false;
       GOTO (done);
@@ -1096,10 +1097,10 @@ mongoc_client_session_start_transaction (mongoc_client_session_t *session,
    }
 
    if (!mongoc_write_concern_is_acknowledged (session->txn.opts.write_concern)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_TRANSACTION,
-                      MONGOC_ERROR_TRANSACTION_INVALID_STATE,
-                      "Transactions do not support unacknowledged write concern");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_TRANSACTION,
+                         MONGOC_ERROR_TRANSACTION_INVALID_STATE,
+                         "Transactions do not support unacknowledged write concern");
       ret = false;
       GOTO (done);
    }
@@ -1194,7 +1195,7 @@ mongoc_client_session_commit_transaction (mongoc_client_session_t *session, bson
 
    switch (session->txn.state) {
    case MONGOC_INTERNAL_TRANSACTION_NONE:
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_TRANSACTION, MONGOC_ERROR_TRANSACTION_INVALID_STATE, "No transaction started");
       _mongoc_bson_init_if_set (reply);
       break;
@@ -1222,10 +1223,10 @@ mongoc_client_session_commit_transaction (mongoc_client_session_t *session, bson
       abort ();
    case MONGOC_INTERNAL_TRANSACTION_ABORTED:
    default:
-      bson_set_error (error,
-                      MONGOC_ERROR_TRANSACTION,
-                      MONGOC_ERROR_TRANSACTION_INVALID_STATE,
-                      "Cannot call commitTransaction after calling abortTransaction");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_TRANSACTION,
+                         MONGOC_ERROR_TRANSACTION_INVALID_STATE,
+                         "Cannot call commitTransaction after calling abortTransaction");
       _mongoc_bson_init_if_set (reply);
       break;
    }
@@ -1261,13 +1262,13 @@ mongoc_client_session_abort_transaction (mongoc_client_session_t *session, bson_
       RETURN (true);
    case MONGOC_INTERNAL_TRANSACTION_COMMITTED:
    case MONGOC_INTERNAL_TRANSACTION_COMMITTED_EMPTY:
-      bson_set_error (error,
-                      MONGOC_ERROR_TRANSACTION,
-                      MONGOC_ERROR_TRANSACTION_INVALID_STATE,
-                      "Cannot call abortTransaction after calling commitTransaction");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_TRANSACTION,
+                         MONGOC_ERROR_TRANSACTION_INVALID_STATE,
+                         "Cannot call abortTransaction after calling commitTransaction");
       RETURN (false);
    case MONGOC_INTERNAL_TRANSACTION_ABORTED:
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_TRANSACTION, MONGOC_ERROR_TRANSACTION_INVALID_STATE, "Cannot call abortTransaction twice");
       RETURN (false);
    case MONGOC_INTERNAL_TRANSACTION_ENDING:
@@ -1275,7 +1276,7 @@ mongoc_client_session_abort_transaction (mongoc_client_session_t *session, bson_
       abort ();
    case MONGOC_INTERNAL_TRANSACTION_NONE:
    default:
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_TRANSACTION, MONGOC_ERROR_TRANSACTION_INVALID_STATE, "No transaction started");
       RETURN (false);
    }
@@ -1293,7 +1294,7 @@ _mongoc_client_session_from_iter (mongoc_client_t *client,
 
    /* must be int64 that fits in uint32 */
    if (!BSON_ITER_HOLDS_INT64 (iter) || bson_iter_int64 (iter) > 0xffffffff) {
-      bson_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "Invalid sessionId");
+      _mongoc_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "Invalid sessionId");
       RETURN (false);
    }
 
@@ -1389,7 +1390,7 @@ _mongoc_client_session_append_txn (mongoc_client_session_t *session, bson_t *cmd
    }
 
    if (bson_empty0 (cmd)) {
-      bson_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "Empty command in transaction");
+      _mongoc_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "Empty command in transaction");
       RETURN (false);
    }
 
@@ -1527,7 +1528,7 @@ mongoc_client_session_append (const mongoc_client_session_t *client_session, bso
    BSON_ASSERT (opts);
 
    if (!bson_append_int64 (opts, "sessionId", 9, client_session->client_session_id)) {
-      bson_set_error (error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, "invalid opts");
+      _mongoc_set_error (error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, "invalid opts");
 
       RETURN (false);
    }

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -96,10 +96,10 @@ _mongoc_client_killcursors_command (mongoc_cluster_t *cluster,
                                     const char *collection,
                                     mongoc_client_session_t *cs);
 
-#define DNS_ERROR(_msg, ...)                                                                               \
-   do {                                                                                                    \
-      bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_NAME_RESOLUTION, _msg, __VA_ARGS__); \
-      GOTO (done);                                                                                         \
+#define DNS_ERROR(_msg, ...)                                                                                  \
+   do {                                                                                                       \
+      _mongoc_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_NAME_RESOLUTION, _msg, __VA_ARGS__); \
+      GOTO (done);                                                                                            \
    } while (0)
 
 
@@ -573,10 +573,10 @@ _mongoc_client_get_rr (const char *hostname,
 
 #if MONGOC_ENABLE_SRV == 0
    // Disabled
-   bson_set_error (error,
-                   MONGOC_ERROR_STREAM,
-                   MONGOC_ERROR_STREAM_NAME_RESOLUTION,
-                   "libresolv unavailable, cannot use mongodb+srv URI");
+   _mongoc_set_error (error,
+                      MONGOC_ERROR_STREAM,
+                      MONGOC_ERROR_STREAM_NAME_RESOLUTION,
+                      "libresolv unavailable, cannot use mongodb+srv URI");
    return false;
 #elif defined(MONGOC_HAVE_DNSAPI)
    return _mongoc_get_rr_dnsapi (hostname, rr_type, rr_data, prefer_tcp, error);
@@ -640,7 +640,7 @@ mongoc_client_connect_tcp (int32_t connecttimeoutms, const mongoc_host_list_t *h
    if (s != 0) {
       mongoc_counter_dns_failure_inc ();
       TRACE ("Failed to resolve %s", host->host);
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_NAME_RESOLUTION, "Failed to resolve %s", host->host);
       RETURN (NULL);
    }
@@ -669,11 +669,11 @@ mongoc_client_connect_tcp (int32_t connecttimeoutms, const mongoc_host_list_t *h
    }
 
    if (!sock) {
-      bson_set_error (error,
-                      MONGOC_ERROR_STREAM,
-                      MONGOC_ERROR_STREAM_CONNECT,
-                      "Failed to connect to target host: %s",
-                      host->host_and_port);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_STREAM,
+                         MONGOC_ERROR_STREAM_CONNECT,
+                         "Failed to connect to target host: %s",
+                         host->host_and_port);
       freeaddrinfo (result);
       RETURN (NULL);
    }
@@ -706,7 +706,7 @@ mongoc_client_connect_unix (const mongoc_host_list_t *host, bson_error_t *error)
 {
 #ifdef _WIN32
    ENTRY;
-   bson_set_error (
+   _mongoc_set_error (
       error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_CONNECT, "UNIX domain sockets not supported on win32.");
    RETURN (NULL);
 #else
@@ -724,20 +724,21 @@ mongoc_client_connect_unix (const mongoc_host_list_t *host, bson_error_t *error)
    int req = bson_snprintf (saddr.sun_path, sizeof saddr.sun_path - 1, "%s", host->host);
 
    if (mcommon_cmp_greater_equal_su (req, sizeof saddr.sun_path - 1)) {
-      bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Failed to define socket address path.");
+      _mongoc_set_error (
+         error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Failed to define socket address path.");
       RETURN (NULL);
    }
 
    sock = mongoc_socket_new (AF_UNIX, SOCK_STREAM, 0);
 
    if (sock == NULL) {
-      bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Failed to create socket.");
+      _mongoc_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Failed to create socket.");
       RETURN (NULL);
    }
 
    if (-1 == mongoc_socket_connect (sock, (struct sockaddr *) &saddr, sizeof saddr, -1)) {
       mongoc_socket_destroy (sock);
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_CONNECT, "Failed to connect to UNIX domain socket.");
       RETURN (NULL);
    }
@@ -765,10 +766,10 @@ mongoc_client_connect (bool buffered,
 
 #ifndef MONGOC_ENABLE_SSL
    if (ssl_opts_void || mongoc_uri_get_tls (uri)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_CLIENT,
-                      MONGOC_ERROR_CLIENT_NO_ACCEPTABLE_PEER,
-                      "TLS is not enabled in this build of mongo-c-driver.");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_CLIENT,
+                         MONGOC_ERROR_CLIENT_NO_ACCEPTABLE_PEER,
+                         "TLS is not enabled in this build of mongo-c-driver.");
       return NULL;
    }
 #endif
@@ -788,11 +789,11 @@ mongoc_client_connect (bool buffered,
       base_stream = mongoc_client_connect_unix (host, error);
       break;
    default:
-      bson_set_error (error,
-                      MONGOC_ERROR_STREAM,
-                      MONGOC_ERROR_STREAM_INVALID_TYPE,
-                      "Invalid address family: 0x%02x",
-                      (unsigned int) host->family);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_STREAM,
+                         MONGOC_ERROR_STREAM_INVALID_TYPE,
+                         "Invalid address family: 0x%02x",
+                         (unsigned int) host->family);
       break;
    }
 
@@ -817,7 +818,7 @@ mongoc_client_connect (bool buffered,
 
          if (!base_stream) {
             mongoc_stream_destroy (original);
-            bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Failed initialize TLS state.");
+            _mongoc_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Failed initialize TLS state.");
             return NULL;
          }
 
@@ -1042,10 +1043,10 @@ mongoc_client_new_from_uri_with_error (const mongoc_uri_t *uri, bson_error_t *er
 
 #ifndef MONGOC_ENABLE_SSL
    if (mongoc_uri_get_tls (uri)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "Can't create SSL client, SSL not enabled in this build.");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "Can't create SSL client, SSL not enabled in this build.");
       RETURN (NULL);
    }
 #endif
@@ -1252,10 +1253,10 @@ mongoc_client_start_session (mongoc_client_t *client, const mongoc_session_opt_t
 
    /* causal consistency and snapshot cannot both be set. */
    if (opts && mongoc_session_opts_get_causal_consistency (opts) && mongoc_session_opts_get_snapshot (opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_CLIENT,
-                      MONGOC_ERROR_CLIENT_SESSION_FAILURE,
-                      "Only one of causal consistency and snapshot can be enabled.");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_CLIENT,
+                         MONGOC_ERROR_CLIENT_SESSION_FAILURE,
+                         "Only one of causal consistency and snapshot can be enabled.");
       _mongoc_client_push_server_session (client, ss);
       RETURN (NULL);
    }
@@ -1853,33 +1854,33 @@ _mongoc_client_command_with_opts (mongoc_client_t *client,
    cs = read_write_opts.client_session;
 
    if (!command_name) {
-      bson_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "Empty command document");
+      _mongoc_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "Empty command document");
       GOTO (done);
    }
 
    if (_mongoc_client_session_in_txn (read_write_opts.client_session)) {
       if ((mode == MONGOC_CMD_READ || mode == MONGOC_CMD_RAW) && !IS_PREF_PRIMARY (user_prefs)) {
-         bson_set_error (error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Read preference in a transaction must be primary");
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_COMMAND,
+                            MONGOC_ERROR_COMMAND_INVALID_ARG,
+                            "Read preference in a transaction must be primary");
          GOTO (done);
       }
 
       if (!bson_empty (&read_write_opts.readConcern)) {
-         bson_set_error (error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Cannot set read concern after starting transaction");
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_COMMAND,
+                            MONGOC_ERROR_COMMAND_INVALID_ARG,
+                            "Cannot set read concern after starting transaction");
          GOTO (done);
       }
 
       if (read_write_opts.writeConcern && strcmp (command_name, "commitTransaction") != 0 &&
           strcmp (command_name, "abortTransaction") != 0) {
-         bson_set_error (error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Cannot set write concern after starting transaction");
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_COMMAND,
+                            MONGOC_ERROR_COMMAND_INVALID_ARG,
+                            "Cannot set write concern after starting transaction");
          GOTO (done);
       }
    }
@@ -2681,10 +2682,10 @@ mongoc_client_select_server (mongoc_client_t *client,
    mongoc_server_description_t *sd;
 
    if (for_writes && prefs) {
-      bson_set_error (error,
-                      MONGOC_ERROR_SERVER_SELECTION,
-                      MONGOC_ERROR_SERVER_SELECTION_FAILURE,
-                      "Cannot use read preferences with for_writes = true");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_SERVER_SELECTION,
+                         MONGOC_ERROR_SERVER_SELECTION_FAILURE,
+                         "Cannot use read preferences with for_writes = true");
       return NULL;
    }
 
@@ -2794,7 +2795,7 @@ _mongoc_client_lookup_session (const mongoc_client_t *client,
       RETURN (true);
    }
 
-   bson_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "Invalid sessionId");
+   _mongoc_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "Invalid sessionId");
 
    RETURN (false);
 }
@@ -2928,11 +2929,11 @@ mongoc_client_enable_auto_encryption (mongoc_client_t *client, mongoc_auto_encry
    BSON_ASSERT_PARAM (client);
 
    if (!client->topology->single_threaded) {
-      bson_set_error (error,
-                      MONGOC_ERROR_CLIENT,
-                      MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
-                      "Cannot enable auto encryption on a pooled client, use "
-                      "mongoc_client_pool_enable_auto_encryption");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_CLIENT,
+                         MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
+                         "Cannot enable auto encryption on a pooled client, use "
+                         "mongoc_client_pool_enable_auto_encryption");
       return false;
    }
    return _mongoc_cse_client_enable_auto_encryption (client, opts, error);
@@ -2945,18 +2946,18 @@ mongoc_client_set_server_api (mongoc_client_t *client, const mongoc_server_api_t
    BSON_ASSERT_PARAM (api);
 
    if (!client->topology->single_threaded) {
-      bson_set_error (error,
-                      MONGOC_ERROR_CLIENT,
-                      MONGOC_ERROR_CLIENT_API_FROM_POOL,
-                      "Cannot set server api on a client checked out from a pool");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_CLIENT,
+                         MONGOC_ERROR_CLIENT_API_FROM_POOL,
+                         "Cannot set server api on a client checked out from a pool");
       return false;
    }
 
    if (mongoc_client_uses_server_api (client)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_CLIENT,
-                      MONGOC_ERROR_CLIENT_API_ALREADY_SET,
-                      "Cannot set server api more than once per client");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_CLIENT,
+                         MONGOC_ERROR_CLIENT_API_ALREADY_SET,
+                         "Cannot set server api more than once per client");
       return false;
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
@@ -20,6 +20,7 @@
 #include "mcd-time.h"
 #include "mongoc-cluster-aws-private.h"
 #include "mongoc-client-private.h"
+#include "mongoc-error-private.h"
 #include "mongoc-host-list-private.h"
 #include "mongoc-rand-private.h"
 #include "mongoc-stream-private.h"
@@ -34,10 +35,10 @@
 #undef MONGOC_LOG_DOMAIN
 #define MONGOC_LOG_DOMAIN "aws_auth"
 
-#define AUTH_ERROR_AND_FAIL(...)                                                                  \
-   do {                                                                                           \
-      bson_set_error (error, MONGOC_ERROR_CLIENT, MONGOC_ERROR_CLIENT_AUTHENTICATE, __VA_ARGS__); \
-      goto fail;                                                                                  \
+#define AUTH_ERROR_AND_FAIL(...)                                                                     \
+   do {                                                                                              \
+      _mongoc_set_error (error, MONGOC_ERROR_CLIENT, MONGOC_ERROR_CLIENT_AUTHENTICATE, __VA_ARGS__); \
+      goto fail;                                                                                     \
    } while (0)
 
 
@@ -553,11 +554,11 @@ _obtain_creds_from_assumerolewithwebidentity (_mongoc_aws_credentials_t *creds, 
          goto fail;
       }
       char *Error_json = bson_as_relaxed_extended_json (&Error_bson, NULL);
-      bson_set_error (error,
-                      MONGOC_ERROR_CLIENT,
-                      MONGOC_ERROR_CLIENT_AUTHENTICATE,
-                      "Response to AssumeRoleWithWebIdentity contains 'Error': %s",
-                      Error_json);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_CLIENT,
+                         MONGOC_ERROR_CLIENT_AUTHENTICATE,
+                         "Response to AssumeRoleWithWebIdentity contains 'Error': %s",
+                         Error_json);
       bson_free (Error_json);
       goto fail;
    }

--- a/src/libmongoc/src/mongoc/mongoc-cluster-cyrus.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-cyrus.c
@@ -21,6 +21,7 @@
 #include "mongoc-cyrus-private.h"
 #include "mongoc-cluster-cyrus-private.h"
 #include "mongoc-error.h"
+#include "mongoc-error-private.h"
 #include "mongoc-trace-private.h"
 
 bool
@@ -105,10 +106,10 @@ _mongoc_cluster_auth_node_cyrus (mongoc_cluster_t *cluster,
       if (!bson_iter_init_find (&iter, &reply, "payload") || !BSON_ITER_HOLDS_UTF8 (&iter)) {
          MONGOC_DEBUG ("SASL: authentication failed");
          bson_destroy (&reply);
-         bson_set_error (error,
-                         MONGOC_ERROR_CLIENT,
-                         MONGOC_ERROR_CLIENT_AUTHENTICATE,
-                         "Received invalid SASL reply from MongoDB server.");
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_CLIENT,
+                            MONGOC_ERROR_CLIENT_AUTHENTICATE,
+                            "Received invalid SASL reply from MongoDB server.");
          goto failure;
       }
 

--- a/src/libmongoc/src/mongoc/mongoc-cluster-sasl.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-sasl.c
@@ -24,6 +24,7 @@
 #include "mongoc-stream-private.h"
 #include "mongoc-stream-socket.h"
 #include "mongoc-error.h"
+#include "mongoc-error-private.h"
 #include "mongoc-util-private.h"
 
 #ifdef MONGOC_ENABLE_SASL
@@ -88,11 +89,11 @@ _mongoc_cluster_auth_node_sasl (mongoc_cluster_t *cluster,
                                 bson_error_t *error)
 {
 #ifndef MONGOC_ENABLE_SASL
-   bson_set_error (error,
-                   MONGOC_ERROR_CLIENT,
-                   MONGOC_ERROR_CLIENT_AUTHENTICATE,
-                   "The GSSAPI authentication mechanism requires libmongoc "
-                   "built with ENABLE_SASL");
+   _mongoc_set_error (error,
+                      MONGOC_ERROR_CLIENT,
+                      MONGOC_ERROR_CLIENT_AUTHENTICATE,
+                      "The GSSAPI authentication mechanism requires libmongoc "
+                      "built with ENABLE_SASL");
    return false;
 #elif defined(MONGOC_ENABLE_SASL_CYRUS)
    return _mongoc_cluster_auth_node_cyrus (cluster, stream, sd, error);

--- a/src/libmongoc/src/mongoc/mongoc-cluster-sspi.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-sspi.c
@@ -23,6 +23,7 @@
 #include "mongoc-sasl-private.h"
 #include "mongoc-sspi-private.h"
 #include "mongoc-error.h"
+#include "mongoc-error-private.h"
 #include "mongoc-util-private.h"
 
 
@@ -140,7 +141,7 @@ _mongoc_cluster_auth_node_sspi (mongoc_cluster_t *cluster,
    state = _mongoc_cluster_sspi_new (cluster->uri, stream, sd->host.host);
 
    if (!state) {
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_CLIENT, MONGOC_ERROR_CLIENT_AUTHENTICATE, "Couldn't initialize SSPI service.");
       goto failure;
    }
@@ -163,7 +164,8 @@ _mongoc_cluster_auth_node_sspi (mongoc_cluster_t *cluster,
       }
 
       if (res == MONGOC_SSPI_AUTH_GSS_ERROR) {
-         bson_set_error (error, MONGOC_ERROR_CLIENT, MONGOC_ERROR_CLIENT_AUTHENTICATE, "Received invalid SSPI data.");
+         _mongoc_set_error (
+            error, MONGOC_ERROR_CLIENT, MONGOC_ERROR_CLIENT_AUTHENTICATE, "Received invalid SSPI data.");
 
          mongoc_cmd_parts_cleanup (&parts);
          bson_destroy (&cmd);
@@ -211,10 +213,10 @@ _mongoc_cluster_auth_node_sspi (mongoc_cluster_t *cluster,
 
       if (!bson_iter_init_find (&iter, &reply, "payload") || !BSON_ITER_HOLDS_UTF8 (&iter)) {
          bson_destroy (&reply);
-         bson_set_error (error,
-                         MONGOC_ERROR_CLIENT,
-                         MONGOC_ERROR_CLIENT_AUTHENTICATE,
-                         "Received invalid SASL reply from MongoDB server.");
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_CLIENT,
+                            MONGOC_ERROR_CLIENT_AUTHENTICATE,
+                            "Received invalid SASL reply from MongoDB server.");
          goto failure;
       }
 

--- a/src/libmongoc/src/mongoc/mongoc-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-cmd.c
@@ -19,6 +19,7 @@
 #include "mongoc-read-prefs-private.h"
 #include "mongoc-trace-private.h"
 #include "mongoc-client-private.h"
+#include "mongoc-error-private.h"
 #include "mongoc-read-concern-private.h"
 #include "mongoc-server-api-private.h"
 #include "mongoc-write-concern-private.h"
@@ -138,7 +139,8 @@ mongoc_cmd_parts_append_opts (mongoc_cmd_parts_t *parts, bson_iter_t *iter, bson
          continue;
       } else if (BSON_ITER_IS_KEY (iter, "readConcern")) {
          if (!BSON_ITER_HOLDS_DOCUMENT (iter)) {
-            bson_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION, "Invalid readConcern");
+            _mongoc_set_error (
+               error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION, "Invalid readConcern");
             RETURN (false);
          }
 
@@ -164,11 +166,11 @@ mongoc_cmd_parts_append_opts (mongoc_cmd_parts_t *parts, bson_iter_t *iter, bson
 
       to_append = bson_iter_key (iter);
       if (!bson_append_iter (&parts->extra, to_append, -1, iter)) {
-         bson_set_error (error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Failed to append \"%s\" to create command.",
-                         to_append);
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_COMMAND,
+                            MONGOC_ERROR_COMMAND_INVALID_ARG,
+                            "Failed to append \"%s\" to create command.",
+                            to_append);
          RETURN (false);
       }
    }
@@ -177,10 +179,10 @@ mongoc_cmd_parts_append_opts (mongoc_cmd_parts_t *parts, bson_iter_t *iter, bson
 }
 
 
-#define OPTS_ERR(_code, ...)                                                           \
-   do {                                                                                \
-      bson_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_##_code, __VA_ARGS__); \
-      RETURN (false);                                                                  \
+#define OPTS_ERR(_code, ...)                                                              \
+   do {                                                                                   \
+      _mongoc_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_##_code, __VA_ARGS__); \
+      RETURN (false);                                                                     \
    } while (0)
 
 
@@ -734,11 +736,11 @@ mongoc_cmd_parts_assemble (mongoc_cmd_parts_t *parts, mongoc_server_stream_t *se
     * been invalidated, error. */
    if (server_type == MONGOC_SERVER_UNKNOWN) {
       if (error) {
-         bson_set_error (error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Cannot assemble command for invalidated server: %s",
-                         server_stream->sd->error.message);
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_COMMAND,
+                            MONGOC_ERROR_COMMAND_INVALID_ARG,
+                            "Cannot assemble command for invalidated server: %s",
+                            server_stream->sd->error.message);
       }
       RETURN (false);
    }
@@ -755,7 +757,7 @@ mongoc_cmd_parts_assemble (mongoc_cmd_parts_t *parts, mongoc_server_stream_t *se
    cmd_name = parts->assembled.command_name = _mongoc_get_command_name (parts->assembled.command);
 
    if (!parts->assembled.command_name) {
-      bson_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "Empty command document");
+      _mongoc_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "Empty command document");
       GOTO (done);
    }
 
@@ -788,10 +790,10 @@ mongoc_cmd_parts_assemble (mongoc_cmd_parts_t *parts, mongoc_server_stream_t *se
 
       if (cs && _mongoc_client_session_in_txn (cs)) {
          if (!IS_PREF_PRIMARY (cs->txn.opts.read_prefs) && !parts->is_write_command) {
-            bson_set_error (error,
-                            MONGOC_ERROR_TRANSACTION,
-                            MONGOC_ERROR_TRANSACTION_INVALID_STATE,
-                            "Read preference in a transaction must be primary");
+            _mongoc_set_error (error,
+                               MONGOC_ERROR_TRANSACTION,
+                               MONGOC_ERROR_TRANSACTION_INVALID_STATE,
+                               "Read preference in a transaction must be primary");
             GOTO (done);
          }
       } else if (mode != MONGOC_READ_PRIMARY && server_type != MONGOC_SERVER_STANDALONE) {
@@ -824,10 +826,10 @@ mongoc_cmd_parts_assemble (mongoc_cmd_parts_t *parts, mongoc_server_stream_t *se
        */
       if (cs) {
          if (!parts->assembled.is_acknowledged) {
-            bson_set_error (error,
-                            MONGOC_ERROR_COMMAND,
-                            MONGOC_ERROR_COMMAND_INVALID_ARG,
-                            "Cannot use client session with unacknowledged command");
+            _mongoc_set_error (error,
+                               MONGOC_ERROR_COMMAND,
+                               MONGOC_ERROR_COMMAND_INVALID_ARG,
+                               "Cannot use client session with unacknowledged command");
             GOTO (done);
          }
 
@@ -879,10 +881,10 @@ mongoc_cmd_parts_assemble (mongoc_cmd_parts_t *parts, mongoc_server_stream_t *se
              * than 13 before potentially appending "snapshot" read concern. */
             if (mongoc_session_opts_get_snapshot (&cs->opts) &&
                 server_stream->sd->max_wire_version < WIRE_VERSION_SNAPSHOT_READS) {
-               bson_set_error (error,
-                               MONGOC_ERROR_CLIENT,
-                               MONGOC_ERROR_CLIENT_SESSION_FAILURE,
-                               "Snapshot reads require MongoDB 5.0 or later");
+               _mongoc_set_error (error,
+                                  MONGOC_ERROR_CLIENT,
+                                  MONGOC_ERROR_CLIENT_SESSION_FAILURE,
+                                  "Snapshot reads require MongoDB 5.0 or later");
                GOTO (done);
             }
 

--- a/src/libmongoc/src/mongoc/mongoc-crypt.c
+++ b/src/libmongoc/src/mongoc/mongoc-crypt.c
@@ -28,6 +28,7 @@
 #include "mongoc-stream-private.h"
 #include "mongoc-ssl-private.h"
 #include "mongoc-cluster-aws-private.h"
+#include "mongoc-error-private.h"
 #include "mongoc-util-private.h"
 #include "mongoc-http-private.h"
 #include "mcd-azure.h"
@@ -169,7 +170,7 @@ _prefix_mongocryptd_error (bson_error_t *error)
    char buf[sizeof (error->message)];
 
    // Truncation is OK.
-   int req = bson_snprintf (buf, sizeof (buf), "mongocryptd error: %s:", error->message);
+   int req = bson_snprintf (buf, sizeof (buf), "mongoc: mongocryptd error: %s:", error->message);
    BSON_ASSERT (req > 0);
    memcpy (error->message, buf, sizeof (buf));
 }
@@ -180,7 +181,7 @@ _prefix_keyvault_error (bson_error_t *error)
    char buf[sizeof (error->message)];
 
    // Truncation is OK.
-   int req = bson_snprintf (buf, sizeof (buf), "key vault error: %s:", error->message);
+   int req = bson_snprintf (buf, sizeof (buf), "mongoc: key vault error: %s:", error->message);
    BSON_ASSERT (req > 0);
    memcpy (error->message, buf, sizeof (buf));
 }
@@ -191,7 +192,7 @@ _status_to_error (mongocrypt_status_t *status, bson_error_t *error)
    bson_set_error (error,
                    MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
                    mongocrypt_status_code (status),
-                   "%s",
+                   "crypt: %s",
                    mongocrypt_status_message (status, NULL));
 }
 
@@ -213,10 +214,10 @@ _ctx_check_error (mongocrypt_ctx_t *ctx, bson_error_t *error, bool error_expecte
       mongocrypt_status_destroy (status);
       return false;
    } else if (error_expected) {
-      bson_set_error (error,
-                      MONGOC_ERROR_CLIENT,
-                      MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_STATE,
-                      "generic error from libmongocrypt operation");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_CLIENT,
+                         MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_STATE,
+                         "generic error from libmongocrypt operation");
       mongocrypt_status_destroy (status);
       return false;
    }
@@ -235,10 +236,10 @@ _kms_ctx_check_error (mongocrypt_kms_ctx_t *kms_ctx, bson_error_t *error, bool e
       mongocrypt_status_destroy (status);
       return false;
    } else if (error_expected) {
-      bson_set_error (error,
-                      MONGOC_ERROR_CLIENT,
-                      MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_STATE,
-                      "generic error from libmongocrypt KMS operation");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_CLIENT,
+                         MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_STATE,
+                         "generic error from libmongocrypt KMS operation");
       mongocrypt_status_destroy (status);
       return false;
    }
@@ -257,10 +258,10 @@ _crypt_check_error (mongocrypt_t *crypt, bson_error_t *error, bool error_expecte
       mongocrypt_status_destroy (status);
       return false;
    } else if (error_expected) {
-      bson_set_error (error,
-                      MONGOC_ERROR_CLIENT,
-                      MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_STATE,
-                      "generic error from libmongocrypt handle");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_CLIENT,
+                         MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_STATE,
+                         "generic error from libmongocrypt handle");
       mongocrypt_status_destroy (status);
       return false;
    }
@@ -274,7 +275,7 @@ _bin_to_static_bson (mongocrypt_binary_t *bin, bson_t *out, bson_error_t *error)
 {
    /* Copy bin into bson_t result. */
    if (!bson_init_static (out, mongocrypt_binary_data (bin), mongocrypt_binary_len (bin))) {
-      bson_set_error (error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, "invalid returned bson");
+      _mongoc_set_error (error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, "invalid returned bson");
       return false;
    }
    return true;
@@ -509,7 +510,7 @@ _get_stream (const char *endpoint, int32_t connecttimeoutms, const mongoc_ssl_op
    tls_stream = mongoc_stream_tls_new_with_hostname (base_stream, host.host, &ssl_opt_copy, 1 /* client */);
 
    if (!tls_stream) {
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Failed to create TLS stream to: %s", endpoint);
       goto fail;
    }
@@ -609,12 +610,12 @@ _state_need_kms (_state_machine_t *state_machine, bson_error_t *error)
          } else {
             bson_error_t kms_error;
             BSON_ASSERT (!_kms_ctx_check_error (kms_ctx, &kms_error, true));
-            bson_set_error (error,
-                            MONGOC_ERROR_STREAM,
-                            MONGOC_ERROR_STREAM_SOCKET,
-                            "%s. Failed to write to KMS stream: %s",
-                            kms_error.message,
-                            endpoint);
+            _mongoc_set_error (error,
+                               MONGOC_ERROR_STREAM,
+                               MONGOC_ERROR_STREAM_SOCKET,
+                               "%s. Failed to write to KMS stream: %s",
+                               kms_error.message,
+                               endpoint);
             goto fail;
          }
       }
@@ -638,12 +639,12 @@ _state_need_kms (_state_machine_t *state_machine, bson_error_t *error)
             } else {
                bson_error_t kms_error;
                BSON_ASSERT (!_kms_ctx_check_error (kms_ctx, &kms_error, true));
-               bson_set_error (error,
-                               MONGOC_ERROR_STREAM,
-                               MONGOC_ERROR_STREAM_SOCKET,
-                               "%s. Failed to read from KMS stream to: %s",
-                               kms_error.message,
-                               endpoint);
+               _mongoc_set_error (error,
+                                  MONGOC_ERROR_STREAM,
+                                  MONGOC_ERROR_STREAM_SOCKET,
+                                  "%s. Failed to read from KMS stream to: %s",
+                                  kms_error.message,
+                                  endpoint);
                goto fail;
             }
          }
@@ -850,10 +851,10 @@ _try_add_azure_from_env (_mongoc_crypt_t *crypt, bson_t *out, bson_error_t *erro
                      BSON_APPEND_DOCUMENT (out, "azure", &new_azure_creds);
    bson_destroy (&new_azure_creds);
    if (!okay) {
-      bson_set_error (error,
-                      MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
-                      MONGOC_ERROR_BSON_INVALID,
-                      "Failed to build new 'azure' credentials");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
+                         MONGOC_ERROR_BSON_INVALID,
+                         "Failed to build new 'azure' credentials");
    }
 
    return okay;
@@ -928,10 +929,10 @@ _try_add_gcp_from_env (bson_t *out, bson_error_t *error)
    bson_destroy (&new_gcp_creds);
    gcp_access_token_destroy (&gcp_token);
    if (!okay) {
-      bson_set_error (error,
-                      MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
-                      MONGOC_ERROR_BSON_INVALID,
-                      "Failed to build new 'gcp' credentials");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
+                         MONGOC_ERROR_BSON_INVALID,
+                         "Failed to build new 'gcp' credentials");
    }
 
    return okay;
@@ -951,11 +952,10 @@ _state_need_kms_credentials (_state_machine_t *sm, bson_error_t *error)
          if (!error->code) {
             // The callback did not set an error, so we'll provide a default
             // one.
-            bson_set_error (error,
-                            MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
-                            MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
-                            "The user-provided callback for on-demand KMS "
-                            "credentials failed.");
+            _mongoc_set_error (error,
+                               MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
+                               MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
+                               "The user-provided callback for on-demand KMS credentials failed.");
          }
          goto fail;
       }
@@ -1107,11 +1107,10 @@ _state_machine_run (_state_machine_t *state_machine, bson_t *result, bson_error_
          goto success;
          break;
       case MONGOCRYPT_CTX_NEED_MONGO_COLLINFO_WITH_DB:
-         bson_set_error (error,
-                         MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
-                         MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_STATE,
-                         "MONGOCRYPT_CTX_NEED_MONGO_COLLINFO_WITH_DB is "
-                         "unimplemented");
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
+                            MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_STATE,
+                            "MONGOCRYPT_CTX_NEED_MONGO_COLLINFO_WITH_DB is unimplemented");
          goto fail;
          break;
       }
@@ -1147,22 +1146,22 @@ _parse_one_tls_opts (bson_iter_t *iter, mongoc_ssl_opt_t *out_opt, bson_error_t 
    memset (out_opt, 0, sizeof (mongoc_ssl_opt_t));
 
    if (!BSON_ITER_HOLDS_DOCUMENT (iter)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
-                      MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
-                      "Expected TLS options for %s to be a document, got: %s",
-                      kms_provider,
-                      _mongoc_bson_type_to_str (bson_iter_type (iter)));
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
+                         MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
+                         "Expected TLS options for %s to be a document, got: %s",
+                         kms_provider,
+                         _mongoc_bson_type_to_str (bson_iter_type (iter)));
       goto fail;
    }
 
    bson_iter_document (iter, &len, &data);
    if (!bson_init_static (&tls_opts_doc, data, len) || !bson_iter_init (&permitted_iter, &tls_opts_doc)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
-                      MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
-                      "Error iterating into TLS options document for %s",
-                      kms_provider);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
+                         MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
+                         "Error iterating into TLS options document for %s",
+                         kms_provider);
       goto fail;
    }
 
@@ -1185,22 +1184,22 @@ _parse_one_tls_opts (bson_iter_t *iter, mongoc_ssl_opt_t *out_opt, bson_error_t 
          continue;
       }
 
-      bson_set_error (error,
-                      MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
-                      MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
-                      "Error setting TLS option %s for %s. Insecure TLS options prohibited.",
-                      key,
-                      kms_provider);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
+                         MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
+                         "Error setting TLS option %s for %s. Insecure TLS options prohibited.",
+                         key,
+                         kms_provider);
       goto fail;
    }
 
    if (!_mongoc_ssl_opts_from_bson (out_opt, &tls_opts_doc, errmsg)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
-                      MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
-                      "Error parsing TLS options for %s: %s",
-                      kms_provider,
-                      errmsg->str);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
+                         MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
+                         "Error parsing TLS options for %s: %s",
+                         kms_provider,
+                         errmsg->str);
       goto fail;
    }
 
@@ -1231,10 +1230,10 @@ _parse_all_tls_opts (_mongoc_crypt_t *crypt, const bson_t *tls_opts, bson_error_
    }
 
    if (!bson_iter_init (&iter, tls_opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
-                      MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
-                      "Error starting iteration of TLS options");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
+                         MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
+                         "Error starting iteration of TLS options");
       goto fail;
    }
 
@@ -1244,11 +1243,11 @@ _parse_all_tls_opts (_mongoc_crypt_t *crypt, const bson_t *tls_opts, bson_error_
       key = bson_iter_key (&iter);
       if (0 == strcmp (key, "aws")) {
          if (has_aws) {
-            bson_set_error (error,
-                            MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
-                            MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
-                            "Error parsing duplicate TLS options for %s",
-                            key);
+            _mongoc_set_error (error,
+                               MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
+                               MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
+                               "Error parsing duplicate TLS options for %s",
+                               key);
             goto fail;
          }
 
@@ -1261,11 +1260,11 @@ _parse_all_tls_opts (_mongoc_crypt_t *crypt, const bson_t *tls_opts, bson_error_
 
       if (0 == strcmp (key, "azure")) {
          if (has_azure) {
-            bson_set_error (error,
-                            MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
-                            MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
-                            "Error parsing duplicate TLS options for %s",
-                            key);
+            _mongoc_set_error (error,
+                               MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
+                               MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
+                               "Error parsing duplicate TLS options for %s",
+                               key);
             goto fail;
          }
 
@@ -1278,11 +1277,11 @@ _parse_all_tls_opts (_mongoc_crypt_t *crypt, const bson_t *tls_opts, bson_error_
 
       if (0 == strcmp (key, "gcp")) {
          if (has_gcp) {
-            bson_set_error (error,
-                            MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
-                            MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
-                            "Error parsing duplicate TLS options for %s",
-                            key);
+            _mongoc_set_error (error,
+                               MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
+                               MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
+                               "Error parsing duplicate TLS options for %s",
+                               key);
             goto fail;
          }
 
@@ -1295,11 +1294,11 @@ _parse_all_tls_opts (_mongoc_crypt_t *crypt, const bson_t *tls_opts, bson_error_
 
       if (0 == strcmp (key, "kmip")) {
          if (has_kmip) {
-            bson_set_error (error,
-                            MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
-                            MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
-                            "Error parsing duplicate TLS options for %s",
-                            key);
+            _mongoc_set_error (error,
+                               MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
+                               MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
+                               "Error parsing duplicate TLS options for %s",
+                               key);
             goto fail;
          }
 
@@ -1314,11 +1313,11 @@ _parse_all_tls_opts (_mongoc_crypt_t *crypt, const bson_t *tls_opts, bson_error_
       if (colon_pos != NULL) {
          // Parse TLS options for a named KMS provider.
          if (mcd_mapof_kmsid_to_tlsopts_has (crypt->kmsid_to_tlsopts, key)) {
-            bson_set_error (error,
-                            MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
-                            MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
-                            "Error parsing duplicate TLS options for %s",
-                            key);
+            _mongoc_set_error (error,
+                               MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
+                               MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
+                               "Error parsing duplicate TLS options for %s",
+                               key);
             goto fail;
          }
 
@@ -1332,11 +1331,11 @@ _parse_all_tls_opts (_mongoc_crypt_t *crypt, const bson_t *tls_opts, bson_error_
          continue;
       }
 
-      bson_set_error (error,
-                      MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
-                      MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
-                      "Cannot configure TLS options for KMS provider: %s",
-                      key);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
+                         MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG,
+                         "Cannot configure TLS options for KMS provider: %s",
+                         key);
       goto fail;
    }
 
@@ -1476,11 +1475,11 @@ _mongoc_crypt_new (const bson_t *kms_providers,
       if (!s || len == 0) {
          // empty/null version string indicates that crypt_shared was not loaded
          // by libmongocrypt
-         bson_set_error (error,
-                         MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
-                         MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_STATE,
-                         "Option 'cryptSharedLibRequired' is 'true', but failed to "
-                         "load the crypt_shared runtime library");
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION,
+                            MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_STATE,
+                            "Option 'cryptSharedLibRequired' is 'true', but failed to "
+                            "load the crypt_shared runtime library");
          goto fail;
       }
       mongoc_log (
@@ -1693,7 +1692,7 @@ _create_explicit_state_machine (_mongoc_crypt_t *crypt,
       bool keyid_ret;
 
       if (keyid->value.v_binary.subtype != BSON_SUBTYPE_UUID) {
-         bson_set_error (
+         _mongoc_set_error (
             error, MONGOC_ERROR_CLIENT, MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG, "keyid must be a UUID");
          goto fail;
       }
@@ -1770,10 +1769,10 @@ _mongoc_crypt_explicit_encrypt (_mongoc_crypt_t *crypt,
 
    /* extract value */
    if (!bson_iter_init_find (&iter, &result, "v")) {
-      bson_set_error (error,
-                      MONGOC_ERROR_CLIENT,
-                      MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_STATE,
-                      "encrypted result unexpected: no 'v' found");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_CLIENT,
+                         MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_STATE,
+                         "encrypted result unexpected: no 'v' found");
       goto fail;
    } else {
       const bson_value_t *tmp;
@@ -1845,20 +1844,20 @@ _mongoc_crypt_explicit_encrypt_expression (_mongoc_crypt_t *crypt,
 
    /* extract document */
    if (!bson_iter_init_find (&iter, &result, "v")) {
-      bson_set_error (error,
-                      MONGOC_ERROR_CLIENT,
-                      MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_STATE,
-                      "encrypted result unexpected: no 'v' found");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_CLIENT,
+                         MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_STATE,
+                         "encrypted result unexpected: no 'v' found");
       goto fail;
    } else {
       bson_t tmp;
 
       if (!BSON_ITER_HOLDS_DOCUMENT (&iter)) {
-         bson_set_error (error,
-                         MONGOC_ERROR_CLIENT,
-                         MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_STATE,
-                         "encrypted result unexpected: 'v' is not a document, got: %s",
-                         _mongoc_bson_type_to_str (bson_iter_type (&iter)));
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_CLIENT,
+                            MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_STATE,
+                            "encrypted result unexpected: 'v' is not a document, got: %s",
+                            _mongoc_bson_type_to_str (bson_iter_type (&iter)));
          goto fail;
       }
 
@@ -1915,7 +1914,7 @@ _mongoc_crypt_explicit_decrypt (_mongoc_crypt_t *crypt,
 
    /* extract value */
    if (!bson_iter_init_find (&iter, &result, "v")) {
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_CLIENT, MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_STATE, "decrypted result unexpected");
       goto fail;
    } else {

--- a/src/libmongoc/src/mongoc/mongoc-cursor-change-stream.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor-change-stream.c
@@ -16,6 +16,7 @@
 #include "mongoc.h"
 #include "mongoc-cursor-private.h"
 #include "mongoc-client-private.h"
+#include "mongoc-error-private.h"
 
 typedef struct _data_change_stream_t {
    mongoc_cursor_response_t response;
@@ -134,7 +135,7 @@ _mongoc_cursor_change_stream_new (mongoc_client_t *client, bson_t *reply, const 
    cursor->state = IN_BATCH;
 
    if (!_mongoc_cursor_start_reading_response (cursor, &data->response)) {
-      bson_set_error (
+      _mongoc_set_error (
          &cursor->error, MONGOC_ERROR_CURSOR, MONGOC_ERROR_CURSOR_INVALID_CURSOR, "Couldn't parse cursor document");
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-cursor-legacy.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor-legacy.c
@@ -25,6 +25,7 @@
 #include "mongoc-client-private.h"
 #include "mongoc-counters-private.h"
 #include "mongoc-error.h"
+#include "mongoc-error-private.h"
 #include "mongoc-log.h"
 #include "mongoc-trace-private.h"
 #include "mongoc-read-concern-private.h"
@@ -198,23 +199,23 @@ _mongoc_cursor_op_getmore (mongoc_cursor_t *cursor, mongoc_cursor_response_legac
 
    const int32_t op_code = mcd_rpc_header_get_op_code (response->rpc);
    if (op_code != MONGOC_OP_CODE_REPLY) {
-      bson_set_error (&cursor->error,
-                      MONGOC_ERROR_PROTOCOL,
-                      MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
-                      "invalid opcode for OP_GET_MORE: expected %" PRId32 ", got %" PRId32,
-                      MONGOC_OP_CODE_REPLY,
-                      op_code);
+      _mongoc_set_error (&cursor->error,
+                         MONGOC_ERROR_PROTOCOL,
+                         MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
+                         "invalid opcode for OP_GET_MORE: expected %" PRId32 ", got %" PRId32,
+                         MONGOC_OP_CODE_REPLY,
+                         op_code);
       GOTO (fail);
    }
 
    const int32_t response_to = mcd_rpc_header_get_response_to (response->rpc);
    if (response_to != request_id) {
-      bson_set_error (&cursor->error,
-                      MONGOC_ERROR_PROTOCOL,
-                      MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
-                      "invalid response_to for OP_GET_MORE: expected %" PRId32 ", got %" PRId32,
-                      request_id,
-                      response_to);
+      _mongoc_set_error (&cursor->error,
+                         MONGOC_ERROR_PROTOCOL,
+                         MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
+                         "invalid response_to for OP_GET_MORE: expected %" PRId32 ", got %" PRId32,
+                         request_id,
+                         response_to);
       GOTO (fail);
    }
 
@@ -255,44 +256,44 @@ done:
 }
 
 
-#define OPT_CHECK(_type)                                         \
-   do {                                                          \
-      if (!BSON_ITER_HOLDS_##_type (&iter)) {                    \
-         bson_set_error (&cursor->error,                         \
-                         MONGOC_ERROR_COMMAND,                   \
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,       \
-                         "invalid option %s, should be type %s", \
-                         key,                                    \
-                         #_type);                                \
-         return NULL;                                            \
-      }                                                          \
+#define OPT_CHECK(_type)                                            \
+   do {                                                             \
+      if (!BSON_ITER_HOLDS_##_type (&iter)) {                       \
+         _mongoc_set_error (&cursor->error,                         \
+                            MONGOC_ERROR_COMMAND,                   \
+                            MONGOC_ERROR_COMMAND_INVALID_ARG,       \
+                            "invalid option %s, should be type %s", \
+                            key,                                    \
+                            #_type);                                \
+         return NULL;                                               \
+      }                                                             \
    } while (false)
 
 
-#define OPT_CHECK_INT()                                          \
-   do {                                                          \
-      if (!BSON_ITER_HOLDS_INT (&iter)) {                        \
-         bson_set_error (&cursor->error,                         \
-                         MONGOC_ERROR_COMMAND,                   \
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,       \
-                         "invalid option %s, should be integer", \
-                         key);                                   \
-         return NULL;                                            \
-      }                                                          \
+#define OPT_CHECK_INT()                                             \
+   do {                                                             \
+      if (!BSON_ITER_HOLDS_INT (&iter)) {                           \
+         _mongoc_set_error (&cursor->error,                         \
+                            MONGOC_ERROR_COMMAND,                   \
+                            MONGOC_ERROR_COMMAND_INVALID_ARG,       \
+                            "invalid option %s, should be integer", \
+                            key);                                   \
+         return NULL;                                               \
+      }                                                             \
    } while (false)
 
 
-#define OPT_ERR(_msg)                                                                                \
-   do {                                                                                              \
-      bson_set_error (&cursor->error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, _msg); \
-      return NULL;                                                                                   \
+#define OPT_ERR(_msg)                                                                                   \
+   do {                                                                                                 \
+      _mongoc_set_error (&cursor->error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, _msg); \
+      return NULL;                                                                                      \
    } while (false)
 
 
-#define OPT_BSON_ERR(_msg)                                                                 \
-   do {                                                                                    \
-      bson_set_error (&cursor->error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, _msg); \
-      return NULL;                                                                         \
+#define OPT_BSON_ERR(_msg)                                                                    \
+   do {                                                                                       \
+      _mongoc_set_error (&cursor->error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, _msg); \
+      return NULL;                                                                            \
    } while (false)
 
 
@@ -422,10 +423,10 @@ _mongoc_cursor_parse_opts_for_op_query (mongoc_cursor_t *cursor,
          PUSH_DOLLAR_QUERY ();
          BSON_APPEND_BOOL (query, "$snapshot", bson_iter_as_bool (&iter));
       } else if (!strcmp (key, MONGOC_CURSOR_COLLATION)) {
-         bson_set_error (&cursor->error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION,
-                         "The selected server does not support collation");
+         _mongoc_set_error (&cursor->error,
+                            MONGOC_ERROR_COMMAND,
+                            MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION,
+                            "The selected server does not support collation");
          return NULL;
       }
       /* singleBatch limit and batchSize are handled in _mongoc_n_return,
@@ -441,11 +442,11 @@ _mongoc_cursor_parse_opts_for_op_query (mongoc_cursor_t *cursor,
          PUSH_DOLLAR_QUERY ();
          dollar_modifier = bson_strdup_printf ("$%s", key);
          if (!bson_append_iter (query, dollar_modifier, -1, &iter)) {
-            bson_set_error (&cursor->error,
-                            MONGOC_ERROR_BSON,
-                            MONGOC_ERROR_BSON_INVALID,
-                            "Error adding \"%s\" to query",
-                            dollar_modifier);
+            _mongoc_set_error (&cursor->error,
+                               MONGOC_ERROR_BSON,
+                               MONGOC_ERROR_BSON_INVALID,
+                               "Error adding \"%s\" to query",
+                               dollar_modifier);
             bson_free (dollar_modifier);
             return NULL;
          }
@@ -566,23 +567,23 @@ _mongoc_cursor_op_query_find (mongoc_cursor_t *cursor, bson_t *filter, mongoc_cu
 
    const int32_t op_code = mcd_rpc_header_get_op_code (response->rpc);
    if (op_code != MONGOC_OP_CODE_REPLY) {
-      bson_set_error (&cursor->error,
-                      MONGOC_ERROR_PROTOCOL,
-                      MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
-                      "invalid opcode for OP_QUERY: expected %" PRId32 ", got %" PRId32,
-                      MONGOC_OP_CODE_REPLY,
-                      op_code);
+      _mongoc_set_error (&cursor->error,
+                         MONGOC_ERROR_PROTOCOL,
+                         MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
+                         "invalid opcode for OP_QUERY: expected %" PRId32 ", got %" PRId32,
+                         MONGOC_OP_CODE_REPLY,
+                         op_code);
       GOTO (done);
    }
 
    const int32_t response_to = mcd_rpc_header_get_response_to (response->rpc);
    if (response_to != request_id) {
-      bson_set_error (&cursor->error,
-                      MONGOC_ERROR_PROTOCOL,
-                      MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
-                      "invalid response_to for OP_QUERY: expected %" PRId32 ", got %" PRId32,
-                      request_id,
-                      response_to);
+      _mongoc_set_error (&cursor->error,
+                         MONGOC_ERROR_PROTOCOL,
+                         MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
+                         "invalid response_to for OP_QUERY: expected %" PRId32 ", got %" PRId32,
+                         request_id,
+                         response_to);
       GOTO (done);
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-database.c
+++ b/src/libmongoc/src/mongoc/mongoc-database.c
@@ -24,6 +24,7 @@
 #include "mongoc-database.h"
 #include "mongoc-database-private.h"
 #include "mongoc-error.h"
+#include "mongoc-error-private.h"
 #include "mongoc-log.h"
 #include "mongoc-trace-private.h"
 #include "mongoc-util-private.h"
@@ -722,7 +723,7 @@ mongoc_database_find_collections (mongoc_database_t *database, const bson_t *fil
 
    if (filter) {
       if (!BSON_APPEND_DOCUMENT (&opts, "filter", filter)) {
-         bson_set_error (error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, "Invalid 'filter' parameter.");
+         _mongoc_set_error (error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, "Invalid 'filter' parameter.");
          bson_destroy (&opts);
          return NULL;
       }
@@ -839,7 +840,7 @@ create_collection (mongoc_database_t *database, const char *name, const bson_t *
    BSON_ASSERT_PARAM (name);
 
    if (strchr (name, '$')) {
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_NAMESPACE, MONGOC_ERROR_NAMESPACE_INVALID, "The namespace \"%s\" is invalid.", name);
       return NULL;
    }
@@ -847,10 +848,10 @@ create_collection (mongoc_database_t *database, const char *name, const bson_t *
    if (opts) {
       if (bson_iter_init_find (&iter, opts, "capped")) {
          if (!BSON_ITER_HOLDS_BOOL (&iter)) {
-            bson_set_error (error,
-                            MONGOC_ERROR_COMMAND,
-                            MONGOC_ERROR_COMMAND_INVALID_ARG,
-                            "The argument \"capped\" must be a boolean.");
+            _mongoc_set_error (error,
+                               MONGOC_ERROR_COMMAND,
+                               MONGOC_ERROR_COMMAND_INVALID_ARG,
+                               "The argument \"capped\" must be a boolean.");
             return NULL;
          }
          capped = bson_iter_bool (&iter);
@@ -858,72 +859,72 @@ create_collection (mongoc_database_t *database, const char *name, const bson_t *
 
       if (bson_iter_init_find (&iter, opts, "size")) {
          if (!BSON_ITER_HOLDS_INT (&iter)) {
-            bson_set_error (error,
-                            MONGOC_ERROR_COMMAND,
-                            MONGOC_ERROR_COMMAND_INVALID_ARG,
-                            "The argument \"size\" must be an integer.");
+            _mongoc_set_error (error,
+                               MONGOC_ERROR_COMMAND,
+                               MONGOC_ERROR_COMMAND_INVALID_ARG,
+                               "The argument \"size\" must be an integer.");
             return NULL;
          }
          if (!capped) {
-            bson_set_error (error,
-                            MONGOC_ERROR_COMMAND,
-                            MONGOC_ERROR_COMMAND_INVALID_ARG,
-                            "The \"size\" parameter requires {\"capped\": true}");
+            _mongoc_set_error (error,
+                               MONGOC_ERROR_COMMAND,
+                               MONGOC_ERROR_COMMAND_INVALID_ARG,
+                               "The \"size\" parameter requires {\"capped\": true}");
             return NULL;
          }
       }
 
       if (bson_iter_init_find (&iter, opts, "max")) {
          if (!BSON_ITER_HOLDS_INT (&iter)) {
-            bson_set_error (error,
-                            MONGOC_ERROR_COMMAND,
-                            MONGOC_ERROR_COMMAND_INVALID_ARG,
-                            "The argument \"max\" must be an integer.");
+            _mongoc_set_error (error,
+                               MONGOC_ERROR_COMMAND,
+                               MONGOC_ERROR_COMMAND_INVALID_ARG,
+                               "The argument \"max\" must be an integer.");
             return NULL;
          }
          if (!capped) {
-            bson_set_error (error,
-                            MONGOC_ERROR_COMMAND,
-                            MONGOC_ERROR_COMMAND_INVALID_ARG,
-                            "The \"max\" parameter requires {\"capped\": true}");
+            _mongoc_set_error (error,
+                               MONGOC_ERROR_COMMAND,
+                               MONGOC_ERROR_COMMAND_INVALID_ARG,
+                               "The \"max\" parameter requires {\"capped\": true}");
             return NULL;
          }
       }
 
       if (bson_iter_init_find (&iter, opts, "storageEngine")) {
          if (!BSON_ITER_HOLDS_DOCUMENT (&iter)) {
-            bson_set_error (error,
-                            MONGOC_ERROR_COMMAND,
-                            MONGOC_ERROR_COMMAND_INVALID_ARG,
-                            "The \"storageEngine\" parameter must be a document");
+            _mongoc_set_error (error,
+                               MONGOC_ERROR_COMMAND,
+                               MONGOC_ERROR_COMMAND_INVALID_ARG,
+                               "The \"storageEngine\" parameter must be a document");
 
             return NULL;
          }
 
          if (bson_iter_find (&iter, "wiredTiger")) {
             if (!BSON_ITER_HOLDS_DOCUMENT (&iter)) {
-               bson_set_error (error,
-                               MONGOC_ERROR_COMMAND,
-                               MONGOC_ERROR_COMMAND_INVALID_ARG,
-                               "The \"wiredTiger\" option must take a document "
-                               "argument with a \"configString\" field");
+               _mongoc_set_error (error,
+                                  MONGOC_ERROR_COMMAND,
+                                  MONGOC_ERROR_COMMAND_INVALID_ARG,
+                                  "The \"wiredTiger\" option must take a document "
+                                  "argument with a \"configString\" field");
                return NULL;
             }
 
             if (bson_iter_find (&iter, "configString")) {
                if (!BSON_ITER_HOLDS_UTF8 (&iter)) {
-                  bson_set_error (error,
-                                  MONGOC_ERROR_COMMAND,
-                                  MONGOC_ERROR_COMMAND_INVALID_ARG,
-                                  "The \"configString\" parameter must be a string");
+                  _mongoc_set_error (error,
+                                     MONGOC_ERROR_COMMAND,
+                                     MONGOC_ERROR_COMMAND_INVALID_ARG,
+                                     "The \"configString\" parameter must be a string");
                   return NULL;
                }
             } else {
-               bson_set_error (error,
-                               MONGOC_ERROR_COMMAND,
-                               MONGOC_ERROR_COMMAND_INVALID_ARG,
-                               "The \"wiredTiger\" option must take a document "
-                               "argument with a \"configString\" field");
+               _mongoc_set_error (error,
+                                  MONGOC_ERROR_COMMAND,
+                                  MONGOC_ERROR_COMMAND_INVALID_ARG,
+                                  "The \"wiredTiger\" option must take a document "
+                                  "argument with a \"configString\" field");
                return NULL;
             }
          }
@@ -969,22 +970,22 @@ _mongoc_get_encryptedField_state_collection (const bson_t *encryptedFields,
    } else if (0 == strcmp (state_collection_suffix, "ecoc")) {
       fieldName = "ecocCollection";
    } else {
-      bson_set_error (error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "expected state_collection_suffix to be 'esc' or "
-                      "'ecoc', got: %s",
-                      state_collection_suffix);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "expected state_collection_suffix to be 'esc' or "
+                         "'ecoc', got: %s",
+                         state_collection_suffix);
       return NULL;
    }
 
    if (bson_iter_init_find (&iter, encryptedFields, fieldName)) {
       if (!BSON_ITER_HOLDS_UTF8 (&iter)) {
-         bson_set_error (error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "expected encryptedFields.%s to be UTF-8",
-                         fieldName);
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_COMMAND,
+                            MONGOC_ERROR_COMMAND_INVALID_ARG,
+                            "expected encryptedFields.%s to be UTF-8",
+                            fieldName);
          return NULL;
       }
       return bson_strdup (bson_iter_utf8 (&iter, NULL));
@@ -1047,14 +1048,14 @@ create_collection_with_encryptedFields (mongoc_database_t *database,
          goto fail;
       }
       if (stream->sd->max_wire_version < WIRE_VERSION_7_0) {
-         bson_set_error (error,
-                         MONGOC_ERROR_PROTOCOL,
-                         MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION,
-                         "Driver support of Queryable Encryption is incompatible "
-                         "with server. Upgrade server to use Queryable Encryption. "
-                         "Got maxWireVersion %" PRId32 " but need maxWireVersion >= %d",
-                         stream->sd->max_wire_version,
-                         WIRE_VERSION_7_0);
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_PROTOCOL,
+                            MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION,
+                            "Driver support of Queryable Encryption is incompatible "
+                            "with server. Upgrade server to use Queryable Encryption. "
+                            "Got maxWireVersion %" PRId32 " but need maxWireVersion >= %d",
+                            stream->sd->max_wire_version,
+                            WIRE_VERSION_7_0);
          mongoc_server_stream_cleanup (stream);
          goto fail;
       }
@@ -1071,7 +1072,7 @@ create_collection_with_encryptedFields (mongoc_database_t *database,
    /* Create data collection. */
    cc_opts = bson_copy (opts);
    if (!BSON_APPEND_DOCUMENT (cc_opts, "encryptedFields", encryptedFields)) {
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "unable to append encryptedFields");
       goto fail;
    }
@@ -1159,7 +1160,7 @@ _mongoc_get_encryptedFields_from_server (
       /* Check if the collInfo has options.encryptedFields. */
       bson_iter_t iter;
       if (!bson_iter_init (&iter, collInfo)) {
-         bson_set_error (
+         _mongoc_set_error (
             error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "unable to iterate listCollections result");
          goto fail;
       }
@@ -1214,11 +1215,11 @@ _mongoc_get_collection_encryptedFields (mongoc_client_t *client,
                        do (found = true)));
       if (bsonParseError) {
          // Error while parsing
-         bson_set_error (error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Invalid createCollection command options: %s",
-                         bsonParseError);
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_COMMAND,
+                            MONGOC_ERROR_COMMAND_INVALID_ARG,
+                            "Invalid createCollection command options: %s",
+                            bsonParseError);
          return false;
       } else if (found) {
          // Found it!

--- a/src/libmongoc/src/mongoc/mongoc-error-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-error-private.h
@@ -105,6 +105,10 @@ typedef enum {
 bool
 mongoc_error_append_contents_to_bson (const bson_error_t *error, bson_t *bson, mongoc_error_content_flags_t flags);
 
+void
+_mongoc_set_error (bson_error_t *error, uint32_t domain, uint32_t code, const char *format, ...)
+   BSON_GNUC_PRINTF (4, 5);
+
 BSON_END_DECLS
 
 #endif /* MONGOC_ERROR_PRIVATE_H */

--- a/src/libmongoc/src/mongoc/mongoc-error.c
+++ b/src/libmongoc/src/mongoc/mongoc-error.c
@@ -338,3 +338,24 @@ mongoc_error_append_contents_to_bson (const bson_error_t *error, bson_t *bson, m
    }
    return true;
 }
+
+void
+_mongoc_set_error (bson_error_t *error, uint32_t domain, uint32_t code, const char *format, ...)
+{
+   const char prefix[] = "mongoc: ";
+   const size_t prefix_len = sizeof (prefix) - 1u; // Exclude null terminator.
+
+   if (error) {
+      error->domain = domain;
+      error->code = code;
+
+      size_t remaining = sizeof error->message;
+      bson_snprintf (error->message, remaining, "%s", prefix);
+      remaining -= prefix_len;
+
+      va_list args;
+      va_start (args, format);
+      bson_vsnprintf (error->message + prefix_len, remaining, format, args);
+      va_end (args);
+   }
+}

--- a/src/libmongoc/src/mongoc/mongoc-gridfs-bucket-file.c
+++ b/src/libmongoc/src/mongoc/mongoc-gridfs-bucket-file.c
@@ -21,6 +21,7 @@
 #include "mongoc-stream-gridfs-download-private.h"
 #include "mongoc-stream-gridfs-upload-private.h"
 #include "mongoc-collection-private.h"
+#include "mongoc-error-private.h"
 #include "mongoc-util-private.h"
 #include <common-cmp-private.h>
 
@@ -240,36 +241,36 @@ _mongoc_gridfs_bucket_read_chunk (mongoc_gridfs_bucket_file_t *file)
    }
 
    if (!r) {
-      bson_set_error (
+      _mongoc_set_error (
          &file->err, MONGOC_ERROR_GRIDFS, MONGOC_ERROR_GRIDFS_CHUNK_MISSING, "Missing chunk %d.", file->curr_chunk);
       return false;
    }
 
    r = bson_iter_init_find (&iter, next, "n");
    if (!r) {
-      bson_set_error (&file->err,
-                      MONGOC_ERROR_GRIDFS,
-                      MONGOC_ERROR_GRIDFS_CORRUPT,
-                      "Chunk %d missing a required field 'n'.",
-                      file->curr_chunk);
+      _mongoc_set_error (&file->err,
+                         MONGOC_ERROR_GRIDFS,
+                         MONGOC_ERROR_GRIDFS_CORRUPT,
+                         "Chunk %d missing a required field 'n'.",
+                         file->curr_chunk);
       return false;
    }
 
    n = bson_iter_int32 (&iter);
 
    if (n != file->curr_chunk) {
-      bson_set_error (
+      _mongoc_set_error (
          &file->err, MONGOC_ERROR_GRIDFS, MONGOC_ERROR_GRIDFS_CHUNK_MISSING, "Missing chunk %d.", file->curr_chunk);
       return false;
    }
 
    r = bson_iter_init_find (&iter, next, "data");
    if (!r) {
-      bson_set_error (&file->err,
-                      MONGOC_ERROR_GRIDFS,
-                      MONGOC_ERROR_GRIDFS_CORRUPT,
-                      "Chunk %d missing a required field 'data'.",
-                      file->curr_chunk);
+      _mongoc_set_error (&file->err,
+                         MONGOC_ERROR_GRIDFS,
+                         MONGOC_ERROR_GRIDFS_CORRUPT,
+                         "Chunk %d missing a required field 'data'.",
+                         file->curr_chunk);
       return false;
    }
 
@@ -283,13 +284,13 @@ _mongoc_gridfs_bucket_read_chunk (mongoc_gridfs_bucket_file_t *file)
    }
 
    if (data_len != expected_size) {
-      bson_set_error (&file->err,
-                      MONGOC_ERROR_GRIDFS,
-                      MONGOC_ERROR_GRIDFS_CORRUPT,
-                      "Chunk %d expected to have size %" PRId64 " but is size %" PRIu32 ".",
-                      file->curr_chunk,
-                      expected_size,
-                      data_len);
+      _mongoc_set_error (&file->err,
+                         MONGOC_ERROR_GRIDFS,
+                         MONGOC_ERROR_GRIDFS_CORRUPT,
+                         "Chunk %d expected to have size %" PRId64 " but is size %" PRIu32 ".",
+                         file->curr_chunk,
+                         expected_size,
+                         data_len);
       return false;
    }
 
@@ -315,10 +316,10 @@ _mongoc_gridfs_bucket_file_writev (mongoc_gridfs_bucket_file_t *file, const mong
    }
 
    if (file->saved) {
-      bson_set_error (&file->err,
-                      MONGOC_ERROR_GRIDFS,
-                      MONGOC_ERROR_GRIDFS_PROTOCOL_ERROR,
-                      "Cannot write after saving/aborting on a GridFS file.");
+      _mongoc_set_error (&file->err,
+                         MONGOC_ERROR_GRIDFS,
+                         MONGOC_ERROR_GRIDFS_PROTOCOL_ERROR,
+                         "Cannot write after saving/aborting on a GridFS file.");
       return -1;
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-gridfs-bucket.c
+++ b/src/libmongoc/src/mongoc/mongoc-gridfs-bucket.c
@@ -18,6 +18,7 @@
 #include "mongoc.h"
 #include "mongoc-cursor-private.h"
 #include "mongoc-database-private.h"
+#include "mongoc-error-private.h"
 #include "mongoc-gridfs-bucket-private.h"
 #include "mongoc-gridfs-bucket-file-private.h"
 #include "mongoc-opts-private.h"
@@ -64,7 +65,7 @@ _mongoc_gridfs_find_file_with_id (mongoc_gridfs_bucket_t *bucket,
    r = mongoc_cursor_next (cursor, &doc);
    if (!r) {
       if (!mongoc_cursor_error (cursor, error)) {
-         bson_set_error (
+         _mongoc_set_error (
             error, MONGOC_ERROR_GRIDFS, MONGOC_ERROR_GRIDFS_BUCKET_FILE_NOT_FOUND, "No file with given id exists");
       }
    } else {
@@ -96,12 +97,12 @@ mongoc_gridfs_bucket_new (mongoc_database_t *db,
 
    /* Initialize the bucket fields */
    if (strlen (gridfs_opts.bucketName) + strlen (".chunks") + 1 > sizeof (buf)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "bucketName \"%s\" must have fewer than %d characters",
-                      gridfs_opts.bucketName,
-                      (int) (sizeof (buf) - (strlen (".chunks") + 1)));
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "bucketName \"%s\" must have fewer than %d characters",
+                         gridfs_opts.bucketName,
+                         (int) (sizeof (buf) - (strlen (".chunks") + 1)));
       return NULL;
    }
 
@@ -254,7 +255,7 @@ mongoc_gridfs_bucket_upload_from_stream_with_id (mongoc_gridfs_bucket_t *bucket,
 
    if (bytes_read < 0) {
       mongoc_gridfs_bucket_abort_upload (upload_stream);
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_GRIDFS, MONGOC_ERROR_GRIDFS_BUCKET_STREAM, "Error occurred on the provided stream.");
       mongoc_stream_destroy (upload_stream);
       return false;
@@ -322,7 +323,7 @@ mongoc_gridfs_bucket_open_download_stream (mongoc_gridfs_bucket_t *bucket,
    }
 
    if (!bson_iter_init (&iter, &file_doc)) {
-      bson_set_error (error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, "File document malformed");
+      _mongoc_set_error (error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, "File document malformed");
       return NULL;
    }
 
@@ -375,7 +376,7 @@ mongoc_gridfs_bucket_download_to_stream (mongoc_gridfs_bucket_t *bucket,
    while ((bytes_read = mongoc_stream_read (download_stream, buf, 256, 1, 0)) > 0) {
       bytes_written = mongoc_stream_write (destination, buf, bytes_read, 0);
       if (bytes_written < 0) {
-         bson_set_error (
+         _mongoc_set_error (
             error, MONGOC_ERROR_GRIDFS, MONGOC_ERROR_GRIDFS_BUCKET_STREAM, "Error occurred on the provided stream.");
          mongoc_stream_destroy (download_stream);
          return false;
@@ -412,7 +413,7 @@ mongoc_gridfs_bucket_delete_by_id (mongoc_gridfs_bucket_t *bucket, const bson_va
    BSON_ASSERT (bson_iter_init_find (&iter, &reply, "deletedCount"));
 
    if (bson_iter_as_int64 (&iter) != 1) {
-      bson_set_error (error, MONGOC_ERROR_GRIDFS, MONGOC_ERROR_GRIDFS_BUCKET_FILE_NOT_FOUND, "File not found");
+      _mongoc_set_error (error, MONGOC_ERROR_GRIDFS, MONGOC_ERROR_GRIDFS_BUCKET_FILE_NOT_FOUND, "File not found");
       bson_destroy (&reply);
       return false;
    }
@@ -441,7 +442,7 @@ mongoc_gridfs_bucket_find (mongoc_gridfs_bucket_t *bucket, const bson_t *filter,
 
    cursor = mongoc_collection_find_with_opts (bucket->files, filter, opts, NULL);
    if (!cursor->error.code && opts && bson_has_field (opts, "sessionId")) {
-      bson_set_error (
+      _mongoc_set_error (
          &cursor->error, MONGOC_ERROR_CURSOR, MONGOC_ERROR_CURSOR_INVALID_CURSOR, "Cannot pass sessionId as an option");
    }
    return cursor;

--- a/src/libmongoc/src/mongoc/mongoc-gridfs-file.c
+++ b/src/libmongoc/src/mongoc/mongoc-gridfs-file.c
@@ -35,6 +35,7 @@
 #include "mongoc-trace-private.h"
 #include "mongoc-util-private.h"
 #include "mongoc-error.h"
+#include "mongoc-error-private.h"
 #include <common-cmp-private.h>
 
 static bool
@@ -107,7 +108,7 @@ bool
 mongoc_gridfs_file_set_id (mongoc_gridfs_file_t *file, const bson_value_t *id, bson_error_t *error)
 {
    if (!file->is_dirty) {
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_GRIDFS, MONGOC_ERROR_GRIDFS_PROTOCOL_ERROR, "Cannot set file id after saving file.");
       return false;
    }
@@ -710,7 +711,7 @@ divide_round_up (int64_t num, int64_t denom)
 static void
 missing_chunk (mongoc_gridfs_file_t *file)
 {
-   bson_set_error (
+   _mongoc_set_error (
       &file->error, MONGOC_ERROR_GRIDFS, MONGOC_ERROR_GRIDFS_CHUNK_MISSING, "missing chunk number %" PRId32, file->n);
 
    if (file->cursor) {
@@ -843,12 +844,12 @@ _mongoc_gridfs_file_refresh_page (mongoc_gridfs_file_t *file)
             bool is_last_chunk = ((file->n + 1) == existing_chunks);
             // If this is not the last chunk, error.
             if (!is_last_chunk && mcommon_cmp_not_equal_us (len, file->chunk_size)) {
-               bson_set_error (&file->error,
-                               MONGOC_ERROR_GRIDFS,
-                               MONGOC_ERROR_GRIDFS_CORRUPT,
-                               "corrupt chunk number %" PRId32 ": not equal to chunk size: %" PRId32,
-                               file->n,
-                               file->chunk_size);
+               _mongoc_set_error (&file->error,
+                                  MONGOC_ERROR_GRIDFS,
+                                  MONGOC_ERROR_GRIDFS_CORRUPT,
+                                  "corrupt chunk number %" PRId32 ": not equal to chunk size: %" PRId32,
+                                  file->n,
+                                  file->chunk_size);
                RETURN (0);
             }
          } else {
@@ -863,21 +864,21 @@ _mongoc_gridfs_file_refresh_page (mongoc_gridfs_file_t *file)
    }
 
    if (!data) {
-      bson_set_error (&file->error,
-                      MONGOC_ERROR_GRIDFS,
-                      MONGOC_ERROR_GRIDFS_CHUNK_MISSING,
-                      "corrupt chunk number %" PRId32 ": no data",
-                      file->n);
+      _mongoc_set_error (&file->error,
+                         MONGOC_ERROR_GRIDFS,
+                         MONGOC_ERROR_GRIDFS_CHUNK_MISSING,
+                         "corrupt chunk number %" PRId32 ": no data",
+                         file->n);
       RETURN (0);
    }
 
    if (mcommon_cmp_greater_us (len, file->chunk_size)) {
-      bson_set_error (&file->error,
-                      MONGOC_ERROR_GRIDFS,
-                      MONGOC_ERROR_GRIDFS_CORRUPT,
-                      "corrupt chunk number %" PRId32 ": greater than chunk size: %" PRId32,
-                      file->n,
-                      file->chunk_size);
+      _mongoc_set_error (&file->error,
+                         MONGOC_ERROR_GRIDFS,
+                         MONGOC_ERROR_GRIDFS_CORRUPT,
+                         "corrupt chunk number %" PRId32 ": greater than chunk size: %" PRId32,
+                         file->n,
+                         file->chunk_size);
       RETURN (0);
    }
 
@@ -994,7 +995,7 @@ mongoc_gridfs_file_error (mongoc_gridfs_file_t *file, bson_error_t *error)
    BSON_ASSERT (error);
 
    if (BSON_UNLIKELY (file->error.domain)) {
-      bson_set_error (error, file->error.domain, file->error.code, "%s", file->error.message);
+      _mongoc_set_error (error, file->error.domain, file->error.code, "%s", file->error.message);
       RETURN (true);
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-gridfs.c
+++ b/src/libmongoc/src/mongoc/mongoc-gridfs.c
@@ -23,6 +23,7 @@
 #include "mongoc-collection.h"
 #include "mongoc-collection-private.h"
 #include "mongoc-error.h"
+#include "mongoc-error-private.h"
 #include "mongoc-index.h"
 #include "mongoc-gridfs.h"
 #include "mongoc-gridfs-private.h"
@@ -385,7 +386,7 @@ mongoc_gridfs_remove_by_filename (mongoc_gridfs_t *gridfs, const char *filename,
    BSON_ASSERT (gridfs);
 
    if (!filename) {
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_GRIDFS, MONGOC_ERROR_GRIDFS_INVALID_FILENAME, "A non-NULL filename must be specified.");
       return false;
    }

--- a/src/libmongoc/src/mongoc/mongoc-host-list.c
+++ b/src/libmongoc/src/mongoc/mongoc-host-list.c
@@ -19,6 +19,7 @@
 #include "mongoc-host-list-private.h"
 /* strcasecmp on windows */
 #include "mongoc-util-private.h"
+#include "mongoc-error-private.h"
 #include "utlist.h"
 #include <common-cmp-private.h>
 
@@ -197,26 +198,26 @@ _mongoc_host_list_from_string_with_err (mongoc_host_list_t *link_, const char *a
       /* if present, the port should immediately follow after ] */
       sport = strchr (close_bracket, ':');
       if (sport > close_bracket + 1) {
-         bson_set_error (error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "If present, port should immediately follow the \"]\""
-                         "in an IPv6 address");
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_COMMAND,
+                            MONGOC_ERROR_COMMAND_INVALID_ARG,
+                            "If present, port should immediately follow the \"]\""
+                            "in an IPv6 address");
          return false;
       }
 
       /* otherwise ] should be the last char. */
       if (!sport && *(close_bracket + 1) != '\0') {
-         bson_set_error (error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "If port is not supplied, \"[\" should be the last"
-                         "character");
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_COMMAND,
+                            MONGOC_ERROR_COMMAND_INVALID_ARG,
+                            "If port is not supplied, \"[\" should be the last"
+                            "character");
          return false;
       }
 
       if (*address != '[') {
-         bson_set_error (
+         _mongoc_set_error (
             error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "Missing matching bracket \"[\"");
          return false;
       }
@@ -232,15 +233,15 @@ _mongoc_host_list_from_string_with_err (mongoc_host_list_t *link_, const char *a
    if (sport) {
       if (sport == address) {
          /* bad address like ":27017" */
-         bson_set_error (error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Bad address, \":\" should not be first character");
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_COMMAND,
+                            MONGOC_ERROR_COMMAND_INVALID_ARG,
+                            "Bad address, \":\" should not be first character");
          return false;
       }
 
       if (!mongoc_parse_port (&port, sport + 1)) {
-         bson_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "Port could not be parsed");
+         _mongoc_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "Port could not be parsed");
          return false;
       }
 
@@ -282,16 +283,16 @@ _mongoc_host_list_from_hostport_with_err (mongoc_host_list_t *link_,
    };
 
    if (host_len == 0) {
-      bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_NAME_RESOLUTION, "Empty hostname in URI");
+      _mongoc_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_NAME_RESOLUTION, "Empty hostname in URI");
       return false;
    }
 
    if (host_len > BSON_HOST_NAME_MAX) {
-      bson_set_error (error,
-                      MONGOC_ERROR_STREAM,
-                      MONGOC_ERROR_STREAM_NAME_RESOLUTION,
-                      "Hostname provided in URI is too long, max is %d chars",
-                      BSON_HOST_NAME_MAX);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_STREAM,
+                         MONGOC_ERROR_STREAM_NAME_RESOLUTION,
+                         "Hostname provided in URI is too long, max is %d chars",
+                         BSON_HOST_NAME_MAX);
       return false;
    }
 
@@ -304,11 +305,11 @@ _mongoc_host_list_from_hostport_with_err (mongoc_host_list_t *link_,
       // Check that IPv6 literal is two less than the max to account for `[` and
       // `]` added below.
       if (host_len > BSON_HOST_NAME_MAX - 2) {
-         bson_set_error (error,
-                         MONGOC_ERROR_STREAM,
-                         MONGOC_ERROR_STREAM_NAME_RESOLUTION,
-                         "IPv6 literal provided in URI is too long, max is %d chars",
-                         BSON_HOST_NAME_MAX - 2);
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_STREAM,
+                            MONGOC_ERROR_STREAM_NAME_RESOLUTION,
+                            "IPv6 literal provided in URI is too long, max is %d chars",
+                            BSON_HOST_NAME_MAX - 2);
          return false;
       }
 

--- a/src/libmongoc/src/mongoc/mongoc-http.c
+++ b/src/libmongoc/src/mongoc/mongoc-http.c
@@ -18,6 +18,7 @@
 
 #include "mongoc-client-private.h"
 #include "mongoc-host-list-private.h"
+#include "mongoc-error-private.h"
 #include "mongoc-stream-tls.h"
 #include "mongoc-stream-private.h"
 #include "mongoc-buffer-private.h"
@@ -131,17 +132,17 @@ _mongoc_http_send (const mongoc_http_request_t *req,
       &host_list,
       error);
    if (!stream) {
-      bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Failed to connect to: %s", req->host);
+      _mongoc_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Failed to connect to: %s", req->host);
       goto fail;
    }
 
 #ifndef MONGOC_ENABLE_SSL
    if (use_tls) {
-      bson_set_error (error,
-                      MONGOC_ERROR_STREAM,
-                      MONGOC_ERROR_STREAM_SOCKET,
-                      "Failed to connect to %s: libmongoc not built with TLS support",
-                      req->host);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_STREAM,
+                         MONGOC_ERROR_STREAM_SOCKET,
+                         "Failed to connect to %s: libmongoc not built with TLS support",
+                         req->host);
       goto fail;
    }
 #else
@@ -151,7 +152,7 @@ _mongoc_http_send (const mongoc_http_request_t *req,
       BSON_ASSERT (ssl_opts);
       tls_stream = mongoc_stream_tls_new_with_hostname (stream, req->host, ssl_opts, true);
       if (!tls_stream) {
-         bson_set_error (
+         _mongoc_set_error (
             error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Failed create TLS stream to: %s", req->host);
          goto fail;
       }
@@ -198,18 +199,19 @@ _mongoc_http_send (const mongoc_http_request_t *req,
          break;
       }
       if (http_response_buf.len > 1024 * 1024 * 8) {
-         bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "HTTP response message is too large");
+         _mongoc_set_error (
+            error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "HTTP response message is too large");
          goto fail;
       }
    }
 
    if (mongoc_stream_timed_out (stream)) {
-      bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Timeout reading from stream");
+      _mongoc_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Timeout reading from stream");
       goto fail;
    }
 
    if (http_response_buf.len == 0) {
-      bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "No response received");
+      _mongoc_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "No response received");
       goto fail;
    }
 
@@ -225,12 +227,12 @@ _mongoc_http_send (const mongoc_http_request_t *req,
    }
 
    if (!ptr) {
-      bson_set_error (error,
-                      MONGOC_ERROR_STREAM,
-                      MONGOC_ERROR_STREAM_SOCKET,
-                      "No HTTP version leader in HTTP response. Expected '%s' or '%s'",
-                      proto_leader_10,
-                      proto_leader_11);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_STREAM,
+                         MONGOC_ERROR_STREAM_SOCKET,
+                         "No HTTP version leader in HTTP response. Expected '%s' or '%s'",
+                         proto_leader_10,
+                         proto_leader_11);
       goto fail;
    }
 
@@ -238,7 +240,7 @@ _mongoc_http_send (const mongoc_http_request_t *req,
    ptr += strlen (proto_leader_10);
    ssize_t remain = resp_end_ptr - ptr;
    if (remain < 4) {
-      bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Short read in HTTP response");
+      _mongoc_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Short read in HTTP response");
       goto fail;
    }
 
@@ -247,22 +249,22 @@ _mongoc_http_send (const mongoc_http_request_t *req,
    char *status_endptr;
    res->status = strtol (status_buf, &status_endptr, 10);
    if (status_endptr != status_buf + 3) {
-      bson_set_error (error,
-                      MONGOC_ERROR_STREAM,
-                      MONGOC_ERROR_STREAM_SOCKET,
-                      "Invalid HTTP response status string %*.s",
-                      4,
-                      status_buf);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_STREAM,
+                         MONGOC_ERROR_STREAM_SOCKET,
+                         "Invalid HTTP response status string %*.s",
+                         4,
+                         status_buf);
       goto fail;
    }
 
    /* Find the end of the headers. */
    ptr = strstr (http_response_str, header_delimiter);
    if (NULL == ptr) {
-      bson_set_error (error,
-                      MONGOC_ERROR_STREAM,
-                      MONGOC_ERROR_STREAM_SOCKET,
-                      "Error occurred reading response: end of headers not found");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_STREAM,
+                         MONGOC_ERROR_STREAM_SOCKET,
+                         "Error occurred reading response: end of headers not found");
       goto fail;
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-matcher.c
+++ b/src/libmongoc/src/mongoc/mongoc-matcher.c
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 
 #include "mongoc-error.h"
+#include "mongoc-error-private.h"
 #include "mongoc-matcher.h"
 #include "mongoc-matcher-private.h"
 #include "mongoc-matcher-op-private.h"
@@ -62,7 +63,8 @@ _mongoc_matcher_parse_compare (bson_iter_t *iter,   /* IN */
 
    if (bson_iter_type (iter) == BSON_TYPE_DOCUMENT) {
       if (!bson_iter_recurse (iter, &child) || !bson_iter_next (&child)) {
-         bson_set_error (error, MONGOC_ERROR_MATCHER, MONGOC_ERROR_MATCHER_INVALID, "Document contains no operations.");
+         _mongoc_set_error (
+            error, MONGOC_ERROR_MATCHER, MONGOC_ERROR_MATCHER_INVALID, "Document contains no operations.");
          return NULL;
       }
 
@@ -94,7 +96,7 @@ _mongoc_matcher_parse_compare (bson_iter_t *iter,   /* IN */
       } else if (strcmp (key, "$type") == 0) {
          op = _mongoc_matcher_op_type_new (path, bson_iter_type (&child));
       } else {
-         bson_set_error (error, MONGOC_ERROR_MATCHER, MONGOC_ERROR_MATCHER_INVALID, "Invalid operator \"%s\"", key);
+         _mongoc_set_error (error, MONGOC_ERROR_MATCHER, MONGOC_ERROR_MATCHER_INVALID, "Invalid operator \"%s\"", key);
          return NULL;
       }
    } else {
@@ -141,7 +143,7 @@ _mongoc_matcher_parse (bson_iter_t *iter,   /* IN */
       BSON_ASSERT (bson_iter_type (iter) == BSON_TYPE_ARRAY);
 
       if (!bson_iter_recurse (iter, &child)) {
-         bson_set_error (
+         _mongoc_set_error (
             error, MONGOC_ERROR_MATCHER, MONGOC_ERROR_MATCHER_INVALID, "Invalid value for operator \"%s\"", key);
          return NULL;
       }
@@ -155,7 +157,7 @@ _mongoc_matcher_parse (bson_iter_t *iter,   /* IN */
       }
    }
 
-   bson_set_error (error, MONGOC_ERROR_MATCHER, MONGOC_ERROR_MATCHER_INVALID, "Invalid operator \"%s\"", key);
+   _mongoc_set_error (error, MONGOC_ERROR_MATCHER, MONGOC_ERROR_MATCHER_INVALID, "Invalid operator \"%s\"", key);
 
    return NULL;
 }
@@ -200,7 +202,7 @@ _mongoc_matcher_parse_logical (mongoc_matcher_opcode_t opcode, /* IN */
    BSON_ASSERT (iter);
 
    if (!bson_iter_next (iter)) {
-      bson_set_error (error, MONGOC_ERROR_MATCHER, MONGOC_ERROR_MATCHER_INVALID, "Invalid logical operator.");
+      _mongoc_set_error (error, MONGOC_ERROR_MATCHER, MONGOC_ERROR_MATCHER_INVALID, "Invalid logical operator.");
       return NULL;
    }
 
@@ -210,17 +212,17 @@ _mongoc_matcher_parse_logical (mongoc_matcher_opcode_t opcode, /* IN */
       }
    } else {
       if (!BSON_ITER_HOLDS_DOCUMENT (iter)) {
-         bson_set_error (error, MONGOC_ERROR_MATCHER, MONGOC_ERROR_MATCHER_INVALID, "Expected document in value.");
+         _mongoc_set_error (error, MONGOC_ERROR_MATCHER, MONGOC_ERROR_MATCHER_INVALID, "Expected document in value.");
          return NULL;
       }
 
       if (!bson_iter_recurse (iter, &child)) {
-         bson_set_error (error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, "corrupt BSON");
+         _mongoc_set_error (error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, "corrupt BSON");
          return NULL;
       }
 
       if (!bson_iter_next (&child)) {
-         bson_set_error (error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, "corrupt BSON");
+         _mongoc_set_error (error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, "corrupt BSON");
          return NULL;
       }
 
@@ -239,17 +241,17 @@ _mongoc_matcher_parse_logical (mongoc_matcher_opcode_t opcode, /* IN */
       }
    } else {
       if (!BSON_ITER_HOLDS_DOCUMENT (iter)) {
-         bson_set_error (error, MONGOC_ERROR_MATCHER, MONGOC_ERROR_MATCHER_INVALID, "Expected document in value.");
+         _mongoc_set_error (error, MONGOC_ERROR_MATCHER, MONGOC_ERROR_MATCHER_INVALID, "Expected document in value.");
          return NULL;
       }
 
       if (!bson_iter_recurse (iter, &child)) {
-         bson_set_error (error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, "bson_iter_recurse failed.");
+         _mongoc_set_error (error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, "bson_iter_recurse failed.");
          return NULL;
       }
 
       if (!bson_iter_next (&child)) {
-         bson_set_error (error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, "corrupt BSON");
+         _mongoc_set_error (error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, "corrupt BSON");
          return NULL;
       }
 

--- a/src/libmongoc/src/mongoc/mongoc-opts-helpers.c
+++ b/src/libmongoc/src/mongoc/mongoc-opts-helpers.c
@@ -17,21 +17,22 @@
 #include "mongoc-opts-helpers-private.h"
 #include "mongoc-client-session-private.h"
 #include "mongoc-write-concern-private.h"
+#include "mongoc-error-private.h"
 #include "mongoc-util-private.h"
 #include "mongoc-read-concern-private.h"
 #include <common-cmp-private.h>
 
-#define BSON_ERR(...)                                                                    \
-   do {                                                                                  \
-      bson_set_error (error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, __VA_ARGS__); \
-      return false;                                                                      \
+#define BSON_ERR(...)                                                                       \
+   do {                                                                                     \
+      _mongoc_set_error (error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, __VA_ARGS__); \
+      return false;                                                                         \
    } while (0)
 
 
-#define CONVERSION_ERR(...)                                                                        \
-   do {                                                                                            \
-      bson_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, __VA_ARGS__); \
-      return false;                                                                                \
+#define CONVERSION_ERR(...)                                                                           \
+   do {                                                                                               \
+      _mongoc_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, __VA_ARGS__); \
+      return false;                                                                                   \
    } while (0)
 
 

--- a/src/libmongoc/src/mongoc/mongoc-opts.c
+++ b/src/libmongoc/src/mongoc/mongoc-opts.c
@@ -1,6 +1,7 @@
 #include "mongoc-opts-helpers-private.h"
 #include "mongoc-opts-private.h"
 #include "mongoc-error.h"
+#include "mongoc-error-private.h"
 #include "mongoc-util-private.h"
 #include "mongoc-client-private.h"
 
@@ -38,10 +39,10 @@ _mongoc_insert_one_opts_parse (
    }
 
    if (!bson_iter_init (&iter, opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_BSON,
-                      MONGOC_ERROR_BSON_INVALID,
-                      "Invalid 'opts' parameter.");
+      _mongoc_set_error (error,
+                        MONGOC_ERROR_BSON,
+                        MONGOC_ERROR_BSON_INVALID,
+                        "Invalid 'opts' parameter.");
       return false;
    }
 
@@ -99,10 +100,10 @@ _mongoc_insert_one_opts_parse (
                &mongoc_insert_one_opts->extra,
                bson_iter_key (&iter),
                bson_iter_value (&iter))) {
-            bson_set_error (error,
-                            MONGOC_ERROR_BSON,
-                            MONGOC_ERROR_BSON_INVALID,
-                            "Invalid 'opts' parameter.");
+            _mongoc_set_error (error,
+                              MONGOC_ERROR_BSON,
+                              MONGOC_ERROR_BSON_INVALID,
+                              "Invalid 'opts' parameter.");
             return false;
          }
       }
@@ -146,10 +147,10 @@ _mongoc_insert_many_opts_parse (
    }
 
    if (!bson_iter_init (&iter, opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_BSON,
-                      MONGOC_ERROR_BSON_INVALID,
-                      "Invalid 'opts' parameter.");
+      _mongoc_set_error (error,
+                        MONGOC_ERROR_BSON,
+                        MONGOC_ERROR_BSON_INVALID,
+                        "Invalid 'opts' parameter.");
       return false;
    }
 
@@ -216,10 +217,10 @@ _mongoc_insert_many_opts_parse (
                &mongoc_insert_many_opts->extra,
                bson_iter_key (&iter),
                bson_iter_value (&iter))) {
-            bson_set_error (error,
-                            MONGOC_ERROR_BSON,
-                            MONGOC_ERROR_BSON_INVALID,
-                            "Invalid 'opts' parameter.");
+            _mongoc_set_error (error,
+                              MONGOC_ERROR_BSON,
+                              MONGOC_ERROR_BSON_INVALID,
+                              "Invalid 'opts' parameter.");
             return false;
          }
       }
@@ -264,10 +265,10 @@ _mongoc_delete_one_opts_parse (
    }
 
    if (!bson_iter_init (&iter, opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_BSON,
-                      MONGOC_ERROR_BSON_INVALID,
-                      "Invalid 'opts' parameter.");
+      _mongoc_set_error (error,
+                        MONGOC_ERROR_BSON,
+                        MONGOC_ERROR_BSON_INVALID,
+                        "Invalid 'opts' parameter.");
       return false;
    }
 
@@ -343,10 +344,10 @@ _mongoc_delete_one_opts_parse (
                &mongoc_delete_one_opts->extra,
                bson_iter_key (&iter),
                bson_iter_value (&iter))) {
-            bson_set_error (error,
-                            MONGOC_ERROR_BSON,
-                            MONGOC_ERROR_BSON_INVALID,
-                            "Invalid 'opts' parameter.");
+            _mongoc_set_error (error,
+                              MONGOC_ERROR_BSON,
+                              MONGOC_ERROR_BSON_INVALID,
+                              "Invalid 'opts' parameter.");
             return false;
          }
       }
@@ -394,10 +395,10 @@ _mongoc_delete_many_opts_parse (
    }
 
    if (!bson_iter_init (&iter, opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_BSON,
-                      MONGOC_ERROR_BSON_INVALID,
-                      "Invalid 'opts' parameter.");
+      _mongoc_set_error (error,
+                        MONGOC_ERROR_BSON,
+                        MONGOC_ERROR_BSON_INVALID,
+                        "Invalid 'opts' parameter.");
       return false;
    }
 
@@ -473,10 +474,10 @@ _mongoc_delete_many_opts_parse (
                &mongoc_delete_many_opts->extra,
                bson_iter_key (&iter),
                bson_iter_value (&iter))) {
-            bson_set_error (error,
-                            MONGOC_ERROR_BSON,
-                            MONGOC_ERROR_BSON_INVALID,
-                            "Invalid 'opts' parameter.");
+            _mongoc_set_error (error,
+                              MONGOC_ERROR_BSON,
+                              MONGOC_ERROR_BSON_INVALID,
+                              "Invalid 'opts' parameter.");
             return false;
          }
       }
@@ -528,10 +529,10 @@ _mongoc_update_one_opts_parse (
    }
 
    if (!bson_iter_init (&iter, opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_BSON,
-                      MONGOC_ERROR_BSON_INVALID,
-                      "Invalid 'opts' parameter.");
+      _mongoc_set_error (error,
+                        MONGOC_ERROR_BSON,
+                        MONGOC_ERROR_BSON_INVALID,
+                        "Invalid 'opts' parameter.");
       return false;
    }
 
@@ -643,10 +644,10 @@ _mongoc_update_one_opts_parse (
                &mongoc_update_one_opts->extra,
                bson_iter_key (&iter),
                bson_iter_value (&iter))) {
-            bson_set_error (error,
-                            MONGOC_ERROR_BSON,
-                            MONGOC_ERROR_BSON_INVALID,
-                            "Invalid 'opts' parameter.");
+            _mongoc_set_error (error,
+                              MONGOC_ERROR_BSON,
+                              MONGOC_ERROR_BSON_INVALID,
+                              "Invalid 'opts' parameter.");
             return false;
          }
       }
@@ -699,10 +700,10 @@ _mongoc_update_many_opts_parse (
    }
 
    if (!bson_iter_init (&iter, opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_BSON,
-                      MONGOC_ERROR_BSON_INVALID,
-                      "Invalid 'opts' parameter.");
+      _mongoc_set_error (error,
+                        MONGOC_ERROR_BSON,
+                        MONGOC_ERROR_BSON_INVALID,
+                        "Invalid 'opts' parameter.");
       return false;
    }
 
@@ -805,10 +806,10 @@ _mongoc_update_many_opts_parse (
                &mongoc_update_many_opts->extra,
                bson_iter_key (&iter),
                bson_iter_value (&iter))) {
-            bson_set_error (error,
-                            MONGOC_ERROR_BSON,
-                            MONGOC_ERROR_BSON_INVALID,
-                            "Invalid 'opts' parameter.");
+            _mongoc_set_error (error,
+                              MONGOC_ERROR_BSON,
+                              MONGOC_ERROR_BSON_INVALID,
+                              "Invalid 'opts' parameter.");
             return false;
          }
       }
@@ -860,10 +861,10 @@ _mongoc_replace_one_opts_parse (
    }
 
    if (!bson_iter_init (&iter, opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_BSON,
-                      MONGOC_ERROR_BSON_INVALID,
-                      "Invalid 'opts' parameter.");
+      _mongoc_set_error (error,
+                        MONGOC_ERROR_BSON,
+                        MONGOC_ERROR_BSON_INVALID,
+                        "Invalid 'opts' parameter.");
       return false;
    }
 
@@ -966,10 +967,10 @@ _mongoc_replace_one_opts_parse (
                &mongoc_replace_one_opts->extra,
                bson_iter_key (&iter),
                bson_iter_value (&iter))) {
-            bson_set_error (error,
-                            MONGOC_ERROR_BSON,
-                            MONGOC_ERROR_BSON_INVALID,
-                            "Invalid 'opts' parameter.");
+            _mongoc_set_error (error,
+                              MONGOC_ERROR_BSON,
+                              MONGOC_ERROR_BSON_INVALID,
+                              "Invalid 'opts' parameter.");
             return false;
          }
       }
@@ -1016,10 +1017,10 @@ _mongoc_bulk_opts_parse (
    }
 
    if (!bson_iter_init (&iter, opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_BSON,
-                      MONGOC_ERROR_BSON_INVALID,
-                      "Invalid 'opts' parameter.");
+      _mongoc_set_error (error,
+                        MONGOC_ERROR_BSON,
+                        MONGOC_ERROR_BSON_INVALID,
+                        "Invalid 'opts' parameter.");
       return false;
    }
 
@@ -1072,11 +1073,11 @@ _mongoc_bulk_opts_parse (
          }
       }
       else {
-         bson_set_error (error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Invalid option '%s'",
-                         bson_iter_key (&iter));
+         _mongoc_set_error (error,
+                           MONGOC_ERROR_COMMAND,
+                           MONGOC_ERROR_COMMAND_INVALID_ARG,
+                           "Invalid option '%s'",
+                           bson_iter_key (&iter));
          return false;
       }
    }
@@ -1114,10 +1115,10 @@ _mongoc_bulk_insert_opts_parse (
    }
 
    if (!bson_iter_init (&iter, opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_BSON,
-                      MONGOC_ERROR_BSON_INVALID,
-                      "Invalid 'opts' parameter.");
+      _mongoc_set_error (error,
+                        MONGOC_ERROR_BSON,
+                        MONGOC_ERROR_BSON_INVALID,
+                        "Invalid 'opts' parameter.");
       return false;
    }
 
@@ -1132,11 +1133,11 @@ _mongoc_bulk_insert_opts_parse (
          }
       }
       else {
-         bson_set_error (error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Invalid option '%s'",
-                         bson_iter_key (&iter));
+         _mongoc_set_error (error,
+                           MONGOC_ERROR_COMMAND,
+                           MONGOC_ERROR_COMMAND_INVALID_ARG,
+                           "Invalid option '%s'",
+                           bson_iter_key (&iter));
          return false;
       }
    }
@@ -1175,10 +1176,10 @@ _mongoc_bulk_update_one_opts_parse (
    }
 
    if (!bson_iter_init (&iter, opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_BSON,
-                      MONGOC_ERROR_BSON_INVALID,
-                      "Invalid 'opts' parameter.");
+      _mongoc_set_error (error,
+                        MONGOC_ERROR_BSON,
+                        MONGOC_ERROR_BSON_INVALID,
+                        "Invalid 'opts' parameter.");
       return false;
    }
 
@@ -1247,11 +1248,11 @@ _mongoc_bulk_update_one_opts_parse (
          }
       }
       else {
-         bson_set_error (error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Invalid option '%s'",
-                         bson_iter_key (&iter));
+         _mongoc_set_error (error,
+                           MONGOC_ERROR_COMMAND,
+                           MONGOC_ERROR_COMMAND_INVALID_ARG,
+                           "Invalid option '%s'",
+                           bson_iter_key (&iter));
          return false;
       }
    }
@@ -1293,10 +1294,10 @@ _mongoc_bulk_update_many_opts_parse (
    }
 
    if (!bson_iter_init (&iter, opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_BSON,
-                      MONGOC_ERROR_BSON_INVALID,
-                      "Invalid 'opts' parameter.");
+      _mongoc_set_error (error,
+                        MONGOC_ERROR_BSON,
+                        MONGOC_ERROR_BSON_INVALID,
+                        "Invalid 'opts' parameter.");
       return false;
    }
 
@@ -1356,11 +1357,11 @@ _mongoc_bulk_update_many_opts_parse (
          }
       }
       else {
-         bson_set_error (error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Invalid option '%s'",
-                         bson_iter_key (&iter));
+         _mongoc_set_error (error,
+                           MONGOC_ERROR_COMMAND,
+                           MONGOC_ERROR_COMMAND_INVALID_ARG,
+                           "Invalid option '%s'",
+                           bson_iter_key (&iter));
          return false;
       }
    }
@@ -1401,10 +1402,10 @@ _mongoc_bulk_replace_one_opts_parse (
    }
 
    if (!bson_iter_init (&iter, opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_BSON,
-                      MONGOC_ERROR_BSON_INVALID,
-                      "Invalid 'opts' parameter.");
+      _mongoc_set_error (error,
+                        MONGOC_ERROR_BSON,
+                        MONGOC_ERROR_BSON_INVALID,
+                        "Invalid 'opts' parameter.");
       return false;
    }
 
@@ -1464,11 +1465,11 @@ _mongoc_bulk_replace_one_opts_parse (
          }
       }
       else {
-         bson_set_error (error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Invalid option '%s'",
-                         bson_iter_key (&iter));
+         _mongoc_set_error (error,
+                           MONGOC_ERROR_COMMAND,
+                           MONGOC_ERROR_COMMAND_INVALID_ARG,
+                           "Invalid option '%s'",
+                           bson_iter_key (&iter));
          return false;
       }
    }
@@ -1506,10 +1507,10 @@ _mongoc_bulk_remove_one_opts_parse (
    }
 
    if (!bson_iter_init (&iter, opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_BSON,
-                      MONGOC_ERROR_BSON_INVALID,
-                      "Invalid 'opts' parameter.");
+      _mongoc_set_error (error,
+                        MONGOC_ERROR_BSON,
+                        MONGOC_ERROR_BSON_INVALID,
+                        "Invalid 'opts' parameter.");
       return false;
    }
 
@@ -1542,11 +1543,11 @@ _mongoc_bulk_remove_one_opts_parse (
          }
       }
       else {
-         bson_set_error (error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Invalid option '%s'",
-                         bson_iter_key (&iter));
+         _mongoc_set_error (error,
+                           MONGOC_ERROR_COMMAND,
+                           MONGOC_ERROR_COMMAND_INVALID_ARG,
+                           "Invalid option '%s'",
+                           bson_iter_key (&iter));
          return false;
       }
    }
@@ -1583,10 +1584,10 @@ _mongoc_bulk_remove_many_opts_parse (
    }
 
    if (!bson_iter_init (&iter, opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_BSON,
-                      MONGOC_ERROR_BSON_INVALID,
-                      "Invalid 'opts' parameter.");
+      _mongoc_set_error (error,
+                        MONGOC_ERROR_BSON,
+                        MONGOC_ERROR_BSON_INVALID,
+                        "Invalid 'opts' parameter.");
       return false;
    }
 
@@ -1619,11 +1620,11 @@ _mongoc_bulk_remove_many_opts_parse (
          }
       }
       else {
-         bson_set_error (error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Invalid option '%s'",
-                         bson_iter_key (&iter));
+         _mongoc_set_error (error,
+                           MONGOC_ERROR_COMMAND,
+                           MONGOC_ERROR_COMMAND_INVALID_ARG,
+                           "Invalid option '%s'",
+                           bson_iter_key (&iter));
          return false;
       }
    }
@@ -1666,10 +1667,10 @@ _mongoc_change_stream_opts_parse (
    }
 
    if (!bson_iter_init (&iter, opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_BSON,
-                      MONGOC_ERROR_BSON_INVALID,
-                      "Invalid 'opts' parameter.");
+      _mongoc_set_error (error,
+                        MONGOC_ERROR_BSON,
+                        MONGOC_ERROR_BSON_INVALID,
+                        "Invalid 'opts' parameter.");
       return false;
    }
 
@@ -1761,10 +1762,10 @@ _mongoc_change_stream_opts_parse (
                &mongoc_change_stream_opts->extra,
                bson_iter_key (&iter),
                bson_iter_value (&iter))) {
-            bson_set_error (error,
-                            MONGOC_ERROR_BSON,
-                            MONGOC_ERROR_BSON_INVALID,
-                            "Invalid 'opts' parameter.");
+            _mongoc_set_error (error,
+                              MONGOC_ERROR_BSON,
+                              MONGOC_ERROR_BSON_INVALID,
+                              "Invalid 'opts' parameter.");
             return false;
          }
       }
@@ -1803,10 +1804,10 @@ _mongoc_create_index_opts_parse (
    }
 
    if (!bson_iter_init (&iter, opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_BSON,
-                      MONGOC_ERROR_BSON_INVALID,
-                      "Invalid 'opts' parameter.");
+      _mongoc_set_error (error,
+                        MONGOC_ERROR_BSON,
+                        MONGOC_ERROR_BSON_INVALID,
+                        "Invalid 'opts' parameter.");
       return false;
    }
 
@@ -1837,10 +1838,10 @@ _mongoc_create_index_opts_parse (
                &mongoc_create_index_opts->extra,
                bson_iter_key (&iter),
                bson_iter_value (&iter))) {
-            bson_set_error (error,
-                            MONGOC_ERROR_BSON,
-                            MONGOC_ERROR_BSON_INVALID,
-                            "Invalid 'opts' parameter.");
+            _mongoc_set_error (error,
+                              MONGOC_ERROR_BSON,
+                              MONGOC_ERROR_BSON_INVALID,
+                              "Invalid 'opts' parameter.");
             return false;
          }
       }
@@ -1882,10 +1883,10 @@ _mongoc_read_write_opts_parse (
    }
 
    if (!bson_iter_init (&iter, opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_BSON,
-                      MONGOC_ERROR_BSON_INVALID,
-                      "Invalid 'opts' parameter.");
+      _mongoc_set_error (error,
+                        MONGOC_ERROR_BSON,
+                        MONGOC_ERROR_BSON_INVALID,
+                        "Invalid 'opts' parameter.");
       return false;
    }
 
@@ -1943,10 +1944,10 @@ _mongoc_read_write_opts_parse (
                &mongoc_read_write_opts->extra,
                bson_iter_key (&iter),
                bson_iter_value (&iter))) {
-            bson_set_error (error,
-                            MONGOC_ERROR_BSON,
-                            MONGOC_ERROR_BSON_INVALID,
-                            "Invalid 'opts' parameter.");
+            _mongoc_set_error (error,
+                              MONGOC_ERROR_BSON,
+                              MONGOC_ERROR_BSON_INVALID,
+                              "Invalid 'opts' parameter.");
             return false;
          }
       }
@@ -1989,10 +1990,10 @@ _mongoc_gridfs_bucket_opts_parse (
    }
 
    if (!bson_iter_init (&iter, opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_BSON,
-                      MONGOC_ERROR_BSON_INVALID,
-                      "Invalid 'opts' parameter.");
+      _mongoc_set_error (error,
+                        MONGOC_ERROR_BSON,
+                        MONGOC_ERROR_BSON_INVALID,
+                        "Invalid 'opts' parameter.");
       return false;
    }
 
@@ -2041,10 +2042,10 @@ _mongoc_gridfs_bucket_opts_parse (
                &mongoc_gridfs_bucket_opts->extra,
                bson_iter_key (&iter),
                bson_iter_value (&iter))) {
-            bson_set_error (error,
-                            MONGOC_ERROR_BSON,
-                            MONGOC_ERROR_BSON_INVALID,
-                            "Invalid 'opts' parameter.");
+            _mongoc_set_error (error,
+                              MONGOC_ERROR_BSON,
+                              MONGOC_ERROR_BSON_INVALID,
+                              "Invalid 'opts' parameter.");
             return false;
          }
       }
@@ -2083,10 +2084,10 @@ _mongoc_gridfs_bucket_upload_opts_parse (
    }
 
    if (!bson_iter_init (&iter, opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_BSON,
-                      MONGOC_ERROR_BSON_INVALID,
-                      "Invalid 'opts' parameter.");
+      _mongoc_set_error (error,
+                        MONGOC_ERROR_BSON,
+                        MONGOC_ERROR_BSON_INVALID,
+                        "Invalid 'opts' parameter.");
       return false;
    }
 
@@ -2115,10 +2116,10 @@ _mongoc_gridfs_bucket_upload_opts_parse (
                &mongoc_gridfs_bucket_upload_opts->extra,
                bson_iter_key (&iter),
                bson_iter_value (&iter))) {
-            bson_set_error (error,
-                            MONGOC_ERROR_BSON,
-                            MONGOC_ERROR_BSON_INVALID,
-                            "Invalid 'opts' parameter.");
+            _mongoc_set_error (error,
+                              MONGOC_ERROR_BSON,
+                              MONGOC_ERROR_BSON_INVALID,
+                              "Invalid 'opts' parameter.");
             return false;
          }
       }
@@ -2164,10 +2165,10 @@ _mongoc_aggregate_opts_parse (
    }
 
    if (!bson_iter_init (&iter, opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_BSON,
-                      MONGOC_ERROR_BSON_INVALID,
-                      "Invalid 'opts' parameter.");
+      _mongoc_set_error (error,
+                        MONGOC_ERROR_BSON,
+                        MONGOC_ERROR_BSON_INVALID,
+                        "Invalid 'opts' parameter.");
       return false;
    }
 
@@ -2272,10 +2273,10 @@ _mongoc_aggregate_opts_parse (
                &mongoc_aggregate_opts->extra,
                bson_iter_key (&iter),
                bson_iter_value (&iter))) {
-            bson_set_error (error,
-                            MONGOC_ERROR_BSON,
-                            MONGOC_ERROR_BSON_INVALID,
-                            "Invalid 'opts' parameter.");
+            _mongoc_set_error (error,
+                              MONGOC_ERROR_BSON,
+                              MONGOC_ERROR_BSON_INVALID,
+                              "Invalid 'opts' parameter.");
             return false;
          }
       }
@@ -2322,10 +2323,10 @@ _mongoc_find_and_modify_appended_opts_parse (
    }
 
    if (!bson_iter_init (&iter, opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_BSON,
-                      MONGOC_ERROR_BSON_INVALID,
-                      "Invalid 'opts' parameter.");
+      _mongoc_set_error (error,
+                        MONGOC_ERROR_BSON,
+                        MONGOC_ERROR_BSON_INVALID,
+                        "Invalid 'opts' parameter.");
       return false;
    }
 
@@ -2383,10 +2384,10 @@ _mongoc_find_and_modify_appended_opts_parse (
                &mongoc_find_and_modify_appended_opts->extra,
                bson_iter_key (&iter),
                bson_iter_value (&iter))) {
-            bson_set_error (error,
-                            MONGOC_ERROR_BSON,
-                            MONGOC_ERROR_BSON_INVALID,
-                            "Invalid 'opts' parameter.");
+            _mongoc_set_error (error,
+                              MONGOC_ERROR_BSON,
+                              MONGOC_ERROR_BSON_INVALID,
+                              "Invalid 'opts' parameter.");
             return false;
          }
       }
@@ -2433,10 +2434,10 @@ _mongoc_count_document_opts_parse (
    }
 
    if (!bson_iter_init (&iter, opts)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_BSON,
-                      MONGOC_ERROR_BSON_INVALID,
-                      "Invalid 'opts' parameter.");
+      _mongoc_set_error (error,
+                        MONGOC_ERROR_BSON,
+                        MONGOC_ERROR_BSON_INVALID,
+                        "Invalid 'opts' parameter.");
       return false;
    }
 
@@ -2519,10 +2520,10 @@ _mongoc_count_document_opts_parse (
                &mongoc_count_document_opts->extra,
                bson_iter_key (&iter),
                bson_iter_value (&iter))) {
-            bson_set_error (error,
-                            MONGOC_ERROR_BSON,
-                            MONGOC_ERROR_BSON_INVALID,
-                            "Invalid 'opts' parameter.");
+            _mongoc_set_error (error,
+                              MONGOC_ERROR_BSON,
+                              MONGOC_ERROR_BSON_INVALID,
+                              "Invalid 'opts' parameter.");
             return false;
          }
       }

--- a/src/libmongoc/src/mongoc/mongoc-read-concern.c
+++ b/src/libmongoc/src/mongoc/mongoc-read-concern.c
@@ -16,6 +16,7 @@
 
 
 #include "mongoc-error.h"
+#include "mongoc-error-private.h"
 #include "mongoc-log.h"
 #include "mongoc-read-concern.h"
 #include "mongoc-read-concern-private.h"
@@ -206,7 +207,7 @@ _mongoc_read_concern_new_from_iter (const bson_iter_t *iter, bson_error_t *error
    return read_concern;
 
 fail:
-   bson_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "Invalid readConcern");
+   _mongoc_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "Invalid readConcern");
 
    mongoc_read_concern_destroy (read_concern);
    return NULL;

--- a/src/libmongoc/src/mongoc/mongoc-read-prefs.c
+++ b/src/libmongoc/src/mongoc/mongoc-read-prefs.c
@@ -16,6 +16,7 @@
 
 
 #include "mongoc-error.h"
+#include "mongoc-error-private.h"
 #include "mongoc-read-prefs-private.h"
 #include "mongoc-trace-private.h"
 #include <common-cmp-private.h>
@@ -404,7 +405,7 @@ bool
 _mongoc_read_prefs_validate (const mongoc_read_prefs_t *read_prefs, bson_error_t *error)
 {
    if (read_prefs && !mongoc_read_prefs_is_valid (read_prefs)) {
-      bson_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "Invalid mongoc_read_prefs_t");
+      _mongoc_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "Invalid mongoc_read_prefs_t");
       return false;
    }
    return true;

--- a/src/libmongoc/src/mongoc/mongoc-scram.c
+++ b/src/libmongoc/src/mongoc/mongoc-scram.c
@@ -20,6 +20,7 @@
 #include <string.h>
 
 #include "mongoc-error.h"
+#include "mongoc-error-private.h"
 #include "mongoc-scram-private.h"
 #include "mongoc-rand-private.h"
 #include "mongoc-util-private.h"
@@ -338,7 +339,7 @@ _mongoc_scram_start (
    BSON_ASSERT (outbuflen);
 
    if (!scram->user) {
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_SCRAM, MONGOC_ERROR_SCRAM_PROTOCOL_ERROR, "SCRAM Failure: username is not set");
       goto FAIL;
    }
@@ -354,11 +355,11 @@ _mongoc_scram_start (
 
    /* the server uses a 24 byte random nonce.  so we do as well */
    if (1 != _mongoc_rand_bytes (nonce, sizeof (nonce))) {
-      bson_set_error (error,
-                      MONGOC_ERROR_SCRAM,
-                      MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
-                      "SCRAM Failure: could not generate a cryptographically "
-                      "secure nonce in sasl step 1");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_SCRAM,
+                         MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
+                         "SCRAM Failure: could not generate a cryptographically "
+                         "secure nonce in sasl step 1");
       goto FAIL;
    }
 
@@ -366,7 +367,7 @@ _mongoc_scram_start (
       mcommon_b64_ntop (nonce, sizeof (nonce), scram->encoded_nonce, sizeof (scram->encoded_nonce));
 
    if (-1 == scram->encoded_nonce_len) {
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_SCRAM, MONGOC_ERROR_SCRAM_PROTOCOL_ERROR, "SCRAM Failure: could not encode nonce");
       goto FAIL;
    }
@@ -426,15 +427,15 @@ _mongoc_scram_start (
    goto CLEANUP;
 
 BUFFER_AUTH:
-   bson_set_error (error,
-                   MONGOC_ERROR_SCRAM,
-                   MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
-                   "SCRAM Failure: could not buffer auth message in sasl step1");
+   _mongoc_set_error (error,
+                      MONGOC_ERROR_SCRAM,
+                      MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
+                      "SCRAM Failure: could not buffer auth message in sasl step1");
 
    goto FAIL;
 
 BUFFER:
-   bson_set_error (
+   _mongoc_set_error (
       error, MONGOC_ERROR_SCRAM, MONGOC_ERROR_SCRAM_PROTOCOL_ERROR, "SCRAM Failure: could not buffer sasl step1");
 
    goto FAIL;
@@ -602,21 +603,21 @@ _mongoc_scram_step2 (mongoc_scram_t *scram,
          current_val_len = &val_i_len;
          break;
       default:
-         bson_set_error (error,
-                         MONGOC_ERROR_SCRAM,
-                         MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
-                         "SCRAM Failure: unknown key (%c) in sasl step 2",
-                         *ptr);
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_SCRAM,
+                            MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
+                            "SCRAM Failure: unknown key (%c) in sasl step 2",
+                            *ptr);
          goto FAIL;
       }
 
       ptr++;
 
       if (*ptr != '=') {
-         bson_set_error (error,
-                         MONGOC_ERROR_SCRAM,
-                         MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
-                         "SCRAM Failure: invalid parse state in sasl step 2");
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_SCRAM,
+                            MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
+                            "SCRAM Failure: invalid parse state in sasl step 2");
 
          goto FAIL;
       }
@@ -643,21 +644,21 @@ _mongoc_scram_step2 (mongoc_scram_t *scram,
    }
 
    if (!val_r) {
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_SCRAM, MONGOC_ERROR_SCRAM_PROTOCOL_ERROR, "SCRAM Failure: no r param in sasl step 2");
 
       goto FAIL;
    }
 
    if (!val_s) {
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_SCRAM, MONGOC_ERROR_SCRAM_PROTOCOL_ERROR, "SCRAM Failure: no s param in sasl step 2");
 
       goto FAIL;
    }
 
    if (!val_i) {
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_SCRAM, MONGOC_ERROR_SCRAM_PROTOCOL_ERROR, "SCRAM Failure: no i param in sasl step 2");
 
       goto FAIL;
@@ -666,10 +667,10 @@ _mongoc_scram_step2 (mongoc_scram_t *scram,
    /* verify our nonce */
    if (mcommon_cmp_less_us (val_r_len, scram->encoded_nonce_len) ||
        mongoc_memcmp (val_r, scram->encoded_nonce, scram->encoded_nonce_len)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_SCRAM,
-                      MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
-                      "SCRAM Failure: client nonce not repeated in sasl step 2");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_SCRAM,
+                         MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
+                         "SCRAM Failure: client nonce not repeated in sasl step 2");
    }
 
    *outbuflen = 0;
@@ -694,19 +695,19 @@ _mongoc_scram_step2 (mongoc_scram_t *scram,
    decoded_salt_len = mcommon_b64_pton ((char *) val_s, decoded_salt, sizeof (decoded_salt));
 
    if (-1 == decoded_salt_len) {
-      bson_set_error (error,
-                      MONGOC_ERROR_SCRAM,
-                      MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
-                      "SCRAM Failure: unable to decode salt in sasl step2");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_SCRAM,
+                         MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
+                         "SCRAM Failure: unable to decode salt in sasl step2");
       goto FAIL;
    }
 
    if (expected_salt_length != decoded_salt_len) {
-      bson_set_error (error,
-                      MONGOC_ERROR_SCRAM,
-                      MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
-                      "SCRAM Failure: invalid salt length of %d in sasl step2",
-                      decoded_salt_len);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_SCRAM,
+                         MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
+                         "SCRAM Failure: invalid salt length of %d in sasl step2",
+                         decoded_salt_len);
       goto FAIL;
    }
 
@@ -715,18 +716,18 @@ _mongoc_scram_step2 (mongoc_scram_t *scram,
     * null, we got to the end of the string and didn't have a parse error */
 
    if (*tmp) {
-      bson_set_error (error,
-                      MONGOC_ERROR_SCRAM,
-                      MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
-                      "SCRAM Failure: unable to parse iterations in sasl step2");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_SCRAM,
+                         MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
+                         "SCRAM Failure: unable to parse iterations in sasl step2");
       goto FAIL;
    }
 
    if (iterations < 0) {
-      bson_set_error (error,
-                      MONGOC_ERROR_SCRAM,
-                      MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
-                      "SCRAM Failure: iterations is negative in sasl step2");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_SCRAM,
+                         MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
+                         "SCRAM Failure: iterations is negative in sasl step2");
       goto FAIL;
    }
 
@@ -734,10 +735,10 @@ _mongoc_scram_step2 (mongoc_scram_t *scram,
     * the authentication conversation specifies a lower count. This mitigates
     * downgrade attacks by a man-in-the-middle attacker. */
    if (iterations < 4096) {
-      bson_set_error (error,
-                      MONGOC_ERROR_SCRAM,
-                      MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
-                      "SCRAM Failure: iterations must be at least 4096");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_SCRAM,
+                         MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
+                         "SCRAM Failure: iterations must be at least 4096");
       goto FAIL;
    }
 
@@ -760,7 +761,7 @@ _mongoc_scram_step2 (mongoc_scram_t *scram,
                                                                  decoded_salt,
                                                                  decoded_salt_len,
                                                                  (uint32_t) iterations)) {
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_SCRAM, MONGOC_ERROR_SCRAM_PROTOCOL_ERROR, "SCRAM Failure: failed to salt password");
       goto FAIL;
    }
@@ -770,15 +771,15 @@ _mongoc_scram_step2 (mongoc_scram_t *scram,
    goto CLEANUP;
 
 BUFFER_AUTH:
-   bson_set_error (error,
-                   MONGOC_ERROR_SCRAM,
-                   MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
-                   "SCRAM Failure: could not buffer auth message in sasl step2");
+   _mongoc_set_error (error,
+                      MONGOC_ERROR_SCRAM,
+                      MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
+                      "SCRAM Failure: could not buffer auth message in sasl step2");
 
    goto FAIL;
 
 BUFFER:
-   bson_set_error (
+   _mongoc_set_error (
       error, MONGOC_ERROR_SCRAM, MONGOC_ERROR_SCRAM_PROTOCOL_ERROR, "SCRAM Failure: could not buffer sasl step2");
 
    goto FAIL;
@@ -872,21 +873,21 @@ _mongoc_scram_step3 (mongoc_scram_t *scram,
          current_val_len = &val_v_len;
          break;
       default:
-         bson_set_error (error,
-                         MONGOC_ERROR_SCRAM,
-                         MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
-                         "SCRAM Failure: unknown key (%c) in sasl step 3",
-                         *ptr);
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_SCRAM,
+                            MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
+                            "SCRAM Failure: unknown key (%c) in sasl step 3",
+                            *ptr);
          goto FAIL;
       }
 
       ptr++;
 
       if (*ptr != '=') {
-         bson_set_error (error,
-                         MONGOC_ERROR_SCRAM,
-                         MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
-                         "SCRAM Failure: invalid parse state in sasl step 3");
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_SCRAM,
+                            MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
+                            "SCRAM Failure: invalid parse state in sasl step 3");
          goto FAIL;
       }
 
@@ -914,25 +915,25 @@ _mongoc_scram_step3 (mongoc_scram_t *scram,
    *outbuflen = 0;
 
    if (val_e) {
-      bson_set_error (error,
-                      MONGOC_ERROR_SCRAM,
-                      MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
-                      "SCRAM Failure: authentication failure in sasl step 3 : %s",
-                      val_e);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_SCRAM,
+                         MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
+                         "SCRAM Failure: authentication failure in sasl step 3 : %s",
+                         val_e);
       goto FAIL;
    }
 
    if (!val_v) {
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_SCRAM, MONGOC_ERROR_SCRAM_PROTOCOL_ERROR, "SCRAM Failure: no v param in sasl step 3");
       goto FAIL;
    }
 
    if (!_mongoc_scram_verify_server_signature (scram, val_v, val_v_len)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_SCRAM,
-                      MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
-                      "SCRAM Failure: could not verify server signature in sasl step 3");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_SCRAM,
+                         MONGOC_ERROR_SCRAM_PROTOCOL_ERROR,
+                         "SCRAM Failure: could not verify server signature in sasl step 3");
       goto FAIL;
    }
 
@@ -976,7 +977,8 @@ _mongoc_scram_step (mongoc_scram_t *scram,
    case 3:
       return _mongoc_scram_step3 (scram, inbuf, inbuflen, outbuf, outbufmax, outbuflen, error);
    default:
-      bson_set_error (error, MONGOC_ERROR_SCRAM, MONGOC_ERROR_SCRAM_NOT_DONE, "SCRAM Failure: maximum steps detected");
+      _mongoc_set_error (
+         error, MONGOC_ERROR_SCRAM, MONGOC_ERROR_SCRAM_NOT_DONE, "SCRAM Failure: maximum steps detected");
       return false;
    }
 }
@@ -1009,10 +1011,10 @@ _mongoc_sasl_prep_impl (const char *name, const char *in_utf8, bson_error_t *err
    ssize_t num_chars;
    uint8_t *out_utf8;
 
-#define SASL_PREP_ERR_RETURN(msg)                                                               \
-   do {                                                                                         \
-      bson_set_error (err, MONGOC_ERROR_SCRAM, MONGOC_ERROR_SCRAM_PROTOCOL_ERROR, (msg), name); \
-      return NULL;                                                                              \
+#define SASL_PREP_ERR_RETURN(msg)                                                                \
+   do {                                                                                          \
+      _mongoc_set_error (err, MONGOC_ERROR_SCRAM, MONGOC_ERROR_SCRAM_PROTOCOL_ERROR, msg, name); \
+      return NULL;                                                                               \
    } while (0)
 
    /* 1. convert str to Unicode codepoints. */

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -29,6 +29,7 @@
 #include "mongoc-stream-tls-secure-channel-private.h"
 #include "mongoc-errno-private.h"
 #include "mongoc-error.h"
+#include "mongoc-error-private.h"
 #include <common-string-private.h>
 #include <common-cmp-private.h>
 
@@ -527,10 +528,10 @@ _mongoc_secure_channel_init_sec_buffer_desc (SecBufferDesc *desc, SecBuffer *buf
 }
 
 
-#define MONGOC_LOG_AND_SET_ERROR(ERROR, DOMAIN, CODE, ...) \
-   do {                                                    \
-      MONGOC_ERROR (__VA_ARGS__);                          \
-      bson_set_error (ERROR, DOMAIN, CODE, __VA_ARGS__);   \
+#define MONGOC_LOG_AND_SET_ERROR(ERROR, DOMAIN, CODE, ...)  \
+   do {                                                     \
+      MONGOC_ERROR (__VA_ARGS__);                           \
+      _mongoc_set_error (ERROR, DOMAIN, CODE, __VA_ARGS__); \
    } while (0)
 
 bool

--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -15,6 +15,7 @@
  */
 
 #include "mongoc-config.h"
+#include "mongoc-error-private.h"
 #include "mongoc-host-list.h"
 #include "mongoc-host-list-private.h"
 #include "mongoc-read-prefs.h"
@@ -500,7 +501,7 @@ _mongoc_server_description_set_error (mongoc_server_description_t *sd, const bso
    if (error && error->code) {
       memcpy (&sd->error, error, sizeof (bson_error_t));
    } else {
-      bson_set_error (&sd->error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_CONNECT, "unknown error calling hello");
+      _mongoc_set_error (&sd->error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_CONNECT, "unknown error calling hello");
    }
 
    /* Server Discovery and Monitoring Spec: if the server type changes from a
@@ -743,12 +744,12 @@ mongoc_server_description_handle_hello (mongoc_server_description_t *sd,
    EXIT;
 
 typefailure:
-   bson_set_error (&sd->error,
-                   MONGOC_ERROR_STREAM,
-                   MONGOC_ERROR_STREAM_INVALID_TYPE,
-                   "unexpected type %s for field %s in hello response",
-                   _mongoc_bson_type_to_str (bson_iter_type (&iter)),
-                   bson_iter_key (&iter));
+   _mongoc_set_error (&sd->error,
+                      MONGOC_ERROR_STREAM,
+                      MONGOC_ERROR_STREAM_INVALID_TYPE,
+                      "unexpected type %s for field %s in hello response",
+                      _mongoc_bson_type_to_str (bson_iter_type (&iter)),
+                      bson_iter_key (&iter));
 authfailure:
    sd->type = MONGOC_SERVER_UNKNOWN;
    sd->round_trip_time_msec = MONGOC_RTT_UNSET;

--- a/src/libmongoc/src/mongoc/mongoc-server-monitor.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-monitor.c
@@ -268,10 +268,10 @@ _server_monitor_send_and_recv_hello_opmsg (mongoc_server_monitor_t *server_monit
    const int32_t message_header_length = 4u * sizeof (int32_t);
 
    if (message_length < message_header_length) {
-      bson_set_error (error,
-                      MONGOC_ERROR_PROTOCOL,
-                      MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
-                      "invalid reply from server: message length");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_PROTOCOL,
+                         MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
+                         "invalid reply from server: message length");
       goto fail;
    }
 
@@ -284,29 +284,29 @@ _server_monitor_send_and_recv_hello_opmsg (mongoc_server_monitor_t *server_monit
 
    mcd_rpc_message_reset (rpc);
    if (!mcd_rpc_message_from_data_in_place (rpc, buffer.data, buffer.len, NULL)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_PROTOCOL,
-                      MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
-                      "invalid reply from server: malformed message");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_PROTOCOL,
+                         MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
+                         "invalid reply from server: malformed message");
       goto fail;
    }
 
    mcd_rpc_message_ingress (rpc);
 
    if (!mcd_rpc_message_decompress_if_necessary (rpc, &decompressed_data, &decompressed_data_len)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_PROTOCOL,
-                      MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
-                      "invalid reply from server: decompression failure");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_PROTOCOL,
+                         MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
+                         "invalid reply from server: decompression failure");
       goto fail;
    }
 
    bson_t body;
    if (!mcd_rpc_message_get_body (rpc, &body)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_PROTOCOL,
-                      MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
-                      "invalid reply from server: malformed body");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_PROTOCOL,
+                         MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
+                         "invalid reply from server: malformed body");
       goto fail;
    }
 
@@ -381,10 +381,10 @@ _server_monitor_send_and_recv_opquery (mongoc_server_monitor_t *server_monitor,
    const int32_t message_header_length = 4u * sizeof (int32_t);
 
    if (message_length < message_header_length) {
-      bson_set_error (error,
-                      MONGOC_ERROR_PROTOCOL,
-                      MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
-                      "invalid reply from server: message length");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_PROTOCOL,
+                         MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
+                         "invalid reply from server: message length");
       goto fail;
    }
 
@@ -397,29 +397,29 @@ _server_monitor_send_and_recv_opquery (mongoc_server_monitor_t *server_monitor,
 
    mcd_rpc_message_reset (rpc);
    if (!mcd_rpc_message_from_data_in_place (rpc, buffer.data, buffer.len, NULL)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_PROTOCOL,
-                      MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
-                      "invalid reply from server: malformed message");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_PROTOCOL,
+                         MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
+                         "invalid reply from server: malformed message");
       goto fail;
    }
 
    mcd_rpc_message_ingress (rpc);
 
    if (!mcd_rpc_message_decompress_if_necessary (rpc, &decompressed_data, &decompressed_data_len)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_PROTOCOL,
-                      MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
-                      "invalid reply from server: decompression failure");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_PROTOCOL,
+                         MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
+                         "invalid reply from server: decompression failure");
       goto fail;
    }
 
    bson_t body;
    if (!mcd_rpc_message_get_body (rpc, &body)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_PROTOCOL,
-                      MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
-                      "invalid reply from server: malformed body");
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_PROTOCOL,
+                         MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
+                         "invalid reply from server: malformed body");
       goto fail;
    }
 
@@ -553,12 +553,12 @@ _server_monitor_poll_with_interrupt (mongoc_server_monitor_t *server_monitor,
       ret = mongoc_stream_poll (poller, 1, (int32_t) BSON_MIN (timeleft_ms, monitor_tick_ms));
       if (ret == -1) {
          MONITOR_LOG (server_monitor, "mongoc_stream_poll error");
-         bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "poll error");
+         _mongoc_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "poll error");
          return false;
       }
 
       if (poller[0].revents & (POLLERR | POLLHUP)) {
-         bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "connection closed while polling");
+         _mongoc_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "connection closed while polling");
          return false;
       }
 
@@ -578,7 +578,7 @@ _server_monitor_poll_with_interrupt (mongoc_server_monitor_t *server_monitor,
          return true;
       }
    }
-   bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "connection timeout while polling");
+   _mongoc_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "connection timeout while polling");
    return false;
 }
 
@@ -594,7 +594,7 @@ _get_timeout_ms (int64_t expire_at_ms, bson_error_t *error)
 
    timeout_ms = expire_at_ms - _now_ms ();
    if (timeout_ms <= 0) {
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "connection timed out reading message length");
       return 0;
    }
@@ -650,12 +650,12 @@ _server_monitor_awaitable_hello_recv (mongoc_server_monitor_t *server_monitor,
    const int32_t message_header_length = 4u * sizeof (int32_t);
 
    if ((message_length < message_header_length) || (message_length > server_monitor->description->max_msg_size)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_PROTOCOL,
-                      MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
-                      "message size %" PRId32 " is not within expected range 16-%" PRId32 " bytes",
-                      message_length,
-                      server_monitor->description->max_msg_size);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_PROTOCOL,
+                         MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
+                         "message size %" PRId32 " is not within expected range 16-%" PRId32 " bytes",
+                         message_length,
+                         server_monitor->description->max_msg_size);
       GOTO (fail);
    }
 
@@ -672,7 +672,7 @@ _server_monitor_awaitable_hello_recv (mongoc_server_monitor_t *server_monitor,
    }
 
    if (!mcd_rpc_message_from_data_in_place (rpc, buffer.data, buffer.len, NULL)) {
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_PROTOCOL, MONGOC_ERROR_PROTOCOL_INVALID_REPLY, "malformed message from server");
       GOTO (fail);
    }
@@ -680,13 +680,13 @@ _server_monitor_awaitable_hello_recv (mongoc_server_monitor_t *server_monitor,
    mcd_rpc_message_ingress (rpc);
 
    if (!mcd_rpc_message_decompress_if_necessary (rpc, &decompressed_data, &decompressed_data_len)) {
-      bson_set_error (error, MONGOC_ERROR_PROTOCOL, MONGOC_ERROR_PROTOCOL_INVALID_REPLY, "decompression failure");
+      _mongoc_set_error (error, MONGOC_ERROR_PROTOCOL, MONGOC_ERROR_PROTOCOL_INVALID_REPLY, "decompression failure");
       GOTO (fail);
    }
 
    bson_t body;
    if (!mcd_rpc_message_get_body (rpc, &body)) {
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_PROTOCOL, MONGOC_ERROR_PROTOCOL_INVALID_REPLY, "malformed BSON payload from server");
       GOTO (fail);
    }

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-libressl.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-libressl.c
@@ -30,6 +30,7 @@
 #include "mongoc-ssl.h"
 #include "mongoc-ssl-private.h"
 #include "mongoc-error.h"
+#include "mongoc-error-private.h"
 #include "mongoc-counters-private.h"
 #include "mongoc-stream-socket.h"
 #include "mongoc-socket-private.h"
@@ -399,7 +400,7 @@ mongoc_stream_tls_libressl_handshake (mongoc_stream_t *stream, const char *host,
       *events = POLLOUT;
    } else if (ret < 0) {
       *events = 0;
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "TLS handshake failed: %s", tls_error (libressl->ctx));
       RETURN (false);
    } else {

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
@@ -65,6 +65,7 @@
 #include "mongoc-ssl.h"
 #include "mongoc-ssl-private.h"
 #include "mongoc-error.h"
+#include "mongoc-error-private.h"
 #include "mongoc-counters-private.h"
 #include "mongoc-errno-private.h"
 
@@ -811,7 +812,7 @@ mongoc_stream_tls_secure_channel_handshake (mongoc_stream_t *stream, const char 
    *events = 0;
 
    if (error && !error->code) {
-      bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "TLS handshake failed");
+      _mongoc_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "TLS handshake failed");
    }
 
    RETURN (false);

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-transport.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-transport.c
@@ -31,6 +31,7 @@
 #include "mongoc-ssl.h"
 #include "mongoc-ssl-private.h"
 #include "mongoc-error.h"
+#include "mongoc-error-private.h"
 #include "mongoc-counters-private.h"
 #include "mongoc-stream-tls.h"
 #include "mongoc-stream-tls-private.h"
@@ -400,7 +401,7 @@ _set_error_from_osstatus (OSStatus status, const char *prefix, bson_error_t *err
 
    err = SecCopyErrorMessageString (status, NULL);
    err_str = _mongoc_cfstringref_to_cstring (err);
-   bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "%s: %s (%d)", prefix, err_str, status);
+   _mongoc_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "%s: %s (%d)", prefix, err_str, status);
 
    bson_free (err_str);
    CFRelease (err);
@@ -537,7 +538,7 @@ _verify_peer (mongoc_stream_t *stream, bson_error_t *error)
 
    if (trust_result != kSecTrustResultProceed && trust_result != kSecTrustResultUnspecified) {
       char *reason = explain_trust_result (trust, trust_result);
-      bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "TLS handshake failed (%s)", reason);
+      _mongoc_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "TLS handshake failed (%s)", reason);
       bson_free (reason);
       goto fail;
    }

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls.c
@@ -25,6 +25,7 @@
 #include "mongoc-log.h"
 #include "mongoc-trace-private.h"
 #include "mongoc-error.h"
+#include "mongoc-error-private.h"
 
 #include "mongoc-stream-tls-private.h"
 #include "mongoc-stream-private.h"
@@ -106,7 +107,7 @@ mongoc_stream_tls_handshake_block (mongoc_stream_t *stream, const char *host, in
             const int64_t now = bson_get_monotonic_time ();
             const int64_t remaining = expire - now;
             if (remaining < 0) {
-               bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "TLS handshake timed out.");
+               _mongoc_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "TLS handshake timed out.");
                return false;
             } else {
                const int64_t msec = remaining / 1000;
@@ -119,7 +120,7 @@ mongoc_stream_tls_handshake_block (mongoc_stream_t *stream, const char *host, in
    } while (events && ret > 0);
 
    if (error && !error->code) {
-      bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "TLS handshake failed.");
+      _mongoc_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "TLS handshake failed.");
    }
    return false;
 }

--- a/src/libmongoc/src/mongoc/mongoc-stream.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream.c
@@ -20,6 +20,7 @@
 #include "mongoc-array-private.h"
 #include "mongoc-buffer-private.h"
 #include "mongoc-error.h"
+#include "mongoc-error-private.h"
 #include "mongoc-errno-private.h"
 #include "mongoc-flags.h"
 #include "mongoc-log.h"
@@ -416,11 +417,11 @@ _mongoc_stream_writev_full (
 
    if (BSON_UNLIKELY (!mcommon_in_range_signed (int32_t, timeout_msec))) {
       // CDRIVER-4589
-      bson_set_error (error,
-                      MONGOC_ERROR_STREAM,
-                      MONGOC_ERROR_STREAM_SOCKET,
-                      "timeout_msec value %" PRId64 " exceeds supported 32-bit range",
-                      timeout_msec);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_STREAM,
+                         MONGOC_ERROR_STREAM_SOCKET,
+                         "timeout_msec value %" PRId64 " exceeds supported 32-bit range",
+                         timeout_msec);
       RETURN (false);
    }
 
@@ -434,26 +435,26 @@ _mongoc_stream_writev_full (
 
          errstr = bson_strerror_r (errno, buf, sizeof (buf));
 
-         bson_set_error (error,
-                         MONGOC_ERROR_STREAM,
-                         MONGOC_ERROR_STREAM_SOCKET,
-                         "Failure during socket delivery: %s (%d)",
-                         errstr,
-                         errno);
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_STREAM,
+                            MONGOC_ERROR_STREAM_SOCKET,
+                            "Failure during socket delivery: %s (%d)",
+                            errstr,
+                            errno);
       }
 
       RETURN (false);
    }
 
    if (mcommon_cmp_not_equal_su (r, total_bytes)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_STREAM,
-                      MONGOC_ERROR_STREAM_SOCKET,
-                      "Failure to send all requested bytes (only sent: %" PRIu64 "/%zu in %" PRId64
-                      "ms) during socket delivery",
-                      (uint64_t) r,
-                      total_bytes,
-                      timeout_msec);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_STREAM,
+                         MONGOC_ERROR_STREAM_SOCKET,
+                         "Failure to send all requested bytes (only sent: %" PRIu64 "/%zu in %" PRId64
+                         "ms) during socket delivery",
+                         (uint64_t) r,
+                         total_bytes,
+                         timeout_msec);
 
       RETURN (false);
    }

--- a/src/libmongoc/src/mongoc/mongoc-topology-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description.c
@@ -16,6 +16,7 @@
 
 #include "mongoc-array-private.h"
 #include "mongoc-error.h"
+#include "mongoc-error-private.h"
 #include "mongoc-server-description-private.h"
 #include "mongoc-topology-description-apm-private.h"
 #include "mongoc-trace-private.h"
@@ -685,24 +686,24 @@ _mongoc_topology_description_validate_max_staleness (const mongoc_topology_descr
    }
 
    if (max_staleness_seconds * 1000 < td->heartbeat_msec + MONGOC_IDLE_WRITE_PERIOD_MS) {
-      bson_set_error (error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "maxStalenessSeconds is set to %" PRId64 ", it must be at least heartbeatFrequencyMS (%" PRId64
-                      ") + server's idle write period (%d seconds)",
-                      max_staleness_seconds,
-                      td->heartbeat_msec,
-                      MONGOC_IDLE_WRITE_PERIOD_MS / 1000);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "maxStalenessSeconds is set to %" PRId64 ", it must be at least heartbeatFrequencyMS (%" PRId64
+                         ") + server's idle write period (%d seconds)",
+                         max_staleness_seconds,
+                         td->heartbeat_msec,
+                         MONGOC_IDLE_WRITE_PERIOD_MS / 1000);
       return false;
    }
 
    if (max_staleness_seconds < MONGOC_SMALLEST_MAX_STALENESS_SECONDS) {
-      bson_set_error (error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "maxStalenessSeconds is set to %" PRId64 ", it must be at least %d seconds",
-                      max_staleness_seconds,
-                      MONGOC_SMALLEST_MAX_STALENESS_SECONDS);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "maxStalenessSeconds is set to %" PRId64 ", it must be at least %d seconds",
+                         max_staleness_seconds,
+                         MONGOC_SMALLEST_MAX_STALENESS_SECONDS);
       return false;
    }
 
@@ -1096,7 +1097,7 @@ mongoc_topology_description_server_by_id_const (const mongoc_topology_descriptio
 
    sd = mongoc_set_get_const (mc_tpld_servers_const (td), id);
    if (!sd) {
-      bson_set_error (
+      _mongoc_set_error (
          error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_NOT_ESTABLISHED, "Could not find description for node %u", id);
    }
 
@@ -1637,7 +1638,7 @@ _mongoc_topology_description_update_rs_from_primary (mongoc_topology_description
          _mongoc_topology_description_set_max_set_version (topology, server);
 
       } else {
-         bson_set_error (
+         _mongoc_set_error (
             &error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_CONNECT, "member's setVersion or electionId is stale");
          mongoc_topology_description_invalidate_server (topology, server->id, &error);
          _update_rs_type (topology);
@@ -1653,7 +1654,7 @@ _mongoc_topology_description_update_rs_from_primary (mongoc_topology_description
           */
          if (_mongoc_topology_description_later_election (topology, server)) {
             // stale primary code return:
-            bson_set_error (
+            _mongoc_set_error (
                &error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_CONNECT, "member's setVersion or electionId is stale");
             mongoc_topology_description_invalidate_server (topology, server->id, &error);
             _update_rs_type (topology);
@@ -2075,24 +2076,24 @@ _mongoc_topology_description_check_compatible (mongoc_topology_description_t *td
       }
 
       if (sd->min_wire_version > WIRE_VERSION_MAX) {
-         bson_set_error (&td->compatibility_error,
-                         MONGOC_ERROR_PROTOCOL,
-                         MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION,
-                         "Server at %s requires wire version %d,"
-                         " but this version of libmongoc only supports up to %d",
-                         sd->host.host_and_port,
-                         sd->min_wire_version,
-                         WIRE_VERSION_MAX);
+         _mongoc_set_error (&td->compatibility_error,
+                            MONGOC_ERROR_PROTOCOL,
+                            MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION,
+                            "Server at %s requires wire version %d,"
+                            " but this version of libmongoc only supports up to %d",
+                            sd->host.host_and_port,
+                            sd->min_wire_version,
+                            WIRE_VERSION_MAX);
       } else if (sd->max_wire_version < WIRE_VERSION_MIN) {
-         bson_set_error (&td->compatibility_error,
-                         MONGOC_ERROR_PROTOCOL,
-                         MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION,
-                         "Server at %s reports wire version %d, but this"
-                         " version of libmongoc requires at least %d (MongoDB %s)",
-                         sd->host.host_and_port,
-                         sd->max_wire_version,
-                         WIRE_VERSION_MIN,
-                         _mongoc_wire_version_to_server_version (WIRE_VERSION_MIN));
+         _mongoc_set_error (&td->compatibility_error,
+                            MONGOC_ERROR_PROTOCOL,
+                            MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION,
+                            "Server at %s reports wire version %d, but this"
+                            " version of libmongoc requires at least %d (MongoDB %s)",
+                            sd->host.host_and_port,
+                            sd->max_wire_version,
+                            WIRE_VERSION_MIN,
+                            _mongoc_wire_version_to_server_version (WIRE_VERSION_MIN));
       }
    }
 }
@@ -2176,19 +2177,19 @@ mongoc_topology_description_handle_hello (mongoc_topology_description_t *topolog
 
       if (!sd->set_name) {
          wrong_set_name = true;
-         bson_set_error (&set_name_err,
-                         MONGOC_ERROR_SERVER_SELECTION,
-                         MONGOC_ERROR_SERVER_SELECTION_FAILURE,
-                         "no reported set name, but expected '%s'",
-                         topology->set_name);
+         _mongoc_set_error (&set_name_err,
+                            MONGOC_ERROR_SERVER_SELECTION,
+                            MONGOC_ERROR_SERVER_SELECTION_FAILURE,
+                            "no reported set name, but expected '%s'",
+                            topology->set_name);
       } else if (0 != strcmp (sd->set_name, topology->set_name)) {
          wrong_set_name = true;
-         bson_set_error (&set_name_err,
-                         MONGOC_ERROR_SERVER_SELECTION,
-                         MONGOC_ERROR_SERVER_SELECTION_FAILURE,
-                         "reported set name '%s' does not match '%s'",
-                         sd->set_name,
-                         topology->set_name);
+         _mongoc_set_error (&set_name_err,
+                            MONGOC_ERROR_SERVER_SELECTION,
+                            MONGOC_ERROR_SERVER_SELECTION_FAILURE,
+                            "reported set name '%s' does not match '%s'",
+                            sd->set_name,
+                            topology->set_name);
       }
 
       if (wrong_set_name) {

--- a/src/libmongoc/src/mongoc/mongoc-topology-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-private.h
@@ -27,6 +27,7 @@
 #include "mongoc-uri.h"
 #include "mongoc-client-session-private.h"
 #include "mongoc-crypt-private.h"
+#include "mongoc-error-private.h"
 #include "mongoc-ts-pool-private.h"
 #include "mongoc-shared-private.h"
 #include "mongoc-sleep.h"
@@ -623,7 +624,7 @@ _mongoc_topology_invalidate_server (mongoc_topology_t *td, uint32_t server_id)
 {
    bson_error_t error;
    mc_tpld_modification tdmod = mc_tpld_modify_begin (td);
-   bson_set_error (&error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_CONNECT, "invalidated");
+   _mongoc_set_error (&error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_CONNECT, "invalidated");
    mongoc_topology_description_invalidate_server (tdmod.new_td, server_id, &error);
    mc_tpld_modify_commit (tdmod);
 }

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
@@ -18,6 +18,7 @@
 
 #include "mongoc-config.h"
 #include "mongoc-error.h"
+#include "mongoc-error-private.h"
 #include "mongoc-trace-private.h"
 #include "mongoc-topology-scanner-private.h"
 #include "mongoc-stream-private.h"
@@ -728,12 +729,12 @@ _async_error_or_timeout (mongoc_async_cmd_t *acmd, int64_t duration_usec, const 
          node->successful_dns_result = NULL;
       }
 
-      bson_set_error (&node->last_error,
-                      MONGOC_ERROR_CLIENT,
-                      MONGOC_ERROR_STREAM_CONNECT,
-                      "%s calling hello on \'%s\'",
-                      message,
-                      node->host.host_and_port);
+      _mongoc_set_error (&node->last_error,
+                         MONGOC_ERROR_CLIENT,
+                         MONGOC_ERROR_STREAM_CONNECT,
+                         "%s calling hello on \'%s\'",
+                         message,
+                         node->host.host_and_port);
 
       _mongoc_topology_scanner_monitor_heartbeat_failed (ts, &node->host, &node->last_error, duration_usec);
 
@@ -884,7 +885,7 @@ mongoc_topology_scanner_node_setup_tcp (mongoc_topology_scanner_node_t *node, bs
 
       if (s != 0) {
          mongoc_counter_dns_failure_inc ();
-         bson_set_error (
+         _mongoc_set_error (
             error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_NAME_RESOLUTION, "Failed to resolve '%s'", host->host);
          RETURN (false);
       }
@@ -917,7 +918,7 @@ mongoc_topology_scanner_node_connect_unix (mongoc_topology_scanner_node_t *node,
 {
 #ifdef _WIN32
    ENTRY;
-   bson_set_error (
+   _mongoc_set_error (
       error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_CONNECT, "UNIX domain sockets not supported on win32.");
    RETURN (false);
 #else
@@ -936,14 +937,15 @@ mongoc_topology_scanner_node_connect_unix (mongoc_topology_scanner_node_t *node,
    int req = bson_snprintf (saddr.sun_path, sizeof saddr.sun_path - 1, "%s", host->host);
 
    if (mcommon_cmp_greater_equal_su (req, sizeof saddr.sun_path - 1)) {
-      bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Failed to define socket address path.");
+      _mongoc_set_error (
+         error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Failed to define socket address path.");
       RETURN (false);
    }
 
    sock = mongoc_socket_new (AF_UNIX, SOCK_STREAM, 0);
 
    if (sock == NULL) {
-      bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Failed to create socket.");
+      _mongoc_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "Failed to create socket.");
       RETURN (false);
    }
 
@@ -953,11 +955,11 @@ mongoc_topology_scanner_node_connect_unix (mongoc_topology_scanner_node_t *node,
 
       errstr = bson_strerror_r (mongoc_socket_errno (sock), buf, sizeof (buf));
 
-      bson_set_error (error,
-                      MONGOC_ERROR_STREAM,
-                      MONGOC_ERROR_STREAM_CONNECT,
-                      "Failed to connect to UNIX domain socket: %s",
-                      errstr);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_STREAM,
+                         MONGOC_ERROR_STREAM_CONNECT,
+                         "Failed to connect to UNIX domain socket: %s",
+                         errstr);
       mongoc_socket_destroy (sock);
       RETURN (false);
    }
@@ -968,7 +970,7 @@ mongoc_topology_scanner_node_connect_unix (mongoc_topology_scanner_node_t *node,
          node, stream, false /* is_setup_done */, NULL /* dns result */, 0 /* delay */, true /* use_handshake */);
       RETURN (true);
    }
-   bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_CONNECT, "Failed to create TLS stream");
+   _mongoc_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_CONNECT, "Failed to create TLS stream");
    RETURN (false);
 #endif
 }
@@ -1176,15 +1178,12 @@ _mongoc_topology_scanner_finish (mongoc_topology_scanner_t *ts)
 
    memset (&ts->error, 0, sizeof (bson_error_t));
 
-   msg = mcommon_string_new (NULL);
+   msg = mcommon_string_new ("mongoc:");
 
    DL_FOREACH_SAFE (ts->nodes, node, tmp)
    {
       if (node->last_error.code) {
-         if (msg->len) {
-            mcommon_string_append_c (msg, ' ');
-         }
-
+         mcommon_string_append_c (msg, ' ');
          mcommon_string_append_printf (msg, "[%s]", node->last_error.message);
 
          /* last error domain and code win */
@@ -1193,7 +1192,7 @@ _mongoc_topology_scanner_finish (mongoc_topology_scanner_t *ts)
       }
    }
 
-   bson_strncpy ((char *) &error->message, msg->str, sizeof (error->message));
+   bson_strncpy (error->message, msg->str, sizeof (error->message));
    mcommon_string_free (msg, true);
 
    _delete_retired_nodes (ts);

--- a/src/libmongoc/src/mongoc/mongoc-uri.c
+++ b/src/libmongoc/src/mongoc/mongoc-uri.c
@@ -25,6 +25,7 @@
 #include "mongoc-util-private.h"
 
 #include "mongoc-config.h"
+#include "mongoc-error-private.h"
 #include "mongoc-host-list.h"
 #include "mongoc-host-list-private.h"
 #include "mongoc-log.h"
@@ -59,7 +60,7 @@ struct _mongoc_uri_t {
 };
 
 #define MONGOC_URI_ERROR(error, format, ...) \
-   bson_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, format, __VA_ARGS__)
+   _mongoc_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, format, __VA_ARGS__)
 
 
 static const char *escape_instructions = "Percent-encode username and password"
@@ -86,16 +87,16 @@ mongoc_uri_do_unescape (char **str)
 }
 
 
-#define VALIDATE_SRV_ERR()                                                \
-   do {                                                                   \
-      bson_set_error (error,                                              \
-                      MONGOC_ERROR_STREAM,                                \
-                      MONGOC_ERROR_STREAM_NAME_RESOLUTION,                \
-                      "Invalid host \"%s\" returned for service \"%s\": " \
-                      "host must be subdomain of service name",           \
-                      host,                                               \
-                      srv_hostname);                                      \
-      return false;                                                       \
+#define VALIDATE_SRV_ERR()                                                   \
+   do {                                                                      \
+      _mongoc_set_error (error,                                              \
+                         MONGOC_ERROR_STREAM,                                \
+                         MONGOC_ERROR_STREAM_NAME_RESOLUTION,                \
+                         "Invalid host \"%s\" returned for service \"%s\": " \
+                         "host must be subdomain of service name",           \
+                         host,                                               \
+                         srv_hostname);                                      \
+      return false;                                                          \
    } while (0)
 
 
@@ -1089,7 +1090,7 @@ mongoc_uri_apply_options (mongoc_uri_t *uri, const bson_t *options, bool from_dn
             }
 
             if (!mongoc_uri_set_option_as_bool (uri, canon, bval)) {
-               bson_set_error (
+               _mongoc_set_error (
                   error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "Failed to set %s to %d", canon, bval);
                return false;
             }

--- a/src/libmongoc/src/mongoc/mongoc-util.c
+++ b/src/libmongoc/src/mongoc/mongoc-util.c
@@ -24,6 +24,7 @@
 
 #include "common-md5-private.h"
 #include "common-thread-private.h"
+#include "mongoc-error-private.h"
 #include "mongoc-rand-private.h"
 #include "mongoc-util-private.h"
 #include "mongoc-client.h"
@@ -336,12 +337,12 @@ _mongoc_get_server_id_from_opts (
    }
 
    if (!BSON_ITER_HOLDS_INT (&iter)) {
-      bson_set_error (error, domain, code, "The serverId option must be an integer");
+      _mongoc_set_error (error, domain, code, "The serverId option must be an integer");
       RETURN (false);
    }
 
    if (bson_iter_as_int64 (&iter) <= 0) {
-      bson_set_error (error, domain, code, "The serverId option must be >= 1");
+      _mongoc_set_error (error, domain, code, "The serverId option must be >= 1");
       RETURN (false);
    }
 
@@ -361,11 +362,11 @@ _mongoc_validate_new_document (const bson_t *doc, bson_validate_flags_t vflags, 
    }
 
    if (!bson_validate_with_error (doc, vflags, &validate_err)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "invalid document for insert: %s",
-                      validate_err.message);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "invalid document for insert: %s",
+                         validate_err.message);
       return false;
    }
 
@@ -385,27 +386,27 @@ _mongoc_validate_replace (const bson_t *doc, bson_validate_flags_t vflags, bson_
    }
 
    if (!bson_validate_with_error (doc, vflags, &validate_err)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "invalid argument for replace: %s",
-                      validate_err.message);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "invalid argument for replace: %s",
+                         validate_err.message);
       return false;
    }
 
    if (!bson_iter_init (&iter, doc)) {
-      bson_set_error (error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, "replace document is corrupt");
+      _mongoc_set_error (error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, "replace document is corrupt");
       return false;
    }
 
    while (bson_iter_next (&iter)) {
       key = bson_iter_key (&iter);
       if (key[0] == '$') {
-         bson_set_error (error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Invalid key '%s': replace prohibits $ operators",
-                         key);
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_COMMAND,
+                            MONGOC_ERROR_COMMAND_INVALID_ARG,
+                            "Invalid key '%s': replace prohibits $ operators",
+                            key);
 
          return false;
       }
@@ -427,11 +428,11 @@ _mongoc_validate_update (const bson_t *update, bson_validate_flags_t vflags, bso
    }
 
    if (!bson_validate_with_error (update, vflags, &validate_err)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "invalid argument for update: %s",
-                      validate_err.message);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "invalid argument for update: %s",
+                         validate_err.message);
       return false;
    }
 
@@ -440,19 +441,19 @@ _mongoc_validate_update (const bson_t *update, bson_validate_flags_t vflags, bso
    }
 
    if (!bson_iter_init (&iter, update)) {
-      bson_set_error (error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, "update document is corrupt");
+      _mongoc_set_error (error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, "update document is corrupt");
       return false;
    }
 
    while (bson_iter_next (&iter)) {
       key = bson_iter_key (&iter);
       if (key[0] != '$') {
-         bson_set_error (error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Invalid key '%s': update only works with $ operators"
-                         " and pipelines",
-                         key);
+         _mongoc_set_error (error,
+                            MONGOC_ERROR_COMMAND,
+                            MONGOC_ERROR_COMMAND_INVALID_ARG,
+                            "Invalid key '%s': update only works with $ operators"
+                            " and pipelines",
+                            key);
 
          return false;
       }
@@ -957,21 +958,21 @@ _mongoc_iter_document_as_bson (const bson_iter_t *iter, bson_t *bson, bson_error
    const uint8_t *data;
 
    if (!BSON_ITER_HOLDS_DOCUMENT (iter)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "expected BSON document for field: %s",
-                      bson_iter_key (iter));
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "expected BSON document for field: %s",
+                         bson_iter_key (iter));
       return false;
    }
 
    bson_iter_document (iter, &len, &data);
    if (!bson_init_static (bson, data, len)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "unable to initialize BSON document from field: %s",
-                      bson_iter_key (iter));
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "unable to initialize BSON document from field: %s",
+                         bson_iter_key (iter));
       return false;
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-write-command.c
+++ b/src/libmongoc/src/mongoc/mongoc-write-command.c
@@ -381,14 +381,14 @@ _mongoc_write_command_init (bson_t *doc, mongoc_write_command_t *command, const 
 static void
 _mongoc_write_command_too_large_error (bson_error_t *error, int32_t idx, int32_t len, int32_t max_bson_size)
 {
-   bson_set_error (error,
-                   MONGOC_ERROR_BSON,
-                   MONGOC_ERROR_BSON_INVALID,
-                   "Document %" PRId32 " is too large for the cluster. "
-                   "Document is %" PRId32 " bytes, max is %" PRId32 ".",
-                   idx,
-                   len,
-                   max_bson_size);
+   _mongoc_set_error (error,
+                      MONGOC_ERROR_BSON,
+                      MONGOC_ERROR_BSON_INVALID,
+                      "Document %" PRId32 " is too large for the cluster. "
+                      "Document is %" PRId32 " bytes, max is %" PRId32 ".",
+                      idx,
+                      len,
+                      max_bson_size);
 }
 
 
@@ -399,7 +399,7 @@ _empty_error (mongoc_write_command_t *command, bson_error_t *error)
                                     MONGOC_ERROR_COLLECTION_INSERT_FAILED,
                                     MONGOC_ERROR_COLLECTION_UPDATE_FAILED};
 
-   bson_set_error (
+   _mongoc_set_error (
       error, MONGOC_ERROR_COLLECTION, codes[command->type], "Cannot do an empty %s", gCommandNames[command->type]);
 }
 
@@ -808,7 +808,7 @@ _mongoc_write_command_execute (mongoc_write_command_t *command,             /* I
    }
 
    if (!mongoc_write_concern_is_valid (write_concern)) {
-      bson_set_error (
+      _mongoc_set_error (
          &result->error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "The write concern is invalid.");
       result->failed = true;
       EXIT;
@@ -843,10 +843,10 @@ _mongoc_write_command_execute_idl (mongoc_write_command_t *command,
    if (command->flags.has_collation) {
       if (!mongoc_write_concern_is_acknowledged (crud->writeConcern)) {
          result->failed = true;
-         bson_set_error (&result->error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Cannot set collation for unacknowledged writes");
+         _mongoc_set_error (&result->error,
+                            MONGOC_ERROR_COMMAND,
+                            MONGOC_ERROR_COMMAND_INVALID_ARG,
+                            "Cannot set collation for unacknowledged writes");
          EXIT;
       }
    }
@@ -854,10 +854,10 @@ _mongoc_write_command_execute_idl (mongoc_write_command_t *command,
    if (command->flags.has_array_filters) {
       if (!mongoc_write_concern_is_acknowledged (crud->writeConcern)) {
          result->failed = true;
-         bson_set_error (&result->error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Cannot use array filters with unacknowledged writes");
+         _mongoc_set_error (&result->error,
+                            MONGOC_ERROR_COMMAND,
+                            MONGOC_ERROR_COMMAND_INVALID_ARG,
+                            "Cannot use array filters with unacknowledged writes");
          EXIT;
       }
    }
@@ -865,10 +865,10 @@ _mongoc_write_command_execute_idl (mongoc_write_command_t *command,
    if (command->flags.has_update_hint) {
       if (server_stream->sd->max_wire_version < WIRE_VERSION_UPDATE_HINT &&
           !mongoc_write_concern_is_acknowledged (crud->writeConcern)) {
-         bson_set_error (&result->error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION,
-                         "The selected server does not support hint for update");
+         _mongoc_set_error (&result->error,
+                            MONGOC_ERROR_COMMAND,
+                            MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION,
+                            "The selected server does not support hint for update");
          result->failed = true;
          EXIT;
       }
@@ -877,10 +877,10 @@ _mongoc_write_command_execute_idl (mongoc_write_command_t *command,
    if (command->flags.has_delete_hint) {
       if (server_stream->sd->max_wire_version < WIRE_VERSION_DELETE_HINT &&
           !mongoc_write_concern_is_acknowledged (crud->writeConcern)) {
-         bson_set_error (&result->error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION,
-                         "The selected server does not support hint for delete");
+         _mongoc_set_error (&result->error,
+                            MONGOC_ERROR_COMMAND,
+                            MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION,
+                            "The selected server does not support hint for delete");
          result->failed = true;
          EXIT;
       }
@@ -889,20 +889,20 @@ _mongoc_write_command_execute_idl (mongoc_write_command_t *command,
    if (command->flags.bypass_document_validation) {
       if (!mongoc_write_concern_is_acknowledged (crud->writeConcern)) {
          result->failed = true;
-         bson_set_error (&result->error,
-                         MONGOC_ERROR_COMMAND,
-                         MONGOC_ERROR_COMMAND_INVALID_ARG,
-                         "Cannot set bypassDocumentValidation for unacknowledged writes");
+         _mongoc_set_error (&result->error,
+                            MONGOC_ERROR_COMMAND,
+                            MONGOC_ERROR_COMMAND_INVALID_ARG,
+                            "Cannot set bypassDocumentValidation for unacknowledged writes");
          EXIT;
       }
    }
 
    if (crud->client_session && !mongoc_write_concern_is_acknowledged (crud->writeConcern)) {
       result->failed = true;
-      bson_set_error (&result->error,
-                      MONGOC_ERROR_COMMAND,
-                      MONGOC_ERROR_COMMAND_INVALID_ARG,
-                      "Cannot use client session with unacknowledged writes");
+      _mongoc_set_error (&result->error,
+                         MONGOC_ERROR_COMMAND,
+                         MONGOC_ERROR_COMMAND_INVALID_ARG,
+                         "Cannot use client session with unacknowledged writes");
       EXIT;
    }
 
@@ -1032,7 +1032,7 @@ _set_error_from_response (bson_t *bson_array,
       }
 
       if (code && compound_err->len) {
-         bson_set_error (error, domain, (uint32_t) code, "%s", compound_err->str);
+         bson_set_error (error, domain, (uint32_t) code, "server: %s", compound_err->str);
       }
    }
 
@@ -1215,12 +1215,13 @@ _mongoc_write_error_update_if_unsupported_storage_engine (bool cmd_ret, bson_err
       return false;
    }
 
-   if (server_error.code == 20 && strstr (server_error.message, "Transaction numbers") == server_error.message) {
+   if (server_error.code == 20 &&
+       strstr (server_error.message, "server: Transaction numbers") == server_error.message) {
       const char *replacement = "This MongoDB deployment does not support "
                                 "retryable writes. Please add "
                                 "retryWrites=false to your connection string.";
 
-      strcpy (cmd_err->message, replacement);
+      bson_snprintf (cmd_err->message, sizeof cmd_err->message, "mongoc: %s", replacement);
 
       if (reply) {
          bson_t *new_reply = bson_new ();

--- a/src/libmongoc/src/mongoc/mongoc-write-concern.c
+++ b/src/libmongoc/src/mongoc/mongoc-write-concern.c
@@ -16,6 +16,7 @@
 
 
 #include "mongoc-error.h"
+#include "mongoc-error-private.h"
 #include "mongoc-log.h"
 #include "mongoc-util-private.h"
 #include "mongoc-write-concern.h"
@@ -417,7 +418,7 @@ static bool
 _mongoc_write_concern_validate (const mongoc_write_concern_t *write_concern, bson_error_t *error)
 {
    if (write_concern && !mongoc_write_concern_is_valid (write_concern)) {
-      bson_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "Invalid writeConcern");
+      _mongoc_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "Invalid writeConcern");
       return false;
    }
    return true;
@@ -450,7 +451,7 @@ _mongoc_parse_wc_err (const bson_t *doc, bson_error_t *error)
             errmsg = bson_iter_utf8 (&inner, NULL);
          }
       }
-      bson_set_error (error, MONGOC_ERROR_WRITE_CONCERN, code, "Write Concern error: %s", errmsg);
+      bson_set_error (error, MONGOC_ERROR_WRITE_CONCERN, code, "server: Write Concern error: %s", errmsg);
       return true;
    }
    return false;
@@ -556,7 +557,7 @@ _mongoc_write_concern_new_from_iter (const bson_iter_t *iter, bson_error_t *erro
    return write_concern;
 
 fail:
-   bson_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "Invalid writeConcern");
+   _mongoc_set_error (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "Invalid writeConcern");
    mongoc_write_concern_destroy (write_concern);
    return NULL;
 }

--- a/src/libmongoc/src/mongoc/service-gcp.c
+++ b/src/libmongoc/src/mongoc/service-gcp.c
@@ -16,6 +16,7 @@
 
 #include "./service-gcp.h"
 
+#include "mongoc-error-private.h"
 #include "mongoc-util-private.h"
 
 #define HOST "metadata.google.internal"
@@ -97,13 +98,13 @@ gcp_access_token_try_parse_from_json (gcp_service_account_token *out, const char
    const char *const token_type = !found ? NULL : bson_iter_utf8 (&iter, NULL);
 
    if (!(access_token && token_type)) {
-      bson_set_error (error,
-                      MONGOC_ERROR_GCP,
-                      MONGOC_ERROR_KMS_SERVER_BAD_JSON,
-                      "One or more required JSON properties are "
-                      "missing/invalid: data: %.*s",
-                      len,
-                      json);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_GCP,
+                         MONGOC_ERROR_KMS_SERVER_BAD_JSON,
+                         "One or more required JSON properties are "
+                         "missing/invalid: data: %.*s",
+                         len,
+                         json);
       goto done;
    }
 
@@ -148,13 +149,13 @@ gcp_access_token_from_gcp_server (gcp_service_account_token *out,
 
    // Only accept an HTTP 200 as success
    if (resp.status != 200) {
-      bson_set_error (error,
-                      MONGOC_ERROR_GCP,
-                      MONGOC_ERROR_KMS_SERVER_HTTP,
-                      "Error from the GCP metadata server while looking for "
-                      "access token: %.*s",
-                      resp.body_len,
-                      resp.body);
+      _mongoc_set_error (error,
+                         MONGOC_ERROR_GCP,
+                         MONGOC_ERROR_KMS_SERVER_HTTP,
+                         "Error from the GCP metadata server while looking for "
+                         "access token: %.*s",
+                         resp.body_len,
+                         resp.body);
       goto fail;
    }
 

--- a/src/libmongoc/tests/test-mongoc-bulk.c
+++ b/src/libmongoc/tests/test-mongoc-bulk.c
@@ -836,7 +836,7 @@ test_update_with_opts_validate (void)
       ASSERT_ERROR_CONTAINS (error,
                              MONGOC_ERROR_COMMAND,
                              MONGOC_ERROR_COMMAND_INVALID_ARG,
-                             "invalid argument for update: keys cannot contain \".\": \"a.a\"");
+                             "invalid argument for update: bson: keys cannot contain \".\": \"a.a\"");
       mongoc_bulk_operation_destroy (bulk);
 
       /* Test a valid update_one with explicit validation on the server. */
@@ -1175,7 +1175,7 @@ test_replace_one_with_opts_validate (void)
    ASSERT_ERROR_CONTAINS (error,
                           MONGOC_ERROR_COMMAND,
                           MONGOC_ERROR_COMMAND_INVALID_ARG,
-                          "invalid argument for replace: keys cannot contain \".\": \"a.a\"");
+                          "invalid argument for replace: bson: keys cannot contain \".\": \"a.a\"");
 
    mongoc_bulk_operation_destroy (bulk);
 
@@ -1916,7 +1916,7 @@ test_insert_with_opts_validate (void)
    ASSERT_ERROR_CONTAINS (error,
                           MONGOC_ERROR_COMMAND,
                           MONGOC_ERROR_COMMAND_INVALID_ARG,
-                          "invalid document for insert: keys cannot contain \".\": \"a.a\"");
+                          "invalid document for insert: bson: keys cannot contain \".\": \"a.a\"");
 
    mongoc_bulk_operation_destroy (bulk);
 
@@ -1970,7 +1970,7 @@ _test_remove_validate (remove_validate_test_t *test)
                              MONGOC_ERROR_COMMAND,
                              MONGOC_ERROR_COMMAND_INVALID_ARG,
                              "Bulk operation is invalid from prior error: "
-                             "invalid document for insert: empty key");
+                             "mongoc: invalid document for insert: bson: empty key");
    } else {
       test->remove (bulk, tmp_bson (NULL));
    }
@@ -1983,7 +1983,7 @@ _test_remove_validate (remove_validate_test_t *test)
    BSON_ASSERT (!r);
    BSON_ASSERT (bson_empty (&reply));
    ASSERT_ERROR_CONTAINS (
-      error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "invalid document for insert: empty key");
+      error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "invalid document for insert: bson: empty key");
 
    bson_destroy (&reply);
    mongoc_bulk_operation_destroy (bulk);
@@ -2652,7 +2652,8 @@ _test_write_concern (bool ordered, bool multi_err)
                     first_err,
                     second_err);
 
-      ASSERT_CMPSTR ("Multiple write concern errors: \"foo\", \"bar\"", error.message);
+      ASSERT_ERROR_CONTAINS (
+         error, MONGOC_ERROR_WRITE_CONCERN, first_err, "Multiple write concern errors: \"foo\", \"bar\"");
    } else {
       ASSERT_MATCH (&reply,
                     "{'nInserted': 1,"
@@ -2664,7 +2665,7 @@ _test_write_concern (bool ordered, bool multi_err)
                     " 'writeConcernErrors': ["
                     "     {'code': %d, 'errmsg': 'foo'}]}",
                     first_err);
-      ASSERT_CMPSTR ("foo", error.message);
+      ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_WRITE_CONCERN, first_err, "foo");
    }
 
    ASSERT_CMPINT (MONGOC_ERROR_WRITE_CONCERN, ==, error.domain);

--- a/src/libmongoc/tests/test-mongoc-client.c
+++ b/src/libmongoc/tests/test-mongoc-client.c
@@ -1940,8 +1940,7 @@ test_get_database_names (void)
 
    names = future_get_char_ptr_ptr (future);
    BSON_ASSERT (!names);
-   ASSERT_CMPINT (MONGOC_ERROR_QUERY, ==, error.domain);
-   ASSERT_CMPSTR ("err", error.message);
+   ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_QUERY, MONGOC_ERROR_QUERY_COMMAND_NOT_FOUND, "err");
 
    request_destroy (request);
    future_destroy (future);

--- a/src/libmongoc/tests/test-mongoc-cluster.c
+++ b/src/libmongoc/tests/test-mongoc-cluster.c
@@ -1397,7 +1397,7 @@ test_cluster_command_error (void)
                           MONGOC_ERROR_STREAM,
                           MONGOC_ERROR_STREAM_SOCKET,
                           "Failed to send \"ping\" command with database "
-                          "\"db\": Failed to read 4 bytes: socket error or "
+                          "\"db\": mongoc: Failed to read 4 bytes: socket error or "
                           "timeout");
    mock_server_destroy (server);
    mongoc_client_destroy (client);

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -4919,7 +4919,7 @@ _test_update_validate (update_fn_t update_fn)
    /* bson_validate_with_error will yield a different error message than the
     * standard key check in _mongoc_validate_replace */
    if (update_fn == mongoc_collection_replace_one) {
-      msg = "invalid argument for replace: keys cannot begin with \"$\": \"$set\"";
+      msg = "invalid argument for replace: bson: keys cannot begin with \"$\": \"$set\"";
    }
 
    ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, msg);

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -3434,7 +3434,7 @@ _test_insert_validate (insert_fn_t insert_fn)
    ASSERT_ERROR_CONTAINS (error,
                           MONGOC_ERROR_COMMAND,
                           MONGOC_ERROR_COMMAND_INVALID_ARG,
-                          "invalid document for insert: keys cannot contain \".\": \"a.a\"");
+                          "invalid document for insert: bson: keys cannot contain \".\": \"a.a\"");
 
    /* {validate: true} is still prohibited */
    BSON_ASSERT (!insert_fn (collection, tmp_bson ("{'a': 1}"), tmp_bson ("{'validate': true}"), &error));

--- a/src/libmongoc/tests/test-mongoc-cursor.c
+++ b/src/libmongoc/tests/test-mongoc-cursor.c
@@ -1251,7 +1251,8 @@ test_cursor_new_invalid_filter (void)
 
    ASSERT (cursor);
    ASSERT (mongoc_cursor_error (cursor, &error));
-   ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_CURSOR, MONGOC_ERROR_CURSOR_INVALID_CURSOR, "Invalid filter: empty key");
+   ASSERT_ERROR_CONTAINS (
+      error, MONGOC_ERROR_CURSOR, MONGOC_ERROR_CURSOR_INVALID_CURSOR, "Invalid filter: bson: empty key");
 
    ASSERT (mongoc_cursor_error_document (cursor, &error, &error_doc));
    ASSERT (bson_empty (error_doc));
@@ -1278,7 +1279,8 @@ test_cursor_new_invalid_opts (void)
 
    ASSERT (cursor);
    ASSERT (mongoc_cursor_error (cursor, &error));
-   ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_CURSOR, MONGOC_ERROR_CURSOR_INVALID_CURSOR, "Invalid opts: empty key");
+   ASSERT_ERROR_CONTAINS (
+      error, MONGOC_ERROR_CURSOR, MONGOC_ERROR_CURSOR_INVALID_CURSOR, "Invalid opts: bson: empty key");
 
    ASSERT (mongoc_cursor_error_document (cursor, &error, &error_doc));
    ASSERT (bson_empty (error_doc));

--- a/src/libmongoc/tests/test-mongoc-server-selection-errors.c
+++ b/src/libmongoc/tests/test-mongoc-server-selection-errors.c
@@ -60,7 +60,7 @@ server_selection_error_dns (const char *uri_str, const char *errmsg, bool expect
    ASSERT_OR_PRINT (success == expect_success, error);
 
    if (!success && errmsg) {
-      ASSERT_CMPSTR (error.message, errmsg);
+      ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_SERVER_SELECTION, MONGOC_ERROR_SERVER_SELECTION_FAILURE, errmsg);
    }
 
    bson_destroy (&reply);
@@ -80,7 +80,7 @@ static void
 test_server_selection_error_dns_direct_single (void)
 {
    server_selection_error_dns ("mongodb://example-localhost.invalid:27017/",
-                               "No suitable servers found (`serverSelectionTryOnce` set): "
+                               "No suitable servers found (`serverSelectionTryOnce` set): mongoc: "
                                "[Fake error for 'example-localhost.invalid']"
                                ". Topology type: Single",
                                false,
@@ -93,7 +93,7 @@ test_server_selection_error_dns_direct_pooled (void *ctx)
    BSON_UNUSED (ctx);
 
    server_selection_error_dns ("mongodb://example-localhost.invalid:27017/",
-                               "No suitable servers found: `serverSelectionTimeoutMS` expired: "
+                               "No suitable servers found: `serverSelectionTimeoutMS` expired: mongoc: "
                                "[Fake error for 'example-localhost.invalid']"
                                ". Topology type: Single",
                                false,
@@ -105,7 +105,7 @@ test_server_selection_error_dns_multi_fail_single (void)
 {
    server_selection_error_dns ("mongodb://"
                                "example-localhost.invalid:27017,other-example-localhost.invalid:27017/",
-                               "No suitable servers found (`serverSelectionTryOnce` set):"
+                               "No suitable servers found (`serverSelectionTryOnce` set): mongoc:"
                                " [Fake error for 'example-localhost.invalid']"
                                " [Fake error for 'other-example-localhost.invalid']"
                                ". Topology type: Unknown",
@@ -120,7 +120,7 @@ test_server_selection_error_dns_multi_fail_pooled (void *ctx)
 
    server_selection_error_dns ("mongodb://"
                                "example-localhost.invalid:27017,other-example-localhost.invalid:27017/",
-                               "No suitable servers found: `serverSelectionTimeoutMS` expired:"
+                               "No suitable servers found: `serverSelectionTimeoutMS` expired: mongoc:"
                                " [Fake error for 'example-localhost.invalid']"
                                " [Fake error for 'other-example-localhost.invalid']"
                                ". Topology type: Unknown",

--- a/src/libmongoc/tests/test-mongoc-stream.c
+++ b/src/libmongoc/tests/test-mongoc-stream.c
@@ -131,16 +131,12 @@ test_stream_writev_full (void)
    r = _mongoc_stream_writev_full (error_stream, iov, 2, 100, &error);
 
    BSON_ASSERT (!r);
-   ASSERT_CMPINT (error.domain, ==, MONGOC_ERROR_STREAM);
-   ASSERT_CMPINT (error.code, ==, MONGOC_ERROR_STREAM_SOCKET);
-   ASSERT_STARTSWITH (error.message, error_message);
+   ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, error_message);
 
    errno = 0;
    r = _mongoc_stream_writev_full (short_stream, iov, 2, 100, &error);
    BSON_ASSERT (!r);
-   ASSERT_CMPINT (error.domain, ==, MONGOC_ERROR_STREAM);
-   ASSERT_CMPINT (error.code, ==, MONGOC_ERROR_STREAM_SOCKET);
-   ASSERT_CMPSTR (error.message, short_message);
+   ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, short_message);
 
    errno = 0;
    r = _mongoc_stream_writev_full (success_stream, iov, 2, 100, &error);

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -1046,8 +1046,8 @@ test_multiple_selection_errors (void)
     */
    ASSERT_CONTAINS (error.message, "No suitable servers found");
    /* either "connection error" or "connection timeout" calling hello */
-   ASSERT_CONTAINS (error.message, "[Failed to resolve 'doesntexist.invalid']");
-   ASSERT_CONTAINS (error.message, "[Failed to resolve 'example.invalid']");
+   ASSERT_CONTAINS (error.message, "[mongoc: Failed to resolve 'doesntexist.invalid']");
+   ASSERT_CONTAINS (error.message, "[mongoc: Failed to resolve 'example.invalid']");
 
    bson_destroy (&reply);
    mongoc_client_destroy (client);
@@ -1064,7 +1064,7 @@ test_invalid_server_id (void)
 
    BSON_ASSERT (
       !mongoc_topology_description_server_by_id_const (mc_tpld_unsafe_get_const (client->topology), 99999, &error));
-   ASSERT_STARTSWITH (error.message, "Could not find description for node");
+   ASSERT_CONTAINS (error.message, "Could not find description for node");
 
    mongoc_client_destroy (client);
 }
@@ -1911,7 +1911,7 @@ _test_request_scan_on_error (
       if (pooled) {
          if (sd->type == MONGOC_SERVER_UNKNOWN) {
             if (server_err) {
-               ASSERT_CMPSTR (server_err, sd->error.message);
+               ASSERT_CONTAINS (sd->error.message, server_err);
             }
          }
       } else {
@@ -1923,7 +1923,7 @@ _test_request_scan_on_error (
          /* check that the error on the server description matches the error
           * message in the response. */
          if (server_err) {
-            ASSERT_CMPSTR (server_err, sd->error.message);
+            ASSERT_CONTAINS (sd->error.message, server_err);
          }
       }
    } else {


### PR DESCRIPTION
## Summary

> [!IMPORTANT]
> This is an experimental PR exploring a possible design space. It is not necessarily expected to be merged. An alternative solution may be pursued instead if the changes proposed by this PR are considered undesirable.

Resolves CDRIVER-5850 as a prerequisite for [CXX-834](https://jira.mongodb.org/browse/CXX-834).

This PR proposes adding a prefix to all error messages returned by the C Driver libraries. This prefix may be used to reliably disambiguate the proper error category of the associated error code. This solution does not introduce any breaking changes beyond the contents of error messages themselves.

This PR is initially split into two separate commits: the first implements the proposed solution (prefixing all error messages), the second applies corresponding required changes in response to the modified error messages. This second commit may be used as a "case study" for the means and likelihood by which user code may be broken by this solution. If sufficiently concerning, we may defer this solution to an upcoming major release.

## Terminology

For clarity, the following terms are used in this PR description:

- **Error Value**: the integer value or enumerator describing an error.
    - e.g. `MONGOC_ERROR_QUERY_FAILURE`, `mongocxx::v_noabi::error_code::k_ssl_not_supported`.
- **Error Category**: the identity used to associate an error code value with its original domain.
    - e.g. `MONGOC_ERROR_SERVER` (`mongoc_error_domain_t`), `mongocxx::v_noabi::error_category()`.
- **Error Code**: an error value and its corresponding error category.
    - e.g. `bson_error_t` (`.domain` + `.code`), `std::error_code` (`.category()` + `.value()`).
- **Error Message**: a string describing an associated error code.

> [!NOTE]
> Integer values and enumerators which are typically referred to as "error codes" are deliberately referred to as "error values" in this PR description for consistency, e.g. ["server error values"](https://www.mongodb.com/docs/manual/reference/error-codes/) rather than "server error codes" when referring specifically to the list of documented integer values.

## Motivation

The goal of this PR is to explore a least-effort-required solution to address CXX-834: that is, to be able to reliably disambiguate the category of error code values.

The meaning of an error value can only be correctly interpreted if its category is known. The C Driver uses the `bson_error_t` type to communicate the triplet of category, value, and message as the `.domain`, `.code`, and `.message` data members respectively. Unfortunately, although the C Driver correctly ensures through this design that a value is always accompanied by its category, it did not sufficiently prepare to accomodate error codes originating from multiple libraries.

The C Driver currently uses `bson_error_t` to describe error codes coming from _at least_ four distinct sources:

- The bson library.
- The mongoc library.
- The libmongocrypt library.
- The MongoDB Server.

[CDRIVER-644](https://jira.mongodb.org/browse/CDRIVER-644) made an effort to disambiguate values coming from the server from those coming from mongoc by introducing an Error API Version which, when set to `MONGOC_ERROR_API_VERSION_2`, uses a dedicated `MONGOC_ERROR_SERVER` domain for server error values. Although this is an improvement, the situation remains complicated by further developments over time, such as Write Concern Errors ([CDRIVER-2900](https://jira.mongodb.org/browse/CDRIVER-2900)) and Client-Side Field Level Encryption through libmongocrypt ([CDRIVER-2875](https://jira.mongodb.org/browse/CDRIVER-2875)).

Most troubling however is the ever-growing list of domains that is supported by the `mongoc_error_domain_t` enumeration, as well as the overloaded list of error values described by `mongoc_error_code_t`. These enumerations do not sufficiently or reliably disambiguate error values coming from the various sources listed above. Issues include but are not limited to:

- Domain values for error codes from bson and mongoc are in conflict.
    - e.g. `BSON_ERROR_JSON` and `MONGOC_ERROR_CLIENT` both have a domain value of `1` ([CDRIVER-3660](https://jira.mongodb.org/browse/CDRIVER-3660)).
- Domain values are overloaded and describe values coming from multiple sources.
    - e.g. `MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION` is used both for values coming from libmongocrypt (via `mongocrypt_status_code`) and from mongoc (e.g. `MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_ARG`).
    - e.g. `MONGOC_ERROR_SERVER` is used both for values coming from the server (both normal values _and_ write concern error values in `_parse_error_reply`) and from mongoc (e.g. `MONGOC_ERROR_QUERY_COMMAND_NOT_FOUND` in `_mongoc_cmd_check_ok`).
- Multiple domain values are used to describe unique error values coming the same source.
    - e.g. `MONGOC_ERROR_SERVER` and `MONGOC_ERROR_WRITE_CONCERN` domain values are both used for equivalent error values coming from the server.
    - e.g. `MONGOC_ERROR_CLIENT`, `MONGOC_ERROR_COLLECTION`, etc. redundantly document the _component_ from which an error value is associated despite the error values used with the domain value `MONGOC_ERROR_CLIENT_NOT_READY`, `MONGOC_ERROR_COLLECTION_DOES_NOT_EXIST`, etc. being unique to the source (mongoc).

This situation led to [CXX-834](https://jira.mongodb.org/browse/CXX-834), which documents the troubles plaguing the C++ Driver (and, by extension, users of the C Driver libraries) concerning error category disambiguation. I do not believe the "Error API Version" approach to extending the `mongoc_error_domain_t` enumeration with further domain values is desirable. Instead, this PR proposes a "least-effort-required" solution of embedding the error category within the error message as a prefix.

Although knowing the component from which an error originates may be situationally useful, this is often sufficiently obvious from context alone. Instead, being able to _easily_ and _unambiguously_ know how to _interpret_ an error value is of far greater importance for programmable error handling purposes. We do not want users (or ourselves, i.e. test code) to be pattern-matching the contents of error messages (which should be "for display only") to make decisions in code.

## Proposed Solution

At the moment, four error categories appear to be sufficient to describe all error codes returned by the C Driver API. These four categories are:

- `bson: ...`: maps to `BSON_ERROR_*` error values.
- `mongoc: ...`: maps to (most) `MONGOC_ERROR_*` error values.
- `server: ...`: maps to server error values (`MONGOC_ERROR_SERVER` and `MONGOC_ERROR_WRITE_CONCERN`).
- `crypt: ...`: maps to libmongocrypt error values (`MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION`).

The documented source of a given error is _not_ used to identify the error category (see: overloaded domain values above). Instead, the _origin_ of the value used to set the `bson_error_t::code` data member is used instead.

All instances of assigning an error value to `bson_error_t::code` were found by grepping either for a call to `bson_set_error` or the pattern `(\.|->)code =` (direct assignment).

### bson

This error category was the most straightforward to identify: any call to `bson_set_error` within bson library code naturally uses the bson error category. No other error category is present within the bson library, aside from `errno` and POSIX error codes, neither of which is directly assigned to `bson_error_t::code`.

The error messages in all such bson library code were manually prefixed with `"bson: "`. The error messages have otherwise been left unchanged.

### mongoc

This error category required the most effort to identify and prefix. Rather than manually prefixing all error messages in mongoc, a new `mongoc_set_error` internal function is used instead to consistently apply the `"mongoc: "` prefix to error messages (a straightforward substitution of calls to `bson_set_error`).

> [!NOTE]
> `mongoc_set_error` cannot be a macro due to some calls providing no argument for `...`, e.g.:
> ```c
> // error: passing no argument for the '...' parameter of a variadic macro is a C23 extension [-Werror,-Wvariadic-macro-arguments-omitted]
> mongoc_set_error(error, domain, code, "mongoc: message");
> ```

Some areas of concern include:

- Several authentication-related error handling code sets `MONGOC_ERROR_CLIENT_AUTHENTICATE` without explicitly setting a corresponding error message (already set beforehand in another context?):
    - `_stream_run_hello`
    - `_mongoc_cluster_auth_node_plain`
    - `_mongoc_cluster_auth_node_x509`
    - `_mongoc_cluster_run_scram_command`
    - `_mongoc_cluster_auth_scram_start`
    - `mongoc_server_description_handle_hello`
- Server error codes are overwritten by mongoc error codes in `_mongoc_cmd_check_ok`.
- The origin of the error message reported by `mongoc_topology_select_server_id` when setting `MONGOC_ERROR_SERVER_SELECTION_FAILURE` is uncertain.

### server

This error category is used whenever an error value coming directly from the server is assigned to `bson_error_t::code`. There appears to be the case in three distinct locations:

- `_mongoc_cmd_check_ok_no_wce` when `_parse_error_reply` returns a non-zero error value obtained from either `reply: {"code": <value> }` or `reply: {"writeConcernError": {"code": <value>}}`.
- `_mongoc_write_result_complete` when `_set_error_from_response` obtains an error value from the first operation which responded with either `reply: {"writeErrors": {"code": <value>}}` or `reply: {"writeConcernErrors": {}}`.
- `_mongoc_client_command_with_opts`, `mongoc_collection_create_index_with_opts`, and `_mongoc_cursor_run_command` when `_mongoc_parse_wc_err` obtains an error value from `reply: {"WriteConcernError": {"code": <value>}}`.

### crypt

This error category is only used in `_status_to_error`, where `mongocrypt_status_code` is used to set `bson_error_t::code`. Use of this function is limited to the `*_check_error` functions provided by `mongoc-crypt.c`. All other usage of the `MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION` domain value appear to describe mongoc error codes, not libmongocrypt error codes.

## Concerns

This proposed solution may potentially break any user code which depends on error message stability for error handling. Examples of such code in our own codebase can be seen as diffs in the second commit, "Update dependent code with new error message prefixes".

Most code which searches for _substrings_ within the error message are unaffected, as their contents remain unchanged. However, code which performs _equality-comparison_ or _starts-with_ operations on error messages are broken by the presence of the prefix, either at the start of the error message or embedded within nested error messages, e.g. `mongoc: invalid argument for update: bson: keys cannot contain ".": "a.a"`.

It is also likely that, given this solution is deliberately designed to support error categories reported by the C++ Driver, users may become reliant on this behavior as well (this is not a problem limited to the C++ Driver), which directly conflicts with our desire to avoid encouraging error handling programmed on error messages. We may need to add documentation loudly warning users against depending on the stability of error messages (reserved only for ourselves).

## Alternatives

An alternative solution, which would require far more significant API breaking changes and internal refactors (thus not demonstrated via PR as done here), but may nevertheless be considered preferable, would be to add a new data member whose purpose is to function as an equivalent to `std::error_code::category()` that is properly distinct from `mongoc_error_domain_t`. This addition can be limited to the mongoc library by the use of a new `mongoc_error_t` type that wraps or replaces `bson_error_t`. This alternative solution is tracked by CDRIVER-5854.

```c
// `bson_error_t` implies `bson_category()`.

typedef struct _mongoc_error_t {
   const void *category; // a la `std::error_category const&`.
   uint32_t domain;      // Do we still want/need this?
   uint32_t code;
   char message[MONGOC_ERROR_BUFFER_SIZE]; // Up to 512? Higher? Alloc instead?
} mongoc_error_t;

BSON_EXPORT (const void*) mongoc_category();
BSON_EXPORT (const void*) server_category();
BSON_EXPORT (const void*) crypt_category();
```

As we probably do not have interest in fully reimplementing all the features of `std::error_code` in C++ (in particular, the flexibility of `std::error_condition`), the `mongoc_error_t::domain` data member could be repurposed/used as the error category specifier instead, e.g.:

```c
typedef struct _mongoc_error_category_t {
  MONGOC_ERROR_CATEGORY_MONGOC = 1,
  MONGOC_ERROR_CATEGORY_SERVER,
  MONGOC_ERROR_CATEGORY_CRYPT,
};

// For all mongoc error values.
// "Source component" info is embedded in the value/identifier, not in a "domain" value.
// Discard "neat" grouping of values, just expand with new values on-demand
// as new errors are required by the library and deprecate old values when no longer used.
typedef struct _mongoc_error_code_t {
  MONGOC_ERROR_CODE_CLIENT_REASON_A = 1,
  MONGOC_ERROR_CODE_CLIENT_REASON_B,
  MONGOC_ERROR_CODE_COLLECTION_REASON_A,
  MONGOC_ERROR_CODE_COLLECTION_REASON_B,
  ...
  MONGOC_ERROR_CODE_MAX_VALUE = UINT32_MAX, // or INT32_MAX if we want signed values?
};

typedef struct _mongoc_error_t {
   _mongoc_error_category_t category;
   uint32_t code; // or `int32_t` for signedness consistency with `int`?
   char message[MONGOC_ERROR_BUFFER_SIZE]; // Up to 512? Higher? Alloc instead?
} mongoc_error_t;
```

> [!NOTE]
> The 512 byte size of `bson_error_t` with an embedded message array has been stable since its introduction in [Aug 2013](https://github.com/mongodb/libbson/commit/efd80c2a897af20d8ebee1f1d8de0e090d685af3). We may want to expand the size of this structure to support longer error messages (i.e. embedded BSON documents) or revert to using an allocated resizeable string buffer instead.
