### PR TITLE
Free `child` on failed call to `bson_append_array_builder_begin`

### DIFF
--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -2971,7 +2971,12 @@ bson_append_array_builder_begin (bson_t *bson, const char *key, int key_length, 
    BSON_ASSERT_PARAM (key);
    BSON_ASSERT_PARAM (child);
    *child = bson_array_builder_new ();
-   return bson_append_array_begin (bson, key, key_length, &(*child)->bson);
+   bool ok = bson_append_array_begin (bson, key, key_length, &(*child)->bson);
+   if (!ok) {
+      bson_array_builder_destroy (*child);
+      *child = NULL;
+   }
+   return ok;
 }
 
 bool

--- a/src/libbson/tests/test-bson.c
+++ b/src/libbson/tests/test-bson.c
@@ -3196,6 +3196,16 @@ test_bson_array_builder (void)
          bson_array_builder_destroy (bab);
       }
    }
+
+   // A failure in bson_append_array_builder_begin does not allocate.
+   {
+      bson_t b = BSON_INITIALIZER;
+      bson_array_builder_t *child;
+      bool ok = bson_append_array_builder_begin (&b, "has_embedded_null\0", strlen ("has_embedded_null") + 1, &child);
+      ASSERT (!ok);
+      bson_destroy (&b);
+      // Not necessary to free `child`.
+   }
 }
 
 void


### PR DESCRIPTION
# Summary

Free `child` on failed call to `bson_append_array_builder_begin`.

Verified with this patch build: https://spruce.mongodb.com/version/67a124ca58a59000075fa19d

# Background & Motivation

Coverity identified a possible resource leak on [this block](https://github.com/mongodb/mongo-c-driver/blob/61592503831ffdb9650bfcbc1a57d29e5f072757/src/libmongoc/src/mongoc/mongoc-topology-description.c#L2573). This roughly does the following:

```c
if (BSON_APPEND_ARRAY_BUILDER_BEGIN (bson, "servers", &array)) {
    // ...
} else {
    return false; // Leaks `array`.
}
```

If `bson_append_array_builder_begin` returns false, the `child` out-param is left allocated. Whereas a failure in `bson_append_array_begin` does not require a clean-up of the `child`.

For consistency with `bson_append_array_begin`, this PR changes `bson_append_array_builder_begin` to free `child` on failure. `child` is set to `NULL` to permit existing code to safely call `bson_append_builder_destroy`.

