### PR TITLE
CDRIVER-5861 support `$lookup` in CSFLE and QE

### DIFF
--- a/.evergreen/scripts/compile-libmongocrypt.sh
+++ b/.evergreen/scripts/compile-libmongocrypt.sh
@@ -10,14 +10,20 @@ compile_libmongocrypt() {
   # `.evergreen/scripts/kms-divergence-check.sh` to ensure that there is no
   # divergence in the copied files.
 
-  git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.12.0 || return
+  # Clone libmongocrypt and check-out commit for MONGOCRYPT-723.
+  # TODO: once libmongocrypt 1.13.0 is released, updated to:
+  # git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.13.0 || return
+  git clone -q https://github.com/mongodb/libmongocrypt || return
+  cd libmongocrypt
+  git checkout 33fdf65cce5a0c0cdd293c64ed40e4a8205c3ce0
+  cd ..
 
   declare -a crypt_cmake_flags=(
     "-DMONGOCRYPT_MONGOC_DIR=${mongoc_dir}"
     "-DBUILD_TESTING=OFF"
     "-DENABLE_ONLINE_TESTS=OFF"
     "-DENABLE_MONGOC=OFF"
-    "-DBUILD_VERSION=1.12.0"
+    "-DBUILD_VERSION=1.13.0-pre"
   )
 
   . "$(dirname "${BASH_SOURCE[0]}")/find-ccache.sh"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -289,8 +289,9 @@ The set of mock KMS servers running in the background and their corresponding in
 | 8999 | ca.pem | server.pem | python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/server.pem --port 8999
 | 9000 | ca.pem | expired.pem | python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 9000
 | 9001 | ca.pem | wrong-host.pem | python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 9001
-| 9002 | ca.pem | server.pem | python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/server.pem --port --require_client_cert 9002
+| 9002 | ca.pem | server.pem | python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/server.pem --require_client_cert --port 9002
 | 5698 | ca.pem | server.pem | python -u kms_kmip_server.py
+| 9003 | ca.pem | server.pem | python kms_failpoint_server.py --port 9003
 
 The path to `ca.pem` and `client.pem` must be passed through the following environment variables:
 

--- a/src/libmongoc/src/mongoc/mongoc-crypt.c
+++ b/src/libmongoc/src/mongoc/mongoc-crypt.c
@@ -170,7 +170,7 @@ _prefix_mongocryptd_error (bson_error_t *error)
    char buf[sizeof (error->message)];
 
    // Truncation is OK.
-   int req = bson_snprintf (buf, sizeof (buf), "mongocryptd error: %s:", error->message);
+   int req = bson_snprintf (buf, sizeof (buf), "mongocryptd error: %s", error->message);
    BSON_ASSERT (req > 0);
    memcpy (error->message, buf, sizeof (buf));
 }
@@ -181,7 +181,7 @@ _prefix_keyvault_error (bson_error_t *error)
    char buf[sizeof (error->message)];
 
    // Truncation is OK.
-   int req = bson_snprintf (buf, sizeof (buf), "key vault error: %s:", error->message);
+   int req = bson_snprintf (buf, sizeof (buf), "key vault error: %s", error->message);
    BSON_ASSERT (req > 0);
    memcpy (error->message, buf, sizeof (buf));
 }

--- a/src/libmongoc/tests/client_side_encryption_prose/lookup/key-doc.json
+++ b/src/libmongoc/tests/client_side_encryption_prose/lookup/key-doc.json
@@ -1,0 +1,30 @@
+{
+    "_id": {
+        "$binary": {
+            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+            "subType": "04"
+        }
+    },
+    "keyMaterial": {
+        "$binary": {
+            "base64": "sHe0kz57YW7v8g9VP9sf/+K1ex4JqKc5rf/URX3n3p8XdZ6+15uXPaSayC6adWbNxkFskuMCOifDoTT+rkqMtFkDclOy884RuGGtUysq3X7zkAWYTKi8QAfKkajvVbZl2y23UqgVasdQu3OVBQCrH/xY00nNAs/52e958nVjBuzQkSb1T8pKJAyjZsHJ60+FtnfafDZSTAIBJYn7UWBCwQ==",
+            "subType": "00"
+        }
+    },
+    "creationDate": {
+        "$date": {
+            "$numberLong": "1648914851981"
+        }
+    },
+    "updateDate": {
+        "$date": {
+            "$numberLong": "1648914851981"
+        }
+    },
+    "status": {
+        "$numberInt": "0"
+    },
+    "masterKey": {
+        "provider": "local"
+    }
+}

