### PR TITLE
CDRIVER-5304 set cluster time in test sessions

### DIFF
--- a/src/libmongoc/tests/unified/entity-map.c
+++ b/src/libmongoc/tests/unified/entity-map.c
@@ -1694,7 +1694,9 @@ entity_session_new (entity_map_t *entity_map,
    if (!session) {
       goto done;
    }
-   mongoc_client_session_advance_cluster_time (session, cluster_time_after_initial_data);
+   if (cluster_time_after_initial_data) {
+      mongoc_client_session_advance_cluster_time (session, cluster_time_after_initial_data);
+   }
    entity->value = session;
    /* Ending a session destroys the session object.
     * After a session is ended, match assertions may be made on the lsid.

--- a/src/libmongoc/tests/unified/entity-map.c
+++ b/src/libmongoc/tests/unified/entity-map.c
@@ -1651,7 +1651,10 @@ done:
 }
 
 entity_t *
-entity_session_new (entity_map_t *entity_map, bson_t *bson, bson_error_t *error)
+entity_session_new (entity_map_t *entity_map,
+                    bson_t *bson,
+                    const bson_t *cluster_time_after_initial_data,
+                    bson_error_t *error)
 {
    bson_parser_t *parser = NULL;
    entity_t *entity = NULL;
@@ -1691,6 +1694,7 @@ entity_session_new (entity_map_t *entity_map, bson_t *bson, bson_error_t *error)
    if (!session) {
       goto done;
    }
+   mongoc_client_session_advance_cluster_time (session, cluster_time_after_initial_data);
    entity->value = session;
    /* Ending a session destroys the session object.
     * After a session is ended, match assertions may be made on the lsid.
@@ -1785,7 +1789,10 @@ done:
  * object immediately.
  */
 bool
-entity_map_create (entity_map_t *entity_map, bson_t *bson, bson_error_t *error)
+entity_map_create (entity_map_t *entity_map,
+                   bson_t *bson,
+                   const bson_t *cluster_time_after_initial_data,
+                   bson_error_t *error)
 {
    bson_iter_t iter;
    const char *entity_type;
@@ -1816,7 +1823,7 @@ entity_map_create (entity_map_t *entity_map, bson_t *bson, bson_error_t *error)
    } else if (0 == strcmp (entity_type, "collection")) {
       entity = entity_collection_new (entity_map, &entity_bson, error);
    } else if (0 == strcmp (entity_type, "session")) {
-      entity = entity_session_new (entity_map, &entity_bson, error);
+      entity = entity_session_new (entity_map, &entity_bson, cluster_time_after_initial_data, error);
    } else if (0 == strcmp (entity_type, "bucket")) {
       entity = entity_bucket_new (entity_map, &entity_bson, error);
    } else {

--- a/src/libmongoc/tests/unified/entity-map.h
+++ b/src/libmongoc/tests/unified/entity-map.h
@@ -96,7 +96,7 @@ entity_map_destroy (entity_map_t *em);
 /* Creates an entry in the entity map based on what is specified in @bson.
  */
 bool
-entity_map_create (entity_map_t *em, bson_t *bson, bson_error_t *error);
+entity_map_create (entity_map_t *em, bson_t *bson, const bson_t *cluster_time_after_initial_data, bson_error_t *error);
 
 /* Steals ownership of changestream. */
 bool

--- a/src/libmongoc/tests/unified/operation.c
+++ b/src/libmongoc/tests/unified/operation.c
@@ -3833,7 +3833,7 @@ operation_create_entities (test_t *test, operation_t *op, result_t *result, bson
    {
       bson_t entity;
       bson_iter_bson (&entity_iter, &entity);
-      bool create_ret = entity_map_create (test->entity_map, &entity, error);
+      bool create_ret = entity_map_create (test->entity_map, &entity, test->cluster_time_after_initial_data, error);
       bson_destroy (&entity);
       if (!create_ret) {
          goto done;

--- a/src/libmongoc/tests/unified/runner.c
+++ b/src/libmongoc/tests/unified/runner.c
@@ -879,7 +879,11 @@ test_setup_initial_data (test_t *test, bson_error_t *error)
       ok = ok && mongoc_client_command_with_opts (
                     test_runner->internal_client, "db", tmp_bson ("{'ping': 1}"), NULL, &opts, NULL, error);
       if (ok) {
-         test->cluster_time_after_initial_data = bson_copy (mongoc_client_session_get_cluster_time (sess));
+         // Check for cluster time (not available on standalone).
+         const bson_t *ct = mongoc_client_session_get_cluster_time (sess);
+         if (ct) {
+            test->cluster_time_after_initial_data = bson_copy (ct);
+         }
       }
       mongoc_client_session_destroy (sess);
       bson_destroy (&opts);
@@ -1003,7 +1007,11 @@ test_setup_initial_data (test_t *test, bson_error_t *error)
    }
 
    // Obtain cluster time to advance client sessions. See DRIVERS-2816.
-   test->cluster_time_after_initial_data = bson_copy (mongoc_client_session_get_cluster_time (sess));
+   // Check for cluster time (not available on standalone).
+   const bson_t *ct = mongoc_client_session_get_cluster_time (sess);
+   if (ct) {
+      test->cluster_time_after_initial_data = bson_copy (ct);
+   }
    mongoc_client_session_destroy (sess);
    return true;
 }

--- a/src/libmongoc/tests/unified/runner.c
+++ b/src/libmongoc/tests/unified/runner.c
@@ -1021,7 +1021,7 @@ test_create_entities (test_t *test, bson_error_t *error)
       bson_t entity_bson;
 
       bson_iter_bson (&iter, &entity_bson);
-      if (!entity_map_create (test->entity_map, &entity_bson, error)) {
+      if (!entity_map_create (test->entity_map, &entity_bson, test->cluster_time_after_initial_data, error)) {
          return false;
       }
    }

--- a/src/libmongoc/tests/unified/runner.h
+++ b/src/libmongoc/tests/unified/runner.h
@@ -63,6 +63,7 @@ typedef struct {
    entity_map_t *entity_map;
    failpoint_t *failpoints;
    bool loop_operation_executed;
+   bson_t *cluster_time_after_initial_data;
 } test_t;
 
 /* Set server_id to 0 if the failpoint was not against a pinned mongos. */


### PR DESCRIPTION
# Summary

Implement test changes described in DRIVERS-2816 to fix test failures:

> Modify the unified test runner to collect the cluster time from the internal MongoClient following initialData operations, and use it to advance cluster times of all session entities created during the subsequent test

This change appears to fix ongoing failures for the `client bulkWrite in a transaction` test ([example](https://spruce.mongodb.com/task/mongo_c_driver_loadbalanced_loadbalanced_rhel8.9_gcc_test_latest_auth_openssl_27a824ccb23f321a2e8a28b34d81c5addabc4104_25_05_07_19_18_06/logs?execution=0)):

```
test file: client bulkWrite transactions
[...]
running test: client bulkWrite in a transaction
[...]
 error: expected result, but got error: Transaction 39dbb2a4-d1db-4913-bdbe-dec0b3056a91 - Il1bctjvfYRA0JpLUY4Xle2E6bw+KM1YpMr4x52qGgE= -  - :1 was aborted on statement 0 due to: a non-retryable snapshot error :: caused by :: Encountered error from localhost:27217 during a transaction :: caused by :: Database transaction-tests has undergone a catalog change operation at time Timestamp(1746646537, 68) and no longer satisfies the requirements for the current transaction which requires Timestamp(1746646537,
```

Tested with this patch build: https://spruce.mongodb.com/version/681cc957c6aad7000796aac0

# Motivation

Quoting DRIVERS-2816:

> SERVER-82353 addressed a correctness issue for sharded clusters, which requires gossipping the cluster time between mongos hsots (particularly the server used to create collections and other(s) used to execute transactions) in order to avoid a MigrationConflict error.
