### PR TITLE
CDRIVER-6011 fix message of `bson_strerror_r` on Windows (#2011)

### DIFF
--- a/src/libbson/src/bson/bson-error.c
+++ b/src/libbson/src/bson/bson-error.c
@@ -113,7 +113,7 @@ bson_strerror_r (int err_code,                    /* IN */
 #if defined(_WIN32)
    // Windows does not provide `strerror_l` or `strerror_r`, but it does
    // unconditionally provide `strerror_s`.
-   if (strerror_s (buf, buflen, err_code) != 0) {
+   if (strerror_s (buf, buflen, err_code) == 0) {
       ret = buf;
    }
 #elif defined(_AIX)

--- a/src/libbson/tests/test-bson-error.c
+++ b/src/libbson/tests/test-bson-error.c
@@ -39,6 +39,10 @@ test_bson_strerror_r (void)
    char *errmsg = bson_strerror_r (errno, errmsg_buf, sizeof errmsg_buf);
    // Check a message is returned. Do not check platform-dependent contents:
    ASSERT (errmsg);
+   const char *unknown_msg = "Unknown error";
+   if (strstr (errmsg, unknown_msg)) {
+      test_error ("Expected error message to contain platform-dependent content, not: '%s'", errmsg);
+   }
 }
 
 void


### PR DESCRIPTION
Backport of https://github.com/mongodb/mongo-c-driver/pull/2011 to r1.30.