### PR TITLE
CDRIVER-5701 remove references to removed symbols

### DIFF
--- a/.evergreen/config_generator/components/earthly.py
+++ b/.evergreen/config_generator/components/earthly.py
@@ -38,7 +38,7 @@ SASLOption = Literal["Cyrus", "off"]
 "Valid options for the SASL configuration parameter"
 TLSOption = Literal["LibreSSL", "OpenSSL", "off"]
 "Options for the TLS backend configuration parameter (AKA 'ENABLE_SSL')"
-CxxVersion = Literal["r3.9.0", "none"]
+CxxVersion = Literal["r4.0.0", "none"]
 "C++ driver refs that are under CI test"
 
 # A separator character, since we cannot use whitespace

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -1097,7 +1097,7 @@ tasks:
   - name: check-headers
     commands:
       - func: check-headers
-  - name: "check:sasl=Cyrus\_\u2022\_tls=LibreSSL\_\u2022\_test_mongocxx_ref=r3.9.0"
+  - name: "check:sasl=Cyrus\_\u2022\_tls=LibreSSL\_\u2022\_test_mongocxx_ref=r4.0.0"
     run_on:
       - ubuntu2204-large
       - debian10-large
@@ -1121,7 +1121,7 @@ tasks:
             - +env-warmup
             - --sasl=Cyrus
             - --tls=LibreSSL
-            - --test_mongocxx_ref=r3.9.0
+            - --test_mongocxx_ref=r4.0.0
             - --env=${MONGOC_EARTHLY_ENV}
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
       - command: subprocess.exec
@@ -1134,7 +1134,7 @@ tasks:
             - --targets=test-example test-cxx-driver
             - --sasl=Cyrus
             - --tls=LibreSSL
-            - --test_mongocxx_ref=r3.9.0
+            - --test_mongocxx_ref=r4.0.0
             - --env=${MONGOC_EARTHLY_ENV}
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
   - name: "check:sasl=Cyrus\_\u2022\_tls=OpenSSL\_\u2022\_test_mongocxx_ref=none"
@@ -1177,7 +1177,7 @@ tasks:
             - --test_mongocxx_ref=none
             - --env=${MONGOC_EARTHLY_ENV}
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
-  - name: "check:sasl=Cyrus\_\u2022\_tls=OpenSSL\_\u2022\_test_mongocxx_ref=r3.9.0"
+  - name: "check:sasl=Cyrus\_\u2022\_tls=OpenSSL\_\u2022\_test_mongocxx_ref=r4.0.0"
     run_on:
       - ubuntu2204-large
       - debian10-large
@@ -1201,7 +1201,7 @@ tasks:
             - +env-warmup
             - --sasl=Cyrus
             - --tls=OpenSSL
-            - --test_mongocxx_ref=r3.9.0
+            - --test_mongocxx_ref=r4.0.0
             - --env=${MONGOC_EARTHLY_ENV}
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
       - command: subprocess.exec
@@ -1214,7 +1214,7 @@ tasks:
             - --targets=test-example test-cxx-driver
             - --sasl=Cyrus
             - --tls=OpenSSL
-            - --test_mongocxx_ref=r3.9.0
+            - --test_mongocxx_ref=r4.0.0
             - --env=${MONGOC_EARTHLY_ENV}
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
   - name: "check:sasl=Cyrus\_\u2022\_tls=off\_\u2022\_test_mongocxx_ref=none"
@@ -1257,7 +1257,7 @@ tasks:
             - --test_mongocxx_ref=none
             - --env=${MONGOC_EARTHLY_ENV}
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
-  - name: "check:sasl=Cyrus\_\u2022\_tls=off\_\u2022\_test_mongocxx_ref=r3.9.0"
+  - name: "check:sasl=Cyrus\_\u2022\_tls=off\_\u2022\_test_mongocxx_ref=r4.0.0"
     run_on:
       - ubuntu2204-large
       - debian10-large
@@ -1281,7 +1281,7 @@ tasks:
             - +env-warmup
             - --sasl=Cyrus
             - --tls=off
-            - --test_mongocxx_ref=r3.9.0
+            - --test_mongocxx_ref=r4.0.0
             - --env=${MONGOC_EARTHLY_ENV}
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
       - command: subprocess.exec
@@ -1294,10 +1294,10 @@ tasks:
             - --targets=test-example test-cxx-driver
             - --sasl=Cyrus
             - --tls=off
