### PR TITLE
Migrate EVG tasks from RHEL 7.6 to RHEL 7.9

### DIFF
--- a/.evergreen/config_generator/components/c_std_compile.py
+++ b/.evergreen/config_generator/components/c_std_compile.py
@@ -28,7 +28,7 @@ MATRIX = [
     ('rhel94',     'clang',    None, [99, 11, 17, 23]), # Clang 17.0 (max: C2x)
     ('rhel95',     'clang',    None, [99, 11, 17, 23]), # Clang 18.0 (max: C23)
 
-    ('rhel76',     'gcc',    None, [99, 11,       ]), # GCC 4.8 (max: C11)
+    ('rhel7.9',    'gcc',    None, [99, 11,       ]), # GCC 4.8 (max: C11)
     ('rhel80',     'gcc',    None, [99, 11, 17,   ]), # GCC 8.2 (max: C17)
     ('debian10',   'gcc-8',  None, [99, 11, 17,   ]), # GCC 8.3 (max: C17)
     ('rhel84',     'gcc',    None, [99, 11, 17,   ]), # GCC 8.4 (max: C17)

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -61,7 +61,7 @@ MACOS_ARM64_DISTROS = [
 ]
 
 RHEL_DISTROS = [
-    *ls_distro(name='rhel76', os='rhel', os_type='linux', os_ver='7.6'),
+    *ls_distro(name='rhel7.9', os='rhel', os_type='linux', os_ver='7.9'),
     *ls_distro(name='rhel80', os='rhel', os_type='linux', os_ver='8.0'),
     *ls_distro(name='rhel84', os='rhel', os_type='linux', os_ver='8.4'),
     *ls_distro(name='rhel90', os='rhel', os_type='linux', os_ver='9.0'),

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -4910,9 +4910,9 @@ tasks:
           CC: gcc-10
           CXX: g++-10
           C_STD_VERSION: 11
-  - name: std-c11-rhel76-gcc-compile
-    run_on: rhel76-large
-    tags: [std-matrix, rhel76, gcc, compile, std-c11]
+  - name: std-c11-rhel7.9-gcc-compile
+    run_on: rhel7.9-large
+    tags: [std-matrix, rhel7.9, gcc, compile, std-c11]
     commands:
       - func: find-cmake-latest
       - func: std-compile
@@ -5510,9 +5510,9 @@ tasks:
           CC: gcc-10
           CXX: g++-10
           C_STD_VERSION: 99
-  - name: std-c99-rhel76-gcc-compile
-    run_on: rhel76-large
-    tags: [std-matrix, rhel76, gcc, compile, std-c99]
+  - name: std-c99-rhel7.9-gcc-compile
+    run_on: rhel7.9-large
+    tags: [std-matrix, rhel7.9, gcc, compile, std-c99]
     commands:
       - func: find-cmake-latest
       - func: std-compile


### PR DESCRIPTION
Per DevProd guidance. RHEL 7.9 is the latest RHEL 7 minor release and the one which is currently recommended for use by DevProd. This distro does not significantly change the available toolchain used for compilation test coverage (still GCC 4.8.5).