### PR TITLE
sync RPM spec w/ upstream

### DIFF
--- a/.evergreen/etc/mongo-c-driver.spec
+++ b/.evergreen/etc/mongo-c-driver.spec
@@ -27,12 +27,14 @@
 Name:      mongo-c-driver
 Summary:   Client library written in C for MongoDB
 Version:   %{up_version}%{?up_prever:~%{up_prever}}
-Release:   1%{?dist}
+Release:   2%{?dist}
 # See THIRD_PARTY_NOTICES
 License:   Apache-2.0 AND ISC AND MIT AND Zlib
 URL:       https://github.com/%{gh_owner}/%{gh_project}
 
 Source0:   https://github.com/%{gh_owner}/%{gh_project}/archive/refs/tags/%{up_version}%{?up_prever:-%{up_prever}}.tar.gz
+
+Patch0:    upstream.patch
 
 BuildRequires: cmake >= 3.15
 BuildRequires: gcc
@@ -127,6 +129,8 @@ Documentation: http://mongoc.org/libbson/%{version}/
 
 %prep
 %setup -q -n %{gh_project}-%{up_version}%{?up_prever:-%{up_prever}}
+
+%patch -P0 -p1 -b .up
 
 
 %build
@@ -259,6 +263,10 @@ exit $ret
 
 
 %changelog
+* Tue Feb 18 2025 Remi Collet <remi@remirepo.net> - 1.30.0-2
+- add upstream patch for GCC 15
+  https://jira.mongodb.org/browse/CDRIVER-5889
+
 * Thu Feb  6 2025 Remi Collet <remi@remirepo.net> - 1.30.0-1
 - update to 1.30.0
 

--- a/.evergreen/etc/spec.patch
+++ b/.evergreen/etc/spec.patch
@@ -1,5 +1,5 @@
---- mongo-c-driver.spec.orig	2025-02-06 12:42:54.806151206 -0500
-+++ mongo-c-driver.spec	2025-02-06 12:47:57.362149295 -0500
+--- mongo-c-driver.spec.orig	2025-02-18 17:59:35.789603056 -0500
++++ mongo-c-driver.spec	2025-02-18 18:06:05.113386323 -0500
 @@ -10,7 +10,7 @@
  %global gh_project   mongo-c-driver
  %global libname      libmongoc
@@ -15,6 +15,24 @@
  Summary:   Client library written in C for MongoDB
 -Version:   %{up_version}%{?up_prever:~%{up_prever}}
 +Version:   %{up_version}%{?up_prever}
- Release:   1%{?dist}
+ Release:   2%{?dist}
  # See THIRD_PARTY_NOTICES
  License:   Apache-2.0 AND ISC AND MIT AND Zlib
+@@ -34,8 +34,6 @@
+ 
+ Source0:   https://github.com/%{gh_owner}/%{gh_project}/archive/refs/tags/%{up_version}%{?up_prever:-%{up_prever}}.tar.gz
+ 
+-Patch0:    upstream.patch
+-
+ BuildRequires: cmake >= 3.15
+ BuildRequires: gcc
+ BuildRequires: gcc-c++
+@@ -130,8 +128,6 @@
+ %prep
+ %setup -q -n %{gh_project}-%{up_version}%{?up_prever:-%{up_prever}}
+ 
+-%patch -P0 -p1 -b .up
+-
+ 
+ %build
+ %cmake \


### PR DESCRIPTION
note: back out gcc-15 patch, since it wouldn't apply in any event

Evergreen patch build: https://spruce.mongodb.com/task/mongo_c_driver_packaging_rpm_package_build_patch_8422cadd2e9e7734503fa0e675417eea872c4a71_67b51309b6c0f70007349303_25_02_18_23_09_03/logs?execution=0