### PR TITLE
CDRIVER-5898 Regenerate SBOM Lite for silkbomb:2.0 forward compatibility

### DIFF
--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -2,6 +2,7 @@
   "components": [
     {
       "bom-ref": "pkg:github/juliastrings/utf8proc@v2.8.0",
+      "copyright": "Copyright \u00a9 2014-2021 by Steven G. Johnson, Jiahao Chen, Tony Kelman, Jonas Fonseca, and other contributors listed in the git history.",
       "externalReferences": [
         {
           "type": "distribution",
@@ -13,6 +14,19 @@
         }
       ],
       "group": "juliastrings",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        },
+        {
+          "license": {
+            "id": "Unicode-TOU",
+            "url": "https://www.unicode.org/copyright.html"
+          }
+        }
+      ],
       "name": "utf8proc",
       "purl": "pkg:github/juliastrings/utf8proc@v2.8.0",
       "type": "library",
@@ -20,6 +34,7 @@
     },
     {
       "bom-ref": "pkg:github/madler/zlib@v1.3.1",
+      "copyright": "(C) 1995-2024 Jean-loup Gailly and Mark Adler",
       "externalReferences": [
         {
           "type": "distribution",
@@ -31,6 +46,13 @@
         }
       ],
       "group": "madler",
+      "licenses": [
+        {
+          "license": {
+            "id": "Zlib"
+          }
+        }
+      ],
       "name": "zlib",
       "purl": "pkg:github/madler/zlib@v1.3.1",
       "type": "library",
@@ -38,6 +60,7 @@
     },
     {
       "bom-ref": "pkg:github/mnunberg/jsonsl",
+      "copyright": "Copyright (c) 2012-2015 M. Nunberg, mnunberg@haskalah.org",
       "externalReferences": [
         {
           "type": "website",
@@ -45,12 +68,20 @@
         }
       ],
       "group": "mnunberg",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
       "name": "jsonsl",
       "purl": "pkg:github/mnunberg/jsonsl",
       "type": "library"
     },
     {
       "bom-ref": "pkg:github/troydhanson/uthash@v2.3.0",
+      "copyright": "Copyright (c) 2005-2018, Troy D. Hanson  http://troydhanson.github.com/uthash/",
       "externalReferences": [
         {
           "type": "distribution",
@@ -62,6 +93,13 @@
         }
       ],
       "group": "troydhanson",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-1-Clause"
+          }
+        }
+      ],
       "name": "uthash",
       "purl": "pkg:github/troydhanson/uthash@v2.3.0",
       "type": "library",

--- a/etc/cyclonedx.sbom.json
+++ b/etc/cyclonedx.sbom.json
@@ -2,7 +2,6 @@
   "components": [
     {
       "bom-ref": "pkg:github/juliastrings/utf8proc@v2.8.0",
-      "copyright": "Copyright \u00a9 2014-2021 by Steven G. Johnson, Jiahao Chen, Tony Kelman, Jonas Fonseca, and other contributors listed in the git history.",
       "externalReferences": [
         {
           "type": "distribution",
@@ -14,19 +13,6 @@
         }
       ],
       "group": "juliastrings",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT"
-          }
-        },
-        {
-          "license": {
-            "id": "Unicode-TOU",
-            "url": "https://www.unicode.org/copyright.html"
-          }
-        }
-      ],
       "name": "utf8proc",
       "purl": "pkg:github/juliastrings/utf8proc@v2.8.0",
       "type": "library",
@@ -34,7 +20,6 @@
     },
     {
       "bom-ref": "pkg:github/madler/zlib@v1.3.1",
-      "copyright": "(C) 1995-2024 Jean-loup Gailly and Mark Adler",
       "externalReferences": [
         {
           "type": "distribution",
@@ -46,13 +31,6 @@
         }
       ],
       "group": "madler",
-      "licenses": [
-        {
-          "license": {
-            "id": "Zlib"
-          }
-        }
-      ],
       "name": "zlib",
       "purl": "pkg:github/madler/zlib@v1.3.1",
       "type": "library",
@@ -60,7 +38,6 @@
     },
     {
       "bom-ref": "pkg:github/mnunberg/jsonsl",
-      "copyright": "Copyright (c) 2012-2015 M. Nunberg, mnunberg@haskalah.org",
       "externalReferences": [
         {
           "type": "website",
@@ -68,20 +45,12 @@
         }
       ],
       "group": "mnunberg",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT"
-          }
-        }
-      ],
       "name": "jsonsl",
       "purl": "pkg:github/mnunberg/jsonsl",
       "type": "library"
     },
     {
       "bom-ref": "pkg:github/troydhanson/uthash@v2.3.0",
-      "copyright": "Copyright (c) 2005-2018, Troy D. Hanson  http://troydhanson.github.com/uthash/",
       "externalReferences": [
         {
           "type": "distribution",
@@ -93,13 +62,6 @@
         }
       ],
       "group": "troydhanson",
-      "licenses": [
-        {
-          "license": {
-            "id": "BSD-1-Clause"
-          }
-        }
-      ],
       "name": "uthash",
       "purl": "pkg:github/troydhanson/uthash@v2.3.0",
       "type": "library",
@@ -121,7 +83,7 @@
     }
   ],
   "metadata": {
-    "timestamp": "2024-07-22T15:57:17.624779+00:00",
+    "timestamp": "2025-02-19T20:13:54.717339+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -164,8 +126,8 @@
       }
     ]
   },
-  "serialNumber": "urn:uuid:e5a75bd1-68a4-499e-81c6-64a8785adaae",
-  "version": 4,
+  "serialNumber": "urn:uuid:48f0be4d-9b15-4dfd-93db-c1e862963f62",
+  "version": 1,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",

--- a/etc/purls.txt
+++ b/etc/purls.txt
@@ -9,7 +9,7 @@
 pkg:github/madler/zlib@v1.3.1
 
 # Lives at src/utf8proc-*
-pkg:github/JuliaStrings/utf8proc@v2.8.0
+pkg:github/juliastrings/utf8proc@v2.8.0
 
 # Lives at src/uthash
 pkg:github/troydhanson/uthash@v2.3.0


### PR DESCRIPTION
Resolves CDRIVER-5898 for the r1.30 branch. See https://github.com/mongodb/mongo-c-driver/pull/1875 for more info.