### PR TITLE
CDRIVER-4485 string append and truncation fixes for structured logging

### DIFF
--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -1096,6 +1096,7 @@ set (test-libmongoc-sources
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-collection-find-with-opts.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-collection-find.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-collection.c
+   ${PROJECT_SOURCE_DIR}/tests/test-mongoc-command-logging-and-monitoring.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-command-monitoring.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-connection-uri.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-counters.c

--- a/src/libmongoc/doc/mongoc_structured_log_opts_get_max_document_length.rst
+++ b/src/libmongoc/doc/mongoc_structured_log_opts_get_max_document_length.rst
@@ -1,0 +1,27 @@
+:man_page: mongoc_structured_log_opts_get_max_document_length
+
+mongoc_structured_log_opts_get_max_document_length()
+====================================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  size_t
+  mongoc_structured_log_opts_get_max_document_length (const mongoc_structured_log_opts_t *opts);
+
+Parameters
+----------
+
+* ``opts``: Structured log options, allocated with :symbol:`mongoc_structured_log_opts_new`.
+
+Returns
+-------
+
+Returns the current maximum document length set in ``opts``, as a ``size_t``. Always succeeds.
+This may be the last value set with :symbol:`mongoc_structured_log_opts_set_max_document_length` or it may be an environment variable captured by :symbol:`mongoc_structured_log_opts_set_max_document_length_from_env` or :symbol:`mongoc_structured_log_opts_new`.
+
+.. seealso::
+
+  | :doc:`structured_log`

--- a/src/libmongoc/doc/mongoc_structured_log_opts_new.rst
+++ b/src/libmongoc/doc/mongoc_structured_log_opts_new.rst
@@ -31,7 +31,7 @@ Environment Variables
 This is a full list of the captured environment variables.
 
 * ``MONGODB_LOG_MAX_DOCUMENT_LENGTH``: Maximum length for JSON-serialized documents that appear within a log message.
-  It may be a number, in bytes, or ``unlimited`` (case insensitive).
+  It may be a number, in bytes, or ``unlimited`` (case insensitive) to choose an implementation-specific value near the maximum representable length.
   By default, the limit is 1000 bytes.
   This limit affects interior documents like commands and replies, not the total length of a structured log message.
 

--- a/src/libmongoc/doc/mongoc_structured_log_opts_set_max_document_length.rst
+++ b/src/libmongoc/doc/mongoc_structured_log_opts_set_max_document_length.rst
@@ -1,0 +1,34 @@
+:man_page: :man_page: mongoc_structured_log_opts_set_max_document_length
+
+:man_page: mongoc_structured_log_opts_set_max_document_length()
+===============================================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   bool
+   mongoc_structured_log_opts_set_max_document_length (mongoc_structured_log_opts_t *opts,
+                                                       size_t max_document_length);
+
+Sets a maximum length for BSON documents that appear serialized in JSON form as part of a structured log message.
+
+This setting is captured from the environment during :symbol:`mongoc_structured_log_opts_new` if a valid setting is found for the ``MONGODB_LOG_MAX_DOCUMENT_LENGTH`` environment variable.
+
+Serialized JSON will be truncated at this limit, interpreted as a count of UTF-8 encoded bytes. Truncation will be indicated with a ``...`` suffix, the length of which is not included in the max document length. If truncation at the exact indicated length would split a valid UTF-8 sequence, we instead truncate the document earlier at the nearest boundary between code points.
+
+Parameters
+----------
+
+* ``opts``: Structured log options, allocated with :symbol:`mongoc_structured_log_opts_new`.
+* ``max_document_length``: Maximum length for each embedded JSON document, in bytes, not including an ellipsis (``...``) added to indicate truncation. Values near or above ``INT_MAX`` will be rejected.
+
+Returns
+-------
+
+Returns ``true`` on success, or ``false`` if the supplied maximum length is too large.
+
+.. seealso::
+
+  | :doc:`structured_log`

--- a/src/libmongoc/doc/mongoc_structured_log_opts_set_max_document_length_from_env.rst
+++ b/src/libmongoc/doc/mongoc_structured_log_opts_set_max_document_length_from_env.rst
@@ -1,0 +1,34 @@
+:man_page: mongoc_structured_log_opts_set_max_document_length_from_env
+
+mongoc_structured_log_opts_set_max_document_length_from_env()
+=============================================================
+
+Synopsis
+--------
+
+.. code-block:: c
+
+   bool
+   mongoc_structured_log_opts_set_max_document_length_from_env (mongoc_structured_log_opts_t *opts);
+
+Sets a maximum document length from the ``MONGODB_LOG_MAX_DOCUMENT_LENGTH`` environment variable, if a valid setting is found.
+See :symbol:`mongoc_structured_log_opts_new` for a description of the supported environment variable formats.
+
+Parse errors may cause a warning message, delivered via unstructured logging.
+
+This happens automatically when :symbol:`mongoc_structured_log_opts_new` establishes defaults.
+Any subsequent programmatic modifications to the :symbol:`mongoc_structured_log_opts_t` will override the environment variable settings.
+For applications that desire the opposite behavior, where environment variables may override programmatic settings, they may call ``mongoc_structured_log_opts_set_max_document_length_from_env()`` after calling :symbol:`mongoc_structured_log_opts_set_max_document_length`.
+This will process the environment a second time, allowing it to override customized defaults.
+
+Returns
+-------
+
+Returns ``true`` on success: either a valid environment setting was found, or the value is unset and ``opts`` will not be modified.
+If warnings are encountered in the environment, returns ``false`` and may log additional information to the unstructured logging facility.
+Note that, by design, these errors are by default non-fatal.
+When :symbol:`mongoc_structured_log_opts_new` internally calls this function, it ignores the return value.
+
+.. seealso::
+
+  | :doc:`structured_log`

--- a/src/libmongoc/doc/mongoc_structured_log_opts_t.rst
+++ b/src/libmongoc/doc/mongoc_structured_log_opts_t.rst
@@ -29,6 +29,9 @@ Functions
   mongoc_structured_log_opts_set_max_level_for_all_components
   mongoc_structured_log_opts_set_max_levels_from_env
   mongoc_structured_log_opts_get_max_level_for_component
+  mongoc_structured_log_opts_set_max_document_length
+  mongoc_structured_log_opts_set_max_document_length_from_env
+  mongoc_structured_log_opts_get_max_document_length
 
 .. seealso::
 

--- a/src/libmongoc/src/mongoc/mongoc-structured-log-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log-private.h
@@ -34,6 +34,18 @@ typedef struct mongoc_structured_log_instance_t mongoc_structured_log_instance_t
 #define MONGOC_STRUCTURED_LOG_DEFAULT_MAX_DOCUMENT_LENGTH 1000
 
 /**
+ * @brief maximum possible value of the 'maximum document length' setting, enforced when reading settings from the
+ * environment.
+ *
+ * Maximum document length applies to a single serialized JSON document within the log.
+ * The overall log document, when serialized as BSON, will be subject to BSON_MAX_SIZE.
+ * At a minimum we should leave room for BSON headers and for the JSON truncation marker ("...").
+ * Choose to leave a little more room, as it's more useful to truncate the huge document early
+ * rather than fail in bson_append_utf8().
+ */
+#define MONGOC_STRUCTURED_LOG_MAXIMUM_MAX_DOCUMENT_LENGTH ((uint32_t) BSON_MAX_SIZE - 4096u)
+
+/**
  * @brief Allocate a new instance of the structured logging system
  * @param opts Options, copied into the new instance.
  *

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.h
@@ -77,6 +77,15 @@ MONGOC_EXPORT (mongoc_structured_log_level_t)
 mongoc_structured_log_opts_get_max_level_for_component (const mongoc_structured_log_opts_t *opts,
                                                         mongoc_structured_log_component_t component);
 
+MONGOC_EXPORT (size_t)
+mongoc_structured_log_opts_get_max_document_length (const mongoc_structured_log_opts_t *opts);
+
+MONGOC_EXPORT (bool)
+mongoc_structured_log_opts_set_max_document_length_from_env (mongoc_structured_log_opts_t *opts);
+
+MONGOC_EXPORT (bool)
+mongoc_structured_log_opts_set_max_document_length (mongoc_structured_log_opts_t *opts, size_t max_document_length);
+
 MONGOC_EXPORT (bson_t *)
 mongoc_structured_log_entry_message_as_bson (const mongoc_structured_log_entry_t *entry);
 

--- a/src/libmongoc/tests/test-libmongoc-main.c
+++ b/src/libmongoc/tests/test-libmongoc-main.c
@@ -70,6 +70,7 @@ main (int argc, char *argv[])
    TEST_INSTALL (test_collection_find_install);
    TEST_INSTALL (test_collection_find_with_opts_install);
    TEST_INSTALL (test_connection_uri_install);
+   TEST_INSTALL (test_command_logging_and_monitoring_install);
    TEST_INSTALL (test_command_monitoring_install);
    TEST_INSTALL (test_cursor_install);
    TEST_INSTALL (test_database_install);

--- a/src/libmongoc/tests/test-mongoc-command-logging-and-monitoring.c
+++ b/src/libmongoc/tests/test-mongoc-command-logging-and-monitoring.c
@@ -1,0 +1,359 @@
+#include <mongoc/mongoc.h>
+
+#include "test-libmongoc.h"
+#include "test-conveniences.h"
+#include "mongoc/mongoc-array-private.h"
+#include "TestSuite.h"
+
+static void
+stored_log_handler (const mongoc_structured_log_entry_t *entry, void *user_data)
+{
+   mongoc_array_t *log_array = (mongoc_array_t *) user_data;
+   bson_t *doc = mongoc_structured_log_entry_message_as_bson (entry);
+   MONGOC_DEBUG ("stored log: %s", tmp_json (doc));
+   _mongoc_array_append_val (log_array, doc);
+}
+
+static void
+stored_log_clear (mongoc_array_t *log_array)
+{
+   for (size_t i = 0; i < log_array->len; i++) {
+      bson_t *doc = _mongoc_array_index (log_array, bson_t *, i);
+      bson_destroy (doc);
+   }
+   _mongoc_array_clear (log_array);
+}
+
+/* specifications/source/command-logging-and-monitoring/tests/README.md
+ * Test 1: Default truncation limit */
+static void
+prose_test_1 (void)
+{
+   // 1. Configure logging with a minimum severity level of "debug" for the "command" component. Do not explicitly
+   // configure the max document length.
+   mongoc_client_t *client = test_framework_new_default_client ();
+   mongoc_array_t stored_log;
+   _mongoc_array_init (&stored_log, sizeof (bson_t *));
+   {
+      mongoc_structured_log_opts_t *log_opts = mongoc_structured_log_opts_new ();
+
+      mongoc_structured_log_opts_set_max_level_for_component (
+         log_opts, MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND, MONGOC_STRUCTURED_LOG_LEVEL_DEBUG);
+
+      mongoc_structured_log_opts_set_handler (log_opts, stored_log_handler, &stored_log);
+
+      mongoc_client_set_structured_log_opts (client, log_opts);
+      mongoc_structured_log_opts_destroy (log_opts);
+   }
+   mongoc_collection_t *coll = mongoc_client_get_collection (client, "db", "coll");
+
+   // 2. Construct an array docs containing the document {"x" : "y"} repeated 100 times.
+   bson_t *docs[100];
+   for (unsigned i = 0; i < sizeof docs / sizeof docs[0]; i++) {
+      docs[i] = tmp_bson (BSON_STR ({"x" : "y"}));
+   }
+
+   // 3. Insert docs to a collection via insertMany.
+   bson_error_t error;
+   ASSERT_OR_PRINT (
+      mongoc_collection_insert_many (coll, (const bson_t **) docs, sizeof docs / sizeof docs[0], NULL, NULL, &error),
+      error);
+
+   // 4. Inspect the resulting "command started" log message and assert that the "command" value is a string of length
+   // 1000 + (length of trailing ellipsis).
+   {
+      ASSERT (stored_log.len >= 1);
+      bson_t *log = _mongoc_array_index (&stored_log, bson_t *, 0);
+      bson_iter_t iter;
+      ASSERT (bson_iter_init (&iter, log));
+      ASSERT (bson_iter_find (&iter, "message"));
+      ASSERT (BSON_ITER_HOLDS_UTF8 (&iter));
+      ASSERT_CMPSTR (bson_iter_utf8 (&iter, NULL), "Command started");
+      ASSERT (bson_iter_find (&iter, "command"));
+      ASSERT (BSON_ITER_HOLDS_UTF8 (&iter));
+      uint32_t command_len;
+      const char *command = bson_iter_utf8 (&iter, &command_len);
+      ASSERT (command);
+      ASSERT_CMPUINT32 (command_len, ==, 1003);
+   }
+
+   // 5. Inspect the resulting "command succeeded" log message and assert that the "reply" value is a string of length
+   // <= 1000 + (length of trailing ellipsis).
+   {
+      ASSERT (stored_log.len == 2);
+      bson_t *log = _mongoc_array_index (&stored_log, bson_t *, 1);
+      bson_iter_t iter;
+      ASSERT (bson_iter_init (&iter, log));
+      ASSERT (bson_iter_find (&iter, "message"));
+      ASSERT (BSON_ITER_HOLDS_UTF8 (&iter));
+      ASSERT_CMPSTR (bson_iter_utf8 (&iter, NULL), "Command succeeded");
+      ASSERT (bson_iter_find (&iter, "reply"));
+      ASSERT (BSON_ITER_HOLDS_UTF8 (&iter));
+      uint32_t reply_len;
+      const char *reply = bson_iter_utf8 (&iter, &reply_len);
+      ASSERT (reply);
+      ASSERT_CMPUINT32 (reply_len, <=, 1003);
+   }
+
+   // 6. Run find() on the collection where the document was inserted.
+   stored_log_clear (&stored_log);
+   mongoc_cursor_t *cursor = mongoc_collection_find_with_opts (coll, tmp_bson ("{}"), NULL, NULL);
+   ASSERT (cursor);
+   {
+      const bson_t *doc;
+      ASSERT (mongoc_cursor_next (cursor, &doc));
+   }
+
+   // 7. Inspect the resulting "command succeeded" log message and assert that the reply is a string of length 1000 +
+   // (length of trailing ellipsis).
+   {
+      ASSERT (stored_log.len >= 1);
+      bson_t *log = _mongoc_array_index (&stored_log, bson_t *, 0);
+      bson_iter_t iter;
+      ASSERT (bson_iter_init (&iter, log));
+      ASSERT (bson_iter_find (&iter, "message"));
+      ASSERT (BSON_ITER_HOLDS_UTF8 (&iter));
+      ASSERT_CMPSTR (bson_iter_utf8 (&iter, NULL), "Command started");
+   }
+   {
+      ASSERT (stored_log.len == 2);
+      bson_t *log = _mongoc_array_index (&stored_log, bson_t *, 1);
+      bson_iter_t iter;
+      ASSERT (bson_iter_init (&iter, log));
+      ASSERT (bson_iter_find (&iter, "message"));
+      ASSERT (BSON_ITER_HOLDS_UTF8 (&iter));
+      ASSERT_CMPSTR (bson_iter_utf8 (&iter, NULL), "Command succeeded");
+      ASSERT (bson_iter_find (&iter, "reply"));
+      ASSERT (BSON_ITER_HOLDS_UTF8 (&iter));
+      uint32_t reply_len;
+      const char *reply = bson_iter_utf8 (&iter, &reply_len);
+      ASSERT (reply);
+      printf ("rep %s\n", reply);
+      ASSERT_CMPUINT32 (reply_len, ==, 1003);
+   }
+
+   mongoc_cursor_destroy (cursor);
+   mongoc_collection_destroy (coll);
+   mongoc_client_destroy (client);
+   stored_log_clear (&stored_log);
+   _mongoc_array_destroy (&stored_log);
+}
+
+/* Test 2: Explicitly configured truncation limit */
+static void
+prose_test_2 (void)
+{
+   // 1. Configure logging with a minimum severity level of "debug" for the "command" component. Set the max document
+   // length to 5.
+   mongoc_client_t *client = test_framework_new_default_client ();
+   mongoc_array_t stored_log;
+   _mongoc_array_init (&stored_log, sizeof (bson_t *));
+   {
+      mongoc_structured_log_opts_t *log_opts = mongoc_structured_log_opts_new ();
+
+      mongoc_structured_log_opts_set_max_document_length (log_opts, 5);
+      mongoc_structured_log_opts_set_max_level_for_component (
+         log_opts, MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND, MONGOC_STRUCTURED_LOG_LEVEL_DEBUG);
+
+      mongoc_structured_log_opts_set_handler (log_opts, stored_log_handler, &stored_log);
+
+      mongoc_client_set_structured_log_opts (client, log_opts);
+      mongoc_structured_log_opts_destroy (log_opts);
+   }
+
+   // 2. Run the command {"hello": true}.
+   {
+      bson_error_t error;
+      ASSERT_OR_PRINT (
+         mongoc_client_command_simple (client, "db", tmp_bson (BSON_STR ({"hello" : true})), NULL, NULL, &error),
+         error);
+   }
+
+   // 3. Inspect the resulting "command started" log message and assert that the "command" value is a string of length 5
+   // + (length of trailing ellipsis).
+   {
+      ASSERT (stored_log.len >= 1);
+      bson_t *log = _mongoc_array_index (&stored_log, bson_t *, 0);
+      bson_iter_t iter;
+      ASSERT (bson_iter_init (&iter, log));
+      ASSERT (bson_iter_find (&iter, "message"));
+      ASSERT (BSON_ITER_HOLDS_UTF8 (&iter));
+      ASSERT_CMPSTR (bson_iter_utf8 (&iter, NULL), "Command started");
+      ASSERT (bson_iter_find (&iter, "command"));
+      ASSERT (BSON_ITER_HOLDS_UTF8 (&iter));
+      uint32_t command_len;
+      const char *command = bson_iter_utf8 (&iter, &command_len);
+      ASSERT (command);
+      ASSERT_CMPUINT32 (command_len, ==, 5 + 3);
+      ASSERT_CMPSTR (command, "{ \"he...");
+   }
+
+   // 4. Inspect the resulting "command succeeded" log message and assert that the "reply" value is a string of length 5
+   // + (length of trailing ellipsis).
+   {
+      ASSERT (stored_log.len == 2);
+      bson_t *log = _mongoc_array_index (&stored_log, bson_t *, 1);
+      bson_iter_t iter;
+      ASSERT (bson_iter_init (&iter, log));
+      ASSERT (bson_iter_find (&iter, "message"));
+      ASSERT (BSON_ITER_HOLDS_UTF8 (&iter));
+      ASSERT_CMPSTR (bson_iter_utf8 (&iter, NULL), "Command succeeded");
+      ASSERT (bson_iter_find (&iter, "reply"));
+      ASSERT (BSON_ITER_HOLDS_UTF8 (&iter));
+      uint32_t reply_len;
+      const char *reply = bson_iter_utf8 (&iter, &reply_len);
+      ASSERT (reply);
+      ASSERT_CMPUINT32 (reply_len, ==, 5 + 3);
+   }
+
+   // 5. If the driver attaches raw server responses to failures and can access these via log messages to assert on, run
+   // the command {"notARealCommand": true}. Inspect the resulting "command failed" log message and confirm that the
+   // server error is a string of length 5 + (length of trailing ellipsis).
+   //
+   // This is not applicable to libmongoc. The spec allows flexible data type for "failure", and here we chose a
+   // document rather than a string. The document is not subject to truncation.
+   //
+   // While we're here, test that the proposed fake command itself is truncated as expected, and the "failure" is a
+   // document.
+   stored_log_clear (&stored_log);
+   ASSERT (
+      !mongoc_client_command_simple (client, "db", tmp_bson (BSON_STR ({"notARealCommand" : true})), NULL, NULL, NULL));
+   {
+      ASSERT (stored_log.len >= 1);
+      bson_t *log = _mongoc_array_index (&stored_log, bson_t *, 0);
+      bson_iter_t iter;
+      ASSERT (bson_iter_init (&iter, log));
+      ASSERT (bson_iter_find (&iter, "message"));
+      ASSERT (BSON_ITER_HOLDS_UTF8 (&iter));
+      ASSERT_CMPSTR (bson_iter_utf8 (&iter, NULL), "Command started");
+      ASSERT (bson_iter_find (&iter, "command"));
+      ASSERT (BSON_ITER_HOLDS_UTF8 (&iter));
+      uint32_t command_len;
+      const char *command = bson_iter_utf8 (&iter, &command_len);
+      ASSERT (command);
+      ASSERT_CMPUINT32 (command_len, ==, 5 + 3);
+      ASSERT_CMPSTR (command, "{ \"no...");
+   }
+   {
+      ASSERT (stored_log.len == 2);
+      bson_t *log = _mongoc_array_index (&stored_log, bson_t *, 1);
+      bson_iter_t iter;
+      ASSERT (bson_iter_init (&iter, log));
+      ASSERT (bson_iter_find (&iter, "message"));
+      ASSERT (BSON_ITER_HOLDS_UTF8 (&iter));
+      ASSERT_CMPSTR (bson_iter_utf8 (&iter, NULL), "Command failed");
+      ASSERT (bson_iter_find (&iter, "failure"));
+      ASSERT (BSON_ITER_HOLDS_DOCUMENT (&iter));
+   }
+
+   mongoc_client_destroy (client);
+   stored_log_clear (&stored_log);
+   _mongoc_array_destroy (&stored_log);
+}
+
+/* Test 3: Truncation with multi-byte code points */
+static void
+prose_test_3 (void)
+{
+   // "Drivers MUST write language-specific tests that confirm truncation of commands, replies, and (if applicable)
+   // server responses included in error messages work as expected when the data being truncated includes multi-byte
+   // Unicode codepoints." "If the driver uses anything other than Unicode codepoints as the unit for max document
+   // length, there also MUST be tests confirming that cases where the max length falls in the middle of a multi-byte
+   // codepoint are handled gracefully."
+   //
+   // For libmongoc, our max length is in bytes and truncation will round lengths down if necessary to avoid splitting a
+   // valid UTF-8 sequence. This test repeatedly sends a fake command to the mock server using every possible maximum
+   // length, checking for the expected truncations.
+
+   bson_t command = BSON_INITIALIZER;
+   BSON_APPEND_BOOL (&command, "notARealCommand", true);
+   BSON_APPEND_UTF8 (&command, "twoByteUtf8", "\xc2\xa9");
+   BSON_APPEND_UTF8 (&command, "threeByteUtf8", "\xef\xbf\xbd");
+   BSON_APPEND_UTF8 (&command, "fourByteUtf8", "\xf4\x8f\xbf\xbf");
+
+   // Stop testing after $db, before we reach lsid. The result will always be truncated.
+   const char *expected_json = "{ \"notARealCommand\" : true, \"twoByteUtf8\" : \"\xc2\xa9\", \"threeByteUtf8\" : "
+                               "\"\xef\xbf\xbd\", \"fourByteUtf8\" : \"\xf4\x8f\xbf\xbf\", \"$db\" : \"db\"";
+   const int max_expected_length = strlen (expected_json);
+
+   // List of lengths we expect not to see when trying every max_expected_length
+   static const int expect_missing_lengths[] = {46, 70, 71, 94, 95, 96};
+
+   mongoc_client_t *client = test_framework_new_default_client ();
+
+   int expected_length = 0;
+   for (int test_length = 0; test_length <= max_expected_length; test_length++) {
+      MONGOC_DEBUG ("testing length %d of %d", test_length, max_expected_length);
+
+      // Track the expected length of a serialized string with the max_document_length set to 'test_length'.
+      // When a length is mentioned in expect_missing_lengths, we let the expected_length lag behind the test_length.
+      // At this point, the ellipsis length is not included.
+      bool expect_missing = false;
+      if (test_length > max_expected_length) {
+         expect_missing = true;
+      } else {
+         for (int missing = 0; missing < sizeof expect_missing_lengths / sizeof expect_missing_lengths[0]; missing++) {
+            if (expect_missing_lengths[missing] == test_length) {
+               expect_missing = true;
+               break;
+            }
+         }
+      }
+      if (!expect_missing) {
+         expected_length = test_length;
+      }
+
+      // Set up the log options for each command, to test this new max_document_length
+      mongoc_structured_log_opts_t *log_opts = mongoc_structured_log_opts_new ();
+      mongoc_structured_log_opts_set_max_document_length (log_opts, test_length);
+      mongoc_structured_log_opts_set_max_level_for_component (
+         log_opts, MONGOC_STRUCTURED_LOG_COMPONENT_COMMAND, MONGOC_STRUCTURED_LOG_LEVEL_DEBUG);
+
+      mongoc_array_t stored_log;
+      _mongoc_array_init (&stored_log, sizeof (bson_t *));
+      mongoc_structured_log_opts_set_handler (log_opts, stored_log_handler, &stored_log);
+      mongoc_client_set_structured_log_opts (client, log_opts);
+      mongoc_structured_log_opts_destroy (log_opts);
+
+      ASSERT (!mongoc_client_command_simple (client, "db", &command, NULL, NULL, NULL));
+
+      ASSERT (stored_log.len >= 1);
+      bson_t *log = _mongoc_array_index (&stored_log, bson_t *, 0);
+      bson_iter_t iter;
+      ASSERT (bson_iter_init (&iter, log));
+      ASSERT (bson_iter_find (&iter, "message"));
+      ASSERT (BSON_ITER_HOLDS_UTF8 (&iter));
+      ASSERT_CMPSTR (bson_iter_utf8 (&iter, NULL), "Command started");
+      ASSERT (bson_iter_find (&iter, "command"));
+      ASSERT (BSON_ITER_HOLDS_UTF8 (&iter));
+      uint32_t command_len;
+      const char *command = bson_iter_utf8 (&iter, &command_len);
+      ASSERT (command);
+      ASSERT_CMPUINT32 (command_len, ==, expected_length + 3);
+
+      // Note that here we do not use mcommon_string to truncate, just as a convenient way to represent the
+      // expected string with ellipsis for ASSERT_CMPSTR. (The code under test internally uses mcommon_string_append_t
+      // also.)
+      mcommon_string_append_t expected_json_truncated;
+      mcommon_string_new_as_append (&expected_json_truncated);
+      mcommon_string_append_bytes (&expected_json_truncated, expected_json, expected_length);
+      mcommon_string_append (&expected_json_truncated, "...");
+      ASSERT_CMPSTR (command, mcommon_str_from_append (&expected_json_truncated));
+      mcommon_string_from_append_destroy (&expected_json_truncated);
+
+      mongoc_client_set_structured_log_opts (client, NULL);
+      stored_log_clear (&stored_log);
+      _mongoc_array_destroy (&stored_log);
+   }
+
+   mongoc_client_destroy (client);
+   bson_destroy (&command);
+}
+
+void
+test_command_logging_and_monitoring_install (TestSuite *suite)
+{
+   TestSuite_Add (suite, "/command-logging-and-monitoring/logging/prose_test_1", prose_test_1);
+   TestSuite_Add (suite, "/command-logging-and-monitoring/logging/prose_test_2", prose_test_2);
+   TestSuite_Add (suite, "/command-logging-and-monitoring/logging/prose_test_3", prose_test_3);
+}

--- a/src/libmongoc/tests/test-mongoc-structured-log.c
+++ b/src/libmongoc/tests/test-mongoc-structured-log.c
@@ -738,6 +738,22 @@ test_structured_log_component_names (void)
 }
 
 void
