### PR TITLE
[CDRIVER-5391] Backport 2.x CMake Package Names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,8 +293,21 @@ if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif ()
 
 include (InstallRequiredSystemLibraries)
-include (GNUInstallDirs)
 include (CMakeDependentOption)
+
+# Installation paths
+include (GNUInstallDirs)
+# The directory where CMake config packages will be installed, based on the libdir from GNUInstallDirs
+mongo_setting(
+   MONGOC_INSTALL_CMAKEDIR "The directory in which CMake package files will be installed"
+   TYPE STRING
+   DEFAULT VALUE "${CMAKE_INSTALL_LIBDIR}/cmake"
+   VALIDATE CODE [[
+      if(IS_ABSOLUTE "${MONGOC_INSTALL_CMAKEDIR}")
+         message(SEND_ERROR "The CMake installation directory must be a relative path (Got “${MONGOC_INSTALL_CMAKEDIR}”)")
+      endif()
+   ]]
+)
 
 include(MongoC-Warnings)
 
@@ -372,6 +385,7 @@ set (BUILD_SOURCE_DIR ${CMAKE_BINARY_DIR})
 include (CTest)
 if (BUILD_TESTING)
    include (TestFixtures)
+   include (src/libmongoc/tests/import-tests.cmake)
 endif ()
 
 # Ensure the default behavior: don't ignore RPATH settings.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,12 +299,12 @@ include (CMakeDependentOption)
 include (GNUInstallDirs)
 # The directory where CMake config packages will be installed, based on the libdir from GNUInstallDirs
 mongo_setting(
-   MONGOC_INSTALL_CMAKEDIR "The directory in which CMake package files will be installed"
+   MONGO_C_DRIVER_INSTALL_CMAKEDIR "The directory in which CMake package files will be installed"
    TYPE STRING
    DEFAULT VALUE "${CMAKE_INSTALL_LIBDIR}/cmake"
    VALIDATE CODE [[
-      if(IS_ABSOLUTE "${MONGOC_INSTALL_CMAKEDIR}")
-         message(SEND_ERROR "The CMake installation directory must be a relative path (Got “${MONGOC_INSTALL_CMAKEDIR}”)")
+      if(IS_ABSOLUTE "${MONGO_C_DRIVER_INSTALL_CMAKEDIR}")
+         message(SEND_ERROR "The CMake installation directory must be a relative path (Got “${MONGO_C_DRIVER_INSTALL_CMAKEDIR}”)")
       endif()
    ]]
 )

--- a/Earthfile
+++ b/Earthfile
@@ -1,5 +1,5 @@
 VERSION --arg-scope-and-set --pass-args 0.7
-LOCALLY
+FROM alpine:3.21
 
 IMPORT ./tools/ AS tools
 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,24 @@
+libmongoc 1.x (Unreleased)
+==========================
+
+New Features:
+
+* In anticipation of the 2.0 release of mongo-c-driver, new CMake packages and
+  imported targets have been defined (for both `bson` and `mongoc`). To import
+  `mongoc` with the new names, call `find_package` for the `mongoc` package. The
+  new imported targets are named `mongoc::static`, `mongoc::shared`, and
+  `mongoc::mongoc` (which points to either the static or the shared library,
+  depending on an import-time configuration option).
+
+  The new package and target names will remain unchanged when upgrading to the
+  2.0 release, allowing consumers to support both major versions without
+  modifying their CMake project. The current imported target names will be
+  removed from the 2.0 release, and should not be used for
+  forward-compatibility.
+
+  Programs that link to BSON libraries directly should also use the new target
+  names `bson::static`, `bson::shared`, or `bson::bson`.
+
 libmongoc 1.30.2
 ================
 

--- a/build/cmake/GeneratePkgConfig.cmake
+++ b/build/cmake/GeneratePkgConfig.cmake
@@ -225,7 +225,8 @@ function(mongo_generate_pkg_config target)
             file(READ [[@gx_tmpfile@]] content)
             # Insert the install prefix:
             string(REPLACE "%INSTALL_PLACEHOLDER%" "${CMAKE_INSTALL_PREFIX}" content "${content}")
-            # Write it before installing again:
+            # Write it before installing again. Lock the file to sync with parallel installs.
+            file(LOCK [[@inst_tmp@.lock]] GUARD PROCESS)
             file(WRITE [[@inst_tmp@]] "${content}")
         >
         $<$<NOT:@gx_cond@>:

--- a/build/cmake/GenerateUninstaller.cmake
+++ b/build/cmake/GenerateUninstaller.cmake
@@ -60,6 +60,8 @@ if(NOT DEFINED UNINSTALL_WRITE_FILE)
     message(FATAL_ERROR "Expected a variable “UNINSTALL_WRITE_FILE” to be defined")
 endif()
 
+# Lock the uninstall file to synchronize with parallel install processes.
+file(LOCK "${UNINSTALL_WRITE_FILE}.lock" GUARD PROCESS RESULT_VARIABLE lockres)
 # Clear out the uninstall script before we begin writing:
 file(WRITE "${UNINSTALL_WRITE_FILE}" "")
 

--- a/build/cmake/LoadTests.cmake
+++ b/build/cmake/LoadTests.cmake
@@ -52,5 +52,8 @@ foreach (line IN LISTS lines)
         TIMEOUT 45
         FIXTURES_REQUIRED "${all_fixtures}"
         ENVIRONMENT "${all_env}"
+        # Mark all tests generated from the executable, so they can be (de)selected
+        # for execution separately.
+        LABELS "test-libmongoc-generated"
         )
 endforeach ()

