### PR TITLE
make SBOM serialNumber unique

### DIFF
--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -164,7 +164,7 @@
       }
     ]
   },
-  "serialNumber": "urn:uuid:e5a75bd1-68a4-499e-81c6-64a8785adaae",
+  "serialNumber": "urn:uuid:7db126ce-8f8e-4b86-b231-d64a8f8ca69c",
   "version": 4,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",


### PR DESCRIPTION
"urn:uuid:e5a75bd1-68a4-499e-81c6-64a8785adaae" is also used for the `master`, `r1.27`, `r1.28`, and `r1.29` SBOMs