+test_structured_log_max_document_length (void)
+{
+   mongoc_structured_log_opts_t *opts = mongoc_structured_log_opts_new ();
+
+   // Test assumes no environment variable option is set
+   ASSERT_CMPINT (
+      MONGOC_STRUCTURED_LOG_DEFAULT_MAX_DOCUMENT_LENGTH, ==, mongoc_structured_log_opts_get_max_document_length (opts));
+   ASSERT (mongoc_structured_log_opts_set_max_document_length (opts, 0));
+   ASSERT (!mongoc_structured_log_opts_set_max_document_length (opts, INT_MAX));
+   ASSERT (mongoc_structured_log_opts_set_max_document_length (opts, INT_MAX / 2));
+   ASSERT_CMPINT (INT_MAX / 2, ==, mongoc_structured_log_opts_get_max_document_length (opts));
+
+   mongoc_structured_log_opts_destroy (opts);
+}
+
+void
 test_structured_log_install (TestSuite *suite)
 {
    TestSuite_Add (suite, "/structured_log/opts", test_structured_log_opts);
@@ -752,4 +768,5 @@ test_structured_log_install (TestSuite *suite)
    TestSuite_Add (suite, "/structured_log/duration", test_structured_log_duration);
    TestSuite_Add (suite, "/structured_log/level_names", test_structured_log_level_names);
    TestSuite_Add (suite, "/structured_log/component_names", test_structured_log_component_names);
+   TestSuite_Add (suite, "/structured_log/max_document_length", test_structured_log_max_document_length);
 }

