### PR TITLE
CDRIVER-5956 raise min wire version from 7 to 8 (server 4.2)

### DIFF
--- a/.evergreen/config_generator/components/sasl/darwinssl.py
+++ b/.evergreen/config_generator/components/sasl/darwinssl.py
@@ -22,7 +22,7 @@ COMPILE_MATRIX = [
 ]
 
 TEST_MATRIX = [
-    ('macos-14', 'clang', None, 'cyrus', ['auth'], ['server'], ['4.0', '4.2', '4.4', '5.0']),
+    ('macos-14', 'clang', None, 'cyrus', ['auth'], ['server'], ['4.2', '4.4', '5.0']),
 
     ('macos-11-arm64', 'clang', None, 'cyrus', ['auth'], ['server'], ['6.0', '7.0',                ]),
     ('macos-14-arm64', 'clang', None, 'cyrus', ['auth'], ['server'], ['6.0', '7.0', '8.0', 'latest']),

--- a/.evergreen/config_generator/components/sasl/winssl.py
+++ b/.evergreen/config_generator/components/sasl/winssl.py
@@ -21,7 +21,7 @@ COMPILE_MATRIX = [
 ]
 
 TEST_MATRIX = [
-    ('windows-vsCurrent', 'vs2017x64', None, 'sspi', ['auth'], ['server'], ['4.0', '4.2', '4.4', '5.0', '6.0', '7.0', '8.0', 'latest']),
+    ('windows-vsCurrent', 'vs2017x64', None, 'sspi', ['auth'], ['server'], ['4.2', '4.4', '5.0', '6.0', '7.0', '8.0', 'latest']),
 
     ('windows-vsCurrent', 'mingw',     None, 'sspi',  ['auth'], ['server'], ['8.0', 'latest']),
     ('windows-vsCurrent', 'vs2017x86', None, 'sspi',  ['auth'], ['server'], ['8.0', 'latest']),

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -3275,27 +3275,6 @@ tasks:
           CC: clang
           CXX: clang++
       - func: upload-build
-  - name: sasl-cyrus-darwinssl-macos-14-clang-test-4.0-server-auth
-    run_on: macos-14
-    tags: [sasl-matrix-darwinssl, test, macos-14, clang, sasl-cyrus, auth, server, "4.0", darwinssl]
-    depends_on: [{ name: sasl-cyrus-darwinssl-macos-14-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-cyrus-darwinssl-macos-14-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: CXX, value: clang++ }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: darwinssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
   - name: sasl-cyrus-darwinssl-macos-14-clang-test-4.2-server-auth
     run_on: macos-14
     tags: [sasl-matrix-darwinssl, test, macos-14, clang, sasl-cyrus, auth, server, "4.2", darwinssl]
@@ -4676,27 +4655,6 @@ tasks:
           CMAKE_GENERATOR: Visual Studio 15 2017
           CMAKE_GENERATOR_PLATFORM: x64
       - func: upload-build
-  - name: sasl-sspi-winssl-windows-2019-vs2017-x64-test-4.0-server-auth
-    run_on: windows-vsCurrent-small
-    tags: [sasl-matrix-winssl, test, windows-vsCurrent, vs2017x64, sasl-sspi, auth, server, "4.0", winssl]
-    depends_on: [{ name: sasl-sspi-winssl-windows-2019-vs2017-x64-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-sspi-winssl-windows-2019-vs2017-x64-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CMAKE_GENERATOR, value: Visual Studio 15 2017 }
-            - { key: CMAKE_GENERATOR_PLATFORM, value: x64 }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: winssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
   - name: sasl-sspi-winssl-windows-2019-vs2017-x64-test-4.2-server-auth
     run_on: windows-vsCurrent-small
     tags: [sasl-matrix-winssl, test, windows-vsCurrent, vs2017x64, sasl-sspi, auth, server, "4.2", winssl]

--- a/.evergreen/scripts/run-auth-tests.sh
+++ b/.evergreen/scripts/run-auth-tests.sh
@@ -99,9 +99,15 @@ elif command -v otool >/dev/null; then
   LD_LIBRARY_PATH="${openssl_lib_prefix}" otool -L "${test_gssapi}" | grep "libssl" || true
 fi
 
-# TODO: Remove `skip_for_zseries` when resolving CDRIVER-5990.
-skip_for_zseries() {
+maybe_skip() {
+  if true; then
+    # TODO: Remove if-block when resolving CDRIVER-5995.
+    echo "Skipping test until DEVPROD-9029 is resolved."
+    return 
+  fi
+
   if $IS_ZSERIES; then
+    # TODO: Remove if-block when resolving CDRIVER-5990.
     echo "Skipping test until DEVPROD-16954 is resolved."
     return
   fi
@@ -113,7 +119,7 @@ if [[ "${ssl}" != "OFF" ]]; then
   # FIXME: CDRIVER-2008 for the cygwin check
   if [[ "${OSTYPE}" != "cygwin" ]]; then
     echo "Authenticating using X.509"
-    LD_LIBRARY_PATH="${openssl_lib_prefix}" skip_for_zseries "${ping}" "mongodb://CN=client,OU=kerneluser,O=10Gen,L=New York City,ST=New York,C=US@${auth_host}/?ssl=true&authMechanism=MONGODB-X509&sslClientCertificateKeyFile=src/libmongoc/tests/x509gen/ldaptest-client-key-and-cert.pem&sslCertificateAuthorityFile=src/libmongoc/tests/x509gen/ldaptest-ca-cert.crt&sslAllowInvalidHostnames=true&${c_timeout}"
+    LD_LIBRARY_PATH="${openssl_lib_prefix}" maybe_skip "${ping}" "mongodb://CN=client,OU=kerneluser,O=10Gen,L=New York City,ST=New York,C=US@${auth_host}/?ssl=true&authMechanism=MONGODB-X509&sslClientCertificateKeyFile=src/libmongoc/tests/x509gen/ldaptest-client-key-and-cert.pem&sslCertificateAuthorityFile=src/libmongoc/tests/x509gen/ldaptest-ca-cert.crt&sslAllowInvalidHostnames=true&${c_timeout}"
   fi
   echo "Connecting to Atlas Free Tier"
   LD_LIBRARY_PATH="${openssl_lib_prefix}" "${ping}" "${atlas_free:?}&${c_timeout}"
@@ -155,18 +161,18 @@ if [[ "${ssl}" != "OFF" ]]; then
 fi
 
 echo "Authenticating using PLAIN"
-LD_LIBRARY_PATH="${openssl_lib_prefix}" skip_for_zseries "${ping}" "mongodb://${auth_plain:?}@${auth_host}/?authMechanism=PLAIN&${c_timeout}"
+LD_LIBRARY_PATH="${openssl_lib_prefix}" maybe_skip "${ping}" "mongodb://${auth_plain:?}@${auth_host}/?authMechanism=PLAIN&${c_timeout}"
 
 echo "Authenticating using default auth mechanism"
 # Though the auth source is named "mongodb-cr", authentication uses the default mechanism (currently SCRAM-SHA-1).
-LD_LIBRARY_PATH="${openssl_lib_prefix}" skip_for_zseries "${ping}" "mongodb://${auth_mongodbcr:?}@${auth_host}/mongodb-cr?${c_timeout}"
+LD_LIBRARY_PATH="${openssl_lib_prefix}" maybe_skip "${ping}" "mongodb://${auth_mongodbcr:?}@${auth_host}/mongodb-cr?${c_timeout}"
 
 if [[ "${sasl}" != "OFF" ]]; then
   echo "Authenticating using GSSAPI"
-  LD_LIBRARY_PATH="${openssl_lib_prefix}" skip_for_zseries "${ping}" "mongodb://${auth_gssapi:?}@${auth_host}/?authMechanism=GSSAPI&${c_timeout}"
+  LD_LIBRARY_PATH="${openssl_lib_prefix}" maybe_skip "${ping}" "mongodb://${auth_gssapi:?}@${auth_host}/?authMechanism=GSSAPI&${c_timeout}"
 
   echo "Authenticating with CANONICALIZE_HOST_NAME"
-  LD_LIBRARY_PATH="${openssl_lib_prefix}" skip_for_zseries "${ping}" "mongodb://${auth_gssapi:?}@${ip_addr}/?authMechanism=GSSAPI&authMechanismProperties=CANONICALIZE_HOST_NAME:true&${c_timeout}"
+  LD_LIBRARY_PATH="${openssl_lib_prefix}" maybe_skip "${ping}" "mongodb://${auth_gssapi:?}@${ip_addr}/?authMechanism=GSSAPI&authMechanismProperties=CANONICALIZE_HOST_NAME:true&${c_timeout}"
 
   declare ld_preload="${LD_PRELOAD:-}"
   if [[ "${ASAN:-}" == "on" ]]; then
@@ -174,13 +180,13 @@ if [[ "${sasl}" != "OFF" ]]; then
   fi
 
   echo "Test threaded GSSAPI auth"
-  LD_LIBRARY_PATH="${openssl_lib_prefix}" MONGOC_TEST_GSSAPI_HOST="${auth_host}" MONGOC_TEST_GSSAPI_USER="${auth_gssapi}" LD_PRELOAD="${ld_preload:-}" skip_for_zseries "${test_gssapi}"
+  LD_LIBRARY_PATH="${openssl_lib_prefix}" MONGOC_TEST_GSSAPI_HOST="${auth_host}" MONGOC_TEST_GSSAPI_USER="${auth_gssapi}" LD_PRELOAD="${ld_preload:-}" maybe_skip "${test_gssapi}"
   echo "Threaded GSSAPI auth OK"
 
   if [[ "${OSTYPE}" == "cygwin" ]]; then
     echo "Authenticating using GSSAPI (service realm: LDAPTEST.10GEN.CC)"
-    LD_LIBRARY_PATH="${openssl_lib_prefix}" skip_for_zseries "${ping}" "mongodb://${auth_crossrealm:?}@${auth_host}/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_REALM:LDAPTEST.10GEN.CC&${c_timeout}"
+    LD_LIBRARY_PATH="${openssl_lib_prefix}" maybe_skip "${ping}" "mongodb://${auth_crossrealm:?}@${auth_host}/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_REALM:LDAPTEST.10GEN.CC&${c_timeout}"
     echo "Authenticating using GSSAPI (UTF-8 credentials)"
-    LD_LIBRARY_PATH="${openssl_lib_prefix}" skip_for_zseries "${ping}" "mongodb://${auth_gssapi_utf8:?}@${auth_host}/?authMechanism=GSSAPI&${c_timeout}"
+    LD_LIBRARY_PATH="${openssl_lib_prefix}" maybe_skip "${ping}" "mongodb://${auth_gssapi_utf8:?}@${auth_host}/?authMechanism=GSSAPI&${c_timeout}"
   fi
 fi

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+libmongoc 2.1.0 (Unreleased)
+============================
+
+## Notes
+
+* The minimum supported MongoDB Server version is raised from 4.0 to 4.2. This is in accordance with [MongoDB Software Lifecycle Schedules](https://www.mongodb.com/legal/support-policy/lifecycles).
+
 libmongoc 1.30.3
 ================
 

--- a/src/libmongoc/src/mongoc/mongoc-change-stream.c
+++ b/src/libmongoc/src/mongoc/mongoc-change-stream.c
@@ -140,7 +140,7 @@ _make_command (mongoc_change_stream_t *stream, bson_t *command)
             /* The driver MUST set resumeAfter to the cached resumeToken */
             BSON_APPEND_DOCUMENT (&change_stream_doc, "resumeAfter", &stream->resume_token);
          }
-      } else if (!_mongoc_timestamp_empty (&stream->operation_time) && stream->max_wire_version >= WIRE_VERSION_4_0) {
+      } else if (!_mongoc_timestamp_empty (&stream->operation_time)) {
          /* Else if there is no cached resumeToken and the ChangeStream
             has a saved operation time and the max wire version is >= 7,
             the driver MUST set startAtOperationTime */
@@ -330,8 +330,7 @@ _make_cursor (mongoc_change_stream_t *stream)
 
    /* Change stream spec: startAtOperationTime */
    if (bson_empty (&stream->opts.resumeAfter) && bson_empty (&stream->opts.startAfter) &&
-       _mongoc_timestamp_empty (&stream->operation_time) && stream->max_wire_version >= WIRE_VERSION_4_0 &&
-       bson_empty (&stream->resume_token) &&
+       _mongoc_timestamp_empty (&stream->operation_time) && bson_empty (&stream->resume_token) &&
        bson_iter_init_find (&iter, _mongoc_cursor_change_stream_get_reply (stream->cursor), "operationTime") &&
        BSON_ITER_HOLDS_TIMESTAMP (&iter)) {
       _mongoc_timestamp_set_from_bson (&stream->operation_time, &iter);

--- a/src/libmongoc/src/mongoc/mongoc-client-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-private.h
@@ -83,7 +83,7 @@ BSON_BEGIN_DECLS
 /* Range of wire protocol versions this driver supports. Bumping
  * WIRE_VERSION_MAX must be accompanied by an update to
  * `_mongoc_wire_version_to_server_version`. */
-#define WIRE_VERSION_MIN WIRE_VERSION_4_0 /* a.k.a. minWireVersion */
+#define WIRE_VERSION_MIN WIRE_VERSION_4_2 /* a.k.a. minWireVersion */
 #define WIRE_VERSION_MAX WIRE_VERSION_8_0 /* a.k.a. maxWireVersion */
 
 struct _mongoc_collection_t;

--- a/src/libmongoc/src/mongoc/mongoc-client-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-private.h
@@ -41,8 +41,6 @@
 
 BSON_BEGIN_DECLS
 
-/* version corresponding to server 4.0 release */
-#define WIRE_VERSION_4_0 7
 /* first version to support hint for "update" command */
 #define WIRE_VERSION_UPDATE_HINT 8
 /* version corresponding to server 4.2 release */

--- a/src/libmongoc/src/mongoc/mongoc-client-session.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-session.c
@@ -1053,17 +1053,6 @@ mongoc_client_session_start_transaction (mongoc_client_session_t *session,
       GOTO (done);
    }
 
-   if (server_stream->sd->max_wire_version < 7 ||
-       (server_stream->sd->max_wire_version < 8 && server_stream->sd->type == MONGOC_SERVER_MONGOS)) {
-      _mongoc_set_error (error,
-                         MONGOC_ERROR_TRANSACTION,
-                         MONGOC_ERROR_TRANSACTION_INVALID_STATE,
-                         "Multi-document transactions are not supported by this "
-                         "server version");
-      ret = false;
-      GOTO (done);
-   }
-
    /* use "switch" so that static checkers ensure we handle all states */
    switch (session->txn.state) {
    case MONGOC_INTERNAL_TRANSACTION_STARTING:

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -1779,7 +1779,7 @@ _handle_sdam_app_error_command (mongoc_topology_t *topology,
       return false;
    }
 
-   should_clear_pool = (max_wire_version <= WIRE_VERSION_4_0 || _mongoc_error_is_shutdown (&cmd_error));
+   should_clear_pool = _mongoc_error_is_shutdown (&cmd_error);
 
    tdmod = mc_tpld_modify_begin (topology);
 

--- a/src/libmongoc/src/mongoc/mongoc-util.c
+++ b/src/libmongoc/src/mongoc/mongoc-util.c
@@ -285,7 +285,7 @@ _mongoc_wire_version_to_server_version (int32_t version)
       return "3.4";
    case 6:
       return "3.6";
-   case WIRE_VERSION_4_0:
+   case 7:
       return "4.0";
    case WIRE_VERSION_4_2:
       return "4.2";

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -1990,7 +1990,7 @@ test_framework_skip_if_no_txns (void)
    }
 
    if (test_framework_skip_if_no_crypto () && test_framework_skip_if_no_sessions () &&
-       test_framework_skip_if_not_mongos () && test_framework_skip_if_max_wire_version_less_than_8 ()) {
+       test_framework_skip_if_not_mongos ()) {
       // Have crypto, sessions, and sharded cluster. Proceed.
       return 1;
    }

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -1984,12 +1984,14 @@ int
 test_framework_skip_if_no_txns (void)
 {
    if (test_framework_skip_if_no_crypto () && test_framework_skip_if_no_sessions () &&
-       test_framework_skip_if_not_replset () && test_framework_skip_if_max_wire_version_less_than_7 ()) {
+       test_framework_skip_if_not_replset ()) {
+      // Have crypto, sessions, and replica set. Proceed.
       return 1;
    }
 
    if (test_framework_skip_if_no_crypto () && test_framework_skip_if_no_sessions () &&
        test_framework_skip_if_not_mongos () && test_framework_skip_if_max_wire_version_less_than_8 ()) {
+      // Have crypto, sessions, and sharded cluster. Proceed.
       return 1;
    }
 
@@ -2252,7 +2254,6 @@ test_framework_skip_if_not_replset (void)
       return (test_framework_max_wire_version_at_least (wv) && test_framework_is_replset ()) ? 0 : 1; \
    }
 
-WIRE_VERSION_CHECKS (7)
 WIRE_VERSION_CHECKS (8)
 WIRE_VERSION_CHECKS (9)
 /* wire versions 10, 11, 12 were internal to the 5.0 release cycle */

--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -2254,7 +2254,9 @@ test_framework_skip_if_not_replset (void)
       return (test_framework_max_wire_version_at_least (wv) && test_framework_is_replset ()) ? 0 : 1; \
    }
 
+/* wire version 8 begins with the 4.2 release. */
 WIRE_VERSION_CHECKS (8)
+/* wire version 9 begins with the 4.4 release. */
 WIRE_VERSION_CHECKS (9)
 /* wire versions 10, 11, 12 were internal to the 5.0 release cycle */
 WIRE_VERSION_CHECKS (13)

--- a/src/libmongoc/tests/test-libmongoc.h
+++ b/src/libmongoc/tests/test-libmongoc.h
@@ -195,7 +195,6 @@ test_framework_skip_if_slow_or_live (void);
    int test_framework_skip_if_rs_version_##wv (void);                 \
    int test_framework_skip_if_not_rs_version_##wv (void);
 
-WIRE_VERSION_CHECK_DECLS (7)
 WIRE_VERSION_CHECK_DECLS (8)
 WIRE_VERSION_CHECK_DECLS (9)
 /* wire versions 10, 11, 12 were internal to the 5.0 release cycle */

--- a/src/libmongoc/tests/test-libmongoc.h
+++ b/src/libmongoc/tests/test-libmongoc.h
@@ -195,7 +195,9 @@ test_framework_skip_if_slow_or_live (void);
    int test_framework_skip_if_rs_version_##wv (void);                 \
    int test_framework_skip_if_not_rs_version_##wv (void);
 
+/* wire version 8 begins with the 4.2 release. */
 WIRE_VERSION_CHECK_DECLS (8)
+/* wire version 9 begins with the 4.4 release. */
 WIRE_VERSION_CHECK_DECLS (9)
 /* wire versions 10, 11, 12 were internal to the 5.0 release cycle */
 WIRE_VERSION_CHECK_DECLS (13)

--- a/src/libmongoc/tests/test-mongoc-bulk.c
+++ b/src/libmongoc/tests/test-mongoc-bulk.c
@@ -4976,9 +4976,7 @@ test_bulk_install (TestSuite *suite)
                       test_bulk_write_multiple_errors,
                       NULL,
                       NULL,
-                      test_framework_skip_if_no_failpoint,
-                      /* Require server 4.2 for failCommand appName */
-                      test_framework_skip_if_max_wire_version_less_than_8);
+                      test_framework_skip_if_no_failpoint);
    TestSuite_AddLive (suite, "/BulkOperation/set_client_after_operation", test_bulk_write_set_client_after_operation);
    TestSuite_AddMockServerTest (suite,
                                 "/BulkOperation/set_client_updates_operation_id_when_client_changes",

--- a/src/libmongoc/tests/test-mongoc-change-stream.c
+++ b/src/libmongoc/tests/test-mongoc-change-stream.c
@@ -1444,7 +1444,7 @@ _test_resume (const char *opts,
    char *msg;
    const bson_t *doc = NULL;
 
-   server = mock_server_with_auto_hello (WIRE_VERSION_4_0);
+   server = mock_server_with_auto_hello (WIRE_VERSION_MIN);
    mock_server_run (server);
    client = test_framework_client_new_from_uri (mock_server_get_uri (server), NULL);
    mongoc_client_set_error_api (client, MONGOC_ERROR_API_VERSION_2);

--- a/src/libmongoc/tests/test-mongoc-change-stream.c
+++ b/src/libmongoc/tests/test-mongoc-change-stream.c
@@ -1317,40 +1317,6 @@ test_change_stream_client_watch (void *test_ctx)
    mongoc_client_destroy (client);
 }
 
-
-static int
-_skip_if_rs_version_less_than (const char *version)
-{
-   if (!TestSuite_CheckLive ()) {
-      return 0;
-   }
-   if (!test_framework_skip_if_not_replset ()) {
-      return 0;
-   }
-   if (test_framework_get_server_version () >= test_framework_str_to_version (version)) {
-      return 1;
-   }
-   return 0;
-}
-
-static int
-_skip_if_no_client_watch (void)
-{
-   return _skip_if_rs_version_less_than ("3.8.0");
-}
-
-static int
-_skip_if_no_db_watch (void)
-{
-   return _skip_if_rs_version_less_than ("3.8.0");
-}
-
-static int
-_skip_if_no_start_at_optime (void)
-{
-   return _skip_if_rs_version_less_than ("3.8.0");
-}
-
 static void
 _test_resume (const char *opts,
               const char *expected_change_stream_opts,
@@ -2157,7 +2123,7 @@ test_change_stream_install (TestSuite *suite)
                       test_change_stream_live_read_prefs,
                       NULL,
                       NULL,
-                      _skip_if_no_start_at_optime,
+                      test_framework_skip_if_not_replset,
                       test_framework_skip_if_no_failpoint);
 
    TestSuite_Add (suite, "/change_stream/server_selection_fails", test_change_stream_server_selection_fails);
@@ -2182,8 +2148,7 @@ test_change_stream_install (TestSuite *suite)
                       NULL,
                       NULL,
                       test_framework_skip_if_not_replset,
-                      test_framework_skip_if_no_crypto,
-                      _skip_if_no_start_at_optime);
+                      test_framework_skip_if_no_crypto);
    TestSuite_AddFull (suite,
                       "/change_stream/resume_with_post_batch_resume_token",
                       test_change_stream_resume_with_post_batch_resume_token,
@@ -2191,28 +2156,26 @@ test_change_stream_install (TestSuite *suite)
                       NULL,
                       test_framework_skip_if_not_replset,
                       test_framework_skip_if_no_crypto,
-                      _skip_if_no_start_at_optime,
                       test_framework_skip_if_no_failpoint);
+   TestSuite_AddFull (suite,
+                      "/change_stream/database",
+                      test_change_stream_database_watch,
+                      NULL,
+                      NULL,
+                      test_framework_skip_if_not_replset);
    TestSuite_AddFull (
-      suite, "/change_stream/database", test_change_stream_database_watch, NULL, NULL, _skip_if_no_db_watch);
-   TestSuite_AddFull (
-      suite, "/change_stream/client", test_change_stream_client_watch, NULL, NULL, _skip_if_no_client_watch);
+      suite, "/change_stream/client", test_change_stream_client_watch, NULL, NULL, test_framework_skip_if_not_replset);
    TestSuite_AddMockServerTest (suite, "/change_stream/resume_with_first_doc", test_resume_cases);
    TestSuite_AddMockServerTest (suite,
                                 "/change_stream/resume_with_first_doc/post_batch_resume_token",
                                 test_resume_cases_with_post_batch_resume_token);
    TestSuite_AddFull (
-      suite, "/change_stream/error_null_doc", test_error_null_doc, NULL, NULL, _skip_if_no_client_watch);
+      suite, "/change_stream/error_null_doc", test_error_null_doc, NULL, NULL, test_framework_skip_if_not_replset);
    TestSuite_AddFull (
       suite, "/change_stream/live/prose_test_11", prose_test_11, NULL, NULL, test_framework_skip_if_not_replset);
    // Prose test 12 is removed. C driver does not support server 4.0.7.
-   TestSuite_AddFull (suite,
-                      "/change_stream/live/prose_test_13",
-                      prose_test_13,
-                      NULL,
-                      NULL,
-                      test_framework_skip_if_not_replset,
-                      _skip_if_no_start_at_optime);
+   TestSuite_AddFull (
+      suite, "/change_stream/live/prose_test_13", prose_test_13, NULL, NULL, test_framework_skip_if_not_replset);
    TestSuite_AddFull (suite,
                       "/change_stream/live/prose_test_14",
                       prose_test_14,

--- a/src/libmongoc/tests/test-mongoc-change-stream.c
+++ b/src/libmongoc/tests/test-mongoc-change-stream.c
@@ -2181,7 +2181,7 @@ test_change_stream_install (TestSuite *suite)
                       test_change_stream_start_at_operation_time,
                       NULL,
                       NULL,
-                      test_framework_skip_if_not_rs_version_7,
+                      test_framework_skip_if_not_replset,
                       test_framework_skip_if_no_crypto,
                       _skip_if_no_start_at_optime);
    TestSuite_AddFull (suite,
@@ -2189,7 +2189,7 @@ test_change_stream_install (TestSuite *suite)
                       test_change_stream_resume_with_post_batch_resume_token,
                       NULL,
                       NULL,
-                      test_framework_skip_if_not_rs_version_7,
+                      test_framework_skip_if_not_replset,
                       test_framework_skip_if_no_crypto,
                       _skip_if_no_start_at_optime,
                       test_framework_skip_if_no_failpoint);
@@ -2224,7 +2224,7 @@ test_change_stream_install (TestSuite *suite)
                       NULL,
                       NULL,
                       test_framework_skip_if_mongos,
-                      test_framework_skip_if_not_rs_version_7);
+                      test_framework_skip_if_not_replset);
    TestSuite_AddMockServerTest (suite, "/change_streams/prose_test_17", prose_test_17);
    TestSuite_AddMockServerTest (suite, "/change_streams/prose_test_18", prose_test_18);
    TestSuite_AddFull (suite,

--- a/src/libmongoc/tests/test-mongoc-change-stream.c
+++ b/src/libmongoc/tests/test-mongoc-change-stream.c
@@ -2203,13 +2203,8 @@ test_change_stream_install (TestSuite *suite)
                                 test_resume_cases_with_post_batch_resume_token);
    TestSuite_AddFull (
       suite, "/change_stream/error_null_doc", test_error_null_doc, NULL, NULL, _skip_if_no_client_watch);
-   TestSuite_AddFull (suite,
-                      "/change_stream/live/prose_test_11",
-                      prose_test_11,
-                      NULL,
-                      NULL,
-                      test_framework_skip_if_not_replset,
-                      test_framework_skip_if_max_wire_version_less_than_8);
+   TestSuite_AddFull (
+      suite, "/change_stream/live/prose_test_11", prose_test_11, NULL, NULL, test_framework_skip_if_not_replset);
    // Prose test 12 is removed. C driver does not support server 4.0.7.
    TestSuite_AddFull (suite,
                       "/change_stream/live/prose_test_13",

--- a/src/libmongoc/tests/test-mongoc-change-stream.c
+++ b/src/libmongoc/tests/test-mongoc-change-stream.c
@@ -705,6 +705,11 @@ test_change_stream_resumable_error (void)
    reply_to_request_simple (request, not_primary_err);
    request_destroy (request);
 
+   /* The "not primary" error does not cause the client to close connection. Expect a killCursors. */
+   request = mock_server_receives_msg (
+      server, MONGOC_MSG_NONE, tmp_bson ("{ 'killCursors' : 'coll', 'cursors' : [ { '$numberLong': '124' } ] }"));
+   reply_to_request_with_ok_and_destroy (request);
+
    /* Retry command */
    request = mock_server_receives_msg (server, MONGOC_MSG_NONE, watch_cmd);
    reply_to_request_simple (request, "{'cursor': {'id': 125, 'ns': 'db.coll','firstBatch': []},'ok': 1}");
@@ -713,6 +718,11 @@ test_change_stream_resumable_error (void)
    request = mock_server_receives_msg (server, MONGOC_MSG_NONE, tmp_bson (expected_msg, 125));
    reply_to_request_simple (request, not_primary_err);
    request_destroy (request);
+
+   /* The "not primary" error does not cause the client to close connection. Expect a killCursors. */
+   request = mock_server_receives_msg (
+      server, MONGOC_MSG_NONE, tmp_bson ("{ 'killCursors' : 'coll', 'cursors' : [ { '$numberLong': '125' } ] }"));
+   reply_to_request_with_ok_and_destroy (request);
 
    /* Retry command */
    request = mock_server_receives_msg (server, MONGOC_MSG_NONE, watch_cmd);
@@ -751,6 +761,11 @@ test_change_stream_resumable_error (void)
    request = mock_server_receives_msg (server, MONGOC_MSG_NONE, tmp_bson (expected_msg, 123));
    reply_to_request_simple (request, "{ 'code': 10107, 'errmsg': 'not primary', 'ok': 0 }");
    request_destroy (request);
+
+   /* The "not primary" error does not cause the client to close connection. Expect a killCursors. */
+   request = mock_server_receives_msg (
+      server, MONGOC_MSG_NONE, tmp_bson ("{ 'killCursors' : 'coll', 'cursors' : [ { '$numberLong': '123' } ] }"));
+   reply_to_request_with_ok_and_destroy (request);
 
    /* Retry command */
    request = mock_server_receives_msg (server, MONGOC_MSG_NONE, watch_cmd);

--- a/src/libmongoc/tests/test-mongoc-change-stream.c
+++ b/src/libmongoc/tests/test-mongoc-change-stream.c
@@ -68,16 +68,6 @@ _setup_for_resume (mongoc_change_stream_t *stream)
    ASSERT_OR_PRINT (ret, error);
 }
 
-
-static int
-test_framework_skip_if_not_single_version_5 (void)
-{
-   if (!TestSuite_CheckLive ()) {
-      return 0;
-   }
-   return (!test_framework_is_replset () && !test_framework_is_mongos ()) ? 1 : 0;
-}
-
 static mongoc_collection_t *
 drop_and_get_coll (mongoc_client_t *client, const char *db_name, const char *coll_name)
 {
@@ -2257,7 +2247,7 @@ test_change_stream_install (TestSuite *suite)
                       test_change_stream_live_single_server,
                       NULL,
                       NULL,
-                      test_framework_skip_if_not_single_version_5);
+                      test_framework_skip_if_not_single);
 
    TestSuite_AddFull (suite,
                       "/change_stream/live/track_resume_token",

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -6887,7 +6887,7 @@ test_client_side_encryption_install (TestSuite *suite)
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8,
+                      TestSuite_CheckLive,
                       test_framework_skip_if_offline /* requires AWS */);
    TestSuite_AddFull (suite,
                       "/client_side_encryption/datakey_and_double_encryption",
@@ -6895,7 +6895,7 @@ test_client_side_encryption_install (TestSuite *suite)
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8,
+                      TestSuite_CheckLive,
                       test_framework_skip_if_offline /* requires AWS */);
    TestSuite_AddFull (suite,
                       "/client_side_encryption/external_key_vault",
@@ -6903,7 +6903,7 @@ test_client_side_encryption_install (TestSuite *suite)
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8,
+                      TestSuite_CheckLive,
                       test_framework_skip_if_no_auth /* requires auth for error check */);
    TestSuite_AddFull (suite,
                       "/client_side_encryption/bson_size_limits_and_batch_splitting",
@@ -6911,21 +6911,21 @@ test_client_side_encryption_install (TestSuite *suite)
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8);
+                      TestSuite_CheckLive);
    TestSuite_AddFull (suite,
                       "/client_side_encryption/views_are_prohibited",
                       test_views_are_prohibited,
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8);
+                      TestSuite_CheckLive);
    TestSuite_AddFull (suite,
                       "/client_side_encryption/corpus",
                       test_corpus,
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8,
+                      TestSuite_CheckLive,
                       test_framework_skip_if_offline /* requires AWS */);
    TestSuite_AddFull (suite,
                       "/client_side_encryption/custom_endpoint",
@@ -6933,7 +6933,7 @@ test_client_side_encryption_install (TestSuite *suite)
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8,
+                      TestSuite_CheckLive,
                       test_framework_skip_if_offline /* requires AWS, Azure, and GCP */);
    TestSuite_AddFull (suite,
                       "/client_side_encryption/bypass_spawning_mongocryptd/"
@@ -6942,7 +6942,7 @@ test_client_side_encryption_install (TestSuite *suite)
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8);
+                      TestSuite_CheckLive);
    TestSuite_AddFull (suite,
                       "/client_side_encryption/bypass_spawning_mongocryptd/"
                       "bypassAutoEncryption",
@@ -6950,7 +6950,7 @@ test_client_side_encryption_install (TestSuite *suite)
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8);
+                      TestSuite_CheckLive);
    TestSuite_AddFull (suite,
                       "/client_side_encryption/bypass_spawning_mongocryptd/"
                       "bypassQueryAnalysis",
@@ -6958,7 +6958,7 @@ test_client_side_encryption_install (TestSuite *suite)
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8);
+                      TestSuite_CheckLive);
    TestSuite_AddFull (suite,
                       "/client_side_encryption/bypass_spawning_mongocryptd/"
                       "cryptSharedLibLoaded",
@@ -6966,7 +6966,7 @@ test_client_side_encryption_install (TestSuite *suite)
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8,
+                      TestSuite_CheckLive,
                       _skip_if_no_crypt_shared);
    TestSuite_AddFull (suite,
                       "/client_side_encryption/kms_tls/valid",
@@ -6974,35 +6974,35 @@ test_client_side_encryption_install (TestSuite *suite)
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8);
+                      TestSuite_CheckLive);
    TestSuite_AddFull (suite,
                       "/client_side_encryption/kms_tls/expired",
                       test_kms_tls_cert_expired,
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8);
+                      TestSuite_CheckLive);
    TestSuite_AddFull (suite,
                       "/client_side_encryption/kms_tls/wrong_host",
                       test_kms_tls_cert_wrong_host,
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8);
+                      TestSuite_CheckLive);
    TestSuite_AddFull (suite,
                       "/client_side_encryption/unique_index_on_keyaltnames",
                       test_unique_index_on_keyaltnames,
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8);
+                      TestSuite_CheckLive);
    TestSuite_AddFull (suite,
                       "/client_side_encryption/prose_test_16/case1",
                       test_rewrap_with_separate_client_encryption,
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8,
+                      TestSuite_CheckLive,
                       test_framework_skip_if_slow);
    TestSuite_AddFull (suite,
                       "/client_side_encryption/prose_test_16/case2",
@@ -7010,7 +7010,7 @@ test_client_side_encryption_install (TestSuite *suite)
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8);
+                      TestSuite_CheckLive);
 
    /* Other, C driver specific, tests. */
    TestSuite_AddFull (suite,
@@ -7019,28 +7019,28 @@ test_client_side_encryption_install (TestSuite *suite)
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8);
+                      TestSuite_CheckLive);
    TestSuite_AddFull (suite,
                       "/client_side_encryption/multi_threaded",
                       test_multi_threaded,
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8);
+                      TestSuite_CheckLive);
    TestSuite_AddFull (suite,
                       "/client_side_encryption/malformed_explicit",
                       test_malformed_explicit,
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8);
+                      TestSuite_CheckLive);
    TestSuite_AddFull (suite,
                       "/client_side_encryption/kms_tls_options",
                       test_kms_tls_options,
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8,
+                      TestSuite_CheckLive,
                       test_framework_skip_if_offline /* requires AWS, Azure, and GCP */,
                       /* Do not run on Windows due to CDRIVER-4181. Tests use a literal IP with
                          a TLS connection. */
@@ -7120,7 +7120,7 @@ test_client_side_encryption_install (TestSuite *suite)
                       NULL /* dtor */,
                       NULL /* ctx */,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8);
