### PR TITLE
[2.0] CDRIVER-6019 Improve error messages from Windows APIs (#2020)

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
@@ -1378,24 +1378,14 @@ _do_spawn (const char *path, char **args, bson_error_t *error)
                         NULL /* current directory */,
                         &startup_info,
                         &process_information)) {
-      long lastError = GetLastError ();
-      LPSTR message = NULL;
-
-      FormatMessageA (FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_ARGUMENT_ARRAY | FORMAT_MESSAGE_FROM_SYSTEM |
-                         FORMAT_MESSAGE_IGNORE_INSERTS,
-                      NULL,
-                      lastError,
-                      0,
-                      (LPSTR) &message,
-                      0,
-                      NULL);
+      char *message = mongoc_winerr_to_string (GetLastError ());
 
       _mongoc_set_error (error,
                          MONGOC_ERROR_CLIENT,
                          MONGOC_ERROR_CLIENT_INVALID_ENCRYPTION_STATE,
                          "failed to spawn mongocryptd: %s",
                          message);
-      LocalFree (message);
+      bson_free (message);
       mcommon_string_from_append_destroy (&command);
       return false;
    }

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -202,13 +202,10 @@ _mongoc_get_rr_dnsapi (
    res = DnsQuery_UTF8 (hostname, nst, options, NULL /* IP Address */, &pdns, 0 /* reserved */);
 
    if (res) {
-      DWORD flags = FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS;
-
-      if (FormatMessage (flags, 0, res, MAKELANGID (LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR) &lpMsgBuf, 0, 0)) {
-         DNS_ERROR ("Failed to look up %s record \"%s\": %s", rr_type_name, hostname, (char *) lpMsgBuf);
-      }
-
-      DNS_ERROR ("Failed to look up %s record \"%s\": Unknown error", rr_type_name, hostname);
+      // Cast signed DNS_STATUS to unsigned DWORD. FormatMessage expects DWORD.
+      char *msg = mongoc_winerr_to_string ((DWORD) res);
+      DNS_ERROR ("Failed to look up %s record \"%s\": %s", rr_type_name, hostname, msg);
+      bson_free (msg);
    }
 
    if (!pdns) {

--- a/src/libmongoc/src/mongoc/mongoc-error-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-error-private.h
@@ -129,6 +129,12 @@ _mongoc_set_error_category (bson_error_t *error, uint8_t category)
    error->reserved = category;
 }
 
+#ifdef _WIN32
+// Call `mongoc_winerr_to_string` on a Windows error code (e.g. a return from GetLastError()).
+char *
+mongoc_winerr_to_string (DWORD err_code);
+#endif
+
 BSON_END_DECLS
 
 #endif /* MONGOC_ERROR_PRIVATE_H */

--- a/src/libmongoc/src/mongoc/mongoc-handshake.c
+++ b/src/libmongoc/src/mongoc/mongoc-handshake.c
@@ -32,6 +32,7 @@
 #include <mongoc/mongoc-client.h>
 #include <mongoc/mongoc-client-private.h>
 #include <mongoc/mongoc-error.h>
+#include <mongoc/mongoc-error-private.h>
 #include <mongoc/mongoc-log.h>
 #include <mongoc/mongoc-version.h>
 #include <mongoc/mongoc-util-private.h>
@@ -305,7 +306,9 @@ _get_os_version (void)
       BSON_ASSERT (req > 0);
       found = true;
    } else {
-      MONGOC_WARNING ("Error with GetVersionEx(): %lu", GetLastError ());
+      char *msg = mongoc_winerr_to_string (GetLastError ());
+      MONGOC_WARNING ("Error with GetVersionEx(): %s", msg);
+      bson_free (msg);
    }
 
 #elif defined(_POSIX_VERSION)

--- a/src/libmongoc/src/mongoc/mongoc-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-openssl.c
@@ -29,6 +29,7 @@
 
 #include <string.h>
 
