### PR TITLE
sync RPM spec from downstream

### DIFF
--- a/.evergreen/etc/mongo-c-driver.spec
+++ b/.evergreen/etc/mongo-c-driver.spec
@@ -10,7 +10,7 @@
 %global gh_project   mongo-c-driver
 %global libname      libmongoc
 %global libver       1.0
-%global up_version   1.30.1
+%global up_version   1.30.2
 #global up_prever    rc0
 # disabled as require a MongoDB server
 %bcond_with          tests
@@ -259,6 +259,9 @@ exit $ret
 
 
 %changelog
+* Wed Mar  5 2025 Remi Collet <remi@remirepo.net> - 1.30.2-1
+- update to 1.30.2
+
 * Tue Feb 25 2025 Remi Collet <remi@remirepo.net> - 1.30.1-1
 - update to 1.30.1
 

--- a/.evergreen/etc/spec.patch
+++ b/.evergreen/etc/spec.patch
@@ -4,7 +4,7 @@
  %global gh_project   mongo-c-driver
  %global libname      libmongoc
  %global libver       1.0
--%global up_version   1.30.1
+-%global up_version   1.30.2
 +%global up_version   1.31.0
  #global up_prever    rc0
  # disabled as require a MongoDB server


### PR DESCRIPTION
Evergreen patch build: https://spruce.mongodb.com/version/67c8dea49ed5850007437540/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Note that the task still fails because libmongocrypt 1.13.0 has not yet landed in Fedora.