--- a/build/cmake/TestFixtures.cmake
+++ b/build/cmake/TestFixtures.cmake
@@ -11,7 +11,7 @@ set (_MONGOC_PROC_CTL_COMMAND "$<TARGET_FILE:Python3::Interpreter>" -u -- "${_MO
 
 function (mongo_define_subprocess_fixture name)
     cmake_parse_arguments(PARSE_ARGV 1 ARG "" "SPAWN_WAIT;STOP_WAIT;WORKING_DIRECTORY" "COMMAND")
-    string (MAKE_C_IDENTIFIER ident "${name}")
+    string (MAKE_C_IDENTIFIER "${name}" ident)
     if (NOT ARG_SPAWN_WAIT)
         set (ARG_SPAWN_WAIT 1)
     endif ()
@@ -40,7 +40,7 @@ endfunction ()
 
 # Create a fixture that runs a fake Azure IMDS server
 mongo_define_subprocess_fixture(
-    mongoc/fixtures/fake_imds
+    mongoc/fixtures/fake_kms_provider_server
     SPAWN_WAIT 1
     COMMAND
         "$<TARGET_FILE:Python3::Interpreter>" -u --

--- a/build/cmake/TestProject.cmake
+++ b/build/cmake/TestProject.cmake
@@ -1,0 +1,261 @@
+#[[
+Add a CMake test that configures, builds, and tests a CMake project.
+
+    add_test_cmake_project(
+        <name> <path>
+        [INSTALL_PARENT]
+        [BUILD_DIR <dir>]
+        [GENERATOR <gen>]
+        [CONFIG <config>]
+        [PASSTHRU_VARS ...]
+        [PASSTHRU_VARS_REGEX <regex>]
+        [CONFIGURE_ARGS ...]
+        [SETTINGS ...]
+    )
+
+The generated test will run CMake configure on the project at `<path>` (which
+is resolved relative to the caller's source directory).
+
+If INSTALL_PARENT is specified, then the host CMake project will be installed to a
+temporary prefix, and that prefix will be passed along with CMAKE_PREFIX_PATH
+when the test project is configured.
+
+PASSTHRU_VARS is a list of CMake variables visible in the current scope that should
+be made visible to the subproject with the same name and value. PASSTHRU_VARS_REGEX
+takes a single regular expression. Any variables currently defined which match
+the regex will be passed through as-if they were specified with PASSTHRU_VARS.
+
+SETTINGS is list of a `[name]=[value]` strings for additional `-D` arguments to
+pass to the sub-project. List arguments *are* supported.
+
+If CONFIG is unspecified, then the generated test will configure+build the project
+according to the configuration of CTest (passed with the `-C` argument).
+
+The default for GENERATOR is to use the same generator as the host project.
+
+The default BUILD_DIR will be a temporary directory that will be automatically
+deleted at the start of each test to ensure a fresh configure+build cycle.
+
+Additional Variables
+####################
+
+In addition to the variables specified explicitly in the call, all variables
+with the suffix `_PATH` or `_DIR` will be passed to the sub-project with
+`HOST_PROJECT_` prepended. For example, CMAKE_SOURCE_DIR will be passed to
+the sub-project as HOST_PROJECT_CMAKE_SOURCE_DIR
+]]
+function(add_test_cmake_project name path)
+    # Logging context
+    list(APPEND CMAKE_MESSAGE_CONTEXT "${CMAKE_CURRENT_FUNCTION}")
+
+    # Parse command arguments:
+    set(options INSTALL_PARENT)
+    set(args BUILD_DIR GENERATOR CONFIG PASSTHRU_VARS_REGEX)
+    set(list_args SETTINGS PASSTHRU_VARS CONFIGURE_ARGS)
+    cmake_parse_arguments(PARSE_ARGV 2 _tp_arg "${options}" "${args}" "${list_args}")
+    foreach(unknown IN LISTS _tp_arg_UNPARSED_ARGUMENTS)
+        message(SEND_ERROR "Unknown argument: “${unknown}”")
+    endforeach()
+    if(_tp_arg_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "Bad arguments (see above)")
+    endif()
+
+    # Default values:
+    if(NOT DEFINED _tp_arg_BUILD_DIR)
+        set(dirname "${name}")
+        if(WIN32)
+            # Escape specials
+            string(REPLACE "%" "%25" dirname "${dirname}")
+            string(REPLACE ":" "%3A" dirname "${dirname}")
+            string(REPLACE "?" "%3F" dirname "${dirname}")
+            string(REPLACE "*" "%2A" dirname "${dirname}")
+            string(REPLACE "\"" "%22" dirname "${dirname}")
+            string(REPLACE "\\" "%5C" dirname "${dirname}")
+            string(REPLACE "<" "%3C" dirname "${dirname}")
+            string(REPLACE ">" "%3E" dirname "${dirname}")
+            string(REPLACE "|" "%7C" dirname "${dirname}")
+        endif()
+        set(_tp_arg_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/TestProject/${dirname}")
+    endif()
+    if(NOT DEFINED _tp_arg_GENERATOR)
+        set(_tp_arg_GENERATOR "${CMAKE_GENERATOR}")
+    endif()
+    # Normalize paths
+    if(NOT IS_ABSOLUTE "${_tp_arg_BUILD_DIR}")
+        set(_tp_arg_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/${_tp_arg_BUILD_DIR}")
+    endif()
+    get_filename_component(path "${path}" ABSOLUTE)
+    message(VERBOSE "Add test project [${path}]")
+
+    # Arguments that will be given during the CMake configure step:
+    string(REPLACE ";" $<SEMICOLON> configure_args "${_tp_arg_CONFIGURE_ARGS}")
+
+    # Build the argument lists that will be passed-through to project configuration -D flags:
+    set(settings_passthru)
+
+    # Pass through all _DIR and _PATH variables with a HOST_PROJECT_ prefix:
+    get_directory_property(fwd_path_vars VARIABLES)
+    list(FILTER fwd_path_vars INCLUDE REGEX "_DIR$|_PATH$")
+    list(FILTER fwd_path_vars EXCLUDE REGEX "^_")
+    list(SORT   fwd_path_vars CASE INSENSITIVE)
+    set(dir_passthrough)
+    foreach(var IN LISTS fwd_path_vars)
+        string(REPLACE ";" $<SEMICOLON> value "${${var}}")
+        list(APPEND settings_passthru "HOST_PROJECT_${var}=${value}")
+    endforeach()
+
+    # Pass through other variables without a prefix:
+    set(passthru_vars "${_tp_arg_PASSTHRU_VARS}")
+    # Some platform variables should always go through:
+    list(APPEND passthru_vars
+        CMAKE_C_COMPILER
+        CMAKE_CXX_COMPILER
+    )
+    if(DEFINED _tp_arg_PASSTHRU_VARS_REGEX)
+        # Pass through variables matching a certain pattern:
+        get_directory_property(fwd_vars VARIABLES)
+        list(FILTER fwd_vars INCLUDE REGEX "${_tp_arg_PASSTHRU_VARS_REGEX}")
+        list(APPEND passthru_vars "${fwd_vars}")
+    endif()
+
+    # Pass through all variables that we've marked to be forwarded
+    foreach(var IN LISTS passthru_vars)
+        string(REPLACE ";" $<SEMICOLON> value "${${var}}")
+        list(APPEND settings_passthru "${var}=${value}")
+    endforeach()
+
+    # Settings set with SETTINGS
+    list(TRANSFORM _tp_arg_SETTINGS REPLACE ";" $<SEMICOLON> OUTPUT_VARIABLE settings_escaped)
+    list(APPEND settings_passthru ${settings_escaped})
+
+    # Add a prefix to each variable to mark it as a pass-thru variable:
+    list(TRANSFORM settings_passthru PREPEND "-D;TEST_PROJECT_SETTINGS/")
+
+    # Generate the test case:
+    add_test(
+        NAME "${name}"
+        COMMAND ${CMAKE_COMMAND}
+            --log-context
+            -D "TEST_PROJECT_NAME=${name}"
+            -D "TEST_PROJECT_PARENT_BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}"
+            -D "TEST_PROJECT_SOURCE_DIR=${path}"
+            -D "TEST_PROJECT_BINARY_DIR=${_tp_arg_BUILD_DIR}"
+            -D "TEST_PROJECT_GENERATOR=${_tp_arg_GENERATOR}"
+            -D TEST_PROJECT_INSTALL_PARENT=${_tp_arg_INSTALL_PARENT}
+            -D "TEST_PROJECT_CONFIGURE_ARGS=${_tp_arg_CONFIGURE_ARGS}"
+            -D "TEST_PROJECT_CONFIG=$<CONFIG>"
+            ${settings_passthru}
+            -D __test_project_run=1
+            -P "${CMAKE_CURRENT_FUNCTION_LIST_FILE}"
+    )
+endfunction()
+
+# This function implements the actual test.
+function(__do_test_project)
+    list(APPEND CMAKE_MESSAGE_CONTEXT "TestProject Execution")
+    cmake_path(ABSOLUTE_PATH TEST_PROJECT_SOURCE_DIR NORMALIZE OUTPUT_VARIABLE src_dir)
+    cmake_path(ABSOLUTE_PATH TEST_PROJECT_BINARY_DIR NORMALIZE OUTPUT_VARIABLE bin_dir)
+
+    string(MD5 test_name_hash "${TEST_PROJECT_NAME}")
+    set(tmp_install_prefix "${TEST_PROJECT_PARENT_BINARY_DIR}/TestProject-install/${test_name_hash}")
+    file(REMOVE_RECURSE "${tmp_install_prefix}")
+    list(APPEND TEST_PROJECT_SETTINGS/CMAKE_INSTALL_PREFIX "${tmp_install_prefix}")
+
+    if(TEST_PROJECT_INSTALL_PARENT)
+        cmake_path(ABSOLUTE_PATH tmp_install_prefix NORMALIZE)
+        message(STATUS "Installing parent project into [${tmp_install_prefix}]")
+        execute_process(
+            COMMAND ${CMAKE_COMMAND}
+                --install "${TEST_PROJECT_PARENT_BINARY_DIR}"
+                --prefix "${tmp_install_prefix}"
+                --config "${TEST_PROJECT_CONFIG}"
+            COMMAND_ERROR_IS_FATAL LAST
+        )
+    endif()
+    message(STATUS "Project source dir: [${src_dir}]")
+    message(STATUS "Project build dir: [${bin_dir}]")
+    message(STATUS "Deleting build directory …")
+    file(REMOVE_RECURSE "${bin_dir}")
+    file(MAKE_DIRECTORY "${bin_dir}")
+
+    # Grab settings passed-through from the parent project:
+    get_directory_property(vars VARIABLES)
+    set(fwd_settings)
+    list(FILTER vars INCLUDE REGEX "^TEST_PROJECT_SETTINGS/")
+    if(vars)
+        message(STATUS "Configuration settings:")
+    endif()
+    foreach(var IN LISTS vars)
+        set(value "${${var}}")
+        # Remove our prefix
+        string(REGEX REPLACE "^TEST_PROJECT_SETTINGS/" "" varname "${var}")
+        # Print the value we received for debugging purposes
+        message(STATUS "  • ${varname}=${value}")
+        # Escape nested lists
+        string(REPLACE ";" "\\;" value "${value}")
+        list(APPEND fwd_settings -D "${varname}=${value}")
+    endforeach()
+
+    message(STATUS "Configuring project [${src_dir}] …")
+    set(config_log "${bin_dir}/TestProject-configure.log")
+    message(STATUS "CMake configure output will be written to [${config_log}]")
+    execute_process(
+        COMMAND_ECHO STDERR
+        WORKING_DIRECTORY "${bin_dir}"
+        RESULT_VARIABLE retc
+        OUTPUT_VARIABLE output
+        ERROR_VARIABLE output
+        ECHO_OUTPUT_VARIABLE
+        ECHO_ERROR_VARIABLE
+        COMMAND ${CMAKE_COMMAND}
+            -S "${src_dir}"
+            -B "${bin_dir}"
+            -G "${TEST_PROJECT_GENERATOR}"
+            -D "CMAKE_BUILD_TYPE=${TEST_PROJECT_BUILD_TYPE}"
+            --no-warn-unused-cli
+            --log-context
+            --log-level=debug
+            ${fwd_settings}
+            ${TEST_PROJECT_CONFIGURE_ARGS}
+    )
+    file(WRITE "${config_log}" "${output}")
+    if(retc)
+        message(FATAL_ERROR "Configure subcommand failed [${retc}]")
+    endif()
+    message(STATUS "CMake configure completed")
+
+    set(build_log "${bin_dir}/TestProject-build.log")
+    message(STATUS "Build output will be written to [${build_log}]")
+    message(STATUS "Building configured project [${bin_dir}] …")
+    execute_process(
+        COMMAND_ECHO STDERR
+        WORKING_DIRECTORY "${bin_dir}"
+        RESULT_VARIABLE retc
+        OUTPUT_VARIABLE out
+        ERROR_VARIABLE out
+        ECHO_OUTPUT_VARIABLE
+        ECHO_ERROR_VARIABLE
+        COMMAND ${CMAKE_COMMAND}
+            --build "${bin_dir}"
+            --config "${TEST_PROJECT_CONFIG}"
+    )
+    file(WRITE "${build_log}" "${output}")
+    if(retc)
+        message(FATAL_ERROR "Project build failed [${retc}]")
+    endif()
+    message(STATUS "Project build completed")
+
+    execute_process(
+        COMMAND ${CMAKE_CTEST_COMMAND}
+            -T Start -T Test
+            -C "${TEST_PROJECT_CONFIG}"
+            --output-on-failure
+        WORKING_DIRECTORY "${bin_dir}"
+        COMMAND_ERROR_IS_FATAL LAST
+    )
+endfunction()
+
+if(__test_project_run)
+    cmake_minimum_required(VERSION 3.20)  # cmake_path/execute_process
+    __do_test_project()
+endif()

--- a/build/cmake/packageConfigVersion.cmake.in
+++ b/build/cmake/packageConfigVersion.cmake.in
@@ -1,0 +1,58 @@
+#[[
+    This package version check file is based on the one that ships with CMake,
+    but supports version ranges that span major versions, while also doing
+    SameMajorVersion matching when a non-range is specified.
+]]
+set(PACKAGE_VERSION "@PROJECT_VERSION@")
+set(__package_version_major "@PROJECT_VERSION_MAJOR@")
+
+# Announce that we are incompatible unless some condition below is satisfied
+set(PACKAGE_VERSION_COMPATIBLE FALSE)
+
+if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
+    # The find_package() requested a version that is at least newer than our own version
+    # Not compatible
+elseif(NOT DEFINED PACKAGE_FIND_VERSION_RANGE)
+    # A simple version check (no range)
+    if(PACKAGE_FIND_VERSION_MAJOR EQUAL __package_version_major)
+        # We are the same major version. Okay!
+        set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    endif()
+    if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
+        # We are an exact match to the requested version
+        set(PACKAGE_VERSION_EXACT TRUE)
+    endif()
+elseif(PACKAGE_VERSION VERSION_GREATER PACKAGE_FIND_VERSION_MAX)
+    # Package is newer than the range max (we already checked the range min)
+    # Not compatible
+else()
+    # We are doing a version range check and our version is within the
+    # requested inclusive range. Set compatible, but we may be incompatible if we are
+    # an exclusive range:
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    # Check whether the range endpoints are compatible:
+    if(PACKAGE_VERSION VERSION_EQUAL PACKAGE_FIND_VERSION_MAX
+            AND PACKAGE_FIND_VERSION_RANGE_MAX STREQUAL "EXCLUDE")
+        # The upper version is excluded from compatibility
+        set(PACKAGE_VERSION_COMPATIBLE FALSE)
+    elseif(PACKAGE_VERSION VERSION_EQUAL PACKAGE_FIND_VERSION_MIN
+            AND PACKAGE_FIND_VERSION_RANGE_MIN STREQUAL "EXCLUDE")
+        # The lower version is excluded from the range
+        set(PACKAGE_VERSION_COMPATIBLE FALSE)
+    endif()
+endif()
+
+# Check if pointer sizes match (this is relevant e.g. if we are a 32-bit build and
+# CMake is building for 64-bit)
+if(CMAKE_SIZEOF_VOID_P STREQUAL "" OR "@CMAKE_SIZEOF_VOID_P@" STREQUAL "")
+    # Unknown pointer size. Don't check
+    return()
+endif()
+# Check:
+if(NOT CMAKE_SIZEOF_VOID_P STREQUAL "@CMAKE_SIZEOF_VOID_P@")
+    math(EXPR bits "@CMAKE_SIZEOF_VOID_P@ * 8")
+    # Announce the bitness of this package for diagnostics:
+    set(PACKAGE_VERSION "${PACKAGE_VERSION} (${bits}bit)")
+    # This package is unsuitable, regardless of version requested in the importer
+    set(PACKAGE_VERSION_UNSUITABLE TRUE)
+endif()

--- a/src/libbson/CMakeLists.txt
+++ b/src/libbson/CMakeLists.txt
@@ -401,6 +401,17 @@ install (EXPORT bson-targets
    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/bson-${BSON_API_VERSION}
 )
 
+set(bson_cmake_prefix "${MONGOC_INSTALL_CMAKEDIR}/bson-${PROJECT_VERSION}")
+configure_file(
+   ${mongo-c-driver_SOURCE_DIR}/build/cmake/packageConfigVersion.cmake.in
+   bsonConfigVersion.cmake
+   @ONLY
+)
+install(
+   FILES etc/bsonConfig.cmake "${CMAKE_CURRENT_BINARY_DIR}/bsonConfigVersion.cmake"
+   DESTINATION "${bson_cmake_prefix}"
+)
+
 include (LegacyPackage)
 include (CPack)
 

--- a/src/libbson/CMakeLists.txt
+++ b/src/libbson/CMakeLists.txt
@@ -401,7 +401,7 @@ install (EXPORT bson-targets
    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/bson-${BSON_API_VERSION}
 )
 
-set(bson_cmake_prefix "${MONGOC_INSTALL_CMAKEDIR}/bson-${PROJECT_VERSION}")
+set(bson_cmake_prefix "${MONGO_C_DRIVER_INSTALL_CMAKEDIR}/bson-${PROJECT_VERSION}")
 configure_file(
    ${mongo-c-driver_SOURCE_DIR}/build/cmake/packageConfigVersion.cmake.in
    bsonConfigVersion.cmake

--- a/src/libbson/NEWS
+++ b/src/libbson/NEWS
@@ -1,3 +1,21 @@
+libbson 1.x (Unreleased)
+========================
+
+New Features:
+
+* In anticipation of the 2.0 release of mongo-c-driver, new CMake packages and
+  imported targets have been defined (for both `bson` and `mongoc`). To import
+  `bson` with the new names, call `find_package` for the `bson` package. The new
+  imported targets are named `bson::static`, `bson::shared`, and `bson::bson`
+  (which points to either the static or the shared library, depending on an
+  import-time configuration option).
+
+  The new package and target names will remain unchanged when upgrading to the
+  2.0 release, allowing consumers to support both major versions without
+  modifying their CMake project. The current imported target names will be
+  removed from the 2.0 release, and should not be used for
+  forward-compatibility.
+
 libbson 1.30.2
 ==============
 

--- a/src/libbson/etc/bsonConfig.cmake
+++ b/src/libbson/etc/bsonConfig.cmake
@@ -1,0 +1,65 @@
+#[[
+    This is a transitional CMake package config file to allow compatibility
+    between libbson 1.x and libbson 2.x CMake packages.
+
+    When distributed with libbson 1.x, this file is mostly just a shim for
+    the `bson-1.0` CMake packages.
+
+    This file imports "bson-1.0" and generates alias targets for it:
+
+    • `bson::shared` → `mongo::bson_shared`
+    • `bson::static` → `mongo::bson_static`
+    • `bson::bson` → Points to either `bson::shared` or `bson::static`,
+        controlled by `BSON_DEFAULT_IMPORTED_LIBRARY_TYPE`
+]]
+
+# Check for missing components before proceeding. We don't provide any, so we
+# should generate an error if the caller requests any *required* components.
+set(missing_required_components)
+foreach(comp IN LISTS bson_FIND_COMPONENTS)
+    if(bson_FIND_REQUIRED_${comp})
+        list(APPEND missing_required_components "${comp}")
+    endif()
+endforeach()
+
+if(missing_required_components)
+    list(JOIN missing_required_components ", " components)
+    set(bson_FOUND FALSE)
+    set(bson_NOT_FOUND_MESSAGE "The package version is compatible, but is missing required components: ${components}")
+    # Stop now. Don't generate any imported targets
+    return()
+endif()
+
+include(CMakeFindDependencyMacro)
+
+# We are installed alongside the `bson-1.0` packages. Forcibly prevent find_package
+# from considering any other `bson-1.0` package that might live elsewhere on the system
+# by setting HINTS and NO_DEFAULT_PATH
+get_filename_component(parent_dir "${CMAKE_CURRENT_LIST_DIR}" DIRECTORY)
+find_dependency(bson-1.0 HINTS ${parent_dir} NO_DEFAULT_PATH)
+
+# The library type that is linked with `bson::bson`
+set(_default_lib_type)
+# Add compat targets for the bson-1.0 package targets
+if(TARGET mongo::bson_shared AND NOT TARGET bson::shared)
+    add_library(bson::shared IMPORTED INTERFACE)
+    set_property(TARGET bson::shared APPEND PROPERTY INTERFACE_LINK_LIBRARIES mongo::bson_shared)
+    set(_default_lib_type SHARED)
+endif()
+if(TARGET mongo::bson_static AND NOT TARGET bson::static)
+    add_library(bson::static IMPORTED INTERFACE)
+    set_property(TARGET bson::static APPEND PROPERTY INTERFACE_LINK_LIBRARIES mongo::bson_static)
+    # If static is available, set it as the default library type
+    set(_default_lib_type STATIC)
+endif()
+
+# Allow the user to tweak what library type is linked for `bson::bson`
+set(BSON_DEFAULT_IMPORTED_LIBRARY_TYPE "${_default_lib_type}"
+    CACHE STRING "The default library type that is used when linking against 'bson::bson' (either SHARED or STATIC, requires that the package was built with the appropriate library type)")
+set_property(CACHE BSON_DEFAULT_IMPORTED_LIBRARY_TYPE PROPERTY STRINGS SHARED STATIC)
+
+if(NOT TARGET bson::bson)  # Don't redefine the target if we were already included
+    string(TOLOWER "${BSON_DEFAULT_IMPORTED_LIBRARY_TYPE}" _type)
+    add_library(bson::bson IMPORTED INTERFACE)
+    set_property(TARGET bson::bson APPEND PROPERTY INTERFACE_LINK_LIBRARIES bson::${_type})
+endif()

