### PR TITLE
CDRIVER-5869 fix bulk write crash with verbose results

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-bulkwrite.c
+++ b/src/libmongoc/src/mongoc/mongoc-bulkwrite.c
@@ -1709,9 +1709,9 @@ mongoc_bulkwrite_execute (mongoc_bulkwrite_t *self, const mongoc_bulkwriteopts_t
       bool batch_ok = false;
       bson_t cmd_reply = BSON_INITIALIZER;
       mongoc_cursor_t *reply_cursor = NULL;
-      // `ops_byte_len` is the number of documents from `ops` to send in this batch.
+      // `ops_byte_len` is the number of bytes from `ops` to send in this batch.
       size_t ops_byte_len = 0;
-      // `ops_doc_len` is the number of bytes from `ops` to send in this batch.
+      // `ops_doc_len` is the number of documents from `ops` to send in this batch.
       size_t ops_doc_len = 0;
 
       if (ops_byte_offset == self->ops.len) {

--- a/src/libmongoc/tests/test-mongoc-bulkwrite.c
+++ b/src/libmongoc/tests/test-mongoc-bulkwrite.c
@@ -665,7 +665,7 @@ test_bulkwrite_two_large_inserts (void *unused)
    ASSERT_OR_PRINT (mongoc_bulkwrite_append_insertone (bw, "db.coll", docs[0], NULL, &error), error);
    ASSERT_OR_PRINT (mongoc_bulkwrite_append_insertone (bw, "db.coll", docs[1], NULL, &error), error);
 
-   mongoc_bulkwritereturn_t bwr = mongoc_bulkwrite_execute (bw, bw_opts); // Crashes!
+   mongoc_bulkwritereturn_t bwr = mongoc_bulkwrite_execute (bw, bw_opts);
    ASSERT_NO_BULKWRITEEXCEPTION (bwr);
    ASSERT (bwr.res);
    const bson_t *insertresults = mongoc_bulkwriteresult_insertresults (bwr.res);

--- a/src/libmongoc/tests/test-mongoc-bulkwrite.c
+++ b/src/libmongoc/tests/test-mongoc-bulkwrite.c
@@ -650,13 +650,14 @@ test_bulkwrite_two_large_inserts (void *unused)
    char *large_string = bson_malloc (large_len + 1);
    memset (large_string, 'a', large_len);
    large_string[large_len] = '\0';
+   ASSERT (mcommon_in_range_unsigned (int, large_len));
 
    // Create two large documents:
    bson_t *docs[2];
    docs[0] = BCON_NEW ("_id", "over_2mib_1");
-   bson_append_utf8 (docs[0], "unencrypted", -1, large_string, large_len);
+   bson_append_utf8 (docs[0], "unencrypted", -1, large_string, (int) large_len);
    docs[1] = BCON_NEW ("_id", "over_2mib_2");
-   bson_append_utf8 (docs[1], "unencrypted", -1, large_string, large_len);
+   bson_append_utf8 (docs[1], "unencrypted", -1, large_string, (int) large_len);
 
    mongoc_bulkwriteopts_t *bw_opts = mongoc_bulkwriteopts_new ();
    mongoc_bulkwriteopts_set_verboseresults (bw_opts, true);


### PR DESCRIPTION
# Summary

Uses integral offsets, rather than a `bson_iter_t`, to refer to "_id" fields in the `bulkWrite` payload.

Verified with this patch build: https://spruce.mongodb.com/version/6798e244aed6b800073ef361

# Background

See CDRIVER-5869 for background.