### PR TITLE
CDRIVER-5891 extend C standard coverage up to C23

### DIFF
--- a/.evergreen/config_generator/components/c_std_compile.py
+++ b/.evergreen/config_generator/components/c_std_compile.py
@@ -17,14 +17,16 @@ TAG = 'std-matrix'
 # pylint: disable=line-too-long
 # fmt: off
 MATRIX = [
-    ('debian92',          'clang',     None,   [11,   ]),
-    ('debian10',          'clang',     None,   [11,   ]),
-    ('debian10',          'gcc',       None,   [11, 17]),
-    ('debian11',          'clang',     None,   [11,   ]),
-    ('debian11',          'gcc',       None,   [11, 17]),
-    ('ubuntu2004',        'clang',     None,   [11,   ]),
-    ('ubuntu2004',        'gcc',       None,   [11,   ]),
-    ('windows-vsCurrent', 'vs2017x64', None,   [11, 17]),
+    ('debian92',   'clang', None, [11]), # Clang 3.8
+    ('debian10',   'clang', None, [11]), # Clang 7.0
+    ('ubuntu2004', 'clang', None, [11]), # Clang 10.0
+    ('debian11',   'clang', None, [11]), # Clang 11.0
+
+    ('debian10',   'gcc', None, [11, 17]), # GCC 8.3
+    ('ubuntu2004', 'gcc', None, [11,   ]), # GCC 9.3
+    ('debian11',   'gcc', None, [11, 17]), # GCC 10.2
+
+    ('windows-vsCurrent', 'vs2017x64', None, [11, 17]),
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/c_std_compile.py
+++ b/.evergreen/config_generator/components/c_std_compile.py
@@ -17,16 +17,31 @@ TAG = 'std-matrix'
 # pylint: disable=line-too-long
 # fmt: off
 MATRIX = [
-    ('debian92',   'clang', None, [11]), # Clang 3.8
-    ('debian10',   'clang', None, [11]), # Clang 7.0
-    ('ubuntu2004', 'clang', None, [11]), # Clang 10.0
-    ('debian11',   'clang', None, [11]), # Clang 11.0
+    ('rhel80',     'clang',    None, [99, 11, 17,   ]), # Clang 7.0
+    ('ubuntu2004', 'clang-10', None, [99, 11, 17, 23]), # Clang 10.0 (max: C2x)
+    ('rhel84',     'clang',    None, [99, 11, 17, 23]), # Clang 11.0 (max: C2x)
+    ('ubuntu2204', 'clang-12', None, [99, 11, 17, 23]), # Clang 12.0 (max: C2x)
+    ('rhel90',     'clang',    None, [99, 11, 17, 23]), # Clang 13.0 (max: C2x)
+    ('rhel91',     'clang',    None, [99, 11, 17, 23]), # Clang 14.0 (max: C2x)
+    ('rhel92',     'clang',    None, [99, 11, 17, 23]), # Clang 15.0 (max: C2x)
+    ('rhel93',     'clang',    None, [99, 11, 17, 23]), # Clang 16.0 (max: C2x)
+    ('rhel94',     'clang',    None, [99, 11, 17, 23]), # Clang 17.0 (max: C2x)
+    ('rhel95',     'clang',    None, [99, 11, 17, 23]), # Clang 18.0 (max: C23)
 
-    ('debian10',   'gcc', None, [11, 17]), # GCC 8.3
-    ('ubuntu2004', 'gcc', None, [11,   ]), # GCC 9.3
-    ('debian11',   'gcc', None, [11, 17]), # GCC 10.2
+    ('rhel76',     'gcc',    None, [99, 11,       ]), # GCC 4.8 (max: C11)
+    ('rhel80',     'gcc',    None, [99, 11, 17,   ]), # GCC 8.2 (max: C17)
+    ('debian10',   'gcc-8',  None, [99, 11, 17,   ]), # GCC 8.3 (max: C17)
+    ('rhel84',     'gcc',    None, [99, 11, 17,   ]), # GCC 8.4 (max: C17)
+    ('ubuntu2004', 'gcc-9',  None, [99, 11, 17, 23]), # GCC 9.4 (max: C2x)
+    ('debian11',   'gcc-10', None, [99, 11, 17, 23]), # GCC 10.2 (max: C2x)
+    ('rhel90',     'gcc',    None, [99, 11, 17, 23]), # GCC 11.2 (max: C2x)
+    ('rhel92',     'gcc',    None, [99, 11, 17, 23]), # GCC 11.3 (max: C2x)
+    ('rhel94',     'gcc',    None, [99, 11, 17, 23]), # GCC 11.4 (max: C2x)
+    ('rhel95',     'gcc',    None, [99, 11, 17, 23]), # GCC 11.5 (max: C2x)
 
-    ('windows-vsCurrent', 'vs2017x64', None, [11, 17]),
+    ('windows-vsCurrent', 'vs2017x64', None, [99, 11, 17, 'latest']), # Max: C17, clatest (C2x)
+    ('windows-vsCurrent', 'vs2019x64', None, [99, 11, 17, 'latest']), # Max: C17, clatest (C2x)
+    ('windows-vsCurrent', 'vs2022x64', None, [99, 11, 17, 'latest']), # Max: C17, clatest (C2x)
 ]
 # fmt: on
 # pylint: enable=line-too-long
@@ -56,7 +71,9 @@ def tasks():
     res = []
 
     for distro_name, compiler, arch, stds in MATRIX:
-        tags = [TAG, distro_name, compiler, 'compile']
+        compiler_type = compiler.split('-')[0]
+
+        tags = [TAG, distro_name, compiler_type, 'compile']
 
         distro = find_large_distro(distro_name)
 
@@ -67,7 +84,7 @@ def tasks():
             tags.append(arch)
             compile_vars.update({'MARCH': arch})
 
-        distro_str = make_distro_str(distro_name, compiler, arch)
+        distro_str = make_distro_str(distro_name, compiler_type, arch)
 
         for std in stds:
             with_std = {'C_STD_VERSION': std}

--- a/.evergreen/config_generator/components/c_std_compile.py
+++ b/.evergreen/config_generator/components/c_std_compile.py
@@ -6,7 +6,7 @@ from config_generator.components.funcs.find_cmake_latest import FindCMakeLatest
 
 from config_generator.etc.distros import find_large_distro
 from config_generator.etc.distros import make_distro_str
-from config_generator.etc.distros import to_cc
+from config_generator.etc.distros import compiler_to_vars
 from config_generator.etc.function import Function
 from config_generator.etc.utils import bash_exec
 
@@ -59,7 +59,7 @@ def tasks():
         distro = find_large_distro(distro_name)
 
         compile_vars = None
-        compile_vars = {'CC': to_cc(compiler)}
+        compile_vars = compiler_to_vars(compiler)
 
         if arch:
             tags.append(arch)

--- a/.evergreen/config_generator/components/openssl_static_compile.py
+++ b/.evergreen/config_generator/components/openssl_static_compile.py
@@ -6,7 +6,7 @@ from config_generator.components.funcs.find_cmake_latest import FindCMakeLatest
 
 from config_generator.etc.distros import find_large_distro
 from config_generator.etc.distros import make_distro_str
-from config_generator.etc.distros import to_cc
+from config_generator.etc.distros import compiler_to_vars
 from config_generator.etc.function import Function
 from config_generator.etc.utils import bash_exec
 
@@ -55,7 +55,7 @@ def tasks():
         distro = find_large_distro(distro_name)
 
         compile_vars = None
-        compile_vars = {'CC': to_cc(compiler)}
+        compile_vars = compiler_to_vars(compiler)
 
         if arch:
             tags.append(arch)
@@ -72,7 +72,7 @@ def tasks():
                 tags=tags,
                 commands=[
                     FindCMakeLatest.call(),
-                    StaticOpenSSLCompile.call(vars=compile_vars),
+                    StaticOpenSSLCompile.call(vars=compile_vars if compile_vars else None),
                 ],
             )
         )

--- a/.evergreen/config_generator/components/scan_build.py
+++ b/.evergreen/config_generator/components/scan_build.py
@@ -7,7 +7,7 @@ from config_generator.components.funcs.find_cmake_latest import FindCMakeLatest
 
 from config_generator.etc.distros import find_large_distro
 from config_generator.etc.distros import make_distro_str
-from config_generator.etc.distros import to_cc
+from config_generator.etc.distros import compiler_to_vars
 from config_generator.etc.function import Function
 from config_generator.etc.utils import bash_exec
 
@@ -56,7 +56,7 @@ def tasks():
         distro = find_large_distro(distro_name)
 
         compile_vars = None
-        compile_vars = {'CC': to_cc(compiler)}
+        compile_vars = compiler_to_vars(compiler)
 
         if arch:
             tags.append(arch)
@@ -73,7 +73,7 @@ def tasks():
                 tags=tags,
                 commands=[
                     FindCMakeLatest.call(),
-                    ScanBuild.call(vars=compile_vars),
+                    ScanBuild.call(vars=compile_vars if compile_vars else None),
                     FunctionCall(func='upload scan artifacts'),
                 ],
             )

--- a/.evergreen/config_generator/etc/compile.py
+++ b/.evergreen/config_generator/etc/compile.py
@@ -2,7 +2,7 @@ from shrub.v3.evg_task import EvgTask
 
 from config_generator.etc.distros import find_large_distro
 from config_generator.etc.distros import make_distro_str
-from config_generator.etc.distros import to_cc
+from config_generator.etc.distros import compiler_to_vars
 
 from config_generator.components.funcs.find_cmake_latest import FindCMakeLatest
 from config_generator.components.funcs.upload_build import UploadBuild