--- a/src/libbson/examples/cmake/find_package/CMakeLists.txt
+++ b/src/libbson/examples/cmake/find_package/CMakeLists.txt
@@ -24,8 +24,8 @@ project (hello_bson LANGUAGES C)
 # building libbson.
 # -- sphinx-include-start --
 # Specify the minimum version you require.
-find_package (bson-1.0 1.7 REQUIRED)
+find_package (bson 1.7 REQUIRED)
 
 # The "hello_bson.c" sample program is shared among four tests.
 add_executable (hello_bson ../../hello_bson.c)
-target_link_libraries (hello_bson PRIVATE mongo::bson_shared)
+target_link_libraries (hello_bson PRIVATE bson::bson)

--- a/src/libbson/examples/cmake/find_package_static/CMakeLists.txt
+++ b/src/libbson/examples/cmake/find_package_static/CMakeLists.txt
@@ -24,8 +24,8 @@ project (hello_bson LANGUAGES C)
 # building libbson.
 # -- sphinx-include-start --
 # Specify the minimum version you require.
-find_package (bson-1.0 1.7 REQUIRED)
+find_package (bson 1.7 REQUIRED)
 
 # The "hello_bson.c" sample program is shared among four tests.
 add_executable (hello_bson ../../hello_bson.c)
-target_link_libraries (hello_bson PRIVATE mongo::bson_static)
+target_link_libraries (hello_bson PRIVATE bson::static)

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -1469,7 +1469,7 @@ install (
       Devel
 )
 
-set(mongoc_cmake_prefix "${MONGOC_INSTALL_CMAKEDIR}/mongoc-${PROJECT_VERSION}")
+set(mongoc_cmake_prefix "${MONGO_C_DRIVER_INSTALL_CMAKEDIR}/mongoc-${PROJECT_VERSION}")
 configure_file(
    ${mongo-c-driver_SOURCE_DIR}/build/cmake/packageConfigVersion.cmake.in
    mongocConfigVersion.cmake

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -1469,6 +1469,17 @@ install (
       Devel
 )
 
+set(mongoc_cmake_prefix "${MONGOC_INSTALL_CMAKEDIR}/mongoc-${PROJECT_VERSION}")
+configure_file(
+   ${mongo-c-driver_SOURCE_DIR}/build/cmake/packageConfigVersion.cmake.in
+   mongocConfigVersion.cmake
+   @ONLY
+)
+install(
+   FILES etc/mongocConfig.cmake "${CMAKE_CURRENT_BINARY_DIR}/mongocConfigVersion.cmake"
+   DESTINATION "${mongoc_cmake_prefix}"
+)
+
 include (LegacyPackage)
 
 if (ENABLE_MAN_PAGES STREQUAL ON OR ENABLE_HTML_DOCS STREQUAL ON)

--- a/src/libmongoc/etc/mongocConfig.cmake
+++ b/src/libmongoc/etc/mongocConfig.cmake
@@ -1,0 +1,67 @@
+#[[
+    This is a transitional CMake package config file to allow compatibility
+    between libmongoc 1.x and libmongoc 2.x CMake packages.
+
+    When distributed with libmongoc 1.x, this file is mostly just a shim for
+    the `mongoc-1.0` CMake packages.
+
+    This file imports "mongoc-1.0" and generates alias targets for it:
+
+    • `mongoc::shared` → `mongo::mongoc_shared`
+    • `mongoc::static` → `mongo::mongoc_static`
+    • `mongoc::mongoc` → Points to either `mongoc::shared` or `mongoc::static`,
+        controlled by `MONGOC_DEFAULT_IMPORTED_LIBRARY_TYPE`
+]]
+
+# Check for missing components before proceeding. We don't provide any, so we
+# should generate an error if the caller requests any *required* components.
+set(missing_required_components)
+foreach(comp IN LISTS mongoc_FIND_COMPONENTS)
+    if(mongoc_FIND_REQUIRED_${comp})
+        list(APPEND missing_required_components "${comp}")
+    endif()
+endforeach()
+
+if(missing_required_components)
+    list(JOIN missing_required_components ", " components)
+    set(mongoc_FOUND FALSE)
+    set(mongoc_NOT_FOUND_MESSAGE "The package version is compatible, but is missing required components: ${components}")
+    # Stop now. Don't generate any imported targets
+    return()
+endif()
+
+include(CMakeFindDependencyMacro)
+
+# We are installed alongside the `mongoc-1.0` packages. Forcibly prevent find_package
+# from considering any other `mongoc-1.0` package that might live elsewhere on the system
+# by setting HINTS and NO_DEFAULT_PATH
+get_filename_component(parent_dir "${CMAKE_CURRENT_LIST_DIR}" DIRECTORY)
+find_dependency(mongoc-1.0 HINTS ${parent_dir} NO_DEFAULT_PATH)
+# Also import the `bson` package, to ensure its targets are also available
+find_dependency(bson ${mongoc_FIND_VERSION} HINTS ${parent_dir} NO_DEFAULT_PATH)
+
+# The library type that is linked with `mongoc::mongoc`
+set(_default_lib_type)
+# Add compat targets for the mongoc-1.0 package targets
+if(TARGET mongo::mongoc_shared AND NOT TARGET mongoc::shared)
+    add_library(mongoc::shared IMPORTED INTERFACE)
+    set_property(TARGET mongoc::shared APPEND PROPERTY INTERFACE_LINK_LIBRARIES mongo::mongoc_shared)
+    set(_default_lib_type SHARED)
+endif()
+if(TARGET mongo::mongoc_static AND NOT TARGET mongoc::static)
+    add_library(mongoc::static IMPORTED INTERFACE)
+    set_property(TARGET mongoc::static APPEND PROPERTY INTERFACE_LINK_LIBRARIES mongo::mongoc_static)
+    # If static is available, set it as the default library type
+    set(_default_lib_type STATIC)
+endif()
+
+# Allow the user to tweak what library type is linked for `mongoc::mongoc`
+set(MONGOC_DEFAULT_IMPORTED_LIBRARY_TYPE "${_default_lib_type}"
+    CACHE STRING "The default library type that is used when linking against 'mongoc::mongoc' (either SHARED or STATIC, requires that the package was built with the appropriate library type)")
+set_property(CACHE MONGOC_DEFAULT_IMPORTED_LIBRARY_TYPE PROPERTY STRINGS SHARED STATIC)
+
+if(NOT TARGET mongoc::mongoc)  # Don't redefine the target if we were already included
+    string(TOLOWER "${MONGOC_DEFAULT_IMPORTED_LIBRARY_TYPE}" _type)
+    add_library(mongoc::mongoc IMPORTED INTERFACE)
+    set_property(TARGET mongoc::mongoc APPEND PROPERTY INTERFACE_LINK_LIBRARIES mongoc::${_type})
+endif()

