### PR TITLE
 CDRIVER-5930 re-enable ABI compliance checks for r1.30

### DIFF
--- a/.evergreen/config_generator/components/funcs/set_cache_dir.py
+++ b/.evergreen/config_generator/components/funcs/set_cache_dir.py
@@ -1,0 +1,43 @@
+from config_generator.etc.function import Function
+from config_generator.etc.utils import bash_exec
+
+from shrub.v3.evg_command import EvgCommandType, expansions_update
+
+
+class SetCacheDir(Function):
+    name = 'set-cache-dir'
+    commands = [
+        bash_exec(
+            command_type=EvgCommandType.SETUP,
+            script='''\
+                if [[ -n "$XDG_CACHE_DIR" ]]; then
+                    cache_dir="$XDG_CACHE_DIR" # XDG Base Directory specification.
+                elif [[ -n "$LOCALAPPDATA" ]]; then
+                    cache_dir="$LOCALAPPDATA" # Windows.
+                elif [[ -n "$USERPROFILE" ]]; then
+                    cache_dir="$USERPROFILE/.cache" # Windows (fallback).
+                elif [[ -d "$HOME/Library/Caches" ]]; then
+                    cache_dir="$HOME/Library/Caches" # MacOS.
+                elif [[ -n "$HOME" ]]; then
+                    cache_dir="$HOME/.cache" # Linux-like.
+                elif [[ -d ~/.cache ]]; then
+                    cache_dir="~/.cache" # Linux-like (fallback).
+                else
+                    cache_dir="$(pwd)/.cache" # EVG task directory (fallback).
+                fi
+
+                mkdir -p "$cache_dir/mongo-c-driver" || exit
+                cache_dir="$(cd "$cache_dir/mongo-c-driver" && pwd)" || exit
+
+                printf "MONGO_C_DRIVER_CACHE_DIR: %s\\n" "$cache_dir" >|expansions.set-cache-dir.yml
+            ''',
+        ),
+        expansions_update(
+            command_type=EvgCommandType.SETUP,
+            file='expansions.set-cache-dir.yml'
+        ),
+    ]
+
+
+def functions():
+    return SetCacheDir.defn()

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -4,33 +4,56 @@ functions:
       type: setup
       params:
         binary: bash
-        working_dir: mongoc
         args:
           - -c
-          - .evergreen/scripts/abi-compliance-check-setup.sh
+          - |
+            if [[ -n "$XDG_CACHE_DIR" ]]; then
+                cache_dir="$XDG_CACHE_DIR" # XDG Base Directory specification.
+            elif [[ -n "$LOCALAPPDATA" ]]; then
+                cache_dir="$LOCALAPPDATA" # Windows.
+            elif [[ -n "$USERPROFILE" ]]; then
+                cache_dir="$USERPROFILE/.cache" # Windows (fallback).
+            elif [[ -d "$HOME/Library/Caches" ]]; then
+                cache_dir="$HOME/Library/Caches" # MacOS.
+            elif [[ -n "$HOME" ]]; then
+                cache_dir="$HOME/.cache" # Linux-like.
+            elif [[ -d ~/.cache ]]; then
+                cache_dir="~/.cache" # Linux-like (fallback).
+            else
+                cache_dir="$(pwd)/.cache" # EVG task directory (fallback).
+            fi
+
+            mkdir -p "$cache_dir/mongo-c-driver" || exit
+            cache_dir="$(cd "$cache_dir/mongo-c-driver" && pwd)" || exit
+
+            printf "MONGO_C_DRIVER_CACHE_DIR: %s\n" "$cache_dir" >|expansions.set-cache-dir.yml
+    - command: expansions.update
+      type: setup
+      params:
+        file: expansions.set-cache-dir.yml
     - command: subprocess.exec
       type: setup
       params:
         binary: bash
         working_dir: mongoc
-        add_expansions_to_env: true
+        include_expansions_in_env:
+          - MONGO_C_DRIVER_CACHE_DIR
         args:
           - -c
