### PR TITLE
[r1.30] CDRIVER-3228 fix memory leaks in SChannel cert loading (#2009)

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-secure-channel-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel-private.h
@@ -33,10 +33,14 @@
 BSON_BEGIN_DECLS
 
 bool
-mongoc_secure_channel_setup_ca (mongoc_stream_tls_secure_channel_t *secure_channel, mongoc_ssl_opt_t *opt);
+mongoc_secure_channel_setup_ca (mongoc_ssl_opt_t *opt);
 
 bool
-mongoc_secure_channel_setup_crl (mongoc_stream_tls_secure_channel_t *secure_channel, mongoc_ssl_opt_t *opt);
+mongoc_secure_channel_setup_crl (mongoc_ssl_opt_t *opt);
+
+// mongoc_secure_channel_load_crl is used in tests.
+PCCRL_CONTEXT
+mongoc_secure_channel_load_crl (const char *crl_file);
 
 ssize_t
 mongoc_secure_channel_read (mongoc_stream_tls_t *tls, void *data, size_t data_length);
@@ -45,7 +49,7 @@ ssize_t
 mongoc_secure_channel_write (mongoc_stream_tls_t *tls, const void *data, size_t data_length);
 
 PCCERT_CONTEXT
-mongoc_secure_channel_setup_certificate (mongoc_stream_tls_secure_channel_t *secure_channel, mongoc_ssl_opt_t *opt);
+mongoc_secure_channel_setup_certificate (mongoc_ssl_opt_t *opt);
 
 
 /* it may require 16k + some overhead to hold one decryptable block of data - do

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -269,7 +269,7 @@ mongoc_secure_channel_setup_ca (mongoc_stream_tls_secure_channel_t *secure_chann
 
    // Read the whole file into one nul-terminated string
    pem_key = (const char *) bson_malloc0 ((size_t) length + 1u);
-   bool read_ok = length == fread ((void *) pem_key, 1, length, file);
+   bool read_ok = (size_t) length == fread ((void *) pem_key, 1, length, file);
    fclose (file);
    if (!read_ok) {
       MONGOC_WARNING ("Couldn't read certificate file '%s'", opt->ca_file);

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -261,14 +261,20 @@ mongoc_secure_channel_setup_ca (mongoc_stream_tls_secure_channel_t *secure_chann
    fseek (file, 0, SEEK_END);
    length = ftell (file);
    fseek (file, 0, SEEK_SET);
-   if (length < 1) {
+   if (length < 1 || length > LONG_MAX - 1) {
       MONGOC_WARNING ("Couldn't determine file size of '%s'", opt->ca_file);
+      fclose (file);
       return false;
    }
 
-   pem_key = (const char *) bson_malloc0 (length);
-   fread ((void *) pem_key, 1, length, file);
+   // Read the whole file into one nul-terminated string
+   pem_key = (const char *) bson_malloc0 ((size_t) length + 1u);
+   bool read_ok = length == fread ((void *) pem_key, 1, length, file);
    fclose (file);
+   if (!read_ok) {
+      MONGOC_WARNING ("Couldn't read certificate file '%s'", opt->ca_file);
+      return false;
+   }
 
    /* If we have private keys or other fuzz, seek to the good stuff */
    pem_key = strstr (pem_key, "-----BEGIN CERTIFICATE-----");

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel-private.h
@@ -44,6 +44,7 @@ typedef enum {
 typedef struct {
    CredHandle cred_handle;
    TimeStamp time_stamp;
+   PCCERT_CONTEXT cert; /* Owning. Optional client cert. */
 } mongoc_secure_channel_cred;
 
 typedef struct {


### PR DESCRIPTION
Backport of https://github.com/mongodb/mongo-c-driver/pull/2009 to r1.30 branch. Commits in CDRIVER-5743 are also backported to avoid a merge conflict. Tested with this [patch](https://spruce.mongodb.com/version/682760cc6c21ed00077a1165).