### PR TITLE
Revert "Temporarily relocate sbom task from rhel80 to rhel8.8 (#1981)"

### DIFF
--- a/.evergreen/config_generator/components/sbom.py
+++ b/.evergreen/config_generator/components/sbom.py
@@ -96,7 +96,7 @@ def functions():
 
 
 def tasks():
-    distro_name = 'rhel8.8'
+    distro_name = 'rhel80'
     distro = find_small_distro(distro_name)
 
     yield EvgTask(

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -63,8 +63,6 @@ MACOS_ARM64_DISTROS = [
 ]
 
 RHEL_DISTROS = [
-    *ls_distro(name='rhel8.8', os='rhel', os_type='linux', os_ver='8.8'),
-
     *ls_distro(name='rhel76', os='rhel', os_type='linux', os_ver='7.6'),
     *ls_distro(name='rhel80', os='rhel', os_type='linux', os_ver='8.0'),
     *ls_distro(name='rhel84', os='rhel', os_type='linux', os_ver='8.4'),

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -4897,8 +4897,8 @@ tasks:
       - func: run-simple-http-server
       - func: run-tests
   - name: sbom
-    run_on: rhel8.8-small
-    tags: [sbom, rhel8.8]
+    run_on: rhel80-small
+    tags: [sbom, rhel80]
     commands:
       - func: sbom
   - name: scan-build-macos-14-arm64-clang


### PR DESCRIPTION
The issues motivating https://github.com/mongodb/mongo-c-driver/pull/1981 have been addressed by [DEVPROD-16404](https://jira.mongodb.org/browse/DEVPROD-16404). Verified by [this patch](https://spruce.mongodb.com/version/67eec1ffedd634000745ceb2/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).