-          - .evergreen/scripts/abi-compliance-check.sh
+          - .evergreen/scripts/abi-compliance-check-setup.sh
     - command: subprocess.exec
       type: test
       params:
         binary: bash
         working_dir: mongoc
-        env:
-          AWS_ACCESS_KEY_ID: ${aws_key}
-          AWS_SECRET_ACCESS_KEY: ${aws_secret}
+        add_expansions_to_env: true
+        include_expansions_in_env:
+          - MONGO_C_DRIVER_CACHE_DIR
         args:
           - -c
-          - |
-            aws s3 cp abi-compliance/compat_reports s3://mciuploads/mongo-c-driver/${build_variant}/${revision}/${version_id}/${build_id}/abi-compliance/compat_reports --recursive --acl public-read --region us-east-1
-            [[ ! -f ./abi-compliance/abi-error.txt ]]
+          - .evergreen/scripts/abi-compliance-check.sh
     - command: s3.put
+      type: system
       params:
         display_name: "ABI Report:"
         aws_key: ${aws_key}
@@ -39,7 +62,18 @@ functions:
         content_type: text/html
         local_files_include_filter: mongoc/abi-compliance/compat_reports/**/*.html
         permissions: public-read
-        remote_file: mongo-c-driver/${build_variant}/${revision}/${version_id}/${build_id}/abi-compliance/compat_report.html
+        remote_file: mongo-c-driver/${branch_name}/${revision}/${version_id}/${build_id}/${task_id}/${execution}/abi-compliance-check/
+    - command: s3.put
+      type: system
+      params:
+        display_name: "ABI Compliance Check: "
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        bucket: mciuploads
+        content_type: text/plain
+        local_files_include_filter: abi-compliance/logs/**/log.txt
+        permissions: public-read
+        remote_file: mongo-c-driver/${branch_name}/${revision}/${version_id}/${build_id}/${task_id}/${execution}/abi-compliance-check/
   backtrace:
     - command: subprocess.exec
       params:
@@ -551,6 +585,38 @@ functions:
         args:
           - -c
           - .evergreen/scripts/compile-scan-build.sh
+  set-cache-dir:
+    - command: subprocess.exec
+      type: setup
+      params:
+        binary: bash
+        args:
+          - -c
+          - |
+            if [[ -n "$XDG_CACHE_DIR" ]]; then
+                cache_dir="$XDG_CACHE_DIR" # XDG Base Directory specification.
+            elif [[ -n "$LOCALAPPDATA" ]]; then
+                cache_dir="$LOCALAPPDATA" # Windows.
+            elif [[ -n "$USERPROFILE" ]]; then
+                cache_dir="$USERPROFILE/.cache" # Windows (fallback).
+            elif [[ -d "$HOME/Library/Caches" ]]; then
+                cache_dir="$HOME/Library/Caches" # MacOS.
+            elif [[ -n "$HOME" ]]; then
+                cache_dir="$HOME/.cache" # Linux-like.
+            elif [[ -d ~/.cache ]]; then
+                cache_dir="~/.cache" # Linux-like (fallback).
+            else
+                cache_dir="$(pwd)/.cache" # EVG task directory (fallback).
+            fi
+
+            mkdir -p "$cache_dir/mongo-c-driver" || exit
+            cache_dir="$(cd "$cache_dir/mongo-c-driver" && pwd)" || exit
+
+            printf "MONGO_C_DRIVER_CACHE_DIR: %s\n" "$cache_dir" >|expansions.set-cache-dir.yml
+    - command: expansions.update
+      type: setup
+      params:
+        file: expansions.set-cache-dir.yml
   start-load-balancer:
     - command: subprocess.exec
       type: setup

--- a/.evergreen/scripts/abi-compliance-check-setup.sh
+++ b/.evergreen/scripts/abi-compliance-check-setup.sh
@@ -18,26 +18,29 @@ fi
 declare parallel_level
 parallel_level="$(("$(nproc)" + 1))"
 
+export PATH
+PATH="${MONGO_C_DRIVER_CACHE_DIR:?}/bin:${PATH:-}" # abi-compliance-checker
+
 # Obtain abi-compliance-checker.
 echo "Fetching abi-compliance-checker..."