@@ -20,7 +20,7 @@ def generate_compile_tasks(SSL, TAG, SASL_TO_FUNC, MATRIX, MORE_TAGS=None, MORE_
         distro = find_large_distro(distro_name)
 
         compile_vars = None
-        compile_vars = {'CC': to_cc(compiler)}
+        compile_vars = compiler_to_vars(compiler)
 
         if arch:
             tags.append(arch)
@@ -38,7 +38,7 @@ def generate_compile_tasks(SSL, TAG, SASL_TO_FUNC, MATRIX, MORE_TAGS=None, MORE_
 
             commands = []
             commands.append(FindCMakeLatest.call())
-            commands.append(SASL_TO_FUNC[sasl].call(vars=compile_vars))
+            commands.append(SASL_TO_FUNC[sasl].call(vars=compile_vars if compile_vars else None))
             commands.append(UploadBuild.call())
 
             res.append(

--- a/.evergreen/config_generator/etc/cse/test.py
+++ b/.evergreen/config_generator/etc/cse/test.py
@@ -6,7 +6,7 @@ from shrub.v3.evg_task import EvgTask, EvgTaskDependency
 
 from config_generator.etc.distros import find_small_distro
 from config_generator.etc.distros import make_distro_str
-from config_generator.etc.distros import to_cc
+from config_generator.etc.distros import compiler_to_vars
 
 from config_generator.components.funcs.bootstrap_mongo_orchestration import BootstrapMongoOrchestration
 from config_generator.components.funcs.fetch_build import FetchBuild
@@ -29,7 +29,7 @@ def generate_test_tasks(SSL, TAG, MATRIX):
         test_distro = find_small_distro(distro_name)
 
         compile_vars = []
-        compile_vars.append(KeyValueParam(key='CC', value=to_cc(compiler)))
+        compile_vars = [KeyValueParam(key=key, value=value) for key, value in compiler_to_vars(compiler).items()]
 
         if arch:
             tags.append(arch)

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -63,8 +63,15 @@ MACOS_ARM64_DISTROS = [
 ]
 
 RHEL_DISTROS = []
+RHEL_DISTROS += ls_distro(name='rhel76', os='rhel', os_type='linux', os_ver='7.6')
 RHEL_DISTROS += ls_distro(name='rhel80', os='rhel', os_type='linux', os_ver='8.0')
 RHEL_DISTROS += ls_distro(name='rhel84', os='rhel', os_type='linux', os_ver='8.4')
+RHEL_DISTROS += ls_distro(name='rhel90', os='rhel', os_type='linux', os_ver='9.0')
+RHEL_DISTROS += ls_distro(name='rhel91', os='rhel', os_type='linux', os_ver='9.1')
+RHEL_DISTROS += ls_distro(name='rhel92', os='rhel', os_type='linux', os_ver='9.2')
+RHEL_DISTROS += ls_distro(name='rhel93', os='rhel', os_type='linux', os_ver='9.3')
+RHEL_DISTROS += ls_distro(name='rhel94', os='rhel', os_type='linux', os_ver='9.4')
+RHEL_DISTROS += ls_distro(name='rhel95', os='rhel', os_type='linux', os_ver='9.5')
 RHEL_DISTROS += ls_distro(name='rhel8.9', os='rhel', os_type='linux', os_ver='8.7')
 RHEL_DISTROS += ls_distro(name='rhel92', os='rhel', os_type='linux', os_ver='9.0')
 
@@ -220,26 +227,26 @@ def to_platform(compiler):
 
 
 def compiler_to_vars(compiler):
-    match compiler:
-        case 'gcc':
+    match compiler, compiler.split('-'):
+        case _, ['gcc', *rest]:
             return {
-                'CC': 'gcc',
-                'CXX': 'g++',
+                'CC': '-'.join(['gcc'] + rest),
+                'CXX': '-'.join(['g++'] + rest),
             }
 
-        case 'clang':
+        case _, ['clang', *rest]:
             return {
-                'CC': 'clang',
-                'CXX': 'clang++',
+                'CC': '-'.join(['clang'] + rest),
+                'CXX': '-'.join(['clang++'] + rest),
             }
 
-        case str(vs) if 'vs' in vs:
+        case str(vs), _ if 'vs' in vs:
             return {
                 'CMAKE_GENERATOR': to_cc(vs),
                 'CMAKE_GENERATOR_PLATFORM': to_platform(vs),
             }
 
-        case _:
+        case compiler, _:
             return {
                 'CC': compiler,
                 'CXX': compiler,

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -77,19 +77,12 @@ RHEL_DISTROS = [
     *ls_distro(name='rhel92', os='rhel', os_type='linux', os_ver='9.0'),
 ]
 
-RHEL_ARM64_DISTROS = [
-    *ls_distro(name='rhel82-arm64', os='rhel', os_type='linux', os_ver='8.2', arch='arm64'),
-    *ls_distro(name='rhel92-arm64', os='rhel', os_type='linux', os_ver='9.0', arch='arm64'),
-]
-
 RHEL_POWER_DISTROS = [
     *ls_distro(name='rhel8-power', os='rhel', os_type='linux', os_ver='8', arch='power'),
-    *ls_distro(name='rhel9-power', os='rhel', os_type='linux', os_ver='9', arch='power'),
 ]
 
 RHEL_ZSERIES_DISTROS = [
     *ls_distro(name='rhel8-zseries', os='rhel', os_type='linux', os_ver='8', arch='zseries'),
-    *ls_distro(name='rhel9-zseries', os='rhel', os_type='linux', os_ver='9', arch='zseries'),
 ]
 
 UBUNTU_DISTROS = [
@@ -99,23 +92,14 @@ UBUNTU_DISTROS = [
 
 UBUNTU_ARM64_DISTROS = [
     *ls_distro(name='ubuntu2004-arm64', os='ubuntu', os_type='linux', os_ver='20.04', arch='arm64'),
-    *ls_distro(name='ubuntu2204-arm64', os='ubuntu', os_type='linux', os_ver='22.04', arch='arm64'),
 ]
 
 WINDOWS_DISTROS = [
-    *ls_distro(name='windows-64-vs2013', os='windows', os_type='windows', vs_ver='2013'),
     *ls_distro(name='windows-64-vs2015', os='windows', os_type='windows', vs_ver='2015'),
     *ls_distro(name='windows-64-vs2017', os='windows', os_type='windows', vs_ver='2017'),
     *ls_distro(name='windows-64-vs2019', os='windows', os_type='windows', vs_ver='2019'),
 
-    *ls_distro(name='windows-2022', os='windows', os_type='windows', os_ver='2022'),
-
-    Distro(name='windows-64-2019', os='windows', os_type='windows', os_ver='2019'),
-    Distro(name='windows-64-vsMulti-small', os='windows', os_type='windows', vs_ver='vsMulti', size='small'),
-
-    *ls_distro(name='windows-vsCurrent-2022', os='windows', os_type='windows', os_ver='2022', vs_ver='vsCurrent'),
-
-    *ls_distro(name='windows-vsCurrent', os='windows', os_type='windows', vs_ver='vsCurrent'), # Windows Server 2019
+    *ls_distro(name='windows-vsCurrent', os='windows', os_type='windows', vs_ver='vsCurrent'),  # Windows Server 2019
 ]
 
 # Ensure no-arch distros are ordered before arch-specific distros.
@@ -124,7 +108,6 @@ ALL_DISTROS = [
     *MACOS_DISTROS,
     *MACOS_ARM64_DISTROS,
     *RHEL_DISTROS,
-    *RHEL_ARM64_DISTROS,
     *RHEL_POWER_DISTROS,
     *RHEL_ZSERIES_DISTROS,
     *UBUNTU_DISTROS,

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -205,6 +205,10 @@ def make_distro_str(distro_name, compiler, arch) -> str:
             'vs2015x86': '-x86',
             'vs2017x64': '-x64',
             'vs2017x86': '-x86',
+            'vs2019x64': '-x64',
+            'vs2019x86': '-x86',
+            'vs2022x64': '-x64',
+            'vs2022x86': '-x86',
         }.get(compiler, f'-{compiler}')
     else:
         distro_str = distro_name
@@ -219,10 +223,56 @@ def make_distro_str(distro_name, compiler, arch) -> str:
 
 def to_cc(compiler):
     return {
-        'vs2013x64': 'Visual Studio 12 2013 Win64',
+        'vs2013x64': 'Visual Studio 12 2013',
         'vs2013x86': 'Visual Studio 12 2013',
-        'vs2015x64': 'Visual Studio 14 2015 Win64',
+        'vs2015x64': 'Visual Studio 14 2015',
         'vs2015x86': 'Visual Studio 14 2015',
-        'vs2017x64': 'Visual Studio 15 2017 Win64',
+        'vs2017x64': 'Visual Studio 15 2017',
         'vs2017x86': 'Visual Studio 15 2017',
+        'vs2019x64': 'Visual Studio 16 2019',
+        'vs2019x86': 'Visual Studio 16 2019',
+        'vs2022x64': 'Visual Studio 17 2022',
+        'vs2022x86': 'Visual Studio 17 2022',
     }.get(compiler, compiler)
+
+
+def to_platform(compiler):
+    return {
+        'vs2013x64': 'x64',
+        'vs2013x86': 'Win32',
+        'vs2015x64': 'x64',
+        'vs2015x86': 'Win32',
+        'vs2017x64': 'x64',
+        'vs2017x86': 'Win32',
+        'vs2019x64': 'x64',
+        'vs2019x86': 'Win32',
+        'vs2022x64': 'x64',
+        'vs2022x86': 'Win32',
+    }.get(compiler, compiler)
+
+
+def compiler_to_vars(compiler):
+    match compiler:
+        case 'gcc':
+            return {
+                'CC': 'gcc',
+                'CXX': 'g++',
+            }
+
+        case 'clang':
+            return {
+                'CC': 'clang',
+                'CXX': 'clang++',
+            }
+
+        case str(vs) if 'vs' in vs:
+            return {
+                'CMAKE_GENERATOR': to_cc(vs),
+                'CMAKE_GENERATOR_PLATFORM': to_platform(vs),
+            }
+
+        case _:
+            return {
+                'CC': compiler,
+                'CXX': compiler,
+            }

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -39,19 +39,19 @@ class Distro(BaseModel):
     def validate_os_ver(cls, value):
         return Version(value)
 
+
+def ls_distro(name, **kwargs):
+    return [
+        Distro(name=f'{name}-large', size='large', **kwargs),
+        Distro(name=f'{name}-small', size='small', **kwargs),
+    ]
+
+
 # See: https://evergreen.mongodb.com/distros
-# pylint: disable=line-too-long
-#fmt: off
-DEBIAN_DISTROS = [
-    Distro(name='debian92-large', os='debian', os_type='linux', os_ver='9.2', size='large'), # CDRIVER-5873
-    Distro(name='debian92-small', os='debian', os_type='linux', os_ver='9.2', size='small'), # CDRIVER-5873
-    Distro(name='debian10-large', os='debian', os_type='linux', os_ver='10', size='large'), # CDRIVER-5874
-    Distro(name='debian10-small', os='debian', os_type='linux', os_ver='10', size='small'), # CDRIVER-5874
-    Distro(name='debian11-large', os='debian', os_type='linux', os_ver='11', size='large'),
-    Distro(name='debian11-small', os='debian', os_type='linux', os_ver='11', size='small'),
-    Distro(name='debian92-large', os='debian', os_type='linux', os_ver='9.2', size='large'),
-    Distro(name='debian92-small', os='debian', os_type='linux', os_ver='9.2', size='small'),
-]
+DEBIAN_DISTROS = []
+DEBIAN_DISTROS += ls_distro(name='debian92', os='debian', os_type='linux', os_ver='9.2')  # CDRIVER-5873
+DEBIAN_DISTROS += ls_distro(name='debian10', os='debian', os_type='linux', os_ver='10')  # CDRIVER-5874
+DEBIAN_DISTROS += ls_distro(name='debian11', os='debian', os_type='linux', os_ver='11')
 
 MACOS_DISTROS = [
     Distro(name='macos-14', os='macos', os_type='macos', os_ver='14'),
@@ -62,77 +62,45 @@ MACOS_ARM64_DISTROS = [
     Distro(name='macos-14-arm64', os='macos', os_type='macos', os_ver='14', arch='arm64'),
 ]
 
-RHEL_DISTROS = [
-    Distro(name='rhel80-large', os='rhel', os_type='linux', os_ver='8.0', size='large'),
-    Distro(name='rhel80-small', os='rhel', os_type='linux', os_ver='8.0', size='small'),
-    Distro(name='rhel84-large', os='rhel', os_type='linux', os_ver='8.4', size='large'),
-    Distro(name='rhel84-small', os='rhel', os_type='linux', os_ver='8.4', size='small'),
-    Distro(name='rhel8.9-large', os='rhel', os_type='linux', os_ver='8.7', size='large'),
-    Distro(name='rhel8.9-small', os='rhel', os_type='linux', os_ver='8.7', size='small'),
-    Distro(name='rhel92-large', os='rhel', os_type='linux', os_ver='9.0', size='large'),
-    Distro(name='rhel92-small', os='rhel', os_type='linux', os_ver='9.0', size='small'),
-]
+RHEL_DISTROS = []
+RHEL_DISTROS += ls_distro(name='rhel80', os='rhel', os_type='linux', os_ver='8.0')
+RHEL_DISTROS += ls_distro(name='rhel84', os='rhel', os_type='linux', os_ver='8.4')
+RHEL_DISTROS += ls_distro(name='rhel8.9', os='rhel', os_type='linux', os_ver='8.7')
+RHEL_DISTROS += ls_distro(name='rhel92', os='rhel', os_type='linux', os_ver='9.0')
 
-RHEL_ARM64_DISTROS = [
-    Distro(name='rhel82-arm64-large', os='rhel', os_type='linux', os_ver='8.2', size='large', arch='arm64'),
-    Distro(name='rhel82-arm64-small', os='rhel', os_type='linux', os_ver='8.2', size='small', arch='arm64'),
-    Distro(name='rhel92-arm64-large', os='rhel', os_type='linux', os_ver='9.0', size='large', arch='arm64'),
-    Distro(name='rhel92-arm64-small', os='rhel', os_type='linux', os_ver='9.0', size='small', arch='arm64'),
-]
+RHEL_ARM64_DISTROS = []
+RHEL_ARM64_DISTROS += ls_distro(name='rhel82-arm64', os='rhel', os_type='linux', os_ver='8.2', arch='arm64')
+RHEL_ARM64_DISTROS += ls_distro(name='rhel92-arm64', os='rhel', os_type='linux', os_ver='9.0', arch='arm64')
 
-RHEL_POWER_DISTROS = [
-    Distro(name='rhel8-power-large', os='rhel', os_type='linux', os_ver='8', size='large', arch='power'),
-    Distro(name='rhel8-power-small', os='rhel', os_type='linux', os_ver='8', size='small', arch='power'),
-    Distro(name='rhel9-power-large', os='rhel', os_type='linux', os_ver='9', size='large', arch='power'),
-    Distro(name='rhel9-power-small', os='rhel', os_type='linux', os_ver='9', size='small', arch='power'),
-]
+RHEL_POWER_DISTROS = []
+RHEL_POWER_DISTROS += ls_distro(name='rhel8-power', os='rhel', os_type='linux', os_ver='8', arch='power')
+RHEL_POWER_DISTROS += ls_distro(name='rhel9-power', os='rhel', os_type='linux', os_ver='9', arch='power')
 
-RHEL_ZSERIES_DISTROS = [
-    Distro(name='rhel8-zseries-large', os='rhel', os_type='linux', os_ver='8', size='large', arch='zseries'),
-    Distro(name='rhel8-zseries-small', os='rhel', os_type='linux', os_ver='8', size='small', arch='zseries'),
-    Distro(name='rhel9-zseries-large', os='rhel', os_type='linux', os_ver='9', size='large', arch='zseries'),
-    Distro(name='rhel9-zseries-small', os='rhel', os_type='linux', os_ver='9', size='small', arch='zseries'),
-]
+RHEL_ZSERIES_DISTROS = []
+RHEL_ZSERIES_DISTROS += ls_distro(name='rhel8-zseries', os='rhel', os_type='linux', os_ver='8', arch='zseries')
+RHEL_ZSERIES_DISTROS += ls_distro(name='rhel9-zseries', os='rhel', os_type='linux', os_ver='9', arch='zseries')
 
-UBUNTU_DISTROS = [
-    Distro(name='ubuntu2004-large', os='ubuntu', os_type='linux', os_ver='20.04', size='large'),
-    Distro(name='ubuntu2004-small', os='ubuntu', os_type='linux', os_ver='20.04', size='small'),
-    Distro(name='ubuntu2204-large', os='ubuntu', os_type='linux', os_ver='22.04', size='large'),
-    Distro(name='ubuntu2204-small', os='ubuntu', os_type='linux', os_ver='22.04', size='small'),
-]
+UBUNTU_DISTROS = []
+UBUNTU_DISTROS += ls_distro(name='ubuntu2004', os='ubuntu', os_type='linux', os_ver='20.04')
+UBUNTU_DISTROS += ls_distro(name='ubuntu2204', os='ubuntu', os_type='linux', os_ver='22.04')
 
-UBUNTU_ARM64_DISTROS = [
-    Distro(name='ubuntu2004-arm64-large', os='ubuntu', os_type='linux', os_ver='20.04', size='large', arch='arm64'),
-    Distro(name='ubuntu2004-arm64-small', os='ubuntu', os_type='linux', os_ver='20.04', size='small', arch='arm64'),
-    Distro(name='ubuntu2204-arm64-large', os='ubuntu', os_type='linux', os_ver='22.04', size='large', arch='arm64'),
-    Distro(name='ubuntu2204-arm64-small', os='ubuntu', os_type='linux', os_ver='22.04', size='small', arch='arm64'),
-]
+UBUNTU_ARM64_DISTROS = []
+UBUNTU_ARM64_DISTROS += ls_distro(name='ubuntu2004-arm64', os='ubuntu', os_type='linux', os_ver='20.04', arch='arm64')
+UBUNTU_ARM64_DISTROS += ls_distro(name='ubuntu2204-arm64', os='ubuntu', os_type='linux', os_ver='22.04', arch='arm64')
 
-WINDOWS_DISTROS = [
-    Distro(name='windows-64-vs2013-large', os='windows', os_type='windows', vs_ver='2013', size='large'),
-    Distro(name='windows-64-vs2013-small', os='windows', os_type='windows', vs_ver='2013', size='small'),
-    Distro(name='windows-64-vs2015-large', os='windows', os_type='windows', vs_ver='2015', size='large'),
-    Distro(name='windows-64-vs2015-small', os='windows', os_type='windows', vs_ver='2015', size='small'),
-    Distro(name='windows-64-vs2017-large', os='windows', os_type='windows', vs_ver='2017', size='large'),
-    Distro(name='windows-64-vs2017-small', os='windows', os_type='windows', vs_ver='2017', size='small'),
-    Distro(name='windows-64-vs2019-large', os='windows', os_type='windows', vs_ver='2019', size='large'),
-    Distro(name='windows-64-vs2019-small', os='windows', os_type='windows', vs_ver='2019', size='small'),
-
-    Distro(name='windows-2022-large', os='windows', os_type='windows', os_ver='2022'),
-    Distro(name='windows-2022-small', os='windows', os_type='windows', os_ver='2022'),
-
-    Distro(name='windows-64-2019', os='windows', os_type='windows', os_ver='2019'),
-
-    Distro(name='windows-64-vsMulti-small', os='windows', os_type='windows', vs_ver='vsMulti', size='small'),
-
-    Distro(name='windows-vsCurrent-2022-large', os='windows', os_type='windows', os_ver='2022', vs_ver='vsCurrent', size='large'),
-    Distro(name='windows-vsCurrent-2022-small', os='windows', os_type='windows', os_ver='2022', vs_ver='vsCurrent', size='small'),
-
-    Distro(name='windows-vsCurrent-large', os='windows', os_type='windows', vs_ver='vsCurrent', size='large'), # Windows Server 2019
-    Distro(name='windows-vsCurrent-small', os='windows', os_type='windows', vs_ver='vsCurrent', size='small'), # Windows Server 2019
-]
-#fmt: on
-# pylint: enable=line-too-long
+WINDOWS_DISTROS = []
+WINDOWS_DISTROS += ls_distro(name='windows-64-vs2013', os='windows', os_type='windows', vs_ver='2013')
+WINDOWS_DISTROS += ls_distro(name='windows-64-vs2015', os='windows', os_type='windows', vs_ver='2015')
+WINDOWS_DISTROS += ls_distro(name='windows-64-vs2017', os='windows', os_type='windows', vs_ver='2017')
+WINDOWS_DISTROS += ls_distro(name='windows-64-vs2019', os='windows', os_type='windows', vs_ver='2019')
+WINDOWS_DISTROS += ls_distro(name='windows-2022', os='windows', os_type='windows', os_ver='2022')
+WINDOWS_DISTROS += [Distro(name='windows-64-2019', os='windows', os_type='windows', os_ver='2019')]
+WINDOWS_DISTROS += [Distro(name='windows-64-vsMulti-small', os='windows',
+                           os_type='windows', vs_ver='vsMulti', size='small')]
+WINDOWS_DISTROS += ls_distro(name='windows-vsCurrent-2022', os='windows',
+                             os_type='windows', os_ver='2022', vs_ver='vsCurrent')
+WINDOWS_DISTROS += ls_distro(name='windows-vsCurrent', os='windows', os_type='windows',
+                             vs_ver='vsCurrent')  # Windows Server 2019
 
 # Ensure no-arch distros are ordered before arch-specific distros.
 ALL_DISTROS = [] + \

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -47,7 +47,6 @@ def ls_distro(name, **kwargs):
     ]
 
 
-# See: https://evergreen.mongodb.com/distros
 DEBIAN_DISTROS = [
     *ls_distro(name='debian92', os='debian', os_type='linux', os_ver='9.2'),  # CDRIVER-5873
     *ls_distro(name='debian10', os='debian', os_type='linux', os_ver='10'),  # CDRIVER-5874
@@ -102,6 +101,7 @@ WINDOWS_DISTROS = [
     *ls_distro(name='windows-vsCurrent', os='windows', os_type='windows', vs_ver='vsCurrent'),  # Windows Server 2019
 ]
 
+# See: https://evergreen.mongodb.com/distros
 # Ensure no-arch distros are ordered before arch-specific distros.
 ALL_DISTROS = [
     *DEBIAN_DISTROS,

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -48,10 +48,11 @@ def ls_distro(name, **kwargs):
 
 
 # See: https://evergreen.mongodb.com/distros
-DEBIAN_DISTROS = []
-DEBIAN_DISTROS += ls_distro(name='debian92', os='debian', os_type='linux', os_ver='9.2')  # CDRIVER-5873
-DEBIAN_DISTROS += ls_distro(name='debian10', os='debian', os_type='linux', os_ver='10')  # CDRIVER-5874
-DEBIAN_DISTROS += ls_distro(name='debian11', os='debian', os_type='linux', os_ver='11')
+DEBIAN_DISTROS = [
+    *ls_distro(name='debian92', os='debian', os_type='linux', os_ver='9.2'),  # CDRIVER-5873
+    *ls_distro(name='debian10', os='debian', os_type='linux', os_ver='10'),  # CDRIVER-5874
+    *ls_distro(name='debian11', os='debian', os_type='linux', os_ver='11'),
+]
 
 MACOS_DISTROS = [
     Distro(name='macos-14', os='macos', os_type='macos', os_ver='14'),
@@ -62,65 +63,74 @@ MACOS_ARM64_DISTROS = [
     Distro(name='macos-14-arm64', os='macos', os_type='macos', os_ver='14', arch='arm64'),
 ]
 
-RHEL_DISTROS = []
-RHEL_DISTROS += ls_distro(name='rhel76', os='rhel', os_type='linux', os_ver='7.6')
-RHEL_DISTROS += ls_distro(name='rhel80', os='rhel', os_type='linux', os_ver='8.0')
-RHEL_DISTROS += ls_distro(name='rhel84', os='rhel', os_type='linux', os_ver='8.4')
-RHEL_DISTROS += ls_distro(name='rhel90', os='rhel', os_type='linux', os_ver='9.0')
-RHEL_DISTROS += ls_distro(name='rhel91', os='rhel', os_type='linux', os_ver='9.1')
-RHEL_DISTROS += ls_distro(name='rhel92', os='rhel', os_type='linux', os_ver='9.2')
-RHEL_DISTROS += ls_distro(name='rhel93', os='rhel', os_type='linux', os_ver='9.3')
-RHEL_DISTROS += ls_distro(name='rhel94', os='rhel', os_type='linux', os_ver='9.4')
-RHEL_DISTROS += ls_distro(name='rhel95', os='rhel', os_type='linux', os_ver='9.5')
-RHEL_DISTROS += ls_distro(name='rhel8.9', os='rhel', os_type='linux', os_ver='8.7')
-RHEL_DISTROS += ls_distro(name='rhel92', os='rhel', os_type='linux', os_ver='9.0')
+RHEL_DISTROS = [
+    *ls_distro(name='rhel76', os='rhel', os_type='linux', os_ver='7.6'),
+    *ls_distro(name='rhel80', os='rhel', os_type='linux', os_ver='8.0'),
+    *ls_distro(name='rhel84', os='rhel', os_type='linux', os_ver='8.4'),
+    *ls_distro(name='rhel90', os='rhel', os_type='linux', os_ver='9.0'),
+    *ls_distro(name='rhel91', os='rhel', os_type='linux', os_ver='9.1'),
+    *ls_distro(name='rhel92', os='rhel', os_type='linux', os_ver='9.2'),
+    *ls_distro(name='rhel93', os='rhel', os_type='linux', os_ver='9.3'),
+    *ls_distro(name='rhel94', os='rhel', os_type='linux', os_ver='9.4'),
+    *ls_distro(name='rhel95', os='rhel', os_type='linux', os_ver='9.5'),
+    *ls_distro(name='rhel8.9', os='rhel', os_type='linux', os_ver='8.7'),
+    *ls_distro(name='rhel92', os='rhel', os_type='linux', os_ver='9.0'),
+]
 
-RHEL_ARM64_DISTROS = []
-RHEL_ARM64_DISTROS += ls_distro(name='rhel82-arm64', os='rhel', os_type='linux', os_ver='8.2', arch='arm64')
-RHEL_ARM64_DISTROS += ls_distro(name='rhel92-arm64', os='rhel', os_type='linux', os_ver='9.0', arch='arm64')
+RHEL_ARM64_DISTROS = [
+    *ls_distro(name='rhel82-arm64', os='rhel', os_type='linux', os_ver='8.2', arch='arm64'),
+    *ls_distro(name='rhel92-arm64', os='rhel', os_type='linux', os_ver='9.0', arch='arm64'),
+]
 
-RHEL_POWER_DISTROS = []
-RHEL_POWER_DISTROS += ls_distro(name='rhel8-power', os='rhel', os_type='linux', os_ver='8', arch='power')
-RHEL_POWER_DISTROS += ls_distro(name='rhel9-power', os='rhel', os_type='linux', os_ver='9', arch='power')
+RHEL_POWER_DISTROS = [
+    *ls_distro(name='rhel8-power', os='rhel', os_type='linux', os_ver='8', arch='power'),
+    *ls_distro(name='rhel9-power', os='rhel', os_type='linux', os_ver='9', arch='power'),
+]
 
-RHEL_ZSERIES_DISTROS = []
-RHEL_ZSERIES_DISTROS += ls_distro(name='rhel8-zseries', os='rhel', os_type='linux', os_ver='8', arch='zseries')
-RHEL_ZSERIES_DISTROS += ls_distro(name='rhel9-zseries', os='rhel', os_type='linux', os_ver='9', arch='zseries')
+RHEL_ZSERIES_DISTROS = [
+    *ls_distro(name='rhel8-zseries', os='rhel', os_type='linux', os_ver='8', arch='zseries'),
+    *ls_distro(name='rhel9-zseries', os='rhel', os_type='linux', os_ver='9', arch='zseries'),
+]
 
-UBUNTU_DISTROS = []
-UBUNTU_DISTROS += ls_distro(name='ubuntu2004', os='ubuntu', os_type='linux', os_ver='20.04')
-UBUNTU_DISTROS += ls_distro(name='ubuntu2204', os='ubuntu', os_type='linux', os_ver='22.04')
+UBUNTU_DISTROS = [
+    *ls_distro(name='ubuntu2004', os='ubuntu', os_type='linux', os_ver='20.04'),
+    *ls_distro(name='ubuntu2204', os='ubuntu', os_type='linux', os_ver='22.04'),
+]
 
-UBUNTU_ARM64_DISTROS = []
-UBUNTU_ARM64_DISTROS += ls_distro(name='ubuntu2004-arm64', os='ubuntu', os_type='linux', os_ver='20.04', arch='arm64')
-UBUNTU_ARM64_DISTROS += ls_distro(name='ubuntu2204-arm64', os='ubuntu', os_type='linux', os_ver='22.04', arch='arm64')
+UBUNTU_ARM64_DISTROS = [
+    *ls_distro(name='ubuntu2004-arm64', os='ubuntu', os_type='linux', os_ver='20.04', arch='arm64'),
+    *ls_distro(name='ubuntu2204-arm64', os='ubuntu', os_type='linux', os_ver='22.04', arch='arm64'),
+]
 
-WINDOWS_DISTROS = []
-WINDOWS_DISTROS += ls_distro(name='windows-64-vs2013', os='windows', os_type='windows', vs_ver='2013')
-WINDOWS_DISTROS += ls_distro(name='windows-64-vs2015', os='windows', os_type='windows', vs_ver='2015')
-WINDOWS_DISTROS += ls_distro(name='windows-64-vs2017', os='windows', os_type='windows', vs_ver='2017')
-WINDOWS_DISTROS += ls_distro(name='windows-64-vs2019', os='windows', os_type='windows', vs_ver='2019')
-WINDOWS_DISTROS += ls_distro(name='windows-2022', os='windows', os_type='windows', os_ver='2022')
-WINDOWS_DISTROS += [Distro(name='windows-64-2019', os='windows', os_type='windows', os_ver='2019')]
-WINDOWS_DISTROS += [Distro(name='windows-64-vsMulti-small', os='windows',
-                           os_type='windows', vs_ver='vsMulti', size='small')]
-WINDOWS_DISTROS += ls_distro(name='windows-vsCurrent-2022', os='windows',
-                             os_type='windows', os_ver='2022', vs_ver='vsCurrent')
-WINDOWS_DISTROS += ls_distro(name='windows-vsCurrent', os='windows', os_type='windows',
-                             vs_ver='vsCurrent')  # Windows Server 2019
+WINDOWS_DISTROS = [
+    *ls_distro(name='windows-64-vs2013', os='windows', os_type='windows', vs_ver='2013'),
+    *ls_distro(name='windows-64-vs2015', os='windows', os_type='windows', vs_ver='2015'),
+    *ls_distro(name='windows-64-vs2017', os='windows', os_type='windows', vs_ver='2017'),
+    *ls_distro(name='windows-64-vs2019', os='windows', os_type='windows', vs_ver='2019'),
+
+    *ls_distro(name='windows-2022', os='windows', os_type='windows', os_ver='2022'),
+
+    Distro(name='windows-64-2019', os='windows', os_type='windows', os_ver='2019'),
+    Distro(name='windows-64-vsMulti-small', os='windows', os_type='windows', vs_ver='vsMulti', size='small'),
+
+    *ls_distro(name='windows-vsCurrent-2022', os='windows', os_type='windows', os_ver='2022', vs_ver='vsCurrent'),
+
+    *ls_distro(name='windows-vsCurrent', os='windows', os_type='windows', vs_ver='vsCurrent'), # Windows Server 2019
+]
 
 # Ensure no-arch distros are ordered before arch-specific distros.
-ALL_DISTROS = [] + \
-    DEBIAN_DISTROS + \
-    MACOS_DISTROS + \
-    MACOS_ARM64_DISTROS + \
-    RHEL_DISTROS + \
-    RHEL_ARM64_DISTROS + \
-    RHEL_POWER_DISTROS + \
-    RHEL_ZSERIES_DISTROS + \
-    UBUNTU_DISTROS + \
-    UBUNTU_ARM64_DISTROS + \
-    WINDOWS_DISTROS
+ALL_DISTROS = [
+    *DEBIAN_DISTROS,
+    *MACOS_DISTROS,
+    *MACOS_ARM64_DISTROS,
+    *RHEL_DISTROS,
+    *RHEL_ARM64_DISTROS,
+    *RHEL_POWER_DISTROS,
+    *RHEL_ZSERIES_DISTROS,
+    *UBUNTU_DISTROS,
+    *UBUNTU_ARM64_DISTROS,
+    *WINDOWS_DISTROS,
+]
 
 
 def find_distro(name) -> Distro:

--- a/.evergreen/config_generator/etc/sanitizers/test.py
+++ b/.evergreen/config_generator/etc/sanitizers/test.py
@@ -6,7 +6,7 @@ from shrub.v3.evg_task import EvgTask, EvgTaskDependency
 
 from config_generator.etc.distros import find_small_distro
 from config_generator.etc.distros import make_distro_str
-from config_generator.etc.distros import to_cc
+from config_generator.etc.distros import compiler_to_vars
 
 from config_generator.components.funcs.bootstrap_mongo_orchestration import BootstrapMongoOrchestration
 from config_generator.components.funcs.fetch_build import FetchBuild
@@ -37,7 +37,7 @@ def generate_test_tasks(SSL, TAG, MATRIX, MORE_COMPILE_TAGS=None, MORE_TEST_TAGS
         test_distro = find_small_distro(distro_name)
 
         compile_vars = []
-        compile_vars.append(KeyValueParam(key='CC', value=to_cc(compiler)))
+        compile_vars = [KeyValueParam(key=key, value=value) for key, value in compiler_to_vars(compiler).items()]
 
         if arch:
             tags.append(arch)

--- a/.evergreen/config_generator/etc/sasl/test.py
+++ b/.evergreen/config_generator/etc/sasl/test.py
@@ -6,7 +6,7 @@ from shrub.v3.evg_task import EvgTask, EvgTaskDependency
 
 from config_generator.etc.distros import find_small_distro
 from config_generator.etc.distros import make_distro_str
-from config_generator.etc.distros import to_cc
+from config_generator.etc.distros import compiler_to_vars
 
 from config_generator.components.funcs.bootstrap_mongo_orchestration import BootstrapMongoOrchestration
 from config_generator.components.funcs.fetch_build import FetchBuild
@@ -29,7 +29,7 @@ def generate_test_tasks(SSL, TAG, MATRIX):
         test_distro = find_small_distro(distro_name)
 
         compile_vars = []
-        compile_vars.append(KeyValueParam(key='CC', value=to_cc(compiler)))
+        compile_vars = [KeyValueParam(key=key, value=value) for key, value in compiler_to_vars(compiler).items()]
 
         if arch:
             tags.append(arch)

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -5024,16 +5024,6 @@ tasks:
           CXX: clang++
           MARCH: i686
       - func: upload scan artifacts
-  - name: std-c11-debian10-clang-compile
-    run_on: debian10-large
-    tags: [std-matrix, debian10, clang, compile, std-c11]
-    commands:
-      - func: find-cmake-latest
-      - func: std-compile
-        vars:
-          CC: clang
-          CXX: clang++
-          C_STD_VERSION: 11
   - name: std-c11-debian10-gcc-compile
     run_on: debian10-large
     tags: [std-matrix, debian10, gcc, compile, std-c11]
@@ -5041,18 +5031,8 @@ tasks:
       - func: find-cmake-latest
       - func: std-compile
         vars:
-          CC: gcc
-          CXX: g++
-          C_STD_VERSION: 11
-  - name: std-c11-debian11-clang-compile
-    run_on: debian11-large
-    tags: [std-matrix, debian11, clang, compile, std-c11]
-    commands:
-      - func: find-cmake-latest
-      - func: std-compile
-        vars:
-          CC: clang
-          CXX: clang++
+          CC: gcc-8
+          CXX: g++-8
           C_STD_VERSION: 11
   - name: std-c11-debian11-gcc-compile
     run_on: debian11-large
@@ -5061,18 +5041,158 @@ tasks:
       - func: find-cmake-latest
       - func: std-compile
         vars:
+          CC: gcc-10
+          CXX: g++-10
+          C_STD_VERSION: 11
+  - name: std-c11-rhel76-gcc-compile
+    run_on: rhel76-large
+    tags: [std-matrix, rhel76, gcc, compile, std-c11]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
           CC: gcc
           CXX: g++
           C_STD_VERSION: 11
-  - name: std-c11-debian92-clang-compile
-    run_on: debian92-large
-    tags: [std-matrix, debian92, clang, compile, std-c11]
+  - name: std-c11-rhel80-clang-compile
+    run_on: rhel80-large
+    tags: [std-matrix, rhel80, clang, compile, std-c11]
     commands:
       - func: find-cmake-latest
       - func: std-compile
         vars:
           CC: clang
           CXX: clang++
+          C_STD_VERSION: 11
+  - name: std-c11-rhel80-gcc-compile
+    run_on: rhel80-large
+    tags: [std-matrix, rhel80, gcc, compile, std-c11]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc
+          CXX: g++
+          C_STD_VERSION: 11
+  - name: std-c11-rhel84-clang-compile
+    run_on: rhel84-large
+    tags: [std-matrix, rhel84, clang, compile, std-c11]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 11
+  - name: std-c11-rhel84-gcc-compile
+    run_on: rhel84-large
+    tags: [std-matrix, rhel84, gcc, compile, std-c11]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc
+          CXX: g++
+          C_STD_VERSION: 11
+  - name: std-c11-rhel90-clang-compile
+    run_on: rhel90-large
+    tags: [std-matrix, rhel90, clang, compile, std-c11]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 11
+  - name: std-c11-rhel90-gcc-compile
+    run_on: rhel90-large
+    tags: [std-matrix, rhel90, gcc, compile, std-c11]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc
+          CXX: g++
+          C_STD_VERSION: 11
+  - name: std-c11-rhel91-clang-compile
+    run_on: rhel91-large
+    tags: [std-matrix, rhel91, clang, compile, std-c11]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 11
+  - name: std-c11-rhel92-clang-compile
+    run_on: rhel92-large
+    tags: [std-matrix, rhel92, clang, compile, std-c11]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 11
+  - name: std-c11-rhel92-gcc-compile
+    run_on: rhel92-large
+    tags: [std-matrix, rhel92, gcc, compile, std-c11]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc
+          CXX: g++
+          C_STD_VERSION: 11
+  - name: std-c11-rhel93-clang-compile
+    run_on: rhel93-large
+    tags: [std-matrix, rhel93, clang, compile, std-c11]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 11
+  - name: std-c11-rhel94-clang-compile
+    run_on: rhel94-large
+    tags: [std-matrix, rhel94, clang, compile, std-c11]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 11
+  - name: std-c11-rhel94-gcc-compile
+    run_on: rhel94-large
+    tags: [std-matrix, rhel94, gcc, compile, std-c11]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc
+          CXX: g++
+          C_STD_VERSION: 11
+  - name: std-c11-rhel95-clang-compile
+    run_on: rhel95-large
+    tags: [std-matrix, rhel95, clang, compile, std-c11]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 11
+  - name: std-c11-rhel95-gcc-compile
+    run_on: rhel95-large
+    tags: [std-matrix, rhel95, gcc, compile, std-c11]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc
+          CXX: g++
           C_STD_VERSION: 11
   - name: std-c11-ubuntu2004-clang-compile
     run_on: ubuntu2004-large
@@ -5081,8 +5201,8 @@ tasks:
       - func: find-cmake-latest
       - func: std-compile
         vars:
-          CC: clang
-          CXX: clang++
+          CC: clang-10
+          CXX: clang++-10
           C_STD_VERSION: 11
   - name: std-c11-ubuntu2004-gcc-compile
     run_on: ubuntu2004-large
@@ -5091,8 +5211,18 @@ tasks:
       - func: find-cmake-latest
       - func: std-compile
         vars:
-          CC: gcc
-          CXX: g++
+          CC: gcc-9
+          CXX: g++-9
+          C_STD_VERSION: 11
+  - name: std-c11-ubuntu2204-clang-compile
+    run_on: ubuntu2204-large
+    tags: [std-matrix, ubuntu2204, clang, compile, std-c11]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang-12
+          CXX: clang++-12
           C_STD_VERSION: 11
   - name: std-c11-windows-2019-vs2017-x64-compile
     run_on: windows-vsCurrent-large
@@ -5104,6 +5234,26 @@ tasks:
           CMAKE_GENERATOR: Visual Studio 15 2017
           CMAKE_GENERATOR_PLATFORM: x64
           C_STD_VERSION: 11
+  - name: std-c11-windows-2019-vs2019-x64-compile
+    run_on: windows-vsCurrent-large
+    tags: [std-matrix, windows-vsCurrent, vs2019x64, compile, std-c11]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CMAKE_GENERATOR: Visual Studio 16 2019
+          CMAKE_GENERATOR_PLATFORM: x64
+          C_STD_VERSION: 11
+  - name: std-c11-windows-2019-vs2022-x64-compile
+    run_on: windows-vsCurrent-large
+    tags: [std-matrix, windows-vsCurrent, vs2022x64, compile, std-c11]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CMAKE_GENERATOR: Visual Studio 17 2022
+          CMAKE_GENERATOR_PLATFORM: x64
+          C_STD_VERSION: 11
   - name: std-c17-debian10-gcc-compile
     run_on: debian10-large
     tags: [std-matrix, debian10, gcc, compile, std-c17]
@@ -5111,8 +5261,8 @@ tasks:
       - func: find-cmake-latest
       - func: std-compile
         vars:
-          CC: gcc
-          CXX: g++
+          CC: gcc-8
+          CXX: g++-8
           C_STD_VERSION: 17
   - name: std-c17-debian11-gcc-compile
     run_on: debian11-large
@@ -5121,8 +5271,178 @@ tasks:
       - func: find-cmake-latest
       - func: std-compile
         vars:
+          CC: gcc-10
+          CXX: g++-10
+          C_STD_VERSION: 17
+  - name: std-c17-rhel80-clang-compile
+    run_on: rhel80-large
+    tags: [std-matrix, rhel80, clang, compile, std-c17]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 17
+  - name: std-c17-rhel80-gcc-compile
+    run_on: rhel80-large
+    tags: [std-matrix, rhel80, gcc, compile, std-c17]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
           CC: gcc
           CXX: g++
+          C_STD_VERSION: 17
+  - name: std-c17-rhel84-clang-compile
+    run_on: rhel84-large
+    tags: [std-matrix, rhel84, clang, compile, std-c17]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 17
+  - name: std-c17-rhel84-gcc-compile
+    run_on: rhel84-large
+    tags: [std-matrix, rhel84, gcc, compile, std-c17]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc
+          CXX: g++
+          C_STD_VERSION: 17
+  - name: std-c17-rhel90-clang-compile
+    run_on: rhel90-large
+    tags: [std-matrix, rhel90, clang, compile, std-c17]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 17
+  - name: std-c17-rhel90-gcc-compile
+    run_on: rhel90-large
+    tags: [std-matrix, rhel90, gcc, compile, std-c17]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc
+          CXX: g++
+          C_STD_VERSION: 17
+  - name: std-c17-rhel91-clang-compile
+    run_on: rhel91-large
+    tags: [std-matrix, rhel91, clang, compile, std-c17]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 17
+  - name: std-c17-rhel92-clang-compile
+    run_on: rhel92-large
+    tags: [std-matrix, rhel92, clang, compile, std-c17]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 17
+  - name: std-c17-rhel92-gcc-compile
+    run_on: rhel92-large
+    tags: [std-matrix, rhel92, gcc, compile, std-c17]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc
+          CXX: g++
+          C_STD_VERSION: 17
+  - name: std-c17-rhel93-clang-compile
+    run_on: rhel93-large
+    tags: [std-matrix, rhel93, clang, compile, std-c17]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 17
+  - name: std-c17-rhel94-clang-compile
+    run_on: rhel94-large
+    tags: [std-matrix, rhel94, clang, compile, std-c17]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 17
+  - name: std-c17-rhel94-gcc-compile
+    run_on: rhel94-large
+    tags: [std-matrix, rhel94, gcc, compile, std-c17]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc
+          CXX: g++
+          C_STD_VERSION: 17
+  - name: std-c17-rhel95-clang-compile
+    run_on: rhel95-large
+    tags: [std-matrix, rhel95, clang, compile, std-c17]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 17
+  - name: std-c17-rhel95-gcc-compile
+    run_on: rhel95-large
+    tags: [std-matrix, rhel95, gcc, compile, std-c17]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc
+          CXX: g++
+          C_STD_VERSION: 17
+  - name: std-c17-ubuntu2004-clang-compile
+    run_on: ubuntu2004-large
+    tags: [std-matrix, ubuntu2004, clang, compile, std-c17]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang-10
+          CXX: clang++-10
+          C_STD_VERSION: 17
+  - name: std-c17-ubuntu2004-gcc-compile
+    run_on: ubuntu2004-large
+    tags: [std-matrix, ubuntu2004, gcc, compile, std-c17]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc-9
+          CXX: g++-9
+          C_STD_VERSION: 17
+  - name: std-c17-ubuntu2204-clang-compile
+    run_on: ubuntu2204-large
+    tags: [std-matrix, ubuntu2204, clang, compile, std-c17]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang-12
+          CXX: clang++-12
           C_STD_VERSION: 17
   - name: std-c17-windows-2019-vs2017-x64-compile
     run_on: windows-vsCurrent-large
@@ -5134,6 +5454,436 @@ tasks:
           CMAKE_GENERATOR: Visual Studio 15 2017
           CMAKE_GENERATOR_PLATFORM: x64
           C_STD_VERSION: 17
+  - name: std-c17-windows-2019-vs2019-x64-compile
+    run_on: windows-vsCurrent-large
+    tags: [std-matrix, windows-vsCurrent, vs2019x64, compile, std-c17]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CMAKE_GENERATOR: Visual Studio 16 2019
+          CMAKE_GENERATOR_PLATFORM: x64
+          C_STD_VERSION: 17
+  - name: std-c17-windows-2019-vs2022-x64-compile
+    run_on: windows-vsCurrent-large
+    tags: [std-matrix, windows-vsCurrent, vs2022x64, compile, std-c17]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CMAKE_GENERATOR: Visual Studio 17 2022
+          CMAKE_GENERATOR_PLATFORM: x64
+          C_STD_VERSION: 17
+  - name: std-c23-debian11-gcc-compile
+    run_on: debian11-large
+    tags: [std-matrix, debian11, gcc, compile, std-c23]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc-10
+          CXX: g++-10
+          C_STD_VERSION: 23
+  - name: std-c23-rhel84-clang-compile
+    run_on: rhel84-large
+    tags: [std-matrix, rhel84, clang, compile, std-c23]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 23
+  - name: std-c23-rhel90-clang-compile
+    run_on: rhel90-large
+    tags: [std-matrix, rhel90, clang, compile, std-c23]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 23
+  - name: std-c23-rhel90-gcc-compile
+    run_on: rhel90-large
+    tags: [std-matrix, rhel90, gcc, compile, std-c23]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc
+          CXX: g++
+          C_STD_VERSION: 23
+  - name: std-c23-rhel91-clang-compile
+    run_on: rhel91-large
+    tags: [std-matrix, rhel91, clang, compile, std-c23]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 23
+  - name: std-c23-rhel92-clang-compile
+    run_on: rhel92-large
+    tags: [std-matrix, rhel92, clang, compile, std-c23]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 23
+  - name: std-c23-rhel92-gcc-compile
+    run_on: rhel92-large
+    tags: [std-matrix, rhel92, gcc, compile, std-c23]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc
+          CXX: g++
+          C_STD_VERSION: 23
+  - name: std-c23-rhel93-clang-compile
+    run_on: rhel93-large
+    tags: [std-matrix, rhel93, clang, compile, std-c23]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 23
+  - name: std-c23-rhel94-clang-compile
+    run_on: rhel94-large
+    tags: [std-matrix, rhel94, clang, compile, std-c23]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 23
+  - name: std-c23-rhel94-gcc-compile
+    run_on: rhel94-large
+    tags: [std-matrix, rhel94, gcc, compile, std-c23]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc
+          CXX: g++
+          C_STD_VERSION: 23
+  - name: std-c23-rhel95-clang-compile
+    run_on: rhel95-large
+    tags: [std-matrix, rhel95, clang, compile, std-c23]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 23
+  - name: std-c23-rhel95-gcc-compile
+    run_on: rhel95-large
+    tags: [std-matrix, rhel95, gcc, compile, std-c23]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc
+          CXX: g++
+          C_STD_VERSION: 23
+  - name: std-c23-ubuntu2004-clang-compile
+    run_on: ubuntu2004-large
+    tags: [std-matrix, ubuntu2004, clang, compile, std-c23]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang-10
+          CXX: clang++-10
+          C_STD_VERSION: 23
+  - name: std-c23-ubuntu2004-gcc-compile
+    run_on: ubuntu2004-large
+    tags: [std-matrix, ubuntu2004, gcc, compile, std-c23]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc-9
+          CXX: g++-9
+          C_STD_VERSION: 23
+  - name: std-c23-ubuntu2204-clang-compile
+    run_on: ubuntu2204-large
+    tags: [std-matrix, ubuntu2204, clang, compile, std-c23]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang-12
+          CXX: clang++-12
+          C_STD_VERSION: 23
+  - name: std-c99-debian10-gcc-compile
+    run_on: debian10-large
+    tags: [std-matrix, debian10, gcc, compile, std-c99]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc-8
+          CXX: g++-8
+          C_STD_VERSION: 99
+  - name: std-c99-debian11-gcc-compile
+    run_on: debian11-large
+    tags: [std-matrix, debian11, gcc, compile, std-c99]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc-10
+          CXX: g++-10
+          C_STD_VERSION: 99
+  - name: std-c99-rhel76-gcc-compile
+    run_on: rhel76-large
+    tags: [std-matrix, rhel76, gcc, compile, std-c99]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc
+          CXX: g++
+          C_STD_VERSION: 99
+  - name: std-c99-rhel80-clang-compile
+    run_on: rhel80-large
+    tags: [std-matrix, rhel80, clang, compile, std-c99]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 99
+  - name: std-c99-rhel80-gcc-compile
+    run_on: rhel80-large
+    tags: [std-matrix, rhel80, gcc, compile, std-c99]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc
+          CXX: g++
+          C_STD_VERSION: 99
+  - name: std-c99-rhel84-clang-compile
+    run_on: rhel84-large
+    tags: [std-matrix, rhel84, clang, compile, std-c99]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 99
+  - name: std-c99-rhel84-gcc-compile
+    run_on: rhel84-large
+    tags: [std-matrix, rhel84, gcc, compile, std-c99]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc
+          CXX: g++
+          C_STD_VERSION: 99
+  - name: std-c99-rhel90-clang-compile
+    run_on: rhel90-large
+    tags: [std-matrix, rhel90, clang, compile, std-c99]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 99
+  - name: std-c99-rhel90-gcc-compile
+    run_on: rhel90-large
+    tags: [std-matrix, rhel90, gcc, compile, std-c99]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc
+          CXX: g++
+          C_STD_VERSION: 99
+  - name: std-c99-rhel91-clang-compile
+    run_on: rhel91-large
+    tags: [std-matrix, rhel91, clang, compile, std-c99]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 99
+  - name: std-c99-rhel92-clang-compile
+    run_on: rhel92-large
+    tags: [std-matrix, rhel92, clang, compile, std-c99]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 99
+  - name: std-c99-rhel92-gcc-compile
+    run_on: rhel92-large
+    tags: [std-matrix, rhel92, gcc, compile, std-c99]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc
+          CXX: g++
+          C_STD_VERSION: 99
+  - name: std-c99-rhel93-clang-compile
+    run_on: rhel93-large
+    tags: [std-matrix, rhel93, clang, compile, std-c99]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 99
+  - name: std-c99-rhel94-clang-compile
+    run_on: rhel94-large
+    tags: [std-matrix, rhel94, clang, compile, std-c99]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 99
+  - name: std-c99-rhel94-gcc-compile
+    run_on: rhel94-large
+    tags: [std-matrix, rhel94, gcc, compile, std-c99]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc
+          CXX: g++
+          C_STD_VERSION: 99
+  - name: std-c99-rhel95-clang-compile
+    run_on: rhel95-large
+    tags: [std-matrix, rhel95, clang, compile, std-c99]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 99
+  - name: std-c99-rhel95-gcc-compile
+    run_on: rhel95-large
+    tags: [std-matrix, rhel95, gcc, compile, std-c99]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc
+          CXX: g++
+          C_STD_VERSION: 99
+  - name: std-c99-ubuntu2004-clang-compile
+    run_on: ubuntu2004-large
+    tags: [std-matrix, ubuntu2004, clang, compile, std-c99]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang-10
+          CXX: clang++-10
+          C_STD_VERSION: 99
+  - name: std-c99-ubuntu2004-gcc-compile
+    run_on: ubuntu2004-large
+    tags: [std-matrix, ubuntu2004, gcc, compile, std-c99]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: gcc-9
+          CXX: g++-9
+          C_STD_VERSION: 99
+  - name: std-c99-ubuntu2204-clang-compile
+    run_on: ubuntu2204-large
+    tags: [std-matrix, ubuntu2204, clang, compile, std-c99]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang-12
+          CXX: clang++-12
+          C_STD_VERSION: 99
+  - name: std-c99-windows-2019-vs2017-x64-compile
+    run_on: windows-vsCurrent-large
+    tags: [std-matrix, windows-vsCurrent, vs2017x64, compile, std-c99]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CMAKE_GENERATOR: Visual Studio 15 2017
+          CMAKE_GENERATOR_PLATFORM: x64
+          C_STD_VERSION: 99
+  - name: std-c99-windows-2019-vs2019-x64-compile
+    run_on: windows-vsCurrent-large
+    tags: [std-matrix, windows-vsCurrent, vs2019x64, compile, std-c99]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CMAKE_GENERATOR: Visual Studio 16 2019
+          CMAKE_GENERATOR_PLATFORM: x64
+          C_STD_VERSION: 99
+  - name: std-c99-windows-2019-vs2022-x64-compile
+    run_on: windows-vsCurrent-large
+    tags: [std-matrix, windows-vsCurrent, vs2022x64, compile, std-c99]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CMAKE_GENERATOR: Visual Studio 17 2022
+          CMAKE_GENERATOR_PLATFORM: x64
+          C_STD_VERSION: 99
+  - name: std-clatest-windows-2019-vs2017-x64-compile
+    run_on: windows-vsCurrent-large
+    tags: [std-matrix, windows-vsCurrent, vs2017x64, compile, std-clatest]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CMAKE_GENERATOR: Visual Studio 15 2017
+          CMAKE_GENERATOR_PLATFORM: x64
+          C_STD_VERSION: latest
+  - name: std-clatest-windows-2019-vs2019-x64-compile
+    run_on: windows-vsCurrent-large
+    tags: [std-matrix, windows-vsCurrent, vs2019x64, compile, std-clatest]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CMAKE_GENERATOR: Visual Studio 16 2019
+          CMAKE_GENERATOR_PLATFORM: x64
+          C_STD_VERSION: latest
+  - name: std-clatest-windows-2019-vs2022-x64-compile
+    run_on: windows-vsCurrent-large
+    tags: [std-matrix, windows-vsCurrent, vs2022x64, compile, std-clatest]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CMAKE_GENERATOR: Visual Studio 17 2022
+          CMAKE_GENERATOR_PLATFORM: x64
+          C_STD_VERSION: latest
   - name: tsan-sasl-cyrus-openssl-debian10-clang-compile
     run_on: debian10-large
     tags: [sanitizers-matrix-tsan, compile, debian10, clang, tsan, sasl-cyrus]

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -10,6 +10,7 @@ tasks:
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: clang
+          CXX: clang++
       - func: upload-build
   - name: asan-cse-sasl-cyrus-openssl-debian10-clang-test-4.2-server-auth
     run_on: debian10-small
@@ -23,6 +24,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.2" }
             - { key: TOPOLOGY, value: server }
@@ -45,6 +47,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.2" }
             - { key: TOPOLOGY, value: server }
@@ -64,6 +67,7 @@ tasks:
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: clang
+          CXX: clang++
       - func: upload-build
   - name: asan-cse-sasl-cyrus-openssl-ubuntu2004-clang-test-4.4-replica-auth
     run_on: ubuntu2004-small
@@ -77,6 +81,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.4" }
             - { key: TOPOLOGY, value: replica_set }
@@ -99,6 +104,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.4" }
             - { key: TOPOLOGY, value: replica_set }
@@ -122,6 +128,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.4" }
             - { key: TOPOLOGY, value: server }
@@ -144,6 +151,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.4" }
             - { key: TOPOLOGY, value: server }
@@ -167,6 +175,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -189,6 +198,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -212,6 +222,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: server }
@@ -234,6 +245,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: server }
@@ -257,6 +269,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -279,6 +292,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -302,6 +316,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: server }
@@ -324,6 +339,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: server }
@@ -347,6 +363,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -369,6 +386,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -392,6 +410,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: server }
@@ -414,6 +433,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: server }
@@ -437,6 +457,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -459,6 +480,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -482,6 +504,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: server }
@@ -504,6 +527,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: server }
@@ -527,6 +551,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: replica_set }
@@ -549,6 +574,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: replica_set }
@@ -572,6 +598,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: server }
@@ -594,6 +621,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: server }
@@ -613,6 +641,7 @@ tasks:
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: clang
+          CXX: clang++
       - func: upload-build
   - name: asan-sasl-cyrus-openssl-debian10-clang-test-4.2-replica-auth
     run_on: debian10-small