+                      TestSuite_CheckLive);
 
    TestSuite_AddFull (suite,
                       "/client_side_encryption/decryption_events/case2",
@@ -7128,7 +7128,7 @@ test_client_side_encryption_install (TestSuite *suite)
                       NULL /* dtor */,
                       NULL /* ctx */,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8);
+                      TestSuite_CheckLive);
 
    TestSuite_AddFull (suite,
                       "/client_side_encryption/decryption_events/case3",
@@ -7136,7 +7136,7 @@ test_client_side_encryption_install (TestSuite *suite)
                       NULL /* dtor */,
                       NULL /* ctx */,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8);
+                      TestSuite_CheckLive);
 
 
    TestSuite_AddFull (suite,
@@ -7145,7 +7145,7 @@ test_client_side_encryption_install (TestSuite *suite)
                       NULL /* dtor */,
                       NULL /* ctx */,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8);
+                      TestSuite_CheckLive);
 
    TestSuite_AddFull (suite,
                       "/client_side_encryption/qe_docs_example",
@@ -7164,7 +7164,7 @@ test_client_side_encryption_install (TestSuite *suite)
                       NULL, // dtor
                       NULL, // ctx
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8);
+                      TestSuite_CheckLive);
 
    TestSuite_AddFull (suite,
                       "/client_side_encryption/kms/auto-aws/fail",
@@ -7172,7 +7172,7 @@ test_client_side_encryption_install (TestSuite *suite)
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8,
+                      TestSuite_CheckLive,
                       _not_have_aws_creds_env);
 
    TestSuite_AddFull (suite,
@@ -7181,7 +7181,7 @@ test_client_side_encryption_install (TestSuite *suite)
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8,
+                      TestSuite_CheckLive,
                       _have_aws_creds_env);
 
    TestSuite_AddFull (suite,
@@ -7190,7 +7190,7 @@ test_client_side_encryption_install (TestSuite *suite)
                       NULL,
                       NULL,
                       test_framework_skip_if_no_client_side_encryption,
-                      test_framework_skip_if_max_wire_version_less_than_8);
+                      TestSuite_CheckLive);
 
    TestSuite_AddFull (suite, "/client_side_encryption/auto_datakeys", test_auto_datakeys, NULL, NULL, NULL);
 

--- a/src/libmongoc/tests/test-mongoc-collection-find-with-opts.c
+++ b/src/libmongoc/tests/test-mongoc-collection-find-with-opts.c
@@ -451,13 +451,14 @@ test_exhaust (void)
 
    future = future_cursor_next (cursor, &doc);
 
-   /* Find, getMore and killCursors commands spec: "The find command does not
-    * support the exhaust flag from OP_QUERY. Drivers that support exhaust MUST
-    * fallback to existing OP_QUERY wire protocol messages."
-    */
-   request = mock_server_receives_request (server);
-   reply_to_find_request (
-      request, MONGOC_QUERY_SECONDARY_OK | MONGOC_QUERY_EXHAUST, 0, 0, "db.collection", "{}", false /* is_command */);
+   // Expect find command with exhaust flag. Reply with one document.
+   {
+      const bson_t *cmd = tmp_bson (BSON_STR ({"find" : "collection", "filter" : {}}));
+      request = mock_server_receives_msg (server, MONGOC_OP_MSG_FLAG_EXHAUST_ALLOWED, cmd);
+      const bson_t *reply = tmp_bson (BSON_STR (
+         {"ok" : 1, "cursor" : {"id" : {"$numberLong" : "0"}, "ns" : "db.collection", "firstBatch" : [ {} ]}}));
+      reply_to_op_msg_request (request, MONGOC_OP_MSG_FLAG_NONE, reply);
+   }
 
    ASSERT (future_get_bool (future));
    ASSERT_OR_PRINT (!mongoc_cursor_error (cursor, &error), error);

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -4931,12 +4931,7 @@ test_collection_install (TestSuite *suite)
    TestSuite_AddLive (suite, "/Collection/regex", test_regex);
    TestSuite_AddFull (suite, "/Collection/decimal128", test_decimal128, NULL, NULL, skip_unless_server_has_decimal128);
    TestSuite_AddLive (suite, "/Collection/update", test_update);
-   TestSuite_AddFull (suite,
-                      "/Collection/update_pipeline",
-                      test_update_pipeline,
-                      NULL,
-                      NULL,
-                      test_framework_skip_if_max_wire_version_less_than_8);
+   TestSuite_AddFull (suite, "/Collection/update_pipeline", test_update_pipeline, NULL, NULL, TestSuite_CheckLive);
    TestSuite_AddLive (suite, "/Collection/update/multi", test_update_multi);
    TestSuite_AddLive (suite, "/Collection/update/upsert", test_update_upsert);
    TestSuite_AddFull (

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -4003,19 +4003,11 @@ _test_update_and_replace (bool is_replace, bool is_multi)
       ret =
          fn (coll, tmp_bson ("{'_id': 6}"), update, tmp_bson ("{'arrayFilters': [{'i.x': {'$gt': 1}}]}"), &reply, &err);
 
-      if (test_framework_max_wire_version_at_least (6)) {
-         ASSERT_OR_PRINT (ret, err);
-         ASSERT_MATCH (&reply,
-                       "{'modifiedCount': 1, 'matchedCount': 1, "
-                       "'upsertedId': {'$exists': false}}");
-         _test_docs_in_coll_matches (coll, tmp_bson ("{'_id':6}"), "{'a': [{'x':1},{'x':3}]}", 1);
-      } else {
-         BSON_ASSERT (!ret);
-         ASSERT_ERROR_CONTAINS (err,
-                                MONGOC_ERROR_COMMAND,
-                                MONGOC_ERROR_PROTOCOL_BAD_WIRE_VERSION,
-                                "The selected server does not support array filters");
-      }
+      ASSERT_OR_PRINT (ret, err);
+      ASSERT_MATCH (&reply,
+                    "{'modifiedCount': 1, 'matchedCount': 1, "
+                    "'upsertedId': {'$exists': false}}");
+      _test_docs_in_coll_matches (coll, tmp_bson ("{'_id':6}"), "{'a': [{'x':1},{'x':3}]}", 1);
 
       bson_destroy (&reply);
 

--- a/src/libmongoc/tests/test-mongoc-crud.c
+++ b/src/libmongoc/tests/test-mongoc-crud.c
@@ -1431,8 +1431,7 @@ test_crud_install (TestSuite *suite)
                       prose_test_1,
                       NULL, /* dtor */
                       NULL, /* ctx */
-                      test_framework_skip_if_no_failpoint,
-                      test_framework_skip_if_max_wire_version_less_than_7);
+                      test_framework_skip_if_no_failpoint);
 
    TestSuite_AddFull (suite,
                       "/crud/prose_test_2",

--- a/src/libmongoc/tests/test-mongoc-exhaust.c
+++ b/src/libmongoc/tests/test-mongoc-exhaust.c
@@ -31,7 +31,7 @@
 
  * Server Version      libmongoc behavior
  * ------------------  -----------------------------------
- * mongod <4.2         uses OP_QUERY.
+ * mongod <4.2         N/A. libmongoc only supports 4.2+.
  * mongod >=4.2,<5.1   uses OP_MSG.
  * mongod >=5.1        uses OP_MSG.
 
@@ -525,7 +525,8 @@ _request_error (request_t *request, exhaust_error_type_t error_type)
    if (error_type == NETWORK_ERROR) {
       reply_to_request_with_reset (request);
    } else {
-      reply_to_request (request, MONGOC_REPLY_QUERY_FAILURE, 123, 0, 0, "{'$err': 'uh oh', 'code': 4321}");
+      reply_to_op_msg_request (
+         request, MONGOC_OP_MSG_FLAG_NONE, tmp_bson (BSON_STR ({"ok" : 0, "errmsg" : "uh oh", "code" : 4321})));
    }
 }
 
@@ -584,12 +585,17 @@ _mock_test_exhaust (bool pooled, exhaust_error_when_t error_when, exhaust_error_
    cursor = mongoc_collection_find_with_opts (collection, tmp_bson ("{}"), tmp_bson ("{'exhaust': true}"), NULL);
 
    future = future_cursor_next (cursor, &doc);
-   request = mock_server_receives_query (
-      server, "db.test", MONGOC_QUERY_SECONDARY_OK | MONGOC_QUERY_EXHAUST, 0, 0, "{}", NULL);
+   // Expect "find" command with exhaust flag. Reply with one document.
+   request = mock_server_receives_msg (
+      server, MONGOC_OP_MSG_FLAG_EXHAUST_ALLOWED, tmp_bson (BSON_STR ({"find" : "test", "filter" : {}})));
 
    if (error_when == SECOND_BATCH) {
       /* initial query succeeds, gets a doc and cursor id of 123 */
-      reply_to_request (request, MONGOC_REPLY_NONE, 123, 1, 1, "{'a': 1}");
+      reply_to_op_msg_request (
+         request, MONGOC_OP_MSG_FLAG_NONE, tmp_bson (BSON_STR ({
+            "ok" : 1,
+            "cursor" : {"id" : {"$numberLong" : "123"}, "ns" : "test.test", "firstBatch" : [ {"a" : 1} ]}
+         })));
       ASSERT (future_get_bool (future));
       assert_match_bson (doc, tmp_bson ("{'a': 1}"), false);
       ASSERT_CMPINT64 ((int64_t) 123, ==, mongoc_cursor_get_id (cursor));
@@ -598,6 +604,11 @@ _mock_test_exhaust (bool pooled, exhaust_error_when_t error_when, exhaust_error_
 
       /* error after initial batch */
       future = future_cursor_next (cursor, &doc);
+
+      request_destroy (request);
+      // Expect "getMore" command.
+      request = mock_server_receives_msg (
+         server, MONGOC_OP_MSG_FLAG_EXHAUST_ALLOWED, tmp_bson (BSON_STR ({"getMore" : {"$numberLong" : "123"}})));
    }
 
    _request_error (request, error_type);
@@ -606,7 +617,22 @@ _mock_test_exhaust (bool pooled, exhaust_error_when_t error_when, exhaust_error_
 
    future_destroy (future);
    request_destroy (request);
-   mongoc_cursor_destroy (cursor);
+   // If error occurs after the first batch, expect `mongoc_cursor_destroy` sends `killCursors` to clean up the
+   // server-side cursor.
+   if (error_when == SECOND_BATCH && error_type != NETWORK_ERROR) {
+      // If connection is still alive, driver will try to send `getMore`, but fail.
+      future = future_cursor_destroy (cursor);
+      request = mock_server_receives_msg (
+         server,
+         MONGOC_OP_MSG_FLAG_NONE,
+         tmp_bson (BSON_STR ({"killCursors" : "test", "cursors" : [ {"$numberLong" : "123"} ]})));
+      reply_to_op_msg_request (request, MONGOC_OP_MSG_FLAG_NONE, tmp_bson ("{'ok': 1}"));
+      request_destroy (request);
+      ASSERT (future_wait (future));
+      future_destroy (future);
+   } else {
+      mongoc_cursor_destroy (cursor);
+   }
    mongoc_collection_destroy (collection);
 
    if (pooled) {

--- a/src/libmongoc/tests/test-mongoc-mongos-pinning.c
+++ b/src/libmongoc/tests/test-mongoc-mongos-pinning.c
@@ -174,7 +174,6 @@ test_mongos_pinning_install (TestSuite *suite)
                       NULL,
                       test_framework_skip_if_no_sessions,
                       test_framework_skip_if_no_crypto,
-                      test_framework_skip_if_max_wire_version_less_than_8,
                       test_framework_skip_if_not_mongos);
 
    TestSuite_AddFull (suite,
@@ -184,6 +183,5 @@ test_mongos_pinning_install (TestSuite *suite)
                       NULL,
                       test_framework_skip_if_no_sessions,
                       test_framework_skip_if_no_crypto,
-                      test_framework_skip_if_max_wire_version_less_than_8,
                       test_framework_skip_if_not_mongos);
 }

--- a/src/libmongoc/tests/test-mongoc-read-prefs.c
+++ b/src/libmongoc/tests/test-mongoc-read-prefs.c
@@ -482,21 +482,21 @@ test_read_prefs_mongos_max_staleness (void)
    prefs = mongoc_read_prefs_new (MONGOC_READ_SECONDARY_PREFERRED);
    mongoc_read_prefs_set_max_staleness_seconds (prefs, 120);
 
-   /* exhaust cursor is required per CDRIVER-3633 so the driver downgrades the
-    * OP_QUERY find command to an OP_QUERY legacy find */
    cursor = mongoc_collection_find_with_opts (collection, tmp_bson ("{'a': 1}"), tmp_bson ("{'exhaust': true}"), prefs);
    future = future_cursor_next (cursor, &doc);
-   request = mock_server_receives_query (server,
-                                         "test.test",
-                                         MONGOC_QUERY_EXHAUST | MONGOC_QUERY_SECONDARY_OK,
-                                         0,
-                                         0,
-                                         "{'$query': {'a': 1},"
-                                         " '$readPreference': {'mode': 'secondaryPreferred',"
-                                         "                     'maxStalenessSeconds': 120}}",
-                                         "{}");
 
-   reply_to_find_request (request, MONGOC_QUERY_EXHAUST | MONGOC_QUERY_SECONDARY_OK, 0, 1, "test.test", "{}", false);
+   // Expect find command with exhaust flag and read preference. Reply with one document.
+   {
+      const bson_t *cmd = tmp_bson (BSON_STR ({
+         "find" : "test",
+         "filter" : {"a" : 1},
+         "$readPreference" : {"mode" : "secondaryPreferred", "maxStalenessSeconds" : {"$numberLong" : "120"}}
+      }));
+      request = mock_server_receives_msg (server, MONGOC_OP_MSG_FLAG_EXHAUST_ALLOWED, cmd);
+      const bson_t *reply = tmp_bson (
+         BSON_STR ({"ok" : 1, "cursor" : {"id" : {"$numberLong" : "0"}, "ns" : "test.test", "firstBatch" : [ {} ]}}));
+      reply_to_op_msg_request (request, MONGOC_OP_MSG_FLAG_NONE, reply);
+   }
 
    /* mongoc_cursor_next returned true */
    BSON_ASSERT (future_get_bool (future));

--- a/src/libmongoc/tests/test-mongoc-retryable-reads.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-reads.c
@@ -583,16 +583,12 @@ test_retryable_reads_install (TestSuite *suite)
                       NULL,
                       NULL,
                       test_framework_skip_if_not_mongos,
-                      test_framework_skip_if_no_failpoint,
-                      // `retryReads=true` is a 4.2+ feature.
-                      test_framework_skip_if_max_wire_version_less_than_8);
+                      test_framework_skip_if_no_failpoint);
    TestSuite_AddFull (suite,
                       "/retryable_reads/sharded/on_same_mongos",
                       test_retry_reads_sharded_on_same_mongos,
                       NULL,
                       NULL,
                       test_framework_skip_if_not_mongos,
-                      test_framework_skip_if_no_failpoint,
-                      // `retryReads=true` is a 4.2+ feature.
-                      test_framework_skip_if_max_wire_version_less_than_8);
+                      test_framework_skip_if_no_failpoint);
 }

