### PR TITLE
CDRIVER-2813 remove `BSON_EXTRA_ALIGNMENT` option

### DIFF
--- a/.evergreen/config_generator/components/loadbalanced.py
+++ b/.evergreen/config_generator/components/loadbalanced.py
@@ -83,7 +83,6 @@ def tasks():
                 env={
                     'CC': _COMPILER,
                     'CFLAGS': '-fno-omit-frame-pointer',
-                    'EXTRA_CONFIGURE_FLAGS': '-DENABLE_EXTRA_ALIGNMENT=OFF',
                     'SSL': 'OPENSSL'
                 },
                 working_dir='mongoc',

--- a/.evergreen/config_generator/components/mock_server.py
+++ b/.evergreen/config_generator/components/mock_server.py
@@ -42,7 +42,6 @@ def variants():
                 'CC': 'gcc',
                 'ASAN': 'on',
                 'CFLAGS': '-fno-omit-frame-pointer',
-                'EXTRA_CONFIGURE_FLAGS': '-DENABLE_EXTRA_ALIGNMENT=OFF',
                 'SANITIZE': 'address,undefined',
             }
         ),

--- a/.evergreen/config_generator/components/sanitizers/asan.py
+++ b/.evergreen/config_generator/components/sanitizers/asan.py
@@ -10,7 +10,6 @@ def variants():
         'ASAN': 'on',
         'CFLAGS': '-fno-omit-frame-pointer',
         'CHECK_LOG': 'ON',
-        'EXTRA_CONFIGURE_FLAGS': '-DENABLE_EXTRA_ALIGNMENT=OFF',
         'SANITIZE': 'address,undefined',
     }
 

--- a/.evergreen/config_generator/components/sanitizers/tsan.py
+++ b/.evergreen/config_generator/components/sanitizers/tsan.py
@@ -9,7 +9,7 @@ def variants():
     expansions = {
         'CFLAGS': '-fno-omit-frame-pointer',
         'CHECK_LOG': 'ON',
-        'EXTRA_CONFIGURE_FLAGS': '-DENABLE_EXTRA_ALIGNMENT=OFF -DENABLE_SHM_COUNTERS=OFF',
+        'EXTRA_CONFIGURE_FLAGS': '-DENABLE_SHM_COUNTERS=OFF',
         'SANITIZE': 'thread',
     }
 

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -368,7 +368,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env EXTRA_CONFIGURE_FLAGS="-DENABLE_EXTRA_ALIGNMENT=OFF" SNAPPY="OFF" ZLIB="BUNDLED" ZSTD="OFF" .evergreen/scripts/compile.sh
+        env SNAPPY="OFF" ZLIB="BUNDLED" ZSTD="OFF" .evergreen/scripts/compile.sh
   - func: upload-build
 - name: debug-compile-nosasl-nossl
   tags:
@@ -1311,7 +1311,7 @@ tasks:
       shell: bash
       script: |-
         set -o errexit
-        env SANITIZE=address SASL=AUTO SSL=OPENSSL EXTRA_CONFIGURE_FLAGS='-DENABLE_EXTRA_ALIGNMENT=OFF' .evergreen/scripts/compile.sh
+        env SANITIZE=address SASL=AUTO SSL=OPENSSL .evergreen/scripts/compile.sh
   - func: prepare-kerberos
   - func: run auth tests
     vars:

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -355,21 +355,6 @@ tasks:
         set -o errexit
         env SNAPPY="OFF" ZLIB="OFF" ZSTD="ON" .evergreen/scripts/compile.sh
   - func: upload-build
-- name: debug-compile-no-align
-  tags:
-  - debug-compile
-  commands:
-  - func: find-cmake-latest
-  - command: shell.exec
-    type: test
-    params:
-      working_dir: mongoc
-      add_expansions_to_env: true
-      shell: bash
-      script: |-
-        set -o errexit
-        env SNAPPY="OFF" ZLIB="BUNDLED" ZSTD="OFF" .evergreen/scripts/compile.sh
-  - func: upload-build
 - name: debug-compile-nosasl-nossl
   tags:
   - debug-compile
