### PR TITLE
CDRIVER-5891 Address implicit bool-to-null conversion in return statements

### DIFF
--- a/src/libmongoc/examples/client-side-encryption-helpers.c
+++ b/src/libmongoc/examples/client-side-encryption-helpers.c
@@ -15,7 +15,7 @@ hex_to_bin (const char *hex, uint32_t *len)
 
    size_t num_bytes = hex_len / 2u;
    if (num_bytes >= UINT32_MAX) {
-      return false;
+      return NULL;
    }
 
    *len = (uint32_t) (hex_len / 2u);

--- a/src/libmongoc/tests/test-mongoc-topology.c
+++ b/src/libmongoc/tests/test-mongoc-topology.c
@@ -2427,7 +2427,7 @@ initiator_fail (const mongoc_uri_t *uri, const mongoc_host_list_t *host, void *u
    bson_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_CONNECT, "failing in initiator");
    printf ("failing in initiator\n");
 
-   return false;
+   return NULL;
 }
 
 // Test failure in `mongoc_topology_scanner_node_setup` during retry of scanning


### PR DESCRIPTION
Related to CDRIVER-5891 (C23 forward compatibility). Similar issues and fixes as in https://github.com/mongodb/mongo-c-driver/pull/1886.