### PR TITLE
CDRIVER-5924 test on Graviton

### DIFF
--- a/.evergreen/config_generator/components/sasl/openssl.py
+++ b/.evergreen/config_generator/components/sasl/openssl.py
@@ -26,6 +26,7 @@ COMPILE_MATRIX = [
     ('ubuntu2004-arm64',  'gcc',        None, ['cyrus']),
     ('ubuntu2004',        'gcc',        None, ['cyrus']),
     ('windows-vsCurrent', 'vs2017x64',  None, ['cyrus']),
+    ('amazon2023-arm64-latest-large-m8g', 'gcc', None, ['cyrus']),
 ]
 
 TEST_MATRIX = [
@@ -38,6 +39,9 @@ TEST_MATRIX = [
 
     # Test 4.2 with Debian 10 since 4.2 does not ship on Ubuntu 20.04+.
     ('debian10',          'gcc',       None, 'cyrus', ['auth'], ['server', 'replica'], ['4.2']), 
+
+    # Test with Graviton processor:
+    ('amazon2023-arm64-latest-large-m8g', 'gcc',  None, 'cyrus', ['auth'], ['server', 'replica', 'sharded'], ['latest']),
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/sasl/openssl.py
+++ b/.evergreen/config_generator/components/sasl/openssl.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from shrub.v3.evg_build_variant import BuildVariant
 
 from config_generator.etc.utils import TaskRef

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -101,6 +101,11 @@ WINDOWS_DISTROS = [
     *ls_distro(name='windows-vsCurrent', os='windows', os_type='windows', vs_ver='vsCurrent'),  # Windows Server 2019
 ]
 
+GRAVITON_DISTROS = [
+    Distro(name='amazon2023-arm64-latest-large-m8g', os='amazon2023', os_type='linux', os_ver='2023', arch='arm64'),
+    Distro(name='amazon2-arm64-latest-large-m8g', os='amazon2', os_type='linux', os_ver='2', arch='arm64'),
+]
+
 # See: https://evergreen.mongodb.com/distros
 # Ensure no-arch distros are ordered before arch-specific distros.
 ALL_DISTROS = [
@@ -113,6 +118,7 @@ ALL_DISTROS = [
     *UBUNTU_DISTROS,
     *UBUNTU_ARM64_DISTROS,
     *WINDOWS_DISTROS,
+    *GRAVITON_DISTROS
 ]
 
 

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -3452,6 +3452,79 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
+  - name: sasl-cyrus-openssl-amazon2023-arm64-latest-large-m8g-gcc-compile
+    run_on: amazon2023-arm64-latest-large-m8g
+    tags: [sasl-matrix-openssl, compile, amazon2023-arm64-latest-large-m8g, gcc, sasl-cyrus]
+    commands:
+      - func: find-cmake-latest
+      - func: sasl-cyrus-openssl-compile
+        vars:
+          CC: gcc
+          CXX: g++
+      - func: upload-build
+  - name: sasl-cyrus-openssl-amazon2023-arm64-latest-large-m8g-gcc-test-latest-replica-auth
+    run_on: amazon2023-arm64-latest-large-m8g
+    tags: [sasl-matrix-openssl, test, amazon2023-arm64-latest-large-m8g, gcc, sasl-cyrus, auth, replica, latest, openssl]
+    depends_on: [{ name: sasl-cyrus-openssl-amazon2023-arm64-latest-large-m8g-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: sasl-cyrus-openssl-amazon2023-arm64-latest-large-m8g-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: latest }
+            - { key: TOPOLOGY, value: replica_set }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: sasl-cyrus-openssl-amazon2023-arm64-latest-large-m8g-gcc-test-latest-server-auth
+    run_on: amazon2023-arm64-latest-large-m8g
+    tags: [sasl-matrix-openssl, test, amazon2023-arm64-latest-large-m8g, gcc, sasl-cyrus, auth, server, latest, openssl]
+    depends_on: [{ name: sasl-cyrus-openssl-amazon2023-arm64-latest-large-m8g-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: sasl-cyrus-openssl-amazon2023-arm64-latest-large-m8g-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: latest }
+            - { key: TOPOLOGY, value: server }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
+  - name: sasl-cyrus-openssl-amazon2023-arm64-latest-large-m8g-gcc-test-latest-sharded-auth
+    run_on: amazon2023-arm64-latest-large-m8g
+    tags: [sasl-matrix-openssl, test, amazon2023-arm64-latest-large-m8g, gcc, sasl-cyrus, auth, sharded, latest, openssl]
+    depends_on: [{ name: sasl-cyrus-openssl-amazon2023-arm64-latest-large-m8g-gcc-compile }]
+    commands:
+      - func: fetch-build
+        vars:
+          BUILD_NAME: sasl-cyrus-openssl-amazon2023-arm64-latest-large-m8g-gcc-compile
+      - command: expansions.update
+        params:
+          updates:
+            - { key: CC, value: gcc }
+            - { key: CXX, value: g++ }
+            - { key: AUTH, value: auth }
+            - { key: MONGODB_VERSION, value: latest }
+            - { key: TOPOLOGY, value: sharded_cluster }
+            - { key: SSL, value: openssl }
+      - func: fetch-det
+      - func: bootstrap-mongo-orchestration
+      - func: run-simple-http-server
+      - func: run-tests
   - name: sasl-cyrus-openssl-debian10-gcc-compile
     run_on: debian10-large
     tags: [sasl-matrix-openssl, compile, debian10, gcc, sasl-cyrus]

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -234,6 +234,7 @@ buildvariants:
       - name: sasl-cyrus-openssl-ubuntu2004-arm64-gcc-compile
       - name: sasl-cyrus-openssl-ubuntu2004-gcc-compile
       - name: sasl-cyrus-openssl-windows-2019-vs2017-x64-compile
+      - name: sasl-cyrus-openssl-amazon2023-arm64-latest-large-m8g-gcc-compile
       - name: sasl-cyrus-openssl-rhel8-power-gcc-test-4.2-server-auth
         batchtime: 1440
       - name: sasl-cyrus-openssl-rhel8-power-gcc-test-4.4-server-auth
@@ -273,6 +274,9 @@ buildvariants:
       - name: sasl-cyrus-openssl-windows-2019-vs2017-x64-test-latest-server-auth
       - name: sasl-cyrus-openssl-debian10-gcc-test-4.2-server-auth
       - name: sasl-cyrus-openssl-debian10-gcc-test-4.2-replica-auth
+      - name: sasl-cyrus-openssl-amazon2023-arm64-latest-large-m8g-gcc-test-latest-server-auth
+      - name: sasl-cyrus-openssl-amazon2023-arm64-latest-large-m8g-gcc-test-latest-replica-auth
+      - name: sasl-cyrus-openssl-amazon2023-arm64-latest-large-m8g-gcc-test-latest-sharded-auth
   - name: sasl-matrix-winssl
     display_name: sasl-matrix-winssl
     expansions: {}


### PR DESCRIPTION
# Summary
Test on Graviton with latest server

# Background & Motivation

Testing Graviton is requested in DRIVERS-2436. MongoDB servers on Graviton is expected to be [more common](https://docs.google.com/document/d/117jiFR_JH6tgNBC5QeoXRpTxJoV308M1Q-JxImN30mM/edit?tab=t.0). Additional testing appears motivated by server issues encountered on Graviton. [HELP-37322](https://jira.mongodb.org/browse/HELP-37322) references two behavior differences:
1. SERVER-69612: [`char` is unsigned](https://github.com/aws/aws-graviton-getting-started/blob/main/c-c%2B%2B.md#signed-vs-unsigned-char) on ARM.
2. SERVER-69611: gcc may enable a default for `-ffp-contract` (which differs from clang).

Neither appear specific to Graviton. (1) applies to other ARM CPUs. The C driver already tests on arm (via `ubuntu2004-arm64`). (2) appears non-applicable to the C driver. Quoting https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html:

> The default is -ffp-contract=off for C in a standards compliant mode

The C driver [specifies C99 by default](https://github.com/mongodb/mongo-c-driver/blob/915277362a01f7304a6e119fb7c2030f5401dca9/CMakeLists.txt#L406). So I expect the default C build agrees with `clang`. Regardless, I expect there are few floating point algorithms in the driver that would be affected.

Though the server supports arm on [4.2-latest](https://docs.google.com/spreadsheets/d/1-sZKW70HbVt2yHOWa18qwBwi-gBcn54tWmronnn89kI/), this PR proposes only testing the latest server.  The C driver already tests on ARM (via `ubuntu2004-arm64`). And a patch build testing [4.2-latest servers](https://spruce.mongodb.com/version/67cee246f1647400074b55b0/) showed no issues.

