### PR TITLE
CDRIVER-5959 temporarily restrict updateDescription tests to 8.1 or older

### DIFF
--- a/src/libmongoc/tests/json/change_streams/unified/change-streams-disambiguatedPaths.json
+++ b/src/libmongoc/tests/json/change_streams/unified/change-streams-disambiguatedPaths.json
@@ -26,6 +26,7 @@
     "runOnRequirements": [
       {
         "minServerVersion": "6.1.0",
+        "maxServerVersion": "8.1.0",
         "topologies": [
           "replicaset",
           "sharded-replicaset",

--- a/src/libmongoc/tests/json/change_streams/unified/change-streams-pre_and_post_images.json
+++ b/src/libmongoc/tests/json/change_streams/unified/change-streams-pre_and_post_images.json
@@ -4,6 +4,7 @@
   "runOnRequirements": [
     {
       "minServerVersion": "6.0.0",
+      "maxServerVersion": "8.1.0",
       "topologies": [
         "replicaset",
         "sharded-replicaset",

--- a/src/libmongoc/tests/json/change_streams/unified/change-streams.json
+++ b/src/libmongoc/tests/json/change_streams/unified/change-streams.json
@@ -4,6 +4,7 @@
   "runOnRequirements": [
     {
       "minServerVersion": "3.6",
+      "maxServerVersion": "8.1",
       "topologies": [
         "replicaset"
       ],
@@ -112,7 +113,8 @@
       "description": "Test array truncation",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.7"
+          "minServerVersion": "4.7",
+          "maxServerVersion": "8.1"
         }
       ],
       "operations": [


### PR DESCRIPTION
Preemptive changes mirroring those in https://github.com/mongodb/mongo-cxx-driver/pull/1365 until a proper solution is implemented for [DRIVERS-3151](https://jira.mongodb.org/browse/DRIVERS-3151).