### PR TITLE
Fix message of `bson_strerror_r` on Windows

### DIFF
--- a/src/libbson/src/bson/bson-error.c
+++ b/src/libbson/src/bson/bson-error.c
@@ -112,7 +112,7 @@ bson_strerror_r (int err_code,                    /* IN */
 #if defined(_WIN32)
    // Windows does not provide `strerror_l` or `strerror_r`, but it does
    // unconditionally provide `strerror_s`.
-   if (strerror_s (buf, buflen, err_code) != 0) {
+   if (strerror_s (buf, buflen, err_code) == 0) {
       ret = buf;
    }
 #elif defined(_AIX)

--- a/src/libbson/tests/test-bson-error.c
+++ b/src/libbson/tests/test-bson-error.c
@@ -40,6 +40,10 @@ test_bson_strerror_r (void)
    char *errmsg = bson_strerror_r (errno, errmsg_buf, sizeof errmsg_buf);
    // Check a message is returned. Do not check platform-dependent contents:
    ASSERT (errmsg);
+   const char *unknown_msg = "Unknown error";
+   if (strstr (errmsg, unknown_msg)) {
+      test_error ("Expected error message not to contain '%s', but got: '%s'", unknown_msg, errmsg);
+   }
 }
 
 void


### PR DESCRIPTION
Fix flipped check of `strerror_s`. This caused calls of `bson_strerror_r` on Windows to output "Unknown error" on known error codes.

Discovered when working on https://github.com/mongodb/mongo-c-driver/pull/2009. 