### PR TITLE
Fix memory leak in `bson_copy_to` when `BSON_MEMCHECK` is enabled

### DIFF
--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -2008,7 +2008,7 @@ bson_copy_to (const bson_t *src, bson_t *dst)
    if ((src->flags & BSON_FLAG_INLINE)) {
 #ifdef BSON_MEMCHECK
       dst->len = src->len;
-      dst->canary = bson_malloc (1);
+      dst->canary = src->canary;
       memcpy (dst->padding, src->padding, sizeof dst->padding);
 #else
       memcpy (dst, src, sizeof *dst);


### PR DESCRIPTION
When `BSON_MEMCHECK` is enabled, `dst->canary = bson_malloc (1);` replaces existing canary, which causes a memory leak (as previously allocated memory is never freed).

Question: Since the size of inline `bson_t` is not affected by the `BSON_MEMCHECK` macro, can the `#ifdef` block be removed, like:
```diff
@@ -1,11 +1,5 @@
    if ((src->flags & BSON_FLAG_INLINE)) {
-#ifdef BSON_MEMCHECK
-      dst->len = src->len;
-      dst->canary = src->canary;
-      memcpy (dst->padding, src->padding, sizeof dst->padding);
-#else
       memcpy (dst, src, sizeof *dst);
-#endif
       dst->flags = (BSON_FLAG_STATIC | BSON_FLAG_INLINE);
       return;
    }
```


Note: `BSON_MEMCHECK` is deprecated.