@@ -626,6 +655,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.2" }
             - { key: TOPOLOGY, value: replica_set }
@@ -646,6 +676,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.2" }
             - { key: TOPOLOGY, value: server }
@@ -666,6 +697,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.2" }
             - { key: TOPOLOGY, value: sharded_cluster }
@@ -682,6 +714,7 @@ tasks:
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: clang
+          CXX: clang++
       - func: upload-build
   - name: asan-sasl-cyrus-openssl-ubuntu2004-clang-test-4.4-replica-auth
     run_on: ubuntu2004-small
@@ -695,6 +728,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.4" }
             - { key: TOPOLOGY, value: replica_set }
@@ -715,6 +749,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.4" }
             - { key: TOPOLOGY, value: server }
@@ -735,6 +770,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.4" }
             - { key: TOPOLOGY, value: sharded_cluster }
@@ -755,6 +791,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -775,6 +812,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: server }
@@ -795,6 +833,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: sharded_cluster }
@@ -815,6 +854,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -835,6 +875,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: server }
@@ -855,6 +896,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: sharded_cluster }
@@ -875,6 +917,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -895,6 +938,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: server }
@@ -915,6 +959,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: sharded_cluster }
@@ -935,6 +980,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -955,6 +1001,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: server }
@@ -975,6 +1022,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: sharded_cluster }
@@ -995,6 +1043,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: replica_set }
@@ -1015,6 +1064,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: server }
@@ -1035,6 +1085,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: sharded_cluster }
@@ -1258,6 +1309,7 @@ tasks:
       - func: cse-sasl-cyrus-darwinssl-compile
         vars:
           CC: clang
