### PR TITLE
CDRIVER-5645 fix and update build-and-run-authentication-tests-* tasks

### DIFF
--- a/.evergreen/scripts/install-ssl.sh
+++ b/.evergreen/scripts/install-ssl.sh
@@ -47,9 +47,9 @@ install_openssl() {
   declare ssl_version="${SSL##openssl-}"
   declare tmp
   tmp="$(echo "${ssl_version:?}" | tr . _)"
-  curl -L --retry 5 -o ssl.tar.gz "https://github.com/openssl/openssl/archive/OpenSSL_${tmp}.tar.gz"
+  curl -L --retry 5 -o ssl.tar.gz "https://github.com/openssl/openssl/releases/download/OpenSSL_${tmp}/openssl-${ssl_version}.tar.gz"
   tar zxf ssl.tar.gz
-  pushd "openssl-OpenSSL_${tmp}"
+  pushd "openssl-${ssl_version}"
   (
     set -o xtrace
     ./config --prefix="${openssl_install_dir}" "${ssl_extra_flags[@]}" shared -fPIC
@@ -61,11 +61,11 @@ install_openssl() {
     make -j
     make install_sw
   ) >/dev/null
-  popd # "openssl-OpenSSL_${tmp}"
+  popd # "openssl-${ssl_version}"
 }
 
 install_openssl_fips() {
-  curl --retry 5 -o fips.tar.gz https://www.openssl.org/source/openssl-fips-2.0.16.tar.gz
+  curl -L --retry 5 -o fips.tar.gz https://github.com/openssl/openssl/releases/download/OpenSSL-fips-2_0_16/openssl-fips-2.0.16.tar.gz
   tar zxf fips.tar.gz
   pushd openssl-fips-2.0.16
   (

--- a/.evergreen/scripts/run-auth-tests.sh
+++ b/.evergreen/scripts/run-auth-tests.sh
@@ -100,16 +100,11 @@ elif command -v otool >/dev/null; then
 fi
 
 if [[ "${ssl}" != "OFF" ]]; then
-  {
-    # Skip 3.6. Remove this block when resolving CDRIVER-5645.
-    echo "Skipping tests on server 3.6 (using 'auth_host' or 'auth_gssapi') until DEVPROD-9029 is addressed."
-  } || {
   # FIXME: CDRIVER-2008 for the cygwin check
   if [[ "${OSTYPE}" != "cygwin" ]]; then
     echo "Authenticating using X.509"
     LD_LIBRARY_PATH="${openssl_lib_prefix}" "${ping}" "mongodb://CN=client,OU=kerneluser,O=10Gen,L=New York City,ST=New York,C=US@${auth_host}/?ssl=true&authMechanism=MONGODB-X509&sslClientCertificateKeyFile=src/libmongoc/tests/x509gen/ldaptest-client-key-and-cert.pem&sslCertificateAuthorityFile=src/libmongoc/tests/x509gen/ldaptest-ca-cert.crt&sslAllowInvalidHostnames=true&${c_timeout}"
   fi
-  }
   echo "Connecting to Atlas Free Tier"
   LD_LIBRARY_PATH="${openssl_lib_prefix}" "${ping}" "${atlas_free:?}&${c_timeout}"
   echo "Connecting to Atlas Free Tier with SRV"
@@ -149,10 +144,6 @@ if [[ "${ssl}" != "OFF" ]]; then
   fi
 fi
 
-{
-  # Skip 3.6. Remove this block when resolving CDRIVER-5645.
-  echo "Skipping tests on server 3.6 (using 'auth_host' or 'auth_gssapi') until DEVPROD-9029 is addressed."
-} || {
 echo "Authenticating using PLAIN"
 LD_LIBRARY_PATH="${openssl_lib_prefix}" "${ping}" "mongodb://${auth_plain:?}@${auth_host}/?authMechanism=PLAIN&${c_timeout}"
 
@@ -183,4 +174,3 @@ if [[ "${sasl}" != "OFF" ]]; then
     LD_LIBRARY_PATH="${openssl_lib_prefix}" "${ping}" "mongodb://${auth_gssapi_utf8:?}@${auth_host}/?authMechanism=GSSAPI&${c_timeout}"
   fi
 fi
-}

--- a/.evergreen/scripts/run-auth-tests.sh
+++ b/.evergreen/scripts/run-auth-tests.sh
@@ -21,12 +21,12 @@ declare openssl_install_dir="${mongoc_dir}/openssl-install-dir"
 declare c_timeout="connectTimeoutMS=30000&serverSelectionTryOnce=false"
 
 declare sasl="OFF"
-if grep -q "#define MONGOC_ENABLE_SASL 1" src/libmongoc/src/mongoc/mongoc-config.h; then
+if grep -r -q "#define MONGOC_ENABLE_SASL 1" "${install_dir:?}"; then
   sasl="ON"
 fi
 
 declare ssl="OFF"
-if grep -q "#define MONGOC_ENABLE_SSL 1" src/libmongoc/src/mongoc/mongoc-config.h; then
+if grep -r -q "#define MONGOC_ENABLE_SSL 1" "${install_dir:?}"; then
   ssl="ON"
 fi
 
@@ -41,20 +41,20 @@ declare test_gssapi
 declare ip_addr
 case "${OSTYPE}" in
 cygwin)
-  ping="./src/libmongoc/Debug/mongoc-ping.exe"
-  test_gssapi="./src/libmongoc/Debug/test-mongoc-gssapi.exe"
+  ping="${mongoc_dir}/cmake-build/src/libmongoc/Debug/mongoc-ping.exe"
+  test_gssapi="${mongoc_dir}/cmake-build/src/libmongoc/Debug/test-mongoc-gssapi.exe"
   ip_addr="$(getent hosts "${auth_host:?}" | head -n 1 | awk '{print $1}')"
   ;;
 
 darwin*)
-  ping="./src/libmongoc/mongoc-ping"
-  test_gssapi="./src/libmongoc/test-mongoc-gssapi"
+  ping="${mongoc_dir}/cmake-build/src/libmongoc/mongoc-ping"
+  test_gssapi="${mongoc_dir}/cmake-build/src/libmongoc/test-mongoc-gssapi"
   ip_addr="$(dig "${auth_host:?}" +short | tail -1)"
   ;;
 
 *)
