### PR TITLE
CDRIVER-5873 reduce Debian 9 task coverage to compile-only

### DIFF
--- a/.evergreen/config_generator/components/cse/openssl.py
+++ b/.evergreen/config_generator/components/cse/openssl.py
@@ -21,7 +21,6 @@ COMPILE_MATRIX = [
     ('debian10', 'gcc',   None, ['cyrus']),
     ('debian11', 'clang', None, ['cyrus']),
     ('debian11', 'gcc',   None, ['cyrus']),
-
     ('rhel80',            'gcc',       None, ['cyrus']),
     ('rhel8-zseries',     'gcc',       None, ['cyrus']),
     ('ubuntu2004',        'clang',     None, ['cyrus']),

--- a/.evergreen/config_generator/components/cse/openssl.py
+++ b/.evergreen/config_generator/components/cse/openssl.py
@@ -15,10 +15,13 @@ TAG = f'cse-matrix-{SSL}'
 # pylint: disable=line-too-long
 # fmt: off
 COMPILE_MATRIX = [
-    ('debian10',          'gcc',       None, ['cyrus']),
-    ('debian11',          'gcc',       None, ['cyrus']),
-    ('debian92',          'clang',     None, ['cyrus']),
-    ('debian92',          'gcc',       None, ['cyrus']),
+    ('debian92', 'clang', None, ['cyrus']),
+    ('debian92', 'gcc',   None, ['cyrus']),
+    ('debian10', 'clang', None, ['cyrus']),
+    ('debian10', 'gcc',   None, ['cyrus']),
+    ('debian11', 'clang', None, ['cyrus']),
+    ('debian11', 'gcc',   None, ['cyrus']),
+
     ('rhel80',            'gcc',       None, ['cyrus']),
     ('rhel8-zseries',     'gcc',       None, ['cyrus']),
     ('ubuntu2004',        'clang',     None, ['cyrus']),
@@ -31,7 +34,7 @@ COMPILE_MATRIX = [
 TEST_MATRIX = [
     # 4.2 and 4.4 not available on rhel8-zseries.
     ('rhel8-zseries', 'gcc', None, 'cyrus', ['auth'], ['server'], ['5.0']),
-    
+
     ('windows-vsCurrent', 'vs2017x64', None, 'cyrus', ['auth'], ['server'], ['4.2', '4.4', '5.0', '6.0' ]),
 
     # Test 7.0+ with a replica set since Queryable Encryption does not support the 'server' topology. Queryable Encryption tests require 7.0+.
@@ -42,7 +45,6 @@ TEST_MATRIX = [
 
     # Test 4.2 with Debian 10 since 4.2 does not ship on Ubuntu 20.04+.
     ('debian10',          'gcc',       None, 'cyrus', ['auth'], ['server', 'replica'], ['4.2']),
-    
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/sasl/openssl.py
+++ b/.evergreen/config_generator/components/sasl/openssl.py
@@ -17,6 +17,8 @@ TAG = f'sasl-matrix-{SSL}'
 # pylint: disable=line-too-long
 # fmt: off
 COMPILE_MATRIX = [
+    ('debian92',          'clang',      None, ['cyrus']),
+    ('debian92',          'gcc',        None, ['cyrus']),
     ('debian10',          'gcc',        None, ['cyrus']),
     ('debian11',          'gcc',        None, ['cyrus']),
     ('debian92',          'clang',      None, ['cyrus']),

--- a/.evergreen/config_generator/components/sasl/openssl.py
+++ b/.evergreen/config_generator/components/sasl/openssl.py
@@ -21,8 +21,6 @@ COMPILE_MATRIX = [
     ('debian92',          'gcc',        None, ['cyrus']),
     ('debian10',          'gcc',        None, ['cyrus']),
     ('debian11',          'gcc',        None, ['cyrus']),
-    ('debian92',          'clang',      None, ['cyrus']),
-    ('debian92',          'gcc',        None, ['cyrus']),
     ('rhel80',            'gcc',        None, ['cyrus']),
     ('rhel8-power',       'gcc',        None, ['cyrus']),
     ('rhel8-zseries',     'gcc',        None, ['cyrus']),

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -43,6 +43,8 @@ class Distro(BaseModel):
 # pylint: disable=line-too-long
 #fmt: off
 DEBIAN_DISTROS = [
+    Distro(name='debian92-large', os='debian', os_type='linux', os_ver='9.2', size='large'), # CDRIVER-5873
+    Distro(name='debian92-small', os='debian', os_type='linux', os_ver='9.2', size='small'), # CDRIVER-5873
     Distro(name='debian10-large', os='debian', os_type='linux', os_ver='10', size='large'),
     Distro(name='debian10-small', os='debian', os_type='linux', os_ver='10', size='small'),
     Distro(name='debian11-large', os='debian', os_type='linux', os_ver='11', size='large'),

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -45,8 +45,8 @@ class Distro(BaseModel):
 DEBIAN_DISTROS = [
     Distro(name='debian92-large', os='debian', os_type='linux', os_ver='9.2', size='large'), # CDRIVER-5873
     Distro(name='debian92-small', os='debian', os_type='linux', os_ver='9.2', size='small'), # CDRIVER-5873
-    Distro(name='debian10-large', os='debian', os_type='linux', os_ver='10', size='large'),
-    Distro(name='debian10-small', os='debian', os_type='linux', os_ver='10', size='small'),
+    Distro(name='debian10-large', os='debian', os_type='linux', os_ver='10', size='large'), # CDRIVER-5874
+    Distro(name='debian10-small', os='debian', os_type='linux', os_ver='10', size='small'), # CDRIVER-5874
     Distro(name='debian11-large', os='debian', os_type='linux', os_ver='11', size='large'),
     Distro(name='debian11-small', os='debian', os_type='linux', os_ver='11', size='small'),
     Distro(name='debian92-large', os='debian', os_type='linux', os_ver='9.2', size='large'),

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -3549,24 +3549,6 @@ tasks:
         vars:
           CC: clang
       - func: upload-build
-  - name: sasl-cyrus-openssl-debian92-clang-compile
-    run_on: debian92-large
-    tags: [sasl-matrix-openssl, compile, debian92, clang, sasl-cyrus]
-    commands:
-      - func: find-cmake-latest
-      - func: sasl-cyrus-openssl-compile
-        vars:
-          CC: clang
-      - func: upload-build
-  - name: sasl-cyrus-openssl-debian92-gcc-compile
-    run_on: debian92-large
-    tags: [sasl-matrix-openssl, compile, debian92, gcc, sasl-cyrus]
-    commands:
-      - func: find-cmake-latest
-      - func: sasl-cyrus-openssl-compile
-        vars:
-          CC: gcc
-      - func: upload-build
   - name: sasl-cyrus-openssl-debian92-gcc-compile
     run_on: debian92-large
     tags: [sasl-matrix-openssl, compile, debian92, gcc, sasl-cyrus]

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -1678,6 +1678,15 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-mock-kms-servers
       - func: run-tests
+  - name: cse-sasl-cyrus-openssl-debian10-clang-compile
+    run_on: debian10-large
+    tags: [cse-matrix-openssl, compile, debian10, clang, cse, sasl-cyrus]
+    commands:
+      - func: find-cmake-latest
+      - func: cse-sasl-cyrus-openssl-compile
+        vars:
+          CC: clang
+      - func: upload-build
   - name: cse-sasl-cyrus-openssl-debian10-gcc-compile
     run_on: debian10-large
     tags: [cse-matrix-openssl, compile, debian10, gcc, cse, sasl-cyrus]
@@ -1727,6 +1736,15 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-mock-kms-servers
       - func: run-tests
+  - name: cse-sasl-cyrus-openssl-debian11-clang-compile
+    run_on: debian11-large
+    tags: [cse-matrix-openssl, compile, debian11, clang, cse, sasl-cyrus]
+    commands:
+      - func: find-cmake-latest
+      - func: cse-sasl-cyrus-openssl-compile
+        vars:
+          CC: clang
+      - func: upload-build
   - name: cse-sasl-cyrus-openssl-debian11-gcc-compile
     run_on: debian11-large
     tags: [cse-matrix-openssl, compile, debian11, gcc, cse, sasl-cyrus]
@@ -3530,6 +3548,24 @@ tasks:
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: clang
+      - func: upload-build
+  - name: sasl-cyrus-openssl-debian92-clang-compile
+    run_on: debian92-large
+    tags: [sasl-matrix-openssl, compile, debian92, clang, sasl-cyrus]
+    commands:
+      - func: find-cmake-latest
+      - func: sasl-cyrus-openssl-compile
+        vars:
+          CC: clang
+      - func: upload-build
+  - name: sasl-cyrus-openssl-debian92-gcc-compile
+    run_on: debian92-large
+    tags: [sasl-matrix-openssl, compile, debian92, gcc, sasl-cyrus]
+    commands:
+      - func: find-cmake-latest
+      - func: sasl-cyrus-openssl-compile
+        vars:
+          CC: gcc
       - func: upload-build
   - name: sasl-cyrus-openssl-debian92-gcc-compile
     run_on: debian92-large

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -101,10 +101,12 @@ buildvariants:
     expansions:
       CLIENT_SIDE_ENCRYPTION: "on"
     tasks:
-      - name: cse-sasl-cyrus-openssl-debian10-gcc-compile
-      - name: cse-sasl-cyrus-openssl-debian11-gcc-compile
       - name: cse-sasl-cyrus-openssl-debian92-clang-compile
       - name: cse-sasl-cyrus-openssl-debian92-gcc-compile
+      - name: cse-sasl-cyrus-openssl-debian10-clang-compile
+      - name: cse-sasl-cyrus-openssl-debian10-gcc-compile
+      - name: cse-sasl-cyrus-openssl-debian11-clang-compile
+      - name: cse-sasl-cyrus-openssl-debian11-gcc-compile
       - name: cse-sasl-cyrus-openssl-rhel80-gcc-compile
       - name: cse-sasl-cyrus-openssl-rhel8-zseries-gcc-compile
         batchtime: 1440
@@ -223,6 +225,8 @@ buildvariants:
     display_name: sasl-matrix-openssl
     expansions: {}
     tasks:
+      - name: sasl-cyrus-openssl-debian92-clang-compile
+      - name: sasl-cyrus-openssl-debian92-gcc-compile
       - name: sasl-cyrus-openssl-debian10-gcc-compile
       - name: sasl-cyrus-openssl-debian11-gcc-compile
       - name: sasl-cyrus-openssl-debian92-clang-compile

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -229,8 +229,6 @@ buildvariants:
       - name: sasl-cyrus-openssl-debian92-gcc-compile
       - name: sasl-cyrus-openssl-debian10-gcc-compile
       - name: sasl-cyrus-openssl-debian11-gcc-compile
-      - name: sasl-cyrus-openssl-debian92-clang-compile
-      - name: sasl-cyrus-openssl-debian92-gcc-compile
       - name: sasl-cyrus-openssl-rhel80-gcc-compile
       - name: sasl-cyrus-openssl-rhel8-power-gcc-compile
         batchtime: 1440

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,10 @@
 libmongoc 1.29.2
 ================
 
+Deprecated:
+
+  * Support for Debian 9 and Debian 10.
+
 Fixes:
   * Rename `set_error` function to avoid symbol conflicts.
   * Fix Windows ARM 64 build.

--- a/src/libbson/NEWS
+++ b/src/libbson/NEWS
@@ -1,6 +1,10 @@
 libbson 1.30.0 (Unreleased)
 ===========================
 
+Deprecated:
+
+  * Support for Debian 9 and Debian 10.
+
 Fixes:
 
   * Truncated output of `bson_as_json_with_opts` is changed to no longer split valid UTF-8 sequences.


### PR DESCRIPTION
Addresses task failures on Evergreen due to the following error thrown by DET's mongodl.py script on Debian 9.2 distros:

```
ValueError: No download was found for version="latest" target="debian92" arch="x86_64" edition="enterprise" component="crypt_shared"
```

Debian 9 is EOL and should probably have been removed from the EVG matrix as part of CDRIVER-4602.

All removed tasks either already have a Debian 10 or Debian 11 equivalent, or were extended accordingly (i.e. Clang coverage), with the sole exception of the `clang38` build variant which ran the `release-compile`, `debug-compile-nosasl-nossl`, and `test-latest-server-*` tasks (there are no equivalent for Clang on Debian 10+, only GCC equivalents).