### PR TITLE
Reduce Warnings: address miscellaneous MSVC warnings

### DIFF
--- a/src/common/src/common-b64.c
+++ b/src/common/src/common-b64.c
@@ -42,6 +42,7 @@
 
 #include <bson/bson.h>
 #include <common-b64-private.h>
+#include <mlib/config.h>
 #include <mlib/loop.h>
 
 #define Assert(Cond) \
@@ -270,7 +271,9 @@ static const uint8_t mongoc_b64rmap_invalid = 0xff;
 #define mongoc_common_once_t INIT_ONCE
 #define MONGOC_COMMON_ONCE_INIT INIT_ONCE_STATIC_INIT
 #define mongoc_common_once(o, c) InitOnceExecuteOnce (o, c, NULL, NULL)
-#define MONGOC_COMMON_ONCE_FUN(n) BOOL CALLBACK n (PINIT_ONCE _ignored_a, PVOID _ignored_b, PVOID *_ignored_c)
+#define MONGOC_COMMON_ONCE_FUN(n)                                               \
+   MLIB_IF_MSVC (__pragma (warning (push)) __pragma (warning (disable : 4100))) \
+   BOOL CALLBACK n (PINIT_ONCE _ignored_a, PVOID _ignored_b, PVOID *_ignored_c) MLIB_IF_MSVC (__pragma (warning (pop)))
 #define MONGOC_COMMON_ONCE_RETURN return true
 #endif
 

--- a/src/common/src/common-bson-dsl-private.h
+++ b/src/common/src/common-bson-dsl-private.h
@@ -36,17 +36,18 @@ enum {
 BSON_IF_GNU_LIKE (_Pragma ("GCC diagnostic ignored \"-Wshadow\""))
 #endif
 
-#define _bsonDSL_disableWarnings()                                        \
-   if (1) {                                                               \
-      BSON_IF_GNU_LIKE (_Pragma ("GCC diagnostic push");)                 \
-      BSON_IF_GNU_LIKE (_Pragma ("GCC diagnostic ignored \"-Wshadow\"");) \
-   } else                                                                 \
+#define _bsonDSL_disableWarnings()           \
+   if (1) {                                  \
+      mlib_diagnostic_push ();               \
+      mlib_gnu_warning_disable ("-Wshadow"); \
+      mlib_msvc_warning (disable : 4456);    \
+   } else                                    \
       ((void) 0)
 
-#define _bsonDSL_restoreWarnings()                       \
-   if (1) {                                              \
-      BSON_IF_GNU_LIKE (_Pragma ("GCC diagnostic pop");) \
-   } else                                                \
+#define _bsonDSL_restoreWarnings() \
+   if (1) {                        \
+      mlib_diagnostic_pop ();      \
+   } else                          \
       ((void) 0)
 
 /**

--- a/src/common/src/common-bson-dsl-private.h
+++ b/src/common/src/common-bson-dsl-private.h
@@ -58,9 +58,12 @@ BSON_IF_GNU_LIKE (_Pragma ("GCC diagnostic ignored \"-Wshadow\""))
    _bsonDSL_begin ("bsonParse(%s)", _bsonDSL_str (Document)); \
    _bsonDSL_disableWarnings ();                               \
    bsonParseError = NULL;                                     \
-   BSON_MAYBE_UNUSED bool _bvHalt = false;                    \
-   BSON_MAYBE_UNUSED const bool _bvContinue = false;          \
-   BSON_MAYBE_UNUSED const bool _bvBreak = false;             \
+   bool _bvHalt = false;                                      \
+   const bool _bvContinue = false;                            \
+   const bool _bvBreak = false;                               \
+   (void) _bvHalt;                                            \
+   (void) _bvContinue;                                        \
+   (void) _bvBreak;                                           \
    _bsonDSL_eval (_bsonParse ((Document), __VA_ARGS__));      \
    _bsonDSL_restoreWarnings ();                               \
    _bsonDSL_end
@@ -71,7 +74,8 @@ BSON_IF_GNU_LIKE (_Pragma ("GCC diagnostic ignored \"-Wshadow\""))
 #define bsonVisitEach(Document, ...)                              \
    _bsonDSL_begin ("bsonVisitEach(%s)", _bsonDSL_str (Document)); \
    _bsonDSL_disableWarnings ();                                   \
-   BSON_MAYBE_UNUSED bool _bvHalt = false;                        \
+   bool _bvHalt = false;                                          \
+   (void) _bvHalt;                                                \
    _bsonDSL_eval (_bsonVisitEach ((Document), __VA_ARGS__));      \
    _bsonDSL_restoreWarnings ();                                   \
    _bsonDSL_end
@@ -516,7 +520,8 @@ BSON_IF_GNU_LIKE (_Pragma ("GCC diagnostic ignored \"-Wshadow\""))
 
 #define _bsonVisitOperation_case(...)                  \
    _bsonDSL_begin ("case:%s", "");                     \
-   BSON_MAYBE_UNUSED bool _bvCaseMatched = false;      \
+   bool _bvCaseMatched = false;                        \
+   (void) _bvCaseMatched;                              \
    _bsonDSL_mapMacro (_bsonVisitCase, ~, __VA_ARGS__); \
    _bsonDSL_end
 
@@ -544,8 +549,10 @@ BSON_IF_GNU_LIKE (_Pragma ("GCC diagnostic ignored \"-Wshadow\""))
       if (!bson_iter_init (&_bvCtx.iter, &(Doc))) {                                       \
          bsonParseError = "Invalid BSON data [a]";                                        \
       }                                                                                   \
-      BSON_MAYBE_UNUSED bool _bvBreak = false;                                            \
-      BSON_MAYBE_UNUSED bool _bvContinue = false;                                         \
+      bool _bvBreak = false;                                                              \
+      bool _bvContinue = false;                                                           \
+      (void) _bvBreak;                                                                    \
+      (void) _bvContinue;                                                                 \
       while (bson_iter_next (&_bvCtx.iter) && !_bvHalt && !bsonParseError && !_bvBreak) { \
          _bvContinue = false;                                                             \
          _bsonVisit_applyOps (__VA_ARGS__);                                               \
@@ -622,19 +629,23 @@ BSON_IF_GNU_LIKE (_Pragma ("GCC diagnostic ignored \"-Wshadow\""))
       }                                                  \
    } while (0);
 
-#define _bsonParse(Doc, ...)                                                                        \
-   do {                                                                                             \
-      BSON_MAYBE_UNUSED const bson_t *_bpDoc = &(Doc);                                              \
-      /* Keep track of which elements have been visited based on their index*/                      \
-      uint64_t _bpVisitBits_static[4] = {0};                                                        \
-      BSON_MAYBE_UNUSED uint64_t *_bpVisitBits = _bpVisitBits_static;                               \
-      BSON_MAYBE_UNUSED size_t _bpNumVisitBitInts = sizeof _bpVisitBits_static / sizeof (uint64_t); \
-      BSON_MAYBE_UNUSED bool _bpFoundElement = false;                                               \
-      _bsonParse_applyOps (__VA_ARGS__);                                                            \
-      /* We may have allocated for visit bits */                                                    \
-      if (_bpVisitBits != _bpVisitBits_static) {                                                    \
-         bson_free (_bpVisitBits);                                                                  \
-      }                                                                                             \
+#define _bsonParse(Doc, ...)                                                      \
+   do {                                                                           \
+      /* Keep track of which elements have been visited based on their index*/    \
+      uint64_t _bpVisitBits_static[4] = {0};                                      \
+      const bson_t *_bpDoc = &(Doc);                                              \
+      uint64_t *_bpVisitBits = _bpVisitBits_static;                               \
+      size_t _bpNumVisitBitInts = sizeof _bpVisitBits_static / sizeof (uint64_t); \
+      bool _bpFoundElement = false;                                               \
+      (void) _bpDoc;                                                              \
+      (void) _bpVisitBits;                                                        \
+      (void) _bpNumVisitBitInts;                                                  \
+      (void) _bpFoundElement;                                                     \
+      _bsonParse_applyOps (__VA_ARGS__);                                          \
+      /* We may have allocated for visit bits */                                  \
+      if (_bpVisitBits != _bpVisitBits_static) {                                  \
+         bson_free (_bpVisitBits);                                                \
+      }                                                                           \
    } while (0)
 
 #define _bsonParse_applyOps(...) _bsonDSL_mapMacro (_bsonParse_applyOp, ~, __VA_ARGS__)

--- a/src/common/src/common-thread-private.h
+++ b/src/common/src/common-thread-private.h
@@ -79,6 +79,8 @@ BSON_BEGIN_DECLS
    } while (0)
 
 #else
