### PR TITLE
CDRIVER-5919 Revert skip to `non-lb-connection-establishment`

### DIFF
--- a/src/libmongoc/tests/json/load_balancers/non-lb-connection-establishment.json
+++ b/src/libmongoc/tests/json/load_balancers/non-lb-connection-establishment.json
@@ -57,19 +57,6 @@
   "tests": [
     {
       "description": "operations against non-load balanced clusters fail if URI contains loadBalanced=true",
-      "runOnRequirements": [
-        {
-          "maxServerVersion": "8.0.99",
-          "topologies": [
-            "single"
-          ]
-        },
-        {
-          "topologies": [
-            "sharded"
-          ]
-        }
-      ],
       "operations": [
         {
           "name": "runCommand",


### PR DESCRIPTION
This reverts commit e5bc5a84bdfa511fdaa38ad4df3513dea57ab880.

The fix of [SERVER-101078](https://jira.mongodb.org/browse/SERVER-101078) enables this test to be run on latest servers again.