+          CXX: clang++
       - func: upload-build
   - name: cse-sasl-cyrus-darwinssl-macos-11-arm64-clang-test-6.0-server-auth
     run_on: macos-11-arm64
@@ -1271,6 +1323,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: server }
@@ -1287,6 +1340,7 @@ tasks:
       - func: cse-sasl-cyrus-darwinssl-compile
         vars:
           CC: clang
+          CXX: clang++
       - func: upload-build
   - name: cse-sasl-cyrus-darwinssl-macos-14-arm64-clang-test-6.0-server-auth
     run_on: macos-14-arm64
@@ -1300,6 +1354,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: server }
@@ -1320,6 +1375,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -1340,6 +1396,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: server }
@@ -1360,6 +1417,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -1380,6 +1438,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: server }
@@ -1400,6 +1459,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: replica_set }
@@ -1420,6 +1480,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: server }
@@ -1436,6 +1497,7 @@ tasks:
       - func: cse-sasl-cyrus-darwinssl-compile
         vars:
           CC: clang
+          CXX: clang++
       - func: upload-build
   - name: cse-sasl-cyrus-darwinssl-macos-14-clang-test-4.2-server-auth
     run_on: macos-14
@@ -1449,6 +1511,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.2" }
             - { key: TOPOLOGY, value: server }
