### PR TITLE
CDRIVER-5968 Fix compiler warning on Windows

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-openssl.c
@@ -148,7 +148,7 @@ _mongoc_openssl_import_cert_store (LPWSTR store_name, DWORD dwFlags, X509_STORE 
                      (LPTSTR) &msg,
                      0,
                      NULL);
-      MONGOC_ERROR ("Can't open CA store: 0x%.8X: '%s'", GetLastError (), msg);
+      MONGOC_ERROR ("Can't open CA store: 0x%.8lX: '%s'", GetLastError (), msg);
       LocalFree (msg);
       return false;
    }


### PR DESCRIPTION
Fixes

```
  mongoc/mongoc-openssl.c:150:21: warning: format '%X' expects argument of type 'unsigned int', but argument 4 has type 'DWORD' {aka 'long unsigned int'} [-Wformat=]
```