### PR TITLE
Format test-mongoc-change-stream.c

### DIFF
--- a/src/libmongoc/tests/test-mongoc-change-stream.c
+++ b/src/libmongoc/tests/test-mongoc-change-stream.c
@@ -1165,7 +1165,10 @@ typedef struct {
    bson_t agg_reply;
 } resume_ctx_t;
 
-#define RESUME_INITIALIZER {false, false, BSON_INITIALIZER}
+#define RESUME_INITIALIZER           \
+   {                                 \
+      false, false, BSON_INITIALIZER \
+   }
 
 static void
 _resume_at_optime_started (const mongoc_apm_command_started_t *event)


### PR DESCRIPTION
Addresses ongoing lint task failure on the r1.30 branch following https://github.com/mongodb/mongo-c-driver/pull/1980.