-[[ -d checker ]] || {
-  git clone -b "2.3" --depth 1 https://github.com/lvc/abi-compliance-checker.git checker
-  pushd checker
-  make -j "${parallel_level:?}" --no-print-directory install prefix="${working_dir:?}/install"
-  popd # checker
+[[ -d "${MONGO_C_DRIVER_CACHE_DIR:?}/checker-2.3" ]] || {
+  git clone -b "2.3" --depth 1 https://github.com/lvc/abi-compliance-checker.git "${MONGO_C_DRIVER_CACHE_DIR:?}/checker-2.3"
+  pushd "${MONGO_C_DRIVER_CACHE_DIR:?}/checker-2.3"
+  make -j "${parallel_level:?}" --no-print-directory install prefix="${MONGO_C_DRIVER_CACHE_DIR:?}"
+  popd # "${MONGO_C_DRIVER_CACHE_DIR:?}/checker-2.3"
 } >/dev/null
 echo "Fetching abi-compliance-checker... done."
 
 # Obtain ctags.
 echo "Fetching ctags..."
-[[ -d ctags ]] || {
-  git clone -b "v6.0.0" --depth 1 https://github.com/universal-ctags/ctags.git ctags
-  pushd ctags
+[[ -d "${MONGO_C_DRIVER_CACHE_DIR:?}/ctags-6.0.0" ]] || {
+  git clone -b "v6.0.0" --depth 1 https://github.com/universal-ctags/ctags.git "${MONGO_C_DRIVER_CACHE_DIR:?}/ctags-6.0.0"
+  pushd "${MONGO_C_DRIVER_CACHE_DIR:?}/ctags-6.0.0"
   ./autogen.sh
-  ./configure --prefix="${working_dir}/install"
+  ./configure --prefix="${MONGO_C_DRIVER_CACHE_DIR:?}"
   make -j "${parallel_level:?}"
   make install
-  popd # ctags
+  popd # "${MONGO_C_DRIVER_CACHE_DIR:?}/ctags-6.0.0"
 } >/dev/null
 echo "Fetching ctags... done."
 

--- a/.evergreen/scripts/abi-compliance-check.sh
+++ b/.evergreen/scripts/abi-compliance-check.sh
@@ -1,71 +1,106 @@
 #!/usr/bin/env bash
 
 set -o errexit
+set -o pipefail
 
 # create all needed directories
 mkdir abi-compliance
-mkdir abi-compliance/changes-install
-mkdir abi-compliance/latest-release-install
+mkdir abi-compliance/current-install
+mkdir abi-compliance/base-install
 mkdir abi-compliance/dumps
 
 declare head_commit today
-# The 10 digits of the current commit
+# The 10 digits of the base commit
 head_commit=$(git rev-parse --revs-only --short=10 "HEAD^{commit}")
 # The YYYYMMDD date
 today=$(date +%Y%m%d)
 
-declare newest current
-current="$(cat VERSION_CURRENT)-$today+git$head_commit"
-newest=$(cat etc/prior_version.txt)
+declare current base
+current="$(cat VERSION_CURRENT)-${today:?}+git${head_commit:?}" # e.g. 2.3.4-dev
+base=$(cat etc/prior_version.txt)                               # e.g. 1.2.3
+
+# Double-check we are testing against the same API major version.
+if [[ "${base_verdir:?}" != 1.* ]]; then
+  echo "API major version mismatch: base version is ${base:?} but current version is ${current:?}" >&2
+  exit 1
+fi
 
 declare working_dir
 working_dir="$(pwd)"
 
 export PATH
-PATH="${working_dir:?}/install/bin:${PATH:-}"
+PATH="${MONGO_C_DRIVER_CACHE_DIR:?}/bin:${PATH:-}" # abi-compliance-checker
+
+cmake_configure_flags=(
+  "-DENABLE_STATIC=OFF"
+  "-DENABLE_TESTS=OFF"
+  "-DENABLE_EXAMPLES=OFF"
+)
 
 # build the current changes
 env \
   CFLAGS="-g -Og" \
-  EXTRA_CONFIGURE_FLAGS="-DCMAKE_INSTALL_PREFIX=./abi-compliance/changes-install" \
+  EXTRA_CONFIGURE_FLAGS="-DCMAKE_INSTALL_PREFIX=./abi-compliance/current-install ${cmake_configure_flags[*]:?}" \
   .evergreen/scripts/compile.sh
 
-# checkout the newest release
-git checkout "tags/${newest}" -f
+# checkout the base release
+git checkout "tags/${base:?}" -f
 
-declare compile_script=".evergreen/scripts/compile.sh"
-if [[ ! -f "${compile_script}" ]]; then
-  # Compatibility: remove once latest release contains relocated script.
-  compile_script=".evergreen/compile.sh"
-fi
+declare compile_script
+compile_script=".evergreen/scripts/compile.sh"
 
-# build the newest release
+# build the base release
 env \
   CFLAGS="-g -Og" \
-  EXTRA_CONFIGURE_FLAGS="-DCMAKE_INSTALL_PREFIX=./abi-compliance/latest-release-install" \
+  EXTRA_CONFIGURE_FLAGS="-DCMAKE_INSTALL_PREFIX=./abi-compliance/base-install ${cmake_configure_flags[*]:?}" \
   bash "${compile_script}"
 
 # check for abi compliance. Generates HTML Reports.
 cd abi-compliance
 
 cat >|old.xml <<DOC
-<version>${newest}</version>
+<version>
+  ${base:?}
+</version>
+
+<libs>
+  $(pwd)/base-install/lib
+</libs>
+
+<add_include_paths>
+  $(pwd)/base-install/include/libbson-1.0/
+  $(pwd)/base-install/include/libmongoc-1.0/
+</add_include_paths>
+
 <headers>
-$(pwd)/latest-release-install/include/libmongoc-1.0/mongoc/mongoc.h
-$(pwd)/latest-release-install/include/libbson-1.0/bson/bson.h
+  $(pwd)/base-install/include/libbson-1.0/bson/bson.h
+  $(pwd)/base-install/include/libmongoc-1.0/mongoc/mongoc.h
 </headers>
-<libs>$(pwd)/latest-release-install/lib</libs>
 DOC
 
 cat >|new.xml <<DOC
-<version>${current}</version>
+<version>
+  ${current:?}
+</version>
+
+<libs>
+  $(pwd)/current-install/lib
+</libs>
+
+<add_include_paths>
+  $(pwd)/current-install/include/libbson-1.0/
+  $(pwd)/current-install/include/libmongoc-1.0/
+</add_include_paths>
+
 <headers>
-$(pwd)/changes-install/include/libmongoc-1.0/mongoc/mongoc.h
-$(pwd)/changes-install/include/libbson-1.0/bson/bson.h
+  $(pwd)/current-install/include/libbson-1.0/bson/bson.h
+  $(pwd)/current-install/include/libmongoc-1.0/mongoc/mongoc.h
 </headers>
-<libs>$(pwd)/changes-install/lib</libs>
 DOC
 
 if ! abi-compliance-checker -lib mongo-c-driver -old old.xml -new new.xml; then
-  touch ./abi-error.txt
+  find . -name log.txt -exec cat {} + >&2 || true
+  declare status
+  status='{"status":"failed", "type":"test", "should_continue":true, "desc":"abi-compliance-checker emitted one or more errors"}'
+  curl -sS -d "${status:?}" -H "Content-Type: application/json" -X POST localhost:2285/task_status || true
 fi


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1976.

Notable differences between the changes committed in https://github.com/mongodb/mongo-c-driver/pull/1976 and this PR include:

- replacing `${project}` with `mongo-c-driver` for AWS S3 put commands to avoid the permissions issues described in https://github.com/mongodb/mongo-c-driver/pull/1975.
- using `libbson-1.0` and `libmongoc-1.0` include directories for v1.30 compatibility instead of `bson-<api-version>` and `mongoc-<api-version>`.
- checking for API major version `1` instead of `2`.