+#include <mongoc/mongoc-error-private.h>
 #include <mongoc/mongoc-http-private.h>
 #include <mongoc/mongoc-init.h>
 #include <mongoc/mongoc-openssl-private.h>
@@ -140,16 +141,9 @@ _mongoc_openssl_import_cert_store (LPWSTR store_name, DWORD dwFlags, X509_STORE 
                                store_name);                             /* system store name. "My" or "Root" */
 
    if (cert_store == NULL) {
-      LPTSTR msg = NULL;
-      FormatMessage (FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ARGUMENT_ARRAY,
-                     NULL,
-                     GetLastError (),
-                     LANG_NEUTRAL,
-                     (LPTSTR) &msg,
-                     0,
-                     NULL);
-      MONGOC_ERROR ("Can't open CA store: 0x%.8X: '%s'", GetLastError (), msg);
-      LocalFree (msg);
+      char *msg = mongoc_winerr_to_string (GetLastError ());
+      MONGOC_ERROR ("Can't open CA store: %s", msg);
+      bson_free (msg);
       return false;
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-sspi.c
+++ b/src/libmongoc/src/mongoc/mongoc-sspi.c
@@ -25,6 +25,7 @@
 #define CRYPT_STRING_NOCRLF 0x40000000
 #endif
 
+#include <mongoc/mongoc-error-private.h>
 #include <mongoc/mongoc-util-private.h>
 #include <mongoc/mongoc-sspi-private.h>
 
@@ -56,16 +57,9 @@ _mongoc_sspi_destroy_sspi_client_state (mongoc_sspi_client_state_t *state)
 void
 _mongoc_sspi_set_gsserror (DWORD errCode, const SEC_CHAR *msg)
 {
-   SEC_CHAR *err;
-   DWORD status;
-   DWORD flags = FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS;
-   status = FormatMessageA (flags, NULL, errCode, MAKELANGID (LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR) &err, 0, NULL);
-   if (status) {
-      MONGOC_ERROR ("SSPI: %s: %s", msg, err);
-      LocalFree (err);
-   } else {
-      MONGOC_ERROR ("SSPI: %s", msg);
-   }
+   char *err = mongoc_winerr_to_string (errCode);
+   MONGOC_ERROR ("SSPI: %s: %s", msg, err);
+   bson_free (err);
 }
 
 static SEC_CHAR *

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl.c
@@ -628,24 +628,9 @@ _mongoc_stream_tls_openssl_handshake (mongoc_stream_t *stream, const char *host,
 
    /* Otherwise, use simple error info. */
    {
-#ifdef _WIN32
-      LPTSTR msg = NULL;
-      FormatMessage (FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ARGUMENT_ARRAY,
-                     NULL,
-                     errno, /* WSAETIMEDOUT */
-                     LANG_NEUTRAL,
-                     (LPTSTR) &msg,
-                     0,
-                     NULL);
-#else
-      const char *msg = strerror (errno); /* ETIMEDOUT */
-#endif
-
+      char errmsg_buf[BSON_ERROR_BUFFER_SIZE];
+      char *msg = bson_strerror_r (errno, errmsg_buf, sizeof errmsg_buf);
       _mongoc_set_error (error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "TLS handshake failed: %s", msg);
-
-#ifdef _WIN32
-      LocalFree (msg);
-#endif
    }
 
    RETURN (false);

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
@@ -954,19 +954,10 @@ mongoc_stream_tls_secure_channel_new (mongoc_stream_t *base_stream, const char *
                                            &secure_channel->cred->time_stamp); /* certificate expiration time */
 
    if (sspi_status != SEC_E_OK) {
-      LPTSTR msg = NULL;
-      FormatMessage (FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ARGUMENT_ARRAY,
-                     NULL,
-                     GetLastError (),
-                     LANG_NEUTRAL,
-                     (LPTSTR) &msg,
-                     0,
-                     NULL);
-      MONGOC_ERROR ("Failed to initialize security context, error code: 0x%04X%04X: '%s'",
-                    (unsigned int) (sspi_status >> 16) & 0xffff,
-                    (unsigned int) sspi_status & 0xffff,
-                    msg);
-      LocalFree (msg);
+      // Cast signed SECURITY_STATUS to unsigned DWORD. FormatMessage expects DWORD.
+      char *msg = mongoc_winerr_to_string ((DWORD) sspi_status);
+      MONGOC_ERROR ("Failed to initialize security context: %s", msg);
+      bson_free (msg);
       RETURN (NULL);
    }
 

--- a/src/libmongoc/tests/TestSuite.c
+++ b/src/libmongoc/tests/TestSuite.c
@@ -387,20 +387,11 @@ _TestSuite_TestFnCtxDtor (void *ctx)
 static void
 _print_getlasterror_win (const char *msg)
 {
-   LPTSTR err_msg;
-
-   FormatMessage (FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-                  NULL,
-                  GetLastError (),
-                  MAKELANGID (LANG_NEUTRAL, SUBLANG_DEFAULT),
-                  /* FormatMessage is weird about this param. */
-                  (LPTSTR) &err_msg,
-                  0,
-                  NULL);
+   char *err_msg = mongoc_winerr_to_string (GetLastError ());
 
    test_error ("%s: %s", msg, err_msg);
 
-   LocalFree (err_msg);
+   bson_free (err_msg);
 }
 
 

--- a/src/libmongoc/tests/test-mongoc-error.c
+++ b/src/libmongoc/tests/test-mongoc-error.c
@@ -233,6 +233,44 @@ test_mongoc_error_with_category (void)
    ASSERT_CMPUINT (error.reserved, ==, 99u);
 }
 
+#ifdef _WIN32
+static void
+test_mongoc_winerr_to_string (void)
+{
+   // Test WIN32 success.
+   {
+      char *got = mongoc_winerr_to_string ((DWORD) NO_ERROR);
+      const char *expect = "(0x00000000) The operation completed successfully.";
+      ASSERT_CMPSTR (expect, got);
+      bson_free (got);
+   }
+
+   // Test WIN32 error.
+   {
+      char *got = mongoc_winerr_to_string ((DWORD) ERROR_FILE_NOT_FOUND);
+      const char *expect = "(0x00000002) The system cannot find the file specified.";
+      ASSERT_CMPSTR (expect, got);
+      bson_free (got);
+   }
+
+   // Test SECURITY_STATUS error.
+   {
+      char *got = mongoc_winerr_to_string ((DWORD) SEC_E_CERT_EXPIRED);
+      const char *expect = "(0x80090328) The received certificate has expired.";
+      ASSERT_CMPSTR (expect, got);
+      bson_free (got);
+   }
+
+   // Test DNS_STATUS error.
+   {
+      char *got = mongoc_winerr_to_string ((DWORD) DNS_ERROR_RCODE_SERVER_FAILURE);
+      const char *expect = "(0x0000232A) DNS server failure.";
+      ASSERT_CMPSTR (expect, got);
+      bson_free (got);
+   }
+}
+#endif // _WIN32
+
 void
 test_error_install (TestSuite *suite)
 {
@@ -245,4 +283,7 @@ test_error_install (TestSuite *suite)
    TestSuite_Add (suite, "/Error/state_change", test_state_change);
    TestSuite_Add (suite, "/Error/basic", test_mongoc_error_basic);
    TestSuite_Add (suite, "/Error/category", test_mongoc_error_with_category);
+#ifdef _WIN32
+   TestSuite_Add (suite, "/Error/windows_error_to_string", test_mongoc_winerr_to_string);
+#endif
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/mongodb/mongo-c-driver/commit/1b0e008d3aab07431827433c783f92680cb0cffe to r2.0.

Only bug fixes are expected to be backported. This change is less of a bug fix, but is expected to be needed for CDRIVER-4269 (which is intended to be backported too).

Tested with this patch build: https://spruce.mongodb.com/version/6837729e811623000746ea1b