-            - --test_mongocxx_ref=r3.9.0
+            - --test_mongocxx_ref=r4.0.0
             - --env=${MONGOC_EARTHLY_ENV}
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
-  - name: "check:sasl=off\_\u2022\_tls=LibreSSL\_\u2022\_test_mongocxx_ref=r3.9.0"
+  - name: "check:sasl=off\_\u2022\_tls=LibreSSL\_\u2022\_test_mongocxx_ref=r4.0.0"
     run_on:
       - ubuntu2204-large
       - debian10-large
@@ -1321,7 +1321,7 @@ tasks:
             - +env-warmup
             - --sasl=off
             - --tls=LibreSSL
-            - --test_mongocxx_ref=r3.9.0
+            - --test_mongocxx_ref=r4.0.0
             - --env=${MONGOC_EARTHLY_ENV}
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
       - command: subprocess.exec
@@ -1334,7 +1334,7 @@ tasks:
             - --targets=test-example test-cxx-driver
             - --sasl=off
             - --tls=LibreSSL
-            - --test_mongocxx_ref=r3.9.0
+            - --test_mongocxx_ref=r4.0.0
             - --env=${MONGOC_EARTHLY_ENV}
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
   - name: "check:sasl=off\_\u2022\_tls=OpenSSL\_\u2022\_test_mongocxx_ref=none"
@@ -1377,7 +1377,7 @@ tasks:
             - --test_mongocxx_ref=none
             - --env=${MONGOC_EARTHLY_ENV}
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
-  - name: "check:sasl=off\_\u2022\_tls=OpenSSL\_\u2022\_test_mongocxx_ref=r3.9.0"
+  - name: "check:sasl=off\_\u2022\_tls=OpenSSL\_\u2022\_test_mongocxx_ref=r4.0.0"
     run_on:
       - ubuntu2204-large
       - debian10-large
@@ -1401,7 +1401,7 @@ tasks:
             - +env-warmup
             - --sasl=off
             - --tls=OpenSSL
-            - --test_mongocxx_ref=r3.9.0
+            - --test_mongocxx_ref=r4.0.0
             - --env=${MONGOC_EARTHLY_ENV}
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
       - command: subprocess.exec
@@ -1414,7 +1414,7 @@ tasks:
             - --targets=test-example test-cxx-driver
             - --sasl=off
             - --tls=OpenSSL
-            - --test_mongocxx_ref=r3.9.0
+            - --test_mongocxx_ref=r4.0.0
             - --env=${MONGOC_EARTHLY_ENV}
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
   - name: "check:sasl=off\_\u2022\_tls=off\_\u2022\_test_mongocxx_ref=none"
@@ -1457,7 +1457,7 @@ tasks:
             - --test_mongocxx_ref=none
             - --env=${MONGOC_EARTHLY_ENV}
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
-  - name: "check:sasl=off\_\u2022\_tls=off\_\u2022\_test_mongocxx_ref=r3.9.0"
+  - name: "check:sasl=off\_\u2022\_tls=off\_\u2022\_test_mongocxx_ref=r4.0.0"
     run_on:
       - ubuntu2204-large
       - debian10-large
@@ -1481,7 +1481,7 @@ tasks:
             - +env-warmup
             - --sasl=off
             - --tls=off
-            - --test_mongocxx_ref=r3.9.0
+            - --test_mongocxx_ref=r4.0.0
             - --env=${MONGOC_EARTHLY_ENV}
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
       - command: subprocess.exec
@@ -1494,7 +1494,7 @@ tasks:
             - --targets=test-example test-cxx-driver
             - --sasl=off
             - --tls=off
-            - --test_mongocxx_ref=r3.9.0
+            - --test_mongocxx_ref=r4.0.0
             - --env=${MONGOC_EARTHLY_ENV}
             - --c_compiler=${MONGOC_EARTHLY_C_COMPILER}
   - name: clang-format

--- a/src/libbson/doc/includes/seealso/bson-as-json.txt
+++ b/src/libbson/doc/includes/seealso/bson-as-json.txt
@@ -5,8 +5,6 @@
 
   | :symbol:`bson_as_legacy_extended_json()`
 
-  | :symbol:`bson_as_json()` (Deprecated)
-
   | :symbol:`bson_as_json_with_opts()`
 
   | :symbol:`bson_array_as_canonical_extended_json()`
@@ -14,6 +12,4 @@
   | :symbol:`bson_array_as_relaxed_extended_json()`
 
   | :symbol:`bson_array_as_legacy_extended_json()`
-
-  | :symbol:`bson_array_as_json()` (Deprecated)
 


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/mongo-c-driver/pull/1920:
- Remove references to removed symbols in documentation to fix `make-docs` task.
- Update C++ driver reference from r3.9.0 to r4.0.0. This includes CXX-2995 to removes use of `bson_as_json`. Fixes Earthly tasks.