### PR TITLE
CDRIVER-5529 update release instructions to account for new rulesets

### DIFF
--- a/docs/dev/releasing.rst
+++ b/docs/dev/releasing.rst
@@ -17,6 +17,8 @@ MongoDB C driver library. The release includes the following steps:
 .. _evg-release: https://spruce.mongodb.com/commits/mongo-c-driver-latest-release
 .. _evg-release-settings: https://spruce.mongodb.com/project/mongo-c-driver-latest-release/settings/general
 .. _snyk: https://app.snyk.io
+.. _dbx-c-cxx-releases-github: https://github.com/orgs/mongodb/teams/dbx-c-cxx-releases/
+.. _dbx-c-cxx-releases-mana: https://mana.corp.mongodb.com/resources/68029673d39aa9f7de6399f9
 
 .. rubric:: Checklist Form
 
@@ -250,6 +252,20 @@ __ https://github.com/settings/tokens
       (Selecting this permission may also enable the *Metadata* permission; this is
       normal.)
 
+Join the Release Team
+#####################
+
+The release process may require creating new branches, new tags, and directly
+pushing to development branches. These operations are normally restricted by
+branch protection rules.
+
+When assigned the responsibility of performing a release, submit a request to a
+repository administrator to be temporarily added to the
+`releases team <dbx-c-cxx-releases-github_>`_ on GitHub for the duration of the
+release process. The team member must be added via
+`MANA <dbx-c-cxx-releases-mana_>`_ (the GitHub team should normally be empty,
+meaning there should not be any member with the "Maintainer" role to add new
+users via GitHub).
 
 Do the Release
 ##############
@@ -484,6 +500,13 @@ Now `create a new GitHub Pull Request`__ to merge the ``post-release-merge``
 changes back into the ``master`` branch.
 
 __ https://github.com/mongodb/mongo-c-driver/pulls
+
+
+Leave the Release Team
+**********************
+
+Remove yourself from the `releases team <dbx-c-cxx-releases-github_>`_ on GitHub
+via `MANA <dbx-c-cxx-releases-mana_>`_.
 
 
 .. _releasing.jira:


### PR DESCRIPTION
Resolves CDRIVER-5529. Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1385.

The rulesets for the C Driver repository are nearly identical to those implemented [for the C++ Driver](https://github.com/mongodb/mongo-cxx-driver/pull/1385#issuecomment-2822366466), re-summarized here:

- Joining the @mongodb/dbx-c-cxx-releases team during a release allows one to bypass to the following rulesets:
    - "Restrict Creations" (branches and tags) to create new release branches and tags.
    - "Require a Pull Request" (new and active branches) to directly push to (new) release branches.
- "Restrict Deletions" apply to all branches and tags without exception.
- "Restrict Updates" applies to all tags without exception and to an _inclusive_ target list of stale branches which may be "locked" from any further changes.
- "Require a Pull Request" applies to all branches, except as bypassed described above, and excluding the `debian/unstable` and `gh-pages` branches (always direct-pushable).

> [!NOTE]
> "Require a Pull Request" also applies the following rules:
> - "Require linear history"
> - "Required approvals" (set to 1)
> - "Require review from Code Owners"
> - "Allowed merge methods" (Squash or Rebase)

No changes to how release tags are created appear to be strictly necessary atm given the release scripts already [GPG-sign the release tag](https://github.com/10gen/mongo-c-driver-tools/blob/6402bac6ff07421eef764cc8336d52b37a97de00/release.py#L454) using the current git author's signing key. This is unlike the C++ Driver's currently-proposed solution which uses the [Release Signing Key](https://github.com/mongodb/mongo-cxx-driver/blob/eec6bd435ea06e0e87243b900f03af9b5e873f9f/etc/garasign_release_tag.sh#L40) instead. We may want to consider switching to using the Release Signing Key for the C Driver as well in the near future to improve the usage experience for users who wish to validate the signature against a well-known, dedicated public key (provided by https://pgp.mongodb.com/) rather than individual developers' public keys. Filed CDRIVER-5994 to track this followup work (which must be individually and manually uploaded to one or more public keyservers for visibility...? GitHub snippets? public wiki page? ¯\\\_(ツ)\_/¯).