--- a/src/libmongoc/tests/unified/entity-map.c
+++ b/src/libmongoc/tests/unified/entity-map.c
@@ -600,6 +600,9 @@ entity_client_new (entity_map_t *em, bson_t *bson, bson_error_t *error)
                BSON_ASSERT (mongoc_structured_log_opts_set_max_level_for_all_components (
                   log_opts, MONGOC_STRUCTURED_LOG_LEVEL_EMERGENCY));
                mongoc_structured_log_opts_set_handler (log_opts, structured_log_cb, entity);
+               // From the Command Logging and Monitoring / Testing spec, unified tests MUST be run with their max
+               // document length set to "a large value e.g. 10,000". Note that the default setting is 1000.
+               mongoc_structured_log_opts_set_max_document_length (log_opts, 10000);
             }),
             visitEach (
                if (not(type (utf8)), then (error ("Every value in 'observeLogMessages' must be a log level string"))),


### PR DESCRIPTION
This PR is a follow-up for #1795 which depends on the new internal string append and json building API from #1816. Note that #1821 (still out for review) will also need a similar follow-up that isn't included in this patch.

* Refines the concept of "maximum max document length" internally as a specific value near INT_MAX, to account for both ellipsis and bson overhead. Currently we choose not to expose the specific value of this constant publicly.
* Adds public APIs for the max_document_length within a mongoc_structured_log_opts_t.
* Addresses the remainder of CDRIVER-4485: JSON documents within structured log messages are truncated correctly according to the rules set out in the Logging specification.
* Addresses the remainder of CDRIVER-4486 by implementing prose tests.
* Addresses CDRIVER-4814. Command or payload data beyond the truncation limit no longer degrades logging performance.