### PR TITLE
[CDRIVER-6017] BSON Validation Refactor

### DIFF
--- a/.evergreen/scripts/check-preludes.py
+++ b/.evergreen/scripts/check-preludes.py
@@ -35,7 +35,7 @@ checks = [
             MONGOC_PREFIX / "mongoc-prelude.h",
             MONGOC_PREFIX / "mongoc.h",
         ],
-        "include": '#include <mongoc/mongoc-prelude.h>',
+        "include": "#include <mongoc/mongoc-prelude.h>",
     },
     {
         "name": "libbson",
@@ -50,7 +50,7 @@ checks = [
         "name": "common",
         "headers": list(COMMON_PREFIX.glob("*.h")),
         "exclusions": [COMMON_PREFIX / "common-prelude.h"],
-        "include": '#include <common-prelude.h>',
+        "include": "#include <common-prelude.h>",
     },
 ]
 
@@ -59,7 +59,7 @@ for check in checks:
     print(f"Checking headers for {NAME}")
     assert len(check["headers"]) > 0
     for header in check["headers"]:
-        if header in check["exclusions"]:
+        if header in check["exclusions"] or header.name.endswith("-private.h"):
             continue
         lines = Path(header).read_text(encoding="utf-8").splitlines()
         if check["include"] not in lines:

--- a/src/libbson/NEWS
+++ b/src/libbson/NEWS
@@ -1,3 +1,17 @@
+Unreleased
+==========
+
+Fixes:
+
+* Various fixes have been applied to the `bson_validate` family of functions,
+  with some minor behavioral changes.
+  * Previously accepted invalid UTF-8 will be rejected when `BSON_VALIDATE_UTF8`
+    is specified.
+  * The scope document in a deprecated "code with scope" element is now
+    validated with a fixed set of rules and is treated as an opaque JavaScript
+    object.
+  * A document nesting limit is now enforced during validation.
+
 libbson 2.0.1
 =============
 

--- a/src/libbson/doc/bson_validate_flags_t.rst
+++ b/src/libbson/doc/bson_validate_flags_t.rst
@@ -19,6 +19,7 @@ Synopsis
     BSON_VALIDATE_DOT_KEYS = (1 << 2),
     BSON_VALIDATE_UTF8_ALLOW_NULL = (1 << 3),
     BSON_VALIDATE_EMPTY_KEYS = (1 << 4),
+    BSON_VALIDATE_CORRUPT = (1 << 5),
   } bson_validate_flags_t;
 
 Description
@@ -40,6 +41,8 @@ Each defined flag aside from ``BSON_VALIDATE_NONE`` describes an optional valida
 * ``BSON_VALIDATE_DOLLAR_KEYS`` Prohibit keys that start with ``$`` outside of a "DBRef" subdocument.
 * ``BSON_VALIDATE_DOT_KEYS`` Prohibit keys that contain ``.`` anywhere in the string.
 * ``BSON_VALIDATE_EMPTY_KEYS`` Prohibit zero-length keys.
+* ``BSON_VALIDATE_CORRUPT`` is not a control flag, but is used as an error code
+  when a validation routine encounters corrupt BSON data.
 
 .. seealso::
 

--- a/src/libbson/src/bson/bson-types.h
+++ b/src/libbson/src/bson/bson-types.h
@@ -185,7 +185,7 @@ typedef struct {
 
 
 /**
- * @brief Flags an error code for BSON validation functions.
+ * @brief Flags and error codes for BSON validation functions.
  *
  * Pass these flags bits to control the behavior of the `bson_validate` family
  * of functions.

--- a/src/libbson/src/bson/bson-types.h
+++ b/src/libbson/src/bson/bson-types.h
@@ -235,18 +235,6 @@ typedef enum {
    BSON_VALIDATE_CORRUPT = (1 << 5),
 } bson_validate_flags_t;
 
-enum {
-   /**
-    * @brief This compile-time constant represents the maximum document nesting
-    * depth permitted by the `bson_validate` family of functions. If the nesting
-    * depth exceeds this limit, the data will be rejected.
-    *
-    * The depth limit of 100 is chosen to match the limit enforced by MongoDB server.
-    * Refer: https://www.mongodb.com/docs/manual/reference/limits/#mongodb-limit-Nested-Depth-for-BSON-Document
-    */
-   BSON_VALIDATION_MAX_NESTING_DEPTH = 100,
-};
-
 
 /**
  * bson_type_t:

--- a/src/libbson/src/bson/bson-types.h
+++ b/src/libbson/src/bson/bson-types.h
@@ -185,25 +185,54 @@ typedef struct {
 
 
 /**
- * bson_validate_flags_t:
+ * @brief Flags an error code for BSON validation functions.
  *
- * This enumeration is used for validation of BSON documents. It allows
- * selective control on what you wish to validate.
+ * Pass these flags bits to control the behavior of the `bson_validate` family
+ * of functions.
  *
- * %BSON_VALIDATE_NONE: No additional validation occurs.
- * %BSON_VALIDATE_UTF8: Check that strings are valid UTF-8.
- * %BSON_VALIDATE_DOLLAR_KEYS: Check that keys do not start with $.
- * %BSON_VALIDATE_DOT_KEYS: Check that keys do not contain a period.
- * %BSON_VALIDATE_UTF8_ALLOW_NULL: Allow NUL bytes in UTF-8 text.
- * %BSON_VALIDATE_EMPTY_KEYS: Prohibit zero-length field names
+ * Additionally, if validation fails, then the error code set on a `bson_error_t`
+ * will have the value corresponding to the reason that validation failed.
  */
 typedef enum {
+   /**
+    * @brief No special validation behavior specified.
+    */
    BSON_VALIDATE_NONE = 0,
+   /**
+    * @brief Check that all text components of the BSON data are valid UTF-8.
+    *
+    * Note that this will also cause validation to reject valid text that contains
+    * a null character. This can be changed by also passing
+    * `BSON_VALIDATE_UTF8_ALLOW_NULL`
+    */
    BSON_VALIDATE_UTF8 = (1 << 0),
+   /**
+    * @brief Check that element keys do not begin with an ASCII dollar `$`
+    */
    BSON_VALIDATE_DOLLAR_KEYS = (1 << 1),
+   /**
+    * @brief Check that element keys do not contain an ASCII period `.`
+    */
    BSON_VALIDATE_DOT_KEYS = (1 << 2),
+   /**
+    * @brief If set then it is *not* an error for a UTF-8 string to contain
+    * embedded null characters.
+    *
+    * This has no effect unless `BSON_VALIDATE_UTF8` is also passed.
+    */
    BSON_VALIDATE_UTF8_ALLOW_NULL = (1 << 3),
+   /**
+    * @brief Check that no element key is a zero-length empty string.
+    */
    BSON_VALIDATE_EMPTY_KEYS = (1 << 4),
+   /**
+    * @brief This is not a flag that controls behavior, but is instead used to indicate
+    * that a BSON document is corrupted in some way. This is the value that will
+    * appear as an error code.
+    *
+    * Passing this as a flag has no effect.
+    */
+   BSON_VALIDATE_CORRUPT = (1 << 30),
 } bson_validate_flags_t;
 
 

--- a/src/libbson/src/bson/bson-types.h
+++ b/src/libbson/src/bson/bson-types.h
@@ -232,7 +232,7 @@ typedef enum {
     *
     * Passing this as a flag has no effect.
     */
-   BSON_VALIDATE_CORRUPT = (1 << 30),
+   BSON_VALIDATE_CORRUPT = (1 << 5),
 } bson_validate_flags_t;
 
 

--- a/src/libbson/src/bson/bson-types.h
+++ b/src/libbson/src/bson/bson-types.h
@@ -235,6 +235,18 @@ typedef enum {
    BSON_VALIDATE_CORRUPT = (1 << 5),
 } bson_validate_flags_t;
 
+enum {
+   /**
+    * @brief This compile-time constant represents the maximum document nesting
+    * depth permitted by the `bson_validate` family of functions. If the nesting
+    * depth exceeds this limit, the data will be rejected.
+    *
+    * The depth limit of 100 is chosen to match the limit enforced by MongoDB server.
+    * Refer: https://www.mongodb.com/docs/manual/reference/limits/#mongodb-limit-Nested-Depth-for-BSON-Document
+    */
+   BSON_VALIDATION_MAX_NESTING_DEPTH = 100,
+};
+
 
 /**
  * bson_type_t:

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -2502,6 +2502,10 @@ bson_validate_with_error_and_offset (const bson_t *bson,
                                      size_t *offset,
                                      bson_error_t *error)
 {
+   BSON_ASSERT_PARAM (bson);
+   BSON_OPTIONAL_PARAM (offset);
+   BSON_OPTIONAL_PARAM (error);
+
    size_t offset_local = 0;
    if (!offset) {
       offset = &offset_local;

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -15,6 +15,7 @@
  */
 
 
+#include <bson/validate-private.h>
 #include <mlib/intencode.h>
 #include <bson/bson.h>
 #include <bson/bson-config.h>