--- a/src/libmongoc/tests/test-mongoc-retryable-reads.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-reads.c
@@ -563,13 +563,11 @@ void
 test_retryable_reads_install (TestSuite *suite)
 {
    test_all_spec_tests (suite);
-   /* Since we need failpoints, require wire version 7 */
    TestSuite_AddFull (suite,
                       "/retryable_reads/cmd_helpers",
                       test_cmd_helpers,
                       NULL,
                       NULL,
-                      test_framework_skip_if_max_wire_version_less_than_7,
                       test_framework_skip_if_mongos,
                       test_framework_skip_if_no_failpoint);
    TestSuite_AddFull (suite,
@@ -577,7 +575,6 @@ test_retryable_reads_install (TestSuite *suite)
                       test_retry_reads_off,
                       NULL,
                       NULL,
-                      test_framework_skip_if_max_wire_version_less_than_7,
                       test_framework_skip_if_mongos,
                       test_framework_skip_if_no_failpoint);
    TestSuite_AddFull (suite,

--- a/src/libmongoc/tests/test-mongoc-sdam.c
+++ b/src/libmongoc/tests/test-mongoc-sdam.c
@@ -153,6 +153,19 @@ test_sdam_cb (void *test_vp)
    BSON_ASSERT_PARAM (test_vp);
    const bson_t *const test = test_vp;
 
+   static const test_skip_t skips[] = {
+      {.description = "Pre-4.2",
+       .check_substring = true,
+       .reason = "libmongoc does not support servers older than 4.2"},
+      {0} // NULL terminated.
+   };
+
+   BSON_ASSERT (bson_iter_init_find (&iter, test, "description"));
+   const char *description = bson_iter_utf8 (&iter, NULL);
+   if (test_should_be_skipped (skips, description)) {
+      return;
+   }
+
    /* parse out the uri and use it to create a client */
    BSON_ASSERT (bson_iter_init_find (&iter, test, "uri"));
    client = test_framework_client_new (bson_iter_utf8 (&iter, NULL), NULL);

--- a/src/libmongoc/tests/test-mongoc-transactions.c
+++ b/src/libmongoc/tests/test-mongoc-transactions.c
@@ -1069,7 +1069,6 @@ test_transactions_install (TestSuite *suite)
                       NULL,
                       test_framework_skip_if_no_sessions,
                       test_framework_skip_if_no_crypto,
-                      test_framework_skip_if_max_wire_version_less_than_8,
                       test_framework_skip_if_not_mongos);
    TestSuite_AddFull (suite,
                       "/transactions/selected_server_pinned_to_mongos",
@@ -1077,7 +1076,6 @@ test_transactions_install (TestSuite *suite)
                       NULL,
                       NULL,
                       test_framework_skip_if_no_sessions,
-                      test_framework_skip_if_max_wire_version_less_than_8,
                       test_framework_skip_if_not_mongos);
    TestSuite_AddMockServerTest (
       suite, "/transactions/get_transaction_opts", test_get_transaction_opts, test_framework_skip_if_no_crypto);

--- a/src/libmongoc/tests/test-mongoc-transactions.c
+++ b/src/libmongoc/tests/test-mongoc-transactions.c
@@ -725,35 +725,6 @@ test_inherit_from_client (void *ctx)
    mongoc_client_destroy (client);
 }
 
-void
-test_transaction_fails_on_unsupported_version_or_sharded_cluster (void *ctx)
-{
-   bson_error_t error;
-   mongoc_client_session_t *session;
-   mongoc_client_t *client;
-   bool r;
-
-   BSON_UNUSED (ctx);
-
-   client = test_framework_new_default_client ();
-   session = mongoc_client_start_session (client, NULL, &error);
-   ASSERT_OR_PRINT (session, error);
-
-   r = mongoc_client_session_start_transaction (session, NULL, &error);
-   if (!test_framework_max_wire_version_at_least (7) ||
-       (test_framework_is_mongos () && !test_framework_max_wire_version_at_least (8))) {
-      BSON_ASSERT (!r);
-      ASSERT_CONTAINS (error.message,
-                       "Multi-document transactions are not supported by this "
-                       "server version");
-   } else {
-      ASSERT_OR_PRINT (r, error);
-   }
-
-   mongoc_client_session_destroy (session);
-   mongoc_client_destroy (client);
-}
-
 
 static void
 test_transaction_recovery_token_cleared (void *ctx)
@@ -1091,14 +1062,6 @@ test_transactions_install (TestSuite *suite)
                       test_framework_skip_if_no_txns);
    TestSuite_AddFull (
       suite, "/transactions/inherit_from_client", test_inherit_from_client, NULL, NULL, test_framework_skip_if_no_txns);
-   TestSuite_AddFull (suite,
-                      "/transactions/"
-                      "transaction_fails_on_unsupported_version_or_sharded_cluster",
-                      test_transaction_fails_on_unsupported_version_or_sharded_cluster,
-                      NULL,
-                      NULL,
-                      test_framework_skip_if_no_sessions,
-                      test_framework_skip_if_no_crypto);
    TestSuite_AddFull (suite,
                       "/transactions/recovery_token_cleared",
                       test_transaction_recovery_token_cleared,

--- a/src/libmongoc/tests/test-mongoc-transactions.c
+++ b/src/libmongoc/tests/test-mongoc-transactions.c
@@ -412,7 +412,7 @@ _test_transient_txn_err (bool hangup)
 
    server = mock_server_new ();
    mock_server_run (server);
-   rs_response_to_hello (server, WIRE_VERSION_4_0, true /* primary */, false /* tags */, server, NULL);
+   rs_response_to_hello (server, WIRE_VERSION_MIN, true /* primary */, false /* tags */, server, NULL);
 
    client = test_framework_client_new_from_uri (mock_server_get_uri (server), NULL);
    /* allow fast reconnect */
@@ -561,7 +561,7 @@ test_unknown_commit_result (void)
 
    server = mock_server_new ();
    mock_server_run (server);
-   rs_response_to_hello (server, WIRE_VERSION_4_0, true /* primary */, false /* tags */, server, NULL);
+   rs_response_to_hello (server, WIRE_VERSION_MIN, true /* primary */, false /* tags */, server, NULL);
 
    client = test_framework_client_new_from_uri (mock_server_get_uri (server), NULL);
    /* allow fast reconnect */
@@ -943,7 +943,7 @@ test_get_transaction_opts (void)
 
    server = mock_server_new ();
    mock_server_run (server);
-   rs_response_to_hello (server, WIRE_VERSION_4_0, true /* primary */, false /* tags */, server, NULL);
+   rs_response_to_hello (server, WIRE_VERSION_MIN, true /* primary */, false /* tags */, server, NULL);
 
    client = test_framework_client_new_from_uri (mock_server_get_uri (server), NULL);
    BSON_ASSERT (client);


### PR DESCRIPTION
# Summary

- Raise minimum supported wire version from 7 (server 4.0) to 8 (server 4.2).
- Remove behavior and tests specific to maxWireVersion < 8.

Verified with this [patch build](https://spruce.mongodb.com/version/68090d0103e0920007b5cec5).

Removing no-longer-needed cursor implementations is not done in this PR and planned for CDRIVER-4722.

Auth tests using the test server are temporarily skipped until the test server is upgraded. Upgrading is tracked in DEVPROD-9029.

## Added `killCursors` in tests

Some tests that destroy cursors (`test_change_stream_resumable_error`) are updated to reflect behavior for server > 4.0. Quoting [SDAM](https://github.com/mongodb/specifications/blob/43d2c7bacd62249de8d2173bf8ee39e6fd7a686e/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md#L939):

> If the old primary server version is 4.2 or newer, the client MUST NOT clear its connection pool for the old primary.

Previously the connection was closed after error. With the connection persisting, destroying the cursor [sends `killCursors`](https://github.com/mongodb/mongo-c-driver/blob/1955cffe9106d46957d0558753dcd869a04b07ac/src/libmongoc/src/mongoc/mongoc-client.c#L2121-L2129). Tests are updated to expect to send `killCursors` when destroying a cursor with a non-zero cursor ID and open connection.