### PR TITLE
CDRIVER-3253 reintroduce VS 2015 task coverage

### DIFF
--- a/.evergreen/config_generator/components/c_std_compile.py
+++ b/.evergreen/config_generator/components/c_std_compile.py
@@ -39,9 +39,10 @@ MATRIX = [
     ('rhel94',     'gcc',    None, [99, 11, 17, 23]), # GCC 11.4 (max: C2x)
     ('rhel95',     'gcc',    None, [99, 11, 17, 23]), # GCC 11.5 (max: C2x)
 
-    ('windows-vsCurrent', 'vs2017x64', None, [99, 11, 17, 'latest']), # Max: C17, clatest (C2x)
-    ('windows-vsCurrent', 'vs2019x64', None, [99, 11, 17, 'latest']), # Max: C17, clatest (C2x)
-    ('windows-vsCurrent', 'vs2022x64', None, [99, 11, 17, 'latest']), # Max: C17, clatest (C2x)
+    ('windows-vsCurrent', 'vs2015x64', None, [99, 11,   ]), # Max: C11
+    ('windows-vsCurrent', 'vs2017x64', None, [99, 11, 17]), # Max: C17
+    ('windows-vsCurrent', 'vs2019x64', None, [99, 11, 17]), # Max: C17
+    ('windows-vsCurrent', 'vs2022x64', None, [99, 11, 17]), # Max: C17
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/c_std_compile.py
+++ b/.evergreen/config_generator/components/c_std_compile.py
@@ -40,7 +40,7 @@ MATRIX = [
     ('rhel95',     'gcc',    None, [99, 11, 17, 23]), # GCC 11.5 (max: C2x)
 
     ('windows-vsCurrent', 'vs2015x64', None, [99, 11,   ]), # Max: C11
-    ('windows-vsCurrent', 'vs2017x64', None, [99, 11, 17]), # Max: C17
+    ('windows-vsCurrent', 'vs2017x64', None, [99, 11,   ]), # Max: C11
     ('windows-vsCurrent', 'vs2019x64', None, [99, 11, 17]), # Max: C17
     ('windows-vsCurrent', 'vs2022x64', None, [99, 11, 17]), # Max: C17
 ]

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -28,8 +28,6 @@ class Distro(BaseModel):
         '2019',
         '2022',
         'vsCurrent',
-        'vsCurrent2',
-        'vsMulti',
     ] | None = None
     size: Literal['small', 'large'] | None = None
     arch: Literal['arm64', 'power', 'zseries'] | None = None
@@ -165,20 +163,7 @@ def make_distro_str(distro_name, compiler, arch) -> str:
             distro_str = 'windows-' + \
                 distro_name[len('windows-vsCurrent-'):] + f'-{compiler_str}'
         else:
-            distro_str = 'windows-2019' + f'-{compiler_str}'
-    elif distro_name.startswith('windows-64-vs'):
-        # Abbreviate 'windows-64-vs<type>' as 'vs<type>' and append '-<arch>' if
-        # given in compiler string as 'vs<type><arch>', e.g.:
-        #     ('windows-64-vs2017', 'vs2017x64', None) -> vs2017-x64
-        #     ('windows-64-vs2017', 'mingw',     None) -> vs2017-mingw
-        distro_str = distro_name[len('windows-64-'):] + {
-            'vs2017x64': '-x64',
-            'vs2017x86': '-x86',
-            'vs2019x64': '-x64',
-            'vs2019x86': '-x86',
-            'vs2022x64': '-x64',
-            'vs2022x86': '-x86',
-        }.get(compiler, f'-{compiler}')
+            distro_str = 'windows-2019-' + compiler_str
     else:
         distro_str = distro_name
         if compiler:
