### PR TITLE
 CDRIVER-4489 promote empty username to client error 

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,7 @@ Unreleased (2.0.0)
 * `bson_oid_init_sequence` is removed. Use `bson_oid_init` instead.
 * `mongoc_server_description_host` changes the return type from `mongoc_host_list_t *` to `const mongoc_host_list_t *`.
 * URI authentication credentials validation (only applicable during creation of a new `mongoc_uri_t` object from a connection string):
+  * The requirement that a username is non-empty when specified is now enforced regardless of authentication mechanism.
   * `authMechanism` is now validated and returns a client error for invalid or unsupported values.
   * `authSource` is now validated and returns a client error for invalid or unsupported values for the specified `authMechanism`.
   * `authSource` is now correctly defaulted to `"$external"` for MONGODB-AWS (instead of the database name or `"admin"`).

--- a/src/libmongoc/src/mongoc/mongoc-uri.c
+++ b/src/libmongoc/src/mongoc/mongoc-uri.c
@@ -1315,6 +1315,10 @@ _finalize_auth_username (const char *username,
 
    case _mongoc_uri_finalize_allowed:
    default:
+      if (username && strlen (username) == 0u) {
+         MONGOC_URI_ERROR (error, "'%s' authentication mechanism requires a non-empty username", mechanism);
+         return false;
+      }
       break;
    }
 

--- a/src/libmongoc/tests/test-mongoc-uri.c
+++ b/src/libmongoc/tests/test-mongoc-uri.c
@@ -704,9 +704,11 @@ test_mongoc_uri_auth_mechanism_mongodb_x509 (void)
          mongoc_uri_t *const uri =
             mongoc_uri_new_with_error ("mongodb://@localhost/?" MONGOC_URI_AUTHMECHANISM "=MONGODB-X509", &error);
          ASSERT_NO_CAPTURED_LOGS ("mongoc_uri_new_with_error"); // CDRIVER-1959
-         ASSERT_OR_PRINT (uri, error);
-         ASSERT_CMPSTR (mongoc_uri_get_username (uri), "");
-         mongoc_uri_destroy (uri);
+         ASSERT (!uri);
+         ASSERT_ERROR_CONTAINS (error,
+                                MONGOC_ERROR_COMMAND,
+                                MONGOC_ERROR_COMMAND_INVALID_ARG,
+                                "'MONGODB-X509' authentication mechanism requires a non-empty username");
       }
 
       // Normal.
@@ -986,9 +988,11 @@ test_mongoc_uri_auth_mechanism_mongodb_aws (void)
          mongoc_uri_t *const uri =
             mongoc_uri_new_with_error ("mongodb://:@localhost/?" MONGOC_URI_AUTHMECHANISM "=MONGODB-AWS", &error);
          ASSERT_NO_CAPTURED_LOGS ("mongoc_uri_new_with_error");
-         ASSERT_OR_PRINT (uri, error);
-         ASSERT_CMPSTR (mongoc_uri_get_username (uri), "");
-         mongoc_uri_destroy (uri);
+         ASSERT (!uri);
+         ASSERT_ERROR_CONTAINS (error,
+                                MONGOC_ERROR_COMMAND,
+                                MONGOC_ERROR_COMMAND_INVALID_ARG,
+                                "'MONGODB-AWS' authentication mechanism requires a non-empty username");
       }
 
       // Normal.

--- a/src/libmongoc/tests/test-mongoc-uri.c
+++ b/src/libmongoc/tests/test-mongoc-uri.c
@@ -323,7 +323,8 @@ _auth_mechanism_password_prohibited (const char *mechanism, const char *user_pre
    {
       bson_error_t error;
       mongoc_uri_t *const uri = mongoc_uri_new_with_error (
-         tmp_str ("mongodb://%s@localhost/?" MONGOC_URI_AUTHMECHANISM "=%s%s", user_prefix, mechanism, uri_suffix), &error);
+         tmp_str ("mongodb://%s@localhost/?" MONGOC_URI_AUTHMECHANISM "=%s%s", user_prefix, mechanism, uri_suffix),
+         &error);
       ASSERT_NO_CAPTURED_LOGS ("mongoc_uri_new_with_error");
       ASSERT_OR_PRINT (uri, error);
       ASSERT_CMPSTR (mongoc_uri_get_username (uri), user_prefix);

--- a/src/libmongoc/tests/test-mongoc-uri.c
+++ b/src/libmongoc/tests/test-mongoc-uri.c
@@ -314,6 +314,59 @@ _auth_mechanism_username_required (const char *mechanism)
 }
 
 static void
