### PR TITLE
CDRIVER-5990 skip auth tests on zSeries

### DIFF
--- a/.evergreen/scripts/run-auth-tests.sh
+++ b/.evergreen/scripts/run-auth-tests.sh
@@ -100,7 +100,7 @@ elif command -v otool >/dev/null; then
 fi
 
 # TODO: Remove `skip_for_zseries` when resolving CDRIVER-5990.
-function skip_for_zseries() {
+skip_for_zseries() {
   if $IS_ZSERIES; then
     echo "Skipping test until DEVPROD-16954 is resolved."
     return

--- a/.evergreen/scripts/run-auth-tests.sh
+++ b/.evergreen/scripts/run-auth-tests.sh
@@ -174,7 +174,7 @@ if [[ "${sasl}" != "OFF" ]]; then
   fi
 
   echo "Test threaded GSSAPI auth"
-  LD_LIBRARY_PATH="${openssl_lib_prefix}" skip_for_zseries MONGOC_TEST_GSSAPI_HOST="${auth_host}" MONGOC_TEST_GSSAPI_USER="${auth_gssapi}" LD_PRELOAD="${ld_preload:-}" "${test_gssapi}"
+  LD_LIBRARY_PATH="${openssl_lib_prefix}" MONGOC_TEST_GSSAPI_HOST="${auth_host}" MONGOC_TEST_GSSAPI_USER="${auth_gssapi}" LD_PRELOAD="${ld_preload:-}" skip_for_zseries "${test_gssapi}"
   echo "Threaded GSSAPI auth OK"
 
   if [[ "${OSTYPE}" == "cygwin" ]]; then


### PR DESCRIPTION
Skip auth tests on zSeries depending on DEVPROD-16954. Tested in this [patch build](https://spruce.mongodb.com/version/6802a216fa9a8e00073cc6b0).

## Background

The C driver tests on zSeries (rhel8-zseries-large) fails to connect to the test host referenced in DEVPROD-16954. From a [patch](https://spruce.mongodb.com/task/mongo_c_driver_zseries_rhel8_survey_patch_8c0a2446ae44350066becfa908c83499b6cca96c_6802918b57ad790007f5f618_25_04_18_17_53_16/logs?execution=0):
```
nc: connect to [REDACTED:auth_host] (54.225.237.121) port 27017 (tcp) failed: Connection timed out
```

I expect this is related to the migration of zSeries hosts in DEVPROD-5083. (Tests did not fail at the time since auth tests were [temporarily skipped](https://github.com/mongodb/mongo-c-driver/blob/ae9fcb388480351800c39485447d9f76b9ecea75/.evergreen/scripts/run-auth-tests.sh#L104-L105) pending a server upgrade from 3.6 to 4.0 for DEVPROD-9029).
