### PR TITLE
Fix variable expansion in r1.30 abi-compliance-check.sh

### DIFF
--- a/.evergreen/scripts/abi-compliance-check.sh
+++ b/.evergreen/scripts/abi-compliance-check.sh
@@ -20,7 +20,7 @@ current="$(cat VERSION_CURRENT)-${today:?}+git${head_commit:?}" # e.g. 2.3.4-dev
 base=$(cat etc/prior_version.txt)                               # e.g. 1.2.3
 
 # Double-check we are testing against the same API major version.
-if [[ "${base_verdir:?}" != 1.* ]]; then
+if [[ "${base:?}" != 1.* ]]; then
   echo "API major version mismatch: base version is ${base:?} but current version is ${current:?}" >&2
   exit 1
 fi


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1978. Fixes a stray reference to the `$base_verdir` variable which does not exist for r1.30 in the API major version compatibility check.