### PR TITLE
fix base64 decoding command in keytab

### DIFF
--- a/.evergreen/config_generator/components/funcs/prepare_kerberos.py
+++ b/.evergreen/config_generator/components/funcs/prepare_kerberos.py
@@ -14,7 +14,7 @@ class PrepareKerberos(Function):
             script='''\
             if test "${keytab|}" && command -v kinit >/dev/null; then
                 echo "${keytab}" > /tmp/drivers.keytab.base64
-                base64 --decode /tmp/drivers.keytab.base64 > /tmp/drivers.keytab
+                cat /tmp/drivers.keytab.base64 | base64 -d > /tmp/drivers.keytab
                 if touch /etc/krb5.conf 2>/dev/null; then
                     cat .evergreen/etc/kerberos.realm | tee -a /etc/krb5.conf
                 elif command sudo true 2>/dev/null; then

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -339,7 +339,7 @@ functions:
           - |
             if test "${keytab|}" && command -v kinit >/dev/null; then
                 echo "${keytab}" > /tmp/drivers.keytab.base64
-                base64 --decode /tmp/drivers.keytab.base64 > /tmp/drivers.keytab
+                cat /tmp/drivers.keytab.base64 | base64 -d > /tmp/drivers.keytab
                 if touch /etc/krb5.conf 2>/dev/null; then
                     cat .evergreen/etc/kerberos.realm | tee -a /etc/krb5.conf
                 elif command sudo true 2>/dev/null; then


### PR DESCRIPTION
Fix base64 decoding of keytab on macOS. Fixes failing task: [authentication-tests-darwinssl](https://spruce.mongodb.com/task/mongo_c_driver_darwin_authentication_tests_darwinssl_3c2161fe78abccbd02c5b5115213eb2096dc9847_25_04_17_23_28_05/logs?execution=0). Tested with this [patch build](https://spruce.mongodb.com/version/68019808d1283200071d51bc).

Running on my local macOS, the previous command errored:
```
% base64 --decode /tmp/drivers.keytab.base64 > /tmp/drivers.keytab
base64: invalid argument /tmp/drivers.keytab.base64
```