### PR TITLE
Fix signedness mismatch in `_bson_reader_data_read` and `_bson_reader_handle_read`

### DIFF
--- a/src/libbson/src/bson/bson-reader.c
+++ b/src/libbson/src/bson/bson-reader.c
@@ -478,7 +478,7 @@ _bson_reader_handle_read (bson_reader_handle_t *reader, /* IN */
          continue;
       }
 
-      if (!bson_init_static (&reader->inline_bson, &reader->data[reader->offset], (uint32_t) blen)) {
+      if (!bson_init_static (&reader->inline_bson, &reader->data[reader->offset], blen)) {
          return NULL;
       }
 
@@ -574,7 +574,7 @@ _bson_reader_data_read (bson_reader_data_t *reader, /* IN */
          return NULL;
       }
 
-      if (!bson_init_static (&reader->inline_bson, &reader->data[reader->offset], (uint32_t) blen)) {
+      if (!bson_init_static (&reader->inline_bson, &reader->data[reader->offset], blen)) {
          return NULL;
       }
 

--- a/src/libbson/src/bson/bson-reader.c
+++ b/src/libbson/src/bson/bson-reader.c
@@ -450,7 +450,7 @@ static const bson_t *
 _bson_reader_handle_read (bson_reader_handle_t *reader, /* IN */
                           bool *reached_eof)            /* IN */
 {
-   int32_t blen;
+   uint32_t blen;
 
    if (reached_eof) {
       *reached_eof = false;
@@ -556,7 +556,7 @@ static const bson_t *
 _bson_reader_data_read (bson_reader_data_t *reader, /* IN */
                         bool *reached_eof)          /* IN */
 {
-   int32_t blen;
+   uint32_t blen;
 
    if (reached_eof) {
       *reached_eof = false;


### PR DESCRIPTION
In `_bson_reader_data_read` and `_bson_reader_handle_read`, `blen` is a signed integer type, which will wrap around when handling BSON documents larger than 2GB. This occurs because `BSON_MAX_SIZE` is defined as `(1U << 31) - 1`, which is 2GB larger than maximum value a signed integer can represent.