+_auth_mechanism_password_prohibited (const char *mechanism, const char *user_prefix, const char *uri_suffix)
+{
+   BSON_ASSERT_PARAM (mechanism);
+   BSON_ASSERT_PARAM (user_prefix);
+
+   bson_error_t error;
+
+   // None.
+   {
+      mongoc_uri_t *const uri = mongoc_uri_new_with_error (
+         tmp_str ("mongodb://localhost/?" MONGOC_URI_AUTHMECHANISM "=%s%s", mechanism, uri_suffix), &error);
+      ASSERT_NO_CAPTURED_LOGS ("mongoc_uri_new_with_error");
+      ASSERT_OR_PRINT (uri, error);
+      ASSERT_CMPSTR (mongoc_uri_get_username (uri), NULL);
+      ASSERT_CMPSTR (mongoc_uri_get_auth_source (uri), "$external");
+      ASSERT_CMPSTR (mongoc_uri_get_password (uri), NULL);
+      ASSERT_CMPSTR (mongoc_uri_get_auth_mechanism (uri), mechanism);
+      mongoc_uri_destroy (uri);
+   }
+
+   // Empty.
+   {
+      bson_error_t error;
+      mongoc_uri_t *const uri = mongoc_uri_new_with_error (
+         tmp_str ("mongodb://%s:@localhost/?" MONGOC_URI_AUTHMECHANISM "=%s%s", user_prefix, mechanism, uri_suffix),
+         &error);
+      ASSERT_NO_CAPTURED_LOGS ("mongoc_uri_new_with_error");
+      ASSERT (!uri);
+      ASSERT_ERROR_CONTAINS (error,
+                             MONGOC_ERROR_COMMAND,
+                             MONGOC_ERROR_COMMAND_INVALID_ARG,
+                             tmp_str ("'%s' authentication mechanism does not accept a password", mechanism));
+      mongoc_uri_destroy (uri);
+   }
+
+   // Normal.
+   {
+      bson_error_t error;
+      mongoc_uri_t *const uri = mongoc_uri_new_with_error (
+         tmp_str ("mongodb://%s:pass@localhost/?" MONGOC_URI_AUTHMECHANISM "=%s%s", user_prefix, mechanism, uri_suffix),
+         &error);
+      ASSERT_NO_CAPTURED_LOGS ("mongoc_uri_new_with_error");
+      ASSERT (!uri);
+      ASSERT_ERROR_CONTAINS (error,
+                             MONGOC_ERROR_COMMAND,
+                             MONGOC_ERROR_COMMAND_INVALID_ARG,
+                             tmp_str ("'%s' authentication mechanism does not accept a password", mechanism));
+      clear_captured_logs ();
+      mongoc_uri_destroy (uri);
+   }
+}
+
+static void
 _auth_mechanism_password_required (const char *mechanism)
 {
    BSON_ASSERT_PARAM (mechanism);
@@ -456,6 +509,71 @@ _auth_mechanism_properties_prohibited (const char *mechanism, const char *userpa
    }
 }
 
