### PR TITLE
Fix example code for `bson_writer_t` in docs

### DIFF
--- a/src/libbson/doc/bson_writer_t.rst
+++ b/src/libbson/doc/bson_writer_t.rst
@@ -61,7 +61,7 @@ Example
 
      writer = bson_writer_new (&buf, &buflen, 0, bson_realloc_ctx, NULL);
 
-     for (i = 0; i < 1000; i++) {
+     for (int i = 0; i < 1000; i++) {
         bson_writer_begin (writer, &doc);
         BSON_APPEND_INT32 (&doc, "i", i);
         bson_writer_end (writer);

--- a/src/libbson/doc/bson_writer_t.rst
+++ b/src/libbson/doc/bson_writer_t.rst
@@ -63,7 +63,7 @@ Example
 
      for (int i = 0; i < 1000; i++) {
         bson_writer_begin (writer, &doc);
-        BSON_APPEND_INT32 (&doc, "i", i);
+        BSON_APPEND_INT32 (doc, "i", i);
         bson_writer_end (writer);
      }
 


### PR DESCRIPTION
1. `i` is not defined in the example program.
2. Invalid usage of pointers will lead to segmentation fault.