--- a/src/libmongoc/tests/client_side_encryption_prose/lookup/schema-csfle.json
+++ b/src/libmongoc/tests/client_side_encryption_prose/lookup/schema-csfle.json
@@ -1,0 +1,19 @@
+{
+    "properties": {
+        "csfle": {
+            "encrypt": {
+                "keyId": [
+                    {
+                        "$binary": {
+                            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                            "subType": "04"
+                        }
+                    }
+                ],
+                "bsonType": "string",
+                "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+            }
+        }
+    },
+    "bsonType": "object"
+}

--- a/src/libmongoc/tests/client_side_encryption_prose/lookup/schema-csfle2.json
+++ b/src/libmongoc/tests/client_side_encryption_prose/lookup/schema-csfle2.json
@@ -1,0 +1,19 @@
+{
+    "properties": {
+        "csfle2": {
+            "encrypt": {
+                "keyId": [
+                    {
+                        "$binary": {
+                            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                            "subType": "04"
+                        }
+                    }
+                ],
+                "bsonType": "string",
+                "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+            }
+        }
+    },
+    "bsonType": "object"
+}

--- a/src/libmongoc/tests/client_side_encryption_prose/lookup/schema-qe.json
+++ b/src/libmongoc/tests/client_side_encryption_prose/lookup/schema-qe.json
@@ -1,0 +1,20 @@
+{
+    "escCollection": "enxcol_.qe.esc",
+    "ecocCollection": "enxcol_.qe.ecoc",
+    "fields": [
+        {
+            "keyId": {
+                "$binary": {
+                    "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                    "subType": "04"
+                }
+            },
+            "path": "qe",
+            "bsonType": "string",
+            "queries": {
+                "queryType": "equality",
+                "contention": 0
+            }
+        }
+    ]
+}

--- a/src/libmongoc/tests/client_side_encryption_prose/lookup/schema-qe2.json
+++ b/src/libmongoc/tests/client_side_encryption_prose/lookup/schema-qe2.json
@@ -1,0 +1,20 @@
+{
+    "escCollection": "enxcol_.qe2.esc",
+    "ecocCollection": "enxcol_.qe2.ecoc",
+    "fields": [
+        {
+            "keyId": {
+                "$binary": {
+                    "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                    "subType": "04"
+                }
+            },
+            "path": "qe2",
+            "bsonType": "string",
+            "queries": {
+                "queryType": "equality",
+                "contention": 0
+            }
+        }
+    ]
+}

--- a/src/libmongoc/tests/json-test.c
+++ b/src/libmongoc/tests/json-test.c
@@ -663,7 +663,7 @@ get_bson_from_json_file (char *filename)
 
    file = fopen (filename, "rb");
    if (!file) {
-      return NULL;
+      test_error ("Failed to open JSON file: %s", filename);
    }
 
    /* get file length */
@@ -671,19 +671,16 @@ get_bson_from_json_file (char *filename)
    length = ftell (file);
    fseek (file, 0, SEEK_SET);
    if (length < 1) {
-      return NULL;
+      test_error ("Failed to read length of JSON file: %s", filename);
    }
 
    /* read entire file into buffer */
    buffer = (const char *) bson_malloc0 (length);
    if (fread ((void *) buffer, 1, length, file) != length) {
-      test_error ("Failed to read JSON file into buffer");
+      test_error ("Failed to read JSON file into buffer: %s", filename);
    }
 
    fclose (file);
-   if (!buffer) {
-      return NULL;
-   }
 
    /* convert to bson */
    data = bson_new_from_json ((const uint8_t *) buffer, length, &error);

--- a/src/libmongoc/tests/test-conveniences.h
+++ b/src/libmongoc/tests/test-conveniences.h
@@ -209,7 +209,7 @@ match_json (const bson_t *doc,
 
 #define ASSERT_EQUAL_BSON(expected, actual)                                   \
    do {                                                                       \
-      bson_t *_expected_bson = expected, *_actual_bson = actual;              \
+      const bson_t *_expected_bson = expected, *_actual_bson = actual;        \
       char *_expected_str, *_actual_str;                                      \
       _expected_str = bson_as_canonical_extended_json (_expected_bson, NULL); \
       _actual_str = bson_as_canonical_extended_json (_actual_bson, NULL);     \

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -2273,6 +2273,8 @@ WIRE_VERSION_CHECKS (23)
 WIRE_VERSION_CHECKS (24)
 /* wire version 25 begins with the 8.0 release. */
 WIRE_VERSION_CHECKS (25)
+/* wire version 26 begins with the 8.1 release. */
+WIRE_VERSION_CHECKS (26)
 
 int
 test_framework_skip_if_no_dual_ip_hostname (void)

--- a/src/libmongoc/tests/test-libmongoc.h
+++ b/src/libmongoc/tests/test-libmongoc.h
@@ -216,6 +216,8 @@ WIRE_VERSION_CHECK_DECLS (23)
 WIRE_VERSION_CHECK_DECLS (24)
 /* wire version 25 begins with the 8.0 release. */
 WIRE_VERSION_CHECK_DECLS (25)
+/* wire version 26 begins with the 8.1 release. */
+WIRE_VERSION_CHECK_DECLS (26)
 
 #undef WIRE_VERSION_CHECK_DECLS
 

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -6374,6 +6374,487 @@ test_kms_retry (void *unused)
    _test_retry_with_masterkey ("gcp", gcp_masterkey);
 }
 
+static mongoc_client_t *
+create_encrypted_client (void)
+{
+   mongoc_client_t *client = test_framework_new_default_client ();
+   bson_error_t error;
+   mongoc_auto_encryption_opts_t *ao = mongoc_auto_encryption_opts_new ();
+   {
+      bson_t extra = BSON_INITIALIZER;
+      _set_extra_bypass (&extra);
+      _set_extra_crypt_shared (&extra);
+      mongoc_auto_encryption_opts_set_extra (ao, &extra);
+      bson_destroy (&extra);
+   }
+   bson_t *kms_providers =
+      BCON_NEW ("local", "{", "key", BCON_BIN (BSON_SUBTYPE_UUID, (uint8_t *) LOCAL_MASTERKEY, 96), "}");
+   mongoc_auto_encryption_opts_set_keyvault_namespace (ao, "db", "keyvault");
+   mongoc_auto_encryption_opts_set_kms_providers (ao, kms_providers);
+   ASSERT_OR_PRINT (mongoc_client_enable_auto_encryption (client, ao, &error), error);
+   bson_destroy (kms_providers);
+   mongoc_auto_encryption_opts_destroy (ao);
+   return client;
+}
+
+#define ASSERT_COLL_MATCHES_ONE(coll, expect)                                                           \
+   if (1) {                                                                                             \
+      mongoc_cursor_t *cursor = mongoc_collection_find_with_opts ((coll), tmp_bson ("{}"), NULL, NULL); \
+      const bson_t *got;                                                                                \
+      bool found = mongoc_cursor_next (cursor, &got);                                                   \
+      if (!found) {                                                                                     \
+         ASSERT_OR_PRINT (!mongoc_cursor_error (cursor, &error), error);                                \
+         test_error ("expected 1 document, but got 0");                                                 \
+      }                                                                                                 \
+      assert_match_bson (got, expect, false);                                                           \
+      ASSERT (!mongoc_cursor_next (cursor, &got)); /* expect exactly one document */                    \
+      mongoc_cursor_destroy (cursor);                                                                   \
+   } else                                                                                               \
+      (void) 0
+
+#define ASSERT_AGG_RETURNS_ONE(coll, pipeline, expect)                                           \
+   if (1) {                                                                                      \
+      mongoc_cursor_t *cursor = mongoc_collection_aggregate ((coll), 0, (pipeline), NULL, NULL); \
+      const bson_t *got;                                                                         \
+      bool found = mongoc_cursor_next (cursor, &got);                                            \
+      if (!found) {                                                                              \
+         ASSERT_OR_PRINT (!mongoc_cursor_error (cursor, &error), error);                         \
+         test_error ("expected 1 document, but got 0");                                          \
+      }                                                                                          \
+      ASSERT_EQUAL_BSON (expect, got);                                                           \
+      ASSERT (!mongoc_cursor_next (cursor, &got)); /* expect exactly one document */             \
+      mongoc_cursor_destroy (cursor);                                                            \
+   } else                                                                                        \
+      (void) 0
+
+#define ASSERT_AGG_ERROR(coll, pipeline, msg)                                                    \
+   if (1) {                                                                                      \
+      mongoc_cursor_t *cursor = mongoc_collection_aggregate ((coll), 0, (pipeline), NULL, NULL); \
+      const bson_t *got;                                                                         \
+      bool found = mongoc_cursor_next (cursor, &got);                                            \
+      ASSERT (!found);                                                                           \
+      ASSERT (mongoc_cursor_error (cursor, &error));                                             \
+      ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_CLIENT_SIDE_ENCRYPTION, 1, msg);                \
+      mongoc_cursor_destroy (cursor);                                                            \
+   } else                                                                                        \
+      (void) 0
+
+#define MAKE_BSON(...) tmp_bson (BSON_STR (__VA_ARGS__))
+
+static void
+test_lookup_setup (void)
+{
+   bool ok;
+   bson_error_t error;
+
+   mongoc_client_t *setup_client = test_framework_new_default_client ();
+
+   // Drop database:
+   {
+      mongoc_database_t *db = mongoc_client_get_database (setup_client, "db");
+      mongoc_database_drop (db, NULL);
+      mongoc_database_destroy (db);
+   }
+
+#define TESTDIR "./src/libmongoc/tests/client_side_encryption_prose/lookup/"
+   // Insert key into key vault:
+   {
+      mongoc_collection_t *keyvault = mongoc_client_get_collection (setup_client, "db", "keyvault");
+      mongoc_collection_drop (keyvault, NULL);
+      bson_t *keydoc = get_bson_from_json_file (TESTDIR "key-doc.json");
+      ASSERT_OR_PRINT (mongoc_collection_insert_one (keyvault, keydoc, NULL, NULL, &error), error);
+      bson_destroy (keydoc);
+      mongoc_collection_destroy (keyvault);
+   }
+
+   // Create collections:
+   {
+      mongoc_database_t *db = mongoc_client_get_database (setup_client, "db");
+      // Create db.csfle:
+      {
+         bson_t *schema = get_bson_from_json_file (TESTDIR "schema-csfle.json");
+         bson_t *create_opts = BCON_NEW ("validator", "{", "$jsonSchema", BCON_DOCUMENT (schema), "}");
+         mongoc_collection_t *coll = mongoc_database_create_collection (db, "csfle", create_opts, &error);
+         ASSERT_OR_PRINT (coll, error);
+         mongoc_collection_destroy (coll);
+         bson_destroy (create_opts);
+         bson_destroy (schema);
+      }
+
+      // Create db.csfle2:
+      {
+         bson_t *schema = get_bson_from_json_file (TESTDIR "schema-csfle2.json");
+         bson_t *create_opts = BCON_NEW ("validator", "{", "$jsonSchema", BCON_DOCUMENT (schema), "}");
+         mongoc_collection_t *coll = mongoc_database_create_collection (db, "csfle2", create_opts, &error);
+         ASSERT_OR_PRINT (coll, error);
+         mongoc_collection_destroy (coll);
+         bson_destroy (create_opts);
+         bson_destroy (schema);
+      }
+
+      // Create db.qe:
+      {
+         bson_t *schema = get_bson_from_json_file (TESTDIR "schema-qe.json");
+         bson_t *create_opts = BCON_NEW ("encryptedFields", BCON_DOCUMENT (schema));
+         mongoc_collection_t *coll = mongoc_database_create_collection (db, "qe", create_opts, &error);
+         ASSERT_OR_PRINT (coll, error);
+         mongoc_collection_destroy (coll);
+         bson_destroy (create_opts);
+         bson_destroy (schema);
+      }
+
+      // Create db.qe2:
+      {
+         bson_t *schema = get_bson_from_json_file (TESTDIR "schema-qe2.json");
+         bson_t *create_opts = BCON_NEW ("encryptedFields", BCON_DOCUMENT (schema));
+         mongoc_collection_t *coll = mongoc_database_create_collection (db, "qe2", create_opts, &error);
+         ASSERT_OR_PRINT (coll, error);
+         mongoc_collection_destroy (coll);
+         bson_destroy (create_opts);
+         bson_destroy (schema);
+      }
+
+      // Create db.no_schema:
+      {
+         mongoc_collection_t *coll = mongoc_database_create_collection (db, "noschema", NULL, &error);
+         ASSERT_OR_PRINT (coll, error);
+         mongoc_collection_destroy (coll);
+      }
+
+      // Create db.no_schema2:
+      {
+         mongoc_collection_t *coll = mongoc_database_create_collection (db, "noschema2", NULL, &error);
+         ASSERT_OR_PRINT (coll, error);
+         mongoc_collection_destroy (coll);
+      }
+
+      mongoc_database_destroy (db);
+   }
+#undef TESTDIR
+
+   // Insert initial documents:
+   {
+      mongoc_client_t *client = create_encrypted_client ();
+
+      // Insert to db.csfle:
+      {
+         mongoc_collection_t *coll = mongoc_client_get_collection (client, "db", "csfle");
+         ok = mongoc_collection_insert_one (coll, MAKE_BSON ({"csfle" : "csfle"}), NULL, NULL, &error);
+         ASSERT_OR_PRINT (ok, error);
+         mongoc_collection_destroy (coll);
+         // Find document with unencrypted client to check it is encrypted.
+         mongoc_collection_t *coll_unencrypted = mongoc_client_get_collection (setup_client, "db", "csfle");
+         ASSERT_COLL_MATCHES_ONE (coll_unencrypted, MAKE_BSON ({"csfle" : {"$$type" : "binData"}}));
+         mongoc_collection_destroy (coll_unencrypted);
+      }
+
+      // Insert to db.csfle2:
+      {
+         mongoc_collection_t *coll = mongoc_client_get_collection (client, "db", "csfle2");
+         ok = mongoc_collection_insert_one (coll, MAKE_BSON ({"csfle2" : "csfle2"}), NULL, NULL, &error);
+         ASSERT_OR_PRINT (ok, error);
+         mongoc_collection_destroy (coll);
+         // Find document with unencrypted client to check it is encrypted.
+         mongoc_collection_t *coll_unencrypted = mongoc_client_get_collection (setup_client, "db", "csfle2");
+         ASSERT_COLL_MATCHES_ONE (coll_unencrypted, MAKE_BSON ({"csfle2" : {"$$type" : "binData"}}));
+         mongoc_collection_destroy (coll_unencrypted);
+      }
+
+      // Insert to db.qe:
+      {
+         mongoc_collection_t *coll = mongoc_client_get_collection (client, "db", "qe");
+         ok = mongoc_collection_insert_one (coll, MAKE_BSON ({"qe" : "qe"}), NULL, NULL, &error);
+         ASSERT_OR_PRINT (ok, error);
+         mongoc_collection_destroy (coll);
+         // Find document with unencrypted client to check it is encrypted.
+         mongoc_collection_t *coll_unencrypted = mongoc_client_get_collection (setup_client, "db", "qe");
+         ASSERT_COLL_MATCHES_ONE (coll_unencrypted, MAKE_BSON ({"qe" : {"$$type" : "binData"}}));
+         mongoc_collection_destroy (coll_unencrypted);
+      }
+
+      // Insert to db.qe2:
+      {
+         mongoc_collection_t *coll = mongoc_client_get_collection (client, "db", "qe2");
+         ok = mongoc_collection_insert_one (coll, MAKE_BSON ({"qe2" : "qe2"}), NULL, NULL, &error);
+         ASSERT_OR_PRINT (ok, error);
+         mongoc_collection_destroy (coll);
+         // Find document with unencrypted client to check it is encrypted.
+         mongoc_collection_t *coll_unencrypted = mongoc_client_get_collection (setup_client, "db", "qe2");
+         ASSERT_COLL_MATCHES_ONE (coll_unencrypted, MAKE_BSON ({"qe2" : {"$$type" : "binData"}}));
+         mongoc_collection_destroy (coll_unencrypted);
+      }
+
+      // Insert to db.no_schema:
+      {
+         mongoc_collection_t *coll = mongoc_client_get_collection (client, "db", "no_schema");
+         ok = mongoc_collection_insert_one (coll, MAKE_BSON ({"no_schema" : "no_schema"}), NULL, NULL, &error);
+         ASSERT_OR_PRINT (ok, error);
+         mongoc_collection_destroy (coll);
+         // Find document with unencrypted client to check it is not encrypted.
+         mongoc_collection_t *coll_unencrypted = mongoc_client_get_collection (setup_client, "db", "no_schema");
+         ASSERT_COLL_MATCHES_ONE (coll_unencrypted, MAKE_BSON ({"no_schema" : "no_schema"}));
+         mongoc_collection_destroy (coll_unencrypted);
+      }
+
+      // Insert to db.no_schema2:
+      {
+         mongoc_collection_t *coll = mongoc_client_get_collection (client, "db", "no_schema2");
+         ok = mongoc_collection_insert_one (coll, MAKE_BSON ({"no_schema2" : "no_schema2"}), NULL, NULL, &error);
+         ASSERT_OR_PRINT (ok, error);
+         mongoc_collection_destroy (coll);
+         // Find document with unencrypted client to check it is not encrypted.
+         mongoc_collection_t *coll_unencrypted = mongoc_client_get_collection (setup_client, "db", "no_schema2");
+         ASSERT_COLL_MATCHES_ONE (coll_unencrypted, MAKE_BSON ({"no_schema2" : "no_schema2"}));
+         mongoc_collection_destroy (coll_unencrypted);
+      }
+
+      mongoc_client_destroy (client);
+   }
+
+   mongoc_client_destroy (setup_client);
+}
+
+static void
+test_lookup (void *unused)
+{
+   BSON_UNUSED (unused);
+
+   test_lookup_setup ();
+   bson_error_t error;
+
+   // Case 1: db.csfle joins db.no_schema:
+   {
+      mongoc_client_t *client = create_encrypted_client (); // Create new client to avoid schema caching.
+      mongoc_collection_t *coll = mongoc_client_get_collection (client, "db", "csfle");
+
+      bson_t *pipeline = MAKE_BSON ({
+         "pipeline" : [
+            {"$match" : {"csfle" : "csfle"}},
+            {
+               "$lookup" : {
+                  "from" : "no_schema",
+                  "as" : "matched",
+                  "pipeline" : [ {"$match" : {"no_schema" : "no_schema"}}, {"$project" : {"_id" : 0}} ]
+               }
+            },
+            {"$project" : {"_id" : 0}}
+         ]
+      });
+
+      bson_t *expect = MAKE_BSON ({"csfle" : "csfle", "matched" : [ {"no_schema" : "no_schema"} ]});
+      ASSERT_AGG_RETURNS_ONE (coll, pipeline, expect);
+      mongoc_collection_destroy (coll);
+      mongoc_client_destroy (client);
+   }
+
+   // Case 2: db.qe joins db.no_schema.
+   {
+      mongoc_client_t *client = create_encrypted_client (); // Create new client to avoid schema caching.
+      mongoc_collection_t *coll = mongoc_client_get_collection (client, "db", "qe");
+
+      bson_t *pipeline = MAKE_BSON ({
+         "pipeline" : [
+            {"$match" : {"qe" : "qe"}},
+            {
+               "$lookup" : {
+                  "from" : "no_schema",
+                  "as" : "matched",
+                  "pipeline" :
+                     [ {"$match" : {"no_schema" : "no_schema"}}, {"$project" : {"_id" : 0, "__safeContent__" : 0}} ]
+               }
+            },
+            {"$project" : {"_id" : 0, "__safeContent__" : 0}}
+         ]
+      });
+
+      bson_t *expect = MAKE_BSON ({"qe" : "qe", "matched" : [ {"no_schema" : "no_schema"} ]});
+      ASSERT_AGG_RETURNS_ONE (coll, pipeline, expect);
+      mongoc_collection_destroy (coll);
+      mongoc_client_destroy (client);
+   }
+
+   // Case 3: db.no_schema joins db.csfle:
+   {
+      mongoc_client_t *client = create_encrypted_client (); // Create new client to avoid schema caching.
+      mongoc_collection_t *coll = mongoc_client_get_collection (client, "db", "no_schema");
+
+      bson_t *pipeline = MAKE_BSON ({
+         "pipeline" : [
+            {"$match" : {"no_schema" : "no_schema"}},
+            {
+               "$lookup" : {
+                  "from" : "csfle",
+                  "as" : "matched",
+                  "pipeline" : [ {"$match" : {"csfle" : "csfle"}}, {"$project" : {"_id" : 0}} ]
+               }
+            },
+            {"$project" : {"_id" : 0}}
+         ]
+      });
+
+      bson_t *expect = MAKE_BSON ({"no_schema" : "no_schema", "matched" : [ {"csfle" : "csfle"} ]});
+      ASSERT_AGG_RETURNS_ONE (coll, pipeline, expect);
+      mongoc_collection_destroy (coll);
+      mongoc_client_destroy (client);
+   }
+
+   // Case 4: db.no_schema joins db.qe:
+   {
+      mongoc_client_t *client = create_encrypted_client (); // Create new client to avoid schema caching.
+      mongoc_collection_t *coll = mongoc_client_get_collection (client, "db", "no_schema");
+
+      bson_t *pipeline = MAKE_BSON ({
+         "pipeline" : [
+            {"$match" : {"no_schema" : "no_schema"}},
+            {
+               "$lookup" : {
+                  "from" : "qe",
+                  "as" : "matched",
+                  "pipeline" : [ {"$match" : {"qe" : "qe"}}, {"$project" : {"_id" : 0, "__safeContent__" : 0}} ]
+               }
+            },
+            {"$project" : {"_id" : 0}}
+         ]
+      });
+
+      bson_t *expect = MAKE_BSON ({"no_schema" : "no_schema", "matched" : [ {"qe" : "qe"} ]});
+      ASSERT_AGG_RETURNS_ONE (coll, pipeline, expect);
+      mongoc_collection_destroy (coll);
+      mongoc_client_destroy (client);
+   }
+
+   // Case 5: db.csfle joins db.csfle2:
+   {
+      mongoc_client_t *client = create_encrypted_client (); // Create new client to avoid schema caching.
+      mongoc_collection_t *coll = mongoc_client_get_collection (client, "db", "csfle");
+
+      bson_t *pipeline = MAKE_BSON ({
+         "pipeline" : [
+            {"$match" : {"csfle" : "csfle"}},
+            {
+               "$lookup" : {
+                  "from" : "csfle2",
+                  "as" : "matched",
+                  "pipeline" : [ {"$match" : {"csfle2" : "csfle2"}}, {"$project" : {"_id" : 0}} ]
+               }
+            },
+            {"$project" : {"_id" : 0}}
+         ]
+      });
+
+      bson_t *expect = MAKE_BSON ({"csfle" : "csfle", "matched" : [ {"csfle2" : "csfle2"} ]});
+      ASSERT_AGG_RETURNS_ONE (coll, pipeline, expect);
+      mongoc_collection_destroy (coll);
+      mongoc_client_destroy (client);
+   }
+
+   // Case 6: qe joins db.qe2:
+   {
+      mongoc_client_t *client = create_encrypted_client (); // Create new client to avoid schema caching.
+      mongoc_collection_t *coll = mongoc_client_get_collection (client, "db", "qe");
+
+      bson_t *pipeline = MAKE_BSON ({
+         "pipeline" : [
+            {"$match" : {"qe" : "qe"}},
+            {
+               "$lookup" : {
+                  "from" : "qe2",
+                  "as" : "matched",
+                  "pipeline" : [ {"$match" : {"qe2" : "qe2"}}, {"$project" : {"_id" : 0, "__safeContent__" : 0}} ]
+               }
+            },
+            {"$project" : {"_id" : 0, "__safeContent__" : 0}}
+         ]
+      });
+
+      bson_t *expect = MAKE_BSON ({"qe" : "qe", "matched" : [ {"qe2" : "qe2"} ]});
+      ASSERT_AGG_RETURNS_ONE (coll, pipeline, expect);
+      mongoc_collection_destroy (coll);
+      mongoc_client_destroy (client);
+   }
+
+   // Case 7: db.no_schema joins db.no_schema2:
+   {
+      mongoc_client_t *client = create_encrypted_client (); // Create new client to avoid schema caching.
+      mongoc_collection_t *coll = mongoc_client_get_collection (client, "db", "no_schema");
+
+      bson_t *pipeline = MAKE_BSON ({
+         "pipeline" : [
+            {"$match" : {"no_schema" : "no_schema"}},
+            {
+               "$lookup" : {
+                  "from" : "no_schema2",
+                  "as" : "matched",
+                  "pipeline" : [ {"$match" : {"no_schema2" : "no_schema2"}}, {"$project" : {"_id" : 0}} ]
+               }
+            },
+            {"$project" : {"_id" : 0}}
+         ]
+      });
+
+      bson_t *expect = MAKE_BSON ({"no_schema" : "no_schema", "matched" : [ {"no_schema2" : "no_schema2"} ]});
+      ASSERT_AGG_RETURNS_ONE (coll, pipeline, expect);
+      mongoc_collection_destroy (coll);
+      mongoc_client_destroy (client);
+   }
+
+   // Case 8: db.csfle joins db.qe:
+   {
+      mongoc_client_t *client = create_encrypted_client (); // Create new client to avoid schema caching.
+      mongoc_collection_t *coll = mongoc_client_get_collection (client, "db", "csfle");
+
+      bson_t *pipeline = MAKE_BSON ({
+         "pipeline" : [
+            {"$match" : {"csfle" : "qe"}},
+            {
+               "$lookup" : {
+                  "from" : "qe",
+                  "as" : "matched",
+                  "pipeline" : [ {"$match" : {"qe" : "qe"}}, {"$project" : {"_id" : 0}} ]
+               }
+            },
+            {"$project" : {"_id" : 0}}
+         ]
+      });
+
+      ASSERT_AGG_ERROR (coll, pipeline, "not supported");
+      mongoc_collection_destroy (coll);
+      mongoc_client_destroy (client);
+   }
+}
+
+static void
+test_lookup_pre81 (void *unused)
+{
+   BSON_UNUSED (unused);
+   test_lookup_setup ();
+   bson_error_t error;
+
+   // Case 9: test error with <8.1
+   {
+      mongoc_client_t *client = create_encrypted_client (); // Create new client to avoid schema caching.
+      mongoc_collection_t *coll = mongoc_client_get_collection (client, "db", "csfle");
+
+      bson_t *pipeline = MAKE_BSON ({
+         "pipeline" : [
+            {"$match" : {"csfle" : "no_schema"}},
+            {
+               "$lookup" : {
+                  "from" : "no_schema",
+                  "as" : "matched",
+                  "pipeline" : [ {"$match" : {"no_schema" : "no_schema"}}, {"$project" : {"_id" : 0}} ]
+               }
+            },
+            {"$project" : {"_id" : 0}}
+         ]
+      });
+
+      ASSERT_AGG_ERROR (coll, pipeline, "Upgrade");
+      mongoc_collection_destroy (coll);
+      mongoc_client_destroy (client);
+   }
+}
+
 void
 test_client_side_encryption_install (TestSuite *suite)
 {
@@ -6821,6 +7302,24 @@ test_client_side_encryption_install (TestSuite *suite)
                          NULL,
                          NULL,
                          // No need to test for server version requirements. Test does not contact server.
+                         test_framework_skip_if_no_client_side_encryption);
+
+      TestSuite_AddFull (suite,
+                         "/client_side_encryption/test_lookup",
+                         test_lookup,
+                         NULL,
+                         NULL,
+                         test_framework_skip_if_max_wire_version_less_than_26 /* require server 8.1+ */,
+                         test_framework_skip_if_single, /* QE not supported on standalone */
+                         test_framework_skip_if_no_client_side_encryption);
+      TestSuite_AddFull (suite,
+                         "/client_side_encryption/test_lookup/pre-8.1",
+                         test_lookup_pre81,
+                         NULL,
+                         NULL,
+                         test_framework_skip_if_max_wire_version_more_than_25 /* require server < 8.1 */,
+                         test_framework_skip_if_max_wire_version_less_than_21 /* require server > 7.0 for QE support */,
+                         test_framework_skip_if_single, /* QE not supported on standalone */
                          test_framework_skip_if_no_client_side_encryption);
    }
 }

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -6442,13 +6442,13 @@ create_encrypted_client (void)
 #define MAKE_BSON(...) tmp_bson (BSON_STR (__VA_ARGS__))
 
 static void
