### PR TITLE
CDRIVER-5877 avoid aligned_alloc on MacOS prior to 10.15

### DIFF
--- a/src/libbson/src/bson/bson-memory.c
+++ b/src/libbson/src/bson/bson-memory.c
@@ -23,6 +23,10 @@
 #include <bson/bson-config.h>
 #include <bson/bson-memory.h>
 
+#ifdef __APPLE__
+#include <AvailabilityMacros.h>
+#endif
+
 
 // Ensure size of exported structs are stable.
 BSON_STATIC_ASSERT2 (bson_mem_vtable_t, sizeof (bson_mem_vtable_t) == sizeof (void *) * 8u);
@@ -32,7 +36,7 @@ BSON_STATIC_ASSERT2 (bson_mem_vtable_t, sizeof (bson_mem_vtable_t) == sizeof (vo
 static void *
 _aligned_alloc_impl (size_t alignment, size_t num_bytes)
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && !defined(_WIN32) && !defined(__ANDROID__) && \
-   !defined(_AIX)
+   !defined(_AIX) && !(defined(__APPLE__) & MAC_OS_X_VERSION_MIN_REQUIRED < 101500)
 {
    return aligned_alloc (alignment, num_bytes);
 }


### PR DESCRIPTION
@NattyNarwhal Could you please review this? Pre-Catalina macOS need the same fix as you have added for AIX in https://github.com/mongodb/mongo-c-driver/commit/9fe8af14e458523bbe57d9e2658295976f2aac08