### PR TITLE
Apply `__cdecl` to all exported callbacks

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -21,6 +21,7 @@ Unreleased (2.0.0)
     * Old behavior: `authMechanismProperties=A:B,C:D:E,F:G` is parsed as `{'A': 'B', 'C': 'D:E,F:G'}`.
     * New behavior: `authMechanismProperties=A:B,C:D:E,F:G` is parsed as `{'A': 'B': 'C': 'D:E', 'F': 'G'}`.
 * Calling `mongoc_bulk_operation_execute` on the same `mongoc_bulk_operation_t` repeatedly is an error. Previously this was only discouraged in documentation.
+* Consistently apply `__cdecl` calling convention to declarations in public API. Intended to support consumers built with other [calling conventions](https://learn.microsoft.com/en-us/cpp/build/reference/gd-gr-gv-gz-calling-convention) with MSVC. libmongoc and libbson only support building with `__cdecl`.
 
 ## Removals
 

--- a/NEWS
+++ b/NEWS
@@ -21,7 +21,7 @@ Unreleased (2.0.0)
     * Old behavior: `authMechanismProperties=A:B,C:D:E,F:G` is parsed as `{'A': 'B', 'C': 'D:E,F:G'}`.
     * New behavior: `authMechanismProperties=A:B,C:D:E,F:G` is parsed as `{'A': 'B': 'C': 'D:E', 'F': 'G'}`.
 * Calling `mongoc_bulk_operation_execute` on the same `mongoc_bulk_operation_t` repeatedly is an error. Previously this was only discouraged in documentation.
-* Consistently apply `__cdecl` calling convention to declarations in public API. Intended to support consumers built with other [calling conventions](https://learn.microsoft.com/en-us/cpp/build/reference/gd-gr-gv-gz-calling-convention) with MSVC. libmongoc and libbson only support building with `__cdecl`.
+* Consistently apply `__cdecl` calling convention to function declarations in public API. Intended to support consumers building their code using a different [default calling convention](https://learn.microsoft.com/en-us/cpp/build/reference/gd-gr-gv-gz-calling-convention) with MSVC. The mongoc and bson libraries only support being built with the `__cdecl` default calling convention.
 
 ## Removals
 

--- a/src/libbson/src/bson/bson-json.h
+++ b/src/libbson/src/bson/bson-json.h
@@ -64,8 +64,8 @@ bson_json_opts_destroy (bson_json_opts_t *opts);
 BSON_EXPORT (void)
 bson_json_opts_set_outermost_array (bson_json_opts_t *opts, bool is_outermost_array);
 
-typedef ssize_t (*bson_json_reader_cb) (void *handle, uint8_t *buf, size_t count);
-typedef void (*bson_json_destroy_cb) (void *handle);
+typedef ssize_t (BSON_CALL *bson_json_reader_cb) (void *handle, uint8_t *buf, size_t count);
+typedef void (BSON_CALL *bson_json_destroy_cb) (void *handle);
 
 
 BSON_EXPORT (bson_json_reader_t *)

--- a/src/libbson/src/bson/bson-memory.h
+++ b/src/libbson/src/bson/bson-memory.h
@@ -28,15 +28,15 @@
 BSON_BEGIN_DECLS
 
 
-typedef void *(*bson_realloc_func) (void *mem, size_t num_bytes, void *ctx);
+typedef void *(BSON_CALL *bson_realloc_func) (void *mem, size_t num_bytes, void *ctx);
 
 
 typedef struct _bson_mem_vtable_t {
-   void *(*malloc) (size_t num_bytes);
-   void *(*calloc) (size_t n_members, size_t num_bytes);
-   void *(*realloc) (void *mem, size_t num_bytes);
-   void (*free) (void *mem);
-   void *(*aligned_alloc) (size_t alignment, size_t num_bytes);
+   void *(BSON_CALL *malloc) (size_t num_bytes);
+   void *(BSON_CALL *calloc) (size_t n_members, size_t num_bytes);
+   void *(BSON_CALL *realloc) (void *mem, size_t num_bytes);
+   void (BSON_CALL *free) (void *mem);
+   void *(BSON_CALL *aligned_alloc) (size_t alignment, size_t num_bytes);
    void *padding[3];
 } bson_mem_vtable_t;
 

--- a/src/libbson/src/bson/bson-reader.h
+++ b/src/libbson/src/bson/bson-reader.h
@@ -59,9 +59,9 @@ BSON_BEGIN_DECLS
  *--------------------------------------------------------------------------
  */
 
-typedef ssize_t (*bson_reader_read_func_t) (void *handle,  /* IN */
-                                            void *buf,     /* IN */
-                                            size_t count); /* IN */
+typedef ssize_t (BSON_CALL *bson_reader_read_func_t) (void *handle,  /* IN */
+                                                      void *buf,     /* IN */
+                                                      size_t count); /* IN */
 
 
 /*
@@ -84,7 +84,7 @@ typedef ssize_t (*bson_reader_read_func_t) (void *handle,  /* IN */
  *--------------------------------------------------------------------------
  */
 
-typedef void (*bson_reader_destroy_func_t) (void *handle); /* IN */
+typedef void (BSON_CALL *bson_reader_destroy_func_t) (void *handle); /* IN */
 
 
 BSON_EXPORT (bson_reader_t *)

--- a/src/libbson/src/bson/bson-types.h
+++ b/src/libbson/src/bson/bson-types.h
@@ -389,57 +389,59 @@ typedef struct {
  */
 typedef struct {
    /* run before / after descending into a document */
-   bool (*visit_before) (const bson_iter_t *iter, const char *key, void *data);
-   bool (*visit_after) (const bson_iter_t *iter, const char *key, void *data);
+   bool (BSON_CALL *visit_before) (const bson_iter_t *iter, const char *key, void *data);
+   bool (BSON_CALL *visit_after) (const bson_iter_t *iter, const char *key, void *data);
    /* corrupt BSON, or unsupported type and visit_unsupported_type not set */
-   void (*visit_corrupt) (const bson_iter_t *iter, void *data);
+   void (BSON_CALL *visit_corrupt) (const bson_iter_t *iter, void *data);
    /* normal bson field callbacks */
-   bool (*visit_double) (const bson_iter_t *iter, const char *key, double v_double, void *data);
-   bool (*visit_utf8) (const bson_iter_t *iter, const char *key, size_t v_utf8_len, const char *v_utf8, void *data);
-   bool (*visit_document) (const bson_iter_t *iter, const char *key, const bson_t *v_document, void *data);
-   bool (*visit_array) (const bson_iter_t *iter, const char *key, const bson_t *v_array, void *data);
-   bool (*visit_binary) (const bson_iter_t *iter,
-                         const char *key,
-                         bson_subtype_t v_subtype,
-                         size_t v_binary_len,
-                         const uint8_t *v_binary,
-                         void *data);
+   bool (BSON_CALL *visit_double) (const bson_iter_t *iter, const char *key, double v_double, void *data);
+   bool (BSON_CALL *visit_utf8) (
+      const bson_iter_t *iter, const char *key, size_t v_utf8_len, const char *v_utf8, void *data);
+   bool (BSON_CALL *visit_document) (const bson_iter_t *iter, const char *key, const bson_t *v_document, void *data);
+   bool (BSON_CALL *visit_array) (const bson_iter_t *iter, const char *key, const bson_t *v_array, void *data);
+   bool (BSON_CALL *visit_binary) (const bson_iter_t *iter,
+                                   const char *key,
+                                   bson_subtype_t v_subtype,
+                                   size_t v_binary_len,
+                                   const uint8_t *v_binary,
+                                   void *data);
    /* normal field with deprecated "Undefined" BSON type */
-   bool (*visit_undefined) (const bson_iter_t *iter, const char *key, void *data);
-   bool (*visit_oid) (const bson_iter_t *iter, const char *key, const bson_oid_t *v_oid, void *data);
-   bool (*visit_bool) (const bson_iter_t *iter, const char *key, bool v_bool, void *data);
-   bool (*visit_date_time) (const bson_iter_t *iter, const char *key, int64_t msec_since_epoch, void *data);
-   bool (*visit_null) (const bson_iter_t *iter, const char *key, void *data);
-   bool (*visit_regex) (
+   bool (BSON_CALL *visit_undefined) (const bson_iter_t *iter, const char *key, void *data);
+   bool (BSON_CALL *visit_oid) (const bson_iter_t *iter, const char *key, const bson_oid_t *v_oid, void *data);
+   bool (BSON_CALL *visit_bool) (const bson_iter_t *iter, const char *key, bool v_bool, void *data);
+   bool (BSON_CALL *visit_date_time) (const bson_iter_t *iter, const char *key, int64_t msec_since_epoch, void *data);
+   bool (BSON_CALL *visit_null) (const bson_iter_t *iter, const char *key, void *data);
+   bool (BSON_CALL *visit_regex) (
       const bson_iter_t *iter, const char *key, const char *v_regex, const char *v_options, void *data);
-   bool (*visit_dbpointer) (const bson_iter_t *iter,
-                            const char *key,
-                            size_t v_collection_len,
-                            const char *v_collection,
-                            const bson_oid_t *v_oid,
-                            void *data);
-   bool (*visit_code) (const bson_iter_t *iter, const char *key, size_t v_code_len, const char *v_code, void *data);
-   bool (*visit_symbol) (
+   bool (BSON_CALL *visit_dbpointer) (const bson_iter_t *iter,
+                                      const char *key,
+                                      size_t v_collection_len,
+                                      const char *v_collection,
+                                      const bson_oid_t *v_oid,
+                                      void *data);
+   bool (BSON_CALL *visit_code) (
+      const bson_iter_t *iter, const char *key, size_t v_code_len, const char *v_code, void *data);
+   bool (BSON_CALL *visit_symbol) (
       const bson_iter_t *iter, const char *key, size_t v_symbol_len, const char *v_symbol, void *data);
-   bool (*visit_codewscope) (const bson_iter_t *iter,
-                             const char *key,
-                             size_t v_code_len,
-                             const char *v_code,
-                             const bson_t *v_scope,
-                             void *data);
-   bool (*visit_int32) (const bson_iter_t *iter, const char *key, int32_t v_int32, void *data);
-   bool (*visit_timestamp) (
+   bool (BSON_CALL *visit_codewscope) (const bson_iter_t *iter,
+                                       const char *key,
+                                       size_t v_code_len,
+                                       const char *v_code,
+                                       const bson_t *v_scope,
+                                       void *data);
+   bool (BSON_CALL *visit_int32) (const bson_iter_t *iter, const char *key, int32_t v_int32, void *data);
+   bool (BSON_CALL *visit_timestamp) (
       const bson_iter_t *iter, const char *key, uint32_t v_timestamp, uint32_t v_increment, void *data);
-   bool (*visit_int64) (const bson_iter_t *iter, const char *key, int64_t v_int64, void *data);
-   bool (*visit_maxkey) (const bson_iter_t *iter, const char *key, void *data);
-   bool (*visit_minkey) (const bson_iter_t *iter, const char *key, void *data);
+   bool (BSON_CALL *visit_int64) (const bson_iter_t *iter, const char *key, int64_t v_int64, void *data);
+   bool (BSON_CALL *visit_maxkey) (const bson_iter_t *iter, const char *key, void *data);
+   bool (BSON_CALL *visit_minkey) (const bson_iter_t *iter, const char *key, void *data);
    /* if set, called instead of visit_corrupt when an apparently valid BSON
     * includes an unrecognized field type (reading future version of BSON) */
-   void (*visit_unsupported_type) (const bson_iter_t *iter, const char *key, uint32_t type_code, void *data);
-   bool (*visit_decimal128) (const bson_iter_t *iter,
-                             const char *key,
-                             const bson_decimal128_t *v_decimal128,
-                             void *data);
+   void (BSON_CALL *visit_unsupported_type) (const bson_iter_t *iter, const char *key, uint32_t type_code, void *data);
+   bool (BSON_CALL *visit_decimal128) (const bson_iter_t *iter,
+                                       const char *key,
+                                       const bson_decimal128_t *v_decimal128,
+                                       void *data);
 
    void *padding[7];
 } bson_visitor_t;

--- a/src/libmongoc/src/mongoc/mongoc-apm.h
+++ b/src/libmongoc/src/mongoc/mongoc-apm.h
@@ -311,18 +311,19 @@ mongoc_apm_server_heartbeat_failed_get_awaited (const mongoc_apm_server_heartbea
  * callbacks
  */
 
-typedef void (*mongoc_apm_command_started_cb_t) (const mongoc_apm_command_started_t *event);
-typedef void (*mongoc_apm_command_succeeded_cb_t) (const mongoc_apm_command_succeeded_t *event);
-typedef void (*mongoc_apm_command_failed_cb_t) (const mongoc_apm_command_failed_t *event);
-typedef void (*mongoc_apm_server_changed_cb_t) (const mongoc_apm_server_changed_t *event);
-typedef void (*mongoc_apm_server_opening_cb_t) (const mongoc_apm_server_opening_t *event);
-typedef void (*mongoc_apm_server_closed_cb_t) (const mongoc_apm_server_closed_t *event);
-typedef void (*mongoc_apm_topology_changed_cb_t) (const mongoc_apm_topology_changed_t *event);
-typedef void (*mongoc_apm_topology_opening_cb_t) (const mongoc_apm_topology_opening_t *event);
-typedef void (*mongoc_apm_topology_closed_cb_t) (const mongoc_apm_topology_closed_t *event);
-typedef void (*mongoc_apm_server_heartbeat_started_cb_t) (const mongoc_apm_server_heartbeat_started_t *event);
-typedef void (*mongoc_apm_server_heartbeat_succeeded_cb_t) (const mongoc_apm_server_heartbeat_succeeded_t *event);
-typedef void (*mongoc_apm_server_heartbeat_failed_cb_t) (const mongoc_apm_server_heartbeat_failed_t *event);
+typedef void (BSON_CALL *mongoc_apm_command_started_cb_t) (const mongoc_apm_command_started_t *event);
+typedef void (BSON_CALL *mongoc_apm_command_succeeded_cb_t) (const mongoc_apm_command_succeeded_t *event);
+typedef void (BSON_CALL *mongoc_apm_command_failed_cb_t) (const mongoc_apm_command_failed_t *event);
+typedef void (BSON_CALL *mongoc_apm_server_changed_cb_t) (const mongoc_apm_server_changed_t *event);
+typedef void (BSON_CALL *mongoc_apm_server_opening_cb_t) (const mongoc_apm_server_opening_t *event);
+typedef void (BSON_CALL *mongoc_apm_server_closed_cb_t) (const mongoc_apm_server_closed_t *event);
+typedef void (BSON_CALL *mongoc_apm_topology_changed_cb_t) (const mongoc_apm_topology_changed_t *event);
+typedef void (BSON_CALL *mongoc_apm_topology_opening_cb_t) (const mongoc_apm_topology_opening_t *event);
+typedef void (BSON_CALL *mongoc_apm_topology_closed_cb_t) (const mongoc_apm_topology_closed_t *event);
+typedef void (BSON_CALL *mongoc_apm_server_heartbeat_started_cb_t) (const mongoc_apm_server_heartbeat_started_t *event);
+typedef void (BSON_CALL *mongoc_apm_server_heartbeat_succeeded_cb_t) (
+   const mongoc_apm_server_heartbeat_succeeded_t *event);
+typedef void (BSON_CALL *mongoc_apm_server_heartbeat_failed_cb_t) (const mongoc_apm_server_heartbeat_failed_t *event);
 
 /*
  * registering callbacks

--- a/src/libmongoc/src/mongoc/mongoc-client-session.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-session.h
@@ -27,10 +27,10 @@
 
 BSON_BEGIN_DECLS
 
-typedef bool (*mongoc_client_session_with_transaction_cb_t) (mongoc_client_session_t *session,
-                                                             void *ctx,
-                                                             bson_t **reply,
-                                                             bson_error_t *error);
+typedef bool (BSON_CALL *mongoc_client_session_with_transaction_cb_t) (mongoc_client_session_t *session,
+                                                                       void *ctx,
+                                                                       bson_t **reply,
+                                                                       bson_error_t *error);
 
 typedef enum {
    MONGOC_TRANSACTION_NONE = 0,

--- a/src/libmongoc/src/mongoc/mongoc-client-side-encryption.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-side-encryption.h
@@ -45,10 +45,10 @@ BSON_BEGIN_DECLS
 
 typedef struct _mongoc_auto_encryption_opts_t mongoc_auto_encryption_opts_t;
 
-typedef bool (*mongoc_kms_credentials_provider_callback_fn) (void *userdata,
-                                                             const bson_t *params,
-                                                             bson_t *out,
-                                                             bson_error_t *error);
+typedef bool (BSON_CALL *mongoc_kms_credentials_provider_callback_fn) (void *userdata,
+                                                                       const bson_t *params,
+                                                                       bson_t *out,
+                                                                       bson_error_t *error);
 
 MONGOC_EXPORT (mongoc_auto_encryption_opts_t *)
 mongoc_auto_encryption_opts_new (void) BSON_GNUC_WARN_UNUSED_RESULT;

--- a/src/libmongoc/src/mongoc/mongoc-client.h
+++ b/src/libmongoc/src/mongoc/mongoc-client.h
@@ -95,10 +95,10 @@ typedef struct _mongoc_transaction_opt_t mongoc_transaction_opt_t;
  *
  * Returns: A newly allocated mongoc_stream_t or NULL on failure.
  */
-typedef mongoc_stream_t *(*mongoc_stream_initiator_t) (const mongoc_uri_t *uri,
-                                                       const mongoc_host_list_t *host,
-                                                       void *user_data,
-                                                       bson_error_t *error);
+typedef mongoc_stream_t *(BSON_CALL *mongoc_stream_initiator_t) (const mongoc_uri_t *uri,
+                                                                 const mongoc_host_list_t *host,
+                                                                 void *user_data,
+                                                                 bson_error_t *error);
 
 
 MONGOC_EXPORT (mongoc_client_t *)

--- a/src/libmongoc/src/mongoc/mongoc-log.h
+++ b/src/libmongoc/src/mongoc/mongoc-log.h
@@ -61,10 +61,10 @@ typedef enum {
  * libmongoc library. This is useful if you would like to show them in a
  * user interface or alternate storage.
  */
-typedef void (*mongoc_log_func_t) (mongoc_log_level_t log_level,
-                                   const char *log_domain,
-                                   const char *message,
-                                   void *user_data);
+typedef void (BSON_CALL *mongoc_log_func_t) (mongoc_log_level_t log_level,
+                                             const char *log_domain,
+                                             const char *message,
+                                             void *user_data);
 
 
 /**

--- a/src/libmongoc/src/mongoc/mongoc-sleep.h
+++ b/src/libmongoc/src/mongoc/mongoc-sleep.h
@@ -14,7 +14,7 @@ BSON_BEGIN_DECLS
  * @usec: Number of microseconds to sleep for.
  * @user_data: User data provided to mongoc_client_set_usleep_impl().
  */
-typedef void (*mongoc_usleep_func_t) (int64_t usec, void *user_data);
+typedef void (BSON_CALL *mongoc_usleep_func_t) (int64_t usec, void *user_data);
 
 /**
  * mongoc_client_set_usleep_impl:

--- a/src/libmongoc/src/mongoc/mongoc-stream.h
+++ b/src/libmongoc/src/mongoc/mongoc-stream.h
@@ -37,19 +37,19 @@ typedef struct _mongoc_stream_poll_t {
 
 struct _mongoc_stream_t {
    int type;
-   void (*destroy) (mongoc_stream_t *stream);
-   int (*close) (mongoc_stream_t *stream);
-   int (*flush) (mongoc_stream_t *stream);
-   ssize_t (*writev) (mongoc_stream_t *stream, mongoc_iovec_t *iov, size_t iovcnt, int32_t timeout_msec);
-   ssize_t (*readv) (
+   void (BSON_CALL *destroy) (mongoc_stream_t *stream);
+   int (BSON_CALL *close) (mongoc_stream_t *stream);
+   int (BSON_CALL *flush) (mongoc_stream_t *stream);
+   ssize_t (BSON_CALL *writev) (mongoc_stream_t *stream, mongoc_iovec_t *iov, size_t iovcnt, int32_t timeout_msec);
+   ssize_t (BSON_CALL *readv) (
       mongoc_stream_t *stream, mongoc_iovec_t *iov, size_t iovcnt, size_t min_bytes, int32_t timeout_msec);
-   int (*setsockopt) (mongoc_stream_t *stream, int level, int optname, void *optval, mongoc_socklen_t optlen);
-   mongoc_stream_t *(*get_base_stream) (mongoc_stream_t *stream);
-   bool (*check_closed) (mongoc_stream_t *stream);
-   ssize_t (*poll) (mongoc_stream_poll_t *streams, size_t nstreams, int32_t timeout);
-   void (*failed) (mongoc_stream_t *stream);
-   bool (*timed_out) (mongoc_stream_t *stream);
-   bool (*should_retry) (mongoc_stream_t *stream);
+   int (BSON_CALL *setsockopt) (mongoc_stream_t *stream, int level, int optname, void *optval, mongoc_socklen_t optlen);
+   mongoc_stream_t *(BSON_CALL *get_base_stream) (mongoc_stream_t *stream);
+   bool (BSON_CALL *check_closed) (mongoc_stream_t *stream);
+   ssize_t (BSON_CALL *poll) (mongoc_stream_poll_t *streams, size_t nstreams, int32_t timeout);
+   void (BSON_CALL *failed) (mongoc_stream_t *stream);
+   bool (BSON_CALL *timed_out) (mongoc_stream_t *stream);
+   bool (BSON_CALL *should_retry) (mongoc_stream_t *stream);
    void *padding[3];
 };
 

--- a/src/libmongoc/src/mongoc/mongoc-structured-log.h
+++ b/src/libmongoc/src/mongoc/mongoc-structured-log.h
@@ -48,7 +48,7 @@ typedef struct mongoc_structured_log_entry_t mongoc_structured_log_entry_t;
 
 typedef struct mongoc_structured_log_opts_t mongoc_structured_log_opts_t;
 
-typedef void (*mongoc_structured_log_func_t) (const mongoc_structured_log_entry_t *entry, void *user_data);
+typedef void (BSON_CALL *mongoc_structured_log_func_t) (const mongoc_structured_log_entry_t *entry, void *user_data);
 
 MONGOC_EXPORT (mongoc_structured_log_opts_t *)
 mongoc_structured_log_opts_new (void);


### PR DESCRIPTION
# Summary

Apply missing `BSON_CALL` to all exported callbacks to ensure `__cdecl` is applied when building with MSVC.

Resolves CDRIVER-2737 and CDRIVER-5678.

Verified with this [patch build](https://spruce.mongodb.com/version/67ea8bcf3bab8700076d6888).


# Background & Motivation

## Existing expectations

This PR assumes libbson and libmongoc do not support building with a non-cdecl calling convention. Attempting to build libbson with [/Gv](https://learn.microsoft.com/en-us/cpp/build/reference/gd-gr-gv-gz-calling-convention) to specify the `__vectorcall` calling convention results in errors:

```
src\libbson\src\bson\bson-clock.c(45): error C2373: 'bson_gettimeofday': redefinition; different type modifier
(... and many more ...)
```

This PR intends to ensure consumers building with MSVC see `__cdecl` in the function declaration when building headers to match the expected calling convention of libmongoc and libbson.

## Skipping CI testing

Similar to https://github.com/mongodb/mongo-cxx-driver/pull/1202, an attempt was made to build test-libmongoc with `/Gv` to test a non-cdecl consumer.

Doing so expectedly appears to require marking all callback functions defined in tests with `__cdecl` to avoid errors like:
```
src\libmongoc\tests\test-mongoc-command-monitoring.c(131): error C2440: 'function': cannot convert from 'void (__vectorcall *)(const mongoc_apm_command_failed_t *)' to 'mongoc_apm_command_failed_cb_t'
(... and many more ...)
```

And also appears to require marking functions in private headers used by tests to be marked `__cdecl`:
```
test-libmongoc-lib.lib(runner.obj) : error LNK2001: unresolved external symbol _mongoc_array_append_vals@@24
(... and many more ...)
```

To expedite the fix, tests in CI are not added.