--- a/src/libmongoc/examples/cmake/find_package/CMakeLists.txt
+++ b/src/libmongoc/examples/cmake/find_package/CMakeLists.txt
@@ -24,8 +24,8 @@ project (hello_mongoc LANGUAGES C)
 # building libmongoc.
 # -- sphinx-include-start --
 # Specify the minimum version you require.
-find_package (mongoc-1.0 1.7 REQUIRED)
+find_package (mongoc 1.7 REQUIRED)
 
 # The "hello_mongoc.c" sample program is shared among four tests.
 add_executable (hello_mongoc ../../hello_mongoc.c)
-target_link_libraries (hello_mongoc PRIVATE mongo::mongoc_shared)
+target_link_libraries (hello_mongoc PRIVATE mongoc::mongoc)

--- a/src/libmongoc/examples/cmake/find_package_static/CMakeLists.txt
+++ b/src/libmongoc/examples/cmake/find_package_static/CMakeLists.txt
@@ -24,8 +24,8 @@ project (hello_mongoc LANGUAGES C)
 # building libmongoc.
 # -- sphinx-include-start --
 # Specify the minimum version you require.
-find_package (mongoc-1.0 1.7 REQUIRED)
+find_package (mongoc 1.7 REQUIRED)
 
 # The "hello_mongoc.c" sample program is shared among four tests.
 add_executable (hello_mongoc ../../hello_mongoc.c)
