### PR TITLE
Address Evergreen validation warnings for link-with-cmake-mac-deprecated

### DIFF
--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -16246,9 +16246,6 @@ buildvariants:
   - name: link-with-cmake-mac
     distros:
     - macos-14-arm64
-  - name: link-with-cmake-mac-deprecated
-    distros:
-    - macos-14-arm64
   - name: link-with-cmake-windows
     distros:
     - windows-vsCurrent-large

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -51,7 +51,6 @@ all_variants = [
             "link-with-cmake-ssl",
             "link-with-cmake-snappy",
             OD([("name", "link-with-cmake-mac"), ("distros", ["macos-14-arm64"])]),
-            OD([("name", "link-with-cmake-mac-deprecated"), ("distros", ["macos-14-arm64"])]),
             OD([("name", "link-with-cmake-windows"), ("distros", ["windows-vsCurrent-large"])]),
             OD([("name", "link-with-cmake-windows-ssl"), ("distros", ["windows-vsCurrent-large"])]),
             OD([("name", "link-with-cmake-windows-snappy"), ("distros", ["windows-vsCurrent-large"])]),


### PR DESCRIPTION
A minor drive-by fix to the EVG configuration following removal of the `link-with-cmake-mac-deprecated` task in https://github.com/mongodb/mongo-c-driver/pull/1956.

```
WARNING: buildvariant 'smoke' has unmatched selector: 'link-with-cmake-mac-deprecated'
WARNING: buildvariant 'smoke' has unmatched criteria: 'link-with-cmake-mac-deprecated'
.evergreen/config.yml is valid with warnings/notices
```