### PR TITLE
[CDRIVER-6017] Reduce `BSON_VALIDATION_MAX_NESTING_DEPTH` to 500

### DIFF
--- a/src/libbson/src/bson/validate-private.h
+++ b/src/libbson/src/bson/validate-private.h
@@ -15,7 +15,7 @@ enum {
     * server might accept. The main purpose of this limit is to prevent stack
     * overflow, not to reject invalid data.
     */
-   BSON_VALIDATION_MAX_NESTING_DEPTH = 1000,
+   BSON_VALIDATION_MAX_NESTING_DEPTH = 500,
 };
 
 /**


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/mongo-c-driver/pull/2026 to fix stack overflow encountered on MSVC on r1.30 branch. An [example](https://spruce.mongodb.com/task/mongo_c_driver_latest_release_1.x_sasl_matrix_winssl_sasl_cyrus_winssl_windows_2019_vs2017_x64_test_4.0_server_auth_40b673787060a80ef7f4875ae776cb4731dadec9_25_06_09_16_05_58/logs?execution=0) does not seem to log, but running with a debugger shows:

![Screenshot 2025-06-09 at 2 56 18 PM](https://github.com/user-attachments/assets/85f667c9-8748-4900-9fa6-f2e68fdf9134)

This test does not fail on r2.0 or master. I expect the stack overflow occurs due to the over-alignment `bson_t` and `bson_iter_t` removed in CDRIVER-2813.

This change could be limited to r1.30. But I propose applying r2.0 and master as well for a consistent nesting depth.