-target_link_libraries (hello_mongoc PRIVATE mongo::mongoc_static)
+target_link_libraries (hello_mongoc PRIVATE mongoc::static)

--- a/src/libmongoc/examples/cmake/vcpkg/CMakeLists.txt
+++ b/src/libmongoc/examples/cmake/vcpkg/CMakeLists.txt
@@ -1,13 +1,13 @@
 cmake_minimum_required(VERSION 3.15)
 project(vcpkg-example-project)
 
-find_package(mongoc-1.0 CONFIG REQUIRED)
-message(STATUS "Found libmongoc: ${mongoc-1.0_DIR}")
+find_package(mongoc CONFIG REQUIRED)
+message(STATUS "Found libmongoc: ${mongoc_DIR}")
 
 enable_testing()
 
 add_executable(my-app app.c)
-target_link_libraries(my-app PRIVATE mongo::mongoc_static)
+target_link_libraries(my-app PRIVATE mongoc::static)
 add_test(my-app my-app)
 set_property(
     TEST my-app

--- a/src/libmongoc/tests/cmake-import/CMakeLists.txt
+++ b/src/libmongoc/tests/cmake-import/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.15)
+project(ImportTestProject)
+
+include(CTest)
+
+add_compile_definitions("EXPECT_BSON_VERSION=\"${EXPECT_BSON_VERSION}\"")
+add_compile_definitions("EXPECT_MONGOC_VERSION=\"${EXPECT_MONGOC_VERSION}\"")
+
+if(FIND_BSON)
+    # Call find_package() twice to check that we can be imported twice
+    find_package(bson ${FIND_BSON_ARGS})
+    find_package(bson ${FIND_BSON_ARGS})
+endif()
+
+if(FIND_MONGOC)
+    find_package(mongoc ${FIND_MONGOC_ARGS})
+    find_package(mongoc ${FIND_MONGOC_ARGS})
+endif()
+
+if(bson_FOUND AND EXPECT_FIND_BSON_FAILS)
+    message(FATAL_ERROR "We expected find_package(bson) to fail, but it succeeded [bson_DIR=${bson_DIR}]")
+endif()
+
+if(mongoc_FOUND AND EXPECT_FIND_MONGOC_FAILS)
+    message(FATAL_ERROR "We expected find_package(mongoc) to fail, but it succeeded [mongoc_DIR=${mongoc_DIR}]")
+endif()
+
+if(EXPECT_BSON_VERSION)
+    add_executable(use-bson use-bson.c)
+    target_link_libraries(use-bson PRIVATE bson::bson)
+    add_test(use-bson-test use-bson)
+endif()
+
+if(EXPECT_MONGOC_VERSION)
+    add_executable(use-mongoc use-mongoc.c)
+    target_link_libraries(use-mongoc PRIVATE mongoc::mongoc)
+    add_test(use-mongoc-test use-mongoc)
+endif()

--- a/src/libmongoc/tests/cmake-import/use-bson.c
+++ b/src/libmongoc/tests/cmake-import/use-bson.c
@@ -1,0 +1,18 @@
+#include <bson/bson.h>
+#include <stdio.h>
+
+#ifndef EXPECT_BSON_VERSION
+#error This file requires EXPECT_BSON_VERSION to be defined
+#define EXPECT_BSON_VERSION ""
+#endif
+
+int
+main (void)
+{
+   if (strcmp (BSON_VERSION_S, EXPECT_BSON_VERSION)) {
+      fprintf (
+         stderr, "Wrong BSON_MAJOR_VERSION found (Expected “%s”, but got “%s”)", EXPECT_BSON_VERSION, BSON_VERSION_S);
+      return 2;
+   }
+   return 0;
+}

--- a/src/libmongoc/tests/cmake-import/use-mongoc.c
+++ b/src/libmongoc/tests/cmake-import/use-mongoc.c
@@ -1,0 +1,20 @@
+#include <mongoc/mongoc.h>
+#include <stdio.h>
+
+#ifndef EXPECT_MONGOC_VERSION
+#error This file requires EXPECT_MONGOC_VERSION to be defined
+#define EXPECT_MONGOC_VERSION ""
+#endif
+
+int
+main (void)
+{
+   if (strcmp (MONGOC_VERSION_S, EXPECT_MONGOC_VERSION)) {
+      fprintf (stderr,
+               "Wrong MONGOC_MAJOR_VERSION found (Expected “%s”, but got “%s”)",
+               EXPECT_MONGOC_VERSION,
+               MONGOC_VERSION_S);
+      return 2;
+   }
+   return 0;
+}

--- a/src/libmongoc/tests/import-tests.cmake
+++ b/src/libmongoc/tests/import-tests.cmake
@@ -1,0 +1,114 @@
+include(TestProject)
+
+# A bare find_package will succeed
+add_test_cmake_project(
+   mongoc/CMake/bare-bson-import src/libmongoc/tests/cmake-import
+   INSTALL_PARENT
+   SETTINGS
+      FIND_BSON=1
+      "FIND_BSON_ARGS=REQUIRED"
+      "EXPECT_BSON_VERSION=${mongo-c-driver_VERSION_FULL}"
+)
+
+add_test_cmake_project(
+   mongoc/CMake/bare-mongoc-import src/libmongoc/tests/cmake-import
+   INSTALL_PARENT
+   SETTINGS
+      FIND_MONGOC=1
+      "FIND_MONGOC_ARGS=REQUIRED"
+      "EXPECT_BSON_VERSION=${mongo-c-driver_VERSION_FULL}"
+      "EXPECT_MONGOC_VERSION=${mongo-c-driver_VERSION_FULL}"
+)
+
+add_test_cmake_project(
+   mongoc/CMake/bson-import-1.0 src/libmongoc/tests/cmake-import
+   INSTALL_PARENT
+   SETTINGS
+      FIND_BSON=1
+      "FIND_BSON_ARGS=1.25;REQUIRED"
+      "EXPECT_BSON_VERSION=${mongo-c-driver_VERSION_FULL}"
+)
+
+# Try to import a too-new version of 1.x that will never exist
+add_test_cmake_project(
+   mongoc/CMake/bson-import-too-new-fails src/libmongoc/tests/cmake-import
+   INSTALL_PARENT
+   SETTINGS
+      FIND_BSON=1
+      "FIND_BSON_ARGS=1.9999.0"
+      EXPECT_FIND_BSON_FAILS=TRUE
+)
+
+# Try to import a 2.0 version, which is not installed in this test case
+add_test_cmake_project(
+   mongoc/CMake/bson-import-2.0-fails src/libmongoc/tests/cmake-import
+   INSTALL_PARENT
+   SETTINGS
+      FIND_BSON=1
+      "FIND_BSON_ARGS=2.0"
+      EXPECT_FIND_BSON_FAILS=TRUE
+)
+
+# Try to import a range of versions
+add_test_cmake_project(
+   mongoc/CMake/bson-import-range-upper src/libmongoc/tests/cmake-import
+   INSTALL_PARENT
+   SETTINGS
+      FIND_BSON=1
+      "FIND_BSON_ARGS=1.0...${PROJECT_VERSION};REQUIRED"
+      "EXPECT_BSON_VERSION=${mongo-c-driver_VERSION_FULL}"
+)
+
+add_test_cmake_project(
+   mongoc/CMake/bson-import-range-lower src/libmongoc/tests/cmake-import
+   INSTALL_PARENT
+   SETTINGS
+      FIND_BSON=1
+      "FIND_BSON_ARGS=${PROJECT_VERSION}...1.9999.0;REQUIRED"
+      "EXPECT_BSON_VERSION=${mongo-c-driver_VERSION_FULL}"
+)
+
+add_test_cmake_project(
+   mongoc/CMake/bson-import-range-exclusive src/libmongoc/tests/cmake-import
+   INSTALL_PARENT
+   SETTINGS
+      FIND_BSON=1
+      "FIND_BSON_ARGS=1.0...<${PROJECT_VERSION}"
+      EXPECT_FIND_BSON_FAILS=TRUE
+)
+
+add_test_cmake_project(
+   mongoc/CMake/bson-import-major-range src/libmongoc/tests/cmake-import
+   INSTALL_PARENT
+   SETTINGS
+      FIND_BSON=1
+      "FIND_BSON_ARGS=1.0...2.0;REQUIRED"
+      "EXPECT_BSON_VERSION=${mongo-c-driver_VERSION_FULL}"
+)
+
+add_test_cmake_project(
+   mongoc/CMake/bson-import-major-range-too-new src/libmongoc/tests/cmake-import
+   INSTALL_PARENT
+   SETTINGS
+      FIND_BSON=1
+      "FIND_BSON_ARGS=2.0...<3"
+      EXPECT_FIND_BSON_FAILS=TRUE
+)
+
+add_test_cmake_project(
+   mongoc/CMake/bson-import-bad-components src/libmongoc/tests/cmake-import
+   INSTALL_PARENT
+   SETTINGS
+      FIND_BSON=1
+      "FIND_BSON_ARGS=COMPONENTS;foo"
+      EXPECT_FIND_BSON_FAILS=TRUE
+)
+
+add_test_cmake_project(
+   mongoc/CMake/bson-import-opt-components src/libmongoc/tests/cmake-import
+   INSTALL_PARENT
+   SETTINGS
+      FIND_BSON=1
+      "FIND_BSON_ARGS=REQUIRED;OPTIONAL_COMPONENTS;foo"
+      "EXPECT_BSON_VERSION=${mongo-c-driver_VERSION_FULL}"
+)


### PR DESCRIPTION
This changeset cherry-picks #1955 onto the 1.30.x release branch. Refer to that PR for details. The following tweaks are made in addition:

1. The CMake cache variable `MONGOC_INSTALL_CMAKEDIR` is renamed `MONGO_C_DRIVER_INSTALL_CMAKEDIR` to match the name used in 2.x. `MONGOC_INSTALL_CMAKEDIR` was never published in a release, so this change does not affect users.
2. The Earthfile's root directive was changed from `LOCALLY` to `FROM alpine:3.21`. This allows the repository to be used with Earthfile `IMPORT`.