@@ -16373,7 +16358,6 @@ buildvariants:
   tasks:
   - release-compile
   - debug-compile-nosasl-nossl
-  - debug-compile-no-align
   - .debug-compile !.sspi .nossl .nosasl
   - .latest .nossl .nosasl
 - name: gcc82rhel
@@ -16417,7 +16401,6 @@ buildvariants:
   tasks:
   - release-compile
   - debug-compile-nosasl-nossl
-  - debug-compile-no-align
   - .latest .nossl .nosasl
 - name: gcc94
   display_name: GCC 9.4 (Ubuntu 20.04)
@@ -16429,7 +16412,6 @@ buildvariants:
   - debug-compile-nosrv
   - release-compile
   - debug-compile-nosasl-nossl
-  - debug-compile-no-align
   - debug-compile-sasl-openssl
   - debug-compile-nosasl-openssl
   - .authentication-tests .openssl
@@ -16449,7 +16431,6 @@ buildvariants:
   - .compression !.snappy
   - release-compile
   - debug-compile-nosasl-nossl
-  - debug-compile-no-align
   - debug-compile-nosrv
   - debug-compile-sasl-darwinssl
   - debug-compile-nosasl-nossl
@@ -16507,13 +16488,6 @@ buildvariants:
   tasks:
   - debug-compile-nosasl-nossl
   - .latest .nossl .nosasl .server
-- name: mingw
-  display_name: MinGW-W64
-  expansions:
-    CC: mingw
-  run_on: windows-vsCurrent-large
-  tasks:
-  - debug-compile-no-align
 - name: rhel8-power
   display_name: Power (ppc64le) (RHEL 8)
   expansions:
@@ -16534,7 +16508,6 @@ buildvariants:
   run_on: ubuntu2004-arm64-large
   tasks:
   - .compression !.snappy !.zstd
-  - debug-compile-no-align
   - release-compile
   - debug-compile-nosasl-nossl
   - debug-compile-nosasl-openssl
@@ -16550,7 +16523,6 @@ buildvariants:
   run_on: rhel8-zseries-large
   tasks:
   - release-compile
-  - debug-compile-no-align
   - debug-compile-nosasl-nossl
   - debug-compile-nosasl-openssl
   - debug-compile-sasl-openssl

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -2949,7 +2949,6 @@ tasks:
           env:
             CC: gcc
             CFLAGS: -fno-omit-frame-pointer
-            EXTRA_CONFIGURE_FLAGS: -DENABLE_EXTRA_ALIGNMENT=OFF
             SSL: OPENSSL
           args:
             - -c

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -180,7 +180,6 @@ buildvariants:
       ASAN: "on"
       CC: gcc
       CFLAGS: -fno-omit-frame-pointer
-      EXTRA_CONFIGURE_FLAGS: -DENABLE_EXTRA_ALIGNMENT=OFF
       SANITIZE: address,undefined
     tasks:
       - name: mock-server-test
@@ -194,7 +193,6 @@ buildvariants:
       ASAN: "on"
       CFLAGS: -fno-omit-frame-pointer
       CHECK_LOG: "ON"
-      EXTRA_CONFIGURE_FLAGS: -DENABLE_EXTRA_ALIGNMENT=OFF
       SANITIZE: address,undefined
     tasks:
       - name: .sanitizers-matrix-asan
@@ -203,7 +201,7 @@ buildvariants:
     expansions:
       CFLAGS: -fno-omit-frame-pointer
       CHECK_LOG: "ON"