+#include <mlib/config.h>
+
 typedef struct {
    pthread_t lock_owner;
    pthread_mutex_t wrapped_mutex;
@@ -113,7 +115,9 @@ typedef struct {
 
 #else
 #include <process.h>
-#define BSON_ONCE_FUN(n) BOOL CALLBACK n (PINIT_ONCE _ignored_a, PVOID _ignored_b, PVOID *_ignored_c)
+#define BSON_ONCE_FUN(n)                                                        \
+   MLIB_IF_MSVC (__pragma (warning (push)) __pragma (warning (disable : 4100))) \
+   BOOL CALLBACK n (PINIT_ONCE _ignored_a, PVOID _ignored_b, PVOID *_ignored_c) MLIB_IF_MSVC (__pragma (warning (pop)))
 #define BSON_ONCE_INIT INIT_ONCE_STATIC_INIT
 #define BSON_ONCE_RETURN return true
 #define bson_mutex_destroy DeleteCriticalSection

--- a/src/common/src/mlib/ckdint.h
+++ b/src/common/src/mlib/ckdint.h
@@ -280,9 +280,9 @@ static inline bool (mlib_add) (uintmax_t *dst, bool dst_signed, bool a_signed, u
             // Expanded:
             // Test whether the product sign is unequal to both input signs
             // X ^ Y yields a negative value if the signs are unequal
-            const bool a_signflipped = (intmax_t) (sum ^ a) < 0;
-            const bool b_signflipped = (intmax_t) (sum ^ b) < 0;
-            return a_signflipped && b_signflipped;
+            //     const bool a_signflipped = (intmax_t) (sum ^ a) < 0;
+            //     const bool b_signflipped = (intmax_t) (sum ^ b) < 0;
+            //     return a_signflipped && b_signflipped;
          } else { // S = S + U
             // Flip the sign bit of a, test whether that sum overflows
             a ^= signbit;
@@ -303,49 +303,48 @@ static inline bool (mlib_add) (uintmax_t *dst, bool dst_signed, bool a_signed, u
          if (b_signed) { // U = S + S
             return signbit & (((sum | a) & b) | ((sum & a) & ~b));
             // Expanded:
-            const bool a_is_negative = (intmax_t) a < 0;
-            const bool b_is_negative = (intmax_t) b < 0;
-            const bool sum_is_large = sum > INTMAX_MAX;
-            if (b_is_negative) {
-               if (a_is_negative) {
-                  // The sum must be negative, and therefore cannot be stored in an unsigned
-                  return true;
-               } else if (sum_is_large) {
-                  // We added a negative value B to a positive value A, but the sum
-                  // ended up larger than the max signed value, so we wrapped
-                  return true;
-               }
-            } else if (a_is_negative) {
-               if (sum_is_large) {
-                  // Same as above case with sum_is_large
-                  return true;
-               }
-            }
-            return false;
+            //     const bool a_is_negative = (intmax_t) a < 0;
+            //     const bool b_is_negative = (intmax_t) b < 0;
+            //     const bool sum_is_large = sum > INTMAX_MAX;
+            //     if (b_is_negative) {
+            //        if (a_is_negative) {
+            //           // The sum must be negative, and therefore cannot be stored in an unsigned
+            //           return true;
+            //        } else if (sum_is_large) {
+            //           // We added a negative value B to a positive value A, but the sum
+            //           // ended up larger than the max signed value, so we wrapped
+            //           return true;
+            //        }
+            //     } else if (a_is_negative) {
+            //        if (sum_is_large) {
+            //           // Same as above case with sum_is_large
+            //           return true;
+            //        }
+            //     }
+            //     return false;
          } else { // U = S + U
             return signbit & (sum ^ a ^ signbit) & (sum ^ b);
             // Expanded:
-            const bool sum_is_large = sum > INTMAX_MAX;
-            const bool b_is_large = b > INTMAX_MAX;
-            const bool a_is_negative = (intmax_t) a < 0;
-
-            if (!a_is_negative && b_is_large) {
-               // We are adding a non-negative value to a large number, so the
-               // sum must also be large
-               if (!sum_is_large) {
-                  // We ended up with a smaller value, meaning that we must have wrapped
-                  return true;
-               }
-            }
-            if (a_is_negative && !b_is_large) {
-               // We subtracted a non-negative value from a non-large number, so
-               // the result should not be large
-               if (sum_is_large) {
-                  // We ended up with a large value, so we must have wrapped
-                  return true;
-               }
-            }
-            return false;
+            //     const bool sum_is_large = sum > INTMAX_MAX;
+            //     const bool b_is_large = b > INTMAX_MAX;
+            //     const bool a_is_negative = (intmax_t) a < 0;
+            //     if (!a_is_negative && b_is_large) {
+            //        // We are adding a non-negative value to a large number, so the
+            //        // sum must also be large
+            //        if (!sum_is_large) {
+            //           // We ended up with a smaller value, meaning that we must have wrapped
+            //           return true;
+            //        }
+            //     }
+            //     if (a_is_negative && !b_is_large) {
+            //        // We subtracted a non-negative value from a non-large number, so
+            //        // the result should not be large
+            //        if (sum_is_large) {
+            //           // We ended up with a large value, so we must have wrapped
+            //           return true;
+            //        }
+            //     }
+            //     return false;
          }
       } else {
          if (b_signed) { // U = U + S  --- (See [U = S + U] for an explanation)
@@ -372,18 +371,18 @@ static inline bool (mlib_sub) (uintmax_t *dst, bool dst_signed, bool a_signed, u
          if (b_signed) { // S = S - S
             return signbit & (a ^ b) & (diff ^ a);
             // Explain:
-            const bool a_is_negative = (intmax_t) a < 0;
-            const bool b_is_negative = (intmax_t) b < 0;
-            if (a_is_negative != b_is_negative) {
-               // Given: Pos - Neg = Pos
-               //      ∧ Neg - Pos = Neg
-               // We expect that the difference preserves the sign of the minuend
-               if (diff_is_negative != a_is_negative) {
-                  return true;
-               }
-            }
-            // Otherwise, `Pos - Pos` and `Neg - Neg` cannot possibly overflow
-            return false;
+            //     const bool a_is_negative = (intmax_t) a < 0;
+            //     const bool b_is_negative = (intmax_t) b < 0;
+            //     if (a_is_negative != b_is_negative) {
+            //        // Given: Pos - Neg = Pos
+            //        //      ∧ Neg - Pos = Neg
+            //        // We expect that the difference preserves the sign of the minuend
+            //        if (diff_is_negative != a_is_negative) {
+            //           return true;
+            //        }
+            //     }
+            //     // Otherwise, `Pos - Pos` and `Neg - Neg` cannot possibly overflow
+            //     return false;
          } else { // S = S - U
             // The diff overflows if the sign-bit-flipped minuend is smaller than the subtrahend
             return (a ^ signbit) < b;
@@ -402,29 +401,29 @@ static inline bool (mlib_sub) (uintmax_t *dst, bool dst_signed, bool a_signed, u
          if (b_signed) { // U = S - S
             return signbit & (((diff & a) & b) | ((diff | a) & ~b));
             // Expanded:
-            const bool a_is_negative = (intmax_t) a < 0;
-            const bool b_is_negative = (intmax_t) b < 0;
-            const bool diff_is_large = diff > INTMAX_MAX;
-            if (!b_is_negative) {
-               if (a_is_negative) {
-                  // We subtracted a non-negative from a negative value, so the difference
-                  // must be negative and cannot be stored as unsigned
-                  return true;
-               }
-               if (diff_is_large) {
-                  // We subtracted a positive value from a signed value, so we must not
-                  // end up with a large value
-                  return true;
-               }
-            }
-            if (a_is_negative) {
-               if (diff_is_large) {
-                  // A is negative, and there is no possible value that we can subtract
-                  // from it to obtain this large integer, so we must have overflowed
-                  return true;
-               }
-            }
-            return false;
+            //     const bool a_is_negative = (intmax_t) a < 0;
+            //     const bool b_is_negative = (intmax_t) b < 0;
+            //     const bool diff_is_large = diff > INTMAX_MAX;
+            //     if (!b_is_negative) {
+            //        if (a_is_negative) {
+            //           // We subtracted a non-negative from a negative value, so the difference
+            //           // must be negative and cannot be stored as unsigned
+            //           return true;
+            //        }
+            //        if (diff_is_large) {
+            //           // We subtracted a positive value from a signed value, so we must not
+            //           // end up with a large value
+            //           return true;
+            //        }
+            //     }
+            //     if (a_is_negative) {
+            //        if (diff_is_large) {
+            //           // A is negative, and there is no possible value that we can subtract
+            //           // from it to obtain this large integer, so we must have overflowed
+            //           return true;
+            //        }
+            //     }
+            //     return false;
          } else { //
             return (b > a) || (signbit & a);
          }
@@ -432,26 +431,26 @@ static inline bool (mlib_sub) (uintmax_t *dst, bool dst_signed, bool a_signed, u
          if (b_signed) { // U = U - S
             return signbit & (a ^ b ^ signbit) & (diff ^ a);
             // Explain:
-            const bool a_is_large = a > INTMAX_MAX;
-            const bool b_is_negative = (intmax_t) b < 0;
-            const bool diff_is_large = diff > INTMAX_MAX;
-            if (a_is_large && b_is_negative) {
-               // The difference between a large value and a negative
-               // value must also be a large value
-               if (!diff_is_large) {
-                  // We expected another large value to appear.
-                  return true;
-               }
-            }
-            if (!a_is_large && !b_is_negative) {
-               // The difference between a non-large positive value and a non-negative value
-               // must not be a large value
-               if (diff_is_large) {
-                  // We did not expect a large difference
-                  return true;
-               }
-            }
-            return false;
+            //     const bool a_is_large = a > INTMAX_MAX;
+            //     const bool b_is_negative = (intmax_t) b < 0;
+            //     const bool diff_is_large = diff > INTMAX_MAX;
+            //     if (a_is_large && b_is_negative) {
+            //        // The difference between a large value and a negative
+            //        // value must also be a large value
+            //        if (!diff_is_large) {
+            //           // We expected another large value to appear.
+            //           return true;
+            //        }
+            //     }
+            //     if (!a_is_large && !b_is_negative) {
+            //        // The difference between a non-large positive value and a non-negative value
+            //        // must not be a large value
+            //        if (diff_is_large) {
+            //           // We did not expect a large difference
+            //           return true;
+            //        }
+            //     }
+            //     return false;
          } else {
             return a < b;
          }

--- a/src/common/src/mlib/config.h
+++ b/src/common/src/mlib/config.h
@@ -355,4 +355,11 @@
  */
 #define mlib_disable_constant_conditional_expression_warnings() mlib_msvc_warning (disable : 4127)
 
+/**
+ * @brief Disable warnings for potentially unused parameters.
+ */
+#define mlib_disable_unused_parameter_warnings()                       \
+   MLIB_IF_GNU_LIKE (mlib_gnu_warning_disable ("-Wunused-parameter");) \
+   MLIB_IF_MSVC (mlib_msvc_warning (disable : 4100);) mlib_static_assert (true, "")
+
 #endif // MLIB_CONFIG_H_INCLUDED

--- a/src/common/src/mlib/intutil.h
+++ b/src/common/src/mlib/intutil.h
@@ -90,9 +90,12 @@ typedef struct mlib_upsized_integer {
  */
 #define mlib_upsize_integer(Value) \
    /* NOLINTNEXTLINE(bugprone-sizeof-expression) */ \
+   MLIB_IF_MSVC (__pragma (warning(push))) \
+   MLIB_IF_MSVC (__pragma (warning(disable : 4189))) \
    ((sizeof ((Value)) < sizeof (intmax_t) || ((0 & (Value)) - 1) < 0) \
       ? mlib_init(mlib_upsized_integer) {{(intmax_t) (Value)}, true} \
-      : mlib_init(mlib_upsized_integer) {{(intmax_t) (uintmax_t) (Value)}})
+      : mlib_init(mlib_upsized_integer) {{(intmax_t) (uintmax_t) (Value)}}) \
+   MLIB_IF_MSVC (__pragma (warning(pop)))
 // clang-format on
 
 #endif // MLIB_INTUTIL_H_INCLUDED

--- a/src/common/src/mlib/intutil.h
+++ b/src/common/src/mlib/intutil.h
@@ -24,6 +24,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include <mlib/config.h>
+
 /**
  * @brief Given an integral type, evaluates to `true` if that type is signed,
  * otherwise `false`
@@ -45,9 +47,12 @@
  * minimal value of that type.
  */
 #define mlib_minof(T) \
+   MLIB_IF_MSVC (__pragma (warning (push))) \
+   MLIB_IF_MSVC (__pragma (warning (disable : 4146))) \
    ((T) (!mlib_is_signed (T) \
         ? (T) 0 \
-        : (T) (-((((T) 1 << (sizeof (T) * CHAR_BIT - 2)) - 1) * 2 + 1) - 1)))
+        : (T) (-((((T) 1 << (sizeof (T) * CHAR_BIT - 2)) - 1) * 2 + 1) - 1))) \
+   MLIB_IF_MSVC (__pragma (warning (pop)))
 // clang-format on
 
 /**

--- a/src/common/tests/test-mlib.c
+++ b/src/common/tests/test-mlib.c
@@ -309,7 +309,8 @@ _test_cmp (void)
    mlib_diagnostic_push ();
    mlib_gnu_warning_disable ("-Wsign-compare");
    mlib_disable_constant_conditional_expression_warnings ();
-   ASSERT (-27 > 20u);
+   mlib_msvc_warning (disable : 4308);
+   ASSERT (-27 > 20u); // Deliberate signed -> unsigned implicit conversion check.
    mlib_diagnostic_pop ();
    // mlib_cmp produces the correct answer:
    ASSERT (mlib_cmp (-27, <, 20u));

--- a/src/libbson/src/bson/bson-context.c
+++ b/src/libbson/src/bson/bson-context.c
@@ -323,7 +323,6 @@ bson_context_destroy (bson_context_t *context) /* IN */
    bson_free (context);
 }
 
-
 static BSON_ONCE_FUN (_bson_context_init_default)
 {
    _bson_context_init (&gContextDefault, BSON_CONTEXT_DISABLE_PID_CACHE);

--- a/src/libbson/src/bson/bson-macros.h
+++ b/src/libbson/src/bson/bson-macros.h
@@ -264,7 +264,7 @@ _bson_assert_failed_on_param (const char *param, const char *func)
 
 // `BSON_OPTIONAL_PARAM` is a documentation-only macro to document X may be NULL.
 // Useful in combination with `BSON_ASSERT_PARAM` to document and assert pointer parameters.
-#define BSON_OPTIONAL_PARAM(param) (void) 0
+#define BSON_OPTIONAL_PARAM(param) ((void) param)
 
 /* obsolete macros, preserved for compatibility */
 #define BSON_STATIC_ASSERT(s) BSON_STATIC_ASSERT_ (s, __LINE__)

--- a/src/libbson/src/bson/bson-memory.c
+++ b/src/libbson/src/bson/bson-memory.c
@@ -24,7 +24,7 @@
 #include <bson/bson-memory.h>
 
 #include <common-macros-private.h>
-
+#include <mlib/config.h>
 
 // Ensure size of exported structs are stable.
 BSON_STATIC_ASSERT2 (bson_mem_vtable_t, sizeof (bson_mem_vtable_t) == sizeof (void *) * 8u);
@@ -59,13 +59,15 @@ _aligned_alloc_impl (size_t alignment, size_t num_bytes)
 }
 #endif
 
-
+mlib_diagnostic_push ();
+mlib_msvc_warning (disable : 4232);
 static bson_mem_vtable_t gMemVtable = {.malloc = malloc,
                                        .calloc = calloc,
                                        .realloc = realloc,
                                        .free = free,
                                        .aligned_alloc = _aligned_alloc_impl,
                                        .padding = {0}};
+mlib_diagnostic_pop ();
 
 
 /*

--- a/src/libbson/src/bson/bson-vector.c
+++ b/src/libbson/src/bson/bson-vector.c
@@ -18,6 +18,8 @@
 #include <bson/bson.h>
 #include <bson/bson-vector-private.h>
 
+#include <mlib/config.h>
+
 
 static BSON_INLINE bool
 bson_vector_binary_header_impl_init (bson_vector_binary_header_impl_t *header_out,
@@ -349,7 +351,11 @@ bson_append_vector_packed_bit_uninit (
    }
    uint8_t *binary;
    if (bson_append_binary_uninit (bson, key, key_length, BSON_SUBTYPE_VECTOR, &binary, length)) {
+      mlib_diagnostic_push ();
+      mlib_msvc_warning (disable : 4146);
       size_t padding = (size_t) 7 & -element_count;
+      mlib_diagnostic_pop ();
+
       bson_vector_binary_header_impl_t header = {
          .bytes[0] = bson_vector_header_byte_0 (BSON_VECTOR_ELEMENT_UNSIGNED_INT, BSON_VECTOR_ELEMENT_1_BIT),
          .bytes[1] = bson_vector_header_byte_1 (padding)};

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -57,7 +57,7 @@ typedef struct {
 /*
  * Globals.
  */
-static const uint8_t gZero;
+static const uint8_t gZero = 0;
 
 /*
  *--------------------------------------------------------------------------

--- a/src/libbson/src/jsonsl/jsonsl.h
+++ b/src/libbson/src/jsonsl/jsonsl.h
@@ -9,10 +9,13 @@
  * See included LICENSE file for license details.
  */
 
-#include <bson/bson-prelude.h>
-
 #ifndef JSONSL_H_
 #define JSONSL_H_
+
+#include <bson/bson-config.h>
+#include <bson/bson-compat.h>
+
+#include <mlib/config.h>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -548,12 +551,21 @@ struct jsonsl_st {
     size_t *jpr_root;
     /*@}*/
 
+#if defined(_MSC_VER)
+#pragma warning (push)
+#pragma warning (disable : 4200)
+#endif // defined(_MSC_VER)
+
     /**
      * This is the stack. Its upper bound is levels_max, or the
      * nlevels argument passed to jsonsl_new. If you modify this structure,
      * make sure that this member is last.
      */
     struct jsonsl_state_st stack[];
+
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif // defined(_MSC_VER)
 };
 
 

--- a/src/libbson/tests/test-bson-vector.c
+++ b/src/libbson/tests/test-bson-vector.c
@@ -1188,7 +1188,7 @@ test_bson_vector_example_float32_const_view (void)
    // setup: construct a sample document
    bson_t doc = BSON_INITIALIZER;
    {
-      static const float values[] = {5.0f, -1e10f, INFINITY, NAN, -1.0f};
+      const float values[] = {5.0f, -1e10f, INFINITY, NAN, -1.0f}; // C2099 "initializer is not a constant"
       bson_vector_float32_view_t view;
       ASSERT (BSON_APPEND_VECTOR_FLOAT32_UNINIT (&doc, "vector", sizeof values / sizeof values[0], &view));
       ASSERT (bson_vector_float32_view_write (view, values, sizeof values / sizeof values[0], 0));

--- a/src/libbson/tests/test-bson.c
+++ b/src/libbson/tests/test-bson.c
@@ -3084,9 +3084,9 @@ test_bson_array_builder (void)
          bson_t b;
          bson_array_builder_t *bab = bson_array_builder_new ();
          {
-            bson_t *b = TMP_BSON_FROM_JSON ({"A" : 1});
+            bson_t *bb = TMP_BSON_FROM_JSON ({"A" : 1});
             bson_iter_t iter;
-            ASSERT (bson_iter_init_find (&iter, b, "A"));
+            ASSERT (bson_iter_init_find (&iter, bb, "A"));
             ASSERT (bson_array_builder_append_iter (bab, &iter));
          }
          ASSERT (bson_array_builder_build (bab, &b));

--- a/src/libbson/tests/test-bson.c
+++ b/src/libbson/tests/test-bson.c
@@ -2601,6 +2601,8 @@ test_bson_dsl_visit (void)
    bson_free (path);
 }
 
+mlib_diagnostic_push ();
+mlib_msvc_warning (disable : 4702); // do (abort())
 static void
 test_bson_dsl_predicate (void)
 {
@@ -2662,6 +2664,7 @@ test_bson_dsl_predicate (void)
       visitOthers (if (key ("unhandled"), then (do (saw_other = true)), else (do (abort ())))));
    BSON_ASSERT (saw_other);
 }
+mlib_diagnostic_pop ();
 
 static void
 do_assert_bson_equal (const bson_t *actual, const bson_t *expected, const char *file, int line)

--- a/src/libmongoc/examples/mongoc-dump.c
+++ b/src/libmongoc/examples/mongoc-dump.c
@@ -26,6 +26,7 @@ mongoc_dump_mkdir_p (const char *path, int mode)
    int r;
 
 #ifdef _WIN32
+   (void) mode;
    r = _mkdir (path);
 #else
    r = mkdir (path, mode);

--- a/src/libmongoc/src/mongoc/mcd-nsinfo.c
+++ b/src/libmongoc/src/mongoc/mcd-nsinfo.c
@@ -60,6 +60,8 @@ mcd_nsinfo_destroy (mcd_nsinfo_t *self)
    bson_free (self);
 }
 
+mlib_diagnostic_push ();
+mlib_msvc_warning (disable : 4702); // HASH_ADD_KEYPTR
 int32_t
 mcd_nsinfo_append (mcd_nsinfo_t *self, const char *ns, bson_error_t *error)
 {
@@ -94,6 +96,7 @@ mcd_nsinfo_append (mcd_nsinfo_t *self, const char *ns, bson_error_t *error)
    bson_destroy (&mcd_nsinfo_bson);
    return ns_index;
 }
+mlib_diagnostic_pop ();
 
 int32_t
 mcd_nsinfo_find (const mcd_nsinfo_t *self, const char *ns)

--- a/src/libmongoc/src/mongoc/mcd-rpc.c
+++ b/src/libmongoc/src/mongoc/mcd-rpc.c
@@ -2419,8 +2419,8 @@ int32_t
 mcd_rpc_op_delete_get_flags (const mcd_rpc_message *rpc)
 {
    ASSERT_MCD_RPC_ACCESSOR_PRECONDITIONS;
-   return rpc->op_delete.flags;
    BSON_ASSERT (rpc->msg_header.op_code == MONGOC_OP_CODE_DELETE);
+   return rpc->op_delete.flags;
 }
 
 const void *

--- a/src/libmongoc/src/mongoc/mongoc-bulkwrite.c
+++ b/src/libmongoc/src/mongoc/mongoc-bulkwrite.c
@@ -236,7 +236,7 @@ bool
 mongoc_bulkwrite_append_insertone (mongoc_bulkwrite_t *self,
                                    const char *ns,
                                    const bson_t *document,
-                                   BSON_MAYBE_UNUSED const mongoc_bulkwrite_insertoneopts_t *opts, // may be NULL
+                                   const mongoc_bulkwrite_insertoneopts_t *opts, // may be NULL
                                    bson_error_t *error)
 {
    BSON_ASSERT_PARAM (self);

--- a/src/libmongoc/src/mongoc/mongoc-client-pool.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-pool.c
@@ -122,6 +122,11 @@ mongoc_client_pool_new (const mongoc_uri_t *uri)
 }
 
 
+// Defined in mongoc-init.c.
+extern bool
+mongoc_get_init_called (void);
+
+
 mongoc_client_pool_t *
 mongoc_client_pool_new_with_error (const mongoc_uri_t *uri, bson_error_t *error)
 {
@@ -136,7 +141,6 @@ mongoc_client_pool_new_with_error (const mongoc_uri_t *uri, bson_error_t *error)
 
    BSON_ASSERT (uri);
 
-   extern bool mongoc_get_init_called (void);
    if (!mongoc_get_init_called ()) {
       _mongoc_set_error (error,
                          MONGOC_ERROR_CLIENT,

--- a/src/libmongoc/src/mongoc/mongoc-client-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-private.h
@@ -168,7 +168,6 @@ void
 _mongoc_client_kill_cursor (mongoc_client_t *client,
                             uint32_t server_id,
                             int64_t cursor_id,
-                            int64_t operation_id,
                             const char *db,
                             const char *collection,
                             mongoc_client_session_t *cs);

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -108,6 +108,8 @@ typedef bool (*mongoc_rr_callback_t) (const char *hostname,
 static bool
 srv_callback (const char *hostname, PDNS_RECORD pdns, mongoc_rr_data_t *rr_data, bson_error_t *error)
 {
+   BSON_UNUSED (hostname);
+
    mongoc_host_list_t new_host;
 
    if (rr_data && rr_data->hosts) {
@@ -126,6 +128,9 @@ srv_callback (const char *hostname, PDNS_RECORD pdns, mongoc_rr_data_t *rr_data,
 static bool
 txt_callback (const char *hostname, PDNS_RECORD pdns, mongoc_rr_data_t *rr_data, bson_error_t *error)
 {
+   BSON_UNUSED (hostname);
+   BSON_UNUSED (error);
+
    DWORD i;
 
    mcommon_string_append_t txt;
@@ -562,6 +567,11 @@ _mongoc_client_get_rr (const char *hostname,
    BSON_ASSERT (rr_data);
 
 #if MONGOC_ENABLE_SRV == 0
+   BSON_UNUSED (hostname);
+   BSON_UNUSED (rr_type);
+   BSON_UNUSED (rr_data);
+   BSON_UNUSED (initial_buffer_size);
+   BSON_UNUSED (prefer_tcp);
    // Disabled
    _mongoc_set_error (error,
                       MONGOC_ERROR_STREAM,
@@ -569,6 +579,8 @@ _mongoc_client_get_rr (const char *hostname,
                       "libresolv unavailable, cannot use mongodb+srv URI");
    return false;
 #elif defined(MONGOC_HAVE_DNSAPI)
+   BSON_UNUSED (hostname);
+   BSON_UNUSED (initial_buffer_size);
    return _mongoc_get_rr_dnsapi (hostname, rr_type, rr_data, prefer_tcp, error);
 #elif (defined(MONGOC_HAVE_RES_NSEARCH) || defined(MONGOC_HAVE_RES_SEARCH))
    return _mongoc_get_rr_search (hostname, rr_type, rr_data, initial_buffer_size, prefer_tcp, error);
@@ -696,6 +708,7 @@ mongoc_client_connect_unix (const mongoc_host_list_t *host, bson_error_t *error)
 {
 #ifdef _WIN32
    ENTRY;
+   BSON_UNUSED (host);
    _mongoc_set_error (
       error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_CONNECT, "UNIX domain sockets not supported on win32.");
    RETURN (NULL);
@@ -753,6 +766,8 @@ mongoc_client_connect (bool buffered,
 
    BSON_ASSERT (uri);
    BSON_ASSERT (host);
+
+   BSON_UNUSED (openssl_ctx_void);
 
 #ifndef MONGOC_ENABLE_SSL
    if (ssl_opts_void || mongoc_uri_get_tls (uri)) {
@@ -2106,7 +2121,6 @@ void
 _mongoc_client_kill_cursor (mongoc_client_t *client,
                             uint32_t server_id,
                             int64_t cursor_id,
-                            int64_t operation_id,
                             const char *db,
                             const char *collection,
                             mongoc_client_session_t *cs)

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -1034,6 +1034,9 @@ mongoc_client_new_from_uri (const mongoc_uri_t *uri)
    return client;
 }
 
+// Defined in mongoc-init.c.
+extern bool
+mongoc_get_init_called (void);
 
 mongoc_client_t *
 mongoc_client_new_from_uri_with_error (const mongoc_uri_t *uri, bson_error_t *error)
@@ -1046,7 +1049,6 @@ mongoc_client_new_from_uri_with_error (const mongoc_uri_t *uri, bson_error_t *er
 
    BSON_ASSERT (uri);
 
-   extern bool mongoc_get_init_called (void);
    if (!mongoc_get_init_called ()) {
       _mongoc_set_error (error,
                          MONGOC_ERROR_CLIENT,

--- a/src/libmongoc/src/mongoc/mongoc-cluster-sspi.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-sspi.c
@@ -129,7 +129,7 @@ _mongoc_cluster_auth_node_sspi (mongoc_cluster_t *cluster,
    uint32_t buflen;
    bson_t reply;
    const char *tmpstr;
-   int conv_id;
+   int conv_id = 0;
    bson_t cmd;
    int res = MONGOC_SSPI_AUTH_GSS_CONTINUE;
    int step;
@@ -174,6 +174,8 @@ _mongoc_cluster_auth_node_sspi (mongoc_cluster_t *cluster,
       if (step == 0) {
          _mongoc_cluster_build_sasl_start (&cmd, "GSSAPI", state->response, (uint32_t) strlen (state->response));
       } else {
+         // `conv_id` is set during step 0 below by invoking `_mongoc_cluster_get_conversation_id` and guarded by `step
+         // > 0`.
          if (state->response) {
             _mongoc_cluster_build_sasl_continue (&cmd, conv_id, state->response, (uint32_t) strlen (state->response));
          } else {

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -3384,9 +3384,6 @@ mcd_rpc_message_compress (mcd_rpc_message *rpc,
 
    const int32_t original_message_length = mcd_rpc_header_get_message_length (rpc);
 
-   // msgHeader consists of four int32 fields.
-   const int32_t message_header_length = 4u * sizeof (int32_t);
-
    // compressedMessage does not include msgHeader fields.
    BSON_ASSERT (original_message_length >= message_header_length);
    const size_t uncompressed_size = (size_t) (original_message_length - message_header_length);
@@ -3471,9 +3468,6 @@ mcd_rpc_message_decompress (mcd_rpc_message *rpc, void **data, size_t *data_len)
    BSON_ASSERT_PARAM (data_len);
 
    BSON_ASSERT (mcd_rpc_header_get_op_code (rpc) == MONGOC_OP_CODE_COMPRESSED);
-
-   // msgHeader consists of four int32 fields.
-   const size_t message_header_length = 4u * sizeof (int32_t);
 
    const int32_t uncompressed_size_raw = mcd_rpc_op_compressed_get_uncompressed_size (rpc);
 

--- a/src/libmongoc/src/mongoc/mongoc-counters-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-counters-private.h
@@ -192,21 +192,22 @@ enum {
 
 #else
 /* when counters are disabled, these functions are no-ops */
-#define COUNTER(ident, Category, Name, Description)                                     \
-   static BSON_INLINE void mongoc_counter_##ident##_add (BSON_MAYBE_UNUSED int64_t val) \
-   {                                                                                    \
-   }                                                                                    \
-   static BSON_INLINE void mongoc_counter_##ident##_inc (void)                          \
-   {                                                                                    \
-   }                                                                                    \
-   static BSON_INLINE void mongoc_counter_##ident##_dec (void)                          \
-   {                                                                                    \
-   }                                                                                    \
-   static BSON_INLINE void mongoc_counter_##ident##_reset (void)                        \
-   {                                                                                    \
-   }                                                                                    \
-   static BSON_INLINE void mongoc_counter_##ident##_count (void)                        \
-   {                                                                                    \
+#define COUNTER(ident, Category, Name, Description)                   \
+   static BSON_INLINE void mongoc_counter_##ident##_add (int64_t val) \
+   {                                                                  \
+      (void) val;                                                     \
+   }                                                                  \
+   static BSON_INLINE void mongoc_counter_##ident##_inc (void)        \
+   {                                                                  \
+   }                                                                  \
+   static BSON_INLINE void mongoc_counter_##ident##_dec (void)        \
+   {                                                                  \
+   }                                                                  \
+   static BSON_INLINE void mongoc_counter_##ident##_reset (void)      \
+   {                                                                  \
+   }                                                                  \
+   static BSON_INLINE void mongoc_counter_##ident##_count (void)      \
+   {                                                                  \
    }
 #include <mongoc/mongoc-counters.defs>
 #undef COUNTER

--- a/src/libmongoc/src/mongoc/mongoc-crypto-cng.c
+++ b/src/libmongoc/src/mongoc/mongoc-crypto-cng.c
@@ -265,6 +265,7 @@ mongoc_crypto_cng_pbkdf2_hmac_sha1 (mongoc_crypto_t *crypto,
                                     unsigned char *output)
 {
 #if defined(MONGOC_HAVE_BCRYPT_PBKDF2)
+   BSON_UNUSED (crypto);
    return _bcrypt_derive_key_pbkdf2 (
       _sha1_hmac_algo, password, password_len, salt, salt_len, iterations, output_len, output);
 #else
@@ -281,6 +282,8 @@ mongoc_crypto_cng_hmac_sha1 (mongoc_crypto_t *crypto,
                              int data_len,
                              unsigned char *hmac_out)
 {
+   BSON_UNUSED (crypto);
+
    if (!_sha1_hmac_algo) {
       return;
    }
@@ -294,6 +297,8 @@ mongoc_crypto_cng_sha1 (mongoc_crypto_t *crypto,
                         const size_t input_len,
                         unsigned char *hash_out)
 {
+   BSON_UNUSED (crypto);
+
    bool res;
 
    if (!_sha1_hash_algo) {
@@ -333,6 +338,8 @@ mongoc_crypto_cng_hmac_sha256 (mongoc_crypto_t *crypto,
                                int data_len,
                                unsigned char *hmac_out)
 {
+   BSON_UNUSED (crypto);
+
    if (!_sha256_hmac_algo) {
       return;
    }
@@ -346,6 +353,8 @@ mongoc_crypto_cng_sha256 (mongoc_crypto_t *crypto,
                           const size_t input_len,
                           unsigned char *hash_out)
 {
+   BSON_UNUSED (crypto);
+
    bool res;
 
    if (!_sha256_hash_algo) {

--- a/src/libmongoc/src/mongoc/mongoc-cursor.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor.c
@@ -587,7 +587,6 @@ mongoc_cursor_destroy (mongoc_cursor_t *cursor)
          _mongoc_client_kill_cursor (cursor->client,
                                      cursor->server_id,
                                      cursor->cursor_id,
-                                     cursor->operation_id,
                                      db,
                                      cursor->ns + cursor->dblen + 1,
                                      cursor->client_session);

--- a/src/libmongoc/src/mongoc/mongoc-handshake.c
+++ b/src/libmongoc/src/mongoc/mongoc-handshake.c
@@ -281,9 +281,10 @@ _get_os_name (void)
       return bson_strndup (system_info.sysname, HANDSHAKE_OS_NAME_MAX);
    }
 
-#endif
-
    return NULL;
+#else
+   return NULL;
+#endif
 }
 
 static char *

--- a/src/libmongoc/src/mongoc/mongoc-init.c
+++ b/src/libmongoc/src/mongoc/mongoc-init.c
@@ -25,6 +25,8 @@
 
 #include <mongoc/mongoc-cluster-aws-private.h>
 
+#include <mlib/config.h>
+
 #ifdef MONGOC_ENABLE_SSL_OPENSSL
 #include <mongoc/mongoc-openssl-private.h>
 #endif

--- a/src/libmongoc/src/mongoc/mongoc-log.c
+++ b/src/libmongoc/src/mongoc/mongoc-log.c
@@ -37,6 +37,8 @@
 #include <mongoc/mongoc-thread-private.h>
 #include <common-string-private.h>
 
+#include <mlib/config.h>
+
 
 static bson_once_t once = BSON_ONCE_INIT;
 static bson_mutex_t gLogMutex;

--- a/src/libmongoc/src/mongoc/mongoc-rand-cng.c
+++ b/src/libmongoc/src/mongoc/mongoc-rand-cng.c
@@ -56,12 +56,17 @@ _mongoc_rand_bytes (uint8_t *buf, int num)
 void
 mongoc_rand_seed (const void *buf, int num)
 {
+   BSON_UNUSED (buf);
+   BSON_UNUSED (num);
    /* N/A - OS Does not need entropy seed */
 }
 
 void
 mongoc_rand_add (const void *buf, int num, double entropy)
 {
+   BSON_UNUSED (buf);
+   BSON_UNUSED (num);
+   BSON_UNUSED (entropy);
    /* N/A - OS Does not need entropy seed */
 }
 

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -237,6 +237,7 @@ fail:
 PCCERT_CONTEXT
 mongoc_secure_channel_setup_certificate (mongoc_stream_tls_secure_channel_t *secure_channel, mongoc_ssl_opt_t *opt)
 {
+   BSON_UNUSED (secure_channel);
    return mongoc_secure_channel_setup_certificate_from_file (opt->pem_file);
 }
 
@@ -257,6 +258,8 @@ _bson_append_szoid (mcommon_string_append_t *retval, PCCERT_CONTEXT cert, const 
 char *
 _mongoc_secure_channel_extract_subject (const char *filename, const char *passphrase)
 {
+   BSON_UNUSED (passphrase);
+
    PCCERT_CONTEXT cert;
    cert = mongoc_secure_channel_setup_certificate_from_file (filename);
    if (!cert) {
@@ -280,6 +283,8 @@ _mongoc_secure_channel_extract_subject (const char *filename, const char *passph
 bool
 mongoc_secure_channel_setup_ca (mongoc_stream_tls_secure_channel_t *secure_channel, mongoc_ssl_opt_t *opt)
 {
+   BSON_UNUSED (secure_channel);
+
    FILE *file;
    long length;
    const char *pem_key;
@@ -364,6 +369,8 @@ mongoc_secure_channel_setup_ca (mongoc_stream_tls_secure_channel_t *secure_chann
 bool
 mongoc_secure_channel_setup_crl (mongoc_stream_tls_secure_channel_t *secure_channel, mongoc_ssl_opt_t *opt)
 {
+   BSON_UNUSED (secure_channel);
+
    HCERTSTORE cert_store = NULL;
    PCCERT_CONTEXT cert = NULL;
    LPWSTR str;

--- a/src/libmongoc/src/mongoc/mongoc-shared.c
+++ b/src/libmongoc/src/mongoc/mongoc-shared.c
@@ -20,6 +20,8 @@
 #include <bson/bson.h>
 #include <common-atomic-private.h>
 
+#include <mlib/config.h>
+
 typedef struct _mongoc_shared_ptr_aux {
    int refcount;
    void (*deleter) (void *);

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
@@ -334,7 +334,6 @@ _mongoc_stream_tls_secure_channel_writev (mongoc_stream_t *stream,
    size_t bytes;
 
    char *to_write = NULL;
-   size_t to_write_len;
 
    BSON_ASSERT (iov);
    BSON_ASSERT (iovcnt);
@@ -353,6 +352,9 @@ _mongoc_stream_tls_secure_channel_writev (mongoc_stream_t *stream,
       while (iov_pos < iov[i].iov_len) {
          BSON_ASSERT (buf_end >= buf_tail);
          const size_t buf_remaining = (size_t) (buf_end - buf_tail);
+
+         // Set below and guarded by `to_write`.
+         size_t to_write_len = 0u;
 
          if (buf_head != buf_tail || ((i + 1u < iovcnt) && (buf_remaining > (iov[i].iov_len - iov_pos)))) {
             /* If we have either of:

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
@@ -840,6 +840,9 @@ _mongoc_stream_tls_secure_channel_should_retry (mongoc_stream_t *stream)
 mongoc_stream_t *
 mongoc_stream_tls_secure_channel_new (mongoc_stream_t *base_stream, const char *host, mongoc_ssl_opt_t *opt, int client)
 {
+   BSON_UNUSED (host);
+   BSON_UNUSED (client);
+
    SECURITY_STATUS sspi_status = SEC_E_OK;
    SCHANNEL_CRED schannel_cred;
    mongoc_stream_tls_t *tls;

--- a/src/libmongoc/src/mongoc/mongoc-thread-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-thread-private.h
@@ -94,6 +94,7 @@ mongo_cond_ret_is_timedout (int ret)
 static BSON_INLINE int
 mongoc_cond_destroy (mongoc_cond_t *_ignored)
 {
+   (void) _ignored;
    return 0;
 }
 #endif

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
@@ -922,6 +922,7 @@ mongoc_topology_scanner_node_connect_unix (mongoc_topology_scanner_node_t *node,
 {
 #ifdef _WIN32
    ENTRY;
+   BSON_UNUSED (node);
    _mongoc_set_error (
       error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_CONNECT, "UNIX domain sockets not supported on win32.");
    RETURN (false);

--- a/src/libmongoc/src/mongoc/mongoc-ts-pool.c
+++ b/src/libmongoc/src/mongoc/mongoc-ts-pool.c
@@ -3,6 +3,7 @@
 
 #include <bson/bson.h>
 #include <common-atomic-private.h>
+#include <mlib/config.h>
 
 /**
  * Toggle this to enable/disable checks that all items are returned to the pool
@@ -28,7 +29,17 @@ static const bool audit_pool_enabled = false;
 typedef struct pool_node {
    struct pool_node *next;
    mongoc_ts_pool *owner_pool;
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4200)
+#endif
+
    unsigned char data[];
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 } pool_node;
 
 // Flexible member array member should not contribute to sizeof result.

--- a/src/libmongoc/src/mongoc/mongoc-util.c
+++ b/src/libmongoc/src/mongoc/mongoc-util.c
@@ -49,6 +49,8 @@ _mongoc_rand_simple (unsigned int *seed)
 {
 #ifdef _WIN32
    /* ignore the seed */
+   BSON_UNUSED (seed);
+
    unsigned int ret = 0;
    errno_t err;
 

--- a/src/libmongoc/tests/TestSuite.c
+++ b/src/libmongoc/tests/TestSuite.c
@@ -105,14 +105,12 @@ TestSuite_SeedRand (TestSuite *suite, /* IN */
 #endif
 }
 
-
 static BSON_ONCE_FUN (_test_suite_ensure_mutex_once)
 {
    bson_mutex_init (&gTestMutex);
 
    BSON_ONCE_RETURN;
 }
-
 
 void
 TestSuite_Init (TestSuite *suite, const char *name, int argc, char **argv)

--- a/src/libmongoc/tests/bsonutil/bson-parser.c
+++ b/src/libmongoc/tests/bsonutil/bson-parser.c
@@ -20,6 +20,7 @@
 #include "test-conveniences.h"
 #include "TestSuite.h"
 #include <mongoc/utlist.h>
+#include <mlib/config.h>
 
 typedef enum {
    BSON_PARSER_UTF8,
@@ -200,7 +201,10 @@ bson_to_read_prefs (bson_t *bson, bson_error_t *error)
    }
 
    if (hedge) {
+      mlib_diagnostic_push ();
+      mlib_disable_deprecation_warnings ();
       mongoc_read_prefs_set_hedge (out, hedge);
+      mlib_diagnostic_pop ();
    }
 
 done:

--- a/src/libmongoc/tests/test-conveniences.c
+++ b/src/libmongoc/tests/test-conveniences.c
@@ -867,7 +867,7 @@ match_bson_with_ctx (const bson_t *doc, const bson_t *pattern, match_ctx_t *ctx)
    bson_type_t bson_type = (bson_type_t) 0;
    bool found;
    bson_iter_t doc_iter;
-   bson_value_t doc_value;
+   bson_value_t doc_value = {0};
    match_ctx_t derived;
 
    if (bson_empty0 (pattern)) {
@@ -910,6 +910,7 @@ match_bson_with_ctx (const bson_t *doc, const bson_t *pattern, match_ctx_t *ctx)
          ASSERT (action == MATCH_ACTION_CONTINUE);
       }
 
+      // `doc_value` is set by `bson_value_copy` above and guarded by `found`.
       if (value->value_type == BSON_TYPE_NULL && found) {
          /* pattern has "key": null, and "key" is in doc */
          if (doc_value.value_type != BSON_TYPE_NULL) {

--- a/src/libmongoc/tests/test-libmongoc-main.c
+++ b/src/libmongoc/tests/test-libmongoc-main.c
@@ -11,9 +11,8 @@ int
 main (int argc, char *argv[])
 {
    TestSuite suite;
-   int ret;
 
-   test_libmongoc_init (&suite, "libmongoc", argc, argv);
+   test_libmongoc_init (&suite, argc, argv);
 
    /* libbson */
 
@@ -162,7 +161,7 @@ main (int argc, char *argv[])
    TEST_INSTALL (test_bulkwrite_install);
    TEST_INSTALL (test_mongoc_oidc_callback_install);
 
-   ret = TestSuite_Run (&suite);
+   const int ret = TestSuite_Run (&suite);
 
    test_libmongoc_destroy (&suite);
 

--- a/src/libmongoc/tests/test-libmongoc-main.c
+++ b/src/libmongoc/tests/test-libmongoc-main.c
@@ -19,7 +19,10 @@ main (int argc, char *argv[])
 
 #define TEST_INSTALL(FuncName)                 \
    if (1) {                                    \
+      mlib_diagnostic_push ();                 \
+      mlib_msvc_warning (disable : 4210);      \
       extern void FuncName (TestSuite *suite); \
+      mlib_diagnostic_pop ();                  \
       FuncName (&suite);                       \
    } else                                      \
       ((void) 0)

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -2550,7 +2550,7 @@ windows_exception_handler (EXCEPTION_POINTERS *pExceptionInfo)
 
 
 void
-test_libmongoc_init (TestSuite *suite, BSON_MAYBE_UNUSED const char *name, int argc, char **argv)
+test_libmongoc_init (TestSuite *suite, int argc, char **argv)
 {
 #if defined(_MSC_VER) && defined(_WIN64)
    SetUnhandledExceptionFilter (windows_exception_handler);

--- a/src/libmongoc/tests/test-libmongoc.h
+++ b/src/libmongoc/tests/test-libmongoc.h
@@ -25,7 +25,7 @@ struct _server_version_t;
 
 
 void
-test_libmongoc_init (struct _TestSuite *suite, const char *name, int argc, char **argv);
+test_libmongoc_init (struct _TestSuite *suite, int argc, char **argv);
 void
 test_libmongoc_destroy (struct _TestSuite *suite);
 

--- a/src/libmongoc/tests/test-mongoc-async.c
+++ b/src/libmongoc/tests/test-mongoc-async.c
@@ -214,6 +214,8 @@ test_large_hello_helper (mongoc_async_cmd_t *acmd,
                          const bson_t *bson,
                          int64_t duration_usec)
 {
+   BSON_UNUSED (duration_usec);
+
    bson_iter_t iter;
    bson_error_t *error = &acmd->error;
 
@@ -235,6 +237,8 @@ test_large_hello_helper (mongoc_async_cmd_t *acmd,
 static void
 test_large_hello (void *ctx)
 {
+   BSON_UNUSED (ctx);
+
    mongoc_async_t *async;
    mongoc_stream_t *sock_stream;
    bson_t q = BSON_INITIALIZER;

--- a/src/libmongoc/tests/test-mongoc-bulk.c
+++ b/src/libmongoc/tests/test-mongoc-bulk.c
@@ -4111,9 +4111,9 @@ _test_bulk_collation (bool w, bulkop op)
    request_t *request;
    future_t *future;
    bson_t *opts;
-   const char *expect_msg;
-   const char *expect_doc;
-   bool r;
+   const char *expect_msg = NULL;
+   const char *expect_doc = NULL;
+   bool r = false;
 
    mock_server = mock_server_with_auto_hello (WIRE_VERSION_MIN);
    mock_server_run (mock_server);
@@ -4465,9 +4465,9 @@ _test_bulk_let (bulkop op)
    bson_error_t error;
    request_t *request;
    future_t *future;
-   const char *expect_msg;
-   const char *expect_doc;
-   bool r;
+   const char *expect_msg = NULL;
+   const char *expect_doc = NULL;
+   bool r = false;
 
    mock_server = mock_server_with_auto_hello (WIRE_VERSION_MIN);
    mock_server_run (mock_server);

--- a/src/libmongoc/tests/test-mongoc-cache.c
+++ b/src/libmongoc/tests/test-mongoc-cache.c
@@ -68,6 +68,9 @@ ping (void)
 int
 main (int argc, char *argv[])
 {
+   (void) argc;
+   (void) argv;
+
 #if defined(__linux__)
    if (argc != 2) {
       fprintf (stderr, "usage: %s CA_FILE_PATH\n", argv[0]);

--- a/src/libmongoc/tests/test-mongoc-hedged-reads.c
+++ b/src/libmongoc/tests/test-mongoc-hedged-reads.c
@@ -18,6 +18,8 @@
 
 #include <mongoc/mongoc-client-private.h>
 
+#include <mlib/config.h>
+
 #include "TestSuite.h"
 #include "mock_server/mock-server.h"
 #include "mock_server/future-functions.h"
@@ -65,7 +67,12 @@ test_mongos_hedged_reads_read_pref (void)
     * with readPreference mode secondaryPreferred and hedge set, readPreference
     * MUST be sent. */
    bson_append_bool (&hedge_doc, "enabled", 7, true);
+
+   mlib_diagnostic_push ();
+   mlib_disable_deprecation_warnings ();
    mongoc_read_prefs_set_hedge (prefs, &hedge_doc);
+   mlib_diagnostic_pop ();
+
    mongoc_collection_set_read_prefs (collection, prefs);
 
    future = future_collection_estimated_document_count (collection, NULL, prefs, NULL, &error);

--- a/src/libmongoc/tests/test-mongoc-linux-distro-scanner.c
+++ b/src/libmongoc/tests/test-mongoc-linux-distro-scanner.c
@@ -216,6 +216,8 @@ test_distro_scanner_reads (void)
 void
 test_linux_distro_scanner_install (TestSuite *suite)
 {
+   BSON_UNUSED (suite);
+
 #ifdef MONGOC_OS_IS_LINUX
    TestSuite_Add (suite, "/LinuxDistroScanner/test_read_generic_release_file", test_read_generic_release_file);
    TestSuite_Add (suite, "/LinuxDistroScanner/test_read_key_value_file", test_read_key_value_file);

--- a/src/libmongoc/tests/test-mongoc-read-prefs.c
+++ b/src/libmongoc/tests/test-mongoc-read-prefs.c
@@ -1,6 +1,8 @@
 #include <mongoc/mongoc.h>
 #include <mongoc/mongoc-uri-private.h>
 
+#include <mlib/config.h>
+
 #include "TestSuite.h"
 #include "mock_server/future.h"
 #include "mock_server/future-functions.h"
@@ -532,7 +534,10 @@ test_read_prefs_mongos_hedged_reads (void)
    prefs = mongoc_read_prefs_new (MONGOC_READ_SECONDARY_PREFERRED);
    bson_append_bool (&hedge_doc, "enabled", 7, true);
 
+   mlib_diagnostic_push ();
+   mlib_disable_deprecation_warnings ();
    mongoc_read_prefs_set_hedge (prefs, &hedge_doc);
+   mlib_diagnostic_pop ();
 
    cursor = mongoc_collection_find_with_opts (collection, tmp_bson ("{'a': 1}"), tmp_bson ("{'exhaust': true}"), prefs);
    future = future_cursor_next (cursor, &doc);

--- a/src/libmongoc/tests/test-mongoc-stream-tls.c
+++ b/src/libmongoc/tests/test-mongoc-stream-tls.c
@@ -413,6 +413,8 @@ test_mongoc_tls_insecure_nowarning (void)
 void
 test_stream_tls_install (TestSuite *suite)
 {
+   BSON_UNUSED (suite);
+
 #if !defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
 
    /* Disable /TLS/commonName on macOS due to CDRIVER-4256. */


### PR DESCRIPTION
This PR in total addresses 3573 (1192 unique) warnings with VS 2022 (version 17.13.6) and MSVC 19.43.34810.

Following the changes in this PR, the only remaining Level 4 warnings observed are related to signedness inconsistency (C4245, C4267, C4389), implicit conversions (C4244), and type casts (C4057). This brings the quality of emitted MSVC warnings to a state that is comparable to that of GCC and Clang, whose currently-emitted warnings are also largely related to unsignedness consistency and implicit conversion warnings.

> [!NOTE]
> Several attempts were made to address the GCC `-Wtype-limits` warnings emitted by the `(unsigned) < 0` comparison by `mlib_upsize_integer` in `intutil.h`, but  was unable to suppress the warning due to unexpected parser errors.

---

Addresses 801 (100 unique) C4146 "unary minus operator applied to unsigned type, result still unsigned" warnings.

Nearly all of these warnings are due to the deliberate use of the unsigned unary minus operator in `mlib_minof` macro (typically via the `mlib_in_range` macro). Because this is deliberate, this PR suppresses this warning.

> [!IMPORTANT]
> Because the `mlib_minof` and `mlib_in_range` macros are used as _expressions_ rather than _statements_, the usual `mlib_*` diagnostic macros are not usable due to forced trailing semicolons. For MSVC, `__pragma` is used explicitly and guarded by `MLIB_IF_MSVC` (`_Pragma` requires `/std:c11` or newer). This is also the case for other instances of explicit `__pragma` instead of `mlib_*` diagnostic macros for warnings described below.

The only other instance of this warning is in `bson-vector.c` in a deliberate bitwise computation of `padding`.

---

Addresses 746 (633 unique) C4189 "local variable is initialized but not referenced" warnings.

These warnings have two categories.

The first category are warnings emitted in the following confusing form:

```
'$S1234': local variable is initialized but not referenced
```

These warnings appear to be referencing the initialization of _data members_ of temporary structs (denoted as `$S1234` for some number `1234`). Most of these warnings are due to the `mlib_upsize_integer` macro. Inline suppressions are added accordingly.

The second category are due to the `BSON_MAYBE_UNUSED` macro, used by the BSON DSL macros, [having no effect](https://github.com/mongodb/mongo-c-driver/blob/74c039a1ebbb6cee4c127e379501ee3d66ea7dd6/src/libbson/src/bson/bson-macros.h#L381) on MSVC due to lack of a feature equivalent to `__attribute__((unused))`. MSVC only supports `[[maybe_unused]]` for VS 2017 15.3 and newer with the `/std:c++17` flag, which is irrelevant to our codebase. Therefore, the `BSON_MAYBE_UNUSED` macro is replaced with the familiar `(void) var;` workaround to silence unused warnings.

---

Addresses 126 C4210 "nonstandard extension used: function given file scope" warnings (124 unique).

These warnings concerns an [old MSVC language extension](https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170) where functions declarations within function scope have file scope instead. Most of these warnings are due to `TEST_INSTALL`, with the remainder pertaining to the `mongoc_get_init_called` function. Due to the limited scope and impact of these warnings, they are either directly silenced using `mlib_msvc_warning` or the declaration simply moved out of function scope into file scope.

---

Addresses 6 (2 unique) C4200 "nonstandard extension used: zero-sized array in struct/union" warnings.

These warnings appear to be false-positives caused by use of a flexible array member in `jsonsl_st` and `pool_node`. Both are using an incomplete array type `T member[];` to declare a flexible array member per the C99 standard; they are not declaring a zero-size array `T member[0];` as C4200 implies. These warnings are therefore suppressed.

---

Addresses 8 (4 unique) C4232 "nonstandard extension used: 'fn': address of dllimport 'fn' is not static, identity not guaranteed" warnings.

These warnings concerns an [old MSVC language extension](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4232?view=msvc-170) permitting one to evaluate the address of a `__declspec(dllimport)`-ed function (address is computed at runtime) at compile-time via static initialization (address is computed at compile-time). In our case, these warnings are due to initializing `gMemVtable`'s function pointers to their default value: `malloc`, `calloc`, `realloc`, and `free`. Because we do not expect users or ourselves to depend on the stability of the address of these stdlib allocation functions, this PR opts to simply silence this warning without making significant changes.

---

Addresses 1350 (91 unique) C4100 "unreferenced formal parameter" warnings.

These warnings have three categories.

The first category are simply parameters which are not referenced either due to obsoletion or conditional compilation. These warnings were addressed by either adding `BSON_UNUSED(param);` or by removing the parameter altogether.

The second category are due to "call once" functions [containing unused parameters](https://github.com/mongodb/mongo-c-driver/blob/74c039a1ebbb6cee4c127e379501ee3d66ea7dd6/src/common/src/common-thread-private.h#L116) when built with MSVC to satisfy [InitOnceExecuteOnce](https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-initonceexecuteonce) API requirements. These warnings are suppressed accordingly using `MLIB_IF_MSVC (__pragma (...))` to avoid interfering with the function declaration syntax.

The third category are (pointer) parameters which _are_ referenced, but only by the `BSON_OPTIONAL_PARAM` macro. These were addressed by changing the definition of `BSON_OPTIONAL_PARAM` from a no-op to `((void) param)`.

---

Addresses 207 (161 unique) C4456 "declaration of 'var' hides previous local declaration" warnings.

Nearly all of these warnings were due to BSON DSL macros, which reuse the same local variable names within nested scopes according to how the DSL macros are used and expanding. The existing suppression of `-Wshadow` warnings for GCC and Clang were extended to also supporess C4456.

The only other change required to address this warning was in `test-bson.c`, which only required a trivial rename.

---

Addresses 1 C4308 "negative integral constant converted to unsigned type" warning.

Although this is normally something to be avoided, this case was a [deliberate sanity check](https://github.com/mongodb/mongo-c-driver/blob/74c039a1ebbb6cee4c127e379501ee3d66ea7dd6/src/common/tests/test-mlib.c#L312) ensuring `signed op unsigned` is implicitly converted to `unsigned op unsigned` prior to further evaluation as expected, rather than implicitly converting to `signed op signed`.

---

Addresses 4 (2 unique) C4459 "declaration of 'var' hides global declaration" warnings.

These were all due to the redundant redefinition of the [`message_header_length`](https://github.com/mongodb/mongo-c-driver/blob/74c039a1ebbb6cee4c127e379501ee3d66ea7dd6/src/libmongoc/src/mongoc/mongoc-cluster.c#L227) constant within function scope in `mongoc-cluster.c`. The redundant definitions are removed accordingly.

---

Addresses 2 (1 unique) C4132 "const object should be initialized" warnings.

These warnings are due to the `gZero` static const variable lacking an explicit initializer in its definition. Even though it is well-defined to perform zero-initialization, there is no harm in being explicit about it, so a `= 0` initializer was added to the definition to address this warning.

---

Addresses 3 (3 unique) C4996 "Hedged Reads are deprecated in 8.0" warnings.

These warnings appear to have been overlooked by https://github.com/mongodb/mongo-c-driver/issues/1889. These are addressed with straightforward use of the `mlib_disable_deprecation_warnings()` diagnostic macro.

---

Address C4702 "unreachable code" warnings.

These warnings have two categories.

The first category are "expanded" or "explanatory" code which were not commented out in `mlib/ckdint.h`. These code blocks were converted into comments accordingly.

The second category are macro expansions which happen to containing unreachable code paths due to build configuration (`HASH_ADD_KEYPTR`) or expanded code branches (BSON DSL macros). In both cases, there is an expanded call to `abort()` which makes  subsequent evaluation of internal code unreachable (e.g. `__bson_dsl_indent;`). Attempting to address these warnings were frustrated by [the following quirk](https://learn.microsoft.com/en-us/cpp/preprocessor/warning?view=msvc-170&redirectedfrom=MSDN):

> Warning numbers in the range 4700-4999 are associated with code generation. For these warnings, the state of the warning in effect when the compiler reaches the function definition remains in effect for the rest of the function. Use of the warning pragma in the function to change the state of a warning number larger than 4699 only takes effect after the end of the function.

Accordingly, attempts to insert suppressions within the relevant BSON DSL macros failed. There was no choice but to silence the warning at the usage sites instead (at file scope to completely surround relevant function definitions).

---

Addresses 4 (4 unique) C4703 "potentially uninitialized local variable" warnings.

Although most of these warnings simply required an explicit initializer to address, a couple cases involved some non-straightforward control flow and branch guards. Comments were added in addition to the initializer to hopefully provide clearer context.

---

Addresses 1 C2099 "initializer is not a constant" warning.

This one is actually not our fault. There is a [regression in the Windows 11 SDK](https://developercommunity.visualstudio.com/t/NAN-is-no-longer-compile-time-constant-i/10688907) where the `NAN` macro constant is no longer a compile-time constant. This regression is yet to be fixed (but planned for a [late April release](https://developercommunity.visualstudio.com/t/NAN-is-no-longer-compile-time-constant-i/10688907#T-N10876610)). Declaring the array as a normal function-local variable is sufficient to workaround this issue.