### PR TITLE
[CDRIVER-6030] sphinx: Pass outfilename as keyword argument to handle_page()

### DIFF
--- a/build/sphinx/mongoc_common.py
+++ b/build/sphinx/mongoc_common.py
@@ -158,7 +158,10 @@ def generate_html_redirs(app: Sphinx, page: str, templatename: str, context: Dic
         f"redirect-for-{page}",
         {"target": page, "writing-redirect": 1},
         str(Path(__file__).parent.resolve() / "redirect.t.html"),
-        outfilename=str(redirect_file),
+        # Note: In Sphinx 8.2, this argument changed from `str` to `Path`, but
+        # continues to work with `str`. A future version might need this changed
+        # to pass a `Path`, but we can keep `str` for now.
+        outfilename=str(redirect_file),  # type: ignore
     )
     # Restore prior state:
     builder.script_files[:] = prev_scripts


### PR DESCRIPTION
This fixes an error with Sphinx 8.2, because commit sphinx-doc/sphinx@285908aa073e5320d5f5a8b4648a2265c76a3f32 added `*` to the function signature (which means that all arguments starting from 4th are keyword-only).

The error was:
```pytb
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/sphinx/events.py", line 404, in emit
    results.append(listener.handler(self.app, *args))
                   ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/tmp/mongo-c-driver-1.30.4/build/sphinx/mongoc_common.py", line 157, in generate_html_redirs
    builder.handle_page(
    ~~~~~~~~~~~~~~~~~~~^
        f"redirect-for-{page}",
        ^^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        str(redirect_file),
        ^^^^^^^^^^^^^^^^^^^
    )
    ^
TypeError: StandaloneHTMLBuilder.handle_page() takes from 3 to 4 positional arguments but 5 were given
```

See also downstream (Ubuntu) bug report: <https://bugs.launchpad.net/ubuntu/+source/mongo-c-driver/+bug/2113467>.