+
+static void
+_auth_mechanism_properties_allowed (const char *mechanism, const char *userpass_prefix, const char *default_properties)
+{
+   BSON_ASSERT_PARAM (mechanism);
+   BSON_ASSERT_PARAM (userpass_prefix);
+   BSON_OPTIONAL_PARAM (default_properties);
+
+   // None.
+   {
+      bson_error_t error;
+      mongoc_uri_t *const uri = mongoc_uri_new_with_error (
+         tmp_str ("mongodb://%slocalhost/?" MONGOC_URI_AUTHMECHANISM "=%s", userpass_prefix, mechanism), &error);
+      ASSERT_NO_CAPTURED_LOGS ("mongoc_uri_new_with_error");
+      ASSERT_OR_PRINT (uri, error);
+
+      bson_t props;
+      if (default_properties) {
+         ASSERT (mongoc_uri_get_mechanism_properties (uri, &props));
+         ASSERT_MATCH (&props, "{%s}", default_properties ? default_properties : "");
+         bson_destroy (&props);
+      } else {
+         ASSERT_WITH_MSG (!mongoc_uri_get_mechanism_properties (uri, &props), "expected failure");
+      }
+
+      mongoc_uri_destroy (uri);
+   }
+
+   // Empty.
+   {
+      bson_error_t error;
+      mongoc_uri_t *const uri = mongoc_uri_new_with_error (tmp_str ("mongodb://%slocalhost/?" MONGOC_URI_AUTHMECHANISM
+                                                                    "=%s&" MONGOC_URI_AUTHMECHANISMPROPERTIES "=",
+                                                                    userpass_prefix,
+                                                                    mechanism),
+                                                           &error);
+      ASSERT_NO_CAPTURED_LOGS ("mongoc_uri_new_with_error");
+      ASSERT_OR_PRINT (uri, error);
+
+      bson_t props;
+      ASSERT (mongoc_uri_get_mechanism_properties (uri, &props));
+      ASSERT_MATCH (&props, "{%s}", default_properties ? default_properties : "");
+
+      bson_destroy (&props);
+      mongoc_uri_destroy (uri);
+   }
+
+   // Invalid properties.
+   {
+      bson_error_t error;
+      mongoc_uri_t *const uri =
+         mongoc_uri_new_with_error (tmp_str ("mongodb://%slocalhost/?" MONGOC_URI_AUTHMECHANISM
+                                             "=%s&" MONGOC_URI_AUTHMECHANISMPROPERTIES "=invalid:value",
+                                             userpass_prefix,
+                                             mechanism),
+                                    &error);
+      ASSERT_NO_CAPTURED_LOGS ("mongoc_uri_new_with_error");
+      ASSERT (!uri);
+      ASSERT_ERROR_CONTAINS (error,
+                             MONGOC_ERROR_COMMAND,
+                             MONGOC_ERROR_COMMAND_INVALID_ARG,
+                             tmp_str ("Unsupported '%s' authentication mechanism property: 'invalid'", mechanism));
+   }
+}
+
 static void
 _auth_mechanism_source_default_db_or_admin (const char *mechanism)
 {
@@ -498,15 +616,18 @@ _auth_mechanism_source_default_db_or_admin (const char *mechanism)
 }
 
 static void
