### PR TITLE
CDRIVER-5913 Fix Windows compilation under C23

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -64,7 +64,7 @@ mongoc_secure_channel_setup_certificate_from_file (const char *filename)
    file = fopen (filename, "rb");
    if (!file) {
       MONGOC_ERROR ("Couldn't open file '%s'", filename);
-      return false;
+      return NULL;
    }
 
    fseek (file, 0, SEEK_END);
@@ -72,7 +72,7 @@ mongoc_secure_channel_setup_certificate_from_file (const char *filename)
    fseek (file, 0, SEEK_SET);
    if (pem_length < 1) {
       MONGOC_ERROR ("Couldn't determine file size of '%s'", filename);
-      return false;
+      return NULL;
    }
 
    pem = (char *) bson_malloc0 (pem_length);


### PR DESCRIPTION
Fixes an error with gcc in c23 mode:

```
gcc  -DNDEBUG -I. -Icommon -Ikms -Iutf8proc -DBSON_COMPILATION -DMONGOC_COMPILATION -DMONGOC_ENABLE_SSL_SECURE_CHANNEL -DMONGOC_ENABLE_CRYPTO_CNG -DKMS_MESSAGE_ENABLE_CRYPTO -DKMS_MESSAGE_ENABLE_CRYPTO_CNG -DMONGOC_HAVE_SASL_CLIENT_DONE -D__USE_MINGW_ANSI_STDIO -DKMS_MESSAGE_LITTLE_ENDIAN -DUTF8PROC_STATIC -DMONGOC_HAVE_BCRYPT_PBKDF2    -I"C:/rtools44/x86_64-w64-mingw32.static.posix/include"      -O2 -Wall -std=gnu2x  -mfpmath=sse -msse2 -mstackrealign   -c mongoc/mongoc-secure-channel.c -o mongoc/mongoc-secure-channel.o
mongoc/mongoc-secure-channel.c: In function 'mongoc_secure_channel_setup_certificate_from_file':
mongoc/mongoc-secure-channel.c:67:14: error: incompatible types when returning type '_Bool' but 'PCCERT_CONTEXT' {aka 'const CERT_CONTEXT *'} was expected
   67 |       return false;
      |              ^~~~~
mongoc/mongoc-secure-channel.c:75:14: error: incompatible types when returning type '_Bool' but 'PCCERT_CONTEXT' {aka 'const CERT_CONTEXT *'} was expected
   75 |       return false;
      |              ^~~~~
make: *** [C:/R/etc/x64/Makeconf:289: mongoc/mongoc-secure-channel.o] Error 1
```