### PR TITLE
sync RPM spec file from downstream (r1.30)

### DIFF
--- a/.evergreen/etc/mongo-c-driver.spec
+++ b/.evergreen/etc/mongo-c-driver.spec
@@ -10,7 +10,7 @@
 %global gh_project   mongo-c-driver
 %global libname      libmongoc
 %global libver       1.0
-%global up_version   1.29.2
+%global up_version   1.30.0
 #global up_prever    rc0
 # disabled as require a MongoDB server
 %bcond_with          tests
@@ -27,7 +27,7 @@
 Name:      mongo-c-driver
 Summary:   Client library written in C for MongoDB
 Version:   %{up_version}%{?up_prever:~%{up_prever}}
-Release:   2%{?dist}
+Release:   1%{?dist}
 # See THIRD_PARTY_NOTICES
 License:   Apache-2.0 AND ISC AND MIT AND Zlib
 URL:       https://github.com/%{gh_owner}/%{gh_project}
@@ -259,6 +259,9 @@ exit $ret
 
 
 %changelog
+* Thu Feb  6 2025 Remi Collet <remi@remirepo.net> - 1.30.0-1
+- update to 1.30.0
+
 * Fri Jan 17 2025 Fedora Release Engineering <releng@fedoraproject.org> - 1.29.2-2
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_42_Mass_Rebuild
 

--- a/.evergreen/etc/spec.patch
+++ b/.evergreen/etc/spec.patch
@@ -1,22 +1,20 @@
---- mongo-c-driver.spec.orig	2025-01-21 14:17:19.855896844 -0500
-+++ mongo-c-driver.spec	2025-01-21 14:25:13.380750157 -0500
+--- mongo-c-driver.spec.orig	2025-02-06 12:55:03.175912820 -0500
++++ mongo-c-driver.spec	2025-02-06 12:55:26.893793221 -0500
 @@ -10,7 +10,7 @@
  %global gh_project   mongo-c-driver
  %global libname      libmongoc
  %global libver       1.0
--%global up_version   1.29.2
-+%global up_version   1.30.0
+-%global up_version   1.30.0
++%global up_version   1.30.1
  #global up_prever    rc0
  # disabled as require a MongoDB server
  %bcond_with          tests
-@@ -26,8 +26,8 @@
+@@ -26,7 +26,7 @@
  
  Name:      mongo-c-driver
  Summary:   Client library written in C for MongoDB
 -Version:   %{up_version}%{?up_prever:~%{up_prever}}
--Release:   2%{?dist}
 +Version:   %{up_version}%{?up_prever}
-+Release:   1%{?dist}
+ Release:   1%{?dist}
  # See THIRD_PARTY_NOTICES
  License:   Apache-2.0 AND ISC AND MIT AND Zlib
- URL:       https://github.com/%{gh_owner}/%{gh_project}


### PR DESCRIPTION
The usual: https://spruce.mongodb.com/version/67a4f7d4cf2da900075c7d83/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC