### PR TITLE
DEVPROD-17323 - Replace perf.send with new data submission end point

### DIFF
--- a/.evergreen/benchmark.yml
+++ b/.evergreen/benchmark.yml
@@ -170,10 +170,44 @@ functions:
       file_location: mongo-c-driver/report.json
 
   "send dashboard data" :
-    command: perf.send
-    params:
-      name: perf
-      file: mongo-c-driver/results.json
+    # Here we begin to generate the request to send the data to SPS
+    - command: shell.exec
+      params:
+        script: |
+          # We use the requester expansion to determine whether the data is from a mainline evergreen run or not
+          if [ "${requester}" == "commit" ]; then
+            echo "is_mainline: true" >> expansion.yml
+          else
+            echo "is_mainline: false" >> expansion.yml
+          fi
+
+          # We parse the username out of the order_id as patches append that in and SPS does not need that information
+          echo "parsed_order_id: $(echo "${revision_order_id}" | awk -F'_' '{print $NF}')"  >> expansion.yml
+    - command: expansions.update
+      params:
+        file: expansion.yml
+    - command: shell.exec
+      params:
+        script: |
+          # Submit the performance data to the SPS endpoint
+          response=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X 'POST' \
+            "https://performance-monitoring-api.corp.mongodb.com/raw_perf_results/cedar_report?project=${project_id}&version=${version_id}&variant=${build_variant}&order=${parsed_order_id}&task_name=${task_name}&task_id=${task_id}&execution=${execution}&mainline=${is_mainline}" \
+            -H 'accept: application/json' \
+            -H 'Content-Type: application/json' \
+            -d @mongo-c-driver/results.json)
+
+          http_status=$(echo "$response" | grep "HTTP_STATUS" | awk -F':' '{print $2}')
+          response_body=$(echo "$response" | sed '/HTTP_STATUS/d')
+
+          # We want to throw an error if the data was not successfully submitted
+          if [ "$http_status" -ne 200 ]; then
+            echo "Error: Received HTTP status $http_status"
+            echo "Response Body: $response_body"
+            exit 1
+          fi
+
+          echo "Response Body: $response_body"
+          echo "HTTP Status: $http_status"
 
   "backtrace":
     - command: shell.exec

--- a/.evergreen/benchmark.yml
+++ b/.evergreen/benchmark.yml
@@ -170,7 +170,7 @@ functions:
       file_location: mongo-c-driver/report.json
 
   "send dashboard data" :
-    # Here we begin to generate the request to send the data to SPS
+    # Here we begin to generate the request to send the data to Signal Processing Service (SPS)
     - command: shell.exec
       params:
         script: |


### PR DESCRIPTION
We replace the perf.send command with new shell scripts that submit the performance data to the new performance data end point available in signal processing service.

Successful patch with changes here, data can be viewed on the Trend Charts tab as before:
https://spruce.mongodb.com/version/681271b6fead0f0007f143bf/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC