### PR TITLE
Reduce Warnings: address -Wextra-semi-stmt warnings

### DIFF
--- a/src/common/tests/test-mlib.c
+++ b/src/common/tests/test-mlib.c
@@ -447,7 +447,7 @@ _test_foreach (void)
       ++n_loops;
       (void) i;
       ASSERT (n_loops <= 10);
-   };
+   }
    ASSERT (n_loops == 10);
 
    n_loops = 0;

--- a/src/libmongoc/tests/unified/operation.c
+++ b/src/libmongoc/tests/unified/operation.c
@@ -3961,7 +3961,7 @@ operation_wait_for_event (test_t *test, operation_t *op, result_t *result, bson_
                          (int) (duration / 1000),
                          (int) WAIT_FOR_EVENT_TIMEOUT_MS);
          goto done;
-      };
+      }
 
       _operation_hidden_wait (test, client, "waitForEvent");
    }

--- a/src/libmongoc/tests/unified/runner.c
+++ b/src/libmongoc/tests/unified/runner.c
@@ -1516,7 +1516,7 @@ test_check_log_message (bson_t *expected, log_message_t *actual, bson_error_t *e
       if (!bson_iter_init_find (&failure_iter, actual->message, "failure")) {
          test_set_error (error, "expected log 'failure' to exist");
          goto done;
-      };
+      }
       if (*failure_is_redacted) {
          if (!check_failure_is_redacted (&failure_iter, error)) {
             test_diagnostics_error_info ("actual log message: %s", tmp_json (actual->message));


### PR DESCRIPTION
Addresses 171 `-Wextra-semi-stmt` warnings (81 unique) with Clang 21.