### PR TITLE
Use majority write concern and remove assert in change stream tests

### DIFF
--- a/src/libmongoc/tests/test-mongoc-change-stream.c
+++ b/src/libmongoc/tests/test-mongoc-change-stream.c
@@ -2160,6 +2160,13 @@ test_change_stream_batchSize0 (void *test_ctx)
    {
       mongoc_client_t *client = test_framework_new_default_client ();
       mongoc_collection_t *coll = drop_and_get_coll (client, "db", "coll");
+      // Insert with majority write concern to ensure documents are visible to change stream.
+      {
+         mongoc_write_concern_t *wc = mongoc_write_concern_new ();
+         mongoc_write_concern_set_w (wc, MONGOC_WRITE_CONCERN_W_MAJORITY);
+         mongoc_collection_set_write_concern (coll, wc);
+         mongoc_write_concern_destroy (wc);
+      }
       mongoc_change_stream_t *cs = mongoc_collection_watch (coll, tmp_bson ("{}"), NULL);
       resumeToken = bson_copy (mongoc_change_stream_get_resume_token (cs));
       // Insert documents to create future events.

--- a/src/libmongoc/tests/test-mongoc-change-stream.c
+++ b/src/libmongoc/tests/test-mongoc-change-stream.c
@@ -353,14 +353,10 @@ test_change_stream_live_track_resume_token (void *test_ctx)
    ASSERT (bson_compare (resume_token, &doc1_rt) != 0);
    bson_copy_to (resume_token, &doc2_rt);
 
-   /* There are no docs left. But the next call should still keep the same
-    * resume token */
+   /* There are no docs left. */
    ASSERT (!mongoc_change_stream_next (stream, &next_doc));
    ASSERT_OR_PRINT (!mongoc_change_stream_error_document (stream, &error, NULL), error);
    ASSERT (!next_doc);
-   resume_token = mongoc_change_stream_get_resume_token (stream);
-   ASSERT (!bson_empty0 (resume_token));
-   ASSERT (bson_compare (resume_token, &doc2_rt) == 0);
 
    bson_destroy (&doc0_rt);
    bson_destroy (&doc1_rt);


### PR DESCRIPTION
# Summary

- Use majority write concern to insert documents in test `/change_stream/batchSize0`.
- Remove faulty assert in `/change_stream/live/track_resume_token`.

# Background & Motivation

Using majority write concern is intended to address this [observed test failure](https://parsley.mongodb.com/evergreen/mongo_c_driver_latest_release_sasl_matrix_nossl_sasl_off_nossl_debian10_gcc_test_4.2_replica_noauth_d79a0bd931e7de88af7e4eeb877421f853ca5bf1_25_04_02_19_28_33/0/task?bookmarks=0,3082&selectedLineRange=L2098), which receives only one of two expected events.

The faulty assert removal follows https://github.com/mongodb/mongo-cxx-driver/pull/1367, which made a similar change in the C++ driver test runner. I suspect the C++ tests were based off of the C driver tests.