### PR TITLE
CDRIVER-5897 Remove duplicated variable assignment in bson-decimal128.c

### DIFF
--- a/src/libbson/src/bson/bson-decimal128.c
+++ b/src/libbson/src/bson/bson-decimal128.c
@@ -601,7 +601,6 @@ bson_decimal128_from_string_w_len (const char *string,     /* IN */
    first_digit = 0;
 
    if (!ndigits_stored) { /* value is zero */
-      first_digit = 0;
       last_digit = 0;
       digits[0] = 0;
       ndigits = 1;


### PR DESCRIPTION
`first_digit` is already cleared out on line 601.