### PR TITLE
CDRIVER-5873 remove Debian 9 tasks from legacy config

### DIFF
--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -16403,15 +16403,6 @@ buildvariants:
   - install-libmongoc-after-libbson
   tags:
   - pr-merge-gate
-- name: clang38
-  display_name: clang 3.8 (Debian 9.2)
-  expansions:
-    CC: clang
-  run_on: debian92-test
-  tasks:
-  - release-compile
-  - debug-compile-nosasl-nossl
-  - .latest .nossl
 - name: openssl
   display_name: OpenSSL / LibreSSL
   run_on: archlinux-build
@@ -16458,15 +16449,6 @@ buildvariants:
   - debug-compile-nosasl-openssl
   - debug-compile-sasl-openssl
   - .authentication-tests .openssl
-  - .latest .nossl
-- name: gcc63
-  display_name: GCC 6.3 (Debian 9.2)
-  expansions:
-    CC: gcc
-  run_on: debian92-test
-  tasks:
-  - release-compile
-  - debug-compile-nosasl-nossl
   - .latest .nossl
 - name: gcc83
   display_name: GCC 8.3 (Debian 10.0)

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -81,13 +81,6 @@ all_variants = [
         tags=["pr-merge-gate"],
     ),
     Variant(
-        "clang38",
-        "clang 3.8 (Debian 9.2)",
-        "debian92-test",
-        ["release-compile", "debug-compile-nosasl-nossl", ".latest .nossl"],
-        {"CC": "clang"},
-    ),
-    Variant(
         "openssl",
         "OpenSSL / LibreSSL",
         "archlinux-build",
@@ -141,13 +134,6 @@ all_variants = [
             ".authentication-tests .openssl",
             ".latest .nossl",
         ],
-        {"CC": "gcc"},
-    ),
-    Variant(
-        "gcc63",
-        "GCC 6.3 (Debian 9.2)",
-        "debian92-test",
-        ["release-compile", "debug-compile-nosasl-nossl", ".latest .nossl"],
         {"CC": "gcc"},
     ),
     Variant(


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1839 which failed to correctly remove Debian 9 tasks from the legacy config despite claiming "tasks in the legacy config remain removed" as the intended changes were inadvertently reverted [by a mistaken rebase](https://github.com/mongodb/mongo-c-driver/compare/99fd5105eea4487e2f1fab2cb5c37ba795dad333..468b6066ac5d67a89bc3e40998a174d377b11b8f).