### PR TITLE
CDRIVER-5912 fix `bounds-strict` sanitizer

### DIFF
--- a/src/libbson/src/jsonsl/jsonsl.c
+++ b/src/libbson/src/jsonsl/jsonsl.c
@@ -111,7 +111,7 @@ jsonsl_t jsonsl_new(int nlevels)
 
     jsn = (struct jsonsl_st *)
             bson_malloc0(sizeof (*jsn) +
-                    ( (nlevels-1) * sizeof (struct jsonsl_state_st) )
+                    ( (nlevels) * sizeof (struct jsonsl_state_st) )
             );
 
     jsn->levels_max = (unsigned int) nlevels;

--- a/src/libbson/src/jsonsl/jsonsl.h
+++ b/src/libbson/src/jsonsl/jsonsl.h
@@ -568,7 +568,7 @@ struct jsonsl_st {
      * nlevels argument passed to jsonsl_new. If you modify this structure,
      * make sure that this member is last.
      */
-    struct jsonsl_state_st stack[1];
+    struct jsonsl_state_st stack[];
 };
 
 


### PR DESCRIPTION
Fixes a reported error when building with `-fsanitize=bounds-strict`.

`jsonsl_st::stack` appears to be treated as a flexible array member, but is declared with size 1. This PR removes the size declaration and updates the allocation.