### PR TITLE
[CDRIVER-5916] Deprecate the Hedged-Reads APIs

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -53,6 +53,9 @@ AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: MultiLine
 AttributeMacros:
   - __capability
+  - BSON_GNUC_WARN_UNUSED_RESULT
+  - BSON_DEPRECATED
+  - BSON_DEPRECATED_FOR
 BinPackArguments: false
 BinPackParameters: false
 BitFieldColonSpacing: Both

--- a/src/common/src/mlib/config.h
+++ b/src/common/src/mlib/config.h
@@ -292,6 +292,13 @@
 #define _mlibTestBuildConfig_MinSizeRel_MinSizeRel()
 
 /**
+ * @brief Emit a _Pragma that will disable warnings about the use of deprecated entities.
+ */
+#define mlib_disable_deprecation_warnings()                \
+   mlib_gnu_warning_disable ("-Wdeprecated-declarations"); \
+   mlib_msvc_warning (disable : 4996)
+
+/**
  * @brief Function-like macro that expands to `1` if we are certain that we are
  * compiling with optimizations enabled.
  *

--- a/src/libbson/src/bson/bson-atomic.h
+++ b/src/libbson/src/bson/bson-atomic.h
@@ -40,6 +40,9 @@
 #define BSON_BEGIN_IGNORE_DEPRECATIONS \
    _Pragma ("clang diagnostic push") _Pragma ("clang diagnostic ignored \"-Wdeprecated-declarations\"")
 #define BSON_END_IGNORE_DEPRECATIONS _Pragma ("clang diagnostic pop")
+#elif defined(_MSC_VER)
+#define BSON_BEGIN_IGNORE_DEPRECATIONS __pragma (warning (push)) __pragma (warning (disable : 4996))
+#define BSON_END_IGNORE_DEPRECATIONS __pragma (warning (pop))
 #else
 #define BSON_BEGIN_IGNORE_DEPRECATIONS
 #define BSON_END_IGNORE_DEPRECATIONS
@@ -49,7 +52,7 @@ BSON_BEGIN_IGNORE_DEPRECATIONS
 
 BSON_BEGIN_DECLS
 
-enum BSON_GNUC_DEPRECATED bson_memory_order {
+enum BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated") bson_memory_order {
    bson_memory_order_seq_cst,
    bson_memory_order_acquire,
    bson_memory_order_release,
@@ -190,8 +193,8 @@ BSON_DISABLE_COVERED_SWITCH_DEFAULT_BEGIN
 
 
 #define DECL_ATOMIC_INTEGRAL(NamePart, Type, VCIntrinSuffix)                                                           \
-   static BSON_INLINE Type BSON_GNUC_DEPRECATED bson_atomic_##NamePart##_fetch_add (                                   \
-      Type volatile *a, Type addend, enum bson_memory_order ord)                                                       \
+   static BSON_INLINE BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated")                                     \
+      Type bson_atomic_##NamePart##_fetch_add (Type volatile *a, Type addend, enum bson_memory_order ord)              \
    {                                                                                                                   \
       DEF_ATOMIC_OP (BSON_CONCAT (_InterlockedExchangeAdd, VCIntrinSuffix),                                            \
                      __atomic_fetch_add,                                                                               \
@@ -201,8 +204,8 @@ BSON_DISABLE_COVERED_SWITCH_DEFAULT_BEGIN
                      addend);                                                                                          \
    }                                                                                                                   \
                                                                                                                        \
-   static BSON_INLINE Type BSON_GNUC_DEPRECATED bson_atomic_##NamePart##_fetch_sub (                                   \
-      Type volatile *a, Type subtrahend, enum bson_memory_order ord)                                                   \
+   static BSON_INLINE BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated")                                     \
+      Type bson_atomic_##NamePart##_fetch_sub (Type volatile *a, Type subtrahend, enum bson_memory_order ord)          \
    {                                                                                                                   \
       /* MSVC doesn't have a subtract intrinsic, so just reuse addition    */                                          \
       BSON_IF_MSVC (return bson_atomic_##NamePart##_fetch_add (a, -subtrahend, ord);)                                  \
@@ -210,8 +213,8 @@ BSON_DISABLE_COVERED_SWITCH_DEFAULT_BEGIN
       BSON_IF_GNU_LEGACY_ATOMICS (DEF_ATOMIC_OP (~, ~, __sync_fetch_and_sub, ord, a, subtrahend);)                     \
    }                                                                                                                   \
                                                                                                                        \
-   static BSON_INLINE Type BSON_GNUC_DEPRECATED bson_atomic_##NamePart##_fetch (Type volatile const *a,                \
-                                                                                enum bson_memory_order order)          \
+   static BSON_INLINE BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated")                                     \
+      Type bson_atomic_##NamePart##_fetch (Type volatile const *a, enum bson_memory_order order)                       \
    {                                                                                                                   \
       /* MSVC doesn't have a load intrinsic, so just add zero */                                                       \
       BSON_IF_MSVC (return bson_atomic_##NamePart##_fetch_add ((Type volatile *) a, 0, order);)                        \
@@ -238,8 +241,8 @@ BSON_DISABLE_COVERED_SWITCH_DEFAULT_BEGIN
       })                                                                                                               \
    }                                                                                                                   \
                                                                                                                        \
-   static BSON_INLINE Type BSON_GNUC_DEPRECATED bson_atomic_##NamePart##_exchange (                                    \
-      Type volatile *a, Type value, enum bson_memory_order ord)                                                        \
+   static BSON_INLINE Type BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated")                                \
+      bson_atomic_##NamePart##_exchange (Type volatile *a, Type value, enum bson_memory_order ord)                     \
    {                                                                                                                   \
       BSON_IF_MSVC (DEF_ATOMIC_OP (BSON_CONCAT (_InterlockedExchange, VCIntrinSuffix), ~, ~, ord, a, value);)          \
       /* GNU doesn't want CONSUME order for the exchange operation, so we                                              \
@@ -262,8 +265,9 @@ BSON_DISABLE_COVERED_SWITCH_DEFAULT_BEGIN
       BSON_IF_GNU_LEGACY_ATOMICS (BSON_UNUSED (ord); return __sync_val_compare_and_swap (a, *a, value);)               \
    }                                                                                                                   \
                                                                                                                        \
-   static BSON_INLINE Type BSON_GNUC_DEPRECATED bson_atomic_##NamePart##_compare_exchange_strong (                     \
-      Type volatile *a, Type expect, Type new_value, enum bson_memory_order ord)                                       \
+   static BSON_INLINE Type BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated")                                \
+      bson_atomic_##NamePart##_compare_exchange_strong (                                                               \
+         Type volatile *a, Type expect, Type new_value, enum bson_memory_order ord)                                    \
    {                                                                                                                   \
       Type actual = expect;                                                                                            \
       switch (ord) {                                                                                                   \
@@ -290,8 +294,9 @@ BSON_DISABLE_COVERED_SWITCH_DEFAULT_BEGIN
       return actual;                                                                                                   \
    }                                                                                                                   \
                                                                                                                        \
-   static BSON_INLINE Type BSON_GNUC_DEPRECATED bson_atomic_##NamePart##_compare_exchange_weak (                       \
-      Type volatile *a, Type expect, Type new_value, enum bson_memory_order ord)                                       \
+   static BSON_INLINE Type BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated")                                \
+      bson_atomic_##NamePart##_compare_exchange_weak (                                                                 \
+         Type volatile *a, Type expect, Type new_value, enum bson_memory_order ord)                                    \
    {                                                                                                                   \
       Type actual = expect;                                                                                            \
       switch (ord) {                                                                                                   \
@@ -417,136 +422,140 @@ DECL_ATOMIC_INTEGRAL (int64, __int64, 64)
 DECL_ATOMIC_STDINT (int64, 64)
 #endif
 #else
-static BSON_INLINE int64_t BSON_GNUC_DEPRECATED
-bson_atomic_int64_fetch (const int64_t volatile *val, enum bson_memory_order order)
+static BSON_INLINE BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated") int64_t
+   bson_atomic_int64_fetch (const int64_t volatile *val, enum bson_memory_order order)
 {
    return _bson_emul_atomic_int64_fetch_add ((int64_t volatile *) val, 0, order);
 }
 
-static BSON_INLINE int64_t BSON_GNUC_DEPRECATED
-bson_atomic_int64_fetch_add (int64_t volatile *val, int64_t v, enum bson_memory_order order)
+static BSON_INLINE BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated") int64_t
+   bson_atomic_int64_fetch_add (int64_t volatile *val, int64_t v, enum bson_memory_order order)
 {
    return _bson_emul_atomic_int64_fetch_add (val, v, order);
 }
 
-static BSON_INLINE int64_t BSON_GNUC_DEPRECATED
-bson_atomic_int64_fetch_sub (int64_t volatile *val, int64_t v, enum bson_memory_order order)
+static BSON_INLINE BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated") int64_t
+   bson_atomic_int64_fetch_sub (int64_t volatile *val, int64_t v, enum bson_memory_order order)
 {
    return _bson_emul_atomic_int64_fetch_add (val, -v, order);
 }
 
-static BSON_INLINE int64_t BSON_GNUC_DEPRECATED
-bson_atomic_int64_exchange (int64_t volatile *val, int64_t v, enum bson_memory_order order)
+static BSON_INLINE BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated") int64_t
+   bson_atomic_int64_exchange (int64_t volatile *val, int64_t v, enum bson_memory_order order)
 {
    return _bson_emul_atomic_int64_exchange (val, v, order);
 }
 
-static BSON_INLINE int64_t BSON_GNUC_DEPRECATED
-bson_atomic_int64_compare_exchange_strong (int64_t volatile *val,
-                                           int64_t expect_value,
-                                           int64_t new_value,
-                                           enum bson_memory_order order)
+static BSON_INLINE BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated") int64_t
+   bson_atomic_int64_compare_exchange_strong (int64_t volatile *val,
+                                              int64_t expect_value,
+                                              int64_t new_value,
+                                              enum bson_memory_order order)
 {
    return _bson_emul_atomic_int64_compare_exchange_strong (val, expect_value, new_value, order);
 }
 
-static BSON_INLINE int64_t BSON_GNUC_DEPRECATED
-bson_atomic_int64_compare_exchange_weak (int64_t volatile *val,
-                                         int64_t expect_value,
-                                         int64_t new_value,
-                                         enum bson_memory_order order)
+static BSON_INLINE BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated") int64_t
+   bson_atomic_int64_compare_exchange_weak (int64_t volatile *val,
+                                            int64_t expect_value,
+                                            int64_t new_value,
+                                            enum bson_memory_order order)
 {
    return _bson_emul_atomic_int64_compare_exchange_weak (val, expect_value, new_value, order);
 }
 #endif
 
 #if defined(BSON_EMULATE_INT32)
-static BSON_INLINE int32_t BSON_GNUC_DEPRECATED
-bson_atomic_int32_fetch (const int32_t volatile *val, enum bson_memory_order order)
+static BSON_INLINE BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated") int32_t
+   bson_atomic_int32_fetch (const int32_t volatile *val, enum bson_memory_order order)
 {
    return _bson_emul_atomic_int32_fetch_add ((int32_t volatile *) val, 0, order);
 }
 
-static BSON_INLINE int32_t BSON_GNUC_DEPRECATED
-bson_atomic_int32_fetch_add (int32_t volatile *val, int32_t v, enum bson_memory_order order)
+static BSON_INLINE BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated") int32_t
+   bson_atomic_int32_fetch_add (int32_t volatile *val, int32_t v, enum bson_memory_order order)
 {
    return _bson_emul_atomic_int32_fetch_add (val, v, order);
 }
 
-static BSON_INLINE int32_t BSON_GNUC_DEPRECATED
-bson_atomic_int32_fetch_sub (int32_t volatile *val, int32_t v, enum bson_memory_order order)
+static BSON_INLINE BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated") int32_t
+   bson_atomic_int32_fetch_sub (int32_t volatile *val, int32_t v, enum bson_memory_order order)
 {
    return _bson_emul_atomic_int32_fetch_add (val, -v, order);
 }
 
-static BSON_INLINE int32_t BSON_GNUC_DEPRECATED
-bson_atomic_int32_exchange (int32_t volatile *val, int32_t v, enum bson_memory_order order)
+static BSON_INLINE BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated") int32_t
+   bson_atomic_int32_exchange (int32_t volatile *val, int32_t v, enum bson_memory_order order)
 {
    return _bson_emul_atomic_int32_exchange (val, v, order);
 }
 
-static BSON_INLINE int32_t BSON_GNUC_DEPRECATED
-bson_atomic_int32_compare_exchange_strong (int32_t volatile *val,
-                                           int32_t expect_value,
-                                           int32_t new_value,
-                                           enum bson_memory_order order)
+static BSON_INLINE BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated") int32_t
+   bson_atomic_int32_compare_exchange_strong (int32_t volatile *val,
+                                              int32_t expect_value,
+                                              int32_t new_value,
+                                              enum bson_memory_order order)
 {
    return _bson_emul_atomic_int32_compare_exchange_strong (val, expect_value, new_value, order);
 }
 
-static BSON_INLINE int32_t BSON_GNUC_DEPRECATED
-bson_atomic_int32_compare_exchange_weak (int32_t volatile *val,
-                                         int32_t expect_value,
-                                         int32_t new_value,
-                                         enum bson_memory_order order)
+static BSON_INLINE BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated") int32_t
+   bson_atomic_int32_compare_exchange_weak (int32_t volatile *val,
+                                            int32_t expect_value,
+                                            int32_t new_value,
+                                            enum bson_memory_order order)
 {
    return _bson_emul_atomic_int32_compare_exchange_weak (val, expect_value, new_value, order);
 }
 #endif /* BSON_EMULATE_INT32 */
 
 #if defined(BSON_EMULATE_INT)
-static BSON_INLINE int BSON_GNUC_DEPRECATED
-bson_atomic_int_fetch (const int volatile *val, enum bson_memory_order order)
+static BSON_INLINE BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated") int bson_atomic_int_fetch (
+   const int volatile *val, enum bson_memory_order order)
 {
    return _bson_emul_atomic_int_fetch_add ((int volatile *) val, 0, order);
 }
 
-static BSON_INLINE int BSON_GNUC_DEPRECATED
-bson_atomic_int_fetch_add (int volatile *val, int v, enum bson_memory_order order)
+static BSON_INLINE BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated") int bson_atomic_int_fetch_add (
+   int volatile *val, int v, enum bson_memory_order order)
 {
    return _bson_emul_atomic_int_fetch_add (val, v, order);
 }
 
-static BSON_INLINE int BSON_GNUC_DEPRECATED
-bson_atomic_int_fetch_sub (int volatile *val, int v, enum bson_memory_order order)
+static BSON_INLINE BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated") int bson_atomic_int_fetch_sub (
+   int volatile *val, int v, enum bson_memory_order order)
 {
    return _bson_emul_atomic_int_fetch_add (val, -v, order);
 }
 
-static BSON_INLINE int BSON_GNUC_DEPRECATED
-bson_atomic_int_exchange (int volatile *val, int v, enum bson_memory_order order)
+static BSON_INLINE BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated") int bson_atomic_int_exchange (
+   int volatile *val, int v, enum bson_memory_order order)
 {
    return _bson_emul_atomic_int_exchange (val, v, order);
 }
 
-static BSON_INLINE int BSON_GNUC_DEPRECATED
-bson_atomic_int_compare_exchange_strong (int volatile *val,
-                                         int expect_value,
-                                         int new_value,
-                                         enum bson_memory_order order)
+static BSON_INLINE BSON_DEPRECATED (
+   "<bson/bson-atomic.h> APIs are deprecated") int bson_atomic_int_compare_exchange_strong (int volatile *val,
+                                                                                            int expect_value,
+                                                                                            int new_value,
+                                                                                            enum bson_memory_order
+                                                                                               order)
 {
    return _bson_emul_atomic_int_compare_exchange_strong (val, expect_value, new_value, order);
 }
 
-static BSON_INLINE int BSON_GNUC_DEPRECATED
-bson_atomic_int_compare_exchange_weak (int volatile *val, int expect_value, int new_value, enum bson_memory_order order)
+static BSON_INLINE BSON_DEPRECATED (
+   "<bson/bson-atomic.h> APIs are deprecated") int bson_atomic_int_compare_exchange_weak (int volatile *val,
+                                                                                          int expect_value,
+                                                                                          int new_value,
+                                                                                          enum bson_memory_order order)
 {
    return _bson_emul_atomic_int_compare_exchange_weak (val, expect_value, new_value, order);
 }
 #endif /* BSON_EMULATE_INT */
 
