### PR TITLE
CDRIVER-5996 Address EVG task failure due to possible VS 2017 compiler bug

### DIFF
--- a/src/common/tests/test-mlib.c
+++ b/src/common/tests/test-mlib.c
@@ -315,8 +315,8 @@ _test_cmp (void)
    // mlib_cmp produces the correct answer:
    ASSERT (mlib_cmp (-27, <, 20u));
 
-   // MSVC versions prior to 19.20(?) do not correctly short-circuit the (sub)expressions of a ternary operator
-   // containing compound initializers.
+   // CDRIVER-6043: until VS 2019 (MSVC 19.20), compound literals seem to "escape" the expression or scope they are
+   // meant to be in. This includes the compound literals used by the conditional operator in mlib_upsize_integer.
 #if !defined(_MSC_VER) || _MSC_VER >= 1920
    {
       // Check that we do not double-evaluate the operand expression.

--- a/src/common/tests/test-mlib.c
+++ b/src/common/tests/test-mlib.c
@@ -315,6 +315,9 @@ _test_cmp (void)
    // mlib_cmp produces the correct answer:
    ASSERT (mlib_cmp (-27, <, 20u));
 
+   // MSVC versions prior to 19.20(?) do not correctly short-circuit the (sub)expressions of a ternary operator
+   // containing compound initializers.
+#if !defined(_MSC_VER) || _MSC_VER >= 1920
    {
       // Check that we do not double-evaluate the operand expression.
       intmax_t a = 4;
@@ -322,6 +325,7 @@ _test_cmp (void)
       // We only increment once:
       mlib_check (a, eq, 5);
    }
+#endif
 }
 
 static void


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/1999. Addresses ongoing VS 2017 test task failures due to what seems to be a VS 2017 compiler bug. Narrowed the issue down to what seems to be a poor interaction between the conditional operator and compound literals, which manifests in the expansion of the `mlib_upsize_integer` macro:

```c
#include <assert.h>
#include <stdio.h>
#include <stdbool.h>

typedef struct S { int v; } S;

int main(void) {
  int x = 0;

  int y = true ? (S){++x}.v : (S){++x}.v;

  assert(y == 1); // OK
  assert(x == 1); // failure (!?!?)
}
```

I am unable to reproduce this behavior on any other currently tested or supported compiler (GCC, Clang, MSVC). I could not find any Visual Studio bug reports relating to this behavior. This behavior does not seem to be present with VS 2019 and newer. [Quoting](https://port70.net/~nsz/c/c99/n1256.html#6.5.15) the C99 draft:

> The first operand is evaluated; there is a sequence point after its evaluation. The second operand is evaluated only if the first compares unequal to 0; the third operand is evaluated only if the first compares equal to 0; the result is the value of the second or third operand (whichever is evaluated), [...]

Similarly [quoting](https://timsong-cpp.github.io/cppwp/n3337/expr.cond) the C++11 draft:

> The first expression is contextually converted to `bool`. It is evaluated and if it is `true`, the result of the conditional expression is the value of the second expression, otherwise that of the third expression. Only one of the second and third expressions is evaluated.

The behavior observed above with VS 2017 clearly violates both of these specifications. I suspect it is an unfortunate consequence of partial C language support in VS 2017. The behavior is as expected if the compound literals are removed:

```c
#include <assert.h>
#include <stdio.h>
#include <stdbool.h>

typedef struct S { int v; } S;

int q(int x, int i) { printf(" - %d: %d\n", i, x); return x; }

int main(void) {
  {
    printf("Compound Initializers:\n");
    int x = 0;
    int y = true ? (S){q(++x, 0)}.v : (S){q(++x, 1)}.v;
    printf(" - x: %d\n - y: %d\n", x, y);
    printf("\n");
  }

  {
    printf("Normal:\n");
    int x = 0;
    int y = true ? q(++x, 0) : q(++x, 1);
    printf(" - x: %d\n - y: %d\n", x, y);
    printf("\n");
  }
}
```
```
Compound Initializers:
 - 0: 1
 - 1: 2
 - x: 2
 - y: 1

Normal:
 - 0: 1
 - x: 1
 - y: 1
```

Rather than complicating the definition of the `mlib_*` macros any further, this PR proposes simply skipping these tests when compiled with VS 2017 or older. We are unlikely to be (and should be avoiding) using these macros with expressions containing side-effects anyways.