### PR TITLE
Exclude -Wpre-c11-compat warnings from public-header-warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,7 @@ target_compile_options(public-header-warnings PRIVATE
   $<$<C_COMPILER_ID:AppleClang,Clang,GNU>:-Wno-declaration-after-statement>
   $<$<C_COMPILER_ID:AppleClang,Clang,GNU>:-Wno-disabled-macro-expansion>
   $<$<C_COMPILER_ID:AppleClang,Clang>:-Wno-c++98-compat-pedantic>
+  $<$<C_COMPILER_ID:AppleClang,Clang>:-Wno-pre-c11-compat>
   $<$<C_COMPILER_ID:AppleClang,Clang>:-Wno-pre-c2x-compat>
   $<$<C_COMPILER_ID:AppleClang,Clang>:-Wno-unsafe-buffer-usage>
   $<$<C_COMPILER_ID:AppleClang,Clang>:-Wno-padded>


### PR DESCRIPTION
Addresses C standard conformance task failures due to the `rhel93` distro updating its system Clang compiler version from 16 to 19 (possibly by accident?). Clang 19 introduces a new [`-Wpre-c11-compat`](https://releases.llvm.org/19.1.0/tools/clang/docs/DiagnosticsReference.html#wpre-c11-compat) warning which is triggering `-Werror` compilation errors when building the `public-header-warnings` target. Regardless whether the upgrade was intentional or not, we should add this warning to our list anyways.