-  ping="./src/libmongoc/mongoc-ping"
-  test_gssapi="./src/libmongoc/test-mongoc-gssapi"
+  ping="${mongoc_dir}/cmake-build/src/libmongoc/mongoc-ping"
+  test_gssapi="${mongoc_dir}/cmake-build/src/libmongoc/test-mongoc-gssapi"
   ip_addr="$(getent hosts "${auth_host:?}" | head -n 1 | awk '{print $1}')"
   ;;
 esac


### PR DESCRIPTION
Resolves CDRIVER-5645. Verified by [this patch](https://spruce.mongodb.com/version/679cfab28738040007b3b867/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).

---

The `build-and-run-authentication-tests-openssl-1.0.1-fips` task has been failing since around [2024-09-30](https://spruce.mongodb.com/task/mongo_c_driver_openssl_build_and_run_authentication_tests_openssl_1.0.1_fips_c5c960a98a8e2d81a3ec9e6f92b4c8b576ba8b10_24_09_24_14_39_27/logs?execution=0). This is presumably due to the old link that was being used to download the OpenSSL FIPS module (at `https://www.openssl.org/source/*`) no longer being supported. The [OpenSSL Downloads page](https://openssl-library.org/source/old/index.html) redirects users to the [/source/old](https://openssl-library.org/source/old/index.html) downlaod pages. Download URLs under these pages all use GitHub release asset download links. This includes both regular OpenSSL releases (e.g. [1.0.1u](https://github.com/openssl/openssl/releases/OpenSSL_1_0_1u/)) and FIPS modules (e.g. [2.0.16](https://github.com/openssl/openssl/releases/OpenSSL-fips-2_0_16/)). Therefore, the `install-ssl.sh` script is updated accordingly to consistently use the new, actively supported GitHub release download links for both the main library and the FIPS module.

---

Although the remaining OpenSSL-related tasks have been reported as "success", most of the tests are actually being skipped due to MongoDB server 3.6 (non-)compatibility workarounds introduced in https://github.com/mongodb/mongo-c-driver/pull/1681. Taking this opportunity to test if the workarounds are still required revealed the workarounds may no longer be necessary despite [DEVPROD-9029](https://jira.mongodb.org/browse/DEVPROD-9029) not yet being marked as resolved (may have been addressed around 2024-09-10 according to [this comment](https://jira.mongodb.org/browse/DEVPROD-9029?focusedCommentId=6679897&focusedId=6679897&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-6679897)). This also revealed script errors caused by https://github.com/mongodb/mongo-c-driver/issues/1710, which moved the location of build artifacts (in-source build -> `cmake-build` subdirectory), breaking paths to both the `mongoc-config.h` file (used to detect the build configuration) and the `mongoc-ping` and `test-mongoc-gssapi` executables.