-_auth_mechanism_source_external_only (const char *mechanism, const char *userpass_prefix)
+_auth_mechanism_source_external_only (const char *mechanism, const char *userpass_prefix, const char *uri_suffix)
 {
    BSON_ASSERT_PARAM (mechanism);
+   BSON_ASSERT_PARAM (userpass_prefix);
+   BSON_ASSERT_PARAM (uri_suffix);
 
    // None (default).
    {
       bson_error_t error;
       mongoc_uri_t *const uri = mongoc_uri_new_with_error (
-         tmp_str ("mongodb://%slocalhost/?" MONGOC_URI_AUTHMECHANISM "=%s", userpass_prefix, mechanism), &error);
+         tmp_str ("mongodb://%slocalhost/?" MONGOC_URI_AUTHMECHANISM "=%s%s", userpass_prefix, mechanism, uri_suffix),
+         &error);
       ASSERT_NO_CAPTURED_LOGS ("mongoc_uri_new_with_error");
       ASSERT_OR_PRINT (uri, error);
       ASSERT_CMPSTR (mongoc_uri_get_auth_source (uri), "$external");
@@ -517,7 +638,8 @@ _auth_mechanism_source_external_only (const char *mechanism, const char *userpas
    {
       bson_error_t error;
       mongoc_uri_t *const uri = mongoc_uri_new_with_error (
-         tmp_str ("mongodb://%slocalhost/db?" MONGOC_URI_AUTHMECHANISM "=%s", userpass_prefix, mechanism), &error);
+         tmp_str ("mongodb://%slocalhost/db?" MONGOC_URI_AUTHMECHANISM "=%s%s", userpass_prefix, mechanism, uri_suffix),
+         &error);
       ASSERT_NO_CAPTURED_LOGS ("mongoc_uri_new_with_error");
       ASSERT_OR_PRINT (uri, error);
       ASSERT_CMPSTR (mongoc_uri_get_auth_source (uri), "$external");
@@ -528,9 +650,10 @@ _auth_mechanism_source_external_only (const char *mechanism, const char *userpas
    {
       bson_error_t error;
       mongoc_uri_t *const uri = mongoc_uri_new_with_error (tmp_str ("mongodb://%slocalhost/db?" MONGOC_URI_AUTHMECHANISM
-                                                                    "=%s&" MONGOC_URI_AUTHSOURCE "=source",
+                                                                    "=%s&" MONGOC_URI_AUTHSOURCE "=source%s",
                                                                     userpass_prefix,
-                                                                    mechanism),
+                                                                    mechanism,
+                                                                    uri_suffix),
                                                            &error);
       ASSERT_NO_CAPTURED_LOGS ("mongoc_uri_new_with_error");
       ASSERT (!uri);
@@ -545,9 +668,10 @@ _auth_mechanism_source_external_only (const char *mechanism, const char *userpas
    {
       bson_error_t error;
       mongoc_uri_t *const uri = mongoc_uri_new_with_error (tmp_str ("mongodb://%slocalhost/db?" MONGOC_URI_AUTHMECHANISM
-                                                                    "=%s&" MONGOC_URI_AUTHSOURCE "=$external",
+                                                                    "=%s&" MONGOC_URI_AUTHSOURCE "=$external%s",
                                                                     userpass_prefix,
-                                                                    mechanism),
+                                                                    mechanism,
+                                                                    uri_suffix),
                                                            &error);
       ASSERT_OR_PRINT (uri, error);
       ASSERT_CMPSTR (mongoc_uri_get_auth_source (uri), "$external");
@@ -598,55 +722,13 @@ test_mongoc_uri_auth_mechanism_mongodb_x509 (void)
    }
 
    // Authentication spec: password: MUST NOT be specified.
-   {
-      // None.
-      {
-         bson_error_t error;
-         mongoc_uri_t *const uri =
-            mongoc_uri_new_with_error ("mongodb://localhost/?" MONGOC_URI_AUTHMECHANISM "=MONGODB-X509", &error);
-         ASSERT_NO_CAPTURED_LOGS ("mongoc_uri_new_with_error");
-         ASSERT_OR_PRINT (uri, error);
-         ASSERT_CMPSTR (mongoc_uri_get_username (uri), NULL);
-         ASSERT_CMPSTR (mongoc_uri_get_auth_source (uri), "$external");
-         ASSERT_CMPSTR (mongoc_uri_get_password (uri), NULL);
-         ASSERT_CMPSTR (mongoc_uri_get_auth_mechanism (uri), "MONGODB-X509");
-         mongoc_uri_destroy (uri);
-      }
-
-      // Empty.
-      {
-         bson_error_t error;
-         mongoc_uri_t *const uri =
-            mongoc_uri_new_with_error ("mongodb://user:@localhost/?" MONGOC_URI_AUTHMECHANISM "=MONGODB-X509", &error);
-         ASSERT_NO_CAPTURED_LOGS ("mongoc_uri_new_with_error"); // CDRIVER-1959
-         ASSERT (!uri);
-         ASSERT_ERROR_CONTAINS (error,
-                                MONGOC_ERROR_COMMAND,
-                                MONGOC_ERROR_COMMAND_INVALID_ARG,
-                                "'MONGODB-X509' authentication mechanism does not accept a password");
-         mongoc_uri_destroy (uri);
-      }
-
-      // Normal.
-      {
-         bson_error_t error;
-         mongoc_uri_t *const uri = mongoc_uri_new_with_error (
-            "mongodb://user:pass@localhost/?" MONGOC_URI_AUTHMECHANISM "=MONGODB-X509", &error);
-         ASSERT_NO_CAPTURED_LOGS ("mongoc_uri_new_with_error"); // CDRIVER-1959
-         ASSERT (!uri);
-         ASSERT_ERROR_CONTAINS (error,
-                                MONGOC_ERROR_COMMAND,
-                                MONGOC_ERROR_COMMAND_INVALID_ARG,
-                                "'MONGODB-X509' authentication mechanism does not accept a password");
-         mongoc_uri_destroy (uri);
-      }
-   }
+   _auth_mechanism_password_prohibited ("MONGODB-X509", "user", "");
 
    // Authentication spec: mechanism_properties: MUST NOT be specified.
    _auth_mechanism_properties_prohibited ("MONGODB-X509", "");
 
    // Authentication spec: source: MUST be "$external". Defaults to "$external".
-   _auth_mechanism_source_external_only ("MONGODB-X509", "");
+   _auth_mechanism_source_external_only ("MONGODB-X509", "", "");
 }
 
 static void
@@ -660,54 +742,7 @@ test_mongoc_uri_auth_mechanism_gssapi (void)
 
    // mechanism_properties are allowed.
    {
-      // None.
-      {
-         bson_error_t error;
-         mongoc_uri_t *const uri =
-            mongoc_uri_new_with_error ("mongodb://user:pass@localhost/?" MONGOC_URI_AUTHMECHANISM "=GSSAPI", &error);
-         ASSERT_NO_CAPTURED_LOGS ("mongoc_uri_new_with_error");
-         ASSERT_OR_PRINT (uri, error);
-
-         bson_t props;
-         ASSERT (mongoc_uri_get_mechanism_properties (uri, &props));
-         ASSERT_EQUAL_BSON (tmp_bson ("{'SERVICE_NAME': 'mongodb'}"), &props);
-
-         bson_destroy (&props);
-         mongoc_uri_destroy (uri);
-      }
-
-      // Empty.
-      {
-         bson_error_t error;
-         mongoc_uri_t *const uri = mongoc_uri_new_with_error ("mongodb://user:pass@localhost/?" MONGOC_URI_AUTHMECHANISM
-                                                              "=GSSAPI&" MONGOC_URI_AUTHMECHANISMPROPERTIES "=",
-                                                              &error);
-         ASSERT_NO_CAPTURED_LOGS ("mongoc_uri_new_with_error");
-         ASSERT_OR_PRINT (uri, error);
-
-         bson_t props;
-         ASSERT (mongoc_uri_get_mechanism_properties (uri, &props));
-         ASSERT_EQUAL_BSON (tmp_bson ("{'SERVICE_NAME': 'mongodb'}"), &props);
-
-         bson_destroy (&props);
-         mongoc_uri_destroy (uri);
-      }
-
-      // Invalid properties.
-      {
-         bson_error_t error;
-         mongoc_uri_t *const uri =
-            mongoc_uri_new_with_error ("mongodb://user:pass@localhost/?" MONGOC_URI_AUTHMECHANISM
-                                       "=GSSAPI&" MONGOC_URI_AUTHMECHANISMPROPERTIES "=invalid:value",
-                                       &error);
-         ASSERT_NO_CAPTURED_LOGS ("mongoc_uri_new_with_error");
-         ASSERT (!uri);
-         ASSERT_ERROR_CONTAINS (error,
-                                MONGOC_ERROR_COMMAND,
-                                MONGOC_ERROR_COMMAND_INVALID_ARG,
-                                "Unsupported 'GSSAPI' authentication mechanism property: 'invalid'");
-         mongoc_uri_destroy (uri);
-      }
+      _auth_mechanism_properties_allowed ("GSSAPI", "user:pass@", "'SERVICE_NAME': 'mongodb'");
 
       // SERVICE_NAME: Drivers MUST allow the user to specify a different service name. The default is "mongodb".
       {
@@ -835,7 +870,7 @@ test_mongoc_uri_auth_mechanism_gssapi (void)
    }
 
    // Authentication spec: source: MUST be "$external". Defaults to "$external".
-   _auth_mechanism_source_external_only ("GSSAPI", "user@");
+   _auth_mechanism_source_external_only ("GSSAPI", "user@", "");
 }
 
 static void
@@ -1010,51 +1045,7 @@ test_mongoc_uri_auth_mechanism_mongodb_aws (void)
 
    // mechanism_properties are allowed.
    {
-      // None.
-      {
-         bson_error_t error;
-         mongoc_uri_t *const uri =
-            mongoc_uri_new_with_error ("mongodb://localhost/?" MONGOC_URI_AUTHMECHANISM "=MONGODB-AWS", &error);
-         ASSERT_NO_CAPTURED_LOGS ("mongoc_uri_new_with_error");
-         ASSERT_OR_PRINT (uri, error);
-
-         bson_t props;
-         ASSERT (!mongoc_uri_get_mechanism_properties (uri, &props));
-
-         mongoc_uri_destroy (uri);
-      }
-
-      // Empty.
-      {
-         bson_error_t error;
-         mongoc_uri_t *const uri = mongoc_uri_new_with_error ("mongodb://localhost/?" MONGOC_URI_AUTHMECHANISM
-                                                              "=MONGODB-AWS&" MONGOC_URI_AUTHMECHANISMPROPERTIES "=",
-                                                              &error);
-         ASSERT_NO_CAPTURED_LOGS ("mongoc_uri_new_with_error");
-         ASSERT_OR_PRINT (uri, error);
-
-         bson_t props;
-         ASSERT (mongoc_uri_get_mechanism_properties (uri, &props));
-         ASSERT_EQUAL_BSON (tmp_bson ("{}"), &props);
-
-         bson_destroy (&props);
-         mongoc_uri_destroy (uri);
-      }
-
-      // Invalid properties.
-      {
-         bson_error_t error;
-         mongoc_uri_t *const uri =
-            mongoc_uri_new_with_error ("mongodb://localhost/?" MONGOC_URI_AUTHMECHANISM
-                                       "=MONGODB-AWS&" MONGOC_URI_AUTHMECHANISMPROPERTIES "=invalid:value",
-                                       &error);
-         ASSERT_NO_CAPTURED_LOGS ("mongoc_uri_new_with_error");
-         ASSERT (!uri);
-         ASSERT_ERROR_CONTAINS (error,
-                                MONGOC_ERROR_COMMAND,
-                                MONGOC_ERROR_COMMAND_INVALID_ARG,
-                                "Unsupported 'MONGODB-AWS' authentication mechanism property: 'invalid'");
-      }
+      _auth_mechanism_properties_allowed ("MONGODB-AWS", "", NULL);
 
       // AWS_SESSION_TOKEN: if *only* a session token is provided Drivers MUST raise an error.
       {
@@ -1111,7 +1102,7 @@ test_mongoc_uri_auth_mechanism_mongodb_aws (void)
    }
 
    // Authentication spec: source: MUST be "$external". Defaults to "$external".
-   _auth_mechanism_source_external_only ("MONGODB-AWS", "");
+   _auth_mechanism_source_external_only ("MONGODB-AWS", "", "");
 }
 
 static void

--- a/src/libmongoc/tests/test-mongoc-uri.c
+++ b/src/libmongoc/tests/test-mongoc-uri.c
@@ -319,10 +319,9 @@ _auth_mechanism_password_prohibited (const char *mechanism, const char *user_pre
    BSON_ASSERT_PARAM (mechanism);
    BSON_ASSERT_PARAM (user_prefix);
 
-   bson_error_t error;
-
    // None.
    {
+      bson_error_t error;
       mongoc_uri_t *const uri = mongoc_uri_new_with_error (
          tmp_str ("mongodb://localhost/?" MONGOC_URI_AUTHMECHANISM "=%s%s", mechanism, uri_suffix), &error);
       ASSERT_NO_CAPTURED_LOGS ("mongoc_uri_new_with_error");

--- a/src/libmongoc/tests/test-mongoc-uri.c
+++ b/src/libmongoc/tests/test-mongoc-uri.c
@@ -323,10 +323,10 @@ _auth_mechanism_password_prohibited (const char *mechanism, const char *user_pre
    {
       bson_error_t error;
       mongoc_uri_t *const uri = mongoc_uri_new_with_error (
-         tmp_str ("mongodb://localhost/?" MONGOC_URI_AUTHMECHANISM "=%s%s", mechanism, uri_suffix), &error);
+         tmp_str ("mongodb://%s@localhost/?" MONGOC_URI_AUTHMECHANISM "=%s%s", user_prefix, mechanism, uri_suffix), &error);
       ASSERT_NO_CAPTURED_LOGS ("mongoc_uri_new_with_error");
       ASSERT_OR_PRINT (uri, error);
-      ASSERT_CMPSTR (mongoc_uri_get_username (uri), NULL);
+      ASSERT_CMPSTR (mongoc_uri_get_username (uri), user_prefix);
       ASSERT_CMPSTR (mongoc_uri_get_auth_source (uri), "$external");
       ASSERT_CMPSTR (mongoc_uri_get_password (uri), NULL);
       ASSERT_CMPSTR (mongoc_uri_get_auth_mechanism (uri), mechanism);


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1896. Enforces that even optional usernames are non-empty when specified (there are no cases where an empty username is desirable).