### PR TITLE
CDRIVER-5900 sync `non-lb-connection-establishment`

### DIFF
--- a/src/libmongoc/tests/json/load_balancers/non-lb-connection-establishment.json
+++ b/src/libmongoc/tests/json/load_balancers/non-lb-connection-establishment.json
@@ -57,6 +57,19 @@
   "tests": [
     {
       "description": "operations against non-load balanced clusters fail if URI contains loadBalanced=true",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "8.0.99",
+          "topologies": [
+            "single"
+          ]
+        },
+        {
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",


### PR DESCRIPTION
Sync `non-lb-connection-establishment` test to https://github.com/mongodb/specifications/commit/d05c33e0a6124ee7d1a9de665084d540b2ff06c5

Verified with [this patch build](https://spruce.mongodb.com/version/67b4ad051cd3dc00077ea2ab/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) (macOS failure is separately related to SERVER-101020)

This is intended to proactively avoid tests failure once drivers start testing 8.1 builds.