-      EXTRA_CONFIGURE_FLAGS: -DENABLE_EXTRA_ALIGNMENT=OFF -DENABLE_SHM_COUNTERS=OFF
+      EXTRA_CONFIGURE_FLAGS: -DENABLE_SHM_COUNTERS=OFF
       SANITIZE: thread
     tasks:
       - name: .sanitizers-matrix-tsan

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -186,11 +186,6 @@ all_tasks = [
     CompileTask("debug-compile-compression-zlib", tags=["zlib", "compression"], compression="zlib"),
     CompileTask("debug-compile-compression-snappy", tags=["snappy", "compression"], compression="snappy"),
     CompileTask("debug-compile-compression-zstd", tags=["zstd", "compression"], compression="zstd"),
-    CompileTask(
-        "debug-compile-no-align",
-        tags=["debug-compile"],
-        compression="zlib",
-    ),
     CompileTask("debug-compile-nosasl-nossl", tags=["debug-compile", "nosasl", "nossl"], SSL="OFF"),
     CompileTask("debug-compile-lto", CFLAGS="-flto"),
     CompileTask("debug-compile-lto-thin", CFLAGS="-flto=thin"),

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -151,7 +151,6 @@ class CompileWithClientSideEncryptionAsan(CompileTask):
         CFLAGS="-fno-omit-frame-pointer",
         COMPILE_LIBMONGOCRYPT="ON",
         CHECK_LOG="ON",
-        EXTRA_CONFIGURE_FLAGS="-DENABLE_EXTRA_ALIGNMENT=OFF",
         PATH="/usr/lib/llvm-3.8/bin:$PATH",
     )
     cls_tags: ClassVar[Sequence[str]] = ["client-side-encryption"]
@@ -191,7 +190,6 @@ all_tasks = [
         "debug-compile-no-align",
         tags=["debug-compile"],
         compression="zlib",
-        EXTRA_CONFIGURE_FLAGS="-DENABLE_EXTRA_ALIGNMENT=OFF",
     ),
     CompileTask("debug-compile-nosasl-nossl", tags=["debug-compile", "nosasl", "nossl"], SSL="OFF"),
     CompileTask("debug-compile-lto", CFLAGS="-flto"),
