### PR TITLE
CDRIVER-3228 fix memory leaks in SChannel cert loading

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-secure-channel-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel-private.h
@@ -40,7 +40,7 @@ mongoc_secure_channel_setup_crl (mongoc_stream_tls_secure_channel_t *secure_chan
 
 // mongoc_secure_channel_load_crl is used in tests.
 PCCRL_CONTEXT
-mongoc_secure_channel_load_crl (const char* crl_file);
+mongoc_secure_channel_load_crl (const char *crl_file);
 
 ssize_t
 mongoc_secure_channel_read (mongoc_stream_tls_t *tls, void *data, size_t data_length);

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel-private.h
@@ -33,10 +33,10 @@
 BSON_BEGIN_DECLS
 
 bool
-mongoc_secure_channel_setup_ca (mongoc_stream_tls_secure_channel_t *secure_channel, mongoc_ssl_opt_t *opt);
+mongoc_secure_channel_setup_ca (mongoc_ssl_opt_t *opt);
 
 bool
-mongoc_secure_channel_setup_crl (mongoc_stream_tls_secure_channel_t *secure_channel, mongoc_ssl_opt_t *opt);
+mongoc_secure_channel_setup_crl (mongoc_ssl_opt_t *opt);
 
 // mongoc_secure_channel_load_crl is used in tests.
 PCCRL_CONTEXT
@@ -49,7 +49,7 @@ ssize_t
 mongoc_secure_channel_write (mongoc_stream_tls_t *tls, const void *data, size_t data_length);
 
 PCCERT_CONTEXT
-mongoc_secure_channel_setup_certificate (mongoc_stream_tls_secure_channel_t *secure_channel, mongoc_ssl_opt_t *opt);
+mongoc_secure_channel_setup_certificate (mongoc_ssl_opt_t *opt);
 
 
 /* it may require 16k + some overhead to hold one decryptable block of data - do

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel-private.h
@@ -38,6 +38,10 @@ mongoc_secure_channel_setup_ca (mongoc_stream_tls_secure_channel_t *secure_chann
 bool
 mongoc_secure_channel_setup_crl (mongoc_stream_tls_secure_channel_t *secure_channel, mongoc_ssl_opt_t *opt);
 
+// mongoc_secure_channel_load_crl is used in tests.
+PCCRL_CONTEXT
+mongoc_secure_channel_load_crl (const char* crl_file);
+
 ssize_t
 mongoc_secure_channel_read (mongoc_stream_tls_t *tls, void *data, size_t data_length);
 

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -77,16 +77,11 @@ read_file_and_null_terminate (const char *filename, size_t *out_len)
    char *contents = NULL;
    char errmsg_buf[BSON_ERROR_BUFFER_SIZE];
 
-   errno = 0; // C99 does not require `fopen` set errno.
    FILE *file = fopen (filename, "rb");
    if (!file) {
-      if (0 != errno) {
-         MONGOC_ERROR ("Failed to open file: '%s' with error: '%s'",
-                       filename,
-                       bson_strerror_r (errno, errmsg_buf, sizeof errmsg_buf));
-      } else {
-         MONGOC_ERROR ("Failed to open file: '%s'", filename);
-      }
+      MONGOC_ERROR ("Failed to open file: '%s' with error: '%s'",
+                    filename,
+                    bson_strerror_r (errno, errmsg_buf, sizeof errmsg_buf));
       goto fail;
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -74,11 +74,16 @@ read_file_and_null_terminate (const char *filename, size_t *out_len)
    char *contents = NULL;
    char errmsg_buf[BSON_ERROR_BUFFER_SIZE];
 
+   errno = 0; // C99 does not require `fopen` set errno.
    FILE *file = fopen (filename, "rb");
    if (!file) {
-      MONGOC_ERROR ("Failed to open file: '%s' with error: '%s'",
-                    filename,
-                    bson_strerror_r (errno, errmsg_buf, sizeof errmsg_buf));
+      if (0 != errno) {
+         MONGOC_ERROR ("Failed to open file: '%s' with error: '%s'",
+                       filename,
+                       bson_strerror_r (errno, errmsg_buf, sizeof errmsg_buf));
+      } else {
+         MONGOC_ERROR ("Failed to open file: '%s'", filename);
+      }
       goto fail;
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -114,6 +114,7 @@ read_file_and_null_terminate (const char *filename, size_t *out_len)
    contents = (char *) bson_malloc ((size_t) file_len + 1u);
    contents[file_len] = '\0';
    if ((size_t) file_len != fread (contents, 1, file_len, file)) {
+      SecureZeroMemory (contents, file_len);
       if (feof (file)) {
          MONGOC_ERROR ("Unexpected EOF reading file: '%s'", filename);
          goto fail;

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -88,7 +88,7 @@ read_file_and_null_terminate (const char *filename, size_t *out_len)
    if (0 != fseek (file, 0, SEEK_END)) {
       MONGOC_ERROR ("Failed to seek in file: '%s' with error: '%s'",
                     filename,
-                    bson_strerror_r (ferror (file), errmsg_buf, sizeof errmsg_buf));
+                    bson_strerror_r (errno, errmsg_buf, sizeof errmsg_buf));
       goto fail;
    }
 
@@ -119,7 +119,7 @@ read_file_and_null_terminate (const char *filename, size_t *out_len)
       } else {
          MONGOC_ERROR ("Failed to read file: '%s' with error: '%s'",
                        filename,
-                       bson_strerror_r (ferror (file), errmsg_buf, sizeof errmsg_buf));
+                       bson_strerror_r (errno, errmsg_buf, sizeof errmsg_buf));
          goto fail;
       }
    }

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -89,7 +89,7 @@ read_file_and_null_terminate (const char *filename, size_t *out_len)
       goto fail;
    }
 
-   long file_len = ftell (file);
+   const long file_len = ftell (file);
    if (file_len < 0) {
       MONGOC_ERROR ("Failed to get length of file: '%s' with error: '%s'",
                     filename,

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -131,7 +131,7 @@ read_file_and_null_terminate (const char *filename, size_t *out_len)
    ok = true;
 fail:
    if (file) {
-      fclose (file); // Ignore error.
+      (void) fclose (file); // Ignore error.
    }
    if (!ok) {
       bson_free (contents);

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -78,14 +78,10 @@ read_file_and_null_terminate (const char *filename, size_t *out_len)
    }
 
    if (file_len > LONG_MAX - 1) {
-      MONGOC_ERROR ("Failed to get length of file: '%s'. File too large", filename);
       goto fail;
    }
 
    if (0 != fseek (file, 0, SEEK_SET)) {
-      MONGOC_ERROR ("Failed to seek in file: '%s' with error: '%s'",
-                    filename,
-                    bson_strerror_r (errno, errmsg_buf, sizeof errmsg_buf));
       goto fail;
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -203,12 +203,14 @@ mongoc_secure_channel_setup_certificate_from_file (const char *filename)
                              &hKey);           /* phKey, OUT */
    if (!success) {
       MONGOC_ERROR ("CryptImportKey for private key failed with error 0x%.8X", (unsigned int) GetLastError ());
+      CryptReleaseContext (provider, 0);
       goto fail;
    }
    CryptDestroyKey (hKey);
 
    /* https://msdn.microsoft.com/en-us/library/windows/desktop/aa376573%28v=vs.85%29.aspx
     */
+   // CertSetCertificateContextProperty takes ownership of `provider`.
    success = CertSetCertificateContextProperty (cert,                         /* pCertContext */
                                                 CERT_KEY_PROV_HANDLE_PROP_ID, /* dwPropId */
                                                 0,                            /* dwFlags */

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -306,9 +306,7 @@ fail:
    }
 
    if (!ret) {
-      if (cert) {
-         CertFreeCertificateContext (cert);
-      }
+      CertFreeCertificateContext (cert);
       return NULL;
    }
 
@@ -372,18 +370,15 @@ mongoc_secure_channel_setup_ca (mongoc_stream_tls_secure_channel_t *secure_chann
 
    if (!CertAddCertificateContextToStore (cert_store, cert, CERT_STORE_ADD_USE_EXISTING, NULL)) {
       MONGOC_WARNING ("Failed adding the cert");
-      CertCloseStore (cert_store, 0);
       goto fail;
    }
 
    TRACE ("%s", "Added the certificate !");
-   CertCloseStore (cert_store, 0);
    ok = true;
 fail:
+   CertCloseStore (cert_store, 0);
    bson_free (encoded_cert);
-   if (cert) {
-      CertFreeCertificateContext (cert);
-   }
+   CertFreeCertificateContext (cert);
    bson_free (pem);
    return ok;
 }
@@ -462,12 +457,8 @@ mongoc_secure_channel_setup_crl (mongoc_stream_tls_secure_channel_t *secure_chan
    ok = true;
 
 fail:
-   if (cert_store) {
-      CertCloseStore (cert_store, 0);
-   }
-   if (crl) {
-      CertFreeCRLContext (crl);
-   }
+   CertCloseStore (cert_store, 0);
+   CertFreeCRLContext (crl);
    return ok;
 }
 

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -274,7 +274,7 @@ mongoc_secure_channel_setup_certificate_from_file (const char *filename)
 
    /* https://msdn.microsoft.com/en-us/library/windows/desktop/aa376573%28v=vs.85%29.aspx
     */
-   // CertSetCertificateContextProperty takes ownership of `provider`.
+   // The CERT_KEY_PROV_HANDLE_PROP_ID property takes ownership of `provider`.
    success = CertSetCertificateContextProperty (cert,                         /* pCertContext */
                                                 CERT_KEY_PROV_HANDLE_PROP_ID, /* dwPropId */
                                                 0,                            /* dwFlags */

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -290,8 +290,10 @@ mongoc_secure_channel_setup_certificate_from_file (const char *filename)
    ret = true;
 
 fail:
-   SecureZeroMemory (pem, pem_length);
-   bson_free (pem);
+   if (pem) {
+      SecureZeroMemory (pem, pem_length);
+      bson_free (pem);
+   }
    bson_free (encoded_cert);
    if (encoded_private) {
       SecureZeroMemory (encoded_private, encoded_private_len);

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -134,8 +134,8 @@ mongoc_secure_channel_setup_certificate_from_file (const char *filename)
    LPBYTE blob_private = NULL;
    PCCERT_CONTEXT cert = NULL;
    DWORD blob_private_len = 0;
-   DWORD encrypted_private_len = 0;
-   LPBYTE encrypted_private = NULL;
+   DWORD encoded_private_len = 0;
+   LPBYTE encoded_private = NULL;
 
    pem = read_file_and_null_terminate (filename, &pem_length);
    if (!pem) {
@@ -189,7 +189,7 @@ mongoc_secure_channel_setup_certificate_from_file (const char *filename)
                                    0,                         /* cchString */
                                    CRYPT_STRING_BASE64HEADER, /* dwFlags */
                                    NULL,                      /* pbBinary */
-                                   &encrypted_private_len,    /* pcBinary, IN/OUT */
+                                   &encoded_private_len,      /* pcBinary, IN/OUT */
                                    NULL,                      /* pdwSkip */
                                    NULL);                     /* pdwFlags */
    if (!success) {
@@ -197,9 +197,9 @@ mongoc_secure_channel_setup_certificate_from_file (const char *filename)
       goto fail;
    }
 
-   encrypted_private = (LPBYTE) bson_malloc0 (encrypted_private_len);
+   encoded_private = (LPBYTE) bson_malloc0 (encoded_private_len);
    success = CryptStringToBinaryA (
-      pem_private, 0, CRYPT_STRING_BASE64HEADER, encrypted_private, &encrypted_private_len, NULL, NULL);
+      pem_private, 0, CRYPT_STRING_BASE64HEADER, encoded_private, &encoded_private_len, NULL, NULL);
    if (!success) {
       MONGOC_ERROR ("Failed to convert base64 private key. Error 0x%.8X", (unsigned int) GetLastError ());
       goto fail;
@@ -209,8 +209,8 @@ mongoc_secure_channel_setup_certificate_from_file (const char *filename)
     */
    success = CryptDecodeObjectEx (X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, /* dwCertEncodingType */
                                   PKCS_RSA_PRIVATE_KEY,                    /* lpszStructType */
-                                  encrypted_private,                       /* pbEncoded */
-                                  encrypted_private_len,                   /* cbEncoded */
+                                  encoded_private,                         /* pbEncoded */
+                                  encoded_private_len,                     /* cbEncoded */
                                   0,                                       /* dwFlags */
                                   NULL,                                    /* pDecodePara */
                                   NULL,                                    /* pvStructInfo */
@@ -232,8 +232,8 @@ mongoc_secure_channel_setup_certificate_from_file (const char *filename)
    blob_private = (LPBYTE) bson_malloc0 (blob_private_len);
    success = CryptDecodeObjectEx (X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
                                   PKCS_RSA_PRIVATE_KEY,
-                                  encrypted_private,
-                                  encrypted_private_len,
+                                  encoded_private,
+                                  encoded_private_len,
                                   0,
                                   NULL,
                                   blob_private,
@@ -289,9 +289,9 @@ mongoc_secure_channel_setup_certificate_from_file (const char *filename)
 fail:
    SecureZeroMemory (pem, pem_length);
    bson_free (pem);
-   if (encrypted_private) {
-      SecureZeroMemory (encrypted_private, encrypted_private_len);
-      bson_free (encrypted_private);
+   if (encoded_private) {
+      SecureZeroMemory (encoded_private, encoded_private_len);
+      bson_free (encoded_private);
    }
 
    if (blob_private) {
@@ -324,8 +324,8 @@ mongoc_secure_channel_setup_ca (mongoc_stream_tls_secure_channel_t *secure_chann
    const char *pem_key;
    HCERTSTORE cert_store = NULL;
    PCCERT_CONTEXT cert = NULL;
-   DWORD encrypted_cert_len = 0;
-   LPBYTE encrypted_cert = NULL;
+   DWORD encoded_cert_len = 0;
+   LPBYTE encoded_cert = NULL;
 
    pem = read_file_and_null_terminate (opt->ca_file, NULL);
    if (!pem) {
@@ -340,18 +340,18 @@ mongoc_secure_channel_setup_ca (mongoc_stream_tls_secure_channel_t *secure_chann
       goto fail;
    }
 
-   if (!CryptStringToBinaryA (pem_key, 0, CRYPT_STRING_BASE64HEADER, NULL, &encrypted_cert_len, NULL, NULL)) {
+   if (!CryptStringToBinaryA (pem_key, 0, CRYPT_STRING_BASE64HEADER, NULL, &encoded_cert_len, NULL, NULL)) {
       MONGOC_ERROR ("Failed to convert BASE64 public key. Error 0x%.8X", (unsigned int) GetLastError ());
       goto fail;
    }
 
-   encrypted_cert = (LPBYTE) LocalAlloc (0, encrypted_cert_len);
-   if (!CryptStringToBinaryA (pem_key, 0, CRYPT_STRING_BASE64HEADER, encrypted_cert, &encrypted_cert_len, NULL, NULL)) {
+   encoded_cert = (LPBYTE) LocalAlloc (0, encoded_cert_len);
+   if (!CryptStringToBinaryA (pem_key, 0, CRYPT_STRING_BASE64HEADER, encoded_cert, &encoded_cert_len, NULL, NULL)) {
       MONGOC_ERROR ("Failed to convert BASE64 public key. Error 0x%.8X", (unsigned int) GetLastError ());
       goto fail;
    }
 
-   cert = CertCreateCertificateContext (X509_ASN_ENCODING, encrypted_cert, encrypted_cert_len);
+   cert = CertCreateCertificateContext (X509_ASN_ENCODING, encoded_cert, encoded_cert_len);
    if (!cert) {
       MONGOC_WARNING ("Could not convert certificate");
       goto fail;
@@ -379,7 +379,7 @@ mongoc_secure_channel_setup_ca (mongoc_stream_tls_secure_channel_t *secure_chann
    CertCloseStore (cert_store, 0);
    ok = true;
 fail:
-   LocalFree (encrypted_cert);
+   LocalFree (encoded_cert);
    if (cert) {
       CertFreeCertificateContext (cert);
    }

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -85,7 +85,7 @@ read_file_and_null_terminate (const char *filename, size_t *out_len)
    if (0 != fseek (file, 0, SEEK_END)) {
       MONGOC_ERROR ("Failed to seek in file: '%s' with error: '%s'",
                     filename,
-                    bson_strerror_r (errno, errmsg_buf, sizeof errmsg_buf));
+                    bson_strerror_r (ferror (file), errmsg_buf, sizeof errmsg_buf));
       goto fail;
    }
 
@@ -115,7 +115,7 @@ read_file_and_null_terminate (const char *filename, size_t *out_len)
       } else {
          MONGOC_ERROR ("Failed to read file: '%s' with error: '%s'",
                        filename,
-                       bson_strerror_r (errno, errmsg_buf, sizeof errmsg_buf));
+                       bson_strerror_r (ferror (file), errmsg_buf, sizeof errmsg_buf));
          goto fail;
       }
    }

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -139,6 +139,11 @@ mongoc_secure_channel_setup_certificate_from_file (const char *filename)
    }
 
    pem_public = strstr (pem, "-----BEGIN CERTIFICATE-----");
+   if (!pem_public) {
+      MONGOC_ERROR ("Can't find public certificate in '%s'", filename);
+      goto fail;
+   }
+
    pem_private = strstr (pem, "-----BEGIN ENCRYPTED PRIVATE KEY-----");
 
    if (pem_private) {

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -377,7 +377,7 @@ fail:
       CertFreeCertificateContext (cert);
    }
    bson_free (pem);
-   return false;
+   return ok;
 }
 
 bool

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -312,14 +312,14 @@ fail:
 }
 
 PCCERT_CONTEXT
-mongoc_secure_channel_setup_certificate (mongoc_stream_tls_secure_channel_t *secure_channel, mongoc_ssl_opt_t *opt)
+mongoc_secure_channel_setup_certificate (mongoc_ssl_opt_t *opt)
 {
    return mongoc_secure_channel_setup_certificate_from_file (opt->pem_file);
 }
 
 
 bool
-mongoc_secure_channel_setup_ca (mongoc_stream_tls_secure_channel_t *secure_channel, mongoc_ssl_opt_t *opt)
+mongoc_secure_channel_setup_ca (mongoc_ssl_opt_t *opt)
 {
    bool ok = false;
    char *pem = NULL;
@@ -425,7 +425,7 @@ fail:
 }
 
 bool
-mongoc_secure_channel_setup_crl (mongoc_stream_tls_secure_channel_t *secure_channel, mongoc_ssl_opt_t *opt)
+mongoc_secure_channel_setup_crl (mongoc_ssl_opt_t *opt)
 {
    HCERTSTORE cert_store = NULL;
    bool ok = false;

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -105,7 +105,7 @@ read_file_and_null_terminate (const char *filename, size_t *out_len)
       goto fail;
    }
 
-   // Read the whole file into one nul-terminated string:
+   // Read the whole file into one NUL-terminated string:
    contents = (char *) bson_malloc ((size_t) file_len + 1u);
    contents[file_len] = '\0';
    if ((size_t) file_len != fread (contents, 1, file_len, file)) {

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -70,12 +70,13 @@ mongoc_secure_channel_setup_certificate_from_file (const char *filename)
    fseek (file, 0, SEEK_END);
    pem_length = ftell (file);
    fseek (file, 0, SEEK_SET);
-   if (pem_length < 1) {
+   if (pem_length < 1 || length > LONG_MAX - 1) {
       MONGOC_ERROR ("Couldn't determine file size of '%s'", filename);
       return NULL;
    }
 
-   pem = (char *) bson_malloc0 (pem_length);
+   // Read the whole file into one nul-terminated string
+   pem = (char *) bson_malloc0 ((size_t) pem_length + 1u);
    fread ((void *) pem, 1, pem_length, file);
    fclose (file);
 

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -49,7 +49,6 @@ mongoc_secure_channel_setup_certificate_from_file (const char *filename)
    FILE *file;
    bool ret = false;
    bool success;
-   HCRYPTKEY hKey;
    long pem_length;
    HCRYPTPROV provider;
    CERT_BLOB public_blob;
@@ -193,6 +192,7 @@ mongoc_secure_channel_setup_certificate_from_file (const char *filename)
       goto fail;
    }
 
+   HCRYPTKEY hKey;
    /* https://msdn.microsoft.com/en-us/library/windows/desktop/aa380207%28v=vs.85%29.aspx
     */
    success = CryptImportKey (provider,         /* hProv */
@@ -205,6 +205,7 @@ mongoc_secure_channel_setup_certificate_from_file (const char *filename)
       MONGOC_ERROR ("CryptImportKey for private key failed with error 0x%.8X", (unsigned int) GetLastError ());
       goto fail;
    }
+   CryptDestroyKey (hKey);
 
    /* https://msdn.microsoft.com/en-us/library/windows/desktop/aa376573%28v=vs.85%29.aspx
     */

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -46,6 +46,9 @@
 static LPBYTE
 decode_pem_base64 (const char *base64_in, DWORD *out_len)
 {
+   BSON_ASSERT_PARAM (base64_in);
+   BSON_ASSERT_PARAM (out_len);
+
    // Get needed output length:
    if (!CryptStringToBinaryA (base64_in, 0, CRYPT_STRING_BASE64HEADER, NULL, out_len, NULL, NULL)) {
       return NULL;

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -293,7 +293,6 @@ mongoc_secure_channel_setup_ca (mongoc_stream_tls_secure_channel_t *secure_chann
 
    /* If we have private keys or other fuzz, seek to the good stuff */
    pem_key = strstr (pem, "-----BEGIN CERTIFICATE-----");
-   /*printf ("%s\n", pem_key);*/
 
    if (!pem_key) {
       MONGOC_WARNING ("Couldn't find certificate in '%s'", opt->ca_file);

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel-private.h
@@ -44,7 +44,7 @@ typedef enum {
 typedef struct {
    CredHandle cred_handle;
    TimeStamp time_stamp;
-   PCCERT_CONTEXT cert; /* optional client cert. Kept to free later */
+   PCCERT_CONTEXT cert; /* Owning. Optional client cert. */
 } mongoc_secure_channel_cred;
 
 typedef struct {

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel-private.h
@@ -44,6 +44,7 @@ typedef enum {
 typedef struct {
    CredHandle cred_handle;
    TimeStamp time_stamp;
+   PCCERT_CONTEXT cert; /* optional client cert. Kept to free later */
 } mongoc_secure_channel_cred;
 
 typedef struct {

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
@@ -162,6 +162,9 @@ _mongoc_stream_tls_secure_channel_destroy (mongoc_stream_t *stream)
       /* if the handle was not cached and the refcount is zero */
       TRACE ("%s", "clear credential handle");
       FreeCredentialsHandle (&secure_channel->cred->cred_handle);
+      if (secure_channel->cred->cert != NULL) {
+         CertFreeCertificateContext (secure_channel->cred->cert);
+      }
       bson_free (secure_channel->cred);
    }
 
@@ -932,6 +935,10 @@ mongoc_stream_tls_secure_channel_new (mongoc_stream_t *base_stream, const char *
    schannel_cred.grbitEnabledProtocols = SP_PROT_TLS1_1_CLIENT | SP_PROT_TLS1_2_CLIENT;
 
    secure_channel->cred = (mongoc_secure_channel_cred *) bson_malloc0 (sizeof (mongoc_secure_channel_cred));
+   if (cert) {
+      // Store client cert to free later.
+      secure_channel->cred->cert = cert;
+   }
 
    /* Example:
     *   https://msdn.microsoft.com/en-us/library/windows/desktop/aa375454%28v=vs.85%29.aspx

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
@@ -162,9 +162,7 @@ _mongoc_stream_tls_secure_channel_destroy (mongoc_stream_t *stream)
       /* if the handle was not cached and the refcount is zero */
       TRACE ("%s", "clear credential handle");
       FreeCredentialsHandle (&secure_channel->cred->cred_handle);
-      if (secure_channel->cred->cert != NULL) {
-         CertFreeCertificateContext (secure_channel->cred->cert);
-      }
+      CertFreeCertificateContext (secure_channel->cred->cert);
       bson_free (secure_channel->cred);
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
@@ -913,15 +913,15 @@ mongoc_stream_tls_secure_channel_new (mongoc_stream_t *base_stream, const char *
    }
 
    if (opt->ca_file) {
-      mongoc_secure_channel_setup_ca (secure_channel, opt);
+      mongoc_secure_channel_setup_ca (opt);
    }
 
    if (opt->crl_file) {
-      mongoc_secure_channel_setup_crl (secure_channel, opt);
+      mongoc_secure_channel_setup_crl (opt);
    }
 
    if (opt->pem_file) {
-      cert = mongoc_secure_channel_setup_certificate (secure_channel, opt);
+      cert = mongoc_secure_channel_setup_certificate (opt);
 
       if (cert) {
          schannel_cred.cCreds = 1;


### PR DESCRIPTION
# Summary

This PR addresses several memory-related found in certificate loading for Secure Channel:

- Fix several memory leaks.
- NUL-terminate the PEM file for the client certificate.

Reading the PEM file is refactored with more error checks logs including the system error.

# Background

Leaks were discovered when implementing PKCS#8 certificate support for (CDRIVER-4269). This may help motivate future addition of leak detection on Windows (CDRIVER-2529).

NUL-terminating the PEM file was similarly done in https://github.com/mongodb/mongo-c-driver/pull/1903. NUL-terminating is intended to avoid reading past beyond the string in later calls to `strstr`.

The Secure Channel implementation would likely benefit from a larger rewrite, and may be done as part of CDRIVER-4463. This PR intends to address the more severe issues and I expect can be backported with low risk of unexpected behavior change.
