### PR TITLE
[CDRIVER-6017] Reduce `BSON_VALIDATION_MAX_NESTING_DEPTH` to 500 [r1.30]

### DIFF
--- a/src/libbson/src/bson/validate-private.h
+++ b/src/libbson/src/bson/validate-private.h
@@ -15,7 +15,7 @@ enum {
     * server might accept. The main purpose of this limit is to prevent stack
     * overflow, not to reject invalid data.
     */
-   BSON_VALIDATION_MAX_NESTING_DEPTH = 1000,
+   BSON_VALIDATION_MAX_NESTING_DEPTH = 500,
 };
 
 /**


### PR DESCRIPTION
Cherry-pick of https://github.com/mongodb/mongo-c-driver/pull/2034 to r1.30.