-static BSON_INLINE void *BSON_GNUC_DEPRECATED
-bson_atomic_ptr_exchange (void *volatile *ptr, void *new_value, enum bson_memory_order ord)
+static BSON_INLINE BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated") void *bson_atomic_ptr_exchange (
+   void *volatile *ptr, void *new_value, enum bson_memory_order ord)
 {
 #if defined(BSON_EMULATE_PTR)
    return _bson_emul_atomic_ptr_exchange (ptr, new_value, ord);
@@ -558,8 +567,11 @@ bson_atomic_ptr_exchange (void *volatile *ptr, void *new_value, enum bson_memory
 #endif
 }
 
-static BSON_INLINE void *BSON_GNUC_DEPRECATED
-bson_atomic_ptr_compare_exchange_strong (void *volatile *ptr, void *expect, void *new_value, enum bson_memory_order ord)
+static BSON_INLINE BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated") void
+   *bson_atomic_ptr_compare_exchange_strong (void *volatile *ptr,
+                                             void *expect,
+                                             void *new_value,
+                                             enum bson_memory_order ord)
 {
    switch (ord) {
    case bson_memory_order_release:
@@ -582,8 +594,11 @@ bson_atomic_ptr_compare_exchange_strong (void *volatile *ptr, void *expect, void
 }
 
 
-static BSON_INLINE void *BSON_GNUC_DEPRECATED
-bson_atomic_ptr_compare_exchange_weak (void *volatile *ptr, void *expect, void *new_value, enum bson_memory_order ord)
+static BSON_INLINE BSON_DEPRECATED (
+   "<bson/bson-atomic.h> APIs are deprecated") void *bson_atomic_ptr_compare_exchange_weak (void *volatile *ptr,
+                                                                                            void *expect,
+                                                                                            void *new_value,
+                                                                                            enum bson_memory_order ord)
 {
    switch (ord) {
    case bson_memory_order_release:
@@ -606,8 +621,8 @@ bson_atomic_ptr_compare_exchange_weak (void *volatile *ptr, void *expect, void *
 }
 
 
-static BSON_INLINE void *BSON_GNUC_DEPRECATED
-bson_atomic_ptr_fetch (void *volatile const *ptr, enum bson_memory_order ord)
+static BSON_INLINE BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated") void *bson_atomic_ptr_fetch (
+   void *volatile const *ptr, enum bson_memory_order ord)
 {
    // Use a union to address cast-qual compilation warning
    union {
@@ -628,8 +643,7 @@ bson_atomic_ptr_fetch (void *volatile const *ptr, enum bson_memory_order ord)
 /**
  * @brief Generate a full-fence memory barrier at the call site.
  */
-static BSON_INLINE void BSON_GNUC_DEPRECATED
-bson_atomic_thread_fence (void)
+static BSON_INLINE void BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated") bson_atomic_thread_fence (void)
 {
    BSON_IF_MSVC (MemoryBarrier ();)
 
@@ -640,8 +654,7 @@ bson_atomic_thread_fence (void)
    BSON_IF_GNU_LEGACY_ATOMICS (__sync_synchronize ();)
 }
 
-static BSON_INLINE void BSON_GNUC_DEPRECATED
-bson_sync_synchronize (void)
+static BSON_INLINE void BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated") bson_sync_synchronize (void)
 {
    bson_atomic_thread_fence ();
 }
@@ -653,13 +666,12 @@ bson_sync_synchronize (void)
 #undef BSON_IF_GNU_LEGACY_ATOMICS
 #undef BSON_USE_LEGACY_GCC_ATOMICS
 
-BSON_GNUC_DEPRECATED
-BSON_EXPORT (void) bson_memory_barrier (void);
+BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated") BSON_EXPORT (void) bson_memory_barrier (void);
 
-BSON_GNUC_DEPRECATED
+BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated")
 BSON_EXPORT (int32_t) bson_atomic_int_add (volatile int32_t *p, int32_t n);
 
-BSON_GNUC_DEPRECATED
+BSON_DEPRECATED ("<bson/bson-atomic.h> APIs are deprecated")
 BSON_EXPORT (int64_t) bson_atomic_int64_add (volatile int64_t *p, int64_t n);
 
 BSON_DISABLE_COVERED_SWITCH_DEFAULT_END

--- a/src/libbson/src/bson/bson-cmp.h
+++ b/src/libbson/src/bson/bson-cmp.h
@@ -39,6 +39,9 @@
 #define BSON_BEGIN_IGNORE_DEPRECATIONS \
    _Pragma ("clang diagnostic push") _Pragma ("clang diagnostic ignored \"-Wdeprecated-declarations\"")
 #define BSON_END_IGNORE_DEPRECATIONS _Pragma ("clang diagnostic pop")
+#elif defined(_MSC_VER)
+#define BSON_BEGIN_IGNORE_DEPRECATIONS __pragma (warning (push)) __pragma (warning (disable : 4996))
+#define BSON_END_IGNORE_DEPRECATIONS __pragma (warning (pop))
 #else
 #define BSON_BEGIN_IGNORE_DEPRECATIONS
 #define BSON_END_IGNORE_DEPRECATIONS
@@ -70,25 +73,29 @@ BSON_BEGIN_DECLS
  * recommended.
  */
 
-#define BSON_CMP_SET(op, ss, uu, su, us)                                                                   \
-   static BSON_INLINE bool BSON_GNUC_DEPRECATED BSON_CONCAT3 (bson_cmp_, op, _ss) (int64_t t, int64_t u)   \
-   {                                                                                                       \
-      return (ss);                                                                                         \
-   }                                                                                                       \
-                                                                                                           \
-   static BSON_INLINE bool BSON_GNUC_DEPRECATED BSON_CONCAT3 (bson_cmp_, op, _uu) (uint64_t t, uint64_t u) \
-   {                                                                                                       \
-      return (uu);                                                                                         \
-   }                                                                                                       \
-                                                                                                           \
-   static BSON_INLINE bool BSON_GNUC_DEPRECATED BSON_CONCAT3 (bson_cmp_, op, _su) (int64_t t, uint64_t u)  \
-   {                                                                                                       \
-      return (su);                                                                                         \
-   }                                                                                                       \
-                                                                                                           \
-   static BSON_INLINE bool BSON_GNUC_DEPRECATED BSON_CONCAT3 (bson_cmp_, op, _us) (uint64_t t, int64_t u)  \
-   {                                                                                                       \
-      return (us);                                                                                         \
+#define BSON_CMP_SET(op, ss, uu, su, us)                                                            \
+   static BSON_INLINE BSON_DEPRECATED ("<bson/bson-cmp.h> APIs are deprecated") bool BSON_CONCAT3 ( \
+      bson_cmp_, op, _ss) (int64_t t, int64_t u)                                                    \
+   {                                                                                                \
+      return (ss);                                                                                  \
+   }                                                                                                \
+                                                                                                    \
+   static BSON_INLINE BSON_DEPRECATED ("<bson/bson-cmp.h> APIs are deprecated") bool BSON_CONCAT3 ( \
+      bson_cmp_, op, _uu) (uint64_t t, uint64_t u)                                                  \
+   {                                                                                                \
+      return (uu);                                                                                  \
+   }                                                                                                \
+                                                                                                    \
+   static BSON_INLINE BSON_DEPRECATED ("<bson/bson-cmp.h> APIs are deprecated") bool BSON_CONCAT3 ( \
+      bson_cmp_, op, _su) (int64_t t, uint64_t u)                                                   \
+   {                                                                                                \
+      return (su);                                                                                  \
+   }                                                                                                \
+                                                                                                    \
+   static BSON_INLINE BSON_DEPRECATED ("<bson/bson-cmp.h> APIs are deprecated") bool BSON_CONCAT3 ( \
+      bson_cmp_, op, _us) (uint64_t t, int64_t u)                                                   \
+   {                                                                                                \
+      return (us);                                                                                  \
    }
 
 BSON_CMP_SET (equal, t == u, t == u, t < 0 ? false : (uint64_t) (t) == u, u < 0 ? false : t == (uint64_t) (u))
@@ -121,28 +128,32 @@ BSON_CMP_SET (greater_equal,
 
 /* Return true if the given value is within the range of the corresponding
  * signed type. The suffix must match the signedness of the given value. */
-#define BSON_IN_RANGE_SET_SIGNED(Type, min, max)                                                                  \
-   static BSON_INLINE bool BSON_GNUC_DEPRECATED BSON_CONCAT3 (bson_in_range, _##Type, _signed) (int64_t value)    \
-   {                                                                                                              \
-      return bson_cmp_greater_equal_ss (value, min) && bson_cmp_less_equal_ss (value, max);                       \
-   }                                                                                                              \
-                                                                                                                  \
-   static BSON_INLINE bool BSON_GNUC_DEPRECATED BSON_CONCAT3 (bson_in_range, _##Type, _unsigned) (uint64_t value) \
-   {                                                                                                              \
-      return bson_cmp_greater_equal_us (value, min) && bson_cmp_less_equal_us (value, max);                       \
+#define BSON_IN_RANGE_SET_SIGNED(Type, min, max)                                                    \
+   static BSON_INLINE BSON_DEPRECATED ("<bson/bson-cmp.h> APIs are deprecated") bool BSON_CONCAT3 ( \
+      bson_in_range, _##Type, _signed) (int64_t value)                                              \
+   {                                                                                                \
+      return bson_cmp_greater_equal_ss (value, min) && bson_cmp_less_equal_ss (value, max);         \
+   }                                                                                                \
+                                                                                                    \
+   static BSON_INLINE BSON_DEPRECATED ("<bson/bson-cmp.h> APIs are deprecated") bool BSON_CONCAT3 ( \
+      bson_in_range, _##Type, _unsigned) (uint64_t value)                                           \
+   {                                                                                                \
+      return bson_cmp_greater_equal_us (value, min) && bson_cmp_less_equal_us (value, max);         \
    }
 
 /* Return true if the given value is within the range of the corresponding
  * unsigned type. The suffix must match the signedness of the given value. */
-#define BSON_IN_RANGE_SET_UNSIGNED(Type, max)                                                                     \
-   static BSON_INLINE bool BSON_GNUC_DEPRECATED BSON_CONCAT3 (bson_in_range, _##Type, _signed) (int64_t value)    \
-   {                                                                                                              \
-      return bson_cmp_greater_equal_su (value, 0u) && bson_cmp_less_equal_su (value, max);                        \
-   }                                                                                                              \
-                                                                                                                  \
-   static BSON_INLINE bool BSON_GNUC_DEPRECATED BSON_CONCAT3 (bson_in_range, _##Type, _unsigned) (uint64_t value) \
-   {                                                                                                              \
-      return bson_cmp_less_equal_uu (value, max);                                                                 \
+#define BSON_IN_RANGE_SET_UNSIGNED(Type, max)                                                       \
+   static BSON_INLINE BSON_DEPRECATED ("<bson/bson-cmp.h> APIs are deprecated") bool BSON_CONCAT3 ( \
+      bson_in_range, _##Type, _signed) (int64_t value)                                              \
+   {                                                                                                \
+      return bson_cmp_greater_equal_su (value, 0u) && bson_cmp_less_equal_su (value, max);          \
+   }                                                                                                \
+                                                                                                    \
+   static BSON_INLINE BSON_DEPRECATED ("<bson/bson-cmp.h> APIs are deprecated") bool BSON_CONCAT3 ( \
+      bson_in_range, _##Type, _unsigned) (uint64_t value)                                           \
+   {                                                                                                \
+      return bson_cmp_less_equal_uu (value, max);                                                   \
    }
 
 BSON_IN_RANGE_SET_SIGNED (signed_char, SCHAR_MIN, SCHAR_MAX)

--- a/src/libbson/src/bson/bson-macros.h
+++ b/src/libbson/src/bson/bson-macros.h
@@ -329,23 +329,39 @@ _bson_assert_failed_on_param (const char *param, const char *func)
 #define BSON_TYPEOF typeof
 #endif
 
+/**
+ * @brief Statically annotate an entity as deprecated, including the given deprecation message
+ *
+ * @param Message The message to be included in a deprecation warning. This
+ * should be a string literal.
+ */
+#define BSON_DEPRECATED(Message) _bsonDeprecatedImpl (Message)
 
-#if BSON_GNUC_CHECK_VERSION(3, 1)
-#define BSON_GNUC_DEPRECATED __attribute__ ((__deprecated__))
+// Pick the appropriate implementation of a deprecation attribute
+#if defined(_MSC_VER)
+// For MSVC, emit __declspec(deprecated(Msg))
+#define _bsonDeprecatedImpl(Msg) __declspec (deprecated (Msg))
+#elif defined(__GNUC__) && (defined(__clang__) || BSON_GNUC_CHECK_VERSION(4, 5))
+// For new enough Clang and GCC, emit __attribute__((__deprecated__(Msg)))
+#define _bsonDeprecatedImpl(Msg) __attribute__ ((__deprecated__ (Msg)))
+#elif defined(__GNUC__)
+// For older GCC, emit deprecation attribute without the message
+#define _bsonDeprecatedImpl(Msg) __attribute__ ((__deprecated__))
 #else
-#define BSON_GNUC_DEPRECATED
+// For other compilers, emit nothing
+#define _bsonDeprecatedImpl(Msg)
 #endif
+
+#define BSON_DEPRECATED_FOR(F) BSON_DEPRECATED ("This API is deprecated. Use " #F " instead.")
+
+#define BSON_GNUC_DEPRECATED BSON_DEPRECATED ("This API is deprecated")
+#define BSON_GNUC_DEPRECATED_FOR(F) BSON_DEPRECATED_FOR (F)
 
 #define BSON_CONCAT_IMPL(a, ...) a##__VA_ARGS__
 #define BSON_CONCAT(a, ...) BSON_CONCAT_IMPL (a, __VA_ARGS__)
 #define BSON_CONCAT3(a, b, c) BSON_CONCAT (a, BSON_CONCAT (b, c))
 #define BSON_CONCAT4(a, b, c, d) BSON_CONCAT (BSON_CONCAT (a, b), BSON_CONCAT (c, d))
 
-#if BSON_GNUC_CHECK_VERSION(4, 5)
-#define BSON_GNUC_DEPRECATED_FOR(f) __attribute__ ((deprecated ("Use " #f " instead")))
-#else
-#define BSON_GNUC_DEPRECATED_FOR(f) BSON_GNUC_DEPRECATED
-#endif
 
 /**
  * @brief String-ify the given argument

--- a/src/libbson/src/bson/bson-md5.h
+++ b/src/libbson/src/bson/bson-md5.h
@@ -73,12 +73,13 @@ typedef struct {
 } bson_md5_t;
 
 
-BSON_EXPORT (void)
-bson_md5_init (bson_md5_t *pms) BSON_GNUC_DEPRECATED;
-BSON_EXPORT (void)
-bson_md5_append (bson_md5_t *pms, const uint8_t *data, uint32_t nbytes) BSON_GNUC_DEPRECATED;
-BSON_EXPORT (void)
-bson_md5_finish (bson_md5_t *pms, uint8_t digest[16]) BSON_GNUC_DEPRECATED;
+BSON_DEPRECATED ("<bson/bson-md5.h> APIs are deprecated") BSON_EXPORT (void) bson_md5_init (bson_md5_t *pms);
+
+BSON_DEPRECATED ("<bson/bson-md5.h> APIs are deprecated")
+BSON_EXPORT (void) bson_md5_append (bson_md5_t *pms, const uint8_t *data, uint32_t nbytes);
+
+BSON_DEPRECATED ("<bson/bson-md5.h> APIs are deprecated")
+BSON_EXPORT (void) bson_md5_finish (bson_md5_t *pms, uint8_t digest[16]);
 
 
 BSON_END_DECLS

--- a/src/libbson/src/bson/bson-oid.h
+++ b/src/libbson/src/bson/bson-oid.h
@@ -50,8 +50,8 @@ BSON_EXPORT (void)
 bson_oid_init_from_data (bson_oid_t *oid, const uint8_t *data);
 BSON_EXPORT (void)
 bson_oid_init_from_string (bson_oid_t *oid, const char *str);
-BSON_EXPORT (void)
-bson_oid_init_sequence (bson_oid_t *oid, bson_context_t *context) BSON_GNUC_DEPRECATED_FOR (bson_oid_init);
+BSON_DEPRECATED_FOR (bson_oid_init)
+BSON_EXPORT (void) bson_oid_init_sequence (bson_oid_t *oid, bson_context_t *context);
 BSON_EXPORT (void)
 bson_oid_to_string (const bson_oid_t *oid, char str[25]);
 

--- a/src/libbson/src/bson/bson-string.h
+++ b/src/libbson/src/bson/bson-string.h
@@ -37,42 +37,59 @@ typedef struct {
 } bson_string_t;
 
 
-BSON_EXPORT (bson_string_t *)
-bson_string_new (const char *str) BSON_GNUC_DEPRECATED;
-BSON_EXPORT (char *)
-bson_string_free (bson_string_t *string, bool free_segment) BSON_GNUC_DEPRECATED;
-BSON_EXPORT (void)
-bson_string_append (bson_string_t *string, const char *str) BSON_GNUC_DEPRECATED;
-BSON_EXPORT (void)
-bson_string_append_c (bson_string_t *string, char str) BSON_GNUC_DEPRECATED;
-BSON_EXPORT (void)
-bson_string_append_unichar (bson_string_t *string, bson_unichar_t unichar) BSON_GNUC_DEPRECATED;
-BSON_EXPORT (void)
-bson_string_append_printf (bson_string_t *string, const char *format, ...) BSON_GNUC_PRINTF (2, 3) BSON_GNUC_DEPRECATED;
-BSON_EXPORT (void)
-bson_string_truncate (bson_string_t *string, uint32_t len) BSON_GNUC_DEPRECATED;
+BSON_DEPRECATED ("bson_string_t APIs are deprecated") BSON_EXPORT (bson_string_t *) bson_string_new (const char *str);
+
+BSON_DEPRECATED ("bson_string_t APIs are deprecated")
+BSON_EXPORT (char *) bson_string_free (bson_string_t *string, bool free_segment);
+
+BSON_DEPRECATED ("bson_string_t APIs are deprecated")
+BSON_EXPORT (void) bson_string_append (bson_string_t *string, const char *str);
+
+BSON_DEPRECATED ("bson_string_t APIs are deprecated")
+BSON_EXPORT (void) bson_string_append_c (bson_string_t *string, char str);
+
+BSON_DEPRECATED ("bson_string_t APIs are deprecated")
+BSON_EXPORT (void) bson_string_append_unichar (bson_string_t *string, bson_unichar_t unichar);
+
+BSON_DEPRECATED ("bson_string_t APIs are deprecated")
+BSON_EXPORT (void) bson_string_append_printf (bson_string_t *string, const char *format, ...) BSON_GNUC_PRINTF (2, 3);
+
+BSON_DEPRECATED ("bson_string_t APIs are deprecated")
+BSON_EXPORT (void) bson_string_truncate (bson_string_t *string, uint32_t len);
+
 BSON_EXPORT (char *)
 bson_strdup (const char *str);
+
 BSON_EXPORT (char *)
 bson_strdup_printf (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
+
 BSON_EXPORT (char *)
 bson_strdupv_printf (const char *format, va_list args) BSON_GNUC_PRINTF (1, 0);
+
 BSON_EXPORT (char *)
 bson_strndup (const char *str, size_t n_bytes);
+
 BSON_EXPORT (void)
 bson_strncpy (char *dst, const char *src, size_t size);
+
 BSON_EXPORT (int)
 bson_vsnprintf (char *str, size_t size, const char *format, va_list ap) BSON_GNUC_PRINTF (3, 0);
+
 BSON_EXPORT (int)
 bson_snprintf (char *str, size_t size, const char *format, ...) BSON_GNUC_PRINTF (3, 4);
+
 BSON_EXPORT (void)
 bson_strfreev (char **strv);
+
 BSON_EXPORT (size_t)
 bson_strnlen (const char *s, size_t maxlen);
+
 BSON_EXPORT (int64_t)
 bson_ascii_strtoll (const char *str, char **endptr, int base);
+
 BSON_EXPORT (int)
 bson_strcasecmp (const char *s1, const char *s2);
+
 BSON_EXPORT (bool)
 bson_isspace (int c);
 

--- a/src/libbson/src/bson/bson.h
+++ b/src/libbson/src/bson/bson.h
@@ -302,9 +302,9 @@ bson_copy_to (const bson_t *src, bson_t *dst);
  * more fields in a bson_t. Note that bson_init() will be called
  * on dst.
  */
+BSON_DEPRECATED_FOR (bson_copy_to_excluding_noinit)
 BSON_EXPORT (void)
-bson_copy_to_excluding (const bson_t *src, bson_t *dst, const char *first_exclude, ...) BSON_GNUC_NULL_TERMINATED
-   BSON_GNUC_DEPRECATED_FOR (bson_copy_to_excluding_noinit);
+   bson_copy_to_excluding (const bson_t *src, bson_t *dst, const char *first_exclude, ...) BSON_GNUC_NULL_TERMINATED;
 
 /**
  * bson_copy_to_excluding_noinit:
@@ -532,7 +532,7 @@ bson_as_canonical_extended_json (const bson_t *bson, size_t *length);
  * Returns: A newly allocated string that should be freed with bson_free().
  */
 BSON_EXPORT (char *)
-bson_as_json (const bson_t *bson, size_t *length) BSON_GNUC_DEPRECATED_FOR (bson_as_legacy_extended_json);
+bson_as_json (const bson_t *bson, size_t *length);
 
 // `bson_as_legacy_extended_json` is a non-deprecated form of `bson_as_json`.
 BSON_EXPORT (char *)
@@ -562,8 +562,8 @@ bson_as_relaxed_extended_json (const bson_t *bson, size_t *length);
 
 
 /* like bson_as_json() but for outermost arrays. */
-BSON_EXPORT (char *)
-bson_array_as_json (const bson_t *bson, size_t *length) BSON_GNUC_DEPRECATED_FOR (bson_array_as_legacy_extended_json);
+BSON_DEPRECATED_FOR (bson_array_as_legacy_extended_json)
+BSON_EXPORT (char *) bson_array_as_json (const bson_t *bson, size_t *length);
 
 // `bson_array_as_legacy_extended_json` is a non-deprecated form of `bson_array_as_json`.
 BSON_EXPORT (char *)

--- a/src/libbson/src/bson/bson.h
+++ b/src/libbson/src/bson/bson.h
@@ -531,8 +531,8 @@ bson_as_canonical_extended_json (const bson_t *bson, size_t *length);
  *
  * Returns: A newly allocated string that should be freed with bson_free().
  */
-BSON_EXPORT (char *)
-bson_as_json (const bson_t *bson, size_t *length);
+BSON_DEPRECATED_FOR (bson_as_legacy_extended_json)
+BSON_EXPORT (char *) bson_as_json (const bson_t *bson, size_t *length);
 
 // `bson_as_legacy_extended_json` is a non-deprecated form of `bson_as_json`.
 BSON_EXPORT (char *)

--- a/src/libmongoc/doc/mongoc_read_prefs_get_hedge.rst
+++ b/src/libmongoc/doc/mongoc_read_prefs_get_hedge.rst
@@ -3,6 +3,11 @@
 mongoc_read_prefs_get_hedge()
 =============================
 
+.. deprecated:: MongoDB Server 8.0
+
+  Hedged reads are deprecated in MongoDB version 8.0 and will be removed in
+  a future release.
+
 Synopsis
 --------
 

--- a/src/libmongoc/doc/mongoc_read_prefs_set_hedge.rst
+++ b/src/libmongoc/doc/mongoc_read_prefs_set_hedge.rst
@@ -3,6 +3,11 @@
 mongoc_read_prefs_set_hedge()
 =============================
 
+.. deprecated:: MongoDB Server 8.0
+
+  Hedged reads are deprecated in MongoDB version 8.0 and will be removed in
+  a future release.
+
 Synopsis
 --------
 

--- a/src/libmongoc/doc/mongoc_read_prefs_t.rst
+++ b/src/libmongoc/doc/mongoc_read_prefs_t.rst
@@ -70,9 +70,19 @@ Max Staleness is also supported by sharded clusters of replica sets if all serve
 Hedged Reads
 ------------
 
-When connecting to a sharded cluster running MongoDB 4.4 or later, reads can be sent in parallel to the two "best" hosts.  Once one result returns, any other outstanding operations that were part of the hedged read are cancelled.
+.. deprecated:: MongoDB Server 8.0
 
-When the read preference mode is ``MONGOC_READ_NEAREST`` and the sharded cluster is running MongoDB 4.4 or later, hedged reads are enabled by default.  Additionally, hedged reads may be explicitly enabled or disabled by calling :symbol:`mongoc_read_prefs_set_hedge` with a BSON document, e.g.
+  Hedged reads are deprecated in MongoDB version 8.0 and will be removed in
+  a future release.
+
+When connecting to a sharded cluster running MongoDB 4.4 or later, reads can be
+sent in parallel to the two "best" hosts. Once one result returns, any other
+outstanding operations that were part of the hedged read are cancelled.
+
+When the read preference mode is ``MONGOC_READ_NEAREST`` and the sharded cluster
+is running MongoDB 4.4 or later, hedged reads are enabled by default.
+Additionally, hedged reads may be explicitly enabled or disabled by calling
+:symbol:`mongoc_read_prefs_set_hedge` with a BSON document, e.g.
 
 .. code-block:: none
 

--- a/src/libmongoc/src/mongoc/mongoc-apm.h
+++ b/src/libmongoc/src/mongoc/mongoc-apm.h
@@ -76,177 +76,243 @@ typedef struct _mongoc_apm_server_heartbeat_failed_t mongoc_apm_server_heartbeat
 
 /* command-started event fields */
 
+
 MONGOC_EXPORT (const bson_t *)
 mongoc_apm_command_started_get_command (const mongoc_apm_command_started_t *event);
+
 MONGOC_EXPORT (const char *)
 mongoc_apm_command_started_get_database_name (const mongoc_apm_command_started_t *event);
+
 MONGOC_EXPORT (const char *)
 mongoc_apm_command_started_get_command_name (const mongoc_apm_command_started_t *event);
+
 MONGOC_EXPORT (int64_t)
 mongoc_apm_command_started_get_request_id (const mongoc_apm_command_started_t *event);
+
 MONGOC_EXPORT (int64_t)
 mongoc_apm_command_started_get_operation_id (const mongoc_apm_command_started_t *event);
+
 MONGOC_EXPORT (const mongoc_host_list_t *)
 mongoc_apm_command_started_get_host (const mongoc_apm_command_started_t *event);
+
 MONGOC_EXPORT (uint32_t)
 mongoc_apm_command_started_get_server_id (const mongoc_apm_command_started_t *event);
+
 MONGOC_EXPORT (const bson_oid_t *)
 mongoc_apm_command_started_get_service_id (const mongoc_apm_command_started_t *event);
-MONGOC_EXPORT (int32_t)
-mongoc_apm_command_started_get_server_connection_id (const mongoc_apm_command_started_t *event)
-   BSON_GNUC_DEPRECATED_FOR ("mongoc_apm_command_started_get_server_connection_id_int64");
+
+BSON_DEPRECATED_FOR (mongoc_apm_command_started_get_server_connection_id_int64)
+MONGOC_EXPORT (int32_t) mongoc_apm_command_started_get_server_connection_id (const mongoc_apm_command_started_t *event);
+
 MONGOC_EXPORT (int64_t)
 mongoc_apm_command_started_get_server_connection_id_int64 (const mongoc_apm_command_started_t *event);
+
 MONGOC_EXPORT (void *)
 mongoc_apm_command_started_get_context (const mongoc_apm_command_started_t *event);
 
 /* command-succeeded event fields */
 
+
 MONGOC_EXPORT (int64_t)
 mongoc_apm_command_succeeded_get_duration (const mongoc_apm_command_succeeded_t *event);
+
 MONGOC_EXPORT (const bson_t *)
 mongoc_apm_command_succeeded_get_reply (const mongoc_apm_command_succeeded_t *event);
+
 MONGOC_EXPORT (const char *)
 mongoc_apm_command_succeeded_get_command_name (const mongoc_apm_command_succeeded_t *event);
+
 MONGOC_EXPORT (const char *)
 mongoc_apm_command_succeeded_get_database_name (const mongoc_apm_command_succeeded_t *event);
+
 MONGOC_EXPORT (int64_t)
 mongoc_apm_command_succeeded_get_request_id (const mongoc_apm_command_succeeded_t *event);
+
 MONGOC_EXPORT (int64_t)
 mongoc_apm_command_succeeded_get_operation_id (const mongoc_apm_command_succeeded_t *event);
+
 MONGOC_EXPORT (const mongoc_host_list_t *)
 mongoc_apm_command_succeeded_get_host (const mongoc_apm_command_succeeded_t *event);
+
 MONGOC_EXPORT (uint32_t)
 mongoc_apm_command_succeeded_get_server_id (const mongoc_apm_command_succeeded_t *event);
+
 MONGOC_EXPORT (const bson_oid_t *)
 mongoc_apm_command_succeeded_get_service_id (const mongoc_apm_command_succeeded_t *event);
+
+BSON_DEPRECATED_FOR (mongoc_apm_command_succeeded_get_server_connection_id_int64)
 MONGOC_EXPORT (int32_t)
-mongoc_apm_command_succeeded_get_server_connection_id (const mongoc_apm_command_succeeded_t *event)
-   BSON_GNUC_DEPRECATED_FOR ("mongoc_apm_command_succeeded_get_server_connection_id_int64");
+   mongoc_apm_command_succeeded_get_server_connection_id (const mongoc_apm_command_succeeded_t *event);
+
 MONGOC_EXPORT (int64_t)
 mongoc_apm_command_succeeded_get_server_connection_id_int64 (const mongoc_apm_command_succeeded_t *event);
+
 MONGOC_EXPORT (void *)
 mongoc_apm_command_succeeded_get_context (const mongoc_apm_command_succeeded_t *event);
 
 /* command-failed event fields */
 
+
 MONGOC_EXPORT (int64_t)
 mongoc_apm_command_failed_get_duration (const mongoc_apm_command_failed_t *event);
+
 MONGOC_EXPORT (const char *)
 mongoc_apm_command_failed_get_command_name (const mongoc_apm_command_failed_t *event);
+
 MONGOC_EXPORT (const char *)
 mongoc_apm_command_failed_get_database_name (const mongoc_apm_command_failed_t *event);
 /* retrieve the error by filling out the passed-in "error" struct */
+
 MONGOC_EXPORT (void)
 mongoc_apm_command_failed_get_error (const mongoc_apm_command_failed_t *event, bson_error_t *error);
+
 MONGOC_EXPORT (const bson_t *)
 mongoc_apm_command_failed_get_reply (const mongoc_apm_command_failed_t *event);
+
 MONGOC_EXPORT (int64_t)
 mongoc_apm_command_failed_get_request_id (const mongoc_apm_command_failed_t *event);
+
 MONGOC_EXPORT (int64_t)
 mongoc_apm_command_failed_get_operation_id (const mongoc_apm_command_failed_t *event);
+
 MONGOC_EXPORT (const mongoc_host_list_t *)
 mongoc_apm_command_failed_get_host (const mongoc_apm_command_failed_t *event);
+
 MONGOC_EXPORT (uint32_t)
 mongoc_apm_command_failed_get_server_id (const mongoc_apm_command_failed_t *event);
+
 MONGOC_EXPORT (const bson_oid_t *)
 mongoc_apm_command_failed_get_service_id (const mongoc_apm_command_failed_t *event);
-MONGOC_EXPORT (int32_t)
-mongoc_apm_command_failed_get_server_connection_id (const mongoc_apm_command_failed_t *event)
-   BSON_GNUC_DEPRECATED_FOR ("mongoc_apm_command_failed_get_server_connection_id_int64");
+
+BSON_DEPRECATED_FOR (mongoc_apm_command_failed_get_server_connection_id_int64)
+MONGOC_EXPORT (int32_t) mongoc_apm_command_failed_get_server_connection_id (const mongoc_apm_command_failed_t *event);
+
 MONGOC_EXPORT (int64_t)
 mongoc_apm_command_failed_get_server_connection_id_int64 (const mongoc_apm_command_failed_t *event);
+
 MONGOC_EXPORT (void *)
 mongoc_apm_command_failed_get_context (const mongoc_apm_command_failed_t *event);
 
 /* server-changed event fields */
 
+
 MONGOC_EXPORT (const mongoc_host_list_t *)
 mongoc_apm_server_changed_get_host (const mongoc_apm_server_changed_t *event);
+
 MONGOC_EXPORT (void)
 mongoc_apm_server_changed_get_topology_id (const mongoc_apm_server_changed_t *event, bson_oid_t *topology_id);
+
 MONGOC_EXPORT (const mongoc_server_description_t *)
 mongoc_apm_server_changed_get_previous_description (const mongoc_apm_server_changed_t *event);
+
 MONGOC_EXPORT (const mongoc_server_description_t *)
 mongoc_apm_server_changed_get_new_description (const mongoc_apm_server_changed_t *event);
+
 MONGOC_EXPORT (void *)
 mongoc_apm_server_changed_get_context (const mongoc_apm_server_changed_t *event);
 
 /* server-opening event fields */
 
+
 MONGOC_EXPORT (const mongoc_host_list_t *)
 mongoc_apm_server_opening_get_host (const mongoc_apm_server_opening_t *event);
+
 MONGOC_EXPORT (void)
 mongoc_apm_server_opening_get_topology_id (const mongoc_apm_server_opening_t *event, bson_oid_t *topology_id);
+
 MONGOC_EXPORT (void *)
 mongoc_apm_server_opening_get_context (const mongoc_apm_server_opening_t *event);
 
 /* server-closed event fields */
 
+
 MONGOC_EXPORT (const mongoc_host_list_t *)
 mongoc_apm_server_closed_get_host (const mongoc_apm_server_closed_t *event);
+
 MONGOC_EXPORT (void)
 mongoc_apm_server_closed_get_topology_id (const mongoc_apm_server_closed_t *event, bson_oid_t *topology_id);
+
 MONGOC_EXPORT (void *)
 mongoc_apm_server_closed_get_context (const mongoc_apm_server_closed_t *event);
 
 /* topology-changed event fields */
 
+
 MONGOC_EXPORT (void)
 mongoc_apm_topology_changed_get_topology_id (const mongoc_apm_topology_changed_t *event, bson_oid_t *topology_id);
+
 MONGOC_EXPORT (const mongoc_topology_description_t *)
 mongoc_apm_topology_changed_get_previous_description (const mongoc_apm_topology_changed_t *event);
+
 MONGOC_EXPORT (const mongoc_topology_description_t *)
 mongoc_apm_topology_changed_get_new_description (const mongoc_apm_topology_changed_t *event);
+
 MONGOC_EXPORT (void *)
 mongoc_apm_topology_changed_get_context (const mongoc_apm_topology_changed_t *event);
 
 /* topology-opening event field */
 
+
 MONGOC_EXPORT (void)
 mongoc_apm_topology_opening_get_topology_id (const mongoc_apm_topology_opening_t *event, bson_oid_t *topology_id);
+
 MONGOC_EXPORT (void *)
 mongoc_apm_topology_opening_get_context (const mongoc_apm_topology_opening_t *event);
 
 /* topology-closed event field */
 
+
 MONGOC_EXPORT (void)
 mongoc_apm_topology_closed_get_topology_id (const mongoc_apm_topology_closed_t *event, bson_oid_t *topology_id);
+
 MONGOC_EXPORT (void *)
 mongoc_apm_topology_closed_get_context (const mongoc_apm_topology_closed_t *event);
 
 /* heartbeat-started event field */
 
+
 MONGOC_EXPORT (const mongoc_host_list_t *)
 mongoc_apm_server_heartbeat_started_get_host (const mongoc_apm_server_heartbeat_started_t *event);
+
 MONGOC_EXPORT (void *)
 mongoc_apm_server_heartbeat_started_get_context (const mongoc_apm_server_heartbeat_started_t *event);
+
 MONGOC_EXPORT (bool)
 mongoc_apm_server_heartbeat_started_get_awaited (const mongoc_apm_server_heartbeat_started_t *event);
 
 /* heartbeat-succeeded event fields */
 
+
 MONGOC_EXPORT (int64_t)
 mongoc_apm_server_heartbeat_succeeded_get_duration (const mongoc_apm_server_heartbeat_succeeded_t *event);
+
 MONGOC_EXPORT (const bson_t *)
 mongoc_apm_server_heartbeat_succeeded_get_reply (const mongoc_apm_server_heartbeat_succeeded_t *event);
+
 MONGOC_EXPORT (const mongoc_host_list_t *)
 mongoc_apm_server_heartbeat_succeeded_get_host (const mongoc_apm_server_heartbeat_succeeded_t *event);
+
 MONGOC_EXPORT (void *)
 mongoc_apm_server_heartbeat_succeeded_get_context (const mongoc_apm_server_heartbeat_succeeded_t *event);
+
 MONGOC_EXPORT (bool)
 mongoc_apm_server_heartbeat_succeeded_get_awaited (const mongoc_apm_server_heartbeat_succeeded_t *event);
 
 /* heartbeat-failed event fields */
 
+
 MONGOC_EXPORT (int64_t)
 mongoc_apm_server_heartbeat_failed_get_duration (const mongoc_apm_server_heartbeat_failed_t *event);
+
 MONGOC_EXPORT (void)
 mongoc_apm_server_heartbeat_failed_get_error (const mongoc_apm_server_heartbeat_failed_t *event, bson_error_t *error);
+
 MONGOC_EXPORT (const mongoc_host_list_t *)
 mongoc_apm_server_heartbeat_failed_get_host (const mongoc_apm_server_heartbeat_failed_t *event);
+
 MONGOC_EXPORT (void *)
 mongoc_apm_server_heartbeat_failed_get_context (const mongoc_apm_server_heartbeat_failed_t *event);
+
 MONGOC_EXPORT (bool)
 mongoc_apm_server_heartbeat_failed_get_awaited (const mongoc_apm_server_heartbeat_failed_t *event);
 
@@ -272,34 +338,48 @@ typedef void (*mongoc_apm_server_heartbeat_failed_cb_t) (const mongoc_apm_server
  * registering callbacks
  */
 
+
 MONGOC_EXPORT (mongoc_apm_callbacks_t *)
 mongoc_apm_callbacks_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (void)
 mongoc_apm_callbacks_destroy (mongoc_apm_callbacks_t *callbacks);
+
 MONGOC_EXPORT (void)
 mongoc_apm_set_command_started_cb (mongoc_apm_callbacks_t *callbacks, mongoc_apm_command_started_cb_t cb);
+
 MONGOC_EXPORT (void)
 mongoc_apm_set_command_succeeded_cb (mongoc_apm_callbacks_t *callbacks, mongoc_apm_command_succeeded_cb_t cb);
+
 MONGOC_EXPORT (void)
 mongoc_apm_set_command_failed_cb (mongoc_apm_callbacks_t *callbacks, mongoc_apm_command_failed_cb_t cb);
+
 MONGOC_EXPORT (void)
 mongoc_apm_set_server_changed_cb (mongoc_apm_callbacks_t *callbacks, mongoc_apm_server_changed_cb_t cb);
+
 MONGOC_EXPORT (void)
 mongoc_apm_set_server_opening_cb (mongoc_apm_callbacks_t *callbacks, mongoc_apm_server_opening_cb_t cb);
+
 MONGOC_EXPORT (void)
 mongoc_apm_set_server_closed_cb (mongoc_apm_callbacks_t *callbacks, mongoc_apm_server_closed_cb_t cb);
+
 MONGOC_EXPORT (void)
 mongoc_apm_set_topology_changed_cb (mongoc_apm_callbacks_t *callbacks, mongoc_apm_topology_changed_cb_t cb);
+
 MONGOC_EXPORT (void)
 mongoc_apm_set_topology_opening_cb (mongoc_apm_callbacks_t *callbacks, mongoc_apm_topology_opening_cb_t cb);
+
 MONGOC_EXPORT (void)
 mongoc_apm_set_topology_closed_cb (mongoc_apm_callbacks_t *callbacks, mongoc_apm_topology_closed_cb_t cb);
+
 MONGOC_EXPORT (void)
 mongoc_apm_set_server_heartbeat_started_cb (mongoc_apm_callbacks_t *callbacks,
                                             mongoc_apm_server_heartbeat_started_cb_t cb);
+
 MONGOC_EXPORT (void)
 mongoc_apm_set_server_heartbeat_succeeded_cb (mongoc_apm_callbacks_t *callbacks,
                                               mongoc_apm_server_heartbeat_succeeded_cb_t cb);
+
 MONGOC_EXPORT (void)
 mongoc_apm_set_server_heartbeat_failed_cb (mongoc_apm_callbacks_t *callbacks,
                                            mongoc_apm_server_heartbeat_failed_cb_t cb);

--- a/src/libmongoc/src/mongoc/mongoc-bulk-operation.h
+++ b/src/libmongoc/src/mongoc/mongoc-bulk-operation.h
@@ -43,72 +43,88 @@ typedef struct _mongoc_bulk_write_flags_t mongoc_bulk_write_flags_t;
 
 MONGOC_EXPORT (void)
 mongoc_bulk_operation_destroy (mongoc_bulk_operation_t *bulk);
+
 MONGOC_EXPORT (uint32_t)
 mongoc_bulk_operation_execute (mongoc_bulk_operation_t *bulk, bson_t *reply, bson_error_t *error);
-MONGOC_EXPORT (void)
-mongoc_bulk_operation_delete (mongoc_bulk_operation_t *bulk, const bson_t *selector)
-   BSON_GNUC_DEPRECATED_FOR (mongoc_bulk_operation_remove);
-MONGOC_EXPORT (void)
-mongoc_bulk_operation_delete_one (mongoc_bulk_operation_t *bulk, const bson_t *selector)
-   BSON_GNUC_DEPRECATED_FOR (mongoc_bulk_operation_remove_one);
+
+BSON_DEPRECATED_FOR (mongoc_bulk_operation_remove)
+MONGOC_EXPORT (void) mongoc_bulk_operation_delete (mongoc_bulk_operation_t *bulk, const bson_t *selector);
+
+BSON_DEPRECATED_FOR (mongoc_bulk_operation_remove_one)
+MONGOC_EXPORT (void) mongoc_bulk_operation_delete_one (mongoc_bulk_operation_t *bulk, const bson_t *selector);
+
 MONGOC_EXPORT (void)
 mongoc_bulk_operation_insert (mongoc_bulk_operation_t *bulk, const bson_t *document);
+
 MONGOC_EXPORT (bool)
 mongoc_bulk_operation_insert_with_opts (mongoc_bulk_operation_t *bulk,
                                         const bson_t *document,
                                         const bson_t *opts,
                                         bson_error_t *error); /* OUT */
+
 MONGOC_EXPORT (void)
 mongoc_bulk_operation_remove (mongoc_bulk_operation_t *bulk, const bson_t *selector);
+
 MONGOC_EXPORT (bool)
 mongoc_bulk_operation_remove_many_with_opts (mongoc_bulk_operation_t *bulk,
                                              const bson_t *selector,
                                              const bson_t *opts,
                                              bson_error_t *error); /* OUT */
+
 MONGOC_EXPORT (void)
 mongoc_bulk_operation_remove_one (mongoc_bulk_operation_t *bulk, const bson_t *selector);
+
 MONGOC_EXPORT (bool)
 mongoc_bulk_operation_remove_one_with_opts (mongoc_bulk_operation_t *bulk,
                                             const bson_t *selector,
                                             const bson_t *opts,
                                             bson_error_t *error); /* OUT */
+
 MONGOC_EXPORT (void)
 mongoc_bulk_operation_replace_one (mongoc_bulk_operation_t *bulk,
                                    const bson_t *selector,
                                    const bson_t *document,
                                    bool upsert);
+
 MONGOC_EXPORT (bool)
 mongoc_bulk_operation_replace_one_with_opts (mongoc_bulk_operation_t *bulk,
                                              const bson_t *selector,
                                              const bson_t *document,
                                              const bson_t *opts,
                                              bson_error_t *error); /* OUT */
+
 MONGOC_EXPORT (void)
 mongoc_bulk_operation_update (mongoc_bulk_operation_t *bulk,
                               const bson_t *selector,
                               const bson_t *document,
                               bool upsert);
+
 MONGOC_EXPORT (bool)
 mongoc_bulk_operation_update_many_with_opts (mongoc_bulk_operation_t *bulk,
                                              const bson_t *selector,
                                              const bson_t *document,
                                              const bson_t *opts,
                                              bson_error_t *error); /* OUT */
+
 MONGOC_EXPORT (void)
 mongoc_bulk_operation_update_one (mongoc_bulk_operation_t *bulk,
                                   const bson_t *selector,
                                   const bson_t *document,
                                   bool upsert);
+
 MONGOC_EXPORT (bool)
 mongoc_bulk_operation_update_one_with_opts (mongoc_bulk_operation_t *bulk,
                                             const bson_t *selector,
                                             const bson_t *document,
                                             const bson_t *opts,
                                             bson_error_t *error); /* OUT */
+
 MONGOC_EXPORT (void)
 mongoc_bulk_operation_set_bypass_document_validation (mongoc_bulk_operation_t *bulk, bool bypass);
+
 MONGOC_EXPORT (void)
 mongoc_bulk_operation_set_comment (mongoc_bulk_operation_t *bulk, const bson_value_t *comment);
+
 MONGOC_EXPORT (void)
 mongoc_bulk_operation_set_let (mongoc_bulk_operation_t *bulk, const bson_t *let);
 
@@ -118,33 +134,43 @@ mongoc_bulk_operation_set_let (mongoc_bulk_operation_t *bulk, const bson_t *let)
  * those wanting to replay a bulk operation to a number of clients or
  * collections.
  */
+
 MONGOC_EXPORT (mongoc_bulk_operation_t *)
 mongoc_bulk_operation_new (bool ordered) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (void)
 mongoc_bulk_operation_set_write_concern (mongoc_bulk_operation_t *bulk, const mongoc_write_concern_t *write_concern);
+
 MONGOC_EXPORT (void)
 mongoc_bulk_operation_set_database (mongoc_bulk_operation_t *bulk, const char *database);
+
 MONGOC_EXPORT (void)
 mongoc_bulk_operation_set_collection (mongoc_bulk_operation_t *bulk, const char *collection);
+
 MONGOC_EXPORT (void)
 mongoc_bulk_operation_set_client (mongoc_bulk_operation_t *bulk, void *client);
+
 MONGOC_EXPORT (void)
 mongoc_bulk_operation_set_client_session (mongoc_bulk_operation_t *bulk,
                                           struct _mongoc_client_session_t *client_session);
 // `mongoc_bulk_operation_set_hint` is deprecated for the more aptly named `mongoc_bulk_operation_set_server_id`.
-MONGOC_EXPORT (void)
-mongoc_bulk_operation_set_hint (mongoc_bulk_operation_t *bulk, uint32_t server_id)
-   BSON_GNUC_DEPRECATED_FOR (mongoc_bulk_operation_set_server_id);
+
+BSON_DEPRECATED_FOR (mongoc_bulk_operation_set_server_id)
+MONGOC_EXPORT (void) mongoc_bulk_operation_set_hint (mongoc_bulk_operation_t *bulk, uint32_t server_id);
+
 MONGOC_EXPORT (void)
 mongoc_bulk_operation_set_server_id (mongoc_bulk_operation_t *bulk, uint32_t server_id);
 // `mongoc_bulk_operation_get_hint` is deprecated for the more aptly named `mongoc_bulk_operation_get_server_id`.
-MONGOC_EXPORT (uint32_t)
-mongoc_bulk_operation_get_hint (const mongoc_bulk_operation_t *bulk)
-   BSON_GNUC_DEPRECATED_FOR (mongoc_bulk_operation_get_server_id);
+
+BSON_DEPRECATED_FOR (mongoc_bulk_operation_get_server_id)
+MONGOC_EXPORT (uint32_t) mongoc_bulk_operation_get_hint (const mongoc_bulk_operation_t *bulk);
+
 MONGOC_EXPORT (uint32_t)
 mongoc_bulk_operation_get_server_id (const mongoc_bulk_operation_t *bulk);
+
 MONGOC_EXPORT (const mongoc_write_concern_t *)
 mongoc_bulk_operation_get_write_concern (const mongoc_bulk_operation_t *bulk);
+
 BSON_END_DECLS
 
 

--- a/src/libmongoc/src/mongoc/mongoc-client-pool.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-pool.h
@@ -40,36 +40,50 @@ typedef struct _mongoc_client_pool_t mongoc_client_pool_t;
 
 MONGOC_EXPORT (mongoc_client_pool_t *)
 mongoc_client_pool_new (const mongoc_uri_t *uri) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (mongoc_client_pool_t *)
 mongoc_client_pool_new_with_error (const mongoc_uri_t *uri, bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (void)
 mongoc_client_pool_destroy (mongoc_client_pool_t *pool);
+
 MONGOC_EXPORT (mongoc_client_t *)
 mongoc_client_pool_pop (mongoc_client_pool_t *pool) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (void)
 mongoc_client_pool_push (mongoc_client_pool_t *pool, mongoc_client_t *client);
+
 MONGOC_EXPORT (mongoc_client_t *)
 mongoc_client_pool_try_pop (mongoc_client_pool_t *pool) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (void)
 mongoc_client_pool_max_size (mongoc_client_pool_t *pool, uint32_t max_pool_size);
-MONGOC_EXPORT (void)
-mongoc_client_pool_min_size (mongoc_client_pool_t *pool, uint32_t min_pool_size) BSON_GNUC_DEPRECATED;
+
+BSON_DEPRECATED ("Setting min_pool_size on an existing client pool is deprecated")
+MONGOC_EXPORT (void) mongoc_client_pool_min_size (mongoc_client_pool_t *pool, uint32_t min_pool_size);
+
 #ifdef MONGOC_ENABLE_SSL
 MONGOC_EXPORT (void)
 mongoc_client_pool_set_ssl_opts (mongoc_client_pool_t *pool, const mongoc_ssl_opt_t *opts);
 #endif
+
 MONGOC_EXPORT (bool)
 mongoc_client_pool_set_apm_callbacks (mongoc_client_pool_t *pool, mongoc_apm_callbacks_t *callbacks, void *context);
+
 MONGOC_EXPORT (bool)
 mongoc_client_pool_set_error_api (mongoc_client_pool_t *pool, int32_t version);
+
 MONGOC_EXPORT (bool)
 mongoc_client_pool_set_appname (mongoc_client_pool_t *pool, const char *appname);
+
 MONGOC_EXPORT (bool)
 mongoc_client_pool_enable_auto_encryption (mongoc_client_pool_t *pool,
                                            mongoc_auto_encryption_opts_t *opts,
                                            bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_client_pool_set_server_api (mongoc_client_pool_t *pool, const mongoc_server_api_t *api, bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_client_pool_set_structured_log_opts (mongoc_client_pool_t *pool, const mongoc_structured_log_opts_t *opts);
 

--- a/src/libmongoc/src/mongoc/mongoc-client-pool.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-pool.h
@@ -59,7 +59,7 @@ mongoc_client_pool_try_pop (mongoc_client_pool_t *pool) BSON_GNUC_WARN_UNUSED_RE
 MONGOC_EXPORT (void)
 mongoc_client_pool_max_size (mongoc_client_pool_t *pool, uint32_t max_pool_size);
 
-BSON_DEPRECATED ("Setting min_pool_size on an existing client pool is deprecated")
+BSON_DEPRECATED ("Setting min_pool_size on a client pool is deprecated")
 MONGOC_EXPORT (void) mongoc_client_pool_min_size (mongoc_client_pool_t *pool, uint32_t min_pool_size);
 
 #ifdef MONGOC_ENABLE_SSL

--- a/src/libmongoc/src/mongoc/mongoc-client.h
+++ b/src/libmongoc/src/mongoc/mongoc-client.h
@@ -225,7 +225,7 @@ MONGOC_EXPORT (mongoc_cursor_t *) mongoc_client_find_databases (mongoc_client_t 
 MONGOC_EXPORT (mongoc_cursor_t *)
 mongoc_client_find_databases_with_opts (mongoc_client_t *client, const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
 
-BSON_DEPRECATED ("Getting the server status does not work with a mongoc_client_session_t, so this function is "
+BSON_DEPRECATED ("This function does not work with a mongoc_client_session_t, so this function is "
                  "deprecated. Prefer to execute a command directly with mongoc_client_read_command_with_opts")
 MONGOC_EXPORT (bool) mongoc_client_get_server_status (mongoc_client_t *client,
                                                       mongoc_read_prefs_t *read_prefs,

--- a/src/libmongoc/src/mongoc/mongoc-client.h
+++ b/src/libmongoc/src/mongoc/mongoc-client.h
@@ -104,29 +104,39 @@ typedef mongoc_stream_t *(*mongoc_stream_initiator_t) (const mongoc_uri_t *uri,
 
 MONGOC_EXPORT (mongoc_client_t *)
 mongoc_client_new (const char *uri_string) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (mongoc_client_t *)
 mongoc_client_new_from_uri (const mongoc_uri_t *uri) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (mongoc_client_t *)
 mongoc_client_new_from_uri_with_error (const mongoc_uri_t *uri, bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (void)
 mongoc_client_set_sockettimeoutms (mongoc_client_t *client, int32_t timeoutms);
+
 MONGOC_EXPORT (const mongoc_uri_t *)
 mongoc_client_get_uri (const mongoc_client_t *client);
+
 MONGOC_EXPORT (void)
 mongoc_client_set_stream_initiator (mongoc_client_t *client, mongoc_stream_initiator_t initiator, void *user_data);
-MONGOC_EXPORT (mongoc_cursor_t *)
-mongoc_client_command (mongoc_client_t *client,
-                       const char *db_name,
-                       mongoc_query_flags_t flags,
-                       uint32_t skip,
-                       uint32_t limit,
-                       uint32_t batch_size,
-                       const bson_t *query,
-                       const bson_t *fields,
-                       const mongoc_read_prefs_t *read_prefs) BSON_GNUC_WARN_UNUSED_RESULT
-   BSON_GNUC_DEPRECATED_FOR (mongoc_client_command_simple);
-MONGOC_EXPORT (void)
-mongoc_client_kill_cursor (mongoc_client_t *client, int64_t cursor_id) BSON_GNUC_DEPRECATED;
+
+BSON_DEPRECATED_FOR (mongoc_client_command_simple)
+MONGOC_EXPORT (mongoc_cursor_t *) mongoc_client_command (mongoc_client_t *client,
+                                                         const char *db_name,
+                                                         mongoc_query_flags_t flags,
+                                                         uint32_t skip,
+                                                         uint32_t limit,
+                                                         uint32_t batch_size,
+                                                         const bson_t *query,
+                                                         const bson_t *fields,
+                                                         const mongoc_read_prefs_t *read_prefs)
+   BSON_GNUC_WARN_UNUSED_RESULT;
+
+
+BSON_DEPRECATED ("mongoc_client_kill_cursor is deprecated")
+MONGOC_EXPORT (void) mongoc_client_kill_cursor (mongoc_client_t *client, int64_t cursor_id);
+
+
 MONGOC_EXPORT (bool)
 mongoc_client_command_simple (mongoc_client_t *client,
                               const char *db_name,
@@ -134,6 +144,7 @@ mongoc_client_command_simple (mongoc_client_t *client,
                               const mongoc_read_prefs_t *read_prefs,
                               bson_t *reply,
                               bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_client_read_command_with_opts (mongoc_client_t *client,
                                       const char *db_name,
@@ -142,6 +153,7 @@ mongoc_client_read_command_with_opts (mongoc_client_t *client,
                                       const bson_t *opts,
                                       bson_t *reply,
                                       bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_client_write_command_with_opts (mongoc_client_t *client,
                                        const char *db_name,
@@ -149,6 +161,7 @@ mongoc_client_write_command_with_opts (mongoc_client_t *client,
                                        const bson_t *opts,
                                        bson_t *reply,
                                        bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_client_read_write_command_with_opts (mongoc_client_t *client,
                                             const char *db_name,
@@ -157,6 +170,7 @@ mongoc_client_read_write_command_with_opts (mongoc_client_t *client,
                                             const bson_t *opts,
                                             bson_t *reply,
                                             bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_client_command_with_opts (mongoc_client_t *client,
                                  const char *db_name,
@@ -165,6 +179,7 @@ mongoc_client_command_with_opts (mongoc_client_t *client,
                                  const bson_t *opts,
                                  bson_t *reply,
                                  bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_client_command_simple_with_server_id (mongoc_client_t *client,
                                              const char *db_name,
@@ -173,81 +188,109 @@ mongoc_client_command_simple_with_server_id (mongoc_client_t *client,
                                              uint32_t server_id,
                                              bson_t *reply,
                                              bson_error_t *error);
+
 MONGOC_EXPORT (void)
 mongoc_client_destroy (mongoc_client_t *client);
+
 MONGOC_EXPORT (mongoc_client_session_t *)
-mongoc_client_start_session (mongoc_client_t *client,
-                             const mongoc_session_opt_t *opts,
-                             bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT;
+mongoc_client_start_session (mongoc_client_t *client, const mongoc_session_opt_t *opts, bson_error_t *error)
+   BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (mongoc_database_t *)
 mongoc_client_get_database (mongoc_client_t *client, const char *name) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (mongoc_database_t *)
 mongoc_client_get_default_database (mongoc_client_t *client) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (mongoc_gridfs_t *)
 mongoc_client_get_gridfs (mongoc_client_t *client, const char *db, const char *prefix, bson_error_t *error)
    BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (mongoc_collection_t *)
-mongoc_client_get_collection (mongoc_client_t *client,
-                              const char *db,
-                              const char *collection) BSON_GNUC_WARN_UNUSED_RESULT;
+mongoc_client_get_collection (mongoc_client_t *client, const char *db, const char *collection)
+   BSON_GNUC_WARN_UNUSED_RESULT;
+
+BSON_DEPRECATED_FOR (mongoc_client_get_database_names_with_opts)
+MONGOC_EXPORT (char **) mongoc_client_get_database_names (mongoc_client_t *client, bson_error_t *error)
+   BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (char **)
-mongoc_client_get_database_names (mongoc_client_t *client, bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT
-   BSON_GNUC_DEPRECATED_FOR (mongoc_client_get_database_names_with_opts);
-MONGOC_EXPORT (char **)
-mongoc_client_get_database_names_with_opts (mongoc_client_t *client,
-                                            const bson_t *opts,
-                                            bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT;
-MONGOC_EXPORT (mongoc_cursor_t *)
-mongoc_client_find_databases (mongoc_client_t *client, bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT
-   BSON_GNUC_DEPRECATED_FOR (mongoc_client_find_databases_with_opts);
+mongoc_client_get_database_names_with_opts (mongoc_client_t *client, const bson_t *opts, bson_error_t *error)
+   BSON_GNUC_WARN_UNUSED_RESULT;
+
+BSON_DEPRECATED_FOR (mongoc_client_find_databases_with_opts)
+MONGOC_EXPORT (mongoc_cursor_t *) mongoc_client_find_databases (mongoc_client_t *client, bson_error_t *error)
+   BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (mongoc_cursor_t *)
 mongoc_client_find_databases_with_opts (mongoc_client_t *client, const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
-MONGOC_EXPORT (bool)
-mongoc_client_get_server_status (mongoc_client_t *client,
-                                 mongoc_read_prefs_t *read_prefs,
-                                 bson_t *reply,
-                                 bson_error_t *error) BSON_GNUC_DEPRECATED;
-MONGOC_EXPORT (int32_t)
-mongoc_client_get_max_message_size (mongoc_client_t *client) BSON_GNUC_DEPRECATED;
-MONGOC_EXPORT (int32_t)
-mongoc_client_get_max_bson_size (mongoc_client_t *client) BSON_GNUC_DEPRECATED;
+
+BSON_DEPRECATED ("Getting the server status does not work with a mongoc_client_session_t, so this function is "
+                 "deprecated. Prefer to execute a command directly with mongoc_client_read_command_with_opts")
+MONGOC_EXPORT (bool) mongoc_client_get_server_status (mongoc_client_t *client,
+                                                      mongoc_read_prefs_t *read_prefs,
+                                                      bson_t *reply,
+                                                      bson_error_t *error);
+
+BSON_DEPRECATED ("Use of this function is deprecated")
+MONGOC_EXPORT (int32_t) mongoc_client_get_max_message_size (mongoc_client_t *client);
+
+BSON_DEPRECATED ("Use of this function is deprecated")
+MONGOC_EXPORT (int32_t) mongoc_client_get_max_bson_size (mongoc_client_t *client);
+
 MONGOC_EXPORT (const mongoc_write_concern_t *)
 mongoc_client_get_write_concern (const mongoc_client_t *client);
+
 MONGOC_EXPORT (void)
 mongoc_client_set_write_concern (mongoc_client_t *client, const mongoc_write_concern_t *write_concern);
+
 MONGOC_EXPORT (const mongoc_read_concern_t *)
 mongoc_client_get_read_concern (const mongoc_client_t *client);
+
 MONGOC_EXPORT (void)
 mongoc_client_set_read_concern (mongoc_client_t *client, const mongoc_read_concern_t *read_concern);
+
 MONGOC_EXPORT (const mongoc_read_prefs_t *)
 mongoc_client_get_read_prefs (const mongoc_client_t *client);
+
 MONGOC_EXPORT (void)
 mongoc_client_set_read_prefs (mongoc_client_t *client, const mongoc_read_prefs_t *read_prefs);
 #ifdef MONGOC_ENABLE_SSL
+
 MONGOC_EXPORT (void)
 mongoc_client_set_ssl_opts (mongoc_client_t *client, const mongoc_ssl_opt_t *opts);
 #endif
+
 MONGOC_EXPORT (bool)
 mongoc_client_set_apm_callbacks (mongoc_client_t *client, mongoc_apm_callbacks_t *callbacks, void *context);
+
 MONGOC_EXPORT (bool)
 mongoc_client_set_structured_log_opts (mongoc_client_t *client, const mongoc_structured_log_opts_t *opts);
+
 MONGOC_EXPORT (mongoc_server_description_t *)
 mongoc_client_get_server_description (mongoc_client_t *client, uint32_t server_id) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (mongoc_server_description_t **)
 mongoc_client_get_server_descriptions (const mongoc_client_t *client, size_t *n) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (void)
 mongoc_server_descriptions_destroy_all (mongoc_server_description_t **sds, size_t n);
+
 MONGOC_EXPORT (mongoc_server_description_t *)
 mongoc_client_select_server (mongoc_client_t *client,
                              bool for_writes,
                              const mongoc_read_prefs_t *prefs,
                              bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (bool)
 mongoc_client_set_error_api (mongoc_client_t *client, int32_t version);
+
 MONGOC_EXPORT (bool)
 mongoc_client_set_appname (mongoc_client_t *client, const char *appname);
+
 MONGOC_EXPORT (mongoc_change_stream_t *)
 mongoc_client_watch (mongoc_client_t *client, const bson_t *pipeline, const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (void)
 mongoc_client_reset (mongoc_client_t *client);
 

--- a/src/libmongoc/src/mongoc/mongoc-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-cmd.c
@@ -15,6 +15,7 @@
  */
 
 
+#include <mlib/config.h>
 #include <mongoc/mongoc-cmd-private.h>
 #include <mongoc/mongoc-read-prefs-private.h>
 #include <mongoc/mongoc-trace-private.h>
@@ -375,7 +376,10 @@ _mongoc_cmd_parts_assemble_mongos (mongoc_cmd_parts_t *parts, const mongoc_serve
       max_staleness_seconds = mongoc_read_prefs_get_max_staleness_seconds (parts->read_prefs);
 
       tags = mongoc_read_prefs_get_tags (parts->read_prefs);
+      mlib_diagnostic_push ();
+      mlib_disable_deprecation_warnings ();
       hedge = mongoc_read_prefs_get_hedge (parts->read_prefs);
+      mlib_diagnostic_pop ();
    }
 
    if (server_stream->must_use_primary) {

--- a/src/libmongoc/src/mongoc/mongoc-collection.h
+++ b/src/libmongoc/src/mongoc/mongoc-collection.h
@@ -37,26 +37,31 @@ BSON_BEGIN_DECLS
 
 typedef struct _mongoc_collection_t mongoc_collection_t;
 
+
 MONGOC_EXPORT (mongoc_cursor_t *)
 mongoc_collection_aggregate (mongoc_collection_t *collection,
                              mongoc_query_flags_t flags,
                              const bson_t *pipeline,
                              const bson_t *opts,
                              const mongoc_read_prefs_t *read_prefs) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (void)
 mongoc_collection_destroy (mongoc_collection_t *collection);
+
 MONGOC_EXPORT (mongoc_collection_t *)
 mongoc_collection_copy (mongoc_collection_t *collection) BSON_GNUC_WARN_UNUSED_RESULT;
-MONGOC_EXPORT (mongoc_cursor_t *)
-mongoc_collection_command (mongoc_collection_t *collection,
-                           mongoc_query_flags_t flags,
-                           uint32_t skip,
-                           uint32_t limit,
-                           uint32_t batch_size,
-                           const bson_t *command,
-                           const bson_t *fields,
-                           const mongoc_read_prefs_t *read_prefs) BSON_GNUC_WARN_UNUSED_RESULT
-   BSON_GNUC_DEPRECATED_FOR (mongoc_collection_command_simple);
+
+BSON_DEPRECATED_FOR (mongoc_collection_command_simple)
+MONGOC_EXPORT (mongoc_cursor_t *) mongoc_collection_command (mongoc_collection_t *collection,
+                                                             mongoc_query_flags_t flags,
+                                                             uint32_t skip,
+                                                             uint32_t limit,
+                                                             uint32_t batch_size,
+                                                             const bson_t *command,
+                                                             const bson_t *fields,
+                                                             const mongoc_read_prefs_t *read_prefs)
+   BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (bool)
 mongoc_collection_read_command_with_opts (mongoc_collection_t *collection,
                                           const bson_t *command,
@@ -64,9 +69,11 @@ mongoc_collection_read_command_with_opts (mongoc_collection_t *collection,
                                           const bson_t *opts,
                                           bson_t *reply,
                                           bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_collection_write_command_with_opts (
    mongoc_collection_t *collection, const bson_t *command, const bson_t *opts, bson_t *reply, bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_collection_read_write_command_with_opts (mongoc_collection_t *collection,
                                                 const bson_t *command,
@@ -74,6 +81,7 @@ mongoc_collection_read_write_command_with_opts (mongoc_collection_t *collection,
                                                 const bson_t *opts,
                                                 bson_t *reply,
                                                 bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_collection_command_with_opts (mongoc_collection_t *collection,
                                      const bson_t *command,
@@ -81,65 +89,76 @@ mongoc_collection_command_with_opts (mongoc_collection_t *collection,
                                      const bson_t *opts,
                                      bson_t *reply,
                                      bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_collection_command_simple (mongoc_collection_t *collection,
                                   const bson_t *command,
                                   const mongoc_read_prefs_t *read_prefs,
                                   bson_t *reply,
                                   bson_error_t *error);
-MONGOC_EXPORT (int64_t)
-mongoc_collection_count (mongoc_collection_t *collection,
-                         mongoc_query_flags_t flags,
-                         const bson_t *query,
-                         int64_t skip,
-                         int64_t limit,
-                         const mongoc_read_prefs_t *read_prefs,
-                         bson_error_t *error)
-   BSON_GNUC_DEPRECATED_FOR (mongoc_collection_count_documents or mongoc_collection_estimated_document_count);
-MONGOC_EXPORT (int64_t)
-mongoc_collection_count_with_opts (mongoc_collection_t *collection,
-                                   mongoc_query_flags_t flags,
-                                   const bson_t *query,
-                                   int64_t skip,
-                                   int64_t limit,
-                                   const bson_t *opts,
-                                   const mongoc_read_prefs_t *read_prefs,
-                                   bson_error_t *error)
-   BSON_GNUC_DEPRECATED_FOR (mongoc_collection_count_documents or mongoc_collection_estimated_document_count);
+
+BSON_DEPRECATED_FOR (mongoc_collection_count_documents or mongoc_collection_estimated_document_count)
+MONGOC_EXPORT (int64_t) mongoc_collection_count (mongoc_collection_t *collection,
+                                                 mongoc_query_flags_t flags,
+                                                 const bson_t *query,
+                                                 int64_t skip,
+                                                 int64_t limit,
+                                                 const mongoc_read_prefs_t *read_prefs,
+                                                 bson_error_t *error);
+
+BSON_DEPRECATED_FOR (mongoc_collection_count_documents or mongoc_collection_estimated_document_count)
+MONGOC_EXPORT (int64_t) mongoc_collection_count_with_opts (mongoc_collection_t *collection,
+                                                           mongoc_query_flags_t flags,
+                                                           const bson_t *query,
+                                                           int64_t skip,
+                                                           int64_t limit,
+                                                           const bson_t *opts,
+                                                           const mongoc_read_prefs_t *read_prefs,
+                                                           bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_collection_drop (mongoc_collection_t *collection, bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_collection_drop_with_opts (mongoc_collection_t *collection, const bson_t *opts, bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_collection_drop_index (mongoc_collection_t *collection, const char *index_name, bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_collection_drop_index_with_opts (mongoc_collection_t *collection,
                                         const char *index_name,
                                         const bson_t *opts,
                                         bson_error_t *error);
-MONGOC_EXPORT (bool)
-mongoc_collection_create_index (mongoc_collection_t *collection,
-                                const bson_t *keys,
-                                const mongoc_index_opt_t *opt,
-                                bson_error_t *error) BSON_GNUC_DEPRECATED;
-MONGOC_EXPORT (bool)
-mongoc_collection_create_index_with_opts (mongoc_collection_t *collection,
-                                          const bson_t *keys,
-                                          const mongoc_index_opt_t *opt,
-                                          const bson_t *opts,
-                                          bson_t *reply,
-                                          bson_error_t *error) BSON_GNUC_DEPRECATED;
-MONGOC_EXPORT (bool)
-mongoc_collection_ensure_index (mongoc_collection_t *collection,
-                                const bson_t *keys,
-                                const mongoc_index_opt_t *opt,
-                                bson_error_t *error) BSON_GNUC_DEPRECATED;
+
+BSON_DEPRECATED_FOR (mongoc_collection_create_indexes_with_opts)
+MONGOC_EXPORT (bool) mongoc_collection_create_index (mongoc_collection_t *collection,
+                                                     const bson_t *keys,
+                                                     const mongoc_index_opt_t *opt,
+                                                     bson_error_t *error);
+
+BSON_DEPRECATED_FOR (mongoc_collection_create_indexes_with_opts)
+MONGOC_EXPORT (bool) mongoc_collection_create_index_with_opts (mongoc_collection_t *collection,
+                                                               const bson_t *keys,
+                                                               const mongoc_index_opt_t *opt,
+                                                               const bson_t *opts,
+                                                               bson_t *reply,
+                                                               bson_error_t *error);
+
+BSON_DEPRECATED_FOR (mongoc_collection_create_indexes_with_opts)
+MONGOC_EXPORT (bool) mongoc_collection_ensure_index (mongoc_collection_t *collection,
+                                                     const bson_t *keys,
+                                                     const mongoc_index_opt_t *opt,
+                                                     bson_error_t *error);
+
+BSON_DEPRECATED_FOR (mongoc_collection_find_indexes_with_opts)
+MONGOC_EXPORT (mongoc_cursor_t *) mongoc_collection_find_indexes (mongoc_collection_t *collection, bson_error_t *error)
+   BSON_GNUC_WARN_UNUSED_RESULT;
+
+
 MONGOC_EXPORT (mongoc_cursor_t *)
-mongoc_collection_find_indexes (mongoc_collection_t *collection, bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT
-   BSON_GNUC_DEPRECATED_FOR (mongoc_collection_find_indexes_with_opts);
-MONGOC_EXPORT (mongoc_cursor_t *)
-mongoc_collection_find_indexes_with_opts (mongoc_collection_t *collection,
-                                          const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
+mongoc_collection_find_indexes_with_opts (mongoc_collection_t *collection, const bson_t *opts)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 
 typedef struct _mongoc_index_model_t mongoc_index_model_t;
 
@@ -156,31 +175,34 @@ mongoc_collection_create_indexes_with_opts (mongoc_collection_t *collection,
                                             bson_t *reply,
                                             bson_error_t *error);
 
+BSON_DEPRECATED_FOR (mongoc_collection_find_with_opts)
+MONGOC_EXPORT (mongoc_cursor_t *) mongoc_collection_find (mongoc_collection_t *collection,
+                                                          mongoc_query_flags_t flags,
+                                                          uint32_t skip,
+                                                          uint32_t limit,
+                                                          uint32_t batch_size,
+                                                          const bson_t *query,
+                                                          const bson_t *fields,
+                                                          const mongoc_read_prefs_t *read_prefs)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 
-MONGOC_EXPORT (mongoc_cursor_t *)
-mongoc_collection_find (mongoc_collection_t *collection,
-                        mongoc_query_flags_t flags,
-                        uint32_t skip,
-                        uint32_t limit,
-                        uint32_t batch_size,
-                        const bson_t *query,
-                        const bson_t *fields,
-                        const mongoc_read_prefs_t *read_prefs)
-   BSON_GNUC_DEPRECATED_FOR (mongoc_collection_find_with_opts) BSON_GNUC_WARN_UNUSED_RESULT;
 MONGOC_EXPORT (mongoc_cursor_t *)
 mongoc_collection_find_with_opts (mongoc_collection_t *collection,
                                   const bson_t *filter,
                                   const bson_t *opts,
                                   const mongoc_read_prefs_t *read_prefs) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (bool)
 mongoc_collection_insert (mongoc_collection_t *collection,
                           mongoc_insert_flags_t flags,
                           const bson_t *document,
                           const mongoc_write_concern_t *write_concern,
                           bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_collection_insert_one (
    mongoc_collection_t *collection, const bson_t *document, const bson_t *opts, bson_t *reply, bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_collection_insert_many (mongoc_collection_t *collection,
                                const bson_t **documents,
@@ -188,13 +210,15 @@ mongoc_collection_insert_many (mongoc_collection_t *collection,
                                const bson_t *opts,
                                bson_t *reply,
                                bson_error_t *error);
-MONGOC_EXPORT (bool)
-mongoc_collection_insert_bulk (mongoc_collection_t *collection,
-                               mongoc_insert_flags_t flags,
-                               const bson_t **documents,
-                               uint32_t n_documents,
-                               const mongoc_write_concern_t *write_concern,
-                               bson_error_t *error) BSON_GNUC_DEPRECATED_FOR (mongoc_collection_insert_many);
+
+BSON_DEPRECATED_FOR (mongoc_collection_insert_many)
+MONGOC_EXPORT (bool) mongoc_collection_insert_bulk (mongoc_collection_t *collection,
+                                                    mongoc_insert_flags_t flags,
+                                                    const bson_t **documents,
+                                                    uint32_t n_documents,
+                                                    const mongoc_write_concern_t *write_concern,
+                                                    bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_collection_update (mongoc_collection_t *collection,
                           mongoc_update_flags_t flags,
@@ -202,6 +226,7 @@ mongoc_collection_update (mongoc_collection_t *collection,
                           const bson_t *update,
                           const mongoc_write_concern_t *write_concern,
                           bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_collection_update_one (mongoc_collection_t *collection,
                               const bson_t *selector,
@@ -209,6 +234,7 @@ mongoc_collection_update_one (mongoc_collection_t *collection,
                               const bson_t *opts,
                               bson_t *reply,
                               bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_collection_update_many (mongoc_collection_t *collection,
                                const bson_t *selector,
@@ -216,6 +242,7 @@ mongoc_collection_update_many (mongoc_collection_t *collection,
                                const bson_t *opts,
                                bson_t *reply,
                                bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_collection_replace_one (mongoc_collection_t *collection,
                                const bson_t *selector,
@@ -223,37 +250,42 @@ mongoc_collection_replace_one (mongoc_collection_t *collection,
                                const bson_t *opts,
                                bson_t *reply,
                                bson_error_t *error);
-MONGOC_EXPORT (bool)
-mongoc_collection_delete (mongoc_collection_t *collection,
-                          mongoc_delete_flags_t flags,
-                          const bson_t *selector,
-                          const mongoc_write_concern_t *write_concern,
-                          bson_error_t *error)
-   BSON_GNUC_DEPRECATED_FOR (mongoc_collection_delete_one or mongoc_collection_delete_many);
-MONGOC_EXPORT (bool)
-mongoc_collection_save (mongoc_collection_t *collection,
-                        const bson_t *document,
-                        const mongoc_write_concern_t *write_concern,
-                        bson_error_t *error)
-   BSON_GNUC_DEPRECATED_FOR (mongoc_collection_insert_one or mongoc_collection_replace_one);
+
+BSON_DEPRECATED_FOR (mongoc_collection_delete_one or mongoc_collection_delete_many)
+MONGOC_EXPORT (bool) mongoc_collection_delete (mongoc_collection_t *collection,
+                                               mongoc_delete_flags_t flags,
+                                               const bson_t *selector,
+                                               const mongoc_write_concern_t *write_concern,
+                                               bson_error_t *error);
+
+BSON_DEPRECATED_FOR (mongoc_collection_insert_one or mongoc_collection_replace_one)
+MONGOC_EXPORT (bool) mongoc_collection_save (mongoc_collection_t *collection,
+                                             const bson_t *document,
+                                             const mongoc_write_concern_t *write_concern,
+                                             bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_collection_remove (mongoc_collection_t *collection,
                           mongoc_remove_flags_t flags,
                           const bson_t *selector,
                           const mongoc_write_concern_t *write_concern,
                           bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_collection_delete_one (
    mongoc_collection_t *collection, const bson_t *selector, const bson_t *opts, bson_t *reply, bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_collection_delete_many (
    mongoc_collection_t *collection, const bson_t *selector, const bson_t *opts, bson_t *reply, bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_collection_rename (mongoc_collection_t *collection,
                           const char *new_db,
                           const char *new_name,
                           bool drop_target_before_rename,
                           bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_collection_rename_with_opts (mongoc_collection_t *collection,
                                     const char *new_db,
@@ -261,12 +293,14 @@ mongoc_collection_rename_with_opts (mongoc_collection_t *collection,
                                     bool drop_target_before_rename,
                                     const bson_t *opts,
                                     bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_collection_find_and_modify_with_opts (mongoc_collection_t *collection,
                                              const bson_t *query,
                                              const mongoc_find_and_modify_opts_t *opts,
                                              bson_t *reply,
                                              bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_collection_find_and_modify (mongoc_collection_t *collection,
                                    const bson_t *query,
@@ -278,42 +312,60 @@ mongoc_collection_find_and_modify (mongoc_collection_t *collection,
                                    bool _new,
                                    bson_t *reply,
                                    bson_error_t *error);
+
+BSON_DEPRECATED ("This function does not work with mongoc_client_session_t and is not recommended. Prefer to execute a "
+                 "command directly with mongoc_client_read_command_with_opts.")
 MONGOC_EXPORT (bool)
-mongoc_collection_stats (mongoc_collection_t *collection, const bson_t *options, bson_t *reply, bson_error_t *error)
-   BSON_GNUC_DEPRECATED;
+   mongoc_collection_stats (mongoc_collection_t *collection, const bson_t *options, bson_t *reply, bson_error_t *error);
+
+BSON_DEPRECATED_FOR (mongoc_collection_create_bulk_operation_with_opts)
 MONGOC_EXPORT (mongoc_bulk_operation_t *)
-mongoc_collection_create_bulk_operation (mongoc_collection_t *collection,
-                                         bool ordered,
-                                         const mongoc_write_concern_t *write_concern) BSON_GNUC_WARN_UNUSED_RESULT
-   BSON_GNUC_DEPRECATED_FOR (mongoc_collection_create_bulk_operation_with_opts);
+   mongoc_collection_create_bulk_operation (mongoc_collection_t *collection,
+                                            bool ordered,
+                                            const mongoc_write_concern_t *write_concern) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (mongoc_bulk_operation_t *)
-mongoc_collection_create_bulk_operation_with_opts (mongoc_collection_t *collection,
-                                                   const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
+mongoc_collection_create_bulk_operation_with_opts (mongoc_collection_t *collection, const bson_t *opts)
+   BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (const mongoc_read_prefs_t *)
 mongoc_collection_get_read_prefs (const mongoc_collection_t *collection);
+
 MONGOC_EXPORT (void)
 mongoc_collection_set_read_prefs (mongoc_collection_t *collection, const mongoc_read_prefs_t *read_prefs);
+
 MONGOC_EXPORT (const mongoc_read_concern_t *)
 mongoc_collection_get_read_concern (const mongoc_collection_t *collection);
+
 MONGOC_EXPORT (void)
 mongoc_collection_set_read_concern (mongoc_collection_t *collection, const mongoc_read_concern_t *read_concern);
+
 MONGOC_EXPORT (const mongoc_write_concern_t *)
 mongoc_collection_get_write_concern (const mongoc_collection_t *collection);
+
 MONGOC_EXPORT (void)
 mongoc_collection_set_write_concern (mongoc_collection_t *collection, const mongoc_write_concern_t *write_concern);
+
 MONGOC_EXPORT (const char *)
 mongoc_collection_get_name (mongoc_collection_t *collection);
-MONGOC_EXPORT (const bson_t *)
-mongoc_collection_get_last_error (const mongoc_collection_t *collection) BSON_GNUC_DEPRECATED;
+
+BSON_DEPRECATED ("Use of this function is deprecated")
+MONGOC_EXPORT (const bson_t *) mongoc_collection_get_last_error (const mongoc_collection_t *collection);
+
 MONGOC_EXPORT (char *)
 mongoc_collection_keys_to_index_string (const bson_t *keys) BSON_GNUC_WARN_UNUSED_RESULT;
-MONGOC_EXPORT (bool)
-mongoc_collection_validate (mongoc_collection_t *collection, const bson_t *options, bson_t *reply, bson_error_t *error)
-   BSON_GNUC_DEPRECATED;
+
+BSON_DEPRECATED ("This function does not work with mongoc_client_session_t and is not recommended. Prefer to "
+                 "execute a command directly with mongoc_client_read_command_with_opts.")
+MONGOC_EXPORT (bool) mongoc_collection_validate (mongoc_collection_t *collection,
+                                                 const bson_t *options,
+                                                 bson_t *reply,
+                                                 bson_error_t *error);
+
 MONGOC_EXPORT (mongoc_change_stream_t *)
-mongoc_collection_watch (const mongoc_collection_t *coll,
-                         const bson_t *pipeline,
-                         const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
+mongoc_collection_watch (const mongoc_collection_t *coll, const bson_t *pipeline, const bson_t *opts)
+   BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (int64_t)
 mongoc_collection_count_documents (mongoc_collection_t *coll,
                                    const bson_t *filter,
@@ -321,6 +373,7 @@ mongoc_collection_count_documents (mongoc_collection_t *coll,
                                    const mongoc_read_prefs_t *read_prefs,
                                    bson_t *reply,
                                    bson_error_t *error);
+
 MONGOC_EXPORT (int64_t)
 mongoc_collection_estimated_document_count (mongoc_collection_t *coll,
                                             const bson_t *opts,

--- a/src/libmongoc/src/mongoc/mongoc-cursor.h
+++ b/src/libmongoc/src/mongoc/mongoc-cursor.h
@@ -33,58 +33,76 @@ typedef struct _mongoc_cursor_t mongoc_cursor_t;
 /* forward decl */
 struct _mongoc_client_t;
 
+
 MONGOC_EXPORT (mongoc_cursor_t *)
 mongoc_cursor_clone (const mongoc_cursor_t *cursor) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (void)
 mongoc_cursor_destroy (mongoc_cursor_t *cursor);
+
 MONGOC_EXPORT (bool)
 mongoc_cursor_more (mongoc_cursor_t *cursor);
+
 MONGOC_EXPORT (bool)
 mongoc_cursor_next (mongoc_cursor_t *cursor, const bson_t **bson);
+
 MONGOC_EXPORT (bool)
 mongoc_cursor_error (mongoc_cursor_t *cursor, bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_cursor_error_document (mongoc_cursor_t *cursor, bson_error_t *error, const bson_t **doc);
+
 MONGOC_EXPORT (void)
 mongoc_cursor_get_host (mongoc_cursor_t *cursor, mongoc_host_list_t *host);
-MONGOC_EXPORT (bool)
-mongoc_cursor_is_alive (const mongoc_cursor_t *cursor) BSON_GNUC_DEPRECATED_FOR (mongoc_cursor_more);
+
+BSON_DEPRECATED_FOR (mongoc_cursor_more) MONGOC_EXPORT (bool) mongoc_cursor_is_alive (const mongoc_cursor_t *cursor);
+
 MONGOC_EXPORT (const bson_t *)
 mongoc_cursor_current (const mongoc_cursor_t *cursor);
+
 MONGOC_EXPORT (void)
 mongoc_cursor_set_batch_size (mongoc_cursor_t *cursor, uint32_t batch_size);
+
 MONGOC_EXPORT (uint32_t)
 mongoc_cursor_get_batch_size (const mongoc_cursor_t *cursor);
+
 MONGOC_EXPORT (bool)
 mongoc_cursor_set_limit (mongoc_cursor_t *cursor, int64_t limit);
+
 MONGOC_EXPORT (int64_t)
 mongoc_cursor_get_limit (const mongoc_cursor_t *cursor);
+
 // `mongoc_cursor_set_hint` is deprecated for more aptly named `mongoc_cursor_set_server_id`.
-MONGOC_EXPORT (bool)
-mongoc_cursor_set_hint (mongoc_cursor_t *cursor, uint32_t server_id)
-   BSON_GNUC_DEPRECATED_FOR (mongoc_cursor_set_server_id);
+BSON_DEPRECATED_FOR (mongoc_cursor_set_server_id)
+MONGOC_EXPORT (bool) mongoc_cursor_set_hint (mongoc_cursor_t *cursor, uint32_t server_id);
+
 MONGOC_EXPORT (bool)
 mongoc_cursor_set_server_id (mongoc_cursor_t *cursor, uint32_t server_id);
+
 // `mongoc_cursor_get_hint` is deprecated for more aptly named `mongoc_cursor_get_server_id`.
-MONGOC_EXPORT (uint32_t)
-mongoc_cursor_get_hint (const mongoc_cursor_t *cursor) BSON_GNUC_DEPRECATED_FOR (mongoc_cursor_get_server_id);
+BSON_DEPRECATED_FOR (mongoc_cursor_get_server_id)
+MONGOC_EXPORT (uint32_t) mongoc_cursor_get_hint (const mongoc_cursor_t *cursor);
+
 MONGOC_EXPORT (uint32_t)
 mongoc_cursor_get_server_id (const mongoc_cursor_t *cursor);
+
 MONGOC_EXPORT (int64_t)
 mongoc_cursor_get_id (const mongoc_cursor_t *cursor);
+
 MONGOC_EXPORT (void)
 mongoc_cursor_set_max_await_time_ms (mongoc_cursor_t *cursor, uint32_t max_await_time_ms);
+
 MONGOC_EXPORT (uint32_t)
 mongoc_cursor_get_max_await_time_ms (const mongoc_cursor_t *cursor);
+
+BSON_DEPRECATED_FOR (mongoc_cursor_new_from_command_reply_with_opts)
 MONGOC_EXPORT (mongoc_cursor_t *)
-mongoc_cursor_new_from_command_reply (struct _mongoc_client_t *client,
-                                      bson_t *reply,
-                                      uint32_t server_id) BSON_GNUC_WARN_UNUSED_RESULT
-   BSON_GNUC_DEPRECATED_FOR (mongoc_cursor_new_from_command_reply_with_opts);
+   mongoc_cursor_new_from_command_reply (struct _mongoc_client_t *client, bson_t *reply, uint32_t server_id)
+      BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (mongoc_cursor_t *)
-mongoc_cursor_new_from_command_reply_with_opts (struct _mongoc_client_t *client,
-                                                bson_t *reply,
-                                                const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
+mongoc_cursor_new_from_command_reply_with_opts (struct _mongoc_client_t *client, bson_t *reply, const bson_t *opts)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 
 BSON_END_DECLS
 

--- a/src/libmongoc/src/mongoc/mongoc-database.h
+++ b/src/libmongoc/src/mongoc/mongoc-database.h
@@ -22,6 +22,8 @@
 #include <bson/bson.h>
 
 #include <mongoc/mongoc-macros.h>
+#include <mongoc/mongoc-change-stream.h>
+#include <mongoc/mongoc-collection.h>
 #include <mongoc/mongoc-cursor.h>
 #include <mongoc/mongoc-flags.h>
 #include <mongoc/mongoc-read-prefs.h>
@@ -36,10 +38,13 @@ typedef struct _mongoc_database_t mongoc_database_t;
 
 MONGOC_EXPORT (const char *)
 mongoc_database_get_name (mongoc_database_t *database);
+
 MONGOC_EXPORT (bool)
 mongoc_database_remove_user (mongoc_database_t *database, const char *username, bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_database_remove_all_users (mongoc_database_t *database, bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_database_add_user (mongoc_database_t *database,
                           const char *username,
@@ -47,25 +52,30 @@ mongoc_database_add_user (mongoc_database_t *database,
                           const bson_t *roles,
                           const bson_t *custom_data,
                           bson_error_t *error);
+
 MONGOC_EXPORT (void)
 mongoc_database_destroy (mongoc_database_t *database);
+
 MONGOC_EXPORT (mongoc_cursor_t *)
 mongoc_database_aggregate (mongoc_database_t *db,
                            const bson_t *pipeline,
                            const bson_t *opts,
                            const mongoc_read_prefs_t *read_prefs) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (mongoc_database_t *)
 mongoc_database_copy (mongoc_database_t *database) BSON_GNUC_WARN_UNUSED_RESULT;
-MONGOC_EXPORT (mongoc_cursor_t *)
-mongoc_database_command (mongoc_database_t *database,
-                         mongoc_query_flags_t flags,
-                         uint32_t skip,
-                         uint32_t limit,
-                         uint32_t batch_size,
-                         const bson_t *command,
-                         const bson_t *fields,
-                         const mongoc_read_prefs_t *read_prefs) BSON_GNUC_WARN_UNUSED_RESULT
-   BSON_GNUC_DEPRECATED_FOR (mongoc_database_command_simple);
+
+BSON_DEPRECATED_FOR (mongoc_database_command_simple)
+MONGOC_EXPORT (mongoc_cursor_t *) mongoc_database_command (mongoc_database_t *database,
+                                                           mongoc_query_flags_t flags,
+                                                           uint32_t skip,
+                                                           uint32_t limit,
+                                                           uint32_t batch_size,
+                                                           const bson_t *command,
+                                                           const bson_t *fields,
+                                                           const mongoc_read_prefs_t *read_prefs)
+   BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (bool)
 mongoc_database_read_command_with_opts (mongoc_database_t *database,
                                         const bson_t *command,
@@ -73,9 +83,11 @@ mongoc_database_read_command_with_opts (mongoc_database_t *database,
                                         const bson_t *opts,
                                         bson_t *reply,
                                         bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_database_write_command_with_opts (
    mongoc_database_t *database, const bson_t *command, const bson_t *opts, bson_t *reply, bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_database_read_write_command_with_opts (mongoc_database_t *database,
                                               const bson_t *command,
@@ -83,6 +95,7 @@ mongoc_database_read_write_command_with_opts (mongoc_database_t *database,
                                               const bson_t *opts,
                                               bson_t *reply,
                                               bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_database_command_with_opts (mongoc_database_t *database,
                                    const bson_t *command,
@@ -90,56 +103,70 @@ mongoc_database_command_with_opts (mongoc_database_t *database,
                                    const bson_t *opts,
                                    bson_t *reply,
                                    bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_database_command_simple (mongoc_database_t *database,
                                 const bson_t *command,
                                 const mongoc_read_prefs_t *read_prefs,
                                 bson_t *reply,
                                 bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_database_drop (mongoc_database_t *database, bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_database_drop_with_opts (mongoc_database_t *database, const bson_t *opts, bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_database_has_collection (mongoc_database_t *database, const char *name, bson_error_t *error);
+
 MONGOC_EXPORT (mongoc_collection_t *)
 mongoc_database_create_collection (mongoc_database_t *database,
                                    const char *name,
                                    const bson_t *options,
                                    bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (const mongoc_read_prefs_t *)
 mongoc_database_get_read_prefs (const mongoc_database_t *database);
+
 MONGOC_EXPORT (void)
 mongoc_database_set_read_prefs (mongoc_database_t *database, const mongoc_read_prefs_t *read_prefs);
+
 MONGOC_EXPORT (const mongoc_write_concern_t *)
 mongoc_database_get_write_concern (const mongoc_database_t *database);
+
 MONGOC_EXPORT (void)
 mongoc_database_set_write_concern (mongoc_database_t *database, const mongoc_write_concern_t *write_concern);
+
 MONGOC_EXPORT (const mongoc_read_concern_t *)
 mongoc_database_get_read_concern (const mongoc_database_t *database);
+
 MONGOC_EXPORT (void)
 mongoc_database_set_read_concern (mongoc_database_t *database, const mongoc_read_concern_t *read_concern);
+
+BSON_DEPRECATED_FOR (mongoc_database_find_collections_with_opts)
 MONGOC_EXPORT (mongoc_cursor_t *)
-mongoc_database_find_collections (mongoc_database_t *database,
-                                  const bson_t *filter,
-                                  bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT
-   BSON_GNUC_DEPRECATED_FOR (mongoc_database_find_collections_with_opts);
+   mongoc_database_find_collections (mongoc_database_t *database, const bson_t *filter, bson_error_t *error)
+      BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (mongoc_cursor_t *)
-mongoc_database_find_collections_with_opts (mongoc_database_t *database,
-                                            const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
+mongoc_database_find_collections_with_opts (mongoc_database_t *database, const bson_t *opts)
+   BSON_GNUC_WARN_UNUSED_RESULT;
+
+BSON_DEPRECATED_FOR (mongoc_database_get_collection_names_with_opts)
+MONGOC_EXPORT (char **) mongoc_database_get_collection_names (mongoc_database_t *database, bson_error_t *error)
+   BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (char **)
-mongoc_database_get_collection_names (mongoc_database_t *database, bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT
-   BSON_GNUC_DEPRECATED_FOR (mongoc_database_get_collection_names_with_opts);
-MONGOC_EXPORT (char **)
-mongoc_database_get_collection_names_with_opts (mongoc_database_t *database,
-                                                const bson_t *opts,
-                                                bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT;
+mongoc_database_get_collection_names_with_opts (mongoc_database_t *database, const bson_t *opts, bson_error_t *error)
+   BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (mongoc_collection_t *)
 mongoc_database_get_collection (mongoc_database_t *database, const char *name) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (mongoc_change_stream_t *)
-mongoc_database_watch (const mongoc_database_t *db,
-                       const bson_t *pipeline,
-                       const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
+mongoc_database_watch (const mongoc_database_t *db, const bson_t *pipeline, const bson_t *opts)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 
 BSON_END_DECLS
 

--- a/src/libmongoc/src/mongoc/mongoc-gridfs-bucket.h
+++ b/src/libmongoc/src/mongoc/mongoc-gridfs-bucket.h
@@ -79,9 +79,8 @@ MONGOC_EXPORT (bool)
 mongoc_gridfs_bucket_delete_by_id (mongoc_gridfs_bucket_t *bucket, const bson_value_t *file_id, bson_error_t *error);
 
 MONGOC_EXPORT (mongoc_cursor_t *)
-mongoc_gridfs_bucket_find (mongoc_gridfs_bucket_t *bucket,
-                           const bson_t *filter,
-                           const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
+mongoc_gridfs_bucket_find (mongoc_gridfs_bucket_t *bucket, const bson_t *filter, const bson_t *opts)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 
 MONGOC_EXPORT (bool)
 mongoc_gridfs_bucket_stream_error (mongoc_stream_t *stream, bson_error_t *error);

--- a/src/libmongoc/src/mongoc/mongoc-gridfs.h
+++ b/src/libmongoc/src/mongoc/mongoc-gridfs.h
@@ -33,40 +33,48 @@ BSON_BEGIN_DECLS
 
 typedef struct _mongoc_gridfs_t mongoc_gridfs_t;
 
+MONGOC_EXPORT (mongoc_gridfs_file_t *)
+mongoc_gridfs_create_file_from_stream (mongoc_gridfs_t *gridfs, mongoc_stream_t *stream, mongoc_gridfs_file_opt_t *opt)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 
 MONGOC_EXPORT (mongoc_gridfs_file_t *)
-mongoc_gridfs_create_file_from_stream (mongoc_gridfs_t *gridfs,
-                                       mongoc_stream_t *stream,
-                                       mongoc_gridfs_file_opt_t *opt) BSON_GNUC_WARN_UNUSED_RESULT;
-MONGOC_EXPORT (mongoc_gridfs_file_t *)
 mongoc_gridfs_create_file (mongoc_gridfs_t *gridfs, mongoc_gridfs_file_opt_t *opt) BSON_GNUC_WARN_UNUSED_RESULT;
-MONGOC_EXPORT (mongoc_gridfs_file_list_t *)
-mongoc_gridfs_find (mongoc_gridfs_t *gridfs, const bson_t *query) BSON_GNUC_WARN_UNUSED_RESULT
-   BSON_GNUC_DEPRECATED_FOR (mongoc_gridfs_find_with_opts);
+
+BSON_DEPRECATED_FOR (mongoc_gridfs_find_with_opts)
+MONGOC_EXPORT (mongoc_gridfs_file_list_t *) mongoc_gridfs_find (mongoc_gridfs_t *gridfs, const bson_t *query)
+   BSON_GNUC_WARN_UNUSED_RESULT;
+
+BSON_DEPRECATED_FOR (mongoc_gridfs_find_one_with_opts)
 MONGOC_EXPORT (mongoc_gridfs_file_t *)
-mongoc_gridfs_find_one (mongoc_gridfs_t *gridfs, const bson_t *query, bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT
-   BSON_GNUC_DEPRECATED_FOR (mongoc_gridfs_find_one_with_opts);
+   mongoc_gridfs_find_one (mongoc_gridfs_t *gridfs, const bson_t *query, bson_error_t *error)
+      BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (mongoc_gridfs_file_list_t *)
-mongoc_gridfs_find_with_opts (mongoc_gridfs_t *gridfs,
-                              const bson_t *filter,
-                              const bson_t *opts) BSON_GNUC_WARN_UNUSED_RESULT;
+mongoc_gridfs_find_with_opts (mongoc_gridfs_t *gridfs, const bson_t *filter, const bson_t *opts)
+   BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (mongoc_gridfs_file_t *)
 mongoc_gridfs_find_one_with_opts (mongoc_gridfs_t *gridfs,
                                   const bson_t *filter,
                                   const bson_t *opts,
                                   bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (mongoc_gridfs_file_t *)
-mongoc_gridfs_find_one_by_filename (mongoc_gridfs_t *gridfs,
-                                    const char *filename,
-                                    bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT;
+mongoc_gridfs_find_one_by_filename (mongoc_gridfs_t *gridfs, const char *filename, bson_error_t *error)
+   BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (bool)
 mongoc_gridfs_drop (mongoc_gridfs_t *gridfs, bson_error_t *error);
+
 MONGOC_EXPORT (void)
 mongoc_gridfs_destroy (mongoc_gridfs_t *gridfs);
+
 MONGOC_EXPORT (mongoc_collection_t *)
 mongoc_gridfs_get_files (mongoc_gridfs_t *gridfs);
+
 MONGOC_EXPORT (mongoc_collection_t *)
 mongoc_gridfs_get_chunks (mongoc_gridfs_t *gridfs);
+
 MONGOC_EXPORT (bool)
 mongoc_gridfs_remove_by_filename (mongoc_gridfs_t *gridfs, const char *filename, bson_error_t *error);
 

--- a/src/libmongoc/src/mongoc/mongoc-matcher.h
+++ b/src/libmongoc/src/mongoc/mongoc-matcher.h
@@ -29,12 +29,15 @@ BSON_BEGIN_DECLS
 typedef struct _mongoc_matcher_t mongoc_matcher_t;
 
 
-MONGOC_EXPORT (mongoc_matcher_t *)
-mongoc_matcher_new (const bson_t *query, bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT BSON_GNUC_DEPRECATED;
-MONGOC_EXPORT (bool)
-mongoc_matcher_match (const mongoc_matcher_t *matcher, const bson_t *document) BSON_GNUC_DEPRECATED;
-MONGOC_EXPORT (void)
-mongoc_matcher_destroy (mongoc_matcher_t *matcher) BSON_GNUC_DEPRECATED;
+BSON_DEPRECATED ("<mongoc/mongoc-matcher.h> APIs are deprecated")
+MONGOC_EXPORT (mongoc_matcher_t *) mongoc_matcher_new (const bson_t *query, bson_error_t *error)
+   BSON_GNUC_WARN_UNUSED_RESULT;
+
+BSON_DEPRECATED ("<mongoc/mongoc-matcher.h> APIs are deprecated")
+MONGOC_EXPORT (bool) mongoc_matcher_match (const mongoc_matcher_t *matcher, const bson_t *document);
+
+BSON_DEPRECATED ("<mongoc/mongoc-matcher.h> APIs are deprecated")
+MONGOC_EXPORT (void) mongoc_matcher_destroy (mongoc_matcher_t *matcher);
 
 
 BSON_END_DECLS

--- a/src/libmongoc/src/mongoc/mongoc-read-prefs.c
+++ b/src/libmongoc/src/mongoc/mongoc-read-prefs.c
@@ -15,6 +15,7 @@
  */
 
 
+#include <mlib/config.h>
 #include <mongoc/mongoc-error-private.h>
 #include <mongoc/mongoc-read-prefs-private.h>
 #include <mongoc/mongoc-trace-private.h>
@@ -234,7 +235,10 @@ _apply_read_preferences_mongos (const mongoc_read_prefs_t *read_prefs,
       max_staleness_seconds = mongoc_read_prefs_get_max_staleness_seconds (read_prefs);
 
       tags = mongoc_read_prefs_get_tags (read_prefs);
+      mlib_diagnostic_push ();
+      mlib_disable_deprecation_warnings ();
       hedge = mongoc_read_prefs_get_hedge (read_prefs);
+      mlib_diagnostic_pop ();
    }
 
    /* Server Selection Spec says:
@@ -308,7 +312,11 @@ mongoc_read_prefs_append_contents_to_bson (const mongoc_read_prefs_t *read_prefs
    if (read_prefs) {
       // Other content is only available for non-NULL read_prefs
       int64_t max_staleness_seconds = mongoc_read_prefs_get_max_staleness_seconds (read_prefs);
+
+      mlib_diagnostic_push ();
+      mlib_disable_deprecation_warnings ();
       const bson_t *hedge = mongoc_read_prefs_get_hedge (read_prefs);
+      mlib_diagnostic_pop ();
       const bson_t *tags = mongoc_read_prefs_get_tags (read_prefs);
 
       if ((flags & MONGOC_READ_PREFS_CONTENT_FLAG_TAGS) && !bson_empty (tags) &&

--- a/src/libmongoc/src/mongoc/mongoc-read-prefs.h
+++ b/src/libmongoc/src/mongoc/mongoc-read-prefs.h
@@ -49,28 +49,40 @@ typedef enum {
 
 MONGOC_EXPORT (mongoc_read_prefs_t *)
 mongoc_read_prefs_new (mongoc_read_mode_t read_mode) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (mongoc_read_prefs_t *)
 mongoc_read_prefs_copy (const mongoc_read_prefs_t *read_prefs) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (void)
 mongoc_read_prefs_destroy (mongoc_read_prefs_t *read_prefs);
+
 MONGOC_EXPORT (mongoc_read_mode_t)
 mongoc_read_prefs_get_mode (const mongoc_read_prefs_t *read_prefs);
+
 MONGOC_EXPORT (void)
 mongoc_read_prefs_set_mode (mongoc_read_prefs_t *read_prefs, mongoc_read_mode_t mode);
+
 MONGOC_EXPORT (const bson_t *)
 mongoc_read_prefs_get_tags (const mongoc_read_prefs_t *read_prefs);
+
 MONGOC_EXPORT (void)
 mongoc_read_prefs_set_tags (mongoc_read_prefs_t *read_prefs, const bson_t *tags);
+
 MONGOC_EXPORT (void)
 mongoc_read_prefs_add_tag (mongoc_read_prefs_t *read_prefs, const bson_t *tag);
+
 MONGOC_EXPORT (int64_t)
 mongoc_read_prefs_get_max_staleness_seconds (const mongoc_read_prefs_t *read_prefs);
+
 MONGOC_EXPORT (void)
 mongoc_read_prefs_set_max_staleness_seconds (mongoc_read_prefs_t *read_prefs, int64_t max_staleness_seconds);
-MONGOC_EXPORT (const bson_t *)
-mongoc_read_prefs_get_hedge (const mongoc_read_prefs_t *read_prefs);
-MONGOC_EXPORT (void)
-mongoc_read_prefs_set_hedge (mongoc_read_prefs_t *read_prefs, const bson_t *hedge);
+
+BSON_DEPRECATED ("Hedged reads are deprecated in MongoDB 8.0 and will be removed in a future release")
+MONGOC_EXPORT (const bson_t *) mongoc_read_prefs_get_hedge (const mongoc_read_prefs_t *read_prefs);
+
+BSON_DEPRECATED ("Hedged reads are deprecated in MongoDB 8.0 and will be removed in a future release")
+MONGOC_EXPORT (void) mongoc_read_prefs_set_hedge (mongoc_read_prefs_t *read_prefs, const bson_t *hedge);
+
 MONGOC_EXPORT (bool)
 mongoc_read_prefs_is_valid (const mongoc_read_prefs_t *read_prefs);
 

--- a/src/libmongoc/src/mongoc/mongoc-server-description.h
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.h
@@ -53,9 +53,8 @@ mongoc_server_description_type (const mongoc_server_description_t *description);
 MONGOC_EXPORT (const bson_t *)
 mongoc_server_description_hello_response (const mongoc_server_description_t *description);
 
-MONGOC_EXPORT (const bson_t *)
-mongoc_server_description_ismaster (const mongoc_server_description_t *description)
-   BSON_GNUC_DEPRECATED_FOR (mongoc_server_description_hello_response);
+BSON_DEPRECATED_FOR (mongoc_server_description_hello_response)
+MONGOC_EXPORT (const bson_t *) mongoc_server_description_ismaster (const mongoc_server_description_t *description);
 
 MONGOC_EXPORT (int32_t)
 mongoc_server_description_compressor_id (const mongoc_server_description_t *description);

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-libressl.h
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-libressl.h
@@ -27,9 +27,10 @@
 
 BSON_BEGIN_DECLS
 
+BSON_DEPRECATED ("LibreSSL support is deprecated in libmongoc and will be removed in a future version")
 MONGOC_EXPORT (mongoc_stream_t *)
-mongoc_stream_tls_libressl_new (mongoc_stream_t *base_stream, const char *host, mongoc_ssl_opt_t *opt, int client)
-   BSON_GNUC_DEPRECATED BSON_GNUC_WARN_UNUSED_RESULT;
+   mongoc_stream_tls_libressl_new (mongoc_stream_t *base_stream, const char *host, mongoc_ssl_opt_t *opt, int client)
+      BSON_GNUC_WARN_UNUSED_RESULT;
 
 BSON_END_DECLS
 

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls.h
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls.h
@@ -33,23 +33,26 @@ typedef struct _mongoc_stream_tls_t mongoc_stream_tls_t;
 MONGOC_EXPORT (bool)
 mongoc_stream_tls_handshake (
    mongoc_stream_t *stream, const char *host, int32_t timeout_msec, int *events, bson_error_t *error);
+
 MONGOC_EXPORT (bool)
 mongoc_stream_tls_handshake_block (mongoc_stream_t *stream,
                                    const char *host,
                                    int32_t timeout_msec,
                                    bson_error_t *error);
-MONGOC_EXPORT (bool)
-mongoc_stream_tls_do_handshake (mongoc_stream_t *stream, int32_t timeout_msec)
-   BSON_GNUC_DEPRECATED_FOR (mongoc_stream_tls_handshake);
-MONGOC_EXPORT (bool)
-mongoc_stream_tls_check_cert (mongoc_stream_t *stream, const char *host)
-   BSON_GNUC_DEPRECATED_FOR (mongoc_stream_tls_handshake);
+
+BSON_DEPRECATED_FOR (mongoc_stream_tls_handshake)
+MONGOC_EXPORT (bool) mongoc_stream_tls_do_handshake (mongoc_stream_t *stream, int32_t timeout_msec);
+
+BSON_DEPRECATED_FOR (mongoc_stream_tls_handshake)
+MONGOC_EXPORT (bool) mongoc_stream_tls_check_cert (mongoc_stream_t *stream, const char *host);
+
 MONGOC_EXPORT (mongoc_stream_t *)
 mongoc_stream_tls_new_with_hostname (mongoc_stream_t *base_stream, const char *host, mongoc_ssl_opt_t *opt, int client)
    BSON_GNUC_WARN_UNUSED_RESULT;
+
+BSON_DEPRECATED_FOR (mongoc_stream_tls_new_with_hostname)
 MONGOC_EXPORT (mongoc_stream_t *)
-mongoc_stream_tls_new (mongoc_stream_t *base_stream, mongoc_ssl_opt_t *opt, int client) BSON_GNUC_WARN_UNUSED_RESULT
-   BSON_GNUC_DEPRECATED_FOR (mongoc_stream_tls_new_with_hostname);
+   mongoc_stream_tls_new (mongoc_stream_t *base_stream, mongoc_ssl_opt_t *opt, int client) BSON_GNUC_WARN_UNUSED_RESULT;
 
 
 BSON_END_DECLS

--- a/src/libmongoc/src/mongoc/mongoc-topology-description.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description.h
@@ -46,8 +46,8 @@ MONGOC_EXPORT (const char *)
 mongoc_topology_description_type (const mongoc_topology_description_t *td);
 
 MONGOC_EXPORT (mongoc_server_description_t **)
-mongoc_topology_description_get_servers (const mongoc_topology_description_t *td,
-                                         size_t *n) BSON_GNUC_WARN_UNUSED_RESULT;
+mongoc_topology_description_get_servers (const mongoc_topology_description_t *td, size_t *n)
+   BSON_GNUC_WARN_UNUSED_RESULT;
 
 BSON_END_DECLS
 

--- a/src/libmongoc/src/mongoc/mongoc-uri.h
+++ b/src/libmongoc/src/mongoc/mongoc-uri.h
@@ -96,110 +96,162 @@ typedef struct _mongoc_uri_t mongoc_uri_t;
 
 MONGOC_EXPORT (mongoc_uri_t *)
 mongoc_uri_copy (const mongoc_uri_t *uri) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (void)
 mongoc_uri_destroy (mongoc_uri_t *uri);
+
 MONGOC_EXPORT (mongoc_uri_t *)
 mongoc_uri_new (const char *uri_string) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (mongoc_uri_t *)
 mongoc_uri_new_with_error (const char *uri_string, bson_error_t *error) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (mongoc_uri_t *)
 mongoc_uri_new_for_host_port (const char *hostname, uint16_t port) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (const mongoc_host_list_t *)
 mongoc_uri_get_hosts (const mongoc_uri_t *uri);
-MONGOC_EXPORT (const char *)
-mongoc_uri_get_service (const mongoc_uri_t *uri) BSON_GNUC_DEPRECATED_FOR (mongoc_uri_get_srv_hostname);
+
+BSON_DEPRECATED_FOR (mongoc_uri_get_srv_hostname)
+MONGOC_EXPORT (const char *) mongoc_uri_get_service (const mongoc_uri_t *uri);
+
 MONGOC_EXPORT (const char *)
 mongoc_uri_get_srv_hostname (const mongoc_uri_t *uri);
+
 MONGOC_EXPORT (const char *)
 mongoc_uri_get_srv_service_name (const mongoc_uri_t *uri);
+
 MONGOC_EXPORT (const char *)
 mongoc_uri_get_database (const mongoc_uri_t *uri);
+
 MONGOC_EXPORT (bool)
 mongoc_uri_set_database (mongoc_uri_t *uri, const char *database);
+
 MONGOC_EXPORT (const bson_t *)
 mongoc_uri_get_compressors (const mongoc_uri_t *uri);
+
 MONGOC_EXPORT (const bson_t *)
 mongoc_uri_get_options (const mongoc_uri_t *uri);
+
 MONGOC_EXPORT (const char *)
 mongoc_uri_get_password (const mongoc_uri_t *uri);
+
 MONGOC_EXPORT (bool)
 mongoc_uri_set_password (mongoc_uri_t *uri, const char *password);
+
 MONGOC_EXPORT (bool)
 mongoc_uri_has_option (const mongoc_uri_t *uri, const char *key);
+
 MONGOC_EXPORT (bool)
 mongoc_uri_option_is_int32 (const char *key);
+
 MONGOC_EXPORT (bool)
 mongoc_uri_option_is_int64 (const char *key);
+
 MONGOC_EXPORT (bool)
 mongoc_uri_option_is_bool (const char *key);
+
 MONGOC_EXPORT (bool)
 mongoc_uri_option_is_utf8 (const char *key);
+
 MONGOC_EXPORT (int32_t)
 mongoc_uri_get_option_as_int32 (const mongoc_uri_t *uri, const char *option, int32_t fallback);
+
 MONGOC_EXPORT (int64_t)
 mongoc_uri_get_option_as_int64 (const mongoc_uri_t *uri, const char *option, int64_t fallback);
+
 MONGOC_EXPORT (bool)
 mongoc_uri_get_option_as_bool (const mongoc_uri_t *uri, const char *option, bool fallback);
+
 MONGOC_EXPORT (const char *)
 mongoc_uri_get_option_as_utf8 (const mongoc_uri_t *uri, const char *option, const char *fallback);
+
 MONGOC_EXPORT (bool)
 mongoc_uri_set_option_as_int32 (mongoc_uri_t *uri, const char *option, int32_t value);
+
 MONGOC_EXPORT (bool)
 mongoc_uri_set_option_as_int64 (mongoc_uri_t *uri, const char *option, int64_t value);
+
 MONGOC_EXPORT (bool)
 mongoc_uri_set_option_as_bool (mongoc_uri_t *uri, const char *option, bool value);
+
 MONGOC_EXPORT (bool)
 mongoc_uri_set_option_as_utf8 (mongoc_uri_t *uri, const char *option, const char *value);
-MONGOC_EXPORT (const bson_t *)
-mongoc_uri_get_read_prefs (const mongoc_uri_t *uri) BSON_GNUC_DEPRECATED_FOR (mongoc_uri_get_read_prefs_t);
+
+BSON_DEPRECATED_FOR (mongoc_uri_get_read_prefs_t)
+MONGOC_EXPORT (const bson_t *) mongoc_uri_get_read_prefs (const mongoc_uri_t *uri);
+
 MONGOC_EXPORT (const char *)
 mongoc_uri_get_replica_set (const mongoc_uri_t *uri);
+
 MONGOC_EXPORT (const char *)
 mongoc_uri_get_string (const mongoc_uri_t *uri);
+
 MONGOC_EXPORT (const char *)
 mongoc_uri_get_username (const mongoc_uri_t *uri);
+
 MONGOC_EXPORT (bool)
 mongoc_uri_set_username (mongoc_uri_t *uri, const char *username);
+
 MONGOC_EXPORT (const bson_t *)
 mongoc_uri_get_credentials (const mongoc_uri_t *uri);
+
 MONGOC_EXPORT (const char *)
 mongoc_uri_get_auth_source (const mongoc_uri_t *uri);
+
 MONGOC_EXPORT (bool)
 mongoc_uri_set_auth_source (mongoc_uri_t *uri, const char *value);
+
 MONGOC_EXPORT (const char *)
 mongoc_uri_get_appname (const mongoc_uri_t *uri);
+
 MONGOC_EXPORT (bool)
 mongoc_uri_set_appname (mongoc_uri_t *uri, const char *value);
+
 MONGOC_EXPORT (bool)
 mongoc_uri_set_compressors (mongoc_uri_t *uri, const char *value);
+
 MONGOC_EXPORT (const char *)
 mongoc_uri_get_auth_mechanism (const mongoc_uri_t *uri);
+
 MONGOC_EXPORT (bool)
 mongoc_uri_set_auth_mechanism (mongoc_uri_t *uri, const char *value);
+
 MONGOC_EXPORT (bool)
 mongoc_uri_get_mechanism_properties (const mongoc_uri_t *uri, bson_t *properties);
+
 MONGOC_EXPORT (bool)
 mongoc_uri_set_mechanism_properties (mongoc_uri_t *uri, const bson_t *properties);
-MONGOC_EXPORT (bool)
-mongoc_uri_get_ssl (const mongoc_uri_t *uri) BSON_GNUC_DEPRECATED_FOR (mongoc_uri_get_tls);
+
+BSON_DEPRECATED_FOR (mongoc_uri_get_tls) MONGOC_EXPORT (bool) mongoc_uri_get_ssl (const mongoc_uri_t *uri);
+
 MONGOC_EXPORT (bool)
 mongoc_uri_get_tls (const mongoc_uri_t *uri);
+
 MONGOC_EXPORT (char *)
 mongoc_uri_unescape (const char *escaped_string) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (const mongoc_read_prefs_t *)
 mongoc_uri_get_read_prefs_t (const mongoc_uri_t *uri);
+
 MONGOC_EXPORT (void)
 mongoc_uri_set_read_prefs_t (mongoc_uri_t *uri, const mongoc_read_prefs_t *prefs);
+
 MONGOC_EXPORT (const mongoc_write_concern_t *)
 mongoc_uri_get_write_concern (const mongoc_uri_t *uri);
+
 MONGOC_EXPORT (void)
 mongoc_uri_set_write_concern (mongoc_uri_t *uri, const mongoc_write_concern_t *wc);
+
 MONGOC_EXPORT (const mongoc_read_concern_t *)
 mongoc_uri_get_read_concern (const mongoc_uri_t *uri);
+
 MONGOC_EXPORT (void)
 mongoc_uri_set_read_concern (mongoc_uri_t *uri, const mongoc_read_concern_t *rc);
+
 MONGOC_EXPORT (const char *)
 mongoc_uri_get_server_monitoring_mode (const mongoc_uri_t *uri);
+
 MONGOC_EXPORT (bool)
 mongoc_uri_set_server_monitoring_mode (mongoc_uri_t *uri, const char *value);
 

--- a/src/libmongoc/src/mongoc/mongoc-write-concern.h
+++ b/src/libmongoc/src/mongoc/mongoc-write-concern.h
@@ -38,46 +38,67 @@ typedef struct _mongoc_write_concern_t mongoc_write_concern_t;
 
 MONGOC_EXPORT (mongoc_write_concern_t *)
 mongoc_write_concern_new (void) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (mongoc_write_concern_t *)
 mongoc_write_concern_copy (const mongoc_write_concern_t *write_concern) BSON_GNUC_WARN_UNUSED_RESULT;
+
 MONGOC_EXPORT (void)
 mongoc_write_concern_destroy (mongoc_write_concern_t *write_concern);
-MONGOC_EXPORT (bool)
-mongoc_write_concern_get_fsync (const mongoc_write_concern_t *write_concern) BSON_GNUC_DEPRECATED;
-MONGOC_EXPORT (void)
-mongoc_write_concern_set_fsync (mongoc_write_concern_t *write_concern, bool fsync_) BSON_GNUC_DEPRECATED;
+
+BSON_DEPRECATED ("The fsync parameter is deprecated")
+MONGOC_EXPORT (bool) mongoc_write_concern_get_fsync (const mongoc_write_concern_t *write_concern);
+
+BSON_DEPRECATED ("The fsync parameter is deprecated")
+MONGOC_EXPORT (void) mongoc_write_concern_set_fsync (mongoc_write_concern_t *write_concern, bool fsync_);
+
 MONGOC_EXPORT (bool)
 mongoc_write_concern_get_journal (const mongoc_write_concern_t *write_concern);
+
 MONGOC_EXPORT (bool)
 mongoc_write_concern_journal_is_set (const mongoc_write_concern_t *write_concern);
+
 MONGOC_EXPORT (void)
 mongoc_write_concern_set_journal (mongoc_write_concern_t *write_concern, bool journal);
+
 MONGOC_EXPORT (int32_t)
 mongoc_write_concern_get_w (const mongoc_write_concern_t *write_concern);
+
 MONGOC_EXPORT (void)
 mongoc_write_concern_set_w (mongoc_write_concern_t *write_concern, int32_t w);
+
 MONGOC_EXPORT (const char *)
 mongoc_write_concern_get_wtag (const mongoc_write_concern_t *write_concern);
+
 MONGOC_EXPORT (void)
 mongoc_write_concern_set_wtag (mongoc_write_concern_t *write_concern, const char *tag);
+
 MONGOC_EXPORT (int32_t)
 mongoc_write_concern_get_wtimeout (const mongoc_write_concern_t *write_concern);
+
 MONGOC_EXPORT (int64_t)
 mongoc_write_concern_get_wtimeout_int64 (const mongoc_write_concern_t *write_concern);
+
 MONGOC_EXPORT (void)
 mongoc_write_concern_set_wtimeout (mongoc_write_concern_t *write_concern, int32_t wtimeout_msec);
+
 MONGOC_EXPORT (void)
 mongoc_write_concern_set_wtimeout_int64 (mongoc_write_concern_t *write_concern, int64_t wtimeout_msec);
+
 MONGOC_EXPORT (bool)
 mongoc_write_concern_get_wmajority (const mongoc_write_concern_t *write_concern);
+
 MONGOC_EXPORT (void)
 mongoc_write_concern_set_wmajority (mongoc_write_concern_t *write_concern, int32_t wtimeout_msec);
+
 MONGOC_EXPORT (bool)
 mongoc_write_concern_is_acknowledged (const mongoc_write_concern_t *write_concern);
+
 MONGOC_EXPORT (bool)
 mongoc_write_concern_is_valid (const mongoc_write_concern_t *write_concern);
+
 MONGOC_EXPORT (bool)
 mongoc_write_concern_append (mongoc_write_concern_t *write_concern, bson_t *doc);
+
 MONGOC_EXPORT (bool)
 mongoc_write_concern_is_default (const mongoc_write_concern_t *write_concern);
 


### PR DESCRIPTION
# Background 

Refer: CDRIVER-5916

DRIVERS-2929 is be a spec update that deprecates Hedge Reads in driver APIs. This changeset adds such deprecation warnings, among other things.

# Summary

This does not change any library behavior, it only adds deprecation warnings, and updates those that already exist. Per-commit review is recommended:

- c17b30f1 Adds new deprecation attribute macros that work on MSVC, to replace the `BSON_GNUC_DEPRECATED` macros. This macro always requires a deprecation message string, which will be included in the emitted attribute if it is supported by the compiler.
- ef8347bb Updates all existing deprecation attributes to use the new macros:
  - This also applies a formatting change and repositions the attributes for MSVC compatibility.
  - We also add several macros to `.clang-format`'s `AttributeMacros` to format them as declaration specifiers on functions.
  - Lots of headers have had whitespace inserted between function declarations, where it was becoming nigh unreadable.
  - Because deprecation warnings are now applied on MSVC, a new deprecation-warning-suppression had to be added to `bson-atomic.h` and `bson-cmp.h`
  - This commit is the largest change, and was largely a find-replace job.
- 0da23b06 Adds an internal declaration-like macro that emits the appropriate `_Pragma` to disable deprecation warnings.
- 4cc8a974 Adds deprecation annotations to "hedge" APIs, and updates the documentation to note the deprecation. Warning suppressions were added in internal locations where the hedged-read APIs are called.

## Note on Attribute Placement:

MSVC attributes are declaration-specifiers (thus "__declspec"), and thus need to be positioned correctly. The following is ill-formed:

```c
int*
BSON_DEPRECATED("oof")
foo();
```

because the `__declspec` is placed between the asterisk and the function name (not a valid position for declaration specifiers). GCC accepts this form, but we cannot use it for compatibility. One possible correct formatting for this declaration would be:

```c
int
BSON_DEPRECATED("oof")
* foo();
```

but that is a extremely weird, so it's easier to just place the deprecation before the return type:

```c
BSON_DEPRECATED("oof")
int* foo();
```

This has been applied throughout the codebase in ef8347bb.
