### PR TITLE
Reduce Warnings - address -Wunused-parameter warnings

### DIFF
--- a/src/common/src/mlib/cmp.h
+++ b/src/common/src/mlib/cmp.h
@@ -64,6 +64,7 @@ mlib_always_inline static enum mlib_cmp_result (mlib_cmp) (struct mlib_upsized_i
                                                            struct mlib_upsized_integer y,
                                                            int always_zero) mlib_noexcept
 {
+   (void) always_zero;
 #if mlib_is_optimized_build() && !mlib_is_msvc() && \
    !(defined(MLIB_DISABLE_INLINING_ASSERTIONS) && MLIB_DISABLE_INLINING_ASSERTIONS)
    if (always_zero != 0) {

--- a/src/libbson/examples/extended-json.c
+++ b/src/libbson/examples/extended-json.c
@@ -20,7 +20,7 @@
 #include <stdio.h>
 
 int
-main (int argc, char *argv[])
+main (void)
 {
    {
       // bson_as_canonical_extended_json ... begin

--- a/src/libmongoc/examples/example-structured-log.c
+++ b/src/libmongoc/examples/example-structured-log.c
@@ -11,6 +11,8 @@ static pthread_mutex_t handler_mutex;
 static void
 example_handler (const mongoc_structured_log_entry_t *entry, void *user_data)
 {
+   (void) user_data;
+
    mongoc_structured_log_component_t component = mongoc_structured_log_entry_get_component (entry);
    mongoc_structured_log_level_t level = mongoc_structured_log_entry_get_level (entry);
    const char *message_string = mongoc_structured_log_entry_get_message_string (entry);

--- a/src/libmongoc/tests/test-mongoc-change-stream.c
+++ b/src/libmongoc/tests/test-mongoc-change-stream.c
@@ -2151,6 +2151,8 @@ test_events_succeeded_cb (const mongoc_apm_command_succeeded_t *e)
 static void
 test_change_stream_batchSize0 (void *test_ctx)
 {
+   BSON_UNUSED (test_ctx);
+
    bson_error_t error;
 
    // Create a change stream. Capture a resume token. Insert documents to create future events.

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -6364,6 +6364,8 @@ _test_retry_with_masterkey (const char *provider, bson_t *masterkey)
 static void
 test_kms_retry (void *unused)
 {
+   BSON_UNUSED (unused);
+
    bson_t *aws_masterkey = tmp_bson (BSON_STR ({"region" : "r", "key" : "k", "endpoint" : "127.0.0.1:9003"}));
    bson_t *azure_masterkey = tmp_bson (BSON_STR ({"keyVaultEndpoint" : "127.0.0.1:9003", "keyName" : "foo"}));
    bson_t *gcp_masterkey = tmp_bson (BSON_STR (

--- a/src/libmongoc/tests/test-mongoc-counters.c
+++ b/src/libmongoc/tests/test-mongoc-counters.c
@@ -1474,6 +1474,7 @@ test_counters_auth_pooled_op_msg (void *context)
 void
 test_counters_install (TestSuite *suite)
 {
+   BSON_UNUSED (suite);
 #ifdef MONGOC_ENABLE_SHM_COUNTERS
    TestSuite_AddFull (suite,
                       "/counters/op_msg",

--- a/src/tools/mongoc-stat.c
+++ b/src/tools/mongoc-stat.c
@@ -220,7 +220,7 @@ main (int argc, char *argv[])
 #include <stdio.h>
 
 int
-main (int argc, char *argv[])
+main (void)
 {
    fprintf (stderr, "mongoc-stat is not supported on your platform.\n");
    return EXIT_FAILURE;


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1930. Address other instances of `-Wunused-parameter` warnings throughout the codebase (including tests, examples, and utils) as locally observed with Clang 21 on Linux.