@@ -192,6 +177,8 @@ def make_distro_str(distro_name, compiler, arch) -> str:
 
 def to_cc(compiler):
     return {
+        'vs2015x64': 'Visual Studio 14 2015',
+        'vs2015x86': 'Visual Studio 14 2015',
         'vs2017x64': 'Visual Studio 15 2017',
         'vs2017x86': 'Visual Studio 15 2017',
         'vs2019x64': 'Visual Studio 16 2019',
@@ -203,6 +190,8 @@ def to_cc(compiler):
 
 def to_platform(compiler):
     return {
+        'vs2015x64': 'x64',
+        'vs2015x86': 'Win32',
         'vs2017x64': 'x64',
         'vs2017x86': 'Win32',
         'vs2019x64': 'x64',

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -5132,6 +5132,16 @@ tasks:
           CC: clang-12
           CXX: clang++-12
           C_STD_VERSION: 11
+  - name: std-c11-windows-2019-vs2015-x64-compile
+    run_on: windows-vsCurrent-large
+    tags: [std-matrix, windows-vsCurrent, vs2015x64, compile, std-c11]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CMAKE_GENERATOR: Visual Studio 14 2015
+          CMAKE_GENERATOR_PLATFORM: x64
+          C_STD_VERSION: 11
   - name: std-c11-windows-2019-vs2017-x64-compile
     run_on: windows-vsCurrent-large
     tags: [std-matrix, windows-vsCurrent, vs2017x64, compile, std-c11]
@@ -5732,6 +5742,16 @@ tasks:
           CC: clang-12
           CXX: clang++-12
           C_STD_VERSION: 99
+  - name: std-c99-windows-2019-vs2015-x64-compile
+    run_on: windows-vsCurrent-large
+    tags: [std-matrix, windows-vsCurrent, vs2015x64, compile, std-c99]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CMAKE_GENERATOR: Visual Studio 14 2015
+          CMAKE_GENERATOR_PLATFORM: x64
+          C_STD_VERSION: 99
   - name: std-c99-windows-2019-vs2017-x64-compile
     run_on: windows-vsCurrent-large
     tags: [std-matrix, windows-vsCurrent, vs2017x64, compile, std-c99]
@@ -5762,36 +5782,6 @@ tasks:
           CMAKE_GENERATOR: Visual Studio 17 2022
           CMAKE_GENERATOR_PLATFORM: x64
           C_STD_VERSION: 99
-  - name: std-clatest-windows-2019-vs2017-x64-compile
-    run_on: windows-vsCurrent-large
-    tags: [std-matrix, windows-vsCurrent, vs2017x64, compile, std-clatest]
-    commands:
-      - func: find-cmake-latest
-      - func: std-compile
-        vars:
-          CMAKE_GENERATOR: Visual Studio 15 2017
-          CMAKE_GENERATOR_PLATFORM: x64
-          C_STD_VERSION: latest
-  - name: std-clatest-windows-2019-vs2019-x64-compile
-    run_on: windows-vsCurrent-large
-    tags: [std-matrix, windows-vsCurrent, vs2019x64, compile, std-clatest]
-    commands:
-      - func: find-cmake-latest
-      - func: std-compile
-        vars:
-          CMAKE_GENERATOR: Visual Studio 16 2019
-          CMAKE_GENERATOR_PLATFORM: x64
-          C_STD_VERSION: latest
-  - name: std-clatest-windows-2019-vs2022-x64-compile
-    run_on: windows-vsCurrent-large
-    tags: [std-matrix, windows-vsCurrent, vs2022x64, compile, std-clatest]
-    commands:
-      - func: find-cmake-latest
-      - func: std-compile
-        vars:
-          CMAKE_GENERATOR: Visual Studio 17 2022
-          CMAKE_GENERATOR_PLATFORM: x64
-          C_STD_VERSION: latest
   - name: tsan-sasl-cyrus-openssl-debian10-clang-compile
     run_on: debian10-large
     tags: [sanitizers-matrix-tsan, compile, debian10, clang, tsan, sasl-cyrus]

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -5362,16 +5362,6 @@ tasks:
           CC: clang-12
           CXX: clang++-12
           C_STD_VERSION: 17
-  - name: std-c17-windows-2019-vs2017-x64-compile
-    run_on: windows-vsCurrent-large
-    tags: [std-matrix, windows-vsCurrent, vs2017x64, compile, std-c17]
-    commands:
-      - func: find-cmake-latest
-      - func: std-compile
-        vars:
-          CMAKE_GENERATOR: Visual Studio 15 2017
-          CMAKE_GENERATOR_PLATFORM: x64
-          C_STD_VERSION: 17
   - name: std-c17-windows-2019-vs2019-x64-compile
     run_on: windows-vsCurrent-large
     tags: [std-matrix, windows-vsCurrent, vs2019x64, compile, std-c17]


### PR DESCRIPTION
Resolves CDRIVER-3253 following resolution of [DEVPROD-16074](https://jira.mongodb.org/browse/DEVPROD-16074). The providing distro is now `windows-vsCurrent` rather than the initially proposed `windows64-vsMulti` distro.

Updated `compile-std.sh` to take advantage of CMake 3.30's [CMAKE_\<LANG\>_STANDARD_LATEST](https://cmake.org/cmake/help/v3.30/variable/CMAKE_LANG_STANDARD_LATEST.html) variable to sanity-check that the requested C standard version is supported by the requested compiler (according to CMake). This exposed VS 2015 does not support C17:

```
CMake Error at CMakeLists.txt:15 (message):
  Latest C standard 11 is less than 17
```

Additionally added a C compiler flag check to ensure the `/std:clatest` flag is actually supported by the compilers rather than an easily-missed warning during the build step:

```
cl : Command line warning D9002: ignoring unknown option '/std:clatest'
```

This revealed _none_ of the current MSVC installations on Evergreen support the `/std:clatest` flag. This was verified via spawn host (however, they _do_ support the `/std:c++latest` flag). It is unknown at the moment why the `/std:clatest` flag is missing or how to enable it (if possible). The tasks are therefore removed for now.

> [!NOTE]
> C11 and C17 tasks for VS 2017 and newer are currently failing with the proposed changes due to [DEVPROD-16743](https://jira.mongodb.org/browse/DEVPROD-16743). The distro is currently missing a [required Windows 10 SDK version](https://github.com/eramongodb/mongo-c-driver/blob/1ca2bfabba1fcd0a4c578377ff8b88521f987c3e/.evergreen/scripts/compile-std.sh#L65) which patches C11 and C17 compatibility in system headers.