### PR TITLE
CDRIVER-5967 do not set CMP0042 to "OLD"

### DIFF
--- a/src/libbson/CMakeLists.txt
+++ b/src/libbson/CMakeLists.txt
@@ -29,10 +29,6 @@ set(libbson_VERSION_FULL ${mongo-c-driver_VERSION_FULL})
 set(CMAKE_C_VISIBILITY_PRESET hidden)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
-if (APPLE)
-   cmake_policy (SET CMP0042 OLD)
-endif ()
-
 #  .d8888b.           888    888    d8b
 # d88P  Y88b          888    888    Y8P
 # Y88b.               888    888

--- a/src/libbson/examples/cmake/find_package/CMakeLists.txt
+++ b/src/libbson/examples/cmake/find_package/CMakeLists.txt
@@ -17,10 +17,6 @@
 
 cmake_minimum_required (VERSION 3.0)
 
-if (APPLE)
-   cmake_policy (SET CMP0042 OLD)
-endif ()
-
 project (hello_bson LANGUAGES C)
 
 # NOTE: For this to work, the CMAKE_PREFIX_PATH variable must be set to point to

--- a/src/libbson/examples/cmake/find_package_static/CMakeLists.txt
+++ b/src/libbson/examples/cmake/find_package_static/CMakeLists.txt
@@ -17,10 +17,6 @@
 
 cmake_minimum_required (VERSION 2.8)
 
-if (APPLE)
-   cmake_policy (SET CMP0042 OLD)
-endif ()
-
 project (hello_bson LANGUAGES C)
 
 # NOTE: For this to work, the CMAKE_PREFIX_PATH variable must be set to point to

--- a/src/libmongoc/examples/cmake/find_package/CMakeLists.txt
+++ b/src/libmongoc/examples/cmake/find_package/CMakeLists.txt
@@ -15,7 +15,7 @@
 # Demonstrates how to use the CMake 'find_package' mechanism to locate
 # and build against libmongoc.
 
-cmake_minimum_required (VERSION 3.0))
+cmake_minimum_required (VERSION 3.0)
 
 project (hello_mongoc LANGUAGES C)
 

--- a/src/libmongoc/examples/cmake/find_package/CMakeLists.txt
+++ b/src/libmongoc/examples/cmake/find_package/CMakeLists.txt
@@ -15,11 +15,7 @@
 # Demonstrates how to use the CMake 'find_package' mechanism to locate
 # and build against libmongoc.
 
-cmake_minimum_required (VERSION 3.0)
-
-if (APPLE)
-   cmake_policy (SET CMP0042 OLD)
-endif ()
+cmake_minimum_required (VERSION 3.0))
 
 project (hello_mongoc LANGUAGES C)
 

--- a/src/libmongoc/examples/cmake/find_package_static/CMakeLists.txt
+++ b/src/libmongoc/examples/cmake/find_package_static/CMakeLists.txt
@@ -17,10 +17,6 @@
 
 cmake_minimum_required (VERSION 3.0)
 
-if (APPLE)
-   cmake_policy (SET CMP0042 OLD)
-endif ()
-
 project (hello_mongoc LANGUAGES C)
 
 # NOTE: For this to work, the CMAKE_PREFIX_PATH variable must be set to point to


### PR DESCRIPTION
# Summary

Remove unnecessary `cmake_policy (SET CMP0042 OLD)` statements that error in CMake 4.

Verified with this [patch build](https://spruce.mongodb.com/version/67ec4d31f11d6b00072d232a/).

# Background & Motivation

Fixes an error on macOS with the recently released CMake 4:

```
% cmake -S. -Bcmake-build
...
CMake Error at src/libbson/CMakeLists.txt:33 (cmake_policy):
  Policy CMP0042 may not be set to OLD behavior because this version of CMake
  no longer supports it.  The policy was introduced in CMake version 3.0.0,
  and use of NEW behavior is now required.
```

[CMP0042 documents](https://cmake.org/cmake/help/latest/policy/CMP0042.html):

> MACOSX_RPATH is enabled by default.

MACOSX_RPATH is already enabled by the [`set (CMAKE_MACOSX_RPATH ON)`](https://github.com/mongodb/mongo-c-driver/blob/8e65858ad870a3379a731f233ab919e5153f8bf0/CMakeLists.txt#L342-L343) in the top-level CMakeLists.txt. The `@rpath` can be observed with `otool -L`:

```
% otool -L .install/lib/libbson2.dylib
.install/lib/libbson2.dylib:
        @rpath/libbson2.2.dylib (compatibility version 2.0.0, current version 2.1.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.0.0
```

I expect the `cmake_policy (SET CMP0042 OLD)` was unintentionally left in.