@@ -2491,10 +2492,6 @@ bson_validate_with_error (const bson_t *bson, bson_validate_flags_t flags, bson_
 {
    return bson_validate_with_error_and_offset (bson, flags, NULL, error);
 }
-
-// Defined in validate.c
-extern bool
-_bson_validate_impl_v2 (const bson_t *bson, bson_validate_flags_t flags, size_t *offset, bson_error_t *error);
 
 bool
 bson_validate_with_error_and_offset (const bson_t *bson,

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -31,29 +31,6 @@
 #include <mlib/config.h>
 
 
-typedef enum {
-   BSON_VALIDATE_PHASE_START,
-   BSON_VALIDATE_PHASE_TOP,
-   BSON_VALIDATE_PHASE_LF_REF_KEY,
-   BSON_VALIDATE_PHASE_LF_REF_UTF8,
-   BSON_VALIDATE_PHASE_LF_ID_KEY,
-   BSON_VALIDATE_PHASE_LF_DB_KEY,
-   BSON_VALIDATE_PHASE_LF_DB_UTF8,
-   BSON_VALIDATE_PHASE_NOT_DBREF,
-} bson_validate_phase_t;
-
-
-/*
- * Structures.
- */
-typedef struct {
-   bson_validate_flags_t flags;
-   ssize_t err_offset;
-   bson_validate_phase_t phase;
-   bson_error_t error;
-} bson_validate_state_t;
-
-
 /*
  * Globals.
  */
@@ -2502,196 +2479,6 @@ bson_array_as_canonical_extended_json (const bson_t *bson, size_t *length)
 }
 
 
-#define VALIDATION_ERR(_flag, _msg, ...) bson_set_error (&state->error, BSON_ERROR_INVALID, _flag, _msg, __VA_ARGS__)
-
-static bool
-_bson_iter_validate_utf8 (const bson_iter_t *iter, const char *key, size_t v_utf8_len, const char *v_utf8, void *data)
-{
-   bson_validate_state_t *state = data;
-   bool allow_null;
-
-   if ((state->flags & BSON_VALIDATE_UTF8)) {
-      allow_null = !!(state->flags & BSON_VALIDATE_UTF8_ALLOW_NULL);
-
-      if (!bson_utf8_validate (v_utf8, v_utf8_len, allow_null)) {
-         state->err_offset = iter->off;
-         VALIDATION_ERR (BSON_VALIDATE_UTF8, "invalid utf8 string for key \"%s\"", key);
-         return true;
-      }
-   }
-
-   if ((state->flags & BSON_VALIDATE_DOLLAR_KEYS)) {
-      if (state->phase == BSON_VALIDATE_PHASE_LF_REF_UTF8) {
-         state->phase = BSON_VALIDATE_PHASE_LF_ID_KEY;
-      } else if (state->phase == BSON_VALIDATE_PHASE_LF_DB_UTF8) {
-         state->phase = BSON_VALIDATE_PHASE_NOT_DBREF;
-      }
-   }
-
-   return false;
-}
-
-
-static void
-_bson_iter_validate_corrupt (const bson_iter_t *iter, void *data)
-{
-   bson_validate_state_t *state = data;
-
-   state->err_offset = iter->err_off;
-   VALIDATION_ERR (BSON_VALIDATE_NONE, "%s", "corrupt BSON");
-}
-
-
-static bool
-_bson_iter_validate_before (const bson_iter_t *iter, const char *key, void *data)
-{
-   bson_validate_state_t *state = data;
-
-   if ((state->flags & BSON_VALIDATE_EMPTY_KEYS)) {
-      if (key[0] == '\0') {
-         state->err_offset = iter->off;
-         VALIDATION_ERR (BSON_VALIDATE_EMPTY_KEYS, "%s", "empty key");
-         return true;
-      }
-   }
-
-   if ((state->flags & BSON_VALIDATE_DOLLAR_KEYS)) {
-      if (key[0] == '$') {
-         if (state->phase == BSON_VALIDATE_PHASE_LF_REF_KEY && strcmp (key, "$ref") == 0) {
-            state->phase = BSON_VALIDATE_PHASE_LF_REF_UTF8;
-         } else if (state->phase == BSON_VALIDATE_PHASE_LF_ID_KEY && strcmp (key, "$id") == 0) {
-            state->phase = BSON_VALIDATE_PHASE_LF_DB_KEY;
-         } else if (state->phase == BSON_VALIDATE_PHASE_LF_DB_KEY && strcmp (key, "$db") == 0) {
-            state->phase = BSON_VALIDATE_PHASE_LF_DB_UTF8;
-         } else {
-            state->err_offset = iter->off;
-            VALIDATION_ERR (BSON_VALIDATE_DOLLAR_KEYS, "keys cannot begin with \"$\": \"%s\"", key);
-            return true;
-         }
-      } else if (state->phase == BSON_VALIDATE_PHASE_LF_ID_KEY || state->phase == BSON_VALIDATE_PHASE_LF_REF_UTF8 ||
-                 state->phase == BSON_VALIDATE_PHASE_LF_DB_UTF8) {
-         state->err_offset = iter->off;
-         VALIDATION_ERR (BSON_VALIDATE_DOLLAR_KEYS, "invalid key within DBRef subdocument: \"%s\"", key);
-         return true;
-      } else {
-         state->phase = BSON_VALIDATE_PHASE_NOT_DBREF;
-      }
-   }
-
-   if ((state->flags & BSON_VALIDATE_DOT_KEYS)) {
-      if (strstr (key, ".")) {
-         state->err_offset = iter->off;
-         VALIDATION_ERR (BSON_VALIDATE_DOT_KEYS, "keys cannot contain \".\": \"%s\"", key);
-         return true;
-      }
-   }
-
-   return false;
-}
-
-
-static bool
-_bson_iter_validate_codewscope (
-   const bson_iter_t *iter, const char *key, size_t v_code_len, const char *v_code, const bson_t *v_scope, void *data)
-{
-   bson_validate_state_t *state = data;
-   size_t offset = 0;
-
-   BSON_UNUSED (key);
-   BSON_UNUSED (v_code_len);
-   BSON_UNUSED (v_code);
-
-   if (!bson_validate (v_scope, state->flags, &offset)) {
-      state->err_offset = iter->off + offset;
-      VALIDATION_ERR (BSON_VALIDATE_NONE, "%s", "corrupt code-with-scope");
-      return false;
-   }
-
-   return true;
-}
-
-
-static bool
-_bson_iter_validate_document (const bson_iter_t *iter, const char *key, const bson_t *v_document, void *data);
-
-
-static const bson_visitor_t bson_validate_funcs = {
-   _bson_iter_validate_before,
-   NULL, /* visit_after */
-   _bson_iter_validate_corrupt,
-   NULL, /* visit_double */
-   _bson_iter_validate_utf8,
-   _bson_iter_validate_document,
-   _bson_iter_validate_document, /* visit_array */
-   NULL,                         /* visit_binary */
-   NULL,                         /* visit_undefined */
-   NULL,                         /* visit_oid */
-   NULL,                         /* visit_bool */
-   NULL,                         /* visit_date_time */
-   NULL,                         /* visit_null */
-   NULL,                         /* visit_regex */
-   NULL,                         /* visit_dbpoint */
-   NULL,                         /* visit_code */
-   NULL,                         /* visit_symbol */
-   _bson_iter_validate_codewscope,
-};
-
-
-static bool
-_bson_iter_validate_document (const bson_iter_t *iter, const char *key, const bson_t *v_document, void *data)
-{
-   bson_validate_state_t *state = data;
-   bson_iter_t child;
-   bson_validate_phase_t phase = state->phase;
-
-   BSON_UNUSED (key);
-
-   if (!bson_iter_init (&child, v_document)) {
-      state->err_offset = iter->off;
-      return true;
-   }
-
-   if (state->phase == BSON_VALIDATE_PHASE_START) {
-      state->phase = BSON_VALIDATE_PHASE_TOP;
-   } else {
-      state->phase = BSON_VALIDATE_PHASE_LF_REF_KEY;
-   }
-
-   (void) bson_iter_visit_all (&child, &bson_validate_funcs, state);
-
-   if (state->phase == BSON_VALIDATE_PHASE_LF_ID_KEY || state->phase == BSON_VALIDATE_PHASE_LF_REF_UTF8 ||
-       state->phase == BSON_VALIDATE_PHASE_LF_DB_UTF8) {
-      if (state->err_offset <= 0) {
-         state->err_offset = iter->off;
-      }
-
-      return true;
-   }
-
-   state->phase = phase;
-
-   return false;
-}
-
-
-static void
-_bson_validate_internal (const bson_t *bson, bson_validate_state_t *state)
-{
-   bson_iter_t iter;
-
-   state->err_offset = -1;
-   state->phase = BSON_VALIDATE_PHASE_START;
-   memset (&state->error, 0, sizeof state->error);
-
-   if (!bson_iter_init (&iter, bson)) {
-      state->err_offset = 0;
-      VALIDATION_ERR (BSON_VALIDATE_NONE, "%s", "corrupt BSON");
-   } else {
-      _bson_iter_validate_document (&iter, NULL, bson, state);
-   }
-}
-
-
 bool
 bson_validate (const bson_t *bson, bson_validate_flags_t flags, size_t *offset)
 {
@@ -2705,6 +2492,9 @@ bson_validate_with_error (const bson_t *bson, bson_validate_flags_t flags, bson_
    return bson_validate_with_error_and_offset (bson, flags, NULL, error);
 }
 
+// Defined in validate.c
+extern bool
+_bson_validate_impl_v2 (const bson_t *bson, bson_validate_flags_t flags, size_t *offset, bson_error_t *error);
 
 bool
 bson_validate_with_error_and_offset (const bson_t *bson,
@@ -2712,22 +2502,16 @@ bson_validate_with_error_and_offset (const bson_t *bson,
                                      size_t *offset,
                                      bson_error_t *error)
 {
-   bson_validate_state_t state;
-
-   state.flags = flags;
-   _bson_validate_internal (bson, &state);
-
-   if (state.err_offset >= 0) {
-      if (offset) {
-         *offset = (size_t) state.err_offset;
-      }
-      if (error) {
-         memcpy (error, &state.error, sizeof *error);
-      }
-      return false;
+   size_t offset_local = 0;
+   if (!offset) {
+      offset = &offset_local;
+   }
+   bson_error_t error_local;
+   if (!error) {
+      error = &error_local;
    }
 
-   return true;
+   return _bson_validate_impl_v2 (bson, flags, offset, error);
 }
 
 

--- a/src/libbson/src/bson/validate-private.h
+++ b/src/libbson/src/bson/validate-private.h
@@ -1,0 +1,22 @@
+#ifndef BSON_VALIDATE_PRIVATE_H_INCLUDED
+#define BSON_VALIDATE_PRIVATE_H_INCLUDED
+
+#include <bson/bson-types.h>
+
+/**
+ * @brief Private function backing the implementation of validation.
+ *
+ * Validation was previously defined in the overburdened `bson-iter.c`, but it
+ * is now defined in its own file.
+ *
+ * @param bson The document to validate. Must be non-null.
+ * @param flags Validation control flags
+ * @param offset Receives the offset at which validation failed. Must be non-null.
+ * @param error Receives the error describing why validation failed. Must be non-null.
+ * @return true If the given document has no validation errors
+ * @return false Otherwise
+ */
+extern bool
+_bson_validate_impl_v2 (const bson_t *bson, bson_validate_flags_t flags, size_t *offset, bson_error_t *error);
+
+#endif // BSON_VALIDATE_PRIVATE_H_INCLUDED

--- a/src/libbson/src/bson/validate-private.h
+++ b/src/libbson/src/bson/validate-private.h
@@ -16,7 +16,7 @@
  * @return true If the given document has no validation errors
  * @return false Otherwise
  */
-extern bool
+bool
 _bson_validate_impl_v2 (const bson_t *bson, bson_validate_flags_t flags, size_t *offset, bson_error_t *error);
 
 #endif // BSON_VALIDATE_PRIVATE_H_INCLUDED

--- a/src/libbson/src/bson/validate-private.h
+++ b/src/libbson/src/bson/validate-private.h
@@ -3,6 +3,21 @@
 
 #include <bson/bson-types.h>
 
+enum {
+   /**
+    * @brief This compile-time constant represents the maximum document nesting
+    * depth permitted by the `bson_validate` family of functions. If the nesting
+    * depth exceeds this limit, the data will be rejected.
+    *
+    * This limit is intentionally larger than the default limit of MongoDB
+    * server, since we cannot anticipate what a libbson user might actually want
+    * to do with BSON, and to prevent accidentally rejecting data that the
+    * server might accept. The main purpose of this limit is to prevent stack
+    * overflow, not to reject invalid data.
+    */
+   BSON_VALIDATION_MAX_NESTING_DEPTH = 1000,
+};
+
 /**
  * @brief Private function backing the implementation of validation.
  *

--- a/src/libbson/src/bson/validate.c
+++ b/src/libbson/src/bson/validate.c
@@ -1,0 +1,506 @@
+/**
+ * @file bson/validate.c
+ * @brief Implementation of BSON document validation
+ * @date 2025-05-28
+ *
+ * This file implements the backend for the `bson_validate` family of functions.
+ *
+ * @copyright Copyright 2009-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <bson/bson.h>
+
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
+
+/**
+ * @brief User parameter's for validation behavior. These correspond to the various
+ * flags that can be given when the user requests validation
+ */
+typedef struct {
+   /**
+    * @brief Should we allow invalid UTF-8 in string components?
+    *
+    * This affects the behavior of validation of key strings and string-like
+    * elements that require UTF-8 encoding.
+    *
+    * Technically invalid UTF-8 is invalid in BSON, but applications may already
+    * rely on this working.
+    */
+   bool allow_invalid_utf8;
+   /// Should we allow element key strings to be empty?
+   bool allow_empty_keys;
+   /**
+    * @brief Should we allow a zero-valued codepoint in text?
+    *
+    * Unicode U+0000 is a valid codepoint, but a lot of software doesn't like
+    * it and handles it poorly. By default, we reject it, but the user may
+    * want to allow it.
+    *
+    * Note that because element keys rely on null termination, element keys
+    * cannot contain U+0000 by construction.
+    */
+   bool allow_null_in_utf8;
+   /// Should we allow ASCII dot "." in element key strings?
+   bool allow_dot_in_keys;
+   /**
+    * @brief Check for special element keys that begin with an ASCII dollar "$"
+    *
+    * By default, we ignore them and treat them as regular elements. If this is
+    * enabled, we reject key strings that start with a dollar, unless it is a
+    * special extended JSON DBref document.
+    */
+   bool check_special_dollar_keys;
+} validation_params;
+
+/**
+ * @brief State for a validator.
+ */
+typedef struct {
+   /// The parameters that control validation behavior
+   const validation_params *params;
+   /// Error storage that is updated if any validation encounters an error
+   bson_error_t error;
+   /// The zero-based index of the byte where validation stopped in case of an error.
+   size_t error_offset;
+} validator;
+
+/**
+ * @brief Check that the given condition is satisfied, or set an error and return `false`
+ *
+ * @param Condition The condition that should evaluate to `true`
+ * @param Offset The byte offset where an error should be indicated.
+ * @param Code The error code that should be set if the condition fails
+ * @param ... The error string and format arguments to be used in the error message
+ *
+ * This macro assumes a `validator* self` is in scope. This macro will evaluate `return false`
+ * if the given condition is not true.
+ */
+#define require_with_error(Condition, Offset, Code, ...)                    \
+   if (!(Condition)) {                                                      \
+      self->error_offset = (Offset);                                        \
+      bson_set_error (&self->error, BSON_ERROR_INVALID, Code, __VA_ARGS__); \
+      return false;                                                         \
+   } else                                                                   \
+      ((void) 0)
+
+/**
+ * @brief Check that the given condition is satisfied, or `return false` immediately.
+ */
+#define require(Cond) \
+   if (!(Cond)) {     \
+      return false;   \
+   } else             \
+      ((void) 0)
+
+/**
+ * @brief Advance the pointed-to iterator, check for errors, and test whether we are done.
+ *
+ * @param DoneVar An l-value of type `bool` that is set to `true` if the iterator hit the end of
+ * the document, otherwise `false`
+ * @param IteratorPointer An expression of type `bson_iter_t*`, which will be advanced.
+ *
+ * If advancing the iterator resulting in a decoding error, then this macro sets an error
+ * on the `validator* self` that is in scope and will immediately `return false`.
+ */
+#define require_advance(DoneVar, IteratorPointer)                                                       \
+   if ((DoneVar = !bson_iter_next (IteratorPointer))) {                                                 \
+      /* The iterator indicates that it stopped */                                                      \
+      if ((IteratorPointer)->err_off) {                                                                 \
+         /* The iterator stopped because of a decoding error */                                         \
+         require_with_error (false, (IteratorPointer)->err_off, BSON_VALIDATE_CORRUPT, "corrupt BSON"); \
+      }                                                                                                 \
+   } else                                                                                               \
+      ((void) 0)
+
+// Test if the element's key is equal to the given string
+static bool
+_key_is (bson_iter_t const *iter, const char *const key)
+{
+   return !strcmp (bson_iter_key (iter), key);
+}
+
+/**
+ * @brief Validate a document or array object, recursively.
+ *
+ * @param self The validator which will be updated and used to do the validation
+ * @param bson The object to be validated
+ * @return true If the object is valid
+ * @return false Otherwise
+ */
+static bool
+_validate_doc (validator *self, const bson_t *bson);
+
+/**
+ * @brief Validate a UTF-8 string, if-and-only-if UTF-8 validation is requested
+ *
+ * @param self Pointer to the validator object
+ * @param offset The byte-offset of the string, used to set the error offset
+ * @param u8 Pointer to the first byte in a UTF-8 string
+ * @param u8len The length of the array pointed-to by `u8`
+ * @return true If the UTF-8 string is valid, or if UTF-8 validation is disabled
+ * @return false If UTF-8 validation is requested, AND (the UTF-8 string is invalid OR (UTF-8 strings should not contain
+ * null characters and the UTf-8 string contains a null character))
+ */
+static bool
+_maybe_validate_u8 (validator *self, size_t offset, const char *u8, size_t u8len)
+{
+   if (self->params->allow_invalid_utf8) {
+      // We are not doing UTF-8 checks, so always succeed
+      return true;
+   }
+   // Validate UTF-8
+   const bool u8okay = bson_utf8_validate (u8, u8len, self->params->allow_null_in_utf8);
+   require_with_error (u8okay, offset, BSON_VALIDATE_UTF8, "Invalid UTF-8 string");
+   return true;
+}
+
+// Same as `_maybe_validate_u8`, but relies on a null-terminated C string to get the string length
+static bool
+_maybe_validate_u8_cstring (validator *self, size_t offset, const char *const u8)
+{
+   return _maybe_validate_u8 (self, offset, u8, strlen (u8));
+}
+
+// Validate a UTF-8 element. Asserts that the given element is a UTF-8 element!
+static bool
+_validate_utf8_elem (validator *self, bson_iter_t const *iter)
+{
+   assert (BSON_ITER_HOLDS_UTF8 (iter));
+   uint32_t u8len;
+   const char *const u8 = bson_iter_utf8 (iter, &u8len);
+   assert (u8);
+   return _maybe_validate_u8 (self, iter->off, u8, u8len);
+}
+
+
+static bool
+_validate_symbol_elem (validator *self, bson_iter_t const *iter)
+{
+   assert (BSON_ITER_HOLDS_SYMBOL (iter));
+   uint32_t u8len;
+   const char *const u8 = bson_iter_symbol (iter, &u8len);
+   assert (u8);
+   return _maybe_validate_u8 (self, iter->off, u8, u8len);
+}
+
+static bool
+_validate_code_elem (validator *self, bson_iter_t const *iter)
+{
+   assert (BSON_ITER_HOLDS_CODE (iter));
+   uint32_t u8len;
+   const char *const u8 = bson_iter_code (iter, &u8len);
+   assert (u8);
+   return _maybe_validate_u8 (self, iter->off, u8, u8len);
+}
+
+
+static bool
+_validate_dbpointer_elem (validator *self, bson_iter_t const *iter)
+{
+   assert (BSON_ITER_HOLDS_DBPOINTER (iter));
+   uint32_t u8len;
+   const char *u8;
+   bson_iter_dbpointer (iter, &u8len, &u8, NULL);
+   assert (u8);
+   return _maybe_validate_u8 (self, iter->off, u8, u8len);
+}
+
+static bool
+_validate_regex_elem (validator *self, bson_iter_t const *iter)
+{
+   assert (BSON_ITER_HOLDS_REGEX (iter));
+   const char *opts;
+   const char *const rx = bson_iter_regex (iter, &opts);
+   assert (rx);
+   assert (opts);
+   return _maybe_validate_u8_cstring (self, iter->off, rx) //
+          && _maybe_validate_u8_cstring (self, iter->off, opts);
+}
+
+static bool
+_validate_codewscope_elem (validator *self, bson_iter_t const *iter)
+{
+   assert (BSON_ITER_HOLDS_CODEWSCOPE (iter));
+   // Extract the code and the scope object
+   uint8_t const *doc;
+   uint32_t doc_len;
+   uint32_t u8len;
+   const char *const u8 = bson_iter_codewscope (iter, &u8len, &doc_len, &doc);
+   bson_t scope;
+   require_with_error (
+      bson_init_static (&scope, doc, doc_len), iter->off, BSON_VALIDATE_CORRUPT, "corrupt scope document");
+
+   // Validate the code string
+   require (_maybe_validate_u8 (self, iter->off, u8, u8len));
+
+   // Now we validate the scope object.
+   // Don't validate the scope document using the parent parameters, because it should
+   // be treated as an opaque closure of JS variables.
+   validation_params const scope_params = {
+      // JS vars cannot contain dots
+      .allow_dot_in_keys = false,
+      // JS vars cannot be empty
+      .allow_empty_keys = false,
+      // JS strings can contain null bytes
+      .allow_null_in_utf8 = true,
+      // JS strings need to encode properly
+      .allow_invalid_utf8 = false,
+      // JS allows variables to have dollars
+      .check_special_dollar_keys = false,
+   };
+   validator scope_validator = {.params = &scope_params};
+   const bool scope_okay = _validate_doc (&scope_validator, &scope);
+   if (!scope_okay) {
+      // Copy the error message, adding the name of the bad element
+      bson_set_error (&self->error,
+                      scope_validator.error.domain,
+                      scope_validator.error.code,
+                      "Error in scope document for element \"%s\": %s",
+                      bson_iter_key (iter),
+                      scope_validator.error.message);
+      // Adjust the error offset by the offset of the iterator
+      self->error_offset = scope_validator.error_offset + iter->off;
+   }
+   return scope_okay;
+}
+
+// Validate an element's key string according to the valiation rules
+static bool
+_validate_element_key (validator *self, bson_iter_t const *iter)
+{
+   const char *const key = bson_iter_key (iter);
+   assert (key);
+
+   // Check the UTF-8 of the key
+   require (_maybe_validate_u8_cstring (self, iter->off, key));
+
+   // Check for special keys
+   if (self->params->check_special_dollar_keys) {
+      // dollar-keys are checked during the startup of _validate_doc. If we get here, there's a problem.
+      require_with_error (key[0] != '$', iter->off, BSON_VALIDATE_DOLLAR_KEYS, "Disallowed element key: \"%s\"", key);
+   }
+
+   if (!self->params->allow_empty_keys) {
+      require_with_error (
+         strlen (key) != 0, iter->off, BSON_VALIDATE_EMPTY_KEYS, "Element key cannot be an empty string");
+   }
+
+   if (!self->params->allow_dot_in_keys) {
+      require_with_error (!strstr (key, "."), iter->off, BSON_VALIDATE_DOT_KEYS, "Disallowed element key: \"%s\"", key);
+   }
+
+   return true;
+}
+
+// Validate the value of an element, without checking its key
+static bool
+_validate_element_value (validator *self, bson_iter_t const *iter)
+{
+   const bson_type_t type = bson_iter_type (iter);
+   switch (type) {
+   default:
+   case BSON_TYPE_EOD:
+      assert (false && "Unreachable");
+   case BSON_TYPE_DOUBLE:
+   case BSON_TYPE_NULL:
+   case BSON_TYPE_OID:
+   case BSON_TYPE_INT32:
+   case BSON_TYPE_INT64:
+   case BSON_TYPE_MINKEY:
+   case BSON_TYPE_MAXKEY:
+   case BSON_TYPE_TIMESTAMP:
+   case BSON_TYPE_UNDEFINED:
+   case BSON_TYPE_DECIMAL128:
+   case BSON_TYPE_DATE_TIME:
+      // No validation on these simple scalar elements
+      return true;
+   case BSON_TYPE_UTF8:
+      return _validate_utf8_elem (self, iter);
+
+   case BSON_TYPE_ARRAY: {
+      const uint8_t *data;
+      uint32_t doclen;
+      bson_iter_array (iter, &doclen, &data);
+      bson_t doc;
+      require_with_error (bson_init_static (&doc, data, doclen),
+                          iter->off,
+                          BSON_VALIDATE_CORRUPT,
+                          "Invalid array \"%s\": corrupt BSON",
+                          bson_iter_key (iter));
+      return _validate_doc (self, &doc);
+   }
+   case BSON_TYPE_DOCUMENT: {
+      const uint8_t *data;
+      uint32_t doclen;
+      bson_iter_document (iter, &doclen, &data);
+      bson_t doc;
+      require_with_error (bson_init_static (&doc, data, doclen),
+                          iter->off,
+                          BSON_VALIDATE_CORRUPT,
+                          "Invalid subdocument \"%s\": corrupt BSON",
+                          bson_iter_key (iter));
+      return _validate_doc (self, &doc);
+   }
+   case BSON_TYPE_BINARY:
+      // Note: BSON binary validation is handled by bson_iter_next, which checks the
+      // internal structure properly. If we get here, then the binary data is okay.
+      return true;
+   case BSON_TYPE_BOOL:
+      // Note: Boolean validation is checked by bson_iter_next, and is indicated as
+      // corruption.
+      return true;
+   case BSON_TYPE_DBPOINTER:
+      return _validate_dbpointer_elem (self, iter);
+   case BSON_TYPE_REGEX:
+      return _validate_regex_elem (self, iter);
+   case BSON_TYPE_CODEWSCOPE:
+      return _validate_codewscope_elem (self, iter);
+   case BSON_TYPE_SYMBOL:
+      return _validate_symbol_elem (self, iter);
+   case BSON_TYPE_CODE:
+      return _validate_code_elem (self, iter);
+   }
+
+   return true;
+}
+
+// Validate a single BSON element referred-to by the given iterator
+static bool
+_validate_element (validator *self, bson_iter_t *iter)
+{
+   return _validate_element_key (self, iter) && _validate_element_value (self, iter);
+}
+
+/**
+ * @brief Validate the elements of a document, beginning with the element pointed-to
+ * by the given iterator.
+ */
+static bool
+_validate_remaining_elements (validator *self, bson_iter_t *iter)
+{
+   bool done = false;
+   while (!done) {
+      require (_validate_element (self, iter));
+      require_advance (done, iter);
+   }
+   return true;
+}
+
+// Do validation for a DBRef document, indicated by a leading $ref key
+static bool
+_validate_dbref (validator *self, bson_iter_t *iter)
+{
+   // The iterator must be pointing to the initial $ref element
+   assert (_key_is (iter, "$ref"));
+   // Check that $ref is a UTF-8 element
+   require_with_error (
+      BSON_ITER_HOLDS_UTF8 (iter), iter->off, BSON_VALIDATE_DOLLAR_KEYS, "$ref element must be a UTF-8 element");
+   require (_validate_element_value (self, iter));
+
+   // We require an $id as the next element
+   bool done;
+   require_advance (done, iter);
+   require_with_error (
+      !done && _key_is (iter, "$id"), iter->off, BSON_VALIDATE_DOLLAR_KEYS, "Expected an $id element following $ref");
+   require (_validate_element_value (self, iter));
+
+   // We should stop, or we should have a $db, or we may have other elements
+   require_advance (done, iter);
+   if (done) {
+      // No more elements. Nothing left to check
+      return true;
+   }
+   // If it's a $db, check that it's a UTF-8 string
+   if (_key_is (iter, "$db")) {
+      require_with_error (BSON_ITER_HOLDS_UTF8 (iter),
+                          iter->off,
+                          BSON_VALIDATE_DOLLAR_KEYS,
+                          "$db element in DBref must be a UTF-8 element");
+      require (_validate_element_value (self, iter));
+      // Advance past the $db
+      require_advance (done, iter);
+      if (done) {
+         // Nothing left to do
+         return true;
+      }
+   }
+   // All subsequent elements should be validated as normal, and we don't expect
+   // any more $-keys
+   return _validate_remaining_elements (self, iter);
+}
+
+// If we are validating special $-keys, validate a document whose first element is a $-key
+static bool
+_validate_dollar_doc (validator *self, bson_iter_t *iter)
+{
+   if (_key_is (iter, "$ref")) {
+      return _validate_dbref (self, iter);
+   }
+   // Have the element key validator issue an error message about the bad $-key
+   bool okay = _validate_element_key (self, iter);
+   assert (!okay);
+   return false;
+}
+
+static bool
+_validate_doc (validator *self, const bson_t *bson)
+{
+   bson_iter_t iter;
+   require_with_error (bson_iter_init (&iter, bson), 0, BSON_VALIDATE_CORRUPT, "Unable to initialize iterator");
+   bool done;
+   require_advance (done, &iter);
+   if (done) {
+      // Nothing to check
+      return true;
+   }
+   // Check if the first key starts with a dollar
+   if (self->params->check_special_dollar_keys) {
+      const char *const key = bson_iter_key (&iter);
+      if (key[0] == '$') {
+         return _validate_dollar_doc (self, &iter);
+      }
+   }
+
+   return _validate_remaining_elements (self, &iter);
+}
+
+// This private function is called by `bson_validate_with_error_and_offset`
+bool
+_bson_validate_impl_v2 (const bson_t *bson, bson_validate_flags_t flags, size_t *offset, bson_error_t *error)
+{
+   // Clear the error
+   *error = (bson_error_t){0};
+
+   // Initialize validation parameters
+   validation_params const params = {
+      .allow_invalid_utf8 = !(flags & BSON_VALIDATE_UTF8),
+      .allow_null_in_utf8 = flags & BSON_VALIDATE_UTF8_ALLOW_NULL,
+      .check_special_dollar_keys = (flags & BSON_VALIDATE_DOLLAR_KEYS),
+      .allow_dot_in_keys = !(flags & BSON_VALIDATE_DOT_KEYS),
+      .allow_empty_keys = !(flags & BSON_VALIDATE_EMPTY_KEYS),
+   };
+
+   // Start the validator on the root document
+   validator v = {0};
+   v.params = &params;
+   bool okay = _validate_doc (&v, bson);
+   *offset = v.error_offset;
+   *error = v.error;
+   assert (okay == (v.error.code == 0) &&
+           "Validation routine should return `false` if-and-only-if it sets an error code");
+   return okay;
+}

--- a/src/libbson/src/bson/validate.c
+++ b/src/libbson/src/bson/validate.c
@@ -321,7 +321,8 @@ _validate_element_key (validator *self, bson_iter_t const *iter)
    // Check for special keys
    if (self->params->check_special_dollar_keys) {
       // dollar-keys are checked during the startup of _validate_doc. If we get here, there's a problem.
-      require_with_error (key[0] != '$', iter->off, BSON_VALIDATE_DOLLAR_KEYS, "Disallowed element key: \"%s\"", key);
+      require_with_error (
+         key[0] != '$', iter->off, BSON_VALIDATE_DOLLAR_KEYS, "Disallowed '$' in element key: \"%s\"", key);
    }
 
    if (!self->params->allow_empty_keys) {
@@ -329,7 +330,8 @@ _validate_element_key (validator *self, bson_iter_t const *iter)
    }
 
    if (!self->params->allow_dot_in_keys) {
-      require_with_error (!strstr (key, "."), iter->off, BSON_VALIDATE_DOT_KEYS, "Disallowed element key: \"%s\"", key);
+      require_with_error (
+         !strstr (key, "."), iter->off, BSON_VALIDATE_DOT_KEYS, "Disallowed '.' in element key: \"%s\"", key);
    }
 
    return true;

--- a/src/libbson/src/bson/validate.c
+++ b/src/libbson/src/bson/validate.c
@@ -509,7 +509,7 @@ _validate_doc (validator *self, const bson_t *bson, int depth)
    BSON_ASSERT_PARAM (bson);
 
    // The depth limit of 100 is chosen to match the limit enforced by MongoDB server.
-   // Refer: https://www.mongodb.com/docs/manual/reference/limits/#mongodb-limit-Nested-Depth-for-BSON-Documen
+   // Refer: https://www.mongodb.com/docs/manual/reference/limits/#mongodb-limit-Nested-Depth-for-BSON-Documents
    require_with_error (
       depth <= BSON_VALIDATION_MAX_NESTING_DEPTH, 0, BSON_VALIDATE_CORRUPT, "BSON document nesting depth is too deep");
    // We increment the depth here, otherwise we'd have `depth + 1` in several places.

--- a/src/libbson/src/bson/validate.c
+++ b/src/libbson/src/bson/validate.c
@@ -515,7 +515,8 @@ _validate_doc (validator *self, const bson_t *bson, int depth)
 
    // Initialize an iterator into the document to be validated
    bson_iter_t iter;
-   require_with_error (bson_iter_init (&iter, bson), 0, BSON_VALIDATE_CORRUPT, "Unable to initialize iterator");
+   require_with_error (
+      bson_iter_init (&iter, bson), 0, BSON_VALIDATE_CORRUPT, "Document header corruption, unable to iterate");
    bool done;
    require_advance (done, &iter);
    if (done) {

--- a/src/libbson/src/bson/validate.c
+++ b/src/libbson/src/bson/validate.c
@@ -506,12 +506,12 @@ _validate_doc (validator *self, const bson_t *bson, int depth)
    BSON_ASSERT_PARAM (self);
    BSON_ASSERT_PARAM (bson);
 
-   // We increment the depth here, otherwise we'd have `depth + 1` in several places.
-   ++depth;
    // The depth limit of 100 is chosen to match the limit enforced by MongoDB server.
    // Refer: https://www.mongodb.com/docs/manual/reference/limits/#mongodb-limit-Nested-Depth-for-BSON-Documen
    require_with_error (
       depth <= BSON_VALIDATION_MAX_NESTING_DEPTH, 0, BSON_VALIDATE_CORRUPT, "BSON document nesting depth is too deep");
+   // We increment the depth here, otherwise we'd have `depth + 1` in several places.
+   ++depth;
 
    // Initialize an iterator into the document to be validated
    bson_iter_t iter;

--- a/src/libbson/src/bson/validate.c
+++ b/src/libbson/src/bson/validate.c
@@ -508,8 +508,6 @@ _validate_doc (validator *self, const bson_t *bson, int depth)
    BSON_ASSERT_PARAM (self);
    BSON_ASSERT_PARAM (bson);
 
-   // The depth limit of 100 is chosen to match the limit enforced by MongoDB server.
-   // Refer: https://www.mongodb.com/docs/manual/reference/limits/#mongodb-limit-Nested-Depth-for-BSON-Documents
    require_with_error (
       depth <= BSON_VALIDATION_MAX_NESTING_DEPTH, 0, BSON_VALIDATE_CORRUPT, "BSON document nesting depth is too deep");
    // We increment the depth here, otherwise we'd have `depth + 1` in several places.

--- a/src/libbson/src/bson/validate.c
+++ b/src/libbson/src/bson/validate.c
@@ -312,9 +312,10 @@ _validate_element_key (validator *self, bson_iter_t const *iter)
 
    const char *const key = bson_iter_key (iter);
    mlib_check (key);
+   const size_t key_len = bson_iter_key_len (iter);
 
    // Check the UTF-8 of the key
-   require (_maybe_validate_utf8_cstring (self, iter->off, key));
+   require (_maybe_validate_utf8 (self, iter->off, key, key_len));
 
    // Check for special keys
    if (self->params->check_special_dollar_keys) {
@@ -323,8 +324,7 @@ _validate_element_key (validator *self, bson_iter_t const *iter)
    }
 
    if (!self->params->allow_empty_keys) {
-      require_with_error (
-         strlen (key) != 0, iter->off, BSON_VALIDATE_EMPTY_KEYS, "Element key cannot be an empty string");
+      require_with_error (key_len != 0, iter->off, BSON_VALIDATE_EMPTY_KEYS, "Element key cannot be an empty string");
    }
 
    if (!self->params->allow_dot_in_keys) {

--- a/src/libbson/src/bson/validate.c
+++ b/src/libbson/src/bson/validate.c
@@ -357,7 +357,8 @@ _validate_element_value (validator *self, bson_iter_t const *iter, int depth)
    switch (type) {
    default:
    case BSON_TYPE_EOD:
-      mlib_check (false && "Unreachable");
+      BSON_UNREACHABLE ("Validation execution encountered an element of type 0x0, but this should not happen as tag "
+                        "validation is handled before we get to this point.");
    case BSON_TYPE_DOUBLE:
    case BSON_TYPE_NULL:
    case BSON_TYPE_OID:

--- a/src/libbson/src/bson/validate.c
+++ b/src/libbson/src/bson/validate.c
@@ -454,6 +454,8 @@ _validate_dbref (validator *self, bson_iter_t *iter, int depth)
    require_advance (done, iter);
    require_with_error (
       !done && _key_is (iter, "$id"), iter->off, BSON_VALIDATE_DOLLAR_KEYS, "Expected an $id element following $ref");
+   // While $id is typically a OID value, it is not constraint to any specific type, so
+   // we just validate it as an arbitrary value.
    require (_validate_element_value (self, iter, depth));
 
    // We should stop, or we should have a $db, or we may have other elements

--- a/src/libbson/src/bson/validate.c
+++ b/src/libbson/src/bson/validate.c
@@ -276,18 +276,20 @@ _validate_codewscope_elem (validator *self, bson_iter_t const *iter, int depth)
    // Don't validate the scope document using the parent parameters, because it should
    // be treated as an opaque closure of JS variables.
    validation_params const scope_params = {
-      // JS vars cannot contain dots
-      .allow_dot_in_keys = false,
-      // JS vars cannot be empty
-      .allow_empty_keys = false,
+      // JS object keys can contain dots
+      .allow_dot_in_keys = true,
+      // JS object keys can be empty
+      .allow_empty_keys = true,
       // JS strings can contain null bytes
       .allow_null_in_utf8 = true,
       // JS strings need to encode properly
       .allow_invalid_utf8 = false,
-      // JS allows variables to have dollars
+      // JS allows object keys to have dollars
       .check_special_dollar_keys = false,
    };
    validator scope_validator = {.params = &scope_params};
+   // We could do more validation that the scope keys are valid JS identifiers,
+   // but that would require using a full Unicode database.
    if (_validate_doc (&scope_validator, &scope, depth)) {
       // No error
       return true;

--- a/src/libbson/src/bson/validate.c
+++ b/src/libbson/src/bson/validate.c
@@ -216,6 +216,8 @@ _maybe_validate_utf8 (validator *self, size_t offset, const char *u8, size_t u8l
 static bool
 _maybe_validate_utf8_cstring (validator *self, size_t offset, const char *const u8)
 {
+   BSON_ASSERT_PARAM (self);
+   BSON_ASSERT_PARAM (u8);
    return _maybe_validate_utf8 (self, offset, u8, strlen (u8));
 }
 
@@ -240,6 +242,8 @@ _validate_stringlike_element (validator *self, bson_iter_t const *iter)
 static bool
 _validate_regex_elem (validator *self, bson_iter_t const *iter)
 {
+   BSON_ASSERT_PARAM (self);
+   BSON_ASSERT_PARAM (iter);
    mlib_check (BSON_ITER_HOLDS_REGEX (iter));
    const char *opts;
    const char *const rx = bson_iter_regex (iter, &opts);
@@ -252,6 +256,8 @@ _validate_regex_elem (validator *self, bson_iter_t const *iter)
 static bool
 _validate_codewscope_elem (validator *self, bson_iter_t const *iter, int depth)
 {
+   BSON_ASSERT_PARAM (self);
+   BSON_ASSERT_PARAM (iter);
    mlib_check (BSON_ITER_HOLDS_CODEWSCOPE (iter));
    // Extract the code and the scope object
    uint8_t const *doc;
@@ -333,6 +339,8 @@ _validate_element_key (validator *self, bson_iter_t const *iter)
 static bool
 _get_subdocument (bson_t *subdoc, bson_iter_t const *iter)
 {
+   BSON_ASSERT_PARAM (subdoc);
+   BSON_ASSERT_PARAM (iter);
    uint32_t len = mlib_read_u32le (iter->raw + iter->d1);
    uint8_t const *data = (uint8_t const *) iter->raw + iter->d1;
    return bson_init_static (subdoc, data, len);
@@ -403,6 +411,8 @@ _validate_element_value (validator *self, bson_iter_t const *iter, int depth)
 static bool
 _validate_element (validator *self, bson_iter_t *iter, int depth)
 {
+   BSON_ASSERT_PARAM (self);
+   BSON_ASSERT_PARAM (iter);
    return _validate_element_key (self, iter) && _validate_element_value (self, iter, depth);
 }
 
@@ -413,6 +423,8 @@ _validate_element (validator *self, bson_iter_t *iter, int depth)
 static bool
 _validate_remaining_elements (validator *self, bson_iter_t *iter, int depth)
 {
+   BSON_ASSERT_PARAM (self);
+   BSON_ASSERT_PARAM (iter);
    bool done = false;
    while (!done) {
       require (_validate_element (self, iter, depth));

--- a/src/libbson/src/bson/validate.c
+++ b/src/libbson/src/bson/validate.c
@@ -27,6 +27,7 @@
  * limitations under the License.
  */
 
+#include <bson/validate-private.h>
 #include <mlib/intencode.h>
 #include <mlib/test.h>
 #include <bson/bson.h>
@@ -501,9 +502,12 @@ _validate_doc (validator *self, const bson_t *bson, int depth)
    BSON_ASSERT_PARAM (self);
    BSON_ASSERT_PARAM (bson);
 
-   // We increment the depth here, otherwise we'd have `depth + 1` in several places
+   // We increment the depth here, otherwise we'd have `depth + 1` in several places.
    ++depth;
-   require_with_error (depth < 1000, 0, BSON_VALIDATE_CORRUPT, "BSON document nesting depth is too deep");
+   // The depth limit of 100 is chosen to match the limit enforced by MongoDB server.
+   // Refer: https://www.mongodb.com/docs/manual/reference/limits/#mongodb-limit-Nested-Depth-for-BSON-Documen
+   require_with_error (
+      depth <= BSON_VALIDATION_MAX_NESTING_DEPTH, 0, BSON_VALIDATE_CORRUPT, "BSON document nesting depth is too deep");
 
    // Initialize an iterator into the document to be validated
    bson_iter_t iter;

--- a/src/libbson/src/bson/validate.c
+++ b/src/libbson/src/bson/validate.c
@@ -89,6 +89,17 @@ typedef struct {
    size_t error_offset;
 } validator;
 
+// Undef these macros, if they are defined.
+#ifdef require_with_error
+#undef require_with_error
+#endif
+#ifdef require
+#undef require
+#endif
+#ifdef require_advance
+#undef require_advance
+#endif
+
 /**
  * @brief Check that the given condition is satisfied, or set an error and return `false`
  *

--- a/src/libbson/tests/test-bson.c
+++ b/src/libbson/tests/test-bson.c
@@ -857,215 +857,15 @@ test_bson_append_deep (void)
 
 
 static void
-test_bson_validate_dbref (void)
+_make_deep_bson (bson_t *const dst, const size_t depth)
 {
-   size_t offset;
-   bson_t dbref, child, child2;
-
-   /* should fail, $ref without an $id */
-   {
-      bson_init (&dbref);
-      BSON_APPEND_DOCUMENT_BEGIN (&dbref, "dbref", &child);
-      BSON_APPEND_UTF8 (&child, "$ref", "foo");
-      bson_append_document_end (&dbref, &child);
-
-      BSON_ASSERT (!bson_validate (&dbref, BSON_VALIDATE_DOLLAR_KEYS, &offset));
-
-      bson_destroy (&dbref);
-   }
-
-   /* should fail, $ref with non id field */
-   {
-      bson_init (&dbref);
-      BSON_APPEND_DOCUMENT_BEGIN (&dbref, "dbref", &child);
-      BSON_APPEND_UTF8 (&child, "$ref", "foo");
-      BSON_APPEND_UTF8 (&child, "extra", "field");
-      bson_append_document_end (&dbref, &child);
-
-      BSON_ASSERT (!bson_validate (&dbref, BSON_VALIDATE_DOLLAR_KEYS, &offset));
-
-      bson_destroy (&dbref);
-   }
-
-   /* should fail, $ref with $id not first keys */
-   {
-      bson_init (&dbref);
-      BSON_APPEND_DOCUMENT_BEGIN (&dbref, "dbref", &child);
-      BSON_APPEND_UTF8 (&child, "extra", "field");
-      BSON_APPEND_UTF8 (&child, "$ref", "foo");
-      BSON_APPEND_UTF8 (&child, "$id", "bar");
-      bson_append_document_end (&dbref, &child);
-
-      BSON_ASSERT (!bson_validate (&dbref, BSON_VALIDATE_DOLLAR_KEYS, &offset));
-
-      bson_destroy (&dbref);
-   }
-
-   /* should fail, $ref with $db */
-   {
-      bson_init (&dbref);
-      BSON_APPEND_DOCUMENT_BEGIN (&dbref, "dbref", &child);
-      BSON_APPEND_UTF8 (&child, "$ref", "foo");
-      BSON_APPEND_UTF8 (&child, "$db", "bar");
-      bson_append_document_end (&dbref, &child);
-
-      BSON_ASSERT (!bson_validate (&dbref, BSON_VALIDATE_DOLLAR_KEYS, &offset));
-
-      bson_destroy (&dbref);
-   }
-
-   /* should fail, non-string $ref with $id */
-   {
-      bson_init (&dbref);
-      BSON_APPEND_DOCUMENT_BEGIN (&dbref, "dbref", &child);
-      BSON_APPEND_INT32 (&child, "$ref", 1);
-      BSON_APPEND_UTF8 (&child, "$id", "bar");
-      bson_append_document_end (&dbref, &child);
-
-      BSON_ASSERT (!bson_validate (&dbref, BSON_VALIDATE_DOLLAR_KEYS, &offset));
-
-      bson_destroy (&dbref);
-   }
-
-   /* should fail, non-string $ref with nothing */
-   {
-      bson_init (&dbref);
-      BSON_APPEND_DOCUMENT_BEGIN (&dbref, "dbref", &child);
-      BSON_APPEND_INT32 (&child, "$ref", 1);
-      bson_append_document_end (&dbref, &child);
-
-      BSON_ASSERT (!bson_validate (&dbref, BSON_VALIDATE_DOLLAR_KEYS, &offset));
-
-      bson_destroy (&dbref);
-   }
-
-   /* should fail, $ref with $id with non-string $db */
-   {
-      bson_init (&dbref);
-      BSON_APPEND_DOCUMENT_BEGIN (&dbref, "dbref", &child);
-      BSON_APPEND_UTF8 (&child, "$ref", "foo");
-      BSON_APPEND_UTF8 (&child, "$id", "bar");
-      BSON_APPEND_INT32 (&child, "$db", 1);
-      bson_append_document_end (&dbref, &child);
-
-      BSON_ASSERT (!bson_validate (&dbref, BSON_VALIDATE_DOLLAR_KEYS, &offset));
-
-      bson_destroy (&dbref);
-   }
-
-   /* should fail, $ref with $id with non-string $db with stuff after */
-   {
-      bson_init (&dbref);
-      BSON_APPEND_DOCUMENT_BEGIN (&dbref, "dbref", &child);
-      BSON_APPEND_UTF8 (&child, "$ref", "foo");
-      BSON_APPEND_UTF8 (&child, "$id", "bar");
-      BSON_APPEND_INT32 (&child, "$db", 1);
-      BSON_APPEND_UTF8 (&child, "extra", "field");
-      bson_append_document_end (&dbref, &child);
-
-      BSON_ASSERT (!bson_validate (&dbref, BSON_VALIDATE_DOLLAR_KEYS, &offset));
-
-      bson_destroy (&dbref);
-   }
-
-   /* should fail, $ref with $id with stuff, then $db */
-   {
-      bson_init (&dbref);
-      BSON_APPEND_DOCUMENT_BEGIN (&dbref, "dbref", &child);
-      BSON_APPEND_UTF8 (&child, "$ref", "foo");
-      BSON_APPEND_UTF8 (&child, "$id", "bar");
-      BSON_APPEND_UTF8 (&child, "extra", "field");
-      BSON_APPEND_UTF8 (&child, "$db", "baz");
-      bson_append_document_end (&dbref, &child);
-
-      BSON_ASSERT (!bson_validate (&dbref, BSON_VALIDATE_DOLLAR_KEYS, &offset));
-
-      bson_destroy (&dbref);
-   }
-
-   /* should succeed, $ref with $id */
-   {
-      bson_init (&dbref);
-      BSON_APPEND_DOCUMENT_BEGIN (&dbref, "dbref", &child);
-      BSON_APPEND_UTF8 (&child, "$ref", "foo");
-      BSON_APPEND_UTF8 (&child, "$id", "bar");
-      bson_append_document_end (&dbref, &child);
-
-      BSON_ASSERT (bson_validate (&dbref, BSON_VALIDATE_DOLLAR_KEYS, &offset));
-
-      bson_destroy (&dbref);
-   }
-
-   /* should succeed, $ref with nested dbref $id */
-   {
-      bson_init (&dbref);
-      BSON_APPEND_DOCUMENT_BEGIN (&dbref, "dbref", &child);
-      BSON_APPEND_UTF8 (&child, "$ref", "foo");
-      BSON_APPEND_DOCUMENT_BEGIN (&child, "$id", &child2);
-      BSON_APPEND_UTF8 (&child2, "$ref", "foo2");
-      BSON_APPEND_UTF8 (&child2, "$id", "bar2");
-      BSON_APPEND_UTF8 (&child2, "$db", "baz2");
-      bson_append_document_end (&child, &child2);
-      BSON_APPEND_UTF8 (&child, "$db", "baz");
-      bson_append_document_end (&dbref, &child);
-
-      bson_error_t err;
-      ASSERT_OR_PRINT (bson_validate_with_error (&dbref, BSON_VALIDATE_DOLLAR_KEYS, &err), err);
-
-      bson_destroy (&dbref);
-   }
-
-   /* should succeed, $ref with $id and $db */
-   {
-      bson_init (&dbref);
-      BSON_APPEND_DOCUMENT_BEGIN (&dbref, "dbref", &child);
-      BSON_APPEND_UTF8 (&child, "$ref", "foo");
-      BSON_APPEND_UTF8 (&child, "$id", "bar");
-      BSON_APPEND_UTF8 (&child, "$db", "baz");
-      bson_append_document_end (&dbref, &child);
-
-      BSON_ASSERT (bson_validate (&dbref, BSON_VALIDATE_DOLLAR_KEYS, &offset));
-
-      bson_destroy (&dbref);
-   }
-
-   /* should succeed, $ref with $id and $db and trailing */
-   {
-      bson_init (&dbref);
-      BSON_APPEND_DOCUMENT_BEGIN (&dbref, "dbref", &child);
-      BSON_APPEND_UTF8 (&child, "$ref", "foo");
-      BSON_APPEND_UTF8 (&child, "$id", "bar");
-      BSON_APPEND_UTF8 (&child, "$db", "baz");
-      BSON_APPEND_UTF8 (&child, "extra", "field");
-      bson_append_document_end (&dbref, &child);
-
-      BSON_ASSERT (bson_validate (&dbref, BSON_VALIDATE_DOLLAR_KEYS, &offset));
-
-      bson_destroy (&dbref);
-   }
-}
-
-
-/**
- * @brief Test case: Check that we stop validating if we go too deep.
- *
- * The current validation is implemented as a simple recursive algorithm. This
- * is fast since it doesn't allocate, but we risk blowing out the stack if the
- * data is too deep. We don't want to crash user applications because of untrusted
- * input, so assert that we stop when we hit a reasonably high depth.
- */
-static void
-test_bson_validate_deep (void)
-{
-   // Build and extremely deep BSON document
-   const size_t validation_depth = 1000;
    // Needed size: 5 bytes for doc header/trailer, 2 bytes for each tag and empty
    // key, minus 2 because the outer document has no tag and key
-   const size_t buffer_size = (validation_depth * (5 + 2)) - 2;
+   const size_t buffer_size = (depth * (5 + 2)) - 2;
    uint8_t *const buffer = calloc (buffer_size, 1);
    mlib_check (buffer);
    uint8_t *out = buffer;
-   mlib_foreach_urange (i, validation_depth) {
+   mlib_foreach_urange (i, depth) {
       // Bytes we have already written:
       const size_t begin_offset = out - buffer;
       // The number of bytes for this inner doc:
@@ -1082,79 +882,34 @@ test_bson_validate_deep (void)
    }
    bson_t big;
    mlib_check (bson_init_static (&big, buffer, buffer_size));
-   bson_error_t err;
-   mlib_check (!bson_validate_with_error (&big, 0, &err));
-   mlib_check (err.code, eq, BSON_VALIDATE_CORRUPT);
-   mlib_check (err.message, str_eq, "BSON document nesting depth is too deep");
+   bson_copy_to (&big, dst);
    free (buffer);
 }
 
-/* BSON spec requires bool value to be exactly 0 or 1 */
+/**
+ * @brief Test case: Check that we stop validating if we go too deep.
+ *
+ * The current validation is implemented as a simple recursive algorithm. This
+ * is fast since it doesn't allocate, but we risk blowing out the stack if the
+ * data is too deep. We don't want to crash user applications because of untrusted
+ * input, so assert that we stop when we hit a reasonably high depth.
+ */
 static void
-test_bson_validate_bool (void)
+test_bson_validate_deep (void)
 {
-   /* {"b": true}, with implicit NULL at end */
-   uint8_t data[] = "\x09\x00\x00\x00\x08\x62\x00\x01";
-   bson_t bson;
-   bson_iter_t iter;
-   size_t err_offset = 0;
-
-   ASSERT (bson_init_static (&bson, data, sizeof data));
-   ASSERT (bson_validate (&bson, BSON_VALIDATE_NONE, &err_offset));
-   ASSERT (bson_iter_init (&iter, &bson));
-   ASSERT (bson_iter_next (&iter));
-   ASSERT (BSON_ITER_HOLDS_BOOL (&iter));
-   ASSERT (bson_iter_bool (&iter));
-
-   /* replace boolean value 1 with 255 */
-   ASSERT (data[7] == '\x01');
-   data[7] = (uint8_t) '\xff';
-
-   ASSERT (bson_init_static (&bson, data, 9));
-   ASSERT (!bson_validate (&bson, BSON_VALIDATE_NONE, &err_offset));
-   ASSERT_CMPSIZE_T (err_offset, ==, (size_t) 7);
-
-   ASSERT (bson_iter_init (&iter, &bson));
-   ASSERT (!bson_iter_next (&iter));
+   bson_t deep;
+   // 1000 is too deep
+   _make_deep_bson (&deep, 1000);
+   bson_error_t err;
+   mlib_check (!bson_validate_with_error (&deep, 0, &err));
+   mlib_check (err.code, eq, BSON_VALIDATE_CORRUPT);
+   mlib_check (err.message, str_eq, "BSON document nesting depth is too deep");
+   bson_destroy (&deep);
+   // 999 is not too deep
+   _make_deep_bson (&deep, 999);
+   mlib_check (bson_validate (&deep, 0, NULL));
+   bson_destroy (&deep);
 }
-
-
-/* BSON spec requires the deprecated DBPointer's value to be NULL-termed */
-static void
-test_bson_validate_dbpointer (void)
-{
-   /* { "a": DBPointer(ObjectId(...), Collection="b") }, implicit NULL at end */
-   uint8_t data[] = "\x1A\x00\x00\x00\x0C\x61\x00\x02\x00\x00\x00\x62\x00"
-                    "\x56\xE1\xFC\x72\xE0\xC9\x17\xE9\xC4\x71\x41\x61";
-
-   bson_t bson;
-   bson_iter_t iter;
-   size_t err_offset = 0;
-   uint32_t collection_len;
-   const char *collection;
-   const bson_oid_t *oid;
-
-   ASSERT (bson_init_static (&bson, data, sizeof data));
-   ASSERT (bson_validate (&bson, BSON_VALIDATE_NONE, &err_offset));
-   ASSERT (bson_iter_init (&iter, &bson));
-   ASSERT (bson_iter_next (&iter));
-   ASSERT (BSON_ITER_HOLDS_DBPOINTER (&iter));
-   bson_iter_dbpointer (&iter, &collection_len, &collection, &oid);
-   ASSERT_CMPSTR (collection, "b");
-   ASSERT_CMPINT (collection_len, ==, 1);
-
-   /* replace the NULL terminator of "b" with 255 */
-   ASSERT (data[12] == '\0');
-   data[12] = (uint8_t) '\xff';
-
-   ASSERT (bson_init_static (&bson, data, sizeof data));
-   ASSERT (!bson_validate (&bson, BSON_VALIDATE_NONE, &err_offset));
-   ASSERT_CMPSIZE_T (err_offset, ==, (size_t) 12);
-
-   ASSERT (bson_iter_init (&iter, &bson));
-   ASSERT (!bson_iter_next (&iter));
-}
-
 
 static void
 test_bson_validate_with_error_and_offset (void)
@@ -1165,107 +920,6 @@ test_bson_validate_with_error_and_offset (void)
    ASSERT (!bson_validate_with_error_and_offset (&bson, BSON_VALIDATE_NONE, &err_offset, &err));
    ASSERT_CMPSIZE_T (err_offset, ==, 0);
    ASSERT_CMPUINT32 (err.domain, !=, 67890); // domain is overwritten.
-}
-
-
-static void
-test_bson_validate (void)
-{
-   char filename[64];
-   size_t offset;
-   bson_t *b;
-   int i;
-   bson_error_t error;
-
-   for (i = 1; i <= 38; i++) {
-      bson_snprintf (filename, sizeof filename, "test%d.bson", i);
-      b = get_bson (filename);
-      BSON_ASSERT (bson_validate (b, BSON_VALIDATE_NONE, &offset));
-      bson_destroy (b);
-   }
-
-   b = get_bson ("codewscope.bson");
-   BSON_ASSERT (bson_validate (b, BSON_VALIDATE_NONE, &offset));
-   bson_destroy (b);
-
-   b = get_bson ("empty_key.bson");
-   BSON_ASSERT (bson_validate (
-      b, BSON_VALIDATE_NONE | BSON_VALIDATE_UTF8 | BSON_VALIDATE_DOLLAR_KEYS | BSON_VALIDATE_DOT_KEYS, &offset));
-   bson_destroy (b);
-
-#define VALIDATE_TEST(_filename, _flags, _offset, _flag, _msg)                      \
-   b = get_bson (_filename);                                                        \
-   BSON_ASSERT (!bson_validate_with_error_and_offset (b, _flags, &offset, &error)); \
-   ASSERT_CMPSIZE_T (offset, ==, (size_t) _offset);                                 \
-   ASSERT_ERROR_CONTAINS (error, BSON_ERROR_INVALID, _flag, _msg);                  \
-   bson_destroy (b)
-
-   VALIDATE_TEST ("overflow2.bson", BSON_VALIDATE_NONE, 9, BSON_VALIDATE_NONE, "corrupt BSON");
-   VALIDATE_TEST ("trailingnull.bson", BSON_VALIDATE_NONE, 14, BSON_VALIDATE_NONE, "corrupt BSON");
-   VALIDATE_TEST ("dollarquery.bson",
-                  BSON_VALIDATE_DOLLAR_KEYS | BSON_VALIDATE_DOT_KEYS,
-                  4,
-                  BSON_VALIDATE_DOLLAR_KEYS,
-                  "Disallowed element key: \"$query\"");
-   VALIDATE_TEST ("dotquery.bson",
-                  BSON_VALIDATE_DOLLAR_KEYS | BSON_VALIDATE_DOT_KEYS,
-                  4,
-                  BSON_VALIDATE_DOT_KEYS,
-                  "Disallowed element key: \"abc.def\"");
-   VALIDATE_TEST ("overflow3.bson", BSON_VALIDATE_NONE, 9, BSON_VALIDATE_CORRUPT, "corrupt BSON");
-   /* same outcome as above, despite different flags */
-   VALIDATE_TEST ("overflow3.bson", BSON_VALIDATE_UTF8, 9, BSON_VALIDATE_CORRUPT, "corrupt BSON");
-   VALIDATE_TEST ("overflow4.bson", BSON_VALIDATE_NONE, 9, BSON_VALIDATE_CORRUPT, "corrupt BSON");
-   VALIDATE_TEST (
-      "empty_key.bson", BSON_VALIDATE_EMPTY_KEYS, 4, BSON_VALIDATE_EMPTY_KEYS, "Element key cannot be an empty string");
-   VALIDATE_TEST ("test40.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_CORRUPT, "corrupt BSON");
-   VALIDATE_TEST ("test41.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_CORRUPT, "corrupt BSON");
-   VALIDATE_TEST ("test42.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_CORRUPT, "corrupt BSON");
-   VALIDATE_TEST ("test43.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_CORRUPT, "corrupt BSON");
-   VALIDATE_TEST ("test44.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_CORRUPT, "corrupt BSON");
-   VALIDATE_TEST ("test45.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_CORRUPT, "corrupt BSON");
-   VALIDATE_TEST ("test46.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_CORRUPT, "corrupt BSON");
-   VALIDATE_TEST ("test47.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_CORRUPT, "corrupt BSON");
-   VALIDATE_TEST ("test48.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_CORRUPT, "corrupt BSON");
-   VALIDATE_TEST ("test49.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_CORRUPT, "corrupt BSON");
-   VALIDATE_TEST ("test50.bson", BSON_VALIDATE_NONE, 10, BSON_VALIDATE_CORRUPT, "corrupt BSON");
-   VALIDATE_TEST ("test51.bson", BSON_VALIDATE_NONE, 10, BSON_VALIDATE_CORRUPT, "corrupt BSON");
-   VALIDATE_TEST ("test52.bson", BSON_VALIDATE_NONE, 9, BSON_VALIDATE_CORRUPT, "corrupt BSON");
-   VALIDATE_TEST ("test53.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_CORRUPT, "corrupt BSON");
-   VALIDATE_TEST ("test54.bson", BSON_VALIDATE_NONE, 12, BSON_VALIDATE_CORRUPT, "corrupt BSON");
-   VALIDATE_TEST ("test59.bson", BSON_VALIDATE_NONE, 9, BSON_VALIDATE_CORRUPT, "corrupt BSON");
-   VALIDATE_TEST ("test60.bson", BSON_VALIDATE_NONE, 4, BSON_VALIDATE_CORRUPT, "corrupt BSON");
-
-   /* DBRef validation */
-   b = BCON_NEW ("my_dbref", "{", "$ref", BCON_UTF8 ("collection"), "$id", BCON_INT32 (1), "}");
-   BSON_ASSERT (bson_validate_with_error (b, BSON_VALIDATE_NONE, &error));
-   BSON_ASSERT (bson_validate_with_error (b, BSON_VALIDATE_DOLLAR_KEYS, &error));
-   bson_destroy (b);
-
-   /* needs "$ref" before "$id" */
-   b = BCON_NEW ("my_dbref", "{", "$id", BCON_INT32 (1), "}");
-   BSON_ASSERT (bson_validate_with_error (b, BSON_VALIDATE_NONE, &error));
-   BSON_ASSERT (!bson_validate_with_error (b, BSON_VALIDATE_DOLLAR_KEYS, &error));
-   ASSERT_ERROR_CONTAINS (error, BSON_ERROR_INVALID, BSON_VALIDATE_DOLLAR_KEYS, "Disallowed element key: \"$id\"");
-   bson_destroy (b);
-
-   /* two $refs */
-   b = BCON_NEW ("my_dbref", "{", "$ref", BCON_UTF8 ("collection"), "$ref", BCON_UTF8 ("collection"), "}");
-   BSON_ASSERT (bson_validate_with_error (b, BSON_VALIDATE_NONE, &error));
-   BSON_ASSERT (!bson_validate_with_error (b, BSON_VALIDATE_DOLLAR_KEYS, &error));
-   ASSERT_ERROR_CONTAINS (
-      error, BSON_ERROR_INVALID, BSON_VALIDATE_DOLLAR_KEYS, "Expected an $id element following $ref");
-   bson_destroy (b);
-
-   /* must not contain invalid key like "extra" */
-   b =
-      BCON_NEW ("my_dbref", "{", "$ref", BCON_UTF8 ("collection"), "extra", BCON_INT32 (2), "$id", BCON_INT32 (1), "}");
-   BSON_ASSERT (bson_validate_with_error (b, BSON_VALIDATE_NONE, &error));
-   BSON_ASSERT (!bson_validate_with_error (b, BSON_VALIDATE_DOLLAR_KEYS, &error));
-   ASSERT_ERROR_CONTAINS (
-      error, BSON_ERROR_INVALID, BSON_VALIDATE_DOLLAR_KEYS, "Expected an $id element following $ref");
-   bson_destroy (b);
-#undef VALIDATE_TEST
 }
 
 
@@ -3347,11 +3001,7 @@ test_bson_install (TestSuite *suite)
    TestSuite_Add (suite, "/bson/append_general", test_bson_append_general);
    TestSuite_Add (suite, "/bson/append_deep", test_bson_append_deep);
    TestSuite_Add (suite, "/bson/utf8_key", test_bson_utf8_key);
-   TestSuite_Add (suite, "/bson/validate", test_bson_validate);
    TestSuite_Add (suite, "/bson/validate/deep", test_bson_validate_deep);
-   TestSuite_Add (suite, "/bson/validate/dbref", test_bson_validate_dbref);
-   TestSuite_Add (suite, "/bson/validate/bool", test_bson_validate_bool);
-   TestSuite_Add (suite, "/bson/validate/dbpointer", test_bson_validate_dbpointer);
    TestSuite_Add (suite, "/bson/validate/with_error_and_offset", test_bson_validate_with_error_and_offset);
    TestSuite_Add (suite, "/bson/new_1mm", test_bson_new_1mm);
    TestSuite_Add (suite, "/bson/init_1mm", test_bson_init_1mm);

--- a/src/libbson/tests/test-bson.c
+++ b/src/libbson/tests/test-bson.c
@@ -898,15 +898,15 @@ static void
 test_bson_validate_deep (void)
 {
    bson_t deep;
-   // 1000 is too deep
-   _make_deep_bson (&deep, 1000);
+   // Just barely too deep
+   _make_deep_bson (&deep, BSON_VALIDATION_MAX_NESTING_DEPTH + 1);
    bson_error_t err;
    mlib_check (!bson_validate_with_error (&deep, 0, &err));
    mlib_check (err.code, eq, BSON_VALIDATE_CORRUPT);
    mlib_check (err.message, str_eq, "BSON document nesting depth is too deep");
    bson_destroy (&deep);
-   // 999 is not too deep
-   _make_deep_bson (&deep, 999);
+   // At the limit
+   _make_deep_bson (&deep, BSON_VALIDATION_MAX_NESTING_DEPTH);
    mlib_check (bson_validate (&deep, 0, NULL));
    bson_destroy (&deep);
 }

--- a/src/libbson/tests/test-bson.c
+++ b/src/libbson/tests/test-bson.c
@@ -859,13 +859,14 @@ test_bson_append_deep (void)
 static void
 _make_deep_bson (bson_t *const dst, const size_t depth)
 {
+   const size_t n_docs = depth + 1;
    // Needed size: 5 bytes for doc header/trailer, 2 bytes for each tag and empty
    // key, minus 2 because the outer document has no tag and key
-   const size_t buffer_size = (depth * (5 + 2)) - 2;
+   const size_t buffer_size = (n_docs * (5 + 2)) - 2;
    uint8_t *const buffer = calloc (buffer_size, 1);
    mlib_check (buffer);
    uint8_t *out = buffer;
-   mlib_foreach_urange (i, depth) {
+   mlib_foreach_urange (i, n_docs) {
       // Bytes we have already written:
       const size_t begin_offset = (size_t) (out - buffer);
       // The number of bytes for this inner doc:

--- a/src/libbson/tests/test-bson.c
+++ b/src/libbson/tests/test-bson.c
@@ -884,17 +884,6 @@ test_bson_validate_dbref (void)
       bson_destroy (&dbref);
    }
 
-   /* should fail, $ref with $id at the top */
-   {
-      bson_init (&dbref);
-      BSON_APPEND_UTF8 (&dbref, "$ref", "foo");
-      BSON_APPEND_UTF8 (&dbref, "$id", "bar");
-
-      BSON_ASSERT (!bson_validate (&dbref, BSON_VALIDATE_DOLLAR_KEYS, &offset));
-
-      bson_destroy (&dbref);
-   }
-
    /* should fail, $ref with $id not first keys */
    {
       bson_init (&dbref);
@@ -1017,7 +1006,8 @@ test_bson_validate_dbref (void)
       BSON_APPEND_UTF8 (&child, "$db", "baz");
       bson_append_document_end (&dbref, &child);
 
-      BSON_ASSERT (bson_validate (&dbref, BSON_VALIDATE_DOLLAR_KEYS, &offset));
+      bson_error_t err;
+      ASSERT_OR_PRINT (bson_validate_with_error (&dbref, BSON_VALIDATE_DOLLAR_KEYS, &err), err);
 
       bson_destroy (&dbref);
    }
@@ -1170,34 +1160,35 @@ test_bson_validate (void)
                   BSON_VALIDATE_DOLLAR_KEYS | BSON_VALIDATE_DOT_KEYS,
                   4,
                   BSON_VALIDATE_DOLLAR_KEYS,
-                  "keys cannot begin with \"$\": \"$query\"");
+                  "Disallowed element key: \"$query\"");
    VALIDATE_TEST ("dotquery.bson",
                   BSON_VALIDATE_DOLLAR_KEYS | BSON_VALIDATE_DOT_KEYS,
                   4,
                   BSON_VALIDATE_DOT_KEYS,
-                  "keys cannot contain \".\": \"abc.def\"");
-   VALIDATE_TEST ("overflow3.bson", BSON_VALIDATE_NONE, 9, BSON_VALIDATE_NONE, "corrupt BSON");
+                  "Disallowed element key: \"abc.def\"");
+   VALIDATE_TEST ("overflow3.bson", BSON_VALIDATE_NONE, 9, BSON_VALIDATE_CORRUPT, "corrupt BSON");
    /* same outcome as above, despite different flags */
-   VALIDATE_TEST ("overflow3.bson", BSON_VALIDATE_UTF8, 9, BSON_VALIDATE_NONE, "corrupt BSON");
-   VALIDATE_TEST ("overflow4.bson", BSON_VALIDATE_NONE, 9, BSON_VALIDATE_NONE, "corrupt BSON");
-   VALIDATE_TEST ("empty_key.bson", BSON_VALIDATE_EMPTY_KEYS, 4, BSON_VALIDATE_EMPTY_KEYS, "empty key");
-   VALIDATE_TEST ("test40.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_NONE, "corrupt BSON");
-   VALIDATE_TEST ("test41.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_NONE, "corrupt BSON");
-   VALIDATE_TEST ("test42.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_NONE, "corrupt BSON");
-   VALIDATE_TEST ("test43.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_NONE, "corrupt BSON");
-   VALIDATE_TEST ("test44.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_NONE, "corrupt BSON");
-   VALIDATE_TEST ("test45.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_NONE, "corrupt BSON");
-   VALIDATE_TEST ("test46.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_NONE, "corrupt BSON");
-   VALIDATE_TEST ("test47.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_NONE, "corrupt BSON");
-   VALIDATE_TEST ("test48.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_NONE, "corrupt BSON");
-   VALIDATE_TEST ("test49.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_NONE, "corrupt BSON");
-   VALIDATE_TEST ("test50.bson", BSON_VALIDATE_NONE, 10, BSON_VALIDATE_NONE, "corrupt code-with-scope");
-   VALIDATE_TEST ("test51.bson", BSON_VALIDATE_NONE, 10, BSON_VALIDATE_NONE, "corrupt code-with-scope");
-   VALIDATE_TEST ("test52.bson", BSON_VALIDATE_NONE, 9, BSON_VALIDATE_NONE, "corrupt BSON");
-   VALIDATE_TEST ("test53.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_NONE, "corrupt BSON");
-   VALIDATE_TEST ("test54.bson", BSON_VALIDATE_NONE, 12, BSON_VALIDATE_NONE, "corrupt BSON");
-   VALIDATE_TEST ("test59.bson", BSON_VALIDATE_NONE, 9, BSON_VALIDATE_NONE, "corrupt BSON");
-   VALIDATE_TEST ("test60.bson", BSON_VALIDATE_NONE, 4, BSON_VALIDATE_NONE, "corrupt BSON");
+   VALIDATE_TEST ("overflow3.bson", BSON_VALIDATE_UTF8, 9, BSON_VALIDATE_CORRUPT, "corrupt BSON");
+   VALIDATE_TEST ("overflow4.bson", BSON_VALIDATE_NONE, 9, BSON_VALIDATE_CORRUPT, "corrupt BSON");
+   VALIDATE_TEST (
+      "empty_key.bson", BSON_VALIDATE_EMPTY_KEYS, 4, BSON_VALIDATE_EMPTY_KEYS, "Element key cannot be an empty string");
+   VALIDATE_TEST ("test40.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_CORRUPT, "corrupt BSON");
+   VALIDATE_TEST ("test41.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_CORRUPT, "corrupt BSON");
+   VALIDATE_TEST ("test42.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_CORRUPT, "corrupt BSON");
+   VALIDATE_TEST ("test43.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_CORRUPT, "corrupt BSON");
+   VALIDATE_TEST ("test44.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_CORRUPT, "corrupt BSON");
+   VALIDATE_TEST ("test45.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_CORRUPT, "corrupt BSON");
+   VALIDATE_TEST ("test46.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_CORRUPT, "corrupt BSON");
+   VALIDATE_TEST ("test47.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_CORRUPT, "corrupt BSON");
+   VALIDATE_TEST ("test48.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_CORRUPT, "corrupt BSON");
+   VALIDATE_TEST ("test49.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_CORRUPT, "corrupt BSON");
+   VALIDATE_TEST ("test50.bson", BSON_VALIDATE_NONE, 10, BSON_VALIDATE_CORRUPT, "corrupt BSON");
+   VALIDATE_TEST ("test51.bson", BSON_VALIDATE_NONE, 10, BSON_VALIDATE_CORRUPT, "corrupt BSON");
+   VALIDATE_TEST ("test52.bson", BSON_VALIDATE_NONE, 9, BSON_VALIDATE_CORRUPT, "corrupt BSON");
+   VALIDATE_TEST ("test53.bson", BSON_VALIDATE_NONE, 6, BSON_VALIDATE_CORRUPT, "corrupt BSON");
+   VALIDATE_TEST ("test54.bson", BSON_VALIDATE_NONE, 12, BSON_VALIDATE_CORRUPT, "corrupt BSON");
+   VALIDATE_TEST ("test59.bson", BSON_VALIDATE_NONE, 9, BSON_VALIDATE_CORRUPT, "corrupt BSON");
+   VALIDATE_TEST ("test60.bson", BSON_VALIDATE_NONE, 4, BSON_VALIDATE_CORRUPT, "corrupt BSON");
 
    /* DBRef validation */
    b = BCON_NEW ("my_dbref", "{", "$ref", BCON_UTF8 ("collection"), "$id", BCON_INT32 (1), "}");
@@ -1209,8 +1200,7 @@ test_bson_validate (void)
    b = BCON_NEW ("my_dbref", "{", "$id", BCON_INT32 (1), "}");
    BSON_ASSERT (bson_validate_with_error (b, BSON_VALIDATE_NONE, &error));
    BSON_ASSERT (!bson_validate_with_error (b, BSON_VALIDATE_DOLLAR_KEYS, &error));
-   ASSERT_ERROR_CONTAINS (
-      error, BSON_ERROR_INVALID, BSON_VALIDATE_DOLLAR_KEYS, "keys cannot begin with \"$\": \"$id\"");
+   ASSERT_ERROR_CONTAINS (error, BSON_ERROR_INVALID, BSON_VALIDATE_DOLLAR_KEYS, "Disallowed element key: \"$id\"");
    bson_destroy (b);
 
    /* two $refs */
@@ -1218,7 +1208,7 @@ test_bson_validate (void)
    BSON_ASSERT (bson_validate_with_error (b, BSON_VALIDATE_NONE, &error));
    BSON_ASSERT (!bson_validate_with_error (b, BSON_VALIDATE_DOLLAR_KEYS, &error));
    ASSERT_ERROR_CONTAINS (
-      error, BSON_ERROR_INVALID, BSON_VALIDATE_DOLLAR_KEYS, "keys cannot begin with \"$\": \"$ref\"");
+      error, BSON_ERROR_INVALID, BSON_VALIDATE_DOLLAR_KEYS, "Expected an $id element following $ref");
    bson_destroy (b);
 
    /* must not contain invalid key like "extra" */
@@ -1227,9 +1217,8 @@ test_bson_validate (void)
    BSON_ASSERT (bson_validate_with_error (b, BSON_VALIDATE_NONE, &error));
    BSON_ASSERT (!bson_validate_with_error (b, BSON_VALIDATE_DOLLAR_KEYS, &error));
    ASSERT_ERROR_CONTAINS (
-      error, BSON_ERROR_INVALID, BSON_VALIDATE_DOLLAR_KEYS, "invalid key within DBRef subdocument: \"extra\"");
+      error, BSON_ERROR_INVALID, BSON_VALIDATE_DOLLAR_KEYS, "Expected an $id element following $ref");
    bson_destroy (b);
-
 #undef VALIDATE_TEST
 }
 

--- a/src/libbson/tests/test-bson.c
+++ b/src/libbson/tests/test-bson.c
@@ -867,7 +867,7 @@ _make_deep_bson (bson_t *const dst, const size_t depth)
    uint8_t *out = buffer;
    mlib_foreach_urange (i, depth) {
       // Bytes we have already written:
-      const size_t begin_offset = out - buffer;
+      const size_t begin_offset = (size_t) (out - buffer);
       // The number of bytes for this inner doc:
       size_t inner_size = buffer_size;
       mlib_check (!mlib_sub (&inner_size, begin_offset));

--- a/src/libbson/tests/test-bson.c
+++ b/src/libbson/tests/test-bson.c
@@ -18,6 +18,7 @@
 #include <bson/bson.h>
 #include <bson/bcon.h>
 #include <bson/bson-private.h>
+#include <bson/validate-private.h>
 #include <fcntl.h>
 #include <time.h>
 

--- a/src/libbson/tests/test-validate.generated.c
+++ b/src/libbson/tests/test-validate.generated.c
@@ -1,0 +1,2350 @@
+// ! This code is GENERATED! Do not edit it directly!
+// clang-format off
+
+#include <bson/bson.h>
+
+#include <mlib/test.h>
+
+#include <TestSuite.h>
+
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: empty
+static inline void _test_case_empty(void) {
+  /**
+   * Test a simple empty document object.
+   */
+  const uint8_t bytes[] = {
+    5, 0, 0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: bad-element
+static inline void _test_case_bad_element(void) {
+  /**
+   * The element content is not valid
+   */
+  const uint8_t bytes[] = {
+    6, 0, 0, 0, 'f', 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 6);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: invalid-type
+static inline void _test_case_invalid_type(void) {
+  /**
+   * The type tag "0x0e" is not a valid type
+   */
+  const uint8_t bytes[] = {
+    0x0d, 0, 0, 0, 0x0e, 'f', 'o', 'o', 0, 'f', 'o', 'o', 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 9);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: key/invalid/accept
+static inline void _test_case_key_invalid_accept(void) {
+  /**
+   * The element key contains an invalid UTF-8 byte, but we accept it
+   * because we aren't doing UTF-8 validation.
+   */
+  const uint8_t bytes[] = {
+    0x28, 0, 0, 0, 2, 'a', 0, 2, 0, 0, 0, 'b', 0, 2, 'f', 'o', 'o', 0xff, 'b',
+    'a', 'r', 0, 4, 0, 0, 0, 'b', 'a', 'z', 0, 2, 'c', 0, 2, 0, 0, 0, 'd', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: key/invalid/reject
+static inline void _test_case_key_invalid_reject(void) {
+  /**
+   * The element key is not valid UTF-8 and we reject it when we do UTF-8
+   * validation.
+   */
+  const uint8_t bytes[] = {
+    0x28, 0, 0, 0, 2, 'a', 0, 2, 0, 0, 0, 'b', 0, 2, 'f', 'o', 'o', 0xff, 'b',
+    'a', 'r', 0, 4, 0, 0, 0, 'b', 'a', 'z', 0, 2, 'c', 0, 2, 0, 0, 0, 'd', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_UTF8, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_UTF8);
+  mlib_check(error.message, str_eq, "Text element is not valid UTF-8");
+  mlib_check(offset, eq, 13);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: key/empty/accept
+static inline void _test_case_key_empty_accept(void) {
+  /**
+   * The element has an empty string key, and we accept this.
+   */
+  const uint8_t bytes[] = {
+    0x12, 0, 0, 0, 2, 0, 7, 0, 0, 0, 's', 't', 'r', 'i', 'n', 'g', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: key/empty/reject
+static inline void _test_case_key_empty_reject(void) {
+  /**
+   * The element has an empty key, and we can reject it.
+   */
+  const uint8_t bytes[] = {
+    0x1b, 0, 0, 0, 2, 'a', 0, 2, 0, 0, 0, 'b', 0, 2, 0, 7, 0, 0, 0, 's', 't',
+    'r', 'i', 'n', 'g', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_EMPTY_KEYS, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_EMPTY_KEYS);
+  mlib_check(error.message, str_eq, "Element key cannot be an empty string");
+  mlib_check(offset, eq, 13);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: key/empty/accept-if-absent
+static inline void _test_case_key_empty_accept_if_absent(void) {
+  /**
+   * We are checking for empty keys, and accept if they are absent.
+   */
+  const uint8_t bytes[] = {
+    0x12, 0, 0, 0, 2, 'f', 'o', 'o', 0, 4, 0, 0, 0, 'b', 'a', 'r', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_EMPTY_KEYS, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: key/dot/accept
+static inline void _test_case_key_dot_accept(void) {
+  /**
+   * The element key has an ASCII dot, and we accept this since we don't
+   * ask to validate it.
+   */
+  const uint8_t bytes[] = {
+    0x16, 0, 0, 0, 2, 'f', 'o', 'o', '.', 'b', 'a', 'r', 0, 4, 0, 0, 0, 'b',
+    'a', 'z', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_EMPTY_KEYS, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: key/dot/reject
+static inline void _test_case_key_dot_reject(void) {
+  /**
+   * The element has an ASCII dot, and we reject it when we ask to validate
+   * it.
+   */
+  const uint8_t bytes[] = {
+    0x1f, 0, 0, 0, 2, 'a', 0, 2, 0, 0, 0, 'b', 0, 2, 'f', 'o', 'o', '.', 'b',
+    'a', 'r', 0, 4, 0, 0, 0, 'b', 'a', 'z', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOT_KEYS, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_DOT_KEYS);
+  mlib_check(error.message, str_eq, "Disallowed element key: \"foo.bar\"");
+  mlib_check(offset, eq, 13);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: key/dot/accept-if-absent
+static inline void _test_case_key_dot_accept_if_absent(void) {
+  /**
+   * We are checking for keys with dot '.', and accept if they are absent.
+   */
+  const uint8_t bytes[] = {
+    0x12, 0, 0, 0, 2, 'f', 'o', 'o', 0, 4, 0, 0, 0, 'b', 'a', 'r', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOT_KEYS, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: key/dollar/accept
+static inline void _test_case_key_dollar_accept(void) {
+  /**
+   * We can accept an element key that starts with a dollar '$' sign.
+   */
+  const uint8_t bytes[] = {
+    0x1c, 0, 0, 0, 2, 'a', 0, 2, 0, 0, 0, 'b', 0, 2, '$', 'f', 'o', 'o', 0, 4,
+    0, 0, 0, 'b', 'a', 'r', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: key/dollar/reject
+static inline void _test_case_key_dollar_reject(void) {
+  /**
+   * We can reject an element key that starts with a dollar '$' sign.
+   */
+  const uint8_t bytes[] = {
+    0x1c, 0, 0, 0, 2, 'a', 0, 2, 0, 0, 0, 'b', 0, 2, '$', 'f', 'o', 'o', 0, 4,
+    0, 0, 0, 'b', 'a', 'r', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_DOLLAR_KEYS);
+  mlib_check(error.message, str_eq, "Disallowed element key: \"$foo\"");
+  mlib_check(offset, eq, 13);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: key/dollar/accept-in-middle
+static inline void _test_case_key_dollar_accept_in_middle(void) {
+  /**
+   * This contains a element key "foo$bar", but we don't reject this, as we
+   * only care about keys that *start* with dollars.
+   */
+  const uint8_t bytes[] = {
+    0x16, 0, 0, 0, 2, 'f', 'o', 'o', '$', 'b', 'a', 'r', 0, 4, 0, 0, 0, 'b',
+    'a', 'z', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: key/dollar/accept-if-absent
+static inline void _test_case_key_dollar_accept_if_absent(void) {
+  /**
+   * We are validating for dollar-keys, and we accept because this document
+   * doesn't contain any such keys.
+   */
+  const uint8_t bytes[] = {
+    0x12, 0, 0, 0, 2, 'f', 'o', 'o', 0, 4, 0, 0, 0, 'b', 'a', 'r', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: utf8/simple
+static inline void _test_case_utf8_simple(void) {
+  /**
+   * Simple UTF-8 string element
+   */
+  const uint8_t bytes[] = {
+    0x1d, 0, 0, 0, 2, 's', 't', 'r', 'i', 'n', 'g', 0, 0x0c, 0, 0, 0, 's', 'o',
+    'm', 'e', 0x20, 's', 't', 'r', 'i', 'n', 'g', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: utf8/missing-null
+static inline void _test_case_utf8_missing_null(void) {
+  /**
+   * The UTF-8 element "a" contains 4 characters and declares its length of 4,
+   * but the fourth character is supposed to be a null terminator. In this case,
+   * it is the letter 'd'.
+   */
+  const uint8_t bytes[] = {
+    0x10, 0, 0, 0, 2, 'a', 0, 4, 0, 0, 0, 'a', 'b', 'c', 'd', 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 14);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: utf8/length-zero
+static inline void _test_case_utf8_length_zero(void) {
+  /**
+   * UTF-8 string length must always be at least 1 for the null terminator
+   */
+  const uint8_t bytes[] = {
+    0x0c, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 6);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: utf8/length-too-short
+static inline void _test_case_utf8_length_too_short(void) {
+  /**
+   * UTF-8 string is three chars and a null terminator, but the declared length is 3 (should be 4)
+   */
+  const uint8_t bytes[] = {
+    0x0f, 0, 0, 0, 2, 0, 3, 0, 0, 0, 'b', 'a', 'r', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 12);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: utf8/header-too-large
+static inline void _test_case_utf8_header_too_large(void) {
+  /**
+   * Data { "foo": "bar" } but the declared length of "bar" is way too large.
+   */
+  const uint8_t bytes[] = {
+    0x12, 0, 0, 0, 2, 'f', 'o', 'o', 0, 0xff, 0xff, 0xff, 0xff, 'b', 'a', 'r',
+    0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 9);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: utf8/valid
+static inline void _test_case_utf8_valid(void) {
+  /**
+   * Validate a valid UTF-8 string with UTF-8 validation enabled.
+   */
+  const uint8_t bytes[] = {
+    0x13, 0, 0, 0, 2, 'f', 'o', 'o', 0, 5, 0, 0, 0, 'a', 'b', 'c', 'd', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_UTF8, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: utf8/invalid/accept
+static inline void _test_case_utf8_invalid_accept(void) {
+  /**
+   * Validate an invalid UTF-8 string, but accept invalid UTF-8.
+   */
+  const uint8_t bytes[] = {
+    0x14, 0, 0, 0, 2, 'f', 'o', 'o', 0, 6, 0, 0, 0, 'a', 'b', 'c', 0xff, 'd', 0,
+    0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: utf8/invalid/reject
+static inline void _test_case_utf8_invalid_reject(void) {
+  /**
+   * Validate an invalid UTF-8 string, and expect rejection.
+   */
+  const uint8_t bytes[] = {
+    0x14, 0, 0, 0, 2, 'f', 'o', 'o', 0, 6, 0, 0, 0, 'a', 'b', 'c', 0xff, 'd', 0,
+    0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_UTF8, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_UTF8);
+  mlib_check(error.message, str_eq, "Text element is not valid UTF-8");
+  mlib_check(offset, eq, 4);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: utf8/valid-with-null/accept-1
+static inline void _test_case_utf8_valid_with_null_accept_1(void) {
+  /**
+   * This is a valid UTF-8 string that contains a null character. We accept
+   * it because we don't do UTF-8 validation.
+   */
+  const uint8_t bytes[] = {
+    0x16, 0, 0, 0, 2, 'f', 'o', 'o', 0, 8, 0, 0, 0, 'a', 'b', 'c', 0, '1', '2',
+    '3', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: utf8/valid-with-null/accept-2
+static inline void _test_case_utf8_valid_with_null_accept_2(void) {
+  /**
+   * This is a valid UTF-8 string that contains a null character. We allow
+   * it explicitly when we request UTF-8 validation.
+   */
+  const uint8_t bytes[] = {
+    0x16, 0, 0, 0, 2, 'f', 'o', 'o', 0, 8, 0, 0, 0, 'a', 'b', 'c', 0, '1', '2',
+    '3', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_UTF8 | BSON_VALIDATE_UTF8_ALLOW_NULL, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: utf8/valid-with-null/reject
+static inline void _test_case_utf8_valid_with_null_reject(void) {
+  /**
+   * This is a valid UTF-8 string that contains a null character. We reject
+   * this because we don't pass BSON_VALIDATE_UTF8_ALLOW_NULL.
+   */
+  const uint8_t bytes[] = {
+    0x16, 0, 0, 0, 2, 'f', 'o', 'o', 0, 8, 0, 0, 0, 'a', 'b', 'c', 0, '1', '2',
+    '3', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_UTF8, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_UTF8_ALLOW_NULL);
+  mlib_check(error.message, str_eq, "UTF-8 string contains a U+0000 (null) character");
+  mlib_check(offset, eq, 4);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: utf8-key/invalid/accept
+static inline void _test_case_utf8_key_invalid_accept(void) {
+  /**
+   * The element key is not valid UTf-8, but we acecpt it if we don't do
+   * UTF-8 validation.
+   */
+  const uint8_t bytes[] = {
+    0x16, 0, 0, 0, 2, 'a', 'b', 'c', 0xff, 'd', 'e', 'f', 0, 4, 0, 0, 0, 'b',
+    'a', 'r', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: utf8-key/invalid/reject
+static inline void _test_case_utf8_key_invalid_reject(void) {
+  /**
+   * The element key is not valid UTF-8, and we reject it when we requested
+   * UTF-8 validation.
+   */
+  const uint8_t bytes[] = {
+    0x16, 0, 0, 0, 2, 'a', 'b', 'c', 0xff, 'd', 'e', 'f', 0, 4, 0, 0, 0, 'b',
+    'a', 'r', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_UTF8, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_UTF8);
+  mlib_check(error.message, str_eq, "Text element is not valid UTF-8");
+  mlib_check(offset, eq, 4);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: array/empty
+static inline void _test_case_array_empty(void) {
+  /**
+   * Simple empty array element
+   */
+  const uint8_t bytes[] = {
+    0x11, 0, 0, 0, 4, 'a', 'r', 'r', 'a', 'y', 0, 5, 0, 0, 0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: array/simple
+static inline void _test_case_array_simple(void) {
+  /**
+   * Simple array element of integers
+   */
+  const uint8_t bytes[] = {
+    0x26, 0, 0, 0, 4, 'a', 'r', 'r', 'a', 'y', 0, 0x1a, 0, 0, 0, 0x10, '0', 0,
+    0x2a, 0, 0, 0, 0x10, '1', 0, 0xc1, 6, 0, 0, 0x10, '2', 0, 0xf8, 0xff, 0xff,
+    0xff, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: array/invalid-element
+static inline void _test_case_array_invalid_element(void) {
+  /**
+   * Simple array element of integers, but one element is truncated
+   */
+  const uint8_t bytes[] = {
+    0x23, 0, 0, 0, 4, 'a', 'r', 'r', 'a', 'y', 0, 0x17, 0, 0, 0, 0x10, '0', 0,
+    0x2a, 0, 0, 0, 0x10, '1', 0, 0, 0x10, '2', 0, 0xf8, 0xff, 0xff, 0xff, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 34);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: array/invalid-element-check-offset
+static inline void _test_case_array_invalid_element_check_offset(void) {
+  /**
+   * This is the same as the array/invalid-element test, but with a longer
+   * key string on the parent array. This is to check that the error offset
+   * is properly adjusted for the additional characters.
+   */
+  const uint8_t bytes[] = {
+    0x2b, 0, 0, 0, 4, 'a', 'r', 'r', 'a', 'y', '-', 's', 'h', 'i', 'f', 't',
+    'e', 'd', 0, 0x17, 0, 0, 0, 0x10, '0', 0, 0x2a, 0, 0, 0, 0x10, '1', 0, 0,
+    0x10, '2', 0, 0xf8, 0xff, 0xff, 0xff, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 42);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: symbol/simple
+static inline void _test_case_symbol_simple(void) {
+  /**
+   * A simple document: { symbol: Symbol("void 0;") }
+   */
+  const uint8_t bytes[] = {
+    0x19, 0, 0, 0, 0x0e, 's', 'y', 'm', 'b', 'o', 'l', 0, 8, 0, 0, 0, 'v', 'o',
+    'i', 'd', 0x20, '0', 0x3b, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: symbol/invalid-utf8/accept
+static inline void _test_case_symbol_invalid_utf8_accept(void) {
+  /**
+   * A simple symbol document, but the string contains invalid UTF-8
+   */
+  const uint8_t bytes[] = {
+    0x1a, 0, 0, 0, 0x0e, 's', 'y', 'm', 'b', 'o', 'l', 0, 9, 0, 0, 0, 'v', 'o',
+    'i', 'd', 0xff, 0x20, '0', 0x3b, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: symbol/invalid-utf8/reject
+static inline void _test_case_symbol_invalid_utf8_reject(void) {
+  /**
+   * A simple symbol document, but the string contains invalid UTF-8
+   */
+  const uint8_t bytes[] = {
+    0x1a, 0, 0, 0, 0x0e, 's', 'y', 'm', 'b', 'o', 'l', 0, 9, 0, 0, 0, 'v', 'o',
+    'i', 'd', 0xff, 0x20, '0', 0x3b, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_UTF8, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_UTF8);
+  mlib_check(error.message, str_eq, "Text element is not valid UTF-8");
+  mlib_check(offset, eq, 4);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: symbol/length-zero
+static inline void _test_case_symbol_length_zero(void) {
+  /**
+   * Symbol string length must always be at least 1 for the null terminator
+   */
+  const uint8_t bytes[] = {
+    0x0c, 0, 0, 0, 0x0e, 0, 0, 0, 0, 0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 6);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: symbol/length-too-short
+static inline void _test_case_symbol_length_too_short(void) {
+  /**
+   * Symbol string is three chars and a null terminator, but the declared
+   * length is 3 (should be 4)
+   */
+  const uint8_t bytes[] = {
+    0x0f, 0, 0, 0, 0x0e, 0, 3, 0, 0, 0, 'b', 'a', 'r', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 12);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: code/simple
+static inline void _test_case_code_simple(void) {
+  /**
+   * A simple document: { code: Code("void 0;") }
+   */
+  const uint8_t bytes[] = {
+    0x17, 0, 0, 0, 0x0d, 'c', 'o', 'd', 'e', 0, 8, 0, 0, 0, 'v', 'o', 'i', 'd',
+    0x20, '0', 0x3b, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: code/invalid-utf8/accept
+static inline void _test_case_code_invalid_utf8_accept(void) {
+  /**
+   * A simple code document, but the string contains invalid UTF-8
+   */
+  const uint8_t bytes[] = {
+    0x18, 0, 0, 0, 0x0d, 'c', 'o', 'd', 'e', 0, 9, 0, 0, 0, 'v', 'o', 'i', 'd',
+    0xff, 0x20, '0', 0x3b, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: code/invalid-utf8/reject
+static inline void _test_case_code_invalid_utf8_reject(void) {
+  /**
+   * A simple code document, but the string contains invalid UTF-8
+   */
+  const uint8_t bytes[] = {
+    0x18, 0, 0, 0, 0x0d, 'c', 'o', 'd', 'e', 0, 9, 0, 0, 0, 'v', 'o', 'i', 'd',
+    0xff, 0x20, '0', 0x3b, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_UTF8, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_UTF8);
+  mlib_check(error.message, str_eq, "Text element is not valid UTF-8");
+  mlib_check(offset, eq, 4);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: code/length-zero
+static inline void _test_case_code_length_zero(void) {
+  /**
+   * Code string length must always be at least 1 for the null terminator
+   */
+  const uint8_t bytes[] = {
+    0x10, 0, 0, 0, 0x0d, 'c', 'o', 'd', 'e', 0, 0, 0, 0, 0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 10);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: code/length-too-short
+static inline void _test_case_code_length_too_short(void) {
+  /**
+   * Code string is three chars and a null terminator, but the declared length is 3 (should be 4)
+   */
+  const uint8_t bytes[] = {
+    0x13, 0, 0, 0, 0x0d, 'c', 'o', 'd', 'e', 0, 3, 0, 0, 0, 'b', 'a', 'r', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 16);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: code-with-scope/simple
+static inline void _test_case_code_with_scope_simple(void) {
+  /**
+   * A simple valid code-with-scope element
+   */
+  const uint8_t bytes[] = {
+    0x1f, 0, 0, 0, 0x0f, 'f', 'o', 'o', 0, 0x15, 0, 0, 0, 8, 0, 0, 0, 'v', 'o',
+    'i', 'd', 0x20, '0', 0x3b, 0, 5, 0, 0, 0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: code-with-scope/invalid-code-length-zero
+static inline void _test_case_code_with_scope_invalid_code_length_zero(void) {
+  /**
+   * Data { "": CodeWithScope("", {}) }, but the code string length is zero, when
+   * it must be at least 1
+   */
+  const uint8_t bytes[] = {
+    0x15, 0, 0, 0, 0x0f, 0, 0x0a, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 6);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: code-with-scope/invalid-code-length-too-large
+static inline void _test_case_code_with_scope_invalid_code_length_too_large(void) {
+  /**
+   * Data { "": CodeWithScope("", {}) }, but the code string length is way too large
+   */
+  const uint8_t bytes[] = {
+    0x15, 0, 0, 0, 0x0f, 0, 0x0a, 0, 0, 0, 0xff, 0xff, 0xff, 0xff, 0, 5, 0, 0,
+    0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 6);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: code-with-scope/invalid-scope
+static inline void _test_case_code_with_scope_invalid_scope(void) {
+  /**
+   * A code-with-scope element, but the scope document is corrupted
+   */
+  const uint8_t bytes[] = {
+    0x1e, 0, 0, 0, 0x0f, 'f', 'o', 'o', 0, 0x14, 0, 0, 0, 8, 0, 0, 0, 'v', 'o',
+    'i', 'd', 0x20, '0', 0x3b, 0, 5, 0, 0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 13);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: code-with-scope/invalid-scope-key
+static inline void _test_case_code_with_scope_invalid_scope_key(void) {
+  /**
+   * A code-with-scope element, but the socpe contains an empty element key
+   */
+  const uint8_t bytes[] = {
+    '2', 0, 0, 0, 0x0f, 'c', 'o', 'd', 'e', 0, 0x27, 0, 0, 0, 8, 0, 0, 0, 'v',
+    'o', 'i', 'd', 0x20, '0', 0x3b, 0, 0x17, 0, 0, 0, 2, 0, 0x0c, 0, 0, 0, 's',
+    'o', 'm', 'e', 0x20, 's', 't', 'r', 'i', 'n', 'g', 0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_EMPTY_KEYS);
+  mlib_check(error.message, str_eq, "Error in scope document for element \"code\": Element key cannot be an empty string");
+  mlib_check(offset, eq, 8);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: code-with-scope/corrupt-scope
+static inline void _test_case_code_with_scope_corrupt_scope(void) {
+  /**
+   * A code-with-scope element, but the scope contains corruption
+   */
+  const uint8_t bytes[] = {
+    0x2a, 0, 0, 0, 0x0f, 'c', 'o', 'd', 'e', 0, 0x1f, 0, 0, 0, 8, 0, 0, 0, 'v',
+    'o', 'i', 'd', 0x20, '0', 0x3b, 0, 0x0f, 0, 0, 0, 2, 'f', 'o', 'o', 0, 0, 0,
+    0, 0, 0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "Error in scope document for element \"code\": corrupt BSON");
+  mlib_check(offset, eq, 13);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: code-with-scope/corrupt-scope-2
+static inline void _test_case_code_with_scope_corrupt_scope_2(void) {
+  /**
+   * A code-with-scope element, but the scope contains corruption
+   */
+  const uint8_t bytes[] = {
+    0x2a, 0, 0, 0, 0x0f, 'c', 'o', 'd', 'e', 0, 0x1f, 0, 0, 0, 8, 0, 0, 0, 'v',
+    'o', 'i', 'd', 0x20, '0', 0x3b, 0, 0x0f, 0, 0, 0, 2, 'f', 'o', 'o', 0, 0xff,
+    0xff, 0xff, 0xff, 0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "Error in scope document for element \"code\": corrupt BSON");
+  mlib_check(offset, eq, 13);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: regex/simple
+static inline void _test_case_regex_simple(void) {
+  /**
+   * Simple document: { regex: Regex("1234", "gi") }
+   */
+  const uint8_t bytes[] = {
+    0x14, 0, 0, 0, 0x0b, 'r', 'e', 'g', 'e', 'x', 0, '1', '2', '3', '4', 0, 'g',
+    'i', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: regex/invalid-opts
+static inline void _test_case_regex_invalid_opts(void) {
+  /**
+   * A regular expression element with missing null terminator. The main
+   * option string "foo" has a null terminator, but the option component "bar"
+   * does not have a null terminator. A naive parse will see the doc's null
+   * terminator as the null terminator for the options string, but that's
+   * invalid!
+   */
+  const uint8_t bytes[] = {
+    0x13, 0, 0, 0, 0x0b, 'r', 'e', 'g', 'e', 'x', 0, 'f', 'o', 'o', 0, 'b', 'a',
+    'r', 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 18);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: regex/double-null
+static inline void _test_case_regex_double_null(void) {
+  /**
+   * A regular expression element with an extra null terminator. Since regex
+   * is delimited by its null terminator, the iterator will stop early before
+   * the actual EOD.
+   */
+  const uint8_t bytes[] = {
+    0x15, 0, 0, 0, 0x0b, 'r', 'e', 'g', 'e', 'x', 0, 'f', 'o', 'o', 0, 'b', 'a',
+    'r', 0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 21);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: regex/invalid-utf8/accept
+static inline void _test_case_regex_invalid_utf8_accept(void) {
+  /**
+   * A regular expression that contains invalid UTf-8.
+   */
+  const uint8_t bytes[] = {
+    0x17, 0, 0, 0, 0x0b, 'r', 'e', 'g', 'e', 'x', 0, 'f', 'o', 'o', 0xff, 'b',
+    'a', 'r', 0, 'g', 'i', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: regex/invalid-utf8/reject
+static inline void _test_case_regex_invalid_utf8_reject(void) {
+  /**
+   * A regular expression that contains invalid UTf-8.
+   */
+  const uint8_t bytes[] = {
+    0x17, 0, 0, 0, 0x0b, 'r', 'e', 'g', 'e', 'x', 0, 'f', 'o', 'o', 0xff, 'b',
+    'a', 'r', 0, 'g', 'i', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_UTF8, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_UTF8);
+  mlib_check(error.message, str_eq, "Text element is not valid UTF-8");
+  mlib_check(offset, eq, 4);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: regex/invalid-utf8/accept-if-absent
+static inline void _test_case_regex_invalid_utf8_accept_if_absent(void) {
+  /**
+   * A regular valid UTf-8 regex. We check for invalid UTf-8, and accept becaues
+   * the regex is fine.
+   */
+  const uint8_t bytes[] = {
+    0x13, 0, 0, 0, 0x0b, 'r', 'e', 'g', 'e', 'x', 0, 'f', 'o', 'o', 0, 'g', 'i',
+    0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_UTF8, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: dbpointer/string-length-zero
+static inline void _test_case_dbpointer_string_length_zero(void) {
+  /**
+   * Document { "foo": DBPointer("", <oid>) }, but the length header on the inner
+   * string is zero, when it must be at least 1.
+   */
+  const uint8_t bytes[] = {
+    0x1b, 0, 0, 0, 0x0c, 'f', 'o', 'o', 0, 0, 0, 0, 0, 0, 'R', 'Y', 0xb5, 'j',
+    0xfa, 0x5b, 0xd8, 'A', 0xd6, 'X', 0x5d, 0x99, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 9);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: dbpointer/string-length-too-big
+static inline void _test_case_dbpointer_string_length_too_big(void) {
+  /**
+   * Document { "foo": DBPointer("foobar", <oid>) }, but the length header on the inner
+   * string is far too large
+   */
+  const uint8_t bytes[] = {
+    0x21, 0, 0, 0, 0x0c, 'f', 'o', 'o', 0, 0xff, 0xff, 0xff, 0xff, 'f', 'o',
+    'o', 'b', 'a', 'r', 0, 'R', 'Y', 0xb5, 'j', 0xfa, 0x5b, 0xd8, 'A', 0xd6,
+    'X', 0x5d, 0x99, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 9);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: dbpointer/truncated
+static inline void _test_case_dbpointer_truncated(void) {
+  /**
+   * Document { "foo": DBPointer("foobar", <oid>) }, but the length header on
+   * the string is one byte too large, causing it to use the first byte of the
+   * OID as the null terminator. This should fail when iterating.
+   */
+  const uint8_t bytes[] = {
+    '2', 0, 0, 0, 2, 'a', 0, 2, 0, 0, 0, 'b', 0, 0x0c, 'f', 'o', 'o', 0, 7, 0,
+    0, 0, 'f', 'o', 'o', 'b', 'a', 'r', 0, 'Y', 0xb5, 'j', 0xfa, 0x5b, 0xd8,
+    'A', 0xd6, 'X', 0x5d, 0x99, 2, 'a', 0, 2, 0, 0, 0, 'b', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 43);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: dbpointer/missing-null
+static inline void _test_case_dbpointer_missing_null(void) {
+  /**
+   * Document { "foo": DBPointer("abcd", <oid>) }, the length header on
+   * the string is 4, but the fourth byte is not a null terminator.
+   */
+  const uint8_t bytes[] = {
+    0x1e, 0, 0, 0, 0x0c, 'f', 'o', 'o', 0, 4, 0, 0, 0, 'a', 'b', 'c', 'd', 'R',
+    'Y', 0xb5, 'j', 0xfa, 0x5b, 0xd8, 'A', 0xd6, 'X', 0x5d, 0x99, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 16);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: dbpointer/invalid-utf8/accept
+static inline void _test_case_dbpointer_invalid_utf8_accept(void) {
+  /**
+   * DBPointer document, but the collection string contains invalid UTF-8
+   */
+  const uint8_t bytes[] = {
+    0x22, 0, 0, 0, 0x0c, 'f', 'o', 'o', 0, 8, 0, 0, 0, 'a', 'b', 'c', 0xff, 'd',
+    'e', 'f', 0, 'R', 'Y', 0xb5, 'j', 0xfa, 0x5b, 0xd8, 'A', 0xd6, 'X', 0x5d,
+    0x99, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: dbpointer/invalid-utf8/reject
+static inline void _test_case_dbpointer_invalid_utf8_reject(void) {
+  /**
+   * DBPointer document, but the collection string contains invalid UTF-8
+   */
+  const uint8_t bytes[] = {
+    0x22, 0, 0, 0, 0x0c, 'f', 'o', 'o', 0, 8, 0, 0, 0, 'a', 'b', 'c', 0xff, 'd',
+    'e', 'f', 0, 'R', 'Y', 0xb5, 'j', 0xfa, 0x5b, 0xd8, 'A', 0xd6, 'X', 0x5d,
+    0x99, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_UTF8, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_UTF8);
+  mlib_check(error.message, str_eq, "Text element is not valid UTF-8");
+  mlib_check(offset, eq, 4);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: dbpointer/invalid-utf8/accept-if-absent
+static inline void _test_case_dbpointer_invalid_utf8_accept_if_absent(void) {
+  /**
+   * DBPointer document, and we validate UTF-8. Accepts because there is no
+   * invalid UTF-8 here.
+   */
+  const uint8_t bytes[] = {
+    0x21, 0, 0, 0, 0x0c, 'f', 'o', 'o', 0, 7, 0, 0, 0, 'a', 'b', 'c', 'd', 'e',
+    'f', 0, 'R', 'Y', 0xb5, 'j', 0xfa, 0x5b, 0xd8, 'A', 0xd6, 'X', 0x5d, 0x99, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_UTF8, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: subdoc/simple
+static inline void _test_case_subdoc_simple(void) {
+  /**
+   * A simple document: { doc: { foo: "bar" } }
+   */
+  const uint8_t bytes[] = {
+    0x1c, 0, 0, 0, 3, 'd', 'o', 'c', 0, 0x12, 0, 0, 0, 2, 'f', 'o', 'o', 0, 4,
+    0, 0, 0, 'b', 'a', 'r', 0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: subdoc/invalid-shared-null
+static inline void _test_case_subdoc_invalid_shared_null(void) {
+  /**
+   * A truncated subdocument element, with its null terminator accidentally
+   * overlapping the parent document's null.
+   */
+  const uint8_t bytes[] = {
+    0x0e, 0, 0, 0, 3, 'd', 'o', 'c', 0, 5, 0, 0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 9);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: subdoc/overlapping-utf8-null
+static inline void _test_case_subdoc_overlapping_utf8_null(void) {
+  /**
+   * Encodes the document:
+   * 
+   *     { "foo": { "bar": "baz" } }
+   * 
+   * but the foo.bar UTF-8 string is truncated improperly and reuses the null
+   * terminator for "foo"
+   */
+  const uint8_t bytes[] = {
+    0x1c, 0, 0, 0, 3, 'd', 'o', 'c', 0, 0x12, 0, 0, 0, 2, 'b', 'a', 'r', 0, 5,
+    0, 0, 0, 'b', 'a', 'z', 0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 18);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: subdoc/invalid-element
+static inline void _test_case_subdoc_invalid_element(void) {
+  /**
+   * A subdocument that contains an invalid element
+   */
+  const uint8_t bytes[] = {
+    0x18, 0, 0, 0, 3, 'd', 'o', 'c', 0, 0x0e, 0, 0, 0, 1, 'd', 'b', 'l', 0, 'a',
+    'b', 'c', 'd', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 18);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: subdoc/header-too-large
+static inline void _test_case_subdoc_header_too_large(void) {
+  /**
+   * Data {"foo": {}}, but the subdoc header is too large.
+   */
+  const uint8_t bytes[] = {
+    0x0f, 0, 0, 0, 3, 'f', 'o', 'o', 0, 0xf7, 0xff, 0xff, 0xff, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 9);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: subdoc/header-too-small
+static inline void _test_case_subdoc_header_too_small(void) {
+  /**
+   * Nested document with a header value of 4, which is always too small.
+   */
+  const uint8_t bytes[] = {
+    0x0f, 0, 0, 0, 3, 't', 'e', 's', 't', 0, 4, 0, 0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 4);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: subdoc/impossible-size
+static inline void _test_case_subdoc_impossible_size(void) {
+  /**
+   * Data {"foo": {}}, but the subdoc header is UINT32_MAX/INT32_MIN, which
+   * becomes is an invalid document header.
+   */
+  const uint8_t bytes[] = {
+    0x0f, 0, 0, 0, 3, 'f', 'o', 'o', 0, 0xff, 0xff, 0xff, 0xff, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 9);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: null/simple
+static inline void _test_case_null_simple(void) {
+  /**
+   * A simple document: { "null": null }
+   */
+  const uint8_t bytes[] = {
+    0x0b, 0, 0, 0, 0x0a, 'n', 'u', 'l', 'l', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: undefined/simple
+static inline void _test_case_undefined_simple(void) {
+  /**
+   * A simple document: { "undefined": undefined }
+   */
+  const uint8_t bytes[] = {
+    0x10, 0, 0, 0, 6, 'u', 'n', 'd', 'e', 'f', 'i', 'n', 'e', 'd', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: binary/simple
+static inline void _test_case_binary_simple(void) {
+  /**
+   * Simple binary data { "binary": Binary(0x80, b'12345') }
+   */
+  const uint8_t bytes[] = {
+    0x17, 0, 0, 0, 5, 'b', 'i', 'n', 'a', 'r', 'y', 0, 5, 0, 0, 0, 0x80, '1',
+    '2', '3', '4', '5', 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: binary/bad-length-zero-subtype-2
+static inline void _test_case_binary_bad_length_zero_subtype_2(void) {
+  /**
+   * Binary data that has an invalid length header. It is subtype 2,
+   * which means it contains an additional length header.
+   */
+  const uint8_t bytes[] = {
+    0x1a, 0, 0, 0, 5, 'b', 'i', 'n', 'a', 'r', 'y', 0, 0, 0, 0, 0, 2, 4, 0, 0,
+    0, '1', '2', '3', '4', 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 12);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: binary/bad-length-too-small
+static inline void _test_case_binary_bad_length_too_small(void) {
+  /**
+   * Data { "binary": Binary(0x80, b'1234') }, but the length header on
+   * the Binary object is too small.
+   * 
+   * This won't cause the binary to decode wrong, but it will cause the iterator
+   * to jump into the middle of the binary data which will not decode as a
+   * proper BSON element.
+   */
+  const uint8_t bytes[] = {
+    0x16, 0, 0, 0, 5, 'b', 'i', 'n', 'a', 'r', 'y', 0, 2, 0, 0, 0, 0x80, '1',
+    '2', '3', '4', 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 22);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: binary/bad-length-too-big
+static inline void _test_case_binary_bad_length_too_big(void) {
+  /**
+   * Data { "binary": Binary(0x80, b'1234') }, but the length header on
+   * the Binary object is too large.
+   */
+  const uint8_t bytes[] = {
+    0x16, 0, 0, 0, 5, 'b', 'i', 'n', 'a', 'r', 'y', 0, 0xf3, 0xff, 0xff, 0xff,
+    0x80, '1', '2', '3', '4', 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 12);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: binary/old-invalid/1
+static inline void _test_case_binary_old_invalid_1(void) {
+  /**
+   * This is an old-style binary type 0x2. It has an inner length header of 5,
+   * but it should be 4.
+   */
+  const uint8_t bytes[] = {
+    0x1a, 0, 0, 0, 5, 'b', 'i', 'n', 'a', 'r', 'y', 0, 8, 0, 0, 0, 2, 5, 0, 0,
+    0, 'a', 'b', 'c', 'd', 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 17);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: binary/old-invalid/2
+static inline void _test_case_binary_old_invalid_2(void) {
+  /**
+   * This is an old-style binary type 0x2. The data segment is too small to
+   * be valid.
+   */
+  const uint8_t bytes[] = {
+    0x12, 0, 0, 0, 5, 'b', 'i', 'n', 0, 3, 0, 0, 0, 2, 'a', 'b', 'c', 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 9);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: minkey/simple
+static inline void _test_case_minkey_simple(void) {
+  /**
+   * A simple document with a MinKey element
+   */
+  const uint8_t bytes[] = {
+    0x0a, 0, 0, 0, 0xff, 'm', 'i', 'n', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: maxkey/simple
+static inline void _test_case_maxkey_simple(void) {
+  /**
+   * A simple document with a MaxKey element
+   */
+  const uint8_t bytes[] = {
+    0x0a, 0, 0, 0, 0x7f, 'm', 'a', 'x', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: int32/simple
+static inline void _test_case_int32_simple(void) {
+  /**
+   * A simple document with a valid single int32 element
+   */
+  const uint8_t bytes[] = {
+    0x10, 0, 0, 0, 0x10, 'i', 'n', 't', '3', '2', 0, 0x2a, 0, 0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: int32/truncated
+static inline void _test_case_int32_truncated(void) {
+  /**
+   * Truncated 32-bit integer
+   */
+  const uint8_t bytes[] = {
+    0x19, 0, 0, 0, 0x10, 'i', 'n', 't', '3', '2', '-', 't', 'r', 'u', 'n', 'c',
+    'a', 't', 'e', 'd', 0, 0x2a, 0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 21);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: timestamp/simple
+static inline void _test_case_timestamp_simple(void) {
+  /**
+   * A simple timestamp element
+   */
+  const uint8_t bytes[] = {
+    0x18, 0, 0, 0, 0x11, 't', 'i', 'm', 'e', 's', 't', 'a', 'm', 'p', 0, 0xc1,
+    6, 0, 0, 0, 0, 0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: timestamp/truncated
+static inline void _test_case_timestamp_truncated(void) {
+  /**
+   * A truncated timestamp element
+   */
+  const uint8_t bytes[] = {
+    0x17, 0, 0, 0, 0x11, 't', 'i', 'm', 'e', 's', 't', 'a', 'm', 'p', 0, 0xc1,
+    6, 0, 0, 0, 0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 15);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: int64/simple
+static inline void _test_case_int64_simple(void) {
+  /**
+   * A simple document with a valid single int64 element
+   */
+  const uint8_t bytes[] = {
+    0x14, 0, 0, 0, 0x12, 'i', 'n', 't', '6', '4', 0, 0xc1, 6, 0, 0, 0, 0, 0, 0,
+    0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: int64/truncated
+static inline void _test_case_int64_truncated(void) {
+  /**
+   * Truncated 64-bit integer
+   */
+  const uint8_t bytes[] = {
+    0x1d, 0, 0, 0, 0x12, 'i', 'n', 't', '6', '4', '-', 't', 'r', 'u', 'n', 'c',
+    'a', 't', 'e', 'd', 0, 0xc1, 6, 0, 0, 0, 0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 21);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: double/simple
+static inline void _test_case_double_simple(void) {
+  /**
+   * Simple float64 element
+   */
+  const uint8_t bytes[] = {
+    0x15, 0, 0, 0, 1, 'd', 'o', 'u', 'b', 'l', 'e', 0, 0x1f, 0x85, 0xeb, 'Q',
+    0xb8, 0x1e, 9, 0x40, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: double/truncated
+static inline void _test_case_double_truncated(void) {
+  /**
+   * Truncated 64-bit float
+   */
+  const uint8_t bytes[] = {
+    0x1e, 0, 0, 0, 1, 'd', 'o', 'u', 'b', 'l', 'e', '-', 't', 'r', 'u', 'n',
+    'c', 'a', 't', 'e', 'd', 0, 0x0a, 0xd7, 0xa3, 'p', 0x3d, 0x0a, 9, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 22);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: boolean/simple-false
+static inline void _test_case_boolean_simple_false(void) {
+  /**
+   * A simple boolean 'false'
+   */
+  const uint8_t bytes[] = {
+    0x0c, 0, 0, 0, 8, 'b', 'o', 'o', 'l', 0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: boolean/simple-true
+static inline void _test_case_boolean_simple_true(void) {
+  /**
+   * A simple boolean 'true'
+   */
+  const uint8_t bytes[] = {
+    0x0c, 0, 0, 0, 8, 'b', 'o', 'o', 'l', 0, 1, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: boolean/invalid
+static inline void _test_case_boolean_invalid(void) {
+  /**
+   * In invalid boolean octet. Must be '0' or '1', but is 0xc3.
+   */
+  const uint8_t bytes[] = {
+    0x0c, 0, 0, 0, 8, 'b', 'o', 'o', 'l', 0, 0xc3, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 10);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: datetime/simple
+static inline void _test_case_datetime_simple(void) {
+  /**
+   * Simple datetime element
+   */
+  const uint8_t bytes[] = {
+    0x12, 0, 0, 0, 9, 'u', 't', 'c', 0, 0x0b, 0x98, 0x8c, 0x2b, '3', 1, 0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: datetime/truncated
+static inline void _test_case_datetime_truncated(void) {
+  /**
+   * Truncated datetime element
+   */
+  const uint8_t bytes[] = {
+    0x11, 0, 0, 0, 9, 'u', 't', 'c', 0, 0x0b, 0x98, 0x8c, 0x2b, '3', 1, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 9);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: dbref/missing-id
+static inline void _test_case_dbref_missing_id(void) {
+  /**
+   * This dbref document is missing an $id element
+   */
+  const uint8_t bytes[] = {
+    0x13, 0, 0, 0, 2, '$', 'r', 'e', 'f', 0, 4, 0, 0, 0, 'f', 'o', 'o', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_DOLLAR_KEYS);
+  mlib_check(error.message, str_eq, "Expected an $id element following $ref");
+  mlib_check(offset, eq, 18);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: dbref/non-id
+static inline void _test_case_dbref_non_id(void) {
+  /**
+   * The 'bar' element should be an '$id' element.
+   */
+  const uint8_t bytes[] = {
+    0x20, 0, 0, 0, 2, '$', 'r', 'e', 'f', 0, 4, 0, 0, 0, 'f', 'o', 'o', 0, 2,
+    'b', 'a', 'r', 0, 4, 0, 0, 0, 'b', 'a', 'z', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_DOLLAR_KEYS);
+  mlib_check(error.message, str_eq, "Expected an $id element following $ref");
+  mlib_check(offset, eq, 18);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: dbref/not-first-elements
+static inline void _test_case_dbref_not_first_elements(void) {
+  /**
+   * This would be a valid DBRef, but the "$ref" key must come first.
+   */
+  const uint8_t bytes[] = {
+    0x29, 0, 0, 0, 2, 'f', 'o', 'o', 0, 4, 0, 0, 0, 'b', 'a', 'r', 0, 2, '$',
+    'r', 'e', 'f', 0, 2, 0, 0, 0, 'a', 0, 2, '$', 'i', 'd', 0, 2, 0, 0, 0, 'b',
+    0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_DOLLAR_KEYS);
+  mlib_check(error.message, str_eq, "Disallowed element key: \"$ref\"");
+  mlib_check(offset, eq, 17);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: dbref/ref-without-id-with-db
+static inline void _test_case_dbref_ref_without_id_with_db(void) {
+  /**
+   * There should be an $id element, but we skip straight to $db
+   */
+  const uint8_t bytes[] = {
+    0x20, 0, 0, 0, 2, '$', 'r', 'e', 'f', 0, 4, 0, 0, 0, 'f', 'o', 'o', 0, 2,
+    '$', 'd', 'b', 0, 4, 0, 0, 0, 'b', 'a', 'r', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_DOLLAR_KEYS);
+  mlib_check(error.message, str_eq, "Expected an $id element following $ref");
+  mlib_check(offset, eq, 18);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: dbref/non-string-ref
+static inline void _test_case_dbref_non_string_ref(void) {
+  /**
+   * The $ref element must be a string, but is an integer.
+   */
+  const uint8_t bytes[] = {
+    0x0f, 0, 0, 0, 0x10, '$', 'r', 'e', 'f', 0, 0x2a, 0, 0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_DOLLAR_KEYS);
+  mlib_check(error.message, str_eq, "$ref element must be a UTF-8 element");
+  mlib_check(offset, eq, 4);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: dbref/non-string-db
+static inline void _test_case_dbref_non_string_db(void) {
+  /**
+   * The $db element should be a string, but is an integer.
+   */
+  const uint8_t bytes[] = {
+    0x29, 0, 0, 0, 2, '$', 'r', 'e', 'f', 0, 4, 0, 0, 0, 'f', 'o', 'o', 0, 2,
+    '$', 'i', 'd', 0, 4, 0, 0, 0, 'b', 'a', 'r', 0, 0x10, '$', 'd', 'b', 0,
+    0x2a, 0, 0, 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_DOLLAR_KEYS);
+  mlib_check(error.message, str_eq, "$db element in DBRef must be a UTF-8 element");
+  mlib_check(offset, eq, 31);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: dbref/invalid-extras-between
+static inline void _test_case_dbref_invalid_extras_between(void) {
+  /**
+   * Almost a valid DBRef, but there is an extra field before $db. We reject $db
+   * as an invalid key.
+   */
+  const uint8_t bytes[] = {
+    0x3e, 0, 0, 0, 2, '$', 'r', 'e', 'f', 0, 4, 0, 0, 0, 'f', 'o', 'o', 0, 2,
+    '$', 'i', 'd', 0, 4, 0, 0, 0, 'b', 'a', 'r', 0, 2, 'e', 'x', 't', 'r', 'a',
+    0, 6, 0, 0, 0, 'f', 'i', 'e', 'l', 'd', 0, 2, '$', 'd', 'b', 0, 4, 0, 0, 0,
+    'b', 'a', 'z', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_DOLLAR_KEYS);
+  mlib_check(error.message, str_eq, "Disallowed element key: \"$db\"");
+  mlib_check(offset, eq, 48);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: dbref/invalid-double-ref
+static inline void _test_case_dbref_invalid_double_ref(void) {
+  /**
+   * Invalid DBRef contains a second $ref element.
+   */
+  const uint8_t bytes[] = {
+    '.', 0, 0, 0, 2, '$', 'r', 'e', 'f', 0, 4, 0, 0, 0, 'f', 'o', 'o', 0, 2,
+    '$', 'r', 'e', 'f', 0, 4, 0, 0, 0, 'b', 'a', 'r', 0, 2, '$', 'i', 'd', 0, 4,
+    0, 0, 0, 'b', 'a', 'z', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_DOLLAR_KEYS);
+  mlib_check(error.message, str_eq, "Expected an $id element following $ref");
+  mlib_check(offset, eq, 18);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: dbref/invalid-missing-ref
+static inline void _test_case_dbref_invalid_missing_ref(void) {
+  /**
+   * DBRef document requires a $ref key to be first.
+   */
+  const uint8_t bytes[] = {
+    0x12, 0, 0, 0, 2, '$', 'i', 'd', 0, 4, 0, 0, 0, 'f', 'o', 'o', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_DOLLAR_KEYS);
+  mlib_check(error.message, str_eq, "Disallowed element key: \"$id\"");
+  mlib_check(offset, eq, 4);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: dbref/valid/simple
+static inline void _test_case_dbref_valid_simple(void) {
+  /**
+   * This is a simple valid DBRef element.
+   */
+  const uint8_t bytes[] = {
+    0x20, 0, 0, 0, 2, '$', 'r', 'e', 'f', 0, 4, 0, 0, 0, 'f', 'o', 'o', 0, 2,
+    '$', 'i', 'd', 0, 4, 0, 0, 0, 'b', 'a', 'r', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: dbref/valid/simple-with-db
+static inline void _test_case_dbref_valid_simple_with_db(void) {
+  /**
+   * A simple DBRef of the form:
+   * 
+   *     { $ref: "foo", $id: "bar", $db: "baz" }
+   */
+  const uint8_t bytes[] = {
+    '-', 0, 0, 0, 2, '$', 'r', 'e', 'f', 0, 4, 0, 0, 0, 'f', 'o', 'o', 0, 2,
+    '$', 'i', 'd', 0, 4, 0, 0, 0, 'b', 'a', 'r', 0, 2, '$', 'd', 'b', 0, 4, 0,
+    0, 0, 'b', 'a', 'z', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: dbref/valid/nested-id-doc
+static inline void _test_case_dbref_valid_nested_id_doc(void) {
+  /**
+   * This is a valid DBRef of the form:
+   * 
+   *     { $ref: foo, $id: { $ref: "foo2", $id: "bar2", $db: "baz2" }, $db: "baz" }
+   */
+  const uint8_t bytes[] = {
+    'U', 0, 0, 0, 2, '$', 'r', 'e', 'f', 0, 4, 0, 0, 0, 'f', 'o', 'o', 0, 3,
+    '$', 'i', 'd', 0, '0', 0, 0, 0, 2, '$', 'r', 'e', 'f', 0, 5, 0, 0, 0, 'f',
+    'o', 'o', '2', 0, 2, '$', 'i', 'd', 0, 5, 0, 0, 0, 'b', 'a', 'r', '2', 0, 2,
+    '$', 'd', 'b', 0, 5, 0, 0, 0, 'b', 'a', 'z', '2', 0, 0, 2, '$', 'd', 'b', 0,
+    4, 0, 0, 0, 'b', 'a', 'z', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: dbref/valid/trailing-content
+static inline void _test_case_dbref_valid_trailing_content(void) {
+  /**
+   * A valid DBRef of the form:
+   * 
+   *     {
+   *         $ref: "foo",
+   *         $id: "bar",
+   *         $db: "baz",
+   *         extra: "field",
+   *     }
+   */
+  const uint8_t bytes[] = {
+    0x3e, 0, 0, 0, 2, '$', 'r', 'e', 'f', 0, 4, 0, 0, 0, 'f', 'o', 'o', 0, 2,
+    '$', 'i', 'd', 0, 4, 0, 0, 0, 'b', 'a', 'r', 0, 2, '$', 'd', 'b', 0, 4, 0,
+    0, 0, 'b', 'a', 'z', 0, 2, 'e', 'x', 't', 'r', 'a', 0, 6, 0, 0, 0, 'f', 'i',
+    'e', 'l', 'd', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: dbref/valid/trailing-content-no-db
+static inline void _test_case_dbref_valid_trailing_content_no_db(void) {
+  /**
+   * A valid DBRef of the form:
+   * 
+   *     {
+   *         $ref: "foo",
+   *         $id: "bar",
+   *         extra: "field",
+   *     }
+   */
+  const uint8_t bytes[] = {
+    '1', 0, 0, 0, 2, '$', 'r', 'e', 'f', 0, 4, 0, 0, 0, 'f', 'o', 'o', 0, 2,
+    '$', 'i', 'd', 0, 4, 0, 0, 0, 'b', 'a', 'r', 0, 2, 'e', 'x', 't', 'r', 'a',
+    0, 6, 0, 0, 0, 'f', 'i', 'e', 'l', 'd', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+void test_install_generated_bson_validation(TestSuite* suite) {
+  TestSuite_Add(suite, "/bson/validate/" "empty", _test_case_empty);
+  TestSuite_Add(suite, "/bson/validate/" "bad-element", _test_case_bad_element);
+  TestSuite_Add(suite, "/bson/validate/" "invalid-type", _test_case_invalid_type);
+  TestSuite_Add(suite, "/bson/validate/" "key/invalid/accept", _test_case_key_invalid_accept);
+  TestSuite_Add(suite, "/bson/validate/" "key/invalid/reject", _test_case_key_invalid_reject);
+  TestSuite_Add(suite, "/bson/validate/" "key/empty/accept", _test_case_key_empty_accept);
+  TestSuite_Add(suite, "/bson/validate/" "key/empty/reject", _test_case_key_empty_reject);
+  TestSuite_Add(suite, "/bson/validate/" "key/empty/accept-if-absent", _test_case_key_empty_accept_if_absent);
+  TestSuite_Add(suite, "/bson/validate/" "key/dot/accept", _test_case_key_dot_accept);
+  TestSuite_Add(suite, "/bson/validate/" "key/dot/reject", _test_case_key_dot_reject);
+  TestSuite_Add(suite, "/bson/validate/" "key/dot/accept-if-absent", _test_case_key_dot_accept_if_absent);
+  TestSuite_Add(suite, "/bson/validate/" "key/dollar/accept", _test_case_key_dollar_accept);
+  TestSuite_Add(suite, "/bson/validate/" "key/dollar/reject", _test_case_key_dollar_reject);
+  TestSuite_Add(suite, "/bson/validate/" "key/dollar/accept-in-middle", _test_case_key_dollar_accept_in_middle);
+  TestSuite_Add(suite, "/bson/validate/" "key/dollar/accept-if-absent", _test_case_key_dollar_accept_if_absent);
+  TestSuite_Add(suite, "/bson/validate/" "utf8/simple", _test_case_utf8_simple);
+  TestSuite_Add(suite, "/bson/validate/" "utf8/missing-null", _test_case_utf8_missing_null);
+  TestSuite_Add(suite, "/bson/validate/" "utf8/length-zero", _test_case_utf8_length_zero);
+  TestSuite_Add(suite, "/bson/validate/" "utf8/length-too-short", _test_case_utf8_length_too_short);
+  TestSuite_Add(suite, "/bson/validate/" "utf8/header-too-large", _test_case_utf8_header_too_large);
+  TestSuite_Add(suite, "/bson/validate/" "utf8/valid", _test_case_utf8_valid);
+  TestSuite_Add(suite, "/bson/validate/" "utf8/invalid/accept", _test_case_utf8_invalid_accept);
+  TestSuite_Add(suite, "/bson/validate/" "utf8/invalid/reject", _test_case_utf8_invalid_reject);
+  TestSuite_Add(suite, "/bson/validate/" "utf8/valid-with-null/accept-1", _test_case_utf8_valid_with_null_accept_1);
+  TestSuite_Add(suite, "/bson/validate/" "utf8/valid-with-null/accept-2", _test_case_utf8_valid_with_null_accept_2);
+  TestSuite_Add(suite, "/bson/validate/" "utf8/valid-with-null/reject", _test_case_utf8_valid_with_null_reject);
+  TestSuite_Add(suite, "/bson/validate/" "utf8-key/invalid/accept", _test_case_utf8_key_invalid_accept);
+  TestSuite_Add(suite, "/bson/validate/" "utf8-key/invalid/reject", _test_case_utf8_key_invalid_reject);
+  TestSuite_Add(suite, "/bson/validate/" "array/empty", _test_case_array_empty);
+  TestSuite_Add(suite, "/bson/validate/" "array/simple", _test_case_array_simple);
+  TestSuite_Add(suite, "/bson/validate/" "array/invalid-element", _test_case_array_invalid_element);
+  TestSuite_Add(suite, "/bson/validate/" "array/invalid-element-check-offset", _test_case_array_invalid_element_check_offset);
+  TestSuite_Add(suite, "/bson/validate/" "symbol/simple", _test_case_symbol_simple);
+  TestSuite_Add(suite, "/bson/validate/" "symbol/invalid-utf8/accept", _test_case_symbol_invalid_utf8_accept);
+  TestSuite_Add(suite, "/bson/validate/" "symbol/invalid-utf8/reject", _test_case_symbol_invalid_utf8_reject);
+  TestSuite_Add(suite, "/bson/validate/" "symbol/length-zero", _test_case_symbol_length_zero);
+  TestSuite_Add(suite, "/bson/validate/" "symbol/length-too-short", _test_case_symbol_length_too_short);
+  TestSuite_Add(suite, "/bson/validate/" "code/simple", _test_case_code_simple);
+  TestSuite_Add(suite, "/bson/validate/" "code/invalid-utf8/accept", _test_case_code_invalid_utf8_accept);
+  TestSuite_Add(suite, "/bson/validate/" "code/invalid-utf8/reject", _test_case_code_invalid_utf8_reject);
+  TestSuite_Add(suite, "/bson/validate/" "code/length-zero", _test_case_code_length_zero);
+  TestSuite_Add(suite, "/bson/validate/" "code/length-too-short", _test_case_code_length_too_short);
+  TestSuite_Add(suite, "/bson/validate/" "code-with-scope/simple", _test_case_code_with_scope_simple);
+  TestSuite_Add(suite, "/bson/validate/" "code-with-scope/invalid-code-length-zero", _test_case_code_with_scope_invalid_code_length_zero);
+  TestSuite_Add(suite, "/bson/validate/" "code-with-scope/invalid-code-length-too-large", _test_case_code_with_scope_invalid_code_length_too_large);
+  TestSuite_Add(suite, "/bson/validate/" "code-with-scope/invalid-scope", _test_case_code_with_scope_invalid_scope);
+  TestSuite_Add(suite, "/bson/validate/" "code-with-scope/invalid-scope-key", _test_case_code_with_scope_invalid_scope_key);
+  TestSuite_Add(suite, "/bson/validate/" "code-with-scope/corrupt-scope", _test_case_code_with_scope_corrupt_scope);
+  TestSuite_Add(suite, "/bson/validate/" "code-with-scope/corrupt-scope-2", _test_case_code_with_scope_corrupt_scope_2);
+  TestSuite_Add(suite, "/bson/validate/" "regex/simple", _test_case_regex_simple);
+  TestSuite_Add(suite, "/bson/validate/" "regex/invalid-opts", _test_case_regex_invalid_opts);
+  TestSuite_Add(suite, "/bson/validate/" "regex/double-null", _test_case_regex_double_null);
+  TestSuite_Add(suite, "/bson/validate/" "regex/invalid-utf8/accept", _test_case_regex_invalid_utf8_accept);
+  TestSuite_Add(suite, "/bson/validate/" "regex/invalid-utf8/reject", _test_case_regex_invalid_utf8_reject);
+  TestSuite_Add(suite, "/bson/validate/" "regex/invalid-utf8/accept-if-absent", _test_case_regex_invalid_utf8_accept_if_absent);
+  TestSuite_Add(suite, "/bson/validate/" "dbpointer/string-length-zero", _test_case_dbpointer_string_length_zero);
+  TestSuite_Add(suite, "/bson/validate/" "dbpointer/string-length-too-big", _test_case_dbpointer_string_length_too_big);
+  TestSuite_Add(suite, "/bson/validate/" "dbpointer/truncated", _test_case_dbpointer_truncated);
+  TestSuite_Add(suite, "/bson/validate/" "dbpointer/missing-null", _test_case_dbpointer_missing_null);
+  TestSuite_Add(suite, "/bson/validate/" "dbpointer/invalid-utf8/accept", _test_case_dbpointer_invalid_utf8_accept);
+  TestSuite_Add(suite, "/bson/validate/" "dbpointer/invalid-utf8/reject", _test_case_dbpointer_invalid_utf8_reject);
+  TestSuite_Add(suite, "/bson/validate/" "dbpointer/invalid-utf8/accept-if-absent", _test_case_dbpointer_invalid_utf8_accept_if_absent);
+  TestSuite_Add(suite, "/bson/validate/" "subdoc/simple", _test_case_subdoc_simple);
+  TestSuite_Add(suite, "/bson/validate/" "subdoc/invalid-shared-null", _test_case_subdoc_invalid_shared_null);
+  TestSuite_Add(suite, "/bson/validate/" "subdoc/overlapping-utf8-null", _test_case_subdoc_overlapping_utf8_null);
+  TestSuite_Add(suite, "/bson/validate/" "subdoc/invalid-element", _test_case_subdoc_invalid_element);
+  TestSuite_Add(suite, "/bson/validate/" "subdoc/header-too-large", _test_case_subdoc_header_too_large);
+  TestSuite_Add(suite, "/bson/validate/" "subdoc/header-too-small", _test_case_subdoc_header_too_small);
+  TestSuite_Add(suite, "/bson/validate/" "subdoc/impossible-size", _test_case_subdoc_impossible_size);
+  TestSuite_Add(suite, "/bson/validate/" "null/simple", _test_case_null_simple);
+  TestSuite_Add(suite, "/bson/validate/" "undefined/simple", _test_case_undefined_simple);
+  TestSuite_Add(suite, "/bson/validate/" "binary/simple", _test_case_binary_simple);
+  TestSuite_Add(suite, "/bson/validate/" "binary/bad-length-zero-subtype-2", _test_case_binary_bad_length_zero_subtype_2);
+  TestSuite_Add(suite, "/bson/validate/" "binary/bad-length-too-small", _test_case_binary_bad_length_too_small);
+  TestSuite_Add(suite, "/bson/validate/" "binary/bad-length-too-big", _test_case_binary_bad_length_too_big);
+  TestSuite_Add(suite, "/bson/validate/" "binary/old-invalid/1", _test_case_binary_old_invalid_1);
+  TestSuite_Add(suite, "/bson/validate/" "binary/old-invalid/2", _test_case_binary_old_invalid_2);
+  TestSuite_Add(suite, "/bson/validate/" "minkey/simple", _test_case_minkey_simple);
+  TestSuite_Add(suite, "/bson/validate/" "maxkey/simple", _test_case_maxkey_simple);
+  TestSuite_Add(suite, "/bson/validate/" "int32/simple", _test_case_int32_simple);
+  TestSuite_Add(suite, "/bson/validate/" "int32/truncated", _test_case_int32_truncated);
+  TestSuite_Add(suite, "/bson/validate/" "timestamp/simple", _test_case_timestamp_simple);
+  TestSuite_Add(suite, "/bson/validate/" "timestamp/truncated", _test_case_timestamp_truncated);
+  TestSuite_Add(suite, "/bson/validate/" "int64/simple", _test_case_int64_simple);
+  TestSuite_Add(suite, "/bson/validate/" "int64/truncated", _test_case_int64_truncated);
+  TestSuite_Add(suite, "/bson/validate/" "double/simple", _test_case_double_simple);
+  TestSuite_Add(suite, "/bson/validate/" "double/truncated", _test_case_double_truncated);
+  TestSuite_Add(suite, "/bson/validate/" "boolean/simple-false", _test_case_boolean_simple_false);
+  TestSuite_Add(suite, "/bson/validate/" "boolean/simple-true", _test_case_boolean_simple_true);
+  TestSuite_Add(suite, "/bson/validate/" "boolean/invalid", _test_case_boolean_invalid);
+  TestSuite_Add(suite, "/bson/validate/" "datetime/simple", _test_case_datetime_simple);
+  TestSuite_Add(suite, "/bson/validate/" "datetime/truncated", _test_case_datetime_truncated);
+  TestSuite_Add(suite, "/bson/validate/" "dbref/missing-id", _test_case_dbref_missing_id);
+  TestSuite_Add(suite, "/bson/validate/" "dbref/non-id", _test_case_dbref_non_id);
+  TestSuite_Add(suite, "/bson/validate/" "dbref/not-first-elements", _test_case_dbref_not_first_elements);
+  TestSuite_Add(suite, "/bson/validate/" "dbref/ref-without-id-with-db", _test_case_dbref_ref_without_id_with_db);
+  TestSuite_Add(suite, "/bson/validate/" "dbref/non-string-ref", _test_case_dbref_non_string_ref);
+  TestSuite_Add(suite, "/bson/validate/" "dbref/non-string-db", _test_case_dbref_non_string_db);
+  TestSuite_Add(suite, "/bson/validate/" "dbref/invalid-extras-between", _test_case_dbref_invalid_extras_between);
+  TestSuite_Add(suite, "/bson/validate/" "dbref/invalid-double-ref", _test_case_dbref_invalid_double_ref);
+  TestSuite_Add(suite, "/bson/validate/" "dbref/invalid-missing-ref", _test_case_dbref_invalid_missing_ref);
+  TestSuite_Add(suite, "/bson/validate/" "dbref/valid/simple", _test_case_dbref_valid_simple);
+  TestSuite_Add(suite, "/bson/validate/" "dbref/valid/simple-with-db", _test_case_dbref_valid_simple_with_db);
+  TestSuite_Add(suite, "/bson/validate/" "dbref/valid/nested-id-doc", _test_case_dbref_valid_nested_id_doc);
+  TestSuite_Add(suite, "/bson/validate/" "dbref/valid/trailing-content", _test_case_dbref_valid_trailing_content);
+  TestSuite_Add(suite, "/bson/validate/" "dbref/valid/trailing-content-no-db", _test_case_dbref_valid_trailing_content_no_db);
+}

--- a/src/libbson/tests/test-validate.generated.c
+++ b/src/libbson/tests/test-validate.generated.c
@@ -22,7 +22,7 @@ static inline void _test_case_empty(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -83,7 +83,7 @@ static inline void _test_case_key_invalid_accept(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -124,7 +124,7 @@ static inline void _test_case_key_empty_accept(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -164,7 +164,7 @@ static inline void _test_case_key_empty_accept_if_absent(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_EMPTY_KEYS, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -185,7 +185,7 @@ static inline void _test_case_key_dot_accept(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_EMPTY_KEYS, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -226,7 +226,7 @@ static inline void _test_case_key_dot_accept_if_absent(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOT_KEYS, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -246,7 +246,7 @@ static inline void _test_case_key_dollar_accept(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -288,7 +288,7 @@ static inline void _test_case_key_dollar_accept_in_middle(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -308,7 +308,7 @@ static inline void _test_case_key_dollar_accept_if_absent(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -328,7 +328,7 @@ static inline void _test_case_utf8_simple(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -430,7 +430,7 @@ static inline void _test_case_utf8_valid(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_UTF8, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -450,7 +450,7 @@ static inline void _test_case_utf8_invalid_accept(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -492,7 +492,7 @@ static inline void _test_case_utf8_valid_with_null_accept_1(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -513,7 +513,7 @@ static inline void _test_case_utf8_valid_with_null_accept_2(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_UTF8 | BSON_VALIDATE_UTF8_ALLOW_NULL, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -556,7 +556,7 @@ static inline void _test_case_utf8_overlong_null_accept_1(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -584,7 +584,7 @@ static inline void _test_case_utf8_overlong_null_accept_2(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_UTF8 | BSON_VALIDATE_UTF8_ALLOW_NULL, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -634,7 +634,7 @@ static inline void _test_case_utf8_key_invalid_accept(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -711,7 +711,7 @@ static inline void _test_case_utf8_key_overlong_null_accept(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_UTF8 | BSON_VALIDATE_UTF8_ALLOW_NULL, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -730,7 +730,7 @@ static inline void _test_case_array_empty(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -751,7 +751,7 @@ static inline void _test_case_array_simple(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -816,7 +816,7 @@ static inline void _test_case_symbol_simple(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -836,7 +836,7 @@ static inline void _test_case_symbol_invalid_utf8_accept(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -918,7 +918,7 @@ static inline void _test_case_code_simple(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -938,7 +938,7 @@ static inline void _test_case_code_invalid_utf8_accept(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -1019,7 +1019,7 @@ static inline void _test_case_code_with_scope_simple(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -1091,7 +1091,10 @@ static inline void _test_case_code_with_scope_invalid_scope(void) {
 // Case: code-with-scope/invalid-scope-key
 static inline void _test_case_code_with_scope_invalid_scope_key(void) {
   /**
-   * A code-with-scope element, but the socpe contains an empty element key
+   * A code-with-scope element, but the socpe contains an empty element key. Even
+   * though we don't request validation of empty keys, the scope document will
+   * be validated according to a fix set of rules to better match the rules
+   * for JS identifiers (including forbidding empty keys).
    */
   const uint8_t bytes[] = {
     '2', 0, 0, 0, 0x0f, 'c', 'o', 'd', 'e', 0, 0x27, 0, 0, 0, 8, 0, 0, 0, 'v',
@@ -1168,7 +1171,7 @@ static inline void _test_case_regex_simple(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -1236,7 +1239,7 @@ static inline void _test_case_regex_invalid_utf8_accept(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -1278,7 +1281,7 @@ static inline void _test_case_regex_invalid_utf8_accept_if_absent(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_UTF8, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -1390,7 +1393,7 @@ static inline void _test_case_dbpointer_invalid_utf8_accept(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -1433,7 +1436,7 @@ static inline void _test_case_dbpointer_invalid_utf8_accept_if_absent(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_UTF8, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -1453,7 +1456,7 @@ static inline void _test_case_subdoc_simple(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -1601,7 +1604,7 @@ static inline void _test_case_null_simple(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -1620,7 +1623,7 @@ static inline void _test_case_undefined_simple(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -1640,7 +1643,7 @@ static inline void _test_case_binary_simple(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -1772,7 +1775,7 @@ static inline void _test_case_minkey_simple(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -1791,7 +1794,7 @@ static inline void _test_case_maxkey_simple(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -1810,7 +1813,7 @@ static inline void _test_case_int32_simple(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -1851,7 +1854,7 @@ static inline void _test_case_timestamp_simple(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -1892,7 +1895,7 @@ static inline void _test_case_int64_simple(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -1933,7 +1936,7 @@ static inline void _test_case_double_simple(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -1973,7 +1976,7 @@ static inline void _test_case_boolean_simple_false(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -1992,7 +1995,7 @@ static inline void _test_case_boolean_simple_true(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -2031,7 +2034,7 @@ static inline void _test_case_datetime_simple(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -2263,7 +2266,7 @@ static inline void _test_case_dbref_valid_simple(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -2286,7 +2289,7 @@ static inline void _test_case_dbref_valid_simple_with_db(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -2311,7 +2314,7 @@ static inline void _test_case_dbref_valid_nested_id_doc(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -2340,7 +2343,7 @@ static inline void _test_case_dbref_valid_trailing_content(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }
@@ -2367,7 +2370,7 @@ static inline void _test_case_dbref_valid_trailing_content_no_db(void) {
   bson_error_t error = {0};
   size_t offset = 999999;
   const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
-  mlib_check(is_valid);
+  ASSERT_OR_PRINT(is_valid, error);
   mlib_check(error.code, eq, 0);
   mlib_check(error.message, str_eq, "");
 }

--- a/src/libbson/tests/test-validate.generated.c
+++ b/src/libbson/tests/test-validate.generated.c
@@ -208,7 +208,7 @@ static inline void _test_case_key_dot_reject(void) {
   const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOT_KEYS, &offset, &error);
   mlib_check(!is_valid);
   mlib_check(error.code, eq, BSON_VALIDATE_DOT_KEYS);
-  mlib_check(error.message, str_eq, "Disallowed element key: \"foo.bar\"");
+  mlib_check(error.message, str_eq, "Disallowed '.' in element key: \"foo.bar\"");
   mlib_check(offset, eq, 13);
 }
 
@@ -268,7 +268,7 @@ static inline void _test_case_key_dollar_reject(void) {
   const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
   mlib_check(!is_valid);
   mlib_check(error.code, eq, BSON_VALIDATE_DOLLAR_KEYS);
-  mlib_check(error.message, str_eq, "Disallowed element key: \"$foo\"");
+  mlib_check(error.message, str_eq, "Disallowed '$' in element key: \"$foo\"");
   mlib_check(offset, eq, 13);
 }
 
@@ -1982,7 +1982,7 @@ static inline void _test_case_dbref_not_first_elements(void) {
   const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
   mlib_check(!is_valid);
   mlib_check(error.code, eq, BSON_VALIDATE_DOLLAR_KEYS);
-  mlib_check(error.message, str_eq, "Disallowed element key: \"$ref\"");
+  mlib_check(error.message, str_eq, "Disallowed '$' in element key: \"$ref\"");
   mlib_check(offset, eq, 17);
 }
 
@@ -2069,7 +2069,7 @@ static inline void _test_case_dbref_invalid_extras_between(void) {
   const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
   mlib_check(!is_valid);
   mlib_check(error.code, eq, BSON_VALIDATE_DOLLAR_KEYS);
-  mlib_check(error.message, str_eq, "Disallowed element key: \"$db\"");
+  mlib_check(error.message, str_eq, "Disallowed '$' in element key: \"$db\"");
   mlib_check(offset, eq, 48);
 }
 
@@ -2111,7 +2111,7 @@ static inline void _test_case_dbref_invalid_missing_ref(void) {
   const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_DOLLAR_KEYS, &offset, &error);
   mlib_check(!is_valid);
   mlib_check(error.code, eq, BSON_VALIDATE_DOLLAR_KEYS);
-  mlib_check(error.message, str_eq, "Disallowed element key: \"$id\"");
+  mlib_check(error.message, str_eq, "Disallowed '$' in element key: \"$id\"");
   mlib_check(offset, eq, 4);
 }
 

--- a/src/libbson/tests/test-validate.generated.c
+++ b/src/libbson/tests/test-validate.generated.c
@@ -1088,28 +1088,27 @@ static inline void _test_case_code_with_scope_invalid_scope(void) {
 }
 
 // ! This code is GENERATED! Do not edit it directly!
-// Case: code-with-scope/invalid-scope-key
-static inline void _test_case_code_with_scope_invalid_scope_key(void) {
+// Case: code-with-scope/empty-key-in-scope
+static inline void _test_case_code_with_scope_empty_key_in_scope(void) {
   /**
-   * A code-with-scope element, but the socpe contains an empty element key. Even
-   * though we don't request validation of empty keys, the scope document will
-   * be validated according to a fix set of rules to better match the rules
-   * for JS identifiers (including forbidding empty keys).
+   * A code-with-scope element. The scope itself contains empty keys within
+   * objects, and we ask to reject empty keys. But the scope document should
+   * be treated as an opaque closure, so our outer validation rules do not
+   * apply.
    */
   const uint8_t bytes[] = {
-    '2', 0, 0, 0, 0x0f, 'c', 'o', 'd', 'e', 0, 0x27, 0, 0, 0, 8, 0, 0, 0, 'v',
-    'o', 'i', 'd', 0x20, '0', 0x3b, 0, 0x17, 0, 0, 0, 2, 0, 0x0c, 0, 0, 0, 's',
-    'o', 'm', 'e', 0x20, 's', 't', 'r', 'i', 'n', 'g', 0, 0, 0
+    '7', 0, 0, 0, 0x0f, 'c', 'o', 'd', 'e', 0, 0x2c, 0, 0, 0, 8, 0, 0, 0, 'v',
+    'o', 'i', 'd', 0x20, '0', 0x3b, 0, 0x1c, 0, 0, 0, 3, 'o', 'b', 'j', 0, 0x12,
+    0, 0, 0, 2, 0, 7, 0, 0, 0, 's', 't', 'r', 'i', 'n', 'g', 0, 0, 0, 0
   };
   bson_t doc;
   mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
   bson_error_t error = {0};
   size_t offset = 999999;
-  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
-  mlib_check(!is_valid);
-  mlib_check(error.code, eq, BSON_VALIDATE_EMPTY_KEYS);
-  mlib_check(error.message, str_eq, "Error in scope document for element \"code\": Element key cannot be an empty string");
-  mlib_check(offset, eq, 8);
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_EMPTY_KEYS, &offset, &error);
+  ASSERT_OR_PRINT(is_valid, error);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
 }
 
 // ! This code is GENERATED! Do not edit it directly!
@@ -2450,7 +2449,7 @@ void test_install_generated_bson_validation(TestSuite* suite) {
   TestSuite_Add(suite, "/bson/validate/" "code-with-scope/invalid-code-length-zero", _test_case_code_with_scope_invalid_code_length_zero);
   TestSuite_Add(suite, "/bson/validate/" "code-with-scope/invalid-code-length-too-large", _test_case_code_with_scope_invalid_code_length_too_large);
   TestSuite_Add(suite, "/bson/validate/" "code-with-scope/invalid-scope", _test_case_code_with_scope_invalid_scope);
-  TestSuite_Add(suite, "/bson/validate/" "code-with-scope/invalid-scope-key", _test_case_code_with_scope_invalid_scope_key);
+  TestSuite_Add(suite, "/bson/validate/" "code-with-scope/empty-key-in-scope", _test_case_code_with_scope_empty_key_in_scope);
   TestSuite_Add(suite, "/bson/validate/" "code-with-scope/corrupt-scope", _test_case_code_with_scope_corrupt_scope);
   TestSuite_Add(suite, "/bson/validate/" "code-with-scope/corrupt-scope-2", _test_case_code_with_scope_corrupt_scope_2);
   TestSuite_Add(suite, "/bson/validate/" "regex/simple", _test_case_regex_simple);

--- a/src/libbson/tests/test-validate.generated.c
+++ b/src/libbson/tests/test-validate.generated.c
@@ -544,7 +544,7 @@ static inline void _test_case_utf8_valid_with_null_reject(void) {
 // Case: utf8-key/invalid/accept
 static inline void _test_case_utf8_key_invalid_accept(void) {
   /**
-   * The element key is not valid UTf-8, but we acecpt it if we don't do
+   * The element key is not valid UTf-8, but we accept it if we don't do
    * UTF-8 validation.
    */
   const uint8_t bytes[] = {
@@ -1092,7 +1092,7 @@ static inline void _test_case_regex_double_null(void) {
 // Case: regex/invalid-utf8/accept
 static inline void _test_case_regex_invalid_utf8_accept(void) {
   /**
-   * A regular expression that contains invalid UTf-8.
+   * A regular expression that contains invalid UTF-8.
    */
   const uint8_t bytes[] = {
     0x17, 0, 0, 0, 0x0b, 'r', 'e', 'g', 'e', 'x', 0, 'f', 'o', 'o', 0xff, 'b',
@@ -1112,7 +1112,7 @@ static inline void _test_case_regex_invalid_utf8_accept(void) {
 // Case: regex/invalid-utf8/reject
 static inline void _test_case_regex_invalid_utf8_reject(void) {
   /**
-   * A regular expression that contains invalid UTf-8.
+   * A regular expression that contains invalid UTF-8.
    */
   const uint8_t bytes[] = {
     0x17, 0, 0, 0, 0x0b, 'r', 'e', 'g', 'e', 'x', 0, 'f', 'o', 'o', 0xff, 'b',
@@ -1868,7 +1868,7 @@ static inline void _test_case_boolean_simple_true(void) {
 // Case: boolean/invalid
 static inline void _test_case_boolean_invalid(void) {
   /**
-   * In invalid boolean octet. Must be '0' or '1', but is 0xc3.
+   * An invalid boolean octet. Must be '0' or '1', but is 0xc3.
    */
   const uint8_t bytes[] = {
     0x0c, 0, 0, 0, 8, 'b', 'o', 'o', 'l', 0, 0xc3, 0

--- a/src/libbson/tests/test-validate.generated.c
+++ b/src/libbson/tests/test-validate.generated.c
@@ -541,6 +541,84 @@ static inline void _test_case_utf8_valid_with_null_reject(void) {
 }
 
 // ! This code is GENERATED! Do not edit it directly!
+// Case: utf8/overlong-null/accept-1
+static inline void _test_case_utf8_overlong_null_accept_1(void) {
+  /**
+   * This is an *invalid* UTF-8 string, and contains an overlong null. We should
+   * accept it because we aren't doing UTF-8 validation.
+   */
+  const uint8_t bytes[] = {
+    0x17, 0, 0, 0, 2, 'f', 'o', 'o', 0, 9, 0, 0, 0, 'a', 'b', 'c', 0xc0, 0x80,
+    '1', '2', '3', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: utf8/overlong-null/accept-2
+static inline void _test_case_utf8_overlong_null_accept_2(void) {
+  /**
+   * ! NOTE: overlong-null: This test relies on our UTF-8 validation accepting the `c0 80` sequence
+   * 
+   * This is an *invalid* UTF-8 string, because it contains an overlong null
+   * "0xc0 0x80". Despite being invalid, we accept it because our current UTF-8
+   * validation considers the overlong null to be a valid encoding for the null
+   * codepoint (it isn't, but changing it would be a breaking change).
+   * 
+   * If/when UTF-8 validation is changed to reject overlong null, then this
+   * test should change to expect rejection the invalid UTF-8.
+   */
+  const uint8_t bytes[] = {
+    0x17, 0, 0, 0, 2, 'f', 'o', 'o', 0, 9, 0, 0, 0, 'a', 'b', 'c', 0xc0, 0x80,
+    '1', '2', '3', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_UTF8 | BSON_VALIDATE_UTF8_ALLOW_NULL, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: utf8/overlong-null/reject
+static inline void _test_case_utf8_overlong_null_reject(void) {
+  /**
+   * ! NOTE: overlong-null: This test relies on our UTF-8 validation accepting the `c0 80` sequence
+   * 
+   * This is an *invalid* UTF-8 string, because it contains an overlong null
+   * character. Our UTF-8 validator wrongly accepts overlong null as a valid
+   * UTF-8 sequence. This test fails because we disallow null codepoints, not
+   * because the UTF-8 is invalid, and the error message reflects that.
+   * 
+   * If/when UTF-8 validation is changed to reject overlong null, then the
+   * expected error code and error message for this test should change.
+   */
+  const uint8_t bytes[] = {
+    0x17, 0, 0, 0, 2, 'f', 'o', 'o', 0, 9, 0, 0, 0, 'a', 'b', 'c', 0xc0, 0x80,
+    '1', '2', '3', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_UTF8, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_UTF8_ALLOW_NULL);
+  mlib_check(error.message, str_eq, "UTF-8 string contains a U+0000 (null) character");
+  mlib_check(offset, eq, 4);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
 // Case: utf8-key/invalid/accept
 static inline void _test_case_utf8_key_invalid_accept(void) {
   /**
@@ -581,6 +659,61 @@ static inline void _test_case_utf8_key_invalid_reject(void) {
   mlib_check(error.code, eq, BSON_VALIDATE_UTF8);
   mlib_check(error.message, str_eq, "Text element is not valid UTF-8");
   mlib_check(offset, eq, 4);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: utf8-key/overlong-null/reject
+static inline void _test_case_utf8_key_overlong_null_reject(void) {
+  /**
+   * ! NOTE: overlong-null: This test relies on our UTF-8 validation accepting the `c0 80` sequence
+   * 
+   * The element key is invalid UTF-8 because it contains an overlong null. We accept the
+   * overlong null as a valid encoding of U+0000, but we reject the key because
+   * we disallow null in UTF-8 strings.
+   * 
+   * If/when UTF-8 validation is changed to reject overlong null, then the
+   * expected error code and error message for this test should change.
+   */
+  const uint8_t bytes[] = {
+    0x17, 0, 0, 0, 2, 'a', 'b', 'c', 0xc0, 0x80, 'd', 'e', 'f', 0, 4, 0, 0, 0,
+    'b', 'a', 'r', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_UTF8, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_UTF8_ALLOW_NULL);
+  mlib_check(error.message, str_eq, "UTF-8 string contains a U+0000 (null) character");
+  mlib_check(offset, eq, 4);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
+// Case: utf8-key/overlong-null/accept
+static inline void _test_case_utf8_key_overlong_null_accept(void) {
+  /**
+   * ! NOTE: overlong-null: This test relies on our UTF-8 validation accepting the `c0 80` sequence
+   * 
+   * The element key is invalid UTF-8 because it contains an overlong null. We accept the
+   * overlong null as a valid encoding of U+0000, and we allow it in an element key because
+   * we pass ALLOW_NULL
+   * 
+   * If/when UTF-8 validation is changed to reject overlong null, then this
+   * test case should instead reject the key string as invalid UTF-8.
+   */
+  const uint8_t bytes[] = {
+    0x17, 0, 0, 0, 2, 'a', 'b', 'c', 0xc0, 0x80, 'd', 'e', 'f', 0, 4, 0, 0, 0,
+    'b', 'a', 'r', 0, 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, BSON_VALIDATE_UTF8 | BSON_VALIDATE_UTF8_ALLOW_NULL, &offset, &error);
+  mlib_check(is_valid);
+  mlib_check(error.code, eq, 0);
+  mlib_check(error.message, str_eq, "");
 }
 
 // ! This code is GENERATED! Do not edit it directly!
@@ -2267,8 +2400,13 @@ void test_install_generated_bson_validation(TestSuite* suite) {
   TestSuite_Add(suite, "/bson/validate/" "utf8/valid-with-null/accept-1", _test_case_utf8_valid_with_null_accept_1);
   TestSuite_Add(suite, "/bson/validate/" "utf8/valid-with-null/accept-2", _test_case_utf8_valid_with_null_accept_2);
   TestSuite_Add(suite, "/bson/validate/" "utf8/valid-with-null/reject", _test_case_utf8_valid_with_null_reject);
+  TestSuite_Add(suite, "/bson/validate/" "utf8/overlong-null/accept-1", _test_case_utf8_overlong_null_accept_1);
+  TestSuite_Add(suite, "/bson/validate/" "utf8/overlong-null/accept-2", _test_case_utf8_overlong_null_accept_2);
+  TestSuite_Add(suite, "/bson/validate/" "utf8/overlong-null/reject", _test_case_utf8_overlong_null_reject);
   TestSuite_Add(suite, "/bson/validate/" "utf8-key/invalid/accept", _test_case_utf8_key_invalid_accept);
   TestSuite_Add(suite, "/bson/validate/" "utf8-key/invalid/reject", _test_case_utf8_key_invalid_reject);
+  TestSuite_Add(suite, "/bson/validate/" "utf8-key/overlong-null/reject", _test_case_utf8_key_overlong_null_reject);
+  TestSuite_Add(suite, "/bson/validate/" "utf8-key/overlong-null/accept", _test_case_utf8_key_overlong_null_accept);
   TestSuite_Add(suite, "/bson/validate/" "array/empty", _test_case_array_empty);
   TestSuite_Add(suite, "/bson/validate/" "array/simple", _test_case_array_simple);
   TestSuite_Add(suite, "/bson/validate/" "array/invalid-element", _test_case_array_invalid_element);

--- a/src/libbson/tests/test-validate.generated.c
+++ b/src/libbson/tests/test-validate.generated.c
@@ -1671,6 +1671,28 @@ static inline void _test_case_binary_bad_length_zero_subtype_2(void) {
 }
 
 // ! This code is GENERATED! Do not edit it directly!
+// Case: binary/bad-inner-length-on-subtype-2
+static inline void _test_case_binary_bad_inner_length_on_subtype_2(void) {
+  /**
+   * Binary data that has an valid outer length header, but the inner length
+   * header for subtype 2 has an incorrect value.
+   */
+  const uint8_t bytes[] = {
+    0x1a, 0, 0, 0, 5, 'b', 'i', 'n', 'a', 'r', 'y', 0, 8, 0, 0, 0, 2, 2, 0, 0,
+    0, '1', '2', '3', '4', 0
+  };
+  bson_t doc;
+  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));
+  bson_error_t error = {0};
+  size_t offset = 999999;
+  const bool is_valid = bson_validate_with_error_and_offset(&doc, 0, &offset, &error);
+  mlib_check(!is_valid);
+  mlib_check(error.code, eq, BSON_VALIDATE_CORRUPT);
+  mlib_check(error.message, str_eq, "corrupt BSON");
+  mlib_check(offset, eq, 17);
+}
+
+// ! This code is GENERATED! Do not edit it directly!
 // Case: binary/bad-length-too-small
 static inline void _test_case_binary_bad_length_too_small(void) {
   /**
@@ -2455,6 +2477,7 @@ void test_install_generated_bson_validation(TestSuite* suite) {
   TestSuite_Add(suite, "/bson/validate/" "undefined/simple", _test_case_undefined_simple);
   TestSuite_Add(suite, "/bson/validate/" "binary/simple", _test_case_binary_simple);
   TestSuite_Add(suite, "/bson/validate/" "binary/bad-length-zero-subtype-2", _test_case_binary_bad_length_zero_subtype_2);
+  TestSuite_Add(suite, "/bson/validate/" "binary/bad-inner-length-on-subtype-2", _test_case_binary_bad_inner_length_on_subtype_2);
   TestSuite_Add(suite, "/bson/validate/" "binary/bad-length-too-small", _test_case_binary_bad_length_too_small);
   TestSuite_Add(suite, "/bson/validate/" "binary/bad-length-too-big", _test_case_binary_bad_length_too_big);
   TestSuite_Add(suite, "/bson/validate/" "binary/old-invalid/1", _test_case_binary_old_invalid_1);

--- a/src/libbson/tests/validate-tests.py
+++ b/src/libbson/tests/validate-tests.py
@@ -762,25 +762,26 @@ CASES: list[TestCase] = [
         error=corruption_at(13),
     ),
     TestCase(
-        "code-with-scope/invalid-scope-key",
+        "code-with-scope/empty-key-in-scope",
         doc(
             elem(
                 "code",
                 Tag.CodeWithScope,
-                code_with_scope("void 0;", doc(utf8elem("", "some string"))),
+                code_with_scope(
+                    "void 0;",
+                    doc(
+                        elem("obj", Tag.Document, doc(utf8elem("", "string"))),
+                    ),
+                ),
             )
         ),
         """
-        A code-with-scope element, but the socpe contains an empty element key. Even
-        though we don't request validation of empty keys, the scope document will
-        be validated according to a fix set of rules to better match the rules
-        for JS identifiers (including forbidding empty keys).
+        A code-with-scope element. The scope itself contains empty keys within
+        objects, and we ask to reject empty keys. But the scope document should
+        be treated as an opaque closure, so our outer validation rules do not
+        apply.
         """,
-        error=ErrorInfo(
-            BSON_VALIDATE_EMPTY_KEYS,
-            'Error in scope document for element "code": Element key cannot be an empty string',
-            8,
-        ),
+        flags=BSON_VALIDATE_EMPTY_KEYS,
     ),
     TestCase(
         "code-with-scope/corrupt-scope",

--- a/src/libbson/tests/validate-tests.py
+++ b/src/libbson/tests/validate-tests.py
@@ -1115,6 +1115,24 @@ CASES: list[TestCase] = [
         error=corruption_at(12),
     ),
     TestCase(
+        "binary/bad-inner-length-on-subtype-2",
+        doc(
+            elem(
+                "binary",
+                Tag.Binary,
+                i32le(8),  # Valid length
+                b"\x02",  # subtype two
+                i32le(2),  # Invalid length of (should be 4)
+                b"1234",  # payload
+            ),
+        ),
+        """
+        Binary data that has an valid outer length header, but the inner length
+        header for subtype 2 has an incorrect value.
+        """,
+        error=corruption_at(17),
+    ),
+    TestCase(
         "binary/bad-length-too-small",
         doc(
             elem(

--- a/src/libbson/tests/validate-tests.py
+++ b/src/libbson/tests/validate-tests.py
@@ -7,6 +7,11 @@ Run this script with Python 3.12+, and pipe the output into a file.
 This script takes no command-line arguments.
 """
 
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
+
 import argparse
 import enum
 import json

--- a/src/libbson/tests/validate-tests.py
+++ b/src/libbson/tests/validate-tests.py
@@ -1,0 +1,1376 @@
+"""
+This script generates a C source file containing test cases for BSON validation
+and iteration.
+
+Run this script with Python 3.12+, and pipe the output into a file.
+
+This script takes no command-line arguments.
+"""
+
+import argparse
+import enum
+import json
+import re
+import struct
+import textwrap
+from dataclasses import dataclass
+from typing import Iterable
+
+
+class Tag(enum.Enum):
+    """BSON type tag byte values"""
+
+    EOD = 0
+    Double = 1
+    UTF8 = 2
+    Document = 3
+    Array = 4
+    Binary = 5
+    Undefined = 6
+    OID = 7
+    Boolean = 8
+    Datetime = 9
+    Null = 10
+    Regex = 11
+    DBPointer = 12
+    Code = 13
+    Symbol = 14
+    CodeWithScope = 15
+    Int32 = 16
+    Timestamp = 17
+    Int64 = 18
+    Decimal128 = 19
+    MinKey = 0xFF
+    MaxKey = 0x7F
+
+
+type _ByteIter = bytes | Iterable[_ByteIter]
+"""A set of bytes, or an iterable that yields more sets of bytes"""
+
+
+def flatten_bytes(data: _ByteIter) -> bytes:
+    """Flatten a (recursive) iterator of bytes into a single bytes object"""
+    match data:
+        case bytes(data):
+            return data
+        case it:
+            return b"".join(map(flatten_bytes, it))
+
+
+def i32le(i: int) -> bytes:
+    """Encode an integer as a 32-bit little-endian integer"""
+    return struct.pack("<i", i)
+
+
+def i64le(i: int) -> bytes:
+    """Encode an integer as a 64-bit little-endian integer"""
+    return struct.pack("<q", i)
+
+
+def f64le(f: float) -> bytes:
+    """Encode a float as a 64-bit little-endian float"""
+    return struct.pack("<d", f)
+
+
+def doc(*data: _ByteIter) -> bytes:
+    """Add a BSON document header a null terminator to a set of bytes"""
+    flat = flatten_bytes(data)
+    # +5 for the null terminator and the header bytes
+    hdr = i32le(len(flat) + 5)
+    return hdr + flat + b"\0"
+
+
+def code_with_scope(code: str, doc: _ByteIter) -> bytes:
+    """Create a BSON code-with-scope object with appropriate header"""
+    s = string(code)
+    doc = flatten_bytes(doc)
+    # +4 to include the length prefix too
+    len_prefix = i32le(len(s) + len(doc) + 4)
+    return len_prefix + s + doc
+
+
+def elem(key: str | _ByteIter, tag: int | Tag, *bs: _ByteIter) -> bytes:
+    """Add a BSON element header to a set of bytes"""
+    if isinstance(tag, Tag):
+        tag = tag.value
+    return bytes([tag]) + cstring(key) + flatten_bytes(bs)
+
+
+def binary(subtype: int, *bs: _ByteIter) -> bytes:
+    """
+    Create a BSON binary object with appropriate header and subtype tag byte.
+    """
+    flat = flatten_bytes(bs)
+    st = bytes([subtype])
+    return i32le(len(flat)) + st + flat
+
+
+def cstring(s: str | _ByteIter) -> bytes:
+    """Encode a string as UTF-8 and add a null terminator"""
+    match s:
+        case str(s):
+            return cstring(s.encode("utf-8"))
+        case bs:
+            bs = flatten_bytes(bs)
+            return bs + b"\0"
+
+
+def string(s: str | _ByteIter) -> bytes:
+    """Add a length header and null terminator to a UTF-8 string"""
+    cs = cstring(s)
+    # Length header includes the null terminator
+    hdr = i32le(len(cs))
+    return hdr + cs
+
+
+def utf8elem(key: str | _ByteIter, s: str | _ByteIter) -> bytes:
+    """Create a valid UTF-8 BSON element for the given string"""
+    return elem(key, Tag.UTF8, string(s))
+
+
+@dataclass(frozen=True)
+class ErrorInfo:
+    """
+    Information about an expected validation error
+    """
+
+    code: str
+    """Spellling of the error code to be expected"""
+    message: str
+    """The expected error message"""
+    offset: int
+    """The expected error offset"""
+
+
+@dataclass(frozen=True)
+class TestCase:
+    """
+    Defines a single validation test case.
+    """
+
+    name: str
+    """The name of the test case, as displayed in test runners, which will valid a "/bson/validate" prefix"""
+    data: bytes
+    """The bytes that will be injested by `bson_init_static` to form the document to be validated"""
+    description: str | None
+    """A plaintext description of the test case and what it actually does. Rendered as a comment."""
+    flags: str = "0"
+    """Spelling of the flags argument passed to the validation API"""
+    error: ErrorInfo = ErrorInfo("0", "", 0)
+    """Expected error, if any"""
+
+    @property
+    def fn_name(self) -> str:
+        """Get a C identifier function name for this test case"""
+        return "_test_case_" + re.sub(r"[^\w]", "_", self.name).lower()
+
+
+def fmt_byte(n: int) -> str:
+    """
+    Format an octet value for C code. Will emit a char literal if certain ASCII,
+    otherwise an integer literal.
+    """
+    match n:
+        case 0:
+            return "0"
+        case a if re.match(r"[a-zA-Z0-9.$-]", chr(a)):
+            return f"'{chr(a)}'"
+        case a if a < 10:
+            return str(a)
+        case n:
+            return f"0x{n:0>2x}"
+
+
+GENERATED_NOTE = "// ! This code is GENERATED! Do not edit it directly!"
+
+HEADER = rf"""{GENERATED_NOTE}
+// clang-format off
+
+#include <bson/bson.h>
+
+#include <mlib/test.h>
+
+#include <TestSuite.h>
+"""
+
+
+def generate(case: TestCase) -> Iterable[str]:
+    """
+    Generate the lines of a test case function.
+    """
+    # A comment header
+    yield f"{GENERATED_NOTE}\n"
+    yield f"// Case: {case.name}\n"
+    # The function head
+    yield f"static inline void {case.fn_name}(void) {{\n"
+    # If we have a description, emit that in a block comment
+    if case.description:
+        yield "  /**\n"
+        lines = textwrap.dedent(case.description).strip().splitlines()
+        yield from (f"   * {ln}\n" for ln in lines)
+        yield "   */\n"
+    # Emit the byte array literal
+    yield "  const uint8_t bytes[] = {\n"
+    yield "\n".join(
+        textwrap.wrap(
+            ", ".join(map(fmt_byte, case.data)),
+            subsequent_indent=" " * 4,
+            initial_indent=" " * 4,
+            width=80,
+        )
+    )
+    yield "\n  };\n"
+    yield from [
+        # Initialize a BSON doc that points to the byte array
+        "  bson_t doc;\n",
+        "  mlib_check(bson_init_static(&doc, bytes, sizeof bytes));\n",
+        # The error object to be filled
+        "  bson_error_t error = {0};\n",
+        # The error offset. Expected to be reset to zero on success.
+        "  size_t offset = 999999;\n"
+        # Do the actual validation:
+        f"  const bool is_valid = bson_validate_with_error_and_offset(&doc, {case.flags}, &offset, &error);\n",
+    ]
+    is_error = case.error.code != "0"
+    yield from [
+        f"  mlib_check({'!is_valid' if is_error else 'is_valid'});\n",
+        f"  mlib_check(error.code, eq, {case.error.code});\n",
+        f"  mlib_check(error.message, str_eq, {json.dumps(case.error.message)});\n",
+        f"  mlib_check(offset, eq, {case.error.offset});\n" if is_error else "",
+    ]
+    yield "}\n"
+
+
+def corruption_at(off: int) -> ErrorInfo:
+    """
+    Generate an ErrorInfo to expect a message of "corrupt BSON" at the given
+    byte offset.
+
+    Note that this won't match if the error message is something other
+    than "corrupt BSON".
+    """
+    return ErrorInfo("BSON_VALIDATE_CORRUPT", "corrupt BSON", off)
+
+
+BSON_VALIDATE_DOLLAR_KEYS = "BSON_VALIDATE_DOLLAR_KEYS"
+BSON_VALIDATE_UTF8 = "BSON_VALIDATE_UTF8"
+MSG_EXPECTED_ID_FOLLOWING_REF = "Expected an $id element following $ref"
+
+
+def disallowed_key(k: str) -> str:
+    return f'Disallowed element key: "{k}"'
+
+
+# d888888b d88888b .d8888. d888888b       .o88b.  .d8b.  .d8888. d88888b .d8888.
+# `~~88~~' 88'     88'  YP `~~88~~'      d8P  Y8 d8' `8b 88'  YP 88'     88'  YP
+#    88    88ooooo `8bo.      88         8P      88ooo88 `8bo.   88ooooo `8bo.
+#    88    88~~~~~   `Y8b.    88         8b      88~~~88   `Y8b. 88~~~~~   `Y8b.
+#    88    88.     db   8D    88         Y8b  d8 88   88 db   8D 88.     db   8D
+#    YP    Y88888P `8888Y'    YP          `Y88P' YP   YP `8888Y' Y88888P `8888Y'
+
+CASES: list[TestCase] = [
+    TestCase(
+        "empty",
+        doc(),
+        """Test a simple empty document object.""",
+    ),
+    TestCase(
+        "bad-element",
+        doc(b"f"),
+        "The element content is not valid",
+        error=corruption_at(6),
+    ),
+    TestCase(
+        "invalid-type",
+        doc(elem("foo", 0xE, b"foo")),
+        """The type tag "0x0e" is not a valid type""",
+        error=corruption_at(9),
+    ),
+    TestCase(
+        "key/invalid/accept",
+        doc(
+            utf8elem("a", "b"),
+            utf8elem(b"foo\xffbar", "baz"),
+            utf8elem("c", "d"),
+        ),
+        """
+        The element key contains an invalid UTF-8 byte, but we accept it
+        because we aren't doing UTF-8 validation.
+        """,
+    ),
+    TestCase(
+        "key/invalid/reject",
+        doc(
+            utf8elem("a", "b"),
+            elem(b"foo\xffbar", Tag.UTF8, string("baz")),
+            utf8elem("c", "d"),
+        ),
+        """
+        The element key is not valid UTF-8 and we reject it when we do UTF-8
+        validation.
+        """,
+        flags=BSON_VALIDATE_UTF8,
+        error=ErrorInfo(BSON_VALIDATE_UTF8, "Text element is not valid UTF-8", 13),
+    ),
+    TestCase(
+        "key/empty/accept",
+        doc(utf8elem("", "string")),
+        """
+        The element has an empty string key, and we accept this.
+        """,
+    ),
+    TestCase(
+        "key/empty/reject",
+        doc(
+            utf8elem("a", "b"),
+            utf8elem("", "string"),
+        ),
+        """
+        The element has an empty key, and we can reject it.
+        """,
+        flags="BSON_VALIDATE_EMPTY_KEYS",
+        error=ErrorInfo("BSON_VALIDATE_EMPTY_KEYS", "Element key cannot be an empty string", 13),
+    ),
+    TestCase(
+        "key/empty/accept-if-absent",
+        doc(utf8elem("foo", "bar")),
+        """
+        We are checking for empty keys, and accept if they are absent.
+        """,
+        flags="BSON_VALIDATE_EMPTY_KEYS",
+    ),
+    TestCase(
+        "key/dot/accept",
+        doc(utf8elem("foo.bar", "baz")),
+        """
+        The element key has an ASCII dot, and we accept this since we don't
+        ask to validate it.
+        """,
+        flags="BSON_VALIDATE_EMPTY_KEYS",
+    ),
+    TestCase(
+        "key/dot/reject",
+        doc(utf8elem("a", "b"), utf8elem("foo.bar", "baz")),
+        """
+        The element has an ASCII dot, and we reject it when we ask to validate
+        it.
+        """,
+        flags="BSON_VALIDATE_DOT_KEYS",
+        error=ErrorInfo("BSON_VALIDATE_DOT_KEYS", disallowed_key("foo.bar"), 13),
+    ),
+    TestCase(
+        "key/dot/accept-if-absent",
+        doc(utf8elem("foo", "bar")),
+        """
+        We are checking for keys with dot '.', and accept if they are absent.
+        """,
+        flags="BSON_VALIDATE_DOT_KEYS",
+    ),
+    TestCase(
+        "key/dollar/accept",
+        doc(utf8elem("a", "b"), utf8elem("$foo", "bar")),
+        """
+        We can accept an element key that starts with a dollar '$' sign.
+        """,
+    ),
+    TestCase(
+        "key/dollar/reject",
+        doc(utf8elem("a", "b"), utf8elem("$foo", "bar")),
+        """
+        We can reject an element key that starts with a dollar '$' sign.
+        """,
+        flags=BSON_VALIDATE_DOLLAR_KEYS,
+        error=ErrorInfo(BSON_VALIDATE_DOLLAR_KEYS, disallowed_key("$foo"), 13),
+    ),
+    TestCase(
+        "key/dollar/accept-in-middle",
+        doc(utf8elem("foo$bar", "baz")),
+        """
+        This contains a element key "foo$bar", but we don't reject this, as we
+        only care about keys that *start* with dollars.
+        """,
+        flags=BSON_VALIDATE_DOLLAR_KEYS,
+    ),
+    TestCase(
+        "key/dollar/accept-if-absent",
+        doc(utf8elem("foo", "bar")),
+        """
+        We are validating for dollar-keys, and we accept because this document
+        doesn't contain any such keys.
+        """,
+        flags=BSON_VALIDATE_DOLLAR_KEYS,
+    ),
+    TestCase(
+        "utf8/simple",
+        doc(utf8elem("string", "some string")),
+        "Simple UTF-8 string element",
+    ),
+    TestCase(
+        "utf8/missing-null",
+        doc(elem("a", Tag.UTF8, i32le(4), b"abcd")),
+        """
+        The UTF-8 element "a" contains 4 characters and declares its length of 4,
+        but the fourth character is supposed to be a null terminator. In this case,
+        it is the letter 'd'.
+        """,
+        error=corruption_at(14),
+    ),
+    TestCase(
+        "utf8/length-zero",
+        doc(elem("", Tag.UTF8, i32le(0), b"\0")),
+        "UTF-8 string length must always be at least 1 for the null terminator",
+        error=corruption_at(6),
+    ),
+    TestCase(
+        "utf8/length-too-short",
+        doc(elem("", Tag.UTF8, i32le(3), b"bar\0")),
+        "UTF-8 string is three chars and a null terminator, but the declared length is 3 (should be 4)",
+        error=corruption_at(12),
+    ),
+    TestCase(
+        "utf8/header-too-large",
+        doc(elem("foo", Tag.UTF8, b"\xff\xff\xff\xffbar\0")),
+        """
+        Data { "foo": "bar" } but the declared length of "bar" is way too large.
+        """,
+        error=corruption_at(9),
+    ),
+    TestCase(
+        "utf8/valid",
+        doc(elem("foo", Tag.UTF8, string("abcd"))),
+        """
+        Validate a valid UTF-8 string with UTF-8 validation enabled.
+        """,
+        flags=BSON_VALIDATE_UTF8,
+    ),
+    TestCase(
+        "utf8/invalid/accept",
+        doc(utf8elem("foo", b"abc\xffd")),
+        """
+        Validate an invalid UTF-8 string, but accept invalid UTF-8.
+        """,
+    ),
+    TestCase(
+        "utf8/invalid/reject",
+        doc(utf8elem("foo", b"abc\xffd")),
+        """
+        Validate an invalid UTF-8 string, and expect rejection.
+        """,
+        flags=BSON_VALIDATE_UTF8,
+        error=ErrorInfo(BSON_VALIDATE_UTF8, "Text element is not valid UTF-8", 4),
+    ),
+    TestCase(
+        "utf8/valid-with-null/accept-1",
+        doc(utf8elem("foo", b"abc\x00123")),
+        """
+        This is a valid UTF-8 string that contains a null character. We accept
+        it because we don't do UTF-8 validation.
+        """,
+    ),
+    TestCase(
+        "utf8/valid-with-null/accept-2",
+        doc(utf8elem("foo", b"abc\x00123")),
+        """
+        This is a valid UTF-8 string that contains a null character. We allow
+        it explicitly when we request UTF-8 validation.
+        """,
+        flags=f"{BSON_VALIDATE_UTF8} | BSON_VALIDATE_UTF8_ALLOW_NULL",
+    ),
+    TestCase(
+        "utf8/valid-with-null/reject",
+        doc(utf8elem("foo", b"abc\x00123")),
+        """
+        This is a valid UTF-8 string that contains a null character. We reject
+        this because we don't pass BSON_VALIDATE_UTF8_ALLOW_NULL.
+        """,
+        flags=BSON_VALIDATE_UTF8,
+        error=ErrorInfo("BSON_VALIDATE_UTF8_ALLOW_NULL", "UTF-8 string contains a U+0000 (null) character", 4),
+    ),
+    TestCase(
+        "utf8-key/invalid/accept",
+        doc(utf8elem(b"abc\xffdef", "bar")),
+        """
+        The element key is not valid UTf-8, but we acecpt it if we don't do
+        UTF-8 validation.
+        """,
+    ),
+    TestCase(
+        "utf8-key/invalid/reject",
+        doc(utf8elem(b"abc\xffdef", "bar")),
+        """
+        The element key is not valid UTF-8, and we reject it when we requested
+        UTF-8 validation.
+        """,
+        flags=BSON_VALIDATE_UTF8,
+        error=ErrorInfo(BSON_VALIDATE_UTF8, "Text element is not valid UTF-8", 4),
+    ),
+    TestCase(
+        "array/empty",
+        doc(elem("array", Tag.Array, doc())),
+        "Simple empty array element",
+    ),
+    TestCase(
+        "array/simple",
+        doc(
+            elem(
+                "array",
+                Tag.Array,
+                doc(
+                    elem("0", Tag.Int32, i32le(42)),
+                    elem("1", Tag.Int32, i32le(1729)),
+                    elem("2", Tag.Int32, i32le(-8)),
+                ),
+            )
+        ),
+        "Simple array element of integers",
+    ),
+    TestCase(
+        "array/invalid-element",
+        doc(
+            elem(
+                "array",
+                Tag.Array,
+                doc(
+                    elem("0", Tag.Int32, i32le(42)),
+                    elem("1", Tag.Int32, i32le(1729)[-1:]),  # Truncated
+                    elem("2", Tag.Int32, i32le(-8)),
+                ),
+            )
+        ),
+        "Simple array element of integers, but one element is truncated",
+        error=corruption_at(34),
+    ),
+    TestCase(
+        "array/invalid-element-check-offset",
+        doc(
+            elem(
+                "array-shifted",
+                Tag.Array,
+                doc(
+                    elem("0", Tag.Int32, i32le(42)),
+                    elem("1", Tag.Int32, i32le(1729)[-1:]),  # Truncated
+                    elem("2", Tag.Int32, i32le(-8)),
+                ),
+            )
+        ),
+        """
+        This is the same as the array/invalid-element test, but with a longer
+        key string on the parent array. This is to check that the error offset
+        is properly adjusted for the additional characters.
+        """,
+        error=corruption_at(42),
+    ),
+    TestCase(
+        "symbol/simple",
+        doc(elem("symbol", Tag.Symbol, string("void 0;"))),
+        """
+        A simple document: { symbol: Symbol("void 0;") }
+        """,
+    ),
+    TestCase(
+        "symbol/invalid-utf8/accept",
+        doc(elem("symbol", Tag.Symbol, string(b"void\xff 0;"))),
+        """
+        A simple symbol document, but the string contains invalid UTF-8
+        """,
+    ),
+    TestCase(
+        "symbol/invalid-utf8/reject",
+        doc(elem("symbol", Tag.Symbol, string(b"void\xff 0;"))),
+        """
+        A simple symbol document, but the string contains invalid UTF-8
+        """,
+        flags=BSON_VALIDATE_UTF8,
+        error=ErrorInfo(BSON_VALIDATE_UTF8, "Text element is not valid UTF-8", 4),
+    ),
+    TestCase(
+        "symbol/length-zero",
+        doc(b"\x0e\0" + i32le(0) + b"\0"),
+        "Symbol string length must always be at least 1 for the null terminator",
+        error=corruption_at(6),
+    ),
+    TestCase(
+        "symbol/length-too-short",
+        doc(b"\x0e\0" + i32le(3) + b"bar\0"),
+        """
+        Symbol string is three chars and a null terminator, but the declared
+        length is 3 (should be 4)
+        """,
+        error=corruption_at(12),
+    ),
+    TestCase(
+        "code/simple",
+        doc(elem("code", Tag.Code, string("void 0;"))),
+        """
+        A simple document: { code: Code("void 0;") }
+        """,
+    ),
+    TestCase(
+        "code/invalid-utf8/accept",
+        doc(elem("code", Tag.Code, string(b"void\xff 0;"))),
+        """
+        A simple code document, but the string contains invalid UTF-8
+        """,
+    ),
+    TestCase(
+        "code/invalid-utf8/reject",
+        doc(elem("code", Tag.Code, string(b"void\xff 0;"))),
+        """
+        A simple code document, but the string contains invalid UTF-8
+        """,
+        flags=BSON_VALIDATE_UTF8,
+        error=ErrorInfo(BSON_VALIDATE_UTF8, "Text element is not valid UTF-8", 4),
+    ),
+    TestCase(
+        "code/length-zero",
+        doc(elem("code", Tag.Code, i32le(0), b"\0")),
+        "Code string length must always be at least 1 for the null terminator",
+        error=corruption_at(10),
+    ),
+    TestCase(
+        "code/length-too-short",
+        doc(elem("code", Tag.Code, i32le(3), b"bar\0")),
+        "Code string is three chars and a null terminator, but the declared length is 3 (should be 4)",
+        error=corruption_at(16),
+    ),
+    # Code w/ scope
+    TestCase(
+        "code-with-scope/simple",
+        doc(elem("foo", Tag.CodeWithScope, code_with_scope("void 0;", doc()))),
+        "A simple valid code-with-scope element",
+    ),
+    TestCase(
+        "code-with-scope/invalid-code-length-zero",
+        doc(
+            elem(
+                "",
+                Tag.CodeWithScope,
+                i32le(10),
+                b"\0\0\0\0",  # strlen
+                b"\0",  # code
+                doc(),  # scope
+            )
+        ),
+        """
+        Data { "": CodeWithScope("", {}) }, but the code string length is zero, when
+        it must be at least 1
+        """,
+        error=corruption_at(6),
+    ),
+    TestCase(
+        "code-with-scope/invalid-code-length-too-large",
+        doc(
+            elem(
+                "",
+                Tag.CodeWithScope,
+                i32le(10),
+                b"\xff\xff\xff\xff",  # strlen (too big)
+                b"\0",
+                doc(),  # Scope
+            )
+        ),
+        """
+        Data { "": CodeWithScope("", {}) }, but the code string length is way too large
+        """,
+        error=corruption_at(6),
+    ),
+    TestCase(
+        "code-with-scope/invalid-scope",
+        doc(elem("foo", Tag.CodeWithScope, code_with_scope("void 0;", doc()[:-1]))),
+        "A code-with-scope element, but the scope document is corrupted",
+        error=corruption_at(13),
+    ),
+    TestCase(
+        "code-with-scope/invalid-scope-key",
+        doc(
+            elem(
+                "code",
+                Tag.CodeWithScope,
+                code_with_scope("void 0;", doc(utf8elem("", "some string"))),
+            )
+        ),
+        "A code-with-scope element, but the socpe contains an empty element key",
+        error=ErrorInfo(
+            "BSON_VALIDATE_EMPTY_KEYS",
+            'Error in scope document for element "code": Element key cannot be an empty string',
+            8,
+        ),
+    ),
+    TestCase(
+        "code-with-scope/corrupt-scope",
+        doc(
+            elem(
+                "code",
+                Tag.CodeWithScope,
+                code_with_scope(
+                    "void 0;",
+                    doc(
+                        elem(
+                            "foo",
+                            Tag.UTF8,
+                            i32le(0),  # Invalid string length
+                            b"\0",
+                        )
+                    ),
+                ),
+            )
+        ),
+        "A code-with-scope element, but the scope contains corruption",
+        error=ErrorInfo("BSON_VALIDATE_CORRUPT", 'Error in scope document for element "code": corrupt BSON', offset=13),
+    ),
+    TestCase(
+        "code-with-scope/corrupt-scope-2",
+        doc(
+            elem(
+                "code",
+                Tag.CodeWithScope,
+                code_with_scope(
+                    "void 0;",
+                    doc(
+                        elem(
+                            "foo",
+                            Tag.UTF8,
+                            b"\xff\xff\xff\xff",  # Invalid string length
+                            b"\0",
+                        )
+                    ),
+                ),
+            )
+        ),
+        "A code-with-scope element, but the scope contains corruption",
+        error=ErrorInfo("BSON_VALIDATE_CORRUPT", 'Error in scope document for element "code": corrupt BSON', offset=13),
+    ),
+    TestCase(
+        "regex/simple",
+        doc(elem("regex", Tag.Regex, b"1234\0gi\0")),
+        """
+        Simple document: { regex: Regex("1234", "gi") }
+        """,
+    ),
+    TestCase(
+        "regex/invalid-opts",
+        doc(elem("regex", Tag.Regex, b"foo\0bar")),
+        """
+        A regular expression element with missing null terminator. The main
+        option string "foo" has a null terminator, but the option component "bar"
+        does not have a null terminator. A naive parse will see the doc's null
+        terminator as the null terminator for the options string, but that's
+        invalid!
+        """,
+        error=corruption_at(18),
+    ),
+    TestCase(
+        "regex/double-null",
+        doc(elem("regex", Tag.Regex, b"foo\0bar\0\0")),
+        """
+        A regular expression element with an extra null terminator. Since regex
+        is delimited by its null terminator, the iterator will stop early before
+        the actual EOD.
+        """,
+        error=corruption_at(21),
+    ),
+    TestCase(
+        "regex/invalid-utf8/accept",
+        doc(elem("regex", Tag.Regex, b"foo\xffbar\0gi\0")),
+        """
+        A regular expression that contains invalid UTf-8.
+        """,
+    ),
+    TestCase(
+        "regex/invalid-utf8/reject",
+        doc(elem("regex", Tag.Regex, b"foo\xffbar\0gi\0")),
+        """
+        A regular expression that contains invalid UTf-8.
+        """,
+        flags=BSON_VALIDATE_UTF8,
+        error=ErrorInfo(BSON_VALIDATE_UTF8, "Text element is not valid UTF-8", 4),
+    ),
+    TestCase(
+        "regex/invalid-utf8/accept-if-absent",
+        doc(elem("regex", Tag.Regex, b"foo\0gi\0")),
+        """
+        A regular valid UTf-8 regex. We check for invalid UTf-8, and accept becaues
+        the regex is fine.
+        """,
+        flags=BSON_VALIDATE_UTF8,
+    ),
+    TestCase(
+        "dbpointer/string-length-zero",
+        doc(
+            elem(
+                "foo",
+                Tag.DBPointer,
+                i32le(0),  # String length (invalid)
+                b"\0",  # Empty string
+                b"\x52\x59\xb5\x6a\xfa\x5b\xd8\x41\xd6\x58\x5d\x99",  # OID
+            )
+        ),
+        """
+        Document { "foo": DBPointer("", <oid>) }, but the length header on the inner
+        string is zero, when it must be at least 1.
+        """,
+        error=corruption_at(9),
+    ),
+    TestCase(
+        "dbpointer/string-length-too-big",
+        doc(
+            elem(
+                "foo",
+                Tag.DBPointer,
+                b"\xff\xff\xff\xff",  # String length  (invalid)
+                b"foobar\0",  # Simple string
+                b"\x52\x59\xb5\x6a\xfa\x5b\xd8\x41\xd6\x58\x5d\x99",  # OID
+            )
+        ),
+        """
+        Document { "foo": DBPointer("foobar", <oid>) }, but the length header on the inner
+        string is far too large
+        """,
+        error=corruption_at(9),
+    ),
+    TestCase(
+        "dbpointer/truncated",
+        doc(
+            utf8elem("a", "b"),
+            elem(
+                "foo",
+                Tag.DBPointer,
+                i32le(7),  # 7 bytes, bleeding into the null terminator
+                b"foobar",  # Simple string, missing a null terminator.
+                b"\x00\x59\xb5\x6a\xfa\x5b\xd8\x41\xd6\x58\x5d\x99",  # OID
+            ),
+            utf8elem("a", "b"),
+        ),
+        """
+        Document { "foo": DBPointer("foobar", <oid>) }, but the length header on
+        the string is one byte too large, causing it to use the first byte of the
+        OID as the null terminator. This should fail when iterating.
+        """,
+        error=corruption_at(43),
+    ),
+    TestCase(
+        "dbpointer/missing-null",
+        doc(
+            elem(
+                "foo",
+                Tag.DBPointer,
+                i32le(4),
+                b"abcd",  # Missing null terminator
+                b"\x52\x59\xb5\x6a\xfa\x5b\xd8\x41\xd6\x58\x5d\x99",  # OID
+            )
+        ),
+        """
+        Document { "foo": DBPointer("abcd", <oid>) }, the length header on
+        the string is 4, but the fourth byte is not a null terminator.
+        """,
+        error=corruption_at(16),
+    ),
+    TestCase(
+        "dbpointer/invalid-utf8/accept",
+        doc(
+            elem(
+                "foo",
+                Tag.DBPointer,
+                string(b"abc\xffdef"),  # String with invalid UTF-8
+                b"\x52\x59\xb5\x6a\xfa\x5b\xd8\x41\xd6\x58\x5d\x99",  # OID
+            )
+        ),
+        """
+        DBPointer document, but the collection string contains invalid UTF-8
+        """,
+    ),
+    TestCase(
+        "dbpointer/invalid-utf8/reject",
+        doc(
+            elem(
+                "foo",
+                Tag.DBPointer,
+                string(b"abc\xffdef"),  # String with invalid UTF-8
+                b"\x52\x59\xb5\x6a\xfa\x5b\xd8\x41\xd6\x58\x5d\x99",  # OID
+            )
+        ),
+        """
+        DBPointer document, but the collection string contains invalid UTF-8
+        """,
+        flags=BSON_VALIDATE_UTF8,
+        error=ErrorInfo(BSON_VALIDATE_UTF8, "Text element is not valid UTF-8", 4),
+    ),
+    TestCase(
+        "dbpointer/invalid-utf8/accept-if-absent",
+        doc(
+            elem(
+                "foo",
+                Tag.DBPointer,
+                string(b"abcdef"),  # Valid string
+                b"\x52\x59\xb5\x6a\xfa\x5b\xd8\x41\xd6\x58\x5d\x99",  # OID
+            )
+        ),
+        """
+        DBPointer document, and we validate UTF-8. Accepts because there is no
+        invalid UTF-8 here.
+        """,
+        flags=BSON_VALIDATE_UTF8,
+    ),
+    TestCase(
+        "subdoc/simple",
+        doc(elem("doc", Tag.Document, doc(utf8elem("foo", "bar")))),
+        """
+        A simple document: { doc: { foo: "bar" } }
+        """,
+    ),
+    TestCase(
+        "subdoc/invalid-shared-null",
+        doc(elem("doc", Tag.Document, doc()[:-1])),
+        """
+        A truncated subdocument element, with its null terminator accidentally
+        overlapping the parent document's null.
+        """,
+        error=corruption_at(9),
+    ),
+    TestCase(
+        "subdoc/overlapping-utf8-null",
+        doc(elem("doc", Tag.Document, doc(utf8elem("bar", "baz\0")[:-1]))),
+        """
+        Encodes the document:
+
+            { "foo": { "bar": "baz" } }
+
+        but the foo.bar UTF-8 string is truncated improperly and reuses the null
+        terminator for "foo"
+        """,
+        error=corruption_at(18),
+    ),
+    TestCase(
+        "subdoc/invalid-element",
+        doc(elem("doc", Tag.Document, doc(elem("dbl", Tag.Double, b"abcd")))),
+        "A subdocument that contains an invalid element",
+        error=corruption_at(18),
+    ),
+    TestCase(
+        "subdoc/header-too-large",
+        doc(
+            elem(
+                "foo",
+                Tag.Document,
+                b"\xf7\xff\xff\xff\0",  # Bad document
+            ),
+        ),
+        """
+        Data {"foo": {}}, but the subdoc header is too large.
+        """,
+        error=corruption_at(9),
+    ),
+    TestCase(
+        "subdoc/header-too-small",
+        doc(
+            elem(
+                "test",
+                Tag.Document,
+                b"\x04\0\0\0",  # Only four bytes. All docs must be at least 5
+            ),
+        ),
+        """
+        Nested document with a header value of 4, which is always too small.
+        """,
+        error=corruption_at(4),
+    ),
+    TestCase(
+        "subdoc/impossible-size",
+        doc(
+            elem(
+                "foo",
+                Tag.Document,
+                b"\xff\xff\xff\xff\0",  # Bad document
+            ),
+        ),
+        """
+        Data {"foo": {}}, but the subdoc header is UINT32_MAX/INT32_MIN, which
+        becomes is an invalid document header.
+        """,
+        error=corruption_at(9),
+    ),
+    TestCase(
+        "null/simple",
+        doc(elem("null", Tag.Null)),
+        """
+        A simple document: { "null": null }
+        """,
+    ),
+    TestCase(
+        "undefined/simple",
+        doc(elem("undefined", Tag.Undefined)),
+        """
+        A simple document: { "undefined": undefined }
+        """,
+    ),
+    TestCase(
+        "binary/simple",
+        doc(elem("binary", Tag.Binary, binary(0x80, b"12345"))),
+        """
+        Simple binary data { "binary": Binary(0x80, b'12345') }
+        """,
+    ),
+    TestCase(
+        "binary/bad-length-zero-subtype-2",
+        doc(
+            elem(
+                "binary",
+                Tag.Binary,
+                i32le(0),  # Invalid: Zero length
+                b"\x02",  # subtype two
+                i32le(4),  # Length of 4
+                b"1234",  # payload
+            ),
+        ),
+        """
+        Binary data that has an invalid length header. It is subtype 2,
+        which means it contains an additional length header.
+        """,
+        error=corruption_at(12),
+    ),
+    TestCase(
+        "binary/bad-length-too-small",
+        doc(
+            elem(
+                "binary",
+                Tag.Binary,
+                i32le(2),  # Length prefix (too small)
+                b"\x80",  # subtype
+                b"1234",  # payload
+            ),
+        ),
+        """
+        Data { "binary": Binary(0x80, b'1234') }, but the length header on
+        the Binary object is too small.
+
+        This won't cause the binary to decode wrong, but it will cause the iterator
+        to jump into the middle of the binary data which will not decode as a
+        proper BSON element.
+        """,
+        error=corruption_at(22),
+    ),
+    TestCase(
+        "binary/bad-length-too-big",
+        doc(
+            elem(
+                "binary",
+                Tag.Binary,
+                b"\xf3\xff\xff\xff",  # Length prefix (too big)
+                b"\x80",  # subtype
+                b"1234",  # data
+            ),
+        ),
+        """
+        Data { "binary": Binary(0x80, b'1234') }, but the length header on
+        the Binary object is too large.
+        """,
+        error=corruption_at(12),
+    ),
+    TestCase(
+        "binary/old-invalid/1",
+        doc(
+            elem(
+                "binary",
+                Tag.Binary,
+                binary(
+                    2,
+                    i32le(5),  # Bad length prefix: Should be 4
+                    b"abcd",
+                ),
+            ),
+        ),
+        """
+        This is an old-style binary type 0x2. It has an inner length header of 5,
+        but it should be 4.
+        """,
+        error=corruption_at(17),
+    ),
+    TestCase(
+        "binary/old-invalid/2",
+        doc(
+            elem(
+                "bin",
+                Tag.Binary,
+                binary(
+                    2,
+                    b"abc",  # Bad: Subtype 2 requires at least four bytes
+                ),
+            )
+        ),
+        """
+        This is an old-style binary type 0x2. The data segment is too small to
+        be valid.
+        """,
+        error=corruption_at(9),
+    ),
+    TestCase(
+        "minkey/simple",
+        doc(elem("min", Tag.MinKey)),
+        "A simple document with a MinKey element",
+    ),
+    TestCase(
+        "maxkey/simple",
+        doc(elem("max", Tag.MaxKey)),
+        "A simple document with a MaxKey element",
+    ),
+    TestCase(
+        "int32/simple",
+        doc(elem("int32", Tag.Int32, i32le(42))),
+        "A simple document with a valid single int32 element",
+    ),
+    TestCase(
+        "int32/truncated",
+        doc(elem("int32-truncated", Tag.Int32, i32le(42)[:-1])),
+        "Truncated 32-bit integer",
+        error=corruption_at(21),
+    ),
+    TestCase("timestamp/simple", doc(elem("timestamp", Tag.Timestamp, i64le(1729))), """A simple timestamp element"""),
+    TestCase(
+        "timestamp/truncated",
+        doc(elem("timestamp", Tag.Timestamp, i64le(1729)[:-1])),
+        """A truncated timestamp element""",
+        error=corruption_at(15),
+    ),
+    TestCase(
+        "int64/simple",
+        doc(elem("int64", Tag.Int64, i64le(1729))),
+        "A simple document with a valid single int64 element",
+    ),
+    TestCase(
+        "int64/truncated",
+        doc(elem("int64-truncated", Tag.Int64, i64le(1729)[:-1])),
+        "Truncated 64-bit integer",
+        error=corruption_at(21),
+    ),
+    TestCase(
+        "double/simple",
+        doc(elem("double", Tag.Double, f64le(3.14))),
+        "Simple float64 element",
+    ),
+    TestCase(
+        "double/truncated",
+        doc(elem("double-truncated", Tag.Double, f64le(3.13)[:-1])),
+        "Truncated 64-bit float",
+        error=corruption_at(22),
+    ),
+    TestCase(
+        "boolean/simple-false",
+        doc(elem("bool", Tag.Boolean, b"\x00")),
+        """A simple boolean 'false'""",
+    ),
+    TestCase(
+        "boolean/simple-true",
+        doc(elem("bool", Tag.Boolean, b"\x01")),
+        """A simple boolean 'true'""",
+    ),
+    TestCase(
+        "boolean/invalid",
+        doc(elem("bool", Tag.Boolean, b"\xc3")),
+        """
+        In invalid boolean octet. Must be '0' or '1', but is 0xc3.
+        """,
+        error=corruption_at(10),
+    ),
+    TestCase(
+        "datetime/simple",
+        doc(elem("utc", Tag.Datetime, b"\x0b\x98\x8c\x2b\x33\x01\x00\x00")),
+        "Simple datetime element",
+    ),
+    TestCase(
+        "datetime/truncated",
+        doc(elem("utc", Tag.Datetime, b"\x0b\x98\x8c\x2b\x33\x01\x00")),
+        "Truncated datetime element",
+        error=corruption_at(9),
+    ),
+    # DBRef
+    TestCase(
+        "dbref/missing-id",
+        doc(utf8elem("$ref", "foo")),
+        """This dbref document is missing an $id element""",
+        flags=BSON_VALIDATE_DOLLAR_KEYS,
+        error=ErrorInfo(BSON_VALIDATE_DOLLAR_KEYS, MSG_EXPECTED_ID_FOLLOWING_REF, 18),
+    ),
+    TestCase(
+        "dbref/non-id",
+        doc(utf8elem("$ref", "foo"), utf8elem("bar", "baz")),
+        """
+        The 'bar' element should be an '$id' element.
+        """,
+        flags=BSON_VALIDATE_DOLLAR_KEYS,
+        error=ErrorInfo(BSON_VALIDATE_DOLLAR_KEYS, MSG_EXPECTED_ID_FOLLOWING_REF, 18),
+    ),
+    TestCase(
+        "dbref/not-first-elements",
+        doc(utf8elem("foo", "bar"), utf8elem("$ref", "a"), utf8elem("$id", "b")),
+        """
+        This would be a valid DBRef, but the "$ref" key must come first.
+        """,
+        flags=BSON_VALIDATE_DOLLAR_KEYS,
+        error=ErrorInfo(BSON_VALIDATE_DOLLAR_KEYS, disallowed_key("$ref"), 17),
+    ),
+    TestCase(
+        "dbref/ref-without-id-with-db",
+        doc(utf8elem("$ref", "foo"), utf8elem("$db", "bar")),
+        """
+        There should be an $id element, but we skip straight to $db
+        """,
+        flags=BSON_VALIDATE_DOLLAR_KEYS,
+        error=ErrorInfo(BSON_VALIDATE_DOLLAR_KEYS, MSG_EXPECTED_ID_FOLLOWING_REF, 18),
+    ),
+    TestCase(
+        "dbref/non-string-ref",
+        doc(elem("$ref", Tag.Int32, i32le(42))),
+        """
+        The $ref element must be a string, but is an integer.
+        """,
+        flags=BSON_VALIDATE_DOLLAR_KEYS,
+        error=ErrorInfo(BSON_VALIDATE_DOLLAR_KEYS, "$ref element must be a UTF-8 element", 4),
+    ),
+    TestCase(
+        "dbref/non-string-db",
+        doc(
+            utf8elem("$ref", "foo"),
+            utf8elem("$id", "bar"),
+            elem("$db", Tag.Int32, i32le(42)),
+        ),
+        """
+        The $db element should be a string, but is an integer.
+        """,
+        flags=BSON_VALIDATE_DOLLAR_KEYS,
+        error=ErrorInfo(BSON_VALIDATE_DOLLAR_KEYS, "$db element in DBRef must be a UTF-8 element", 31),
+    ),
+    TestCase(
+        "dbref/invalid-extras-between",
+        doc(
+            utf8elem("$ref", "foo"),
+            utf8elem("$id", "bar"),
+            utf8elem("extra", "field"),
+            utf8elem("$db", "baz"),
+        ),
+        """
+        Almost a valid DBRef, but there is an extra field before $db. We reject $db
+        as an invalid key.
+        """,
+        flags=BSON_VALIDATE_DOLLAR_KEYS,
+        error=ErrorInfo(BSON_VALIDATE_DOLLAR_KEYS, disallowed_key("$db"), 48),
+    ),
+    TestCase(
+        "dbref/invalid-double-ref",
+        doc(
+            utf8elem("$ref", "foo"),
+            utf8elem("$ref", "bar"),
+            utf8elem("$id", "baz"),
+        ),
+        """
+        Invalid DBRef contains a second $ref element.
+        """,
+        flags=BSON_VALIDATE_DOLLAR_KEYS,
+        error=ErrorInfo(BSON_VALIDATE_DOLLAR_KEYS, MSG_EXPECTED_ID_FOLLOWING_REF, 18),
+    ),
+    TestCase(
+        "dbref/invalid-missing-ref",
+        doc(utf8elem("$id", "foo")),
+        """
+        DBRef document requires a $ref key to be first.
+        """,
+        flags=BSON_VALIDATE_DOLLAR_KEYS,
+        error=ErrorInfo(BSON_VALIDATE_DOLLAR_KEYS, disallowed_key("$id"), 4),
+    ),
+    TestCase(
+        "dbref/valid/simple",
+        doc(utf8elem("$ref", "foo"), utf8elem("$id", "bar")),
+        """
+        This is a simple valid DBRef element.
+        """,
+        flags=BSON_VALIDATE_DOLLAR_KEYS,
+    ),
+    TestCase(
+        "dbref/valid/simple-with-db",
+        doc(utf8elem("$ref", "foo"), utf8elem("$id", "bar"), utf8elem("$db", "baz")),
+        """
+        A simple DBRef of the form:
+
+            { $ref: "foo", $id: "bar", $db: "baz" }
+        """,
+        flags=BSON_VALIDATE_DOLLAR_KEYS,
+    ),
+    TestCase(
+        "dbref/valid/nested-id-doc",
+        doc(
+            utf8elem("$ref", "foo"),
+            elem(
+                "$id",
+                Tag.Document,
+                doc(
+                    utf8elem("$ref", "foo2"),
+                    utf8elem("$id", "bar2"),
+                    utf8elem("$db", "baz2"),
+                ),
+            ),
+            utf8elem("$db", "baz"),
+        ),
+        """
+        This is a valid DBRef of the form:
+
+            { $ref: foo, $id: { $ref: "foo2", $id: "bar2", $db: "baz2" }, $db: "baz" }
+        """,
+        flags=BSON_VALIDATE_DOLLAR_KEYS,
+    ),
+    TestCase(
+        "dbref/valid/trailing-content",
+        doc(
+            utf8elem("$ref", "foo"),
+            utf8elem("$id", "bar"),
+            utf8elem("$db", "baz"),
+            utf8elem("extra", "field"),
+        ),
+        """
+        A valid DBRef of the form:
+
+            {
+                $ref: "foo",
+                $id: "bar",
+                $db: "baz",
+                extra: "field",
+            }
+        """,
+        flags=BSON_VALIDATE_DOLLAR_KEYS,
+    ),
+    TestCase(
+        "dbref/valid/trailing-content-no-db",
+        doc(
+            utf8elem("$ref", "foo"),
+            utf8elem("$id", "bar"),
+            utf8elem("extra", "field"),
+        ),
+        """
+        A valid DBRef of the form:
+
+            {
+                $ref: "foo",
+                $id: "bar",
+                extra: "field",
+            }
+        """,
+        flags=BSON_VALIDATE_DOLLAR_KEYS,
+    ),
+]
+
+if __name__ == "__main__":
+    # We don't take an arguments, but error if any are given
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.parse_args()
+    # Start with the header
+    print(HEADER)
+    # Print each test case
+    for c in CASES:
+        print()
+        for part in generate(c):
+            print(part, end="")
+
+    # Print the registration function
+    print(f"\n{GENERATED_NOTE}")
+    print("void test_install_generated_bson_validation(TestSuite* suite) {")
+    for c in CASES:
+        print(f'  TestSuite_Add(suite, "/bson/validate/" {json.dumps(c.name)}, {c.fn_name});')
+    print("}")

--- a/src/libbson/tests/validate-tests.py
+++ b/src/libbson/tests/validate-tests.py
@@ -149,7 +149,7 @@ class TestCase:
     """
 
     name: str
-    """The name of the test case, as displayed in test runners, which will valid a "/bson/validate" prefix"""
+    """The name of the test case, as displayed in test runners, which will have a "/bson/validate" prefix"""
     data: bytes
     """The bytes that will be injested by `bson_init_static` to form the document to be validated"""
     description: str | None
@@ -490,7 +490,7 @@ CASES: list[TestCase] = [
         "utf8-key/invalid/accept",
         doc(utf8elem(b"abc\xffdef", "bar")),
         """
-        The element key is not valid UTf-8, but we acecpt it if we don't do
+        The element key is not valid UTf-8, but we accept it if we don't do
         UTF-8 validation.
         """,
     ),
@@ -773,14 +773,14 @@ CASES: list[TestCase] = [
         "regex/invalid-utf8/accept",
         doc(elem("regex", Tag.Regex, b"foo\xffbar\0gi\0")),
         """
-        A regular expression that contains invalid UTf-8.
+        A regular expression that contains invalid UTF-8.
         """,
     ),
     TestCase(
         "regex/invalid-utf8/reject",
         doc(elem("regex", Tag.Regex, b"foo\xffbar\0gi\0")),
         """
-        A regular expression that contains invalid UTf-8.
+        A regular expression that contains invalid UTF-8.
         """,
         flags=BSON_VALIDATE_UTF8,
         error=ErrorInfo(BSON_VALIDATE_UTF8, "Text element is not valid UTF-8", 4),
@@ -1167,7 +1167,7 @@ CASES: list[TestCase] = [
         "boolean/invalid",
         doc(elem("bool", Tag.Boolean, b"\xc3")),
         """
-        In invalid boolean octet. Must be '0' or '1', but is 0xc3.
+        An invalid boolean octet. Must be '0' or '1', but is 0xc3.
         """,
         error=corruption_at(10),
     ),

--- a/src/libbson/tests/validate-tests.py
+++ b/src/libbson/tests/validate-tests.py
@@ -262,8 +262,8 @@ BSON_VALIDATE_UTF8 = "BSON_VALIDATE_UTF8"
 MSG_EXPECTED_ID_FOLLOWING_REF = "Expected an $id element following $ref"
 
 
-def disallowed_key(k: str) -> str:
-    return f'Disallowed element key: "{k}"'
+def disallowed_key(char: str, k: str) -> str:
+    return f"Disallowed '{char}' in element key: \"{k}\""
 
 
 # d888888b d88888b .d8888. d888888b       .o88b.  .d8b.  .d8888. d88888b .d8888.
@@ -361,7 +361,7 @@ CASES: list[TestCase] = [
         it.
         """,
         flags="BSON_VALIDATE_DOT_KEYS",
-        error=ErrorInfo("BSON_VALIDATE_DOT_KEYS", disallowed_key("foo.bar"), 13),
+        error=ErrorInfo("BSON_VALIDATE_DOT_KEYS", disallowed_key(".", "foo.bar"), 13),
     ),
     TestCase(
         "key/dot/accept-if-absent",
@@ -385,7 +385,7 @@ CASES: list[TestCase] = [
         We can reject an element key that starts with a dollar '$' sign.
         """,
         flags=BSON_VALIDATE_DOLLAR_KEYS,
-        error=ErrorInfo(BSON_VALIDATE_DOLLAR_KEYS, disallowed_key("$foo"), 13),
+        error=ErrorInfo(BSON_VALIDATE_DOLLAR_KEYS, disallowed_key("$", "$foo"), 13),
     ),
     TestCase(
         "key/dollar/accept-in-middle",
@@ -1211,7 +1211,7 @@ CASES: list[TestCase] = [
         This would be a valid DBRef, but the "$ref" key must come first.
         """,
         flags=BSON_VALIDATE_DOLLAR_KEYS,
-        error=ErrorInfo(BSON_VALIDATE_DOLLAR_KEYS, disallowed_key("$ref"), 17),
+        error=ErrorInfo(BSON_VALIDATE_DOLLAR_KEYS, disallowed_key("$", "$ref"), 17),
     ),
     TestCase(
         "dbref/ref-without-id-with-db",
@@ -1257,7 +1257,7 @@ CASES: list[TestCase] = [
         as an invalid key.
         """,
         flags=BSON_VALIDATE_DOLLAR_KEYS,
-        error=ErrorInfo(BSON_VALIDATE_DOLLAR_KEYS, disallowed_key("$db"), 48),
+        error=ErrorInfo(BSON_VALIDATE_DOLLAR_KEYS, disallowed_key("$", "$db"), 48),
     ),
     TestCase(
         "dbref/invalid-double-ref",
@@ -1279,7 +1279,7 @@ CASES: list[TestCase] = [
         DBRef document requires a $ref key to be first.
         """,
         flags=BSON_VALIDATE_DOLLAR_KEYS,
-        error=ErrorInfo(BSON_VALIDATE_DOLLAR_KEYS, disallowed_key("$id"), 4),
+        error=ErrorInfo(BSON_VALIDATE_DOLLAR_KEYS, disallowed_key("$", "$id"), 4),
     ),
     TestCase(
         "dbref/valid/simple",

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -1000,7 +1000,6 @@ set (test-libmongoc-sources
    ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-utf8.c
    ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-validate.generated.c
    ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-value.c
-   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-validate.generated.c
    ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-writer.c
    ${PROJECT_SOURCE_DIR}/tests/bsonutil/bson-match.c
    ${PROJECT_SOURCE_DIR}/tests/bsonutil/bson-parser.c

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -998,7 +998,9 @@ set (test-libmongoc-sources
    ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-reader.c
    ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-string.c
    ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-utf8.c
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-validate.generated.c
    ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-value.c
+   ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-validate.generated.c
    ${mongo-c-driver_SOURCE_DIR}/src/libbson/tests/test-writer.c
    ${PROJECT_SOURCE_DIR}/tests/bsonutil/bson-match.c
    ${PROJECT_SOURCE_DIR}/tests/bsonutil/bson-parser.c

--- a/src/libmongoc/src/mongoc/mongoc-util.c
+++ b/src/libmongoc/src/mongoc/mongoc-util.c
@@ -35,14 +35,19 @@
 #include <mlib/cmp.h>
 #include <mlib/loop.h>
 
-const bson_validate_flags_t _mongoc_default_insert_vflags =
-   BSON_VALIDATE_UTF8 | BSON_VALIDATE_UTF8_ALLOW_NULL | BSON_VALIDATE_EMPTY_KEYS;
-
-const bson_validate_flags_t _mongoc_default_replace_vflags =
-   BSON_VALIDATE_UTF8 | BSON_VALIDATE_UTF8_ALLOW_NULL | BSON_VALIDATE_EMPTY_KEYS;
-
-const bson_validate_flags_t _mongoc_default_update_vflags =
-   BSON_VALIDATE_UTF8 | BSON_VALIDATE_UTF8_ALLOW_NULL | BSON_VALIDATE_EMPTY_KEYS;
+/**
+ * ! NOTE
+ *
+ * In earlier releases, these flags had `BSON_VALIDATE_UTF8` and `BSON_VALIDATE_UTF8_ALLOW_NULL`.
+ * Due to a bug, the CRUD APIs did not actually do UTF-8 validation. This issue has been fixed, but
+ * we want to maintain backward compatibility, so the UTF-8 validation was removed from these flag
+ * values.
+ *
+ * A future API may add the UTF-8 validation back, but it would be a breaking change.
+ */
+const bson_validate_flags_t _mongoc_default_insert_vflags = BSON_VALIDATE_EMPTY_KEYS;
+const bson_validate_flags_t _mongoc_default_replace_vflags = BSON_VALIDATE_EMPTY_KEYS;
+const bson_validate_flags_t _mongoc_default_update_vflags = BSON_VALIDATE_EMPTY_KEYS;
 
 int
 _mongoc_rand_simple (unsigned int *seed)

--- a/src/libmongoc/tests/test-libmongoc-main.c
+++ b/src/libmongoc/tests/test-libmongoc-main.c
@@ -33,6 +33,7 @@ main (int argc, char *argv[])
    TEST_INSTALL (test_bson_install);
    TEST_INSTALL (test_bson_version_install);
    TEST_INSTALL (test_bson_vector_install);
+   TEST_INSTALL (test_install_generated_bson_validation);
    TEST_INSTALL (test_clock_install);
    TEST_INSTALL (test_decimal128_install);
    TEST_INSTALL (test_endian_install);

--- a/src/libmongoc/tests/test-mongoc-bulk.c
+++ b/src/libmongoc/tests/test-mongoc-bulk.c
@@ -442,7 +442,7 @@ test_insert_check_keys (void)
    mongoc_bulk_operation_insert (bulk, tmp_bson ("{'': 1}"));
    r = (bool) mongoc_bulk_operation_execute (bulk, &reply, &error);
    BSON_ASSERT (!r);
-   ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "empty key");
+   ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "empty string");
 
    BSON_ASSERT (bson_empty (&reply));
 
@@ -457,7 +457,7 @@ test_insert_check_keys (void)
    mongoc_bulk_operation_insert (bulk, tmp_bson ("{'': 1}"));
    r = (bool) mongoc_bulk_operation_execute (bulk, &reply, &error);
    BSON_ASSERT (!r);
-   ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "empty key");
+   ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "empty string");
 
    BSON_ASSERT (bson_empty (&reply));
 
@@ -833,7 +833,7 @@ test_update_with_opts_validate (void)
       ASSERT_ERROR_CONTAINS (error,
                              MONGOC_ERROR_COMMAND,
                              MONGOC_ERROR_COMMAND_INVALID_ARG,
-                             "invalid argument for update: keys cannot contain \".\": \"a.a\"");
+                             "invalid argument for update: Disallowed element key: \"a.a\"");
       mongoc_bulk_operation_destroy (bulk);
 
       /* Test a valid update_one with explicit validation on the server. */
@@ -1172,7 +1172,7 @@ test_replace_one_with_opts_validate (void)
    ASSERT_ERROR_CONTAINS (error,
                           MONGOC_ERROR_COMMAND,
                           MONGOC_ERROR_COMMAND_INVALID_ARG,
-                          "invalid argument for replace: keys cannot contain \".\": \"a.a\"");
+                          "invalid argument for replace: Disallowed element key: \"a.a\"");
 
    mongoc_bulk_operation_destroy (bulk);
 
@@ -1783,7 +1783,7 @@ _test_insert_invalid (bool with_opts, bool invalid_first)
    bson_t reply;
    bson_error_t error;
    bool r;
-   const char *err = "empty key";
+   const char *err = "empty string";
 
    client = test_framework_new_default_client ();
    collection = get_test_collection (client, "test_insert_validate");
@@ -1899,7 +1899,7 @@ test_insert_with_opts_validate (void)
    bulk = mongoc_collection_create_bulk_operation_with_opts (collection, NULL);
 
    BSON_ASSERT (!mongoc_bulk_operation_insert_with_opts (bulk, tmp_bson ("{'': 1}"), NULL, &error));
-   ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "empty key");
+   ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "empty string");
 
    ASSERT_OR_PRINT (mongoc_bulk_operation_insert_with_opts (
                        bulk, tmp_bson ("{'': 1}"), tmp_bson ("{'validate': %d}", BSON_VALIDATE_NONE), &error),
@@ -1913,7 +1913,7 @@ test_insert_with_opts_validate (void)
    ASSERT_ERROR_CONTAINS (error,
                           MONGOC_ERROR_COMMAND,
                           MONGOC_ERROR_COMMAND_INVALID_ARG,
-                          "invalid document for insert: keys cannot contain \".\": \"a.a\"");
+                          "invalid document for insert: Disallowed element key: \"a.a\"");
 
    mongoc_bulk_operation_destroy (bulk);
 
@@ -1967,7 +1967,7 @@ _test_remove_validate (remove_validate_test_t *test)
                              MONGOC_ERROR_COMMAND,
                              MONGOC_ERROR_COMMAND_INVALID_ARG,
                              "Bulk operation is invalid from prior error: "
-                             "invalid document for insert: empty key");
+                             "invalid document for insert: Element key cannot be an empty string");
    } else {
       test->remove (bulk, tmp_bson (NULL));
    }
@@ -1979,8 +1979,10 @@ _test_remove_validate (remove_validate_test_t *test)
    r = (bool) mongoc_bulk_operation_execute (bulk, &reply, &error);
    BSON_ASSERT (!r);
    BSON_ASSERT (bson_empty (&reply));
-   ASSERT_ERROR_CONTAINS (
-      error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "invalid document for insert: empty key");
+   ASSERT_ERROR_CONTAINS (error,
+                          MONGOC_ERROR_COMMAND,
+                          MONGOC_ERROR_COMMAND_INVALID_ARG,
+                          "invalid document for insert: Element key cannot be an empty string");
 
    bson_destroy (&reply);
    mongoc_bulk_operation_destroy (bulk);

--- a/src/libmongoc/tests/test-mongoc-bulk.c
+++ b/src/libmongoc/tests/test-mongoc-bulk.c
@@ -833,7 +833,7 @@ test_update_with_opts_validate (void)
       ASSERT_ERROR_CONTAINS (error,
                              MONGOC_ERROR_COMMAND,
                              MONGOC_ERROR_COMMAND_INVALID_ARG,
-                             "invalid argument for update: Disallowed element key: \"a.a\"");
+                             "invalid argument for update: Disallowed '.' in element key: \"a.a\"");
       mongoc_bulk_operation_destroy (bulk);
 
       /* Test a valid update_one with explicit validation on the server. */
@@ -1172,7 +1172,7 @@ test_replace_one_with_opts_validate (void)
    ASSERT_ERROR_CONTAINS (error,
                           MONGOC_ERROR_COMMAND,
                           MONGOC_ERROR_COMMAND_INVALID_ARG,
-                          "invalid argument for replace: Disallowed element key: \"a.a\"");
+                          "invalid argument for replace: Disallowed '.' in element key: \"a.a\"");
 
    mongoc_bulk_operation_destroy (bulk);
 
@@ -1913,7 +1913,7 @@ test_insert_with_opts_validate (void)
    ASSERT_ERROR_CONTAINS (error,
                           MONGOC_ERROR_COMMAND,
                           MONGOC_ERROR_COMMAND_INVALID_ARG,
-                          "invalid document for insert: Disallowed element key: \"a.a\"");
+                          "invalid document for insert: Disallowed '.' in element key: \"a.a\"");
 
    mongoc_bulk_operation_destroy (bulk);
 

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -2793,7 +2793,7 @@ _test_insert_validate (insert_fn_t insert_fn)
    ASSERT_ERROR_CONTAINS (error,
                           MONGOC_ERROR_COMMAND,
                           MONGOC_ERROR_COMMAND_INVALID_ARG,
-                          "invalid document for insert: Disallowed element key: \"a.a\"");
+                          "invalid document for insert: Disallowed '.' in element key: \"a.a\"");
 
    /* {validate: true} is still prohibited */
    BSON_ASSERT (!insert_fn (collection, tmp_bson ("{'a': 1}"), tmp_bson ("{'validate': true}"), &error));
@@ -4126,7 +4126,7 @@ _test_update_validate (update_fn_t update_fn)
    /* bson_validate_with_error will yield a different error message than the
     * standard key check in _mongoc_validate_replace */
    if (update_fn == mongoc_collection_replace_one) {
-      msg = "invalid argument for replace: Disallowed element key: \"$set\"";
+      msg = "invalid argument for replace: Disallowed '$' in element key: \"$set\"";
    }
 
    ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, msg);

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -944,7 +944,7 @@ test_update (void)
       bson_t *u = tmp_bson ("{'': 1 }");
       bool ok = mongoc_collection_update (coll, MONGOC_UPDATE_NONE, q, u, NULL, &error);
       ASSERT (!ok);
-      ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "empty key");
+      ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "empty string");
    }
 
    // Test a successful replacement:
@@ -2777,7 +2777,7 @@ _test_insert_validate (insert_fn_t insert_fn)
    collection = get_test_collection (client, "test_insert_validate");
 
    BSON_ASSERT (!insert_fn (collection, tmp_bson ("{'': 1}"), NULL, &error));
-   ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "empty key");
+   ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, "empty string");
 
    BSON_ASSERT (!insert_fn (collection, tmp_bson ("{'_id': {'$a': 1}}"), tmp_bson ("{'validate': false}"), &error));
    ASSERT_CMPUINT32 (error.domain, ==, (uint32_t) MONGOC_ERROR_SERVER);
@@ -2793,7 +2793,7 @@ _test_insert_validate (insert_fn_t insert_fn)
    ASSERT_ERROR_CONTAINS (error,
                           MONGOC_ERROR_COMMAND,
                           MONGOC_ERROR_COMMAND_INVALID_ARG,
-                          "invalid document for insert: keys cannot contain \".\": \"a.a\"");
+                          "invalid document for insert: Disallowed element key: \"a.a\"");
 
    /* {validate: true} is still prohibited */
    BSON_ASSERT (!insert_fn (collection, tmp_bson ("{'a': 1}"), tmp_bson ("{'validate': true}"), &error));
@@ -4126,7 +4126,7 @@ _test_update_validate (update_fn_t update_fn)
    /* bson_validate_with_error will yield a different error message than the
     * standard key check in _mongoc_validate_replace */
    if (update_fn == mongoc_collection_replace_one) {
-      msg = "invalid argument for replace: keys cannot begin with \"$\": \"$set\"";
+      msg = "invalid argument for replace: Disallowed element key: \"$set\"";
    }
 
    ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_COMMAND, MONGOC_ERROR_COMMAND_INVALID_ARG, msg);

--- a/src/libmongoc/tests/test-mongoc-cursor.c
+++ b/src/libmongoc/tests/test-mongoc-cursor.c
@@ -1152,7 +1152,10 @@ test_cursor_new_invalid_filter (void)
 
    ASSERT (cursor);
    ASSERT (mongoc_cursor_error (cursor, &error));
-   ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_CURSOR, MONGOC_ERROR_CURSOR_INVALID_CURSOR, "Invalid filter: empty key");
+   ASSERT_ERROR_CONTAINS (error,
+                          MONGOC_ERROR_CURSOR,
+                          MONGOC_ERROR_CURSOR_INVALID_CURSOR,
+                          "Invalid filter: Element key cannot be an empty string");
 
    ASSERT (mongoc_cursor_error_document (cursor, &error, &error_doc));
    ASSERT (bson_empty (error_doc));
@@ -1179,7 +1182,10 @@ test_cursor_new_invalid_opts (void)
 
    ASSERT (cursor);
    ASSERT (mongoc_cursor_error (cursor, &error));
-   ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_CURSOR, MONGOC_ERROR_CURSOR_INVALID_CURSOR, "Invalid opts: empty key");
+   ASSERT_ERROR_CONTAINS (error,
+                          MONGOC_ERROR_CURSOR,
+                          MONGOC_ERROR_CURSOR_INVALID_CURSOR,
+                          "Invalid opts: Element key cannot be an empty string");
 
    ASSERT (mongoc_cursor_error_document (cursor, &error, &error_doc));
    ASSERT (bson_empty (error_doc));


### PR DESCRIPTION
This changeset is a large refactor of the `bson_validate` implementation.

Existing validation test cases were rewritten to use a uniform code generation mechanism that notes the purpose of each case. Many more validation scenarios were added.

The `BSON_VALIDATE_UTF8` flags have been removed from the default flags used by the CRUD API. Because of a bug, UTF-8 validation wasn't being applied to the CRUD API, so removing the flag is necessary since it would otherwise be a breaking change.

The new validation is written as a straightforward recursive algorithm, and doesn't use the error-prone `bson_visit` API.

The following changes are of note:

1. The error code `BSON_VALIDATE_CORRUPT` is now set on corruption. Previously, this was set to `BSON_VALIDATE_NONE`, which had a value of zero. This was very confusing, as it was also set to zero in case of success.
2. Doc comments are added to better explain the behavior of the validation flags.
3. The "error offset" parameter is now adjusted properly in the case of document nesting.
4. Error message strings have been updated and made more explanatory.
5. BSON data that has over 1000 levels of nesting is now rejected, unconditionally.