-drop_coll (mongoc_database_t *db, const char *coll)
+drop_coll (mongoc_database_t *db, const char *collname)
 {
    bson_error_t error;
-   mongoc_collection_t *coll = mongoc_database_get_collection (db, coll);
+   mongoc_collection_t *coll = mongoc_database_get_collection (db, collname);
    bool ok = mongoc_collection_drop (coll, &error);
    if (!ok && error.code != MONGOC_SERVER_ERR_NS_NOT_FOUND) {
-      test_error ("unexpected error dropping %s: %s", coll, error.message);
+      test_error ("unexpected error dropping %s: %s", collname, error.message);
    }
    mongoc_collection_destroy (coll);
 }


### PR DESCRIPTION
# Summary
- Update protocol to `libmongocrypt` to support `$lookup`
    - Pass all `listCollections` results to libmongocrypt.
    - Opt-in to supporting multi-collection commands by calling `mongocrypt_setopt_enable_multiple_collinfo`.
- Implement prose tests from DRIVERS-3082.

Verified by this patch build: https://spruce.mongodb.com/version/67b7337b99718b000730e99c

# Drive-By improvements
- Print the version of the server in `integration-tests.sh`. This was helpful to verify that the `latest` server version was the expected 8.1 "latest build" version. https://github.com/mongodb-labs/drivers-evergreen-tools/pull/607 fixed the download version of `latest`.
- Fix description of mock KMS server set-up in CONTRIBUTING.md.
- Abort in `get_bson_from_json_file` on failure (rather than return NULL) to surface error sooner.