@@ -697,7 +695,7 @@ all_tasks = chain(
                 func("find-cmake-latest"),
                 shell_mongoc(
                     """
-            env SANITIZE=address SASL=AUTO SSL=OPENSSL EXTRA_CONFIGURE_FLAGS='-DENABLE_EXTRA_ALIGNMENT=OFF' .evergreen/scripts/compile.sh
+            env SANITIZE=address SASL=AUTO SSL=OPENSSL .evergreen/scripts/compile.sh
             """,
                     add_expansions_to_env=True,
                 ),

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -111,7 +111,6 @@ all_variants = [
         [
             "release-compile",
             "debug-compile-nosasl-nossl",
-            "debug-compile-no-align",
             ".debug-compile !.sspi .nossl .nosasl",
             ".latest .nossl .nosasl",
         ],
@@ -151,7 +150,7 @@ all_variants = [
         "gcc94-i686",
         "GCC 9.4 (i686) (Ubuntu 20.04)",
         "ubuntu2004-test",
-        ["release-compile", "debug-compile-nosasl-nossl", "debug-compile-no-align", ".latest .nossl .nosasl"],
+        ["release-compile", "debug-compile-nosasl-nossl", ".latest .nossl .nosasl"],
         {"CC": "gcc", "MARCH": "i686"},
     ),
     Variant(
@@ -163,7 +162,6 @@ all_variants = [
             "debug-compile-nosrv",
             "release-compile",
             "debug-compile-nosasl-nossl",
-            "debug-compile-no-align",
             "debug-compile-sasl-openssl",
             "debug-compile-nosasl-openssl",
             ".authentication-tests .openssl",
@@ -185,7 +183,6 @@ all_variants = [
             ".compression !.snappy",
             "release-compile",
             "debug-compile-nosasl-nossl",
-            "debug-compile-no-align",
             "debug-compile-nosrv",
             "debug-compile-sasl-darwinssl",
             "debug-compile-nosasl-nossl",
@@ -250,7 +247,6 @@ all_variants = [
         ["debug-compile-nosasl-nossl", ".latest .nossl .nosasl .server"],
         {"CC": "mingw"},
     ),
-    Variant("mingw", "MinGW-W64", "windows-vsCurrent-large", ["debug-compile-no-align"], {"CC": "mingw"}),
     Variant(
         "rhel8-power",
         "Power (ppc64le) (RHEL 8)",
@@ -272,7 +268,6 @@ all_variants = [
         "ubuntu2004-arm64-large",
         [
             ".compression !.snappy !.zstd",
-            "debug-compile-no-align",
             "release-compile",
             "debug-compile-nosasl-nossl",
             "debug-compile-nosasl-openssl",
@@ -291,7 +286,6 @@ all_variants = [
         [
             "release-compile",
             #      '.compression', --> TODO: waiting on ticket CDRIVER-3258
-            "debug-compile-no-align",
             "debug-compile-nosasl-nossl",
             "debug-compile-nosasl-openssl",
             "debug-compile-sasl-openssl",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,19 +185,6 @@ mongo_bool_setting(
    ]]
 )
 
-# Deprecated options:
-mongo_bool_setting(
-   ENABLE_EXTRA_ALIGNMENT
-      "[Deprecated] Enable extra alignment on libbson types"
-   DEFAULT VALUE ON
-      DEVEL VALUE OFF
-   VALIDATE CODE [[
-      if(ENABLE_EXTRA_ALIGNMENT AND MONGO_SANITIZE MATCHES "undefined")
-         message(WARNING "ENABLE_EXTRA_ALIGNMENT=“${ENABLE_EXTRA_ALIGNMENT}” will create conflicts with UndefinedBehaviorSanitizer")
-      endif()
-   ]]
-)
-
 # Announce the build configuration. Used by `mlib_build_config_is()` in `mlib/config.h`
 add_compile_definitions(_MLIB_BUILD_CONFIG=$<CONFIG>)
 
@@ -301,8 +288,6 @@ endif ()
 if ( (ENABLE_BUILD_DEPENDECIES STREQUAL OFF) AND (NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR) )
    set (ENABLE_BUILD_DEPENDECIES ON)
 endif ()
-
-mongo_pick(BSON_EXTRA_ALIGN 1 0 ENABLE_EXTRA_ALIGNMENT)
 
 mongo_pick(MONGOC_ENABLE_RDTSCP 1 0 ENABLE_RDTSCP)
 

--- a/Earthfile
+++ b/Earthfile
@@ -39,7 +39,6 @@ build:
     RUN cmake -S "$source_dir" -B "$build_dir" -G "Ninja Multi-Config" \
         -D ENABLE_MAINTAINER_FLAGS=ON \
         -D ENABLE_SHM_COUNTERS=ON \
-        -D ENABLE_EXTRA_ALIGNMENT=OFF \
         -D ENABLE_SASL=$(echo $sasl | __str upper) \
         -D ENABLE_SNAPPY=ON \
         -D ENABLE_SRV=ON \

--- a/src/libbson/NEWS
+++ b/src/libbson/NEWS
@@ -14,6 +14,7 @@ libbson 2.0.0 (Unreleased)
 * Remove deprecated atomic and threading interfaces: `bson_atomic_*` and `bson_thrd_yield`.
 * The deprecated `ENABLE_EXTRA_ALIGNMENT` CMake option is removed.
   * `bson_t` and `bson_iter_t` are now aligned to the size of a pointer instead of `128`.
+  * `bson_error_t` is now aligned to the size of a pointer instead of `8`.
   * `BSON_ALIGNED_BEGIN` and `BSON_ALIGNED_END` now unconditionally apply their requested alignment.
 
 

--- a/src/libbson/NEWS
+++ b/src/libbson/NEWS
@@ -13,7 +13,7 @@ libbson 2.0.0 (Unreleased)
 * Remove deprecated integral comparison interfaces: `bson_in_range_*` and `bson_cmp_*`.
 * Remove deprecated atomic and threading interfaces: `bson_atomic_*` and `bson_thrd_yield`.
 * The deprecated `ENABLE_EXTRA_ALIGNMENT` CMake option is removed.
-  * `bson_t` and `bson_iter_t` are now aligned to the size of a pointer.
+  * `bson_t` and `bson_iter_t` are now aligned to the size of a pointer instead of `128`.
   * `BSON_ALIGNED_BEGIN` and `BSON_ALIGNED_END` now unconditionally apply their requested alignment.
 
 

--- a/src/libbson/NEWS
+++ b/src/libbson/NEWS
@@ -12,6 +12,10 @@ libbson 2.0.0 (Unreleased)
 * Compiling with `BSON_MEMCHECK` defined now has no effect.
 * Remove deprecated integral comparison interfaces: `bson_in_range_*` and `bson_cmp_*`.
 * Remove deprecated atomic and threading interfaces: `bson_atomic_*` and `bson_thrd_yield`.
+* The deprecated `ENABLE_EXTRA_ALIGNMENT` CMake option is removed.
+  * `bson_t` and `bson_iter_t` are now aligned to the size of a pointer.
+  * `BSON_ALIGNED_BEGIN` and `BSON_ALIGNED_END` now unconditionally apply their requested alignment.
+
 
 libbson 1.30.2
 ==============

--- a/src/libbson/NEWS
+++ b/src/libbson/NEWS
@@ -14,7 +14,7 @@ libbson 2.0.0 (Unreleased)
 * Remove deprecated atomic and threading interfaces: `bson_atomic_*` and `bson_thrd_yield`.
 * The deprecated `ENABLE_EXTRA_ALIGNMENT` CMake option is removed.
   * `bson_t` and `bson_iter_t` are now aligned to the size of a pointer instead of `128`.
-  * `bson_error_t` and `bson_value_t` are now aligned to the size of a pointer instead of `8`.
+  * `bson_error_t`, `bson_value_t`, and `bson_visitor_t` are now aligned to the size of a pointer instead of `8`.
   * `BSON_ALIGNED_BEGIN` and `BSON_ALIGNED_END` now unconditionally apply their requested alignment.
 
 

--- a/src/libbson/NEWS
+++ b/src/libbson/NEWS
@@ -14,7 +14,7 @@ libbson 2.0.0 (Unreleased)
 * Remove deprecated atomic and threading interfaces: `bson_atomic_*` and `bson_thrd_yield`.
 * The deprecated `ENABLE_EXTRA_ALIGNMENT` CMake option is removed.
   * `bson_t` and `bson_iter_t` are now aligned to the size of a pointer instead of `128`.
-  * `bson_error_t` is now aligned to the size of a pointer instead of `8`.
+  * `bson_error_t` and `bson_value_t` are now aligned to the size of a pointer instead of `8`.
   * `BSON_ALIGNED_BEGIN` and `BSON_ALIGNED_END` now unconditionally apply their requested alignment.
 
 

--- a/src/libbson/doc/bson_t.rst
+++ b/src/libbson/doc/bson_t.rst
@@ -127,12 +127,11 @@ Synopsis
   #define BSON_APPEND_VALUE(b, key, val) \
      bson_append_value (b, key, (int) strlen (key), (val))
 
-  BSON_ALIGNED_BEGIN (128)
   typedef struct {
      uint32_t flags;       /* Internal flags for the bson_t. */
      uint32_t len;         /* Length of BSON data. */
      uint8_t padding[120]; /* Padding for stack allocation. */
-  } bson_t BSON_ALIGNED_END (128);
+  } bson_t;
 
 Description
 -----------

--- a/src/libbson/src/bson/bson-config.h.in
+++ b/src/libbson/src/bson/bson-config.h.in
@@ -96,14 +96,6 @@
 #endif
 
 
-/*
- * Define to 1 if you want extra aligned types in libbson
- */
-#define BSON_EXTRA_ALIGN @BSON_EXTRA_ALIGN@
-#if BSON_EXTRA_ALIGN != 1
-# undef BSON_EXTRA_ALIGN
-#endif
-
 
 /*
  * Define to 1 if you have rand_r available on your platform.

--- a/src/libbson/src/bson/bson-macros.h
+++ b/src/libbson/src/bson/bson-macros.h
@@ -162,22 +162,12 @@
 #define BSON_ALIGN_OF_PTR (BSON_ALIGNOF (void *))
 #endif
 
-#ifdef BSON_EXTRA_ALIGN
-#if defined(_MSC_VER)
-#define BSON_ALIGNED_BEGIN(_N) __declspec (align (_N))
-#define BSON_ALIGNED_END(_N)
-#else
-#define BSON_ALIGNED_BEGIN(_N)
-#define BSON_ALIGNED_END(_N) __attribute__ ((aligned (_N)))
-#endif
-#else
 #if defined(_MSC_VER)
 #define BSON_ALIGNED_BEGIN(_N) __declspec (align (BSON_ALIGN_OF_PTR))
 #define BSON_ALIGNED_END(_N)
 #else
 #define BSON_ALIGNED_BEGIN(_N)
 #define BSON_ALIGNED_END(_N) __attribute__ ((aligned ((_N) > BSON_ALIGN_OF_PTR ? BSON_ALIGN_OF_PTR : (_N))))
-#endif
 #endif
 
 

--- a/src/libbson/src/bson/bson-private.h
+++ b/src/libbson/src/bson/bson-private.h
@@ -43,18 +43,18 @@ typedef enum {
 #define BSON_INLINE_DATA_SIZE 120
 
 
-BSON_ALIGNED_BEGIN (128)
+BSON_ALIGNED_BEGIN (BSON_ALIGN_OF_PTR)
 typedef struct {
    bson_flags_t flags;
    uint32_t len;
    uint8_t data[BSON_INLINE_DATA_SIZE];
-} bson_impl_inline_t BSON_ALIGNED_END (128);
+} bson_impl_inline_t BSON_ALIGNED_END (BSON_ALIGN_OF_PTR);
 
 
 BSON_STATIC_ASSERT2 (impl_inline_t, sizeof (bson_impl_inline_t) == 128);
 
 
-BSON_ALIGNED_BEGIN (128)
+BSON_ALIGNED_BEGIN (BSON_ALIGN_OF_PTR)
 typedef struct {
    bson_flags_t flags; /* flags describing the bson_t */
    /* len is part of the public bson_t declaration. It is not
@@ -71,7 +71,7 @@ typedef struct {
    size_t alloclen;           /* length of buffer that we own. */
    bson_realloc_func realloc; /* our realloc implementation */
    void *realloc_func_ctx;    /* context for our realloc func */
-} bson_impl_alloc_t BSON_ALIGNED_END (128);
+} bson_impl_alloc_t BSON_ALIGNED_END (BSON_ALIGN_OF_PTR);
 
 
 BSON_STATIC_ASSERT2 (impl_alloc_t, sizeof (bson_impl_alloc_t) <= 128);

--- a/src/libbson/src/bson/bson-private.h
+++ b/src/libbson/src/bson/bson-private.h
@@ -53,8 +53,6 @@ typedef struct {
 
 BSON_STATIC_ASSERT2 (impl_inline_t, sizeof (bson_impl_inline_t) == 128);
 
-
-BSON_ALIGNED_BEGIN (BSON_ALIGN_OF_PTR)
 typedef struct {
    bson_flags_t flags; /* flags describing the bson_t */
    /* len is part of the public bson_t declaration. It is not
@@ -71,10 +69,15 @@ typedef struct {
    size_t alloclen;           /* length of buffer that we own. */
    bson_realloc_func realloc; /* our realloc implementation */
    void *realloc_func_ctx;    /* context for our realloc func */
-} bson_impl_alloc_t BSON_ALIGNED_END (BSON_ALIGN_OF_PTR);
+} bson_impl_alloc_t;
 
 
 BSON_STATIC_ASSERT2 (impl_alloc_t, sizeof (bson_impl_alloc_t) <= 128);
+
+// Ensure both `bson_t` implementations have the same alignment requirement:
+BSON_STATIC_ASSERT2 (impls_match_alignment, BSON_ALIGNOF (bson_impl_inline_t) == BSON_ALIGNOF (bson_impl_alloc_t));
+// Ensure `bson_t` has same alignment requirement as implementations:
+BSON_STATIC_ASSERT2 (impls_match_alignment, BSON_ALIGNOF (bson_t) == BSON_ALIGNOF (bson_impl_alloc_t));
 
 
 BSON_END_DECLS

--- a/src/libbson/src/bson/bson-types.h
+++ b/src/libbson/src/bson/bson-types.h
@@ -274,7 +274,6 @@ typedef enum {
  *--------------------------------------------------------------------------
  */
 
-BSON_ALIGNED_BEGIN (8)
 typedef struct _bson_value_t {
    bson_type_t value_type;
    int32_t padding;
@@ -328,7 +327,7 @@ typedef struct _bson_value_t {
       } v_symbol;
       bson_decimal128_t v_decimal128;
    } value;
-} bson_value_t BSON_ALIGNED_END (8);
+} bson_value_t;
 
 
 /**

--- a/src/libbson/src/bson/bson-types.h
+++ b/src/libbson/src/bson/bson-types.h
@@ -120,11 +120,11 @@ typedef struct _bson_json_opts_t bson_json_opts_t;
  *
  * This structure is meant to fit in two sequential 64-byte cachelines.
  */
-BSON_ALIGNED_BEGIN (128) typedef struct _bson_t {
+BSON_ALIGNED_BEGIN (BSON_ALIGN_OF_PTR) typedef struct _bson_t {
    uint32_t flags;       /* Internal flags for the bson_t. */
    uint32_t len;         /* Length of BSON data. */
    uint8_t padding[120]; /* Padding for stack allocation. */
-} bson_t BSON_ALIGNED_END (128);
+} bson_t BSON_ALIGNED_END (BSON_ALIGN_OF_PTR);
 
 /**
  * BSON_INITIALIZER:
@@ -342,7 +342,7 @@ typedef struct _bson_value_t {
  * This structure is safe to discard on the stack. No cleanup is necessary
  * after using it.
  */
-BSON_ALIGNED_BEGIN (128)
+BSON_ALIGNED_BEGIN (BSON_ALIGN_OF_PTR)
 typedef struct {
    const uint8_t *raw; /* The raw buffer being iterated. */
    uint32_t len;       /* The length of raw. */
@@ -356,7 +356,7 @@ typedef struct {
    uint32_t next_off;  /* The offset of the next field. */
    uint32_t err_off;   /* The offset of the error. */
    bson_value_t value; /* Internal value for various state. */
-} bson_iter_t BSON_ALIGNED_END (128);
+} bson_iter_t BSON_ALIGNED_END (BSON_ALIGN_OF_PTR);
 
 
 /**

--- a/src/libbson/src/bson/bson-types.h
+++ b/src/libbson/src/bson/bson-types.h
@@ -342,7 +342,6 @@ typedef struct _bson_value_t {
  * This structure is safe to discard on the stack. No cleanup is necessary
  * after using it.
  */
-BSON_ALIGNED_BEGIN (BSON_ALIGN_OF_PTR)
 typedef struct {
    const uint8_t *raw; /* The raw buffer being iterated. */
    uint32_t len;       /* The length of raw. */
@@ -356,7 +355,7 @@ typedef struct {
    uint32_t next_off;  /* The offset of the next field. */
    uint32_t err_off;   /* The offset of the error. */
    bson_value_t value; /* Internal value for various state. */
-} bson_iter_t BSON_ALIGNED_END (BSON_ALIGN_OF_PTR);
+} bson_iter_t;
 
 
 /**

--- a/src/libbson/src/bson/bson-types.h
+++ b/src/libbson/src/bson/bson-types.h
@@ -448,13 +448,13 @@ typedef struct {
 
 #define BSON_ERROR_BUFFER_SIZE 503
 
-BSON_ALIGNED_BEGIN (8)
+BSON_ALIGNED_BEGIN (BSON_ALIGN_OF_PTR) // Aligned for backwards-compatibility.
 typedef struct _bson_error_t {
    uint32_t domain;
    uint32_t code;
    char message[BSON_ERROR_BUFFER_SIZE];
    uint8_t reserved; // For internal use only!
-} bson_error_t BSON_ALIGNED_END (8);
+} bson_error_t BSON_ALIGNED_END (BSON_ALIGN_OF_PTR);
 
 
 BSON_STATIC_ASSERT2 (error_t, sizeof (bson_error_t) == 512);

--- a/src/libbson/src/bson/bson-types.h
+++ b/src/libbson/src/bson/bson-types.h
@@ -387,7 +387,6 @@ typedef struct {
  * You may pre-maturely stop the visitation of fields by returning true in your
  * visitor. Returning false will continue visitation to further fields.
  */
-BSON_ALIGNED_BEGIN (8)
 typedef struct {
    /* run before / after descending into a document */
    bool (*visit_before) (const bson_iter_t *iter, const char *key, void *data);
@@ -443,7 +442,7 @@ typedef struct {
                              void *data);
 
    void *padding[7];
-} bson_visitor_t BSON_ALIGNED_END (8);
+} bson_visitor_t;
 
 #define BSON_ERROR_BUFFER_SIZE 503
 


### PR DESCRIPTION
# Summary
- Remove CMake option `ENABLE_EXTRA_ALIGNMENT`.
- Align `bson_t` and `bson_iter_t` to the size of a pointer.

Verified with this patch build: https://spruce.mongodb.com/version/67dc0db1caab950007b0f764

# Motivation

Addresses long-standing ask to remove default over-alignment: CDRIVER-2813.

Removing alignment specifiers entirely was considered. However, removing the alignment specifier on `bson_t` resulted in a runtime error in calls to `BSON_ALIGNED_ALLOC (bson_t)`:

> Failure to allocate memory in bson_aligned_alloc()

I expect this is due to `bson_t` having alignment of 4. `bson_t` does not contain a pointer.

From `man aligned_alloc` (emphasis mine):
> In addition, aligned_alloc() returns a NULL pointer and sets errno to EINVAL if size is not an integral multiple of alignment, or if alignment is not a power of 2 **at least as large as sizeof(void *)**.

To limit the risk of causing runtime errors in user upgrades, this PR proposes keeping existing alignment specifiers. Only the over-alignment of `bson_t` and `bson_iter_t` is changed. 

## Alignment changes

The following were printed on my 64-bit machine to compare alignment changes.

Prior to this PR. With `ENABLE_EXTRA_ALIGNMENT=ON`:
```
alignof(bson_t):           128
alignof(bson_iter_t):      128
alignof(bson_visitor_t):   8
alignof(bson_reader_t):    8
alignof(bson_value_t):     8
alignof(bson_error_t):     8
```

With all alignment specifiers removed (not done in this PR):
```
alignof(bson_t):           4
alignof(bson_iter_t):      8
alignof(bson_visitor_t):   8
alignof(bson_reader_t):    4
alignof(bson_value_t):     8
alignof(bson_error_t):     4
```


With this PR:
```
alignof(bson_t):           8
alignof(bson_iter_t):      8
alignof(bson_visitor_t):   8
alignof(bson_reader_t):    8
alignof(bson_value_t):     8
alignof(bson_error_t):     8
```