@@ -1469,6 +1532,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.4" }
             - { key: TOPOLOGY, value: server }
@@ -1489,6 +1553,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: server }
@@ -1505,6 +1570,7 @@ tasks:
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: clang
+          CXX: clang++
       - func: upload-build
   - name: cse-sasl-cyrus-openssl-debian10-gcc-compile
     run_on: debian10-large
@@ -1514,6 +1580,7 @@ tasks:
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: gcc
+          CXX: g++
       - func: upload-build
   - name: cse-sasl-cyrus-openssl-debian10-gcc-test-4.2-replica-auth
     run_on: debian10-small
@@ -1527,6 +1594,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.2" }
             - { key: TOPOLOGY, value: replica_set }
@@ -1547,6 +1615,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.2" }
             - { key: TOPOLOGY, value: server }
@@ -1563,6 +1632,7 @@ tasks:
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: clang
+          CXX: clang++
       - func: upload-build
   - name: cse-sasl-cyrus-openssl-debian11-gcc-compile
     run_on: debian11-large
@@ -1572,6 +1642,7 @@ tasks:
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: gcc
+          CXX: g++
       - func: upload-build
   - name: cse-sasl-cyrus-openssl-debian92-clang-compile
     run_on: debian92-large
@@ -1581,6 +1652,7 @@ tasks:
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: clang
+          CXX: clang++
       - func: upload-build
   - name: cse-sasl-cyrus-openssl-debian92-gcc-compile
     run_on: debian92-large
@@ -1590,6 +1662,7 @@ tasks:
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: gcc
+          CXX: g++
       - func: upload-build
   - name: cse-sasl-cyrus-openssl-rhel8-zseries-gcc-compile
     run_on: rhel8-zseries-large
@@ -1600,6 +1673,7 @@ tasks:
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: gcc
+          CXX: g++
       - func: upload-build
   - name: cse-sasl-cyrus-openssl-rhel8-zseries-gcc-test-5.0-server-auth
     run_on: rhel8-zseries-small
@@ -1614,6 +1688,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: server }
@@ -1635,6 +1710,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -1656,6 +1732,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: server }
@@ -1677,6 +1754,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -1698,6 +1776,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: server }
@@ -1719,6 +1798,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: replica_set }
@@ -1740,6 +1820,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: server }
@@ -1756,6 +1837,7 @@ tasks:
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: gcc
+          CXX: g++
       - func: upload-build
   - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
     run_on: ubuntu2004-arm64-large
@@ -1765,6 +1847,7 @@ tasks:
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: gcc
+          CXX: g++
       - func: upload-build
   - name: cse-sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-4.4-replica-auth
     run_on: ubuntu2004-arm64-small
@@ -1778,6 +1861,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.4" }
             - { key: TOPOLOGY, value: replica_set }
@@ -1798,6 +1882,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.4" }
             - { key: TOPOLOGY, value: server }
@@ -1818,6 +1903,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -1838,6 +1924,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: server }
@@ -1858,6 +1945,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -1878,6 +1966,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: server }
@@ -1898,6 +1987,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -1918,6 +2008,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: server }
@@ -1938,6 +2029,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -1958,6 +2050,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: server }
@@ -1978,6 +2071,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: replica_set }
@@ -1998,6 +2092,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: server }
@@ -2014,6 +2109,7 @@ tasks:
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: clang
+          CXX: clang++
       - func: upload-build
   - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-compile
     run_on: ubuntu2004-large
@@ -2023,6 +2119,7 @@ tasks:
       - func: cse-sasl-cyrus-openssl-compile
         vars:
           CC: gcc
+          CXX: g++
       - func: upload-build
   - name: cse-sasl-cyrus-openssl-ubuntu2004-gcc-test-4.4-replica-auth
     run_on: ubuntu2004-small
@@ -2036,6 +2133,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.4" }
             - { key: TOPOLOGY, value: replica_set }
@@ -2056,6 +2154,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.4" }
             - { key: TOPOLOGY, value: server }
@@ -2076,6 +2175,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -2096,6 +2196,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: server }
@@ -2116,6 +2217,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -2136,6 +2238,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: server }
@@ -2156,6 +2259,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -2176,6 +2280,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: server }
@@ -2196,6 +2301,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -2216,6 +2322,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: server }
@@ -2236,6 +2343,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: replica_set }
@@ -2256,6 +2364,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: server }
@@ -2271,7 +2380,8 @@ tasks:
       - func: find-cmake-latest
       - func: cse-sasl-cyrus-openssl-compile
         vars:
-          CC: Visual Studio 15 2017 Win64
+          CMAKE_GENERATOR: Visual Studio 15 2017
+          CMAKE_GENERATOR_PLATFORM: x64
       - func: upload-build
   - name: cse-sasl-cyrus-openssl-windows-2019-vs2017-x64-test-4.2-server-auth
     run_on: windows-vsCurrent-small
@@ -2284,7 +2394,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.2" }
             - { key: TOPOLOGY, value: server }
@@ -2304,7 +2415,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.4" }
             - { key: TOPOLOGY, value: server }
@@ -2324,7 +2436,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: server }
@@ -2344,7 +2457,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: server }
@@ -2364,7 +2478,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -2384,7 +2499,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: server }
@@ -2404,7 +2520,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -2424,7 +2541,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: server }
@@ -2444,7 +2562,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: replica_set }
@@ -2464,7 +2583,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: server }
@@ -2480,7 +2600,8 @@ tasks:
       - func: find-cmake-latest
       - func: cse-sasl-cyrus-winssl-compile
         vars:
-          CC: Visual Studio 14 2015 Win64
+          CMAKE_GENERATOR: Visual Studio 14 2015
+          CMAKE_GENERATOR_PLATFORM: x64
       - func: upload-build
   - name: cse-sasl-cyrus-winssl-windows-2019-vs2017-x64-compile
     run_on: windows-vsCurrent-large
@@ -2489,7 +2610,8 @@ tasks:
       - func: find-cmake-latest
       - func: cse-sasl-cyrus-winssl-compile
         vars:
-          CC: Visual Studio 15 2017 Win64
+          CMAKE_GENERATOR: Visual Studio 15 2017
+          CMAKE_GENERATOR_PLATFORM: x64
       - func: upload-build
   - name: cse-sasl-cyrus-winssl-windows-2019-vs2017-x64-test-4.2-server-auth
     run_on: windows-vsCurrent-small
@@ -2502,7 +2624,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.2" }
             - { key: TOPOLOGY, value: server }
@@ -2522,7 +2645,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.4" }
             - { key: TOPOLOGY, value: server }
@@ -2542,7 +2666,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: server }
@@ -2562,7 +2687,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: server }
@@ -2582,7 +2708,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -2602,7 +2729,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: server }
@@ -2622,7 +2750,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -2642,7 +2771,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: server }
@@ -2662,7 +2792,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: replica_set }
@@ -2682,7 +2813,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: server }
@@ -3010,6 +3142,7 @@ tasks:
       - func: openssl-static-compile
         vars:
           CC: gcc
+          CXX: g++
   - name: openssl-static-compile-debian11-gcc
     run_on: debian11-large
     tags: [openssl-static-matrix, debian11, gcc]
@@ -3018,6 +3151,7 @@ tasks:
       - func: openssl-static-compile
         vars:
           CC: gcc
+          CXX: g++
   - name: openssl-static-compile-debian92-gcc
     run_on: debian92-large
     tags: [openssl-static-matrix, debian92, gcc]
@@ -3026,6 +3160,7 @@ tasks:
       - func: openssl-static-compile
         vars:
           CC: gcc
+          CXX: g++
   - name: openssl-static-compile-ubuntu2004-gcc
     run_on: ubuntu2004-large
     tags: [openssl-static-matrix, ubuntu2004, gcc]
@@ -3034,6 +3169,7 @@ tasks:
       - func: openssl-static-compile
         vars:
           CC: gcc
