### PR TITLE
Fix upload of ABI Compatibility Report HTML on failure

### DIFF
--- a/.evergreen/config_generator/components/abi_compliance_check.py
+++ b/.evergreen/config_generator/components/abi_compliance_check.py
@@ -15,32 +15,20 @@ class CheckABICompliance(Function):
             script='.evergreen/scripts/abi-compliance-check-setup.sh'
         ),
         bash_exec(
-            command_type=EvgCommandType.SETUP,
+            command_type=EvgCommandType.TEST,
             add_expansions_to_env=True,
             working_dir='mongoc',
             script='.evergreen/scripts/abi-compliance-check.sh'
-        ),
-        bash_exec(
-            command_type=EvgCommandType.TEST,
-            working_dir='mongoc',
-            env={
-                'AWS_ACCESS_KEY_ID': '${aws_key}',
-                'AWS_SECRET_ACCESS_KEY': '${aws_secret}',
-            },
-            script='''\
-                aws s3 cp abi-compliance/compat_reports s3://mciuploads/${project}/${build_variant}/${revision}/${version_id}/${build_id}/abi-compliance/compat_reports --recursive --acl public-read --region us-east-1
-                [[ ! -f ./abi-compliance/abi-error.txt ]]
-            '''
         ),
         s3_put(
             aws_key='${aws_key}',
             aws_secret='${aws_secret}',
             bucket='mciuploads',
             content_type='text/html',
-            display_name='ABI Report:',
-            local_files_include_filter='mongoc/abi-compliance/compat_reports/**/*.html',
+            display_name='ABI Compliance Check: ',
+            local_files_include_filter='abi-compliance/compat_reports/**/compat_report.html',
             permissions='public-read',
-            remote_file='${project}/${build_variant}/${revision}/${version_id}/${build_id}/abi-compliance/compat_report.html',
+            remote_file='${project}/${build_variant}/${revision}/${version_id}/${build_id}/abi-compliance/compat_reports/',
         ),
     ]
 

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -9,7 +9,7 @@ functions:
           - -c
           - .evergreen/scripts/abi-compliance-check-setup.sh
     - command: subprocess.exec
-      type: setup
+      type: test
       params:
         binary: bash
         working_dir: mongoc
@@ -17,29 +17,16 @@ functions:
         args:
           - -c
           - .evergreen/scripts/abi-compliance-check.sh
-    - command: subprocess.exec
-      type: test
-      params:
-        binary: bash
-        working_dir: mongoc
-        env:
-          AWS_ACCESS_KEY_ID: ${aws_key}
-          AWS_SECRET_ACCESS_KEY: ${aws_secret}
-        args:
-          - -c
-          - |
-            aws s3 cp abi-compliance/compat_reports s3://mciuploads/${project}/${build_variant}/${revision}/${version_id}/${build_id}/abi-compliance/compat_reports --recursive --acl public-read --region us-east-1
-            [[ ! -f ./abi-compliance/abi-error.txt ]]
     - command: s3.put
       params:
-        display_name: "ABI Report:"
+        display_name: "ABI Compliance Check: "
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         bucket: mciuploads
         content_type: text/html
-        local_files_include_filter: mongoc/abi-compliance/compat_reports/**/*.html
+        local_files_include_filter: abi-compliance/compat_reports/**/compat_report.html
         permissions: public-read
-        remote_file: ${project}/${build_variant}/${revision}/${version_id}/${build_id}/abi-compliance/compat_report.html
+        remote_file: ${project}/${build_variant}/${revision}/${version_id}/${build_id}/abi-compliance/compat_reports/
   backtrace:
     - command: subprocess.exec
       params:

--- a/.evergreen/scripts/abi-compliance-check.sh
+++ b/.evergreen/scripts/abi-compliance-check.sh
@@ -65,7 +65,8 @@ DOC
 
 # Allow task to upload the HTML report despite failed status.
 if ! abi-compliance-checker -lib mongo-c-driver -old old.xml -new new.xml; then
-  declare status
-  status='{"status":"failed", "type":"test", "should_continue":true, "desc":"abi-compliance-checker emitted one or more errors"}'
-  curl -sS -d "${status:?}" -H "Content-Type: application/json" -X POST localhost:2285/task_status || true
+  : # CDRIVER-5930: re-enable task failure once 2.0.0 is released.
+  # declare status
+  # status='{"status":"failed", "type":"test", "should_continue":true, "desc":"abi-compliance-checker emitted one or more errors"}'
+  # curl -sS -d "${status:?}" -H "Content-Type: application/json" -X POST localhost:2285/task_status || true
 fi

--- a/.evergreen/scripts/abi-compliance-check.sh
+++ b/.evergreen/scripts/abi-compliance-check.sh
@@ -63,6 +63,9 @@ $(pwd)/changes-install/include/libbson-1.0/bson/bson.h
 <libs>$(pwd)/changes-install/lib</libs>
 DOC
 
+# Allow task to upload the HTML report despite failed status.
 if ! abi-compliance-checker -lib mongo-c-driver -old old.xml -new new.xml; then
-  touch ./abi-error.txt
+  declare status
+  status='{"status":"failed", "type":"test", "should_continue":true, "desc":"abi-compliance-checker emitted one or more errors"}'
+  curl -sS -d "${status:?}" -H "Content-Type: application/json" -X POST localhost:2285/task_status || true
 fi


### PR DESCRIPTION
The `compat_report.html` file is not being uploaded properly to AWS on task failure. This PR fixes the upload routine such that the task will have a "failed" status (via the curl command) while proceeding with subsequent `s3.put` operations. However, this curl command is temporarily disabled given the deliberate breaking changes targeting the 2.0.0 release. CDRIVER-5930 tracks re-enabling task failure after the 2.0.0 release.