### PR TITLE
CDRIVER-5934 sync spec test

### DIFF
--- a/src/libmongoc/tests/json/command-logging-and-monitoring/monitoring/unacknowledged-client-bulkWrite.json
+++ b/src/libmongoc/tests/json/command-logging-and-monitoring/monitoring/unacknowledged-client-bulkWrite.json
@@ -95,29 +95,34 @@
             "ordered": false
           },
           "expectResult": {
-            "insertedCount": {
-              "$$unsetOrMatches": 0
-            },
-            "upsertedCount": {
-              "$$unsetOrMatches": 0
-            },
-            "matchedCount": {
-              "$$unsetOrMatches": 0
-            },
-            "modifiedCount": {
-              "$$unsetOrMatches": 0
-            },
-            "deletedCount": {
-              "$$unsetOrMatches": 0
-            },
-            "insertResults": {
-              "$$unsetOrMatches": {}
-            },
-            "updateResults": {
-              "$$unsetOrMatches": {}
-            },
-            "deleteResults": {
-              "$$unsetOrMatches": {}
+            "$$unsetOrMatches": {
+              "acknowledged": {
+                "$$unsetOrMatches": false
+              },
+              "insertedCount": {
+                "$$unsetOrMatches": 0
+              },
+              "upsertedCount": {
+                "$$unsetOrMatches": 0
+              },
+              "matchedCount": {
+                "$$unsetOrMatches": 0
+              },
+              "modifiedCount": {
+                "$$unsetOrMatches": 0
+              },
+              "deletedCount": {
+                "$$unsetOrMatches": 0
+              },
+              "insertResults": {
+                "$$unsetOrMatches": {}
+              },
+              "updateResults": {
+                "$$unsetOrMatches": {}
+              },
+              "deleteResults": {
+                "$$unsetOrMatches": {}
+              }
             }
           }
         },


### PR DESCRIPTION
Sync from https://github.com/mongodb/specifications/commit/78916887729bf0d3088541bd9a7390770fae5f77

No test runner changes were needed.The C driver test runner [represents an unacknowledged result as an empty BSON document `{}`](https://github.com/mongodb/mongo-c-driver/blob/1ca2bfabba1fcd0a4c578377ff8b88521f987c3e/src/libmongoc/tests/unified/result.c#L667-L687). Before: matching `{}` against `{ "insertedCount": { "$$unsetOrMatches": 0 } , ... }` succeeded. After: matching `{}` to `{ "$$unsetOrMatches": { "insertedCount": { "$$unsetOrMatches": 0 } , ... }}` also succeeds.