+          CXX: g++
   - name: sasl-cyrus-darwinssl-macos-11-arm64-clang-compile
     run_on: macos-11-arm64
     tags: [sasl-matrix-darwinssl, compile, macos-11-arm64, clang, sasl-cyrus]
@@ -3042,6 +3178,7 @@ tasks:
       - func: sasl-cyrus-darwinssl-compile
         vars:
           CC: clang
+          CXX: clang++
       - func: upload-build
   - name: sasl-cyrus-darwinssl-macos-11-arm64-clang-test-6.0-server-auth
     run_on: macos-11-arm64
@@ -3055,6 +3192,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: server }
@@ -3075,6 +3213,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: server }
@@ -3095,6 +3234,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: server }
@@ -3115,6 +3255,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: server }
@@ -3131,6 +3272,7 @@ tasks:
       - func: sasl-cyrus-darwinssl-compile
         vars:
           CC: clang
+          CXX: clang++
       - func: upload-build
   - name: sasl-cyrus-darwinssl-macos-14-arm64-clang-test-6.0-server-auth
     run_on: macos-14-arm64
@@ -3144,6 +3286,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: server }
@@ -3164,6 +3307,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: server }
@@ -3184,6 +3328,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: server }
@@ -3204,6 +3349,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: server }
@@ -3220,6 +3366,7 @@ tasks:
       - func: sasl-cyrus-darwinssl-compile
         vars:
           CC: clang
+          CXX: clang++
       - func: upload-build
   - name: sasl-cyrus-darwinssl-macos-14-clang-test-4.0-server-auth
     run_on: macos-14
@@ -3233,6 +3380,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.0" }
             - { key: TOPOLOGY, value: server }
@@ -3253,6 +3401,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.2" }
             - { key: TOPOLOGY, value: server }
@@ -3273,6 +3422,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.4" }
             - { key: TOPOLOGY, value: server }
@@ -3293,6 +3443,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: server }
@@ -3309,6 +3460,7 @@ tasks:
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: gcc
+          CXX: g++
       - func: upload-build
   - name: sasl-cyrus-openssl-debian10-gcc-test-4.2-replica-auth
     run_on: debian10-small
@@ -3322,6 +3474,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.2" }
             - { key: TOPOLOGY, value: replica_set }
@@ -3342,6 +3495,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.2" }
             - { key: TOPOLOGY, value: server }
@@ -3358,6 +3512,7 @@ tasks:
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: gcc
+          CXX: g++
       - func: upload-build
   - name: sasl-cyrus-openssl-debian92-clang-compile
     run_on: debian92-large
@@ -3367,6 +3522,7 @@ tasks:
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: clang
+          CXX: clang++
       - func: upload-build
   - name: sasl-cyrus-openssl-debian92-gcc-compile
     run_on: debian92-large
@@ -3376,6 +3532,7 @@ tasks:
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: gcc
+          CXX: g++
       - func: upload-build
   - name: sasl-cyrus-openssl-rhel8-power-gcc-compile
     run_on: rhel8-power-large
@@ -3386,6 +3543,7 @@ tasks:
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: gcc
+          CXX: g++
       - func: upload-build
   - name: sasl-cyrus-openssl-rhel8-power-gcc-test-4.2-server-auth
     run_on: rhel8-power-small
@@ -3400,6 +3558,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.2" }
             - { key: TOPOLOGY, value: server }
@@ -3421,6 +3580,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.4" }
             - { key: TOPOLOGY, value: server }
@@ -3442,6 +3602,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: server }
@@ -3463,6 +3624,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: server }
@@ -3484,6 +3646,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: server }
@@ -3505,6 +3668,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: server }
@@ -3526,6 +3690,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: server }
@@ -3543,6 +3708,7 @@ tasks:
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: gcc
+          CXX: g++
       - func: upload-build
   - name: sasl-cyrus-openssl-rhel8-zseries-gcc-test-5.0-server-auth
     run_on: rhel8-zseries-small
@@ -3557,6 +3723,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: server }
@@ -3578,6 +3745,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: server }
@@ -3599,6 +3767,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: server }
@@ -3620,6 +3789,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: server }
@@ -3641,6 +3811,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: server }
@@ -3657,6 +3828,7 @@ tasks:
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: gcc
+          CXX: g++
       - func: upload-build
   - name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
     run_on: ubuntu2004-arm64-large
@@ -3666,6 +3838,7 @@ tasks:
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: gcc
+          CXX: g++
       - func: upload-build
   - name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-test-4.4-server-auth
     run_on: ubuntu2004-arm64-small
@@ -3679,6 +3852,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.4" }
             - { key: TOPOLOGY, value: server }
@@ -3699,6 +3873,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: server }
@@ -3719,6 +3894,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: server }
@@ -3739,6 +3915,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: server }
@@ -3759,6 +3936,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: server }
@@ -3779,6 +3957,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: server }
@@ -3795,6 +3974,7 @@ tasks:
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: clang
+          CXX: clang++
       - func: upload-build
   - name: sasl-cyrus-openssl-ubuntu2004-gcc-compile
     run_on: ubuntu2004-large
@@ -3804,6 +3984,7 @@ tasks:
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: gcc
+          CXX: g++
       - func: upload-build
   - name: sasl-cyrus-openssl-ubuntu2004-gcc-test-4.4-server-auth
     run_on: ubuntu2004-small
@@ -3817,6 +3998,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.4" }
             - { key: TOPOLOGY, value: server }
@@ -3837,6 +4019,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: server }
@@ -3857,6 +4040,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: server }
@@ -3877,6 +4061,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: server }
@@ -3897,6 +4082,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: server }
@@ -3917,6 +4103,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: server }
@@ -3932,7 +4119,8 @@ tasks:
       - func: find-cmake-latest
       - func: sasl-cyrus-openssl-compile
         vars:
-          CC: Visual Studio 15 2017 Win64
+          CMAKE_GENERATOR: Visual Studio 15 2017
+          CMAKE_GENERATOR_PLATFORM: x64
       - func: upload-build
   - name: sasl-cyrus-openssl-windows-2019-vs2017-x64-test-latest-server-auth
     run_on: windows-vsCurrent-small
@@ -3945,7 +4133,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: server }
@@ -3961,7 +4150,8 @@ tasks:
       - func: find-cmake-latest
       - func: sasl-cyrus-winssl-compile
         vars:
-          CC: Visual Studio 14 2015 Win64
+          CMAKE_GENERATOR: Visual Studio 14 2015
+          CMAKE_GENERATOR_PLATFORM: x64
       - func: upload-build
   - name: sasl-cyrus-winssl-windows-2019-vs2017-x64-compile
     run_on: windows-vsCurrent-large
@@ -3970,7 +4160,8 @@ tasks:
       - func: find-cmake-latest
       - func: sasl-cyrus-winssl-compile
         vars:
-          CC: Visual Studio 15 2017 Win64
+          CMAKE_GENERATOR: Visual Studio 15 2017
+          CMAKE_GENERATOR_PLATFORM: x64
       - func: upload-build
   - name: sasl-cyrus-winssl-windows-2019-vs2017-x64-test-4.0-server-auth
     run_on: windows-vsCurrent-small
@@ -3983,7 +4174,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.0" }
             - { key: TOPOLOGY, value: server }
@@ -4003,7 +4195,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.2" }
             - { key: TOPOLOGY, value: server }
@@ -4023,7 +4216,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.4" }
             - { key: TOPOLOGY, value: server }
@@ -4043,7 +4237,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: server }
@@ -4063,7 +4258,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: server }
@@ -4083,7 +4279,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: server }
@@ -4103,7 +4300,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: server }
@@ -4123,7 +4321,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: server }
@@ -4140,6 +4339,7 @@ tasks:
       - func: sasl-off-nossl-compile
         vars:
           CC: gcc
+          CXX: g++
       - func: upload-build
   - name: sasl-off-nossl-debian10-gcc-test-4.2-replica-noauth
     run_on: debian10-small
@@ -4153,6 +4353,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: noauth }
             - { key: MONGODB_VERSION, value: "4.2" }
             - { key: TOPOLOGY, value: replica_set }
@@ -4173,6 +4374,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: noauth }
             - { key: MONGODB_VERSION, value: "4.2" }
             - { key: TOPOLOGY, value: server }
@@ -4193,6 +4395,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: noauth }
             - { key: MONGODB_VERSION, value: "4.2" }
             - { key: TOPOLOGY, value: sharded_cluster }
@@ -4209,6 +4412,7 @@ tasks:
       - func: sasl-off-nossl-compile
         vars:
           CC: gcc
+          CXX: g++
       - func: upload-build
   - name: sasl-off-nossl-ubuntu2004-gcc-test-4.4-replica-noauth
     run_on: ubuntu2004-small
@@ -4222,6 +4426,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: noauth }
             - { key: MONGODB_VERSION, value: "4.4" }
             - { key: TOPOLOGY, value: replica_set }
@@ -4242,6 +4447,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: noauth }
             - { key: MONGODB_VERSION, value: "4.4" }
             - { key: TOPOLOGY, value: server }
@@ -4262,6 +4468,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: noauth }
             - { key: MONGODB_VERSION, value: "4.4" }
             - { key: TOPOLOGY, value: sharded_cluster }
@@ -4282,6 +4489,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: noauth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -4302,6 +4510,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: noauth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: server }
@@ -4322,6 +4531,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: noauth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: sharded_cluster }
@@ -4342,6 +4552,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: noauth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -4362,6 +4573,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: noauth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: server }
@@ -4382,6 +4594,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: noauth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: sharded_cluster }
@@ -4402,6 +4615,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: noauth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -4422,6 +4636,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: noauth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: server }
@@ -4442,6 +4657,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: noauth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: sharded_cluster }
@@ -4462,6 +4678,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: noauth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -4482,6 +4699,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: noauth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: server }
@@ -4502,6 +4720,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: noauth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: sharded_cluster }
@@ -4522,6 +4741,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: noauth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: replica_set }
@@ -4542,6 +4762,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: noauth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: server }
@@ -4562,6 +4783,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
             - { key: AUTH, value: noauth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: sharded_cluster }
@@ -4577,7 +4799,8 @@ tasks:
       - func: find-cmake-latest
       - func: sasl-off-nossl-compile
         vars:
-          CC: Visual Studio 15 2017 Win64
+          CMAKE_GENERATOR: Visual Studio 15 2017
+          CMAKE_GENERATOR_PLATFORM: x64
       - func: upload-build
   - name: sasl-off-winssl-vs2015-x86-compile
     run_on: windows-64-vs2015-large
@@ -4586,7 +4809,8 @@ tasks:
       - func: find-cmake-latest
       - func: sasl-off-winssl-compile
         vars:
-          CC: Visual Studio 14 2015
+          CMAKE_GENERATOR: Visual Studio 14 2015
+          CMAKE_GENERATOR_PLATFORM: Win32
       - func: upload-build
   - name: sasl-off-winssl-windows-2019-vs2017-x64-compile
     run_on: windows-vsCurrent-large
@@ -4595,7 +4819,8 @@ tasks:
       - func: find-cmake-latest
       - func: sasl-off-winssl-compile
         vars:
-          CC: Visual Studio 15 2017 Win64
+          CMAKE_GENERATOR: Visual Studio 15 2017
+          CMAKE_GENERATOR_PLATFORM: x64
       - func: upload-build
   - name: sasl-off-winssl-windows-2019-vs2017-x86-compile
     run_on: windows-vsCurrent-large
@@ -4604,7 +4829,8 @@ tasks:
       - func: find-cmake-latest
       - func: sasl-off-winssl-compile
         vars:
-          CC: Visual Studio 15 2017
+          CMAKE_GENERATOR: Visual Studio 15 2017
+          CMAKE_GENERATOR_PLATFORM: Win32
       - func: upload-build
   - name: sasl-sspi-winssl-windows-2019-mingw-compile
     run_on: windows-vsCurrent-large
@@ -4614,6 +4840,7 @@ tasks:
       - func: sasl-sspi-winssl-compile
         vars:
           CC: mingw
+          CXX: mingw
       - func: upload-build
   - name: sasl-sspi-winssl-windows-2019-mingw-test-8.0-server-auth
     run_on: windows-vsCurrent-small
@@ -4627,6 +4854,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: mingw }
+            - { key: CXX, value: mingw }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: server }
@@ -4647,6 +4875,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: mingw }
+            - { key: CXX, value: mingw }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: server }
@@ -4662,7 +4891,8 @@ tasks:
       - func: find-cmake-latest
       - func: sasl-sspi-winssl-compile
         vars:
-          CC: Visual Studio 15 2017 Win64
+          CMAKE_GENERATOR: Visual Studio 15 2017
+          CMAKE_GENERATOR_PLATFORM: x64
       - func: upload-build
   - name: sasl-sspi-winssl-windows-2019-vs2017-x64-test-8.0-server-auth
     run_on: windows-vsCurrent-small
@@ -4675,7 +4905,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: server }
@@ -4695,7 +4926,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 Win64 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: server }
@@ -4711,7 +4943,8 @@ tasks:
       - func: find-cmake-latest
       - func: sasl-sspi-winssl-compile
         vars:
-          CC: Visual Studio 15 2017
+          CMAKE_GENERATOR: Visual Studio 15 2017
+          CMAKE_GENERATOR_PLATFORM: Win32
       - func: upload-build
   - name: sasl-sspi-winssl-windows-2019-vs2017-x86-test-8.0-server-auth
     run_on: windows-vsCurrent-small
@@ -4724,7 +4957,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: Win32 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: server }
@@ -4744,7 +4978,8 @@ tasks:
       - command: expansions.update
         params:
           updates:
-            - { key: CC, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
+            - { key: CMAKE_GENERATOR_PLATFORM, value: Win32 }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: server }
@@ -4766,6 +5001,7 @@ tasks:
       - func: scan-build
         vars:
           CC: clang
+          CXX: clang++
       - func: upload scan artifacts
   - name: scan-build-ubuntu2004-arm64-clang
     run_on: ubuntu2004-arm64-large
@@ -4775,6 +5011,7 @@ tasks:
       - func: scan-build
         vars:
           CC: clang
+          CXX: clang++
       - func: upload scan artifacts
   - name: scan-build-ubuntu2004-clang-i686
     run_on: ubuntu2004-large
@@ -4784,6 +5021,7 @@ tasks:
       - func: scan-build
         vars:
           CC: clang
+          CXX: clang++
           MARCH: i686
       - func: upload scan artifacts
   - name: std-c11-debian10-clang-compile
@@ -4794,6 +5032,7 @@ tasks:
       - func: std-compile
         vars:
           CC: clang
+          CXX: clang++
           C_STD_VERSION: 11
   - name: std-c11-debian10-gcc-compile
     run_on: debian10-large
@@ -4803,6 +5042,7 @@ tasks:
       - func: std-compile
         vars:
           CC: gcc
+          CXX: g++
           C_STD_VERSION: 11
   - name: std-c11-debian11-clang-compile
     run_on: debian11-large
@@ -4812,6 +5052,7 @@ tasks:
       - func: std-compile
         vars:
           CC: clang
+          CXX: clang++
           C_STD_VERSION: 11
   - name: std-c11-debian11-gcc-compile
     run_on: debian11-large
@@ -4821,6 +5062,7 @@ tasks:
       - func: std-compile
         vars:
           CC: gcc
+          CXX: g++
           C_STD_VERSION: 11
   - name: std-c11-debian92-clang-compile
     run_on: debian92-large
@@ -4830,6 +5072,7 @@ tasks:
       - func: std-compile
         vars:
           CC: clang
+          CXX: clang++
           C_STD_VERSION: 11
   - name: std-c11-ubuntu2004-clang-compile
     run_on: ubuntu2004-large
