### PR TITLE
CDRIVER-6010 use `ec2.assume_role` for mongohouse task

### DIFF
--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -212,9 +212,16 @@ functions:
         set -o errexit
         COVERAGE=ON .evergreen/scripts/compile.sh
   build mongohouse:
+  - command: ec2.assume_role
+    params:
+      role_arn: ${aws_test_secrets_role}
   - command: shell.exec
     type: test
     params:
+      include_expansions_in_env:
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
       shell: bash
       script: |-
         set -o errexit

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/functions.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/functions.py
@@ -156,11 +156,19 @@ all_functions = OD([
         ''', add_expansions_to_env=True),
     )),
     ('build mongohouse', Function(
+        # Assume role to get AWS secrets.
+        {
+            "command": "ec2.assume_role",
+            "params": {
+                "role_arn": "${aws_test_secrets_role}"
+            }
+        },
+
         shell_exec(r'''
         cd drivers-evergreen-tools
         export DRIVERS_TOOLS=$(pwd)
         .evergreen/atlas_data_lake/pull-mongohouse-image.sh
-        '''),
+        ''', include_expansions_in_env=[ "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN" ]),
     )),
     ('run mongohouse', Function(
         shell_exec(r'''


### PR DESCRIPTION
See DRIVERS-3188. Use `ec2.assume_role` to fix failing [test-mongohouse](https://spruce.mongodb.com/task/mongo_c_driver_mongohouse_test_mongohouse_1b0e008d3aab07431827433c783f92680cb0cffe_25_05_28_19_40_43/logs?execution=0) task:

```
An error occurred (AccessDenied) when calling the AssumeRole operation
```

Tested with this [patch build](https://spruce.mongodb.com/version/6837acc2e5c4bc000761874d).