### PR TITLE
ccache: support MSVC by using /Z7 via MSVC_DEBUG_INFORMATION_FORMAT

### DIFF
--- a/.evergreen/scripts/compile-libmongocrypt.sh
+++ b/.evergreen/scripts/compile-libmongocrypt.sh
@@ -20,6 +20,8 @@ compile_libmongocrypt() {
     "-DBUILD_VERSION=1.12.0"
   )
 
+  . "$(dirname "${BASH_SOURCE[0]}")/find-ccache.sh"
+  find_ccache_and_export_vars "$(pwd)/libmongocrypt" || true
   if command -v "${CMAKE_C_COMPILER_LAUNCHER:-}" && [[ "${OSTYPE:?}" == cygwin ]]; then
     crypt_cmake_flags+=(
       "-DCMAKE_POLICY_DEFAULT_CMP0141=NEW"

--- a/.evergreen/scripts/compile-libmongocrypt.sh
+++ b/.evergreen/scripts/compile-libmongocrypt.sh
@@ -20,6 +20,13 @@ compile_libmongocrypt() {
     "-DBUILD_VERSION=1.12.0"
   )
 
+  if [[ "${OSTYPE:?}" == cygwin ]]; then
+    crypt_cmake_flags+=(
+      "-DCMAKE_POLICY_DEFAULT_CMP0141=NEW"
+      "-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded"
+    )
+  fi
+
   env \
     DEBUG="0" \
     CMAKE_EXE="${cmake_binary}" \

--- a/.evergreen/scripts/compile-libmongocrypt.sh
+++ b/.evergreen/scripts/compile-libmongocrypt.sh
@@ -20,7 +20,7 @@ compile_libmongocrypt() {
     "-DBUILD_VERSION=1.12.0"
   )
 
-  if [[ "${OSTYPE:?}" == cygwin ]]; then
+  if command -v "${CMAKE_C_COMPILER_LAUNCHER:-}" && [[ "${OSTYPE:?}" == cygwin ]]; then
     crypt_cmake_flags+=(
       "-DCMAKE_POLICY_DEFAULT_CMP0141=NEW"
       "-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded"

--- a/.evergreen/scripts/compile-std.sh
+++ b/.evergreen/scripts/compile-std.sh
@@ -134,7 +134,7 @@ echo "Installing libmongocrypt... done."
 # Use ccache if able.
 . "${script_dir:?}/find-ccache.sh"
 find_ccache_and_export_vars "$(pwd)" || true
-if [[ "${OSTYPE:?}" == cygwin ]]; then
+if command -v "${CMAKE_C_COMPILER_LAUNCHER:-}" && [[ "${OSTYPE:?}" == cygwin ]]; then
   configure_flags_append "-DCMAKE_POLICY_DEFAULT_CMP0141=NEW"
   configure_flags_append "-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>"
 fi

--- a/.evergreen/scripts/compile-std.sh
+++ b/.evergreen/scripts/compile-std.sh
@@ -131,12 +131,16 @@ echo "Installing libmongocrypt..."
 }
 echo "Installing libmongocrypt... done."
 
-echo "CFLAGS: ${CFLAGS}"
-echo "configure_flags: ${configure_flags[*]}"
-
 # Use ccache if able.
 . "${script_dir:?}/find-ccache.sh"
 find_ccache_and_export_vars "$(pwd)" || true
+if [[ "${OSTYPE:?}" == cygwin ]]; then
+  configure_flags_append "-DCMAKE_POLICY_DEFAULT_CMP0141=NEW"
+  configure_flags_append "-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>"
+fi
+
+echo "CFLAGS: ${CFLAGS}"
+echo "configure_flags: ${configure_flags[*]}"
 
 "${cmake_binary}" "${configure_flags[@]}" .
 "${cmake_binary}" --build .

--- a/.evergreen/scripts/compile-windows.sh
+++ b/.evergreen/scripts/compile-windows.sh
@@ -137,7 +137,7 @@ fi
 # Use ccache if able.
 . "${script_dir:?}/find-ccache.sh"
 find_ccache_and_export_vars "$(pwd)" || true
-if [[ "${OSTYPE:?}" == cygwin ]]; then
+if command -v "${CMAKE_C_COMPILER_LAUNCHER:-}" && [[ "${OSTYPE:?}" == cygwin ]]; then
   configure_flags_append "-DCMAKE_POLICY_DEFAULT_CMP0141=NEW"
   configure_flags_append "-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>"
 fi

--- a/.evergreen/scripts/compile-windows.sh
+++ b/.evergreen/scripts/compile-windows.sh
@@ -134,6 +134,14 @@ if [ "${COMPILE_LIBMONGOCRYPT}" = "ON" ]; then
   configure_flags_append "-DENABLE_CLIENT_SIDE_ENCRYPTION=ON"
 fi
 
+# Use ccache if able.
+. "${script_dir:?}/find-ccache.sh"
+find_ccache_and_export_vars "$(pwd)" || true
+if [[ "${OSTYPE:?}" == cygwin ]]; then
+  configure_flags_append "-DCMAKE_POLICY_DEFAULT_CMP0141=NEW"
+  configure_flags_append "-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>"
+fi
+
 "${cmake_binary:?}" -S . -B "${build_dir:?}" -G "$CC" "${configure_flags[@]}" "${extra_configure_flags[@]}"
 "${cmake_binary:?}" --build "${build_dir:?}" --config "${build_config:?}"
 "${cmake_binary:?}" --install "${build_dir:?}" --config "${build_config:?}"

--- a/.evergreen/scripts/link-sample-program.sh
+++ b/.evergreen/scripts/link-sample-program.sh
@@ -76,6 +76,10 @@ ZSTD="AUTO"
 if [[ -f $DIR/find-ccache.sh ]]; then
   . $DIR/find-ccache.sh
   find_ccache_and_export_vars "$SCRATCH_DIR" || true
+  if command -v "${CMAKE_C_COMPILER_LAUNCHER:-}" && [[ "${OSTYPE:?}" == cygwin ]]; then
+    configure_flags_append "-DCMAKE_POLICY_DEFAULT_CMP0141=NEW"
+    configure_flags_append "-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>"
+  fi
 fi
 
 $CMAKE -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DCMAKE_PREFIX_PATH=$INSTALL_DIR/lib/cmake $SSL_CMAKE_OPTION $SNAPPY_CMAKE_OPTION $STATIC_CMAKE_OPTION -DENABLE_ZSTD=$ZSTD "$SCRATCH_DIR"


### PR DESCRIPTION
Attempt to improve support for building with ccache on Windows distros.

CMake uses `/Zi` in `CMAKE_<LANG>_FLAGS_DEBUG` by default. Unfortunately, ccache [does not support](/ccache/ccache/issues/1040) `/Zi`. This means building C projects with CMake and Visual Studio is incompatible with ccache by default when using debug configurations.

CMake 3.25 introduces [CMP0141](https://cmake.org/cmake/help/v3.25/policy/CMP0141.html) which moves the `/Zi` flag out of `CMAKE_<LANG>_FLAGS_DEBUG` into a new, dedicated [`MSVC_DEBUG_INFORMATION_FORMAT`](https://cmake.org/cmake/help/v3.25/prop_tgt/MSVC_DEBUG_INFORMATION_FORMAT.html) target property instead. This property is initialized by the new [`CMAKE_MSVC_DEBUG_INFORMATION_FORMAT`](https://cmake.org/cmake/help/v3.25/variable/CMAKE_MSVC_DEBUG_INFORMATION_FORMAT.html) variable, which still defaults to `/Zi` (aka `ProgramDatabase`) when the compiler supports it (which, for MSVC, it usually does). However, other debug information formats such as `/Z7` (aka `Embedded`) which _are_ compatible with ccache are now available to be specified directly in a controlled manner (rather than messing with `*_FLAGS` variables).

Therefore, this PR adds `find_ccache_and_export_vars` (from https://github.com/mongodb/mongo-c-driver/issues/1524) to `compile-windows.sh`, sets `CMP0141` to `NEW`, and `MSVC_DEBUG_INFORMATION_FORMAT` top `Embedded` (`/Z7`) (when debug info is requested by the build configuration) to fully opt-into ccache-compatible builds.