@@ -4839,6 +5082,7 @@ tasks:
       - func: std-compile
         vars:
           CC: clang
+          CXX: clang++
           C_STD_VERSION: 11
   - name: std-c11-ubuntu2004-gcc-compile
     run_on: ubuntu2004-large
@@ -4848,6 +5092,7 @@ tasks:
       - func: std-compile
         vars:
           CC: gcc
+          CXX: g++
           C_STD_VERSION: 11
   - name: std-c11-windows-2019-vs2017-x64-compile
     run_on: windows-vsCurrent-large
@@ -4856,7 +5101,8 @@ tasks:
       - func: find-cmake-latest
       - func: std-compile
         vars:
-          CC: Visual Studio 15 2017 Win64
+          CMAKE_GENERATOR: Visual Studio 15 2017
+          CMAKE_GENERATOR_PLATFORM: x64
           C_STD_VERSION: 11
   - name: std-c17-debian10-gcc-compile
     run_on: debian10-large
@@ -4866,6 +5112,7 @@ tasks:
       - func: std-compile
         vars:
           CC: gcc
+          CXX: g++
           C_STD_VERSION: 17
   - name: std-c17-debian11-gcc-compile
     run_on: debian11-large
@@ -4875,6 +5122,7 @@ tasks:
       - func: std-compile
         vars:
           CC: gcc
+          CXX: g++
           C_STD_VERSION: 17
   - name: std-c17-windows-2019-vs2017-x64-compile
     run_on: windows-vsCurrent-large
@@ -4883,7 +5131,8 @@ tasks:
       - func: find-cmake-latest
       - func: std-compile
         vars:
-          CC: Visual Studio 15 2017 Win64
+          CMAKE_GENERATOR: Visual Studio 15 2017
+          CMAKE_GENERATOR_PLATFORM: x64
           C_STD_VERSION: 17
   - name: tsan-sasl-cyrus-openssl-debian10-clang-compile
     run_on: debian10-large
@@ -4893,6 +5142,7 @@ tasks:
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: clang
+          CXX: clang++
       - func: upload-build
   - name: tsan-sasl-cyrus-openssl-debian10-clang-test-4.2-replica-auth
     run_on: debian10-small
@@ -4906,6 +5156,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.2" }
             - { key: TOPOLOGY, value: replica_set }
@@ -4926,6 +5177,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.2" }
             - { key: TOPOLOGY, value: server }
@@ -4946,6 +5198,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.2" }
             - { key: TOPOLOGY, value: sharded_cluster }
@@ -4962,6 +5215,7 @@ tasks:
       - func: sasl-cyrus-openssl-compile
         vars:
           CC: clang
+          CXX: clang++
       - func: upload-build
   - name: tsan-sasl-cyrus-openssl-ubuntu2004-clang-test-4.4-replica-auth
     run_on: ubuntu2004-small
@@ -4975,6 +5229,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.4" }
             - { key: TOPOLOGY, value: replica_set }
@@ -4995,6 +5250,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.4" }
             - { key: TOPOLOGY, value: server }
@@ -5015,6 +5271,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.4" }
             - { key: TOPOLOGY, value: sharded_cluster }
@@ -5035,6 +5292,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -5055,6 +5313,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: server }
@@ -5075,6 +5334,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "5.0" }
             - { key: TOPOLOGY, value: sharded_cluster }
@@ -5095,6 +5355,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -5115,6 +5376,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: server }
@@ -5135,6 +5397,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
             - { key: TOPOLOGY, value: sharded_cluster }
@@ -5155,6 +5418,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -5175,6 +5439,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: server }
@@ -5195,6 +5460,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
             - { key: TOPOLOGY, value: sharded_cluster }
@@ -5215,6 +5481,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: replica_set }
@@ -5235,6 +5502,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: server }
@@ -5255,6 +5523,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: sharded_cluster }
@@ -5275,6 +5544,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: replica_set }
@@ -5295,6 +5565,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: server }
@@ -5315,6 +5586,7 @@ tasks:
         params:
           updates:
             - { key: CC, value: clang }
+            - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
             - { key: TOPOLOGY, value: sharded_cluster }

--- a/.evergreen/scripts/compile-openssl-static.sh
+++ b/.evergreen/scripts/compile-openssl-static.sh
@@ -8,6 +8,8 @@ set -o pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/use-tools.sh" paths
 
 check_var_opt CC
+check_var_opt CMAKE_GENERATOR
+check_var_opt CMAKE_GENERATOR_PLATFORM
 check_var_opt MARCH
 
 declare script_dir
@@ -76,15 +78,6 @@ CXXFLAGS+=" ${flags+${flags[*]}}"
 if [[ "${OSTYPE}" == darwin* ]]; then
   CFLAGS+=" -Wno-unknown-pragmas"
 fi
-
-case "${CC}" in
-clang)
-  CXX=clang++
-  ;;
-gcc)
-  CXX=g++
-  ;;
-esac
 
 if [[ "${OSTYPE}" == darwin* && "${HOSTTYPE}" == "arm64" ]]; then
   configure_flags_append "-DCMAKE_OSX_ARCHITECTURES=arm64"

--- a/.evergreen/scripts/compile-std.sh
+++ b/.evergreen/scripts/compile-std.sh
@@ -47,7 +47,7 @@ configure_flags_append "-DENABLE_MAINTAINER_FLAGS=ON"
 
 if [[ "${C_STD_VERSION}" == "latest" ]]; then
   [[ "${CMAKE_GENERATOR:-}" =~ "Visual Studio" ]] || {
-    echo "C_STD_VERSION=clatest is only supported with Visual Studio generators" 1>&2
+    echo "C_STD_VERSION=latest to enable /std:clatest is only supported with Visual Studio generators" 1>&2
     exit 1
   }
 

--- a/.evergreen/scripts/compile-std.sh
+++ b/.evergreen/scripts/compile-std.sh
@@ -11,8 +11,9 @@ check_var_opt CC
 check_var_opt CMAKE_GENERATOR
 check_var_opt CMAKE_GENERATOR_PLATFORM
 
-check_var_opt C_STD_VERSION
+check_var_req C_STD_VERSION
 check_var_opt CFLAGS
+check_var_opt CXXFLAGS
 check_var_opt MARCH
 
 declare script_dir
@@ -44,7 +45,16 @@ configure_flags_append "-DENABLE_CLIENT_SIDE_ENCRYPTION=ON"
 configure_flags_append "-DENABLE_DEBUG_ASSERTIONS=ON"
 configure_flags_append "-DENABLE_MAINTAINER_FLAGS=ON"
 
-configure_flags_append_if_not_null C_STD_VERSION "-DCMAKE_C_STANDARD=${C_STD_VERSION}"
+if [[ "${C_STD_VERSION}" == "latest" ]]; then
+  [[ "${CMAKE_GENERATOR:-}" =~ "Visual Studio" ]] || {
+    echo "C_STD_VERSION=clatest is only supported with Visual Studio generators" 1>&2
+    exit 1
+  }
+
+  configure_flags_append "-DCMAKE_C_FLAGS=/std:clatest"
+else
+  configure_flags_append_if_not_null C_STD_VERSION "-DCMAKE_C_STANDARD=${C_STD_VERSION}"
+fi
 
 if [[ "${OSTYPE}" == darwin* && "${HOSTTYPE}" == "arm64" ]]; then
   configure_flags_append "-DCMAKE_OSX_ARCHITECTURES=arm64"
@@ -58,29 +68,13 @@ fi
 
 declare -a flags
 
-if [[ ! "${CMAKE_GENERATOR:-}" =~ "Visual Studio" ]]; then
-  case "${MARCH}" in
-  i686)
-    flags+=("-m32" "-march=i386")
-    ;;
-  esac
-
-  case "${HOSTTYPE}" in
-  s390x)
-    flags+=("-march=z196" "-mtune=zEC12")
-    ;;
-  x86_64)
-    flags+=("-m64" "-march=x86-64")
-    ;;
-  powerpc64le)
-    flags+=("-mcpu=power8" "-mtune=power8" "-mcmodel=medium")
-    ;;
-  esac
-fi
-
 if [[ "${CMAKE_GENERATOR:-}" =~ "Visual Studio" ]]; then
   # Even with -DCMAKE_SYSTEM_VERSION=10.0.20348.0, winbase.h emits conformance warnings.
   flags+=('/wd5105')
+fi
+
+if [[ "${OSTYPE}" == darwin* ]]; then
+  flags+=('-Wno-unknown-pragmas')
 fi
 
 # CMake and compiler environment variables.
@@ -90,16 +84,15 @@ export CXXFLAGS
 CFLAGS+=" ${flags+${flags[*]}}"
 CXXFLAGS+=" ${flags+${flags[*]}}"
 
-if [[ "${OSTYPE}" == darwin* ]]; then
-  CFLAGS+=" -Wno-unknown-pragmas"
-fi
-
 # Ensure find-cmake-latest.sh is sourced *before* add-build-dirs-to-paths.sh
 # to avoid interfering with potential CMake build configuration.
 # shellcheck source=.evergreen/scripts/find-cmake-latest.sh
 . "${script_dir}/find-cmake-latest.sh"
 declare cmake_binary
 cmake_binary="$(find_cmake_latest)"
+
+declare build_dir
+build_dir="cmake-build"
 
 # shellcheck source=.evergreen/scripts/add-build-dirs-to-paths.sh
 . "${script_dir}/add-build-dirs-to-paths.sh"
@@ -112,6 +105,16 @@ if [[ "${OSTYPE}" == darwin* ]]; then
   nproc() {
     sysctl -n hw.logicalcpu
   }
+fi
+
+export CMAKE_BUILD_PARALLEL_LEVEL
+CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
+
+if [[ "${CMAKE_GENERATOR:-}" =~ "Visual Studio" ]]; then
+  # MSBuild needs additional assistance.
+  # https://devblogs.microsoft.com/cppblog/improved-parallelism-in-msbuild/
+  export UseMultiToolTask=1
+  export EnforceProcessCountAcrossBuilds=1
 fi
 
 echo "Installing libmongocrypt..."
@@ -133,5 +136,15 @@ fi
 echo "CFLAGS: ${CFLAGS}"
 echo "configure_flags: ${configure_flags[*]}"
 
-"${cmake_binary}" "${configure_flags[@]}" .
-"${cmake_binary}" --build .
+if [[ "${CMAKE_GENERATOR:-}" =~ "Visual Studio" ]]; then
+  all_target="ALL_BUILD"
+else
+  all_target="all"
+fi
+
+"${cmake_binary}" -S . -B "${build_dir:?}" "${configure_flags[@]}"
+"${cmake_binary}" --build "${build_dir:?}" --config Debug \
+  --target mongo_c_driver_tests \
+  --target mongo_c_driver_examples \
+  --target public-header-warnings \
+  --target "${all_target:?}"

--- a/.evergreen/scripts/compile-unix.sh
+++ b/.evergreen/scripts/compile-unix.sh
@@ -10,6 +10,8 @@ set -o pipefail
 check_var_opt BYPASS_FIND_CMAKE "OFF"
 check_var_opt C_STD_VERSION # CMake default: 99.
 check_var_opt CC
+check_var_opt CMAKE_GENERATOR
+check_var_opt CMAKE_GENERATOR_PLATFORM
 check_var_opt CFLAGS
 check_var_opt CHECK_LOG "OFF"
 check_var_opt COMPILE_LIBMONGOCRYPT "OFF"
@@ -119,8 +121,6 @@ powerpc64le)
 esac
 
 # CMake and compiler environment variables.
-export CC
-export CXX
 export CFLAGS
 export CXXFLAGS
 
@@ -134,15 +134,6 @@ fi
 if [[ "${OSTYPE}" == darwin* && "${HOSTTYPE}" == "arm64" ]]; then
   configure_flags_append "-DCMAKE_OSX_ARCHITECTURES=arm64"
 fi
-
-case "${CC}" in
-clang)
-  CXX=clang++
-  ;;
-gcc)
-  CXX=g++
-  ;;
-esac
 
 declare cmake_binary
 if [[ "${BYPASS_FIND_CMAKE}" == "OFF" ]]; then

--- a/.evergreen/scripts/compile-windows.sh
+++ b/.evergreen/scripts/compile-windows.sh
@@ -11,7 +11,9 @@ set -o igncr # Ignore CR in this script for Windows compatibility.
 
 check_var_opt BYPASS_FIND_CMAKE "OFF"
 check_var_opt C_STD_VERSION # CMake default: 99.
-check_var_opt CC "Visual Studio 15 2017 Win64"
+check_var_opt CC
+check_var_opt CMAKE_GENERATOR
+check_var_opt CMAKE_GENERATOR_PLATFORM
 check_var_opt COMPILE_LIBMONGOCRYPT "OFF"
 check_var_opt EXTRA_CONFIGURE_FLAGS
 check_var_opt RELEASE "OFF"
@@ -142,7 +144,7 @@ if command -v "${CMAKE_C_COMPILER_LAUNCHER:-}" && [[ "${OSTYPE:?}" == cygwin ]];
   configure_flags_append "-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>"
 fi
 
-"${cmake_binary:?}" -S . -B "${build_dir:?}" -G "$CC" "${configure_flags[@]}" "${extra_configure_flags[@]}"
+"${cmake_binary:?}" -S . -B "${build_dir:?}" "${configure_flags[@]}" "${extra_configure_flags[@]}"
 "${cmake_binary:?}" --build "${build_dir:?}" --config "${build_config:?}"
 "${cmake_binary:?}" --install "${build_dir:?}" --config "${build_config:?}"
 

--- a/.evergreen/scripts/link-sample-program-msvc-bson.cmd
+++ b/.evergreen/scripts/link-sample-program-msvc-bson.cmd
@@ -26,9 +26,9 @@ cd %BUILD_DIR%
 robocopy "%SRCROOT%" "%BUILD_DIR%" /E /XD ".git" "%BUILD_DIR%" "_build" "cmake-build" /NP /NFL /NDL
 
 if "%LINK_STATIC%"=="1" (
-  %CMAKE% -G "Visual Studio 15 2017 Win64" -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DENABLE_TESTS=OFF .
+  %CMAKE% -G "Visual Studio 15 2017" -A x64 -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DENABLE_TESTS=OFF .
 ) else (
-  %CMAKE% -G "Visual Studio 15 2017 Win64" -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DENABLE_TESTS=OFF -DENABLE_STATIC=OFF .
+  %CMAKE% -G "Visual Studio 15 2017" -A x64 -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DENABLE_TESTS=OFF -DENABLE_STATIC=OFF .
 )
 
 %CMAKE% --build . --target ALL_BUILD --config "Debug" -- /m
@@ -47,7 +47,7 @@ if "%LINK_STATIC%"=="1" (
 )
 
 cd %EXAMPLE_DIR%
-%CMAKE% -G "Visual Studio 15 2017 Win64" -DCMAKE_PREFIX_PATH=%INSTALL_DIR%\lib\cmake .
+%CMAKE% -G "Visual Studio 15 2017" -A x64 -DCMAKE_PREFIX_PATH=%INSTALL_DIR%\lib\cmake .
 %CMAKE% --build . --target ALL_BUILD --config "Debug" -- /m
 
 rem Yes, they should've named it "dependencies".

--- a/.evergreen/scripts/link-sample-program-msvc.cmd
+++ b/.evergreen/scripts/link-sample-program-msvc.cmd
@@ -33,7 +33,7 @@ if "%ENABLE_SNAPPY%"=="1" (
   curl -sS --retry 5 -LO https://github.com/google/snappy/archive/1.1.7.tar.gz
   %TAR% xzf 1.1.7.tar.gz
   cd snappy-1.1.7
-  %CMAKE% -G "Visual Studio 15 2017 Win64" -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% .
+  %CMAKE% -G "Visual Studio 15 2017" -A x64 -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% .
   %CMAKE% --build . --target ALL_BUILD --config "Debug" -- /m
   %CMAKE% --build . --target INSTALL --config "Debug" -- /m
   set SNAPPY_OPTION=-DENABLE_SNAPPY=ON
@@ -44,9 +44,9 @@ if "%ENABLE_SNAPPY%"=="1" (
 cd %BUILD_DIR%
 rem Build libmongoc
 if "%ENABLE_SSL%"=="1" (
-  %CMAKE% -G "Visual Studio 15 2017 Win64" -DCMAKE_PREFIX_PATH=%INSTALL_DIR%\lib\cmake -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DENABLE_SSL=WINDOWS %ENABLE_SNAPPY_OPTION% .
+  %CMAKE% -G "Visual Studio 15 2017" -A x64 -DCMAKE_PREFIX_PATH=%INSTALL_DIR%\lib\cmake -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DENABLE_SSL=WINDOWS %ENABLE_SNAPPY_OPTION% .
 ) else (
-  %CMAKE% -G "Visual Studio 15 2017 Win64" -DCMAKE_PREFIX_PATH=%INSTALL_DIR%\lib\cmake -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DENABLE_SSL=OFF %ENABLE_SNAPPY_OPTION% .
+  %CMAKE% -G "Visual Studio 15 2017" -A x64 -DCMAKE_PREFIX_PATH=%INSTALL_DIR%\lib\cmake -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DENABLE_SSL=OFF %ENABLE_SNAPPY_OPTION% .
 )
 
 %CMAKE% --build . --target ALL_BUILD --config "Debug" -- /m
@@ -90,7 +90,7 @@ if "%ENABLE_SSL%"=="1" (
   set MONGODB_EXAMPLE_URI="mongodb://localhost/?ssl=true&sslclientcertificatekeyfile=client.pem&sslcertificateauthorityfile=ca.pem&sslallowinvalidhostnames=true"
 )
 
-%CMAKE% -G "Visual Studio 15 2017 Win64" -DCMAKE_PREFIX_PATH=%INSTALL_DIR%\lib\cmake .
+%CMAKE% -G "Visual Studio 15 2017" -A x64 -DCMAKE_PREFIX_PATH=%INSTALL_DIR%\lib\cmake .
 %CMAKE% --build . --target ALL_BUILD --config "Debug" -- /m
 
 rem Yes, they should've named it "dependencies".

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,7 @@ target_compile_options(public-header-warnings PRIVATE
   $<$<C_COMPILER_ID:AppleClang,Clang,GNU>:-Wno-disabled-macro-expansion>
   $<$<C_COMPILER_ID:AppleClang,Clang>:-Wno-c++98-compat-pedantic>
   $<$<C_COMPILER_ID:AppleClang,Clang>:-Wno-pre-c2x-compat>
+  $<$<C_COMPILER_ID:AppleClang,Clang>:-Wno-unsafe-buffer-usage>
   $<$<C_COMPILER_ID:AppleClang,Clang>:-Wno-padded>
   $<$<C_COMPILER_ID:AppleClang,Clang>:-Wno-reserved-identifier>
   $<$<C_COMPILER_ID:AppleClang,Clang>:-Wno-documentation-unknown-command>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,7 @@ target_compile_options(public-header-warnings PRIVATE
   $<$<C_COMPILER_ID:AppleClang,Clang,GNU>:-Wno-declaration-after-statement>
   $<$<C_COMPILER_ID:AppleClang,Clang,GNU>:-Wno-disabled-macro-expansion>
   $<$<C_COMPILER_ID:AppleClang,Clang>:-Wno-c++98-compat-pedantic>
+  $<$<C_COMPILER_ID:AppleClang,Clang>:-Wno-pre-c2x-compat>
   $<$<C_COMPILER_ID:AppleClang,Clang>:-Wno-padded>
   $<$<C_COMPILER_ID:AppleClang,Clang>:-Wno-reserved-identifier>
   $<$<C_COMPILER_ID:AppleClang,Clang>:-Wno-documentation-unknown-command>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,7 @@ target_compile_options(public-header-warnings PRIVATE
   $<$<C_COMPILER_ID:AppleClang,Clang,GNU>:-Werror>
   $<$<C_COMPILER_ID:AppleClang,Clang,GNU>:-Wno-declaration-after-statement>
   $<$<C_COMPILER_ID:AppleClang,Clang,GNU>:-Wno-disabled-macro-expansion>
+  $<$<C_COMPILER_ID:AppleClang,Clang>:-Wno-c++98-compat-pedantic>
   $<$<C_COMPILER_ID:AppleClang,Clang>:-Wno-padded>
   $<$<C_COMPILER_ID:AppleClang,Clang>:-Wno-reserved-identifier>
   $<$<C_COMPILER_ID:AppleClang,Clang>:-Wno-documentation-unknown-command>

--- a/src/common/src/bson-dsl.md
+++ b/src/common/src/bson-dsl.md
@@ -203,7 +203,7 @@ satisfies `cond` into the parent document.
 The *Predicate* `cond` will be evaluated for every element in `b`. Refer:
 [*Predicate*](#Predicate).
 
-To copy *all* elements from `b`, simply use the bare `true` predicate.
+To copy *all* elements from `b`, simply use the bare `always` predicate.
 
 
 #### `insertFromIter()`
@@ -618,7 +618,7 @@ Each `when` is considered in the listed order. If the *Predicate* `w` of a
 After any `when` clause matches an element, no subsequent `when` clauses are
 considered.
 
-An `else(ops...)` clause is equivalent to `when(true, ops...)`.
+An `else(ops...)` clause is equivalent to `when(always, ops...)`.
 
 If no clause matches the element, nothing happens.
 
@@ -670,12 +670,12 @@ The `isNumeric` predicate matches if the element's value is a numeric type
 Matches only the final element in a document.
 
 
-#### `true`
+#### `always`
 
 Always matches.
 
 
-#### `false`
+#### `never`
 
 Never matches.
 
@@ -1032,4 +1032,3 @@ by a single `AGAIN(f)`.
 
 There are additional tricks required to make `EVAL`, `MAP`, and token pasting
 play nice, but those details are not necessary here.
-

--- a/src/common/src/common-bson-dsl-private.h
+++ b/src/common/src/common-bson-dsl-private.h
@@ -741,8 +741,8 @@ BSON_IF_GNU_LIKE (_Pragma ("GCC diagnostic ignored \"-Wshadow\""))
 
 #define _bsonPredicate_Condition_1 1
 #define _bsonPredicate_Condition_0 0
-#define _bsonPredicate_Condition_true true
-#define _bsonPredicate_Condition_false false
+#define _bsonPredicate_Condition_always true
+#define _bsonPredicate_Condition_never false
 
 #define _bsonPredicate_Condition_isTrue (bson_iter_as_bool (&bsonVisitIter))
 #define _bsonPredicate_Condition_isFalse (!bson_iter_as_bool (&bsonVisitIter))

--- a/src/libbson/tests/test-bson.c
+++ b/src/libbson/tests/test-bson.c
@@ -2652,7 +2652,7 @@ test_bson_dsl_build (void)
    // Insert a subdoc
    bson_t *subdoc = TMP_BSON_FROM_JSON ({"child" : [ 1, 2, 3 ], "other" : null});
 
-   bsonBuild (doc, kv ("subdoc", doc (insert (*subdoc, true))));
+   bsonBuild (doc, kv ("subdoc", doc (insert (*subdoc, always))));
    ASSERT_BSON_EQUAL (doc, {"subdoc" : {"child" : [ 1, 2, 3 ], "other" : null}});
    bson_destroy (&doc);
 
@@ -2667,7 +2667,7 @@ test_bson_dsl_build (void)
                   doc (kv ("inner1", array ()),
                        kv ("inner2", null),
                        kv ("inner3", array (int32 (1), int32 (2), int32 (3))),
-                       insert (*subdoc, true),
+                       insert (*subdoc, always),
                        kv ("inner4", doc (kv ("innermost", int32 (42)))))));
    ASSERT_BSON_EQUAL (doc, {
       "top" : {

--- a/src/libmongoc/src/mongoc/mongoc-aggregate.c
+++ b/src/libmongoc/src/mongoc/mongoc-aggregate.c
@@ -120,7 +120,7 @@ _make_agg_cmd (
                     append (*command, kv ("pipeline", iterValue (bsonVisitIter)))),
               else ( // We did not find a "pipeline" array. copy the pipeline as
                      // an array into the command
-                 append (*command, kv ("pipeline", array (insert (*pipeline, true))))));
+                 append (*command, kv ("pipeline", array (insert (*pipeline, always))))));
    if ((error = bsonParseError)) {
       error_hint = "append-pipeline";
       goto fail;

--- a/src/libmongoc/src/mongoc/mongoc-uri.c
+++ b/src/libmongoc/src/mongoc/mongoc-uri.c
@@ -1626,7 +1626,7 @@ mongoc_uri_set_mechanism_properties (mongoc_uri_t *uri, const bson_t *properties
                     // Append the new properties
                     kv (MONGOC_URI_AUTHMECHANISMPROPERTIES, bson (*properties)));
    bson_reinit (&uri->credentials);
-   bsonBuildAppend (uri->credentials, insert (tmp, true));
+   bsonBuildAppend (uri->credentials, insert (tmp, always));
    bson_destroy (&tmp);
    return bsonBuildError == NULL;
 }


### PR DESCRIPTION
## Summary

Resolves CDRIVER-5891.

Extends `std-matrix` Evergreen tasks to support compilation with C99 through C23 using GCC, Clang, and MSVC.

## Drive-By EVG Config and Script Improvements

To facilitate the expansion of compilation coverage to newer versions of Visual Studio, compile scripts (beyond `std-matrix` tasks) are updated to utilize the CMake `CMAKE_GENERATOR` and `CMAKE_GENERATOR_PLATFORM` environment variables to specify the Visual Studio version and target architecture (equivalent to `-G` + `-A`; similar changes to https://github.com/mongodb/mongo-cxx-driver/pull/1082). The definition of `CC` and `CXX` variables are also moved into the config generator to ensure copmiler consistency (no need for `if [[ "$CC" == "gcc" ]]`-esque logic in scripts), including specific compiler version requests (e.g. `clang-12`). The list of distros in `distros.py` was also refactored to use the `ls_distro` pattern to specify small+large distro pairs (similar changes to https://github.com/mongodb/mongo-cxx-driver/pull/1082).

## Compiler Support

Reliably deducing compiler support for any given standard is a chore, especially given ongoing partial implementations of the C2x standard (as well as the C17 standard for older compiler versions). For example, support for `static_assert` is already available as early as GCC 9, while other C2x features such as `[[nodiscard]]`, `__VA_OPT__`, and `nullptr` are implemented by GCC 14, with more features such as `#embed` provided by GCC 15, and etc. (see [major version changelogs](https://gcc.gnu.org/gcc-15/changes.html) for 15.1, 14.1, 13.1, etc.). Similarly, `static_assert` and `[[nodiscard]]` are supported by Clang 9, with a scattering of C2x features being partially implemented across versions up to Clang 20 (technically even C11 standard support is [still in a partial state](https://clang.llvm.org/c_status.html)).

Instead of laborously deducing compiler support for language standards or features, detection of C standard support is completely deferred to CMake's built-in feature detection routines (regardless of what flag may be required: `-std=c11`, `-std=c1x`, `-std=c17`, `-std=c2x`, or `-std=c23`). When a compiler does not support a given standard or feature, CMake will emit errors similar to the following (e.g. for GCC):

```
CMake Error in [...]/CMakeFiles/CMakeScratch/TryCompile-cX1jWr/CMakeLists.txt:
  Target "cmTC_700ec" requires the language dialect "C23" .  But the current
  compiler "GNU" does not support this, or CMake does not know the flags to
  enable it.
CMake Error at [...]/Modules/CheckSymbolExists.cmake:154 (try_compile):
  Failed to generate test project build system.
Call Stack (most recent call first):
  [...]/Modules/CheckSymbolExists.cmake:66 (__CHECK_SYMBOL_EXISTS_IMPL)
  src/libbson/CMakeLists.txt:93 (check_symbol_exists)
```

The absence of C standards in the matrix for older compiler versions as proposed by this PR was entirely decided by the presence CMake errors similar to the one shown above.

## Disabled Warnings

The `public-header-warnings` (+ tests and examples) are added to the C standard task matrix. This motivated adding some new warning flags to be explicitly disabled for Clang with `-Weverything`:

- `-Wc++98-compat-pedantic`: we are not interested in continuing to support C++98 in either the C or C++ Driver. (Note: C++11 references the C99 spec.)
- `-Wpre-c2x-compat`: we actively test pre-C2x compatibility and do not need to rely on this warning.
    - Warning for use of `bool` despite pre-C2x `#define bool _Bool` and inclusion of C99 `<stdbool.h>` is unnecessarily noisy.
- `-Wunsafe-buffer-usage`: too aggressive, warning on nearly any subscript of a pointer. Impractical to address this warning.

## C2x Boolean Compatibility

The following code:

```c
bson_t bson;
bsonParse (bson, require (true, do ((void) 0)));
//                        ^~~~
```

and similarly:

```c
bson_t other = BSON_INITIALIZER;
bsonBuildDecl (bson, insert (other, true));
//                                  ^~~~
```

produces the following compiler error with GCC 11 and GCC 12 given `-std=c2x`:

```
error: pasting "_bsonPredicate_Condition_" and "(" does not give a valid preprocessing token
  704 | #define _bsonPredicate(P) _bsonPredicate_Condition_##P
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~
```

due to GCC 11 and GCC 12 defining boolean constants as:

```c
#define true    ((_Bool)+1u)
#define false   ((_Bool)+0u)
```

instead of as a simple `1` and `0` (as in C17 and prior) or as keywords (in GCC 13 and newer with `-std=c2x` or `-std=c23`). The `"("` mentioned in the error message is the first `(` in `((_Bool)+1u)`.

According to https://github.com/gcc-mirror/gcc, this change is due to [this commit](https://github.com/gcc-mirror/gcc/commit/40749db75caff2fed7b7053e0d1868feaa21bcb4#diff-ab3b990dfb45ff891f5c5bae5656c83ec2763f666a80050be94487ccb180ddcb) on Oct 29, 2020, which was motivated by [this feature request](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82272). The `((_Bool)+1u)` form was proposed by [N2393](https://www.open-std.org/JTC1/SC22/WG14/www/docs/n2393.pdf) as an intermediate solution until the compiler has completed implementing the booleans as keywords. It seems `<stdbool.h>` for GCC 11 and GCC 12 implement this intermediate solution. These changes were later superceded by [this commit](https://github.com/gcc-mirror/gcc/commit/0a91bdaf177409a2a5e7895bce4f0e7091b4b3ca#diff-ab3b990dfb45ff891f5c5bae5656c83ec2763f666a80050be94487ccb180ddcb) on Sep 7, 2022, which remove the macros entirely for `-std=c2x`. This seems to correspond to the GCC 13 release and onwards which implemented the keyword-based solution.

Because the language does not support contextually redefining `true` and `false` as "simple" macros wherever the BSON DSL macros may be expanded (that is, we cannot `#define` in a `#define`), a solution that attempts to preserve the use of `true` and `false` as unconditional DSL predicates was considered but rejected. Instead, the special `true` and `false` DSL predicates are renamed to new and equivalent DSL predicates: `always` and `never`.

Therefore, the code above must now be written instead as:

```c
bson_t bson;
bsonParse (bson, require (always, do ((void) 0)));
//                        ^~~~~~
```

and similarly:

```c
bson_t other = BSON_INITIALIZER;
bsonBuildDecl (bson, insert (other, always));
//                                  ^~~~~~
```
