### PR TITLE
Bump clang-format from 17.0.6 to 20.1.0

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,5 @@
 ---
 Language:        Cpp
-# BasedOnStyle:  LLVM
 AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
 AlignArrayOfStructures: None
@@ -9,30 +8,63 @@ AlignConsecutiveAssignments:
   AcrossEmptyLines: false
   AcrossComments:  false
   AlignCompound:   false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
   PadOperators:    true
 AlignConsecutiveBitFields:
   Enabled:         false
   AcrossEmptyLines: false
   AcrossComments:  false
   AlignCompound:   false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
   PadOperators:    false
 AlignConsecutiveDeclarations:
   Enabled:         false
   AcrossEmptyLines: false
   AcrossComments:  false
   AlignCompound:   false
+  AlignFunctionDeclarations: true
+  AlignFunctionPointers: false
   PadOperators:    false
 AlignConsecutiveMacros:
   Enabled:         false
   AcrossEmptyLines: false
   AcrossComments:  false
   AlignCompound:   false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
   PadOperators:    false
 AlignConsecutiveShortCaseStatements:
   Enabled:         false
   AcrossEmptyLines: false
   AcrossComments:  false
+  AlignCaseArrows: false
   AlignCaseColons: false
+AlignConsecutiveTableGenBreakingDAGArgColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveTableGenCondOperatorColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveTableGenDefinitionColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
+  PadOperators:    false
 AlignEscapedNewlines: Left
 AlignOperands:   Align
 AlignTrailingComments:
@@ -40,17 +72,19 @@ AlignTrailingComments:
   OverEmptyLines:  0
 AllowAllArgumentsOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
+AllowBreakBeforeNoexceptSpecifier: Never
 AllowShortBlocksOnASingleLine: Never
+AllowShortCaseExpressionOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: false
+AllowShortCompoundRequirementOnASingleLine: true
 AllowShortEnumsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLambdasOnASingleLine: All
 AllowShortLoopsOnASingleLine: false
+AllowShortNamespacesOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakAfterReturnType: All
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: MultiLine
 AttributeMacros:
   - __capability
   - BSON_GNUC_WARN_UNUSED_RESULT
@@ -78,17 +112,22 @@ BraceWrapping:
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
+BreakAdjacentStringLiterals: true
 BreakAfterAttributes: Never
 BreakAfterJavaFieldAnnotations: false
+BreakAfterReturnType: All
 BreakArrays:     true
 BreakBeforeBinaryOperators: None
 BreakBeforeConceptDeclarations: Always
 BreakBeforeBraces: Linux
 BreakBeforeInlineASMColon: OnlyMultiline
 BreakBeforeTernaryOperators: true
+BreakBinaryOperations: Never
 BreakConstructorInitializers: BeforeColon
+BreakFunctionDefinitionParameters: false
 BreakInheritanceList: BeforeColon
 BreakStringLiterals: true
+BreakTemplateDeclarations: MultiLine
 ColumnLimit:     120
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
@@ -131,6 +170,7 @@ IncludeIsMainSourceRegex: ''
 IndentAccessModifiers: false
 IndentCaseBlocks: false
 IndentCaseLabels: false
+IndentExportBlock: true
 IndentExternBlock: AfterExternBlock
 IndentGotoLabels: true
 IndentPPDirectives: None
@@ -149,12 +189,16 @@ IntegerLiteralSeparator:
   HexMinDigits:    0
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: false
-KeepEmptyLinesAtEOF: false
+KeepEmptyLines:
+  AtEndOfFile:     false
+  AtStartOfBlock:  false
+  AtStartOfFile:   false
+KeepFormFeed:    false
 LambdaBodyIndentation: Signature
 LineEnding:      DeriveLF
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
+MainIncludeChar: AngleBracket
 MaxEmptyLinesToKeep: 2
 NamespaceIndentation: None
 ObjCBinPackProtocolList: Auto
@@ -165,9 +209,11 @@ ObjCSpaceBeforeProtocolList: true
 PackConstructorInitializers: BinPack
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakBeforeMemberAccess: 150
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakOpenParenthesis: 0
+PenaltyBreakScopeResolution: 500
 PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
@@ -177,14 +223,16 @@ PointerAlignment: Right
 PPIndentWidth:   -1
 QualifierAlignment: Leave
 ReferenceAlignment: Pointer
-ReflowComments:  true
+ReflowComments:  Always
 RemoveBracesLLVM: false
+RemoveEmptyLinesInUnwrappedLines: false
 RemoveParentheses: Leave
 RemoveSemicolon: false
 RequiresClausePosition: OwnLine
 RequiresExpressionIndentation: OuterScope
 SeparateDefinitionBlocks: Leave
 ShortNamespaceLines: 1
+SkipMacroDefinitionBody: false
 SortIncludes:    Never
 SortJavaStaticImport: Before
 SortUsingDeclarations: LexicographicNumeric
@@ -206,6 +254,7 @@ SpaceBeforeParensOptions:
   AfterFunctionDeclarationName: false
   AfterIfMacros:   true
   AfterOverloadedOperator: false
+  AfterPlacementOperator: false
   AfterRequiresInClause: false
   AfterRequiresInExpression: false
   BeforeNonEmptyParentheses: false
@@ -220,6 +269,7 @@ SpacesInLineCommentPrefix:
   Maximum:         -1
 SpacesInParens:  Never
 SpacesInParensOptions:
+  ExceptDoubleParentheses: false
   InCStyleCasts:   false
   InConditionalStatements: false
   InEmptyParentheses: false
@@ -231,6 +281,7 @@ StatementAttributeLikeMacros:
 StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
+TableGenBreakInsideDAGArg: DontBreak
 TabWidth:        3
 UseTab:          Never
 VerilogBreakBetweenInstancePorts: true
@@ -240,4 +291,5 @@ WhitespaceSensitiveMacros:
   - NS_SWIFT_NAME
   - PP_STRINGIZE
   - STRINGIZE
+WrapNamespaceBodyWithEmptyLines: Leave
 ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dev = [
 
 format = [
     # .evergreen/scripts/clang-format-all.sh
-    "clang-format~=17.0.6",
+    "clang-format~=20.1.0",
 ]
 
 docs = [

--- a/src/libbson/src/bson/bson-decimal128.c
+++ b/src/libbson/src/bson/bson-decimal128.c
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2009-present MongoDB, Inc.
  *

--- a/src/libbson/src/bson/bson-iter.c
+++ b/src/libbson/src/bson/bson-iter.c
@@ -64,7 +64,7 @@ bson_iter_init (bson_iter_t *iter,  /* OUT */
    iter->d4 = 0;
    iter->next_off = 4;
    iter->err_off = 0;
-   iter->value = (bson_value_t){0};
+   iter->value = (bson_value_t) {0};
 
    return true;
 }

--- a/src/libbson/src/bson/bson-json.c
+++ b/src/libbson/src/bson/bson-json.c
@@ -396,7 +396,7 @@ bson_json_opts_new (bson_json_mode_t mode, int32_t max_len)
    bson_json_opts_t *opts;
 
    opts = (bson_json_opts_t *) bson_malloc (sizeof *opts);
-   *opts = (bson_json_opts_t){
+   *opts = (bson_json_opts_t) {
       .mode = mode,
       .max_len = max_len,
       .is_outermost_array = false,

--- a/src/libbson/src/bson/bson-types.h
+++ b/src/libbson/src/bson/bson-types.h
@@ -136,13 +136,7 @@ BSON_ALIGNED_BEGIN (BSON_ALIGN_OF_PTR) typedef struct _bson_t {
  * bson_t b = BSON_INITIALIZER;
  * ]|
  */
-#define BSON_INITIALIZER \
-   {                     \
-      3, 5,              \
-      {                  \
-         5               \
-      }                  \
-   }
+#define BSON_INITIALIZER {3, 5, {5}}
 
 
 BSON_STATIC_ASSERT2 (bson_t, sizeof (bson_t) == 128);

--- a/src/libbson/src/bson/bson-vector.c
+++ b/src/libbson/src/bson/bson-vector.c
@@ -83,7 +83,7 @@ bson_vector_int8_view_init (bson_vector_int8_view_t *view_out, uint8_t *binary_d
    if (bson_vector_binary_header_impl_init (&header, binary_data, binary_data_len) &&
        bson_vector_int8_validate (header)) {
       if (view_out) {
-         *view_out = (bson_vector_int8_view_t){
+         *view_out = (bson_vector_int8_view_t) {
             .binary.data = binary_data, .binary.data_len = binary_data_len, .binary.header_copy = header};
       }
       return true;
@@ -103,7 +103,7 @@ bson_vector_int8_const_view_init (bson_vector_int8_const_view_t *view_out,
    if (bson_vector_binary_header_impl_init (&header, binary_data, binary_data_len) &&
        bson_vector_int8_validate (header)) {
       if (view_out) {
-         *view_out = (bson_vector_int8_const_view_t){
+         *view_out = (bson_vector_int8_const_view_t) {
             .binary.data = binary_data, .binary.data_len = binary_data_len, .binary.header_copy = header};
       }
       return true;
@@ -121,7 +121,7 @@ bson_vector_float32_view_init (bson_vector_float32_view_t *view_out, uint8_t *bi
    if (bson_vector_binary_header_impl_init (&header, binary_data, binary_data_len) &&
        bson_vector_float32_validate (header, binary_data_len)) {
       if (view_out) {
-         *view_out = (bson_vector_float32_view_t){
+         *view_out = (bson_vector_float32_view_t) {
             .binary.data = binary_data, .binary.data_len = binary_data_len, .binary.header_copy = header};
       }
       return true;
@@ -141,7 +141,7 @@ bson_vector_float32_const_view_init (bson_vector_float32_const_view_t *view_out,
    if (bson_vector_binary_header_impl_init (&header, binary_data, binary_data_len) &&
        bson_vector_float32_validate (header, binary_data_len)) {
       if (view_out) {
-         *view_out = (bson_vector_float32_const_view_t){
+         *view_out = (bson_vector_float32_const_view_t) {
             .binary.data = binary_data, .binary.data_len = binary_data_len, .binary.header_copy = header};
       }
       return true;
@@ -161,7 +161,7 @@ bson_vector_packed_bit_view_init (bson_vector_packed_bit_view_t *view_out,
    if (bson_vector_binary_header_impl_init (&header, binary_data, binary_data_len) &&
        bson_vector_packed_bit_validate (header, binary_data, binary_data_len)) {
       if (view_out) {
-         *view_out = (bson_vector_packed_bit_view_t){
+         *view_out = (bson_vector_packed_bit_view_t) {
             .binary.data = binary_data, .binary.data_len = binary_data_len, .binary.header_copy = header};
       }
       return true;
@@ -181,7 +181,7 @@ bson_vector_packed_bit_const_view_init (bson_vector_packed_bit_const_view_t *vie
    if (bson_vector_binary_header_impl_init (&header, binary_data, binary_data_len) &&
        bson_vector_packed_bit_validate (header, binary_data, binary_data_len)) {
       if (view_out) {
-         *view_out = (bson_vector_packed_bit_const_view_t){
+         *view_out = (bson_vector_packed_bit_const_view_t) {
             .binary.data = binary_data, .binary.data_len = binary_data_len, .binary.header_copy = header};
       }
       return true;
@@ -306,7 +306,7 @@ bson_append_vector_int8_uninit (
          .bytes[1] = bson_vector_header_byte_1 (0)};
       memcpy (binary, header.bytes, BSON_VECTOR_HEADER_LEN);
       *view_out =
-         (bson_vector_int8_view_t){.binary.data = binary, .binary.data_len = length, .binary.header_copy = header};
+         (bson_vector_int8_view_t) {.binary.data = binary, .binary.data_len = length, .binary.header_copy = header};
       return true;
    } else {
       return false;
@@ -331,7 +331,7 @@ bson_append_vector_float32_uninit (
          .bytes[1] = bson_vector_header_byte_1 (0)};
       memcpy (binary, header.bytes, BSON_VECTOR_HEADER_LEN);
       *view_out =
-         (bson_vector_float32_view_t){.binary.data = binary, .binary.data_len = length, .binary.header_copy = header};
+         (bson_vector_float32_view_t) {.binary.data = binary, .binary.data_len = length, .binary.header_copy = header};
       return true;
    } else {
       return false;
@@ -365,7 +365,7 @@ bson_append_vector_packed_bit_uninit (
          // No reason to read-modify-write here, it's better to write the whole byte.
          binary[length - 1u] = 0u;
       }
-      *view_out = (bson_vector_packed_bit_view_t){
+      *view_out = (bson_vector_packed_bit_view_t) {
          .binary.data = binary, .binary.data_len = length, .binary.header_copy = header};
       return true;
    } else {

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -299,7 +299,7 @@ BSON_STATIC_ASSERT2 (max_alloc_grow_fits_min_sizet, (uint64_t) BSON_MAX_SIZE * 2
       mlib_diagnostic_pop ();                                         \
       goto append_failure;                                            \
    } else if ((_length) > 0) {                                        \
-      *(_list).current++ = (_bson_append_bytes_arg){                  \
+      *(_list).current++ = (_bson_append_bytes_arg) {                 \
          .bytes = (const uint8_t *) (_bytes),                         \
          .length = (_length),                                         \
       };                                                              \

--- a/src/libbson/src/bson/validate.c
+++ b/src/libbson/src/bson/validate.c
@@ -544,7 +544,7 @@ _bson_validate_impl_v2 (const bson_t *bson, bson_validate_flags_t flags, size_t 
    BSON_ASSERT_PARAM (error);
 
    // Clear the error
-   *error = (bson_error_t){0};
+   *error = (bson_error_t) {0};
 
    // Initialize validation parameters
    validation_params const params = {

--- a/src/libmongoc/examples/find_and_modify_with_opts/fam.c
+++ b/src/libmongoc/examples/find_and_modify_with_opts/fam.c
@@ -1,4 +1,3 @@
-
 #include <mongoc/mongoc.h>
 
 /* EXAMPLE_FAM_BYPASS_BEGIN */

--- a/src/libmongoc/src/mongoc/mcd-azure.c
+++ b/src/libmongoc/src/mongoc/mcd-azure.c
@@ -80,7 +80,7 @@ mcd_azure_access_token_try_init_from_json_str (mcd_azure_access_token *out,
    }
 
    // Zero the output
-   *out = (mcd_azure_access_token){0};
+   *out = (mcd_azure_access_token) {0};
 
    // Parse the JSON data
    bson_t bson;
@@ -112,7 +112,7 @@ mcd_azure_access_token_try_init_from_json_str (mcd_azure_access_token *out,
                          json);
    } else {
       // Set the output, duplicate each string
-      *out = (mcd_azure_access_token){
+      *out = (mcd_azure_access_token) {
          .access_token = bson_strdup (access_token),
          .resource = bson_strdup (resource),
          .token_type = bson_strdup (token_type),
@@ -165,7 +165,7 @@ mcd_azure_access_token_from_imds (mcd_azure_access_token *const out,
    bool okay = false;
 
    // Clear the output
-   *out = (mcd_azure_access_token){0};
+   *out = (mcd_azure_access_token) {0};
 
    mongoc_http_response_t resp;
    _mongoc_http_response_init (&resp);

--- a/src/libmongoc/src/mongoc/mcd-nsinfo.c
+++ b/src/libmongoc/src/mongoc/mcd-nsinfo.c
@@ -82,7 +82,7 @@ mcd_nsinfo_append (mcd_nsinfo_t *self, const char *ns, bson_error_t *error)
 
    // Add to hash table.
    ns_to_index_t *entry = bson_malloc (sizeof (*entry));
-   *entry = (ns_to_index_t){.index = ns_index, .ns = bson_strdup (ns), .hh = {0}};
+   *entry = (ns_to_index_t) {.index = ns_index, .ns = bson_strdup (ns), .hh = {0}};
 
    mlib_diagnostic_push ();
    mlib_disable_constant_conditional_expression_warnings ();

--- a/src/libmongoc/src/mongoc/mcd-rpc.c
+++ b/src/libmongoc/src/mongoc/mcd-rpc.c
@@ -201,7 +201,7 @@ union _mcd_rpc_message {
       return true;                                                                          \
    }
 
-MONGOC_RPC_CONSUME (uint8_t, uint8_t, (uint8_t))
+MONGOC_RPC_CONSUME (uint8_t, uint8_t, (uint8_t) )
 MONGOC_RPC_CONSUME (int32_t, uint32_t, BSON_UINT32_FROM_LE)
 MONGOC_RPC_CONSUME (uint32_t, uint32_t, BSON_UINT32_FROM_LE)
 MONGOC_RPC_CONSUME (int64_t, uint64_t, BSON_UINT64_FROM_LE)
@@ -811,7 +811,7 @@ mcd_rpc_message_from_data (const void *data, size_t length, const void **data_en
    mcd_rpc_message *rpc = bson_malloc (sizeof (mcd_rpc_message));
    mcd_rpc_message *ret = NULL;
 
-   *rpc = (mcd_rpc_message){.msg_header = {0}};
+   *rpc = (mcd_rpc_message) {.msg_header = {0}};
 
    if (!mcd_rpc_message_from_data_in_place (rpc, data, length, data_end)) {
       goto fail;
@@ -991,13 +991,13 @@ _append_iovec (mongoc_iovec_t *iovecs, size_t *capacity, size_t *count, mongoc_i
       return _append_iovec (iovecs,                                                                        \
                             capacity,                                                                      \
                             count,                                                                         \
-                            (mongoc_iovec_t){                                                              \
+                            (mongoc_iovec_t) {                                                             \
                                .iov_base = (void *) value,                                                 \
                                .iov_len = sizeof (type),                                                   \
                             });                                                                            \
    }
 
-MONGOC_RPC_APPEND_IOVEC (uint8_t, uint8_t, (uint8_t))
+MONGOC_RPC_APPEND_IOVEC (uint8_t, uint8_t, (uint8_t) )
 MONGOC_RPC_APPEND_IOVEC (int32_t, uint32_t, BSON_UINT32_TO_LE)
 MONGOC_RPC_APPEND_IOVEC (uint32_t, uint32_t, BSON_UINT32_TO_LE)
 MONGOC_RPC_APPEND_IOVEC (int64_t, uint64_t, BSON_UINT64_TO_LE)
@@ -1008,7 +1008,7 @@ _append_iovec_data (mongoc_iovec_t *iovecs, size_t *capacity, size_t *count, con
    return _append_iovec (iovecs,
                          capacity,
                          count,
-                         (mongoc_iovec_t){
+                         (mongoc_iovec_t) {
                             .iov_base = (void *) data,
                             .iov_len = length,
                          });
@@ -1022,7 +1022,7 @@ _append_iovec_reserved_zero (mongoc_iovec_t *iovecs, size_t *capacity, size_t *c
    return _append_iovec (iovecs,
                          capacity,
                          count,
-                         (mongoc_iovec_t){
+                         (mongoc_iovec_t) {
                             .iov_base = (void *) &zero,
                             .iov_len = sizeof (zero),
                          });
@@ -1543,7 +1543,7 @@ mcd_rpc_message *
 mcd_rpc_message_new (void)
 {
    mcd_rpc_message *const rpc = bson_malloc (sizeof (mcd_rpc_message));
-   *rpc = (mcd_rpc_message){.msg_header = {0}};
+   *rpc = (mcd_rpc_message) {.msg_header = {0}};
    return rpc;
 }
 
@@ -1639,7 +1639,7 @@ mcd_rpc_message_reset (mcd_rpc_message *rpc)
 
    _mcd_rpc_message_free_owners (rpc);
 
-   *rpc = (mcd_rpc_message){.msg_header = {0}};
+   *rpc = (mcd_rpc_message) {.msg_header = {0}};
 }
 
 void

--- a/src/libmongoc/src/mongoc/mcd-time.h
+++ b/src/libmongoc/src/mongoc/mcd-time.h
@@ -37,9 +37,9 @@ typedef struct mcd_time_point {
 } mcd_time_point;
 
 /// The latest representable future point-in-time
-#define MCD_TIME_POINT_MAX ((mcd_time_point){._rep = INT64_MAX})
+#define MCD_TIME_POINT_MAX ((mcd_time_point) {._rep = INT64_MAX})
 /// The oldest representable past point-in-time
-#define MCD_TIME_POINT_MIN ((mcd_time_point){._rep = INT64_MIN})
+#define MCD_TIME_POINT_MIN ((mcd_time_point) {._rep = INT64_MIN})
 
 /**
  * @brief Represents a (possibly negative) duration of time.
@@ -56,11 +56,11 @@ typedef struct mcd_duration {
 } mcd_duration;
 
 /// The maximum representable duration
-#define MCD_DURATION_MAX ((mcd_duration){._rep = INT64_MAX})
+#define MCD_DURATION_MAX ((mcd_duration) {._rep = INT64_MAX})
 /// The minimal representable (negative) duration
-#define MCD_DURATION_MIN ((mcd_duration){._rep = INT64_MIN})
+#define MCD_DURATION_MIN ((mcd_duration) {._rep = INT64_MIN})
 /// A duration representing zero amount of time
-#define MCD_DURATION_ZERO ((mcd_duration){._rep = 0})
+#define MCD_DURATION_ZERO ((mcd_duration) {._rep = 0})
 
 /**
  * @brief Obtain the current time point. This is only an abstract
@@ -71,7 +71,7 @@ static BSON_INLINE mcd_time_point
 mcd_now (void)
 {
    // Create a time point representing the current time.
-   return (mcd_time_point){._rep = bson_get_monotonic_time ()};
+   return (mcd_time_point) {._rep = bson_get_monotonic_time ()};
 }
 
 /**
@@ -88,7 +88,7 @@ mcd_microseconds (int64_t s)
 {
    // 'mcd_duration' is encoded in a number of microseconds, so we don't need to
    // do bounds checking here.
-   return (mcd_duration){._rep = s};
+   return (mcd_duration) {._rep = s};
 }
 
 /**
@@ -305,7 +305,7 @@ typedef struct mcd_timer {
 static BSON_INLINE mcd_timer
 mcd_timer_expire_at (mcd_time_point time)
 {
-   return (mcd_timer){time};
+   return (mcd_timer) {time};
 }
 
 /**

--- a/src/libmongoc/src/mongoc/mongoc-bulk-operation.h
+++ b/src/libmongoc/src/mongoc/mongoc-bulk-operation.h
@@ -27,10 +27,7 @@
 #include <mongoc/mongoc-write-concern.h>
 
 /* ordered, bypass_document_validation, has_collation, multi */
-#define MONGOC_BULK_WRITE_FLAGS_INIT \
-   {                                 \
-      true, false, 0                 \
-   }
+#define MONGOC_BULK_WRITE_FLAGS_INIT {true, false, 0}
 
 BSON_BEGIN_DECLS
 

--- a/src/libmongoc/src/mongoc/mongoc-bulkwrite.c
+++ b/src/libmongoc/src/mongoc/mongoc-bulkwrite.c
@@ -60,7 +60,7 @@ set_bson_value_opt (bson_value_t *dst, const bson_value_t *src)
 {
    BSON_ASSERT_PARAM (dst);
    bson_value_destroy (dst);
-   *dst = (bson_value_t){0};
+   *dst = (bson_value_t) {0};
    if (src) {
       bson_value_copy (src, dst);
    }

--- a/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
@@ -3000,7 +3000,7 @@ _mongoc_encryptedFields_fill_auto_datakeys (
    BSON_ASSERT_PARAM (factory);
 
    if (error) {
-      *error = (bson_error_t){0};
+      *error = (bson_error_t) {0};
    }
    bson_init (out_fields);
 

--- a/src/libmongoc/src/mongoc/mongoc-crypt.c
+++ b/src/libmongoc/src/mongoc/mongoc-crypt.c
@@ -739,7 +739,7 @@ static bool
 _check_azure_kms_auto (const bson_t *kmsprov, bson_error_t *error)
 {
    if (error) {
-      *error = (bson_error_t){0};
+      *error = (bson_error_t) {0};
    }
 
    bson_iter_t iter;
@@ -877,7 +877,7 @@ static bool
 _check_gcp_kms_auto (const bson_t *kmsprov, bson_error_t *error)
 {
    if (error) {
-      *error = (bson_error_t){0};
+      *error = (bson_error_t) {0};
    }
 
    bson_iter_t iter;

--- a/src/libmongoc/src/mongoc/mongoc-deprioritized-servers.c
+++ b/src/libmongoc/src/mongoc/mongoc-deprioritized-servers.c
@@ -16,7 +16,7 @@ mongoc_deprioritized_servers_new (void)
 {
    mongoc_deprioritized_servers_t *const ret = bson_malloc (sizeof (*ret));
 
-   *ret = (mongoc_deprioritized_servers_t){
+   *ret = (mongoc_deprioritized_servers_t) {
       .ids = mongoc_set_new (1u, NULL, NULL),
    };
 

--- a/src/libmongoc/src/mongoc/mongoc-handshake.c
+++ b/src/libmongoc/src/mongoc/mongoc-handshake.c
@@ -543,7 +543,7 @@ _mongoc_handshake_cleanup (void)
    _free_driver_info (h);
    _free_platform_string (h);
    _free_env_info (h);
-   *h = (mongoc_handshake_t){0};
+   *h = (mongoc_handshake_t) {0};
 
    bson_mutex_destroy (&gHandshakeLock);
 }

--- a/src/libmongoc/src/mongoc/mongoc-host-list.c
+++ b/src/libmongoc/src/mongoc/mongoc-host-list.c
@@ -277,7 +277,7 @@ _mongoc_host_list_from_hostport_with_err (mongoc_host_list_t *link_,
    BSON_ASSERT (host);
    BSON_ASSERT (link_);
    size_t host_len = strlen (host);
-   *link_ = (mongoc_host_list_t){
+   *link_ = (mongoc_host_list_t) {
       .next = NULL,
       .port = port,
    };

--- a/src/libmongoc/src/mongoc/mongoc-log-and-monitor-private.c
+++ b/src/libmongoc/src/mongoc/mongoc-log-and-monitor-private.c
@@ -81,7 +81,7 @@ mongoc_log_and_monitor_instance_set_apm_callbacks (mongoc_log_and_monitor_instan
                                                    void *context)
 {
    BSON_ASSERT_PARAM (instance);
-   instance->apm_callbacks = callbacks ? *callbacks : (mongoc_apm_callbacks_t){0};
+   instance->apm_callbacks = callbacks ? *callbacks : (mongoc_apm_callbacks_t) {0};
    instance->apm_context = context;
 }
 

--- a/src/libmongoc/src/mongoc/mongoc-oidc-callback.c
+++ b/src/libmongoc/src/mongoc/mongoc-oidc-callback.c
@@ -48,7 +48,7 @@ mongoc_oidc_callback_new (mongoc_oidc_callback_fn_t fn)
    }
 
    mongoc_oidc_callback_t *const ret = bson_malloc (sizeof (*ret));
-   *ret = (mongoc_oidc_callback_t){.fn = fn};
+   *ret = (mongoc_oidc_callback_t) {.fn = fn};
    return ret;
 }
 
@@ -60,7 +60,7 @@ mongoc_oidc_callback_new_with_user_data (mongoc_oidc_callback_fn_t fn, void *use
    }
 
    mongoc_oidc_callback_t *const ret = bson_malloc (sizeof (*ret));
-   *ret = (mongoc_oidc_callback_t){.fn = fn, .user_data = user_data};
+   *ret = (mongoc_oidc_callback_t) {.fn = fn, .user_data = user_data};
    return ret;
 }
 
@@ -97,7 +97,7 @@ mongoc_oidc_callback_params_t *
 mongoc_oidc_callback_params_new (void)
 {
    mongoc_oidc_callback_params_t *const ret = bson_malloc (sizeof (*ret));
-   *ret = (mongoc_oidc_callback_params_t){
+   *ret = (mongoc_oidc_callback_params_t) {
       .version = MONGOC_PRIVATE_OIDC_CALLBACK_API_VERSION,
    };
    return ret;
@@ -207,7 +207,7 @@ mongoc_oidc_credential_new (const char *access_token)
    }
 
    mongoc_oidc_credential_t *const ret = bson_malloc (sizeof (*ret));
-   *ret = (mongoc_oidc_credential_t){
+   *ret = (mongoc_oidc_credential_t) {
       .access_token = bson_strdup (access_token),
       .expires_in_set = false, // Infinite.
    };
@@ -226,7 +226,7 @@ mongoc_oidc_credential_new_with_expires_in (const char *access_token, int64_t ex
    }
 
    mongoc_oidc_credential_t *const ret = bson_malloc (sizeof (*ret));
-   *ret = (mongoc_oidc_credential_t){
+   *ret = (mongoc_oidc_credential_t) {
       .access_token = bson_strdup (access_token),
       .expires_in_set = true,
       .expires_in = expires_in,

--- a/src/libmongoc/src/mongoc/mongoc-oidc-env.c
+++ b/src/libmongoc/src/mongoc/mongoc-oidc-env.c
@@ -114,8 +114,8 @@ mongoc_oidc_env_callback_new (const mongoc_oidc_env_t *env, const char *token_re
    // Note that the callback's user_data points back to this containing mongoc_oidc_env_callback_t.
    // We expect that the inner callback can only be destroyed via mongoc_oidc_env_callback_destroy.
    *env_callback =
-      (mongoc_oidc_env_callback_t){.inner = mongoc_oidc_callback_new_with_user_data (env->callback_fn, env_callback),
-                                   .token_resource = bson_strdup (token_resource)};
+      (mongoc_oidc_env_callback_t) {.inner = mongoc_oidc_callback_new_with_user_data (env->callback_fn, env_callback),
+                                    .token_resource = bson_strdup (token_resource)};
    return env_callback;
 }
 

--- a/src/libmongoc/src/mongoc/mongoc-queue-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-queue-private.h
@@ -27,10 +27,7 @@
 BSON_BEGIN_DECLS
 
 
-#define MONGOC_QUEUE_INITIALIZER \
-   {                             \
-      NULL, NULL                 \
-   }
+#define MONGOC_QUEUE_INITIALIZER {NULL, NULL}
 
 
 typedef struct _mongoc_queue_t mongoc_queue_t;

--- a/src/libmongoc/src/mongoc/mongoc-read-prefs-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-read-prefs-private.h
@@ -42,10 +42,7 @@ typedef struct _mongoc_assemble_query_result_t {
 } mongoc_assemble_query_result_t;
 
 
-#define ASSEMBLE_QUERY_RESULT_INIT   \
-   {                                 \
-      NULL, false, MONGOC_QUERY_NONE \
-   }
+#define ASSEMBLE_QUERY_RESULT_INIT {NULL, false, MONGOC_QUERY_NONE}
 
 const char *
 _mongoc_read_mode_as_str (mongoc_read_mode_t mode);

--- a/src/libmongoc/src/mongoc/mongoc-rpc.c
+++ b/src/libmongoc/src/mongoc/mongoc-rpc.c
@@ -35,7 +35,7 @@ mcd_rpc_message_get_body (const mcd_rpc_message *rpc, bson_t *reply)
          case 0: { // Body.
             const uint8_t *const body = mcd_rpc_op_msg_section_get_body (rpc, index);
 
-            const int32_t body_len = bson_iter_int32_unsafe (&(bson_iter_t){.raw = body});
+            const int32_t body_len = bson_iter_int32_unsafe (&(bson_iter_t) {.raw = body});
 
             return bson_init_static (reply, body, (size_t) body_len);
          }
@@ -59,7 +59,7 @@ mcd_rpc_message_get_body (const mcd_rpc_message *rpc, bson_t *reply)
       // Assume the first document in OP_REPLY is the body.
       const uint8_t *const body = mcd_rpc_op_reply_get_documents (rpc);
 
-      return bson_init_static (reply, body, (size_t) bson_iter_int32_unsafe (&(bson_iter_t){.raw = body}));
+      return bson_init_static (reply, body, (size_t) bson_iter_int32_unsafe (&(bson_iter_t) {.raw = body}));
    }
 
    default:
@@ -328,14 +328,14 @@ mcd_rpc_message_egress (const mcd_rpc_message *rpc)
    // `mcd_rpc_message_to_iovecs`, which converts the opCode field to
    // little endian.
    int32_t op_code = mcd_rpc_header_get_op_code (rpc);
-   op_code = bson_iter_int32_unsafe (&(bson_iter_t){.raw = (const uint8_t *) &op_code});
+   op_code = bson_iter_int32_unsafe (&(bson_iter_t) {.raw = (const uint8_t *) &op_code});
 
    if (op_code == MONGOC_OP_CODE_COMPRESSED) {
       mongoc_counter_op_egress_compressed_inc ();
       mongoc_counter_op_egress_total_inc ();
 
       op_code = mcd_rpc_op_compressed_get_original_opcode (rpc);
-      op_code = bson_iter_int32_unsafe (&(bson_iter_t){.raw = (const uint8_t *) &op_code});
+      op_code = bson_iter_int32_unsafe (&(bson_iter_t) {.raw = (const uint8_t *) &op_code});
    }
 
    switch (op_code) {

--- a/src/libmongoc/src/mongoc/mongoc-shared-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-shared-private.h
@@ -61,7 +61,7 @@ typedef struct mongoc_shared_ptr {
  * @brief A "null" pointer constant for a mongoc_shared_ptr.
  */
 #define MONGOC_SHARED_PTR_NULL \
-   ((mongoc_shared_ptr){       \
+   ((mongoc_shared_ptr) {      \
       .ptr = NULL,             \
       ._aux = NULL,            \
    })

--- a/src/libmongoc/src/mongoc/mongoc-topology-background-monitoring-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-background-monitoring-private.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2009-present MongoDB, Inc.
  *

--- a/src/libmongoc/src/mongoc/mongoc-topology-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-private.h
@@ -107,7 +107,7 @@ typedef union mc_shared_tpld {
 } mc_shared_tpld;
 
 /** A null-pointer initializer for an `mc_shared_tpld` */
-#define MC_SHARED_TPLD_NULL ((mc_shared_tpld){._sptr_ = MONGOC_SHARED_PTR_NULL})
+#define MC_SHARED_TPLD_NULL ((mc_shared_tpld) {._sptr_ = MONGOC_SHARED_PTR_NULL})
 
 typedef struct _mongoc_topology_t {
    /**
@@ -498,7 +498,7 @@ _mongoc_topology_get_connection_pool_generation (const mongoc_topology_descripti
 static BSON_INLINE mc_shared_tpld
 mc_tpld_take_ref (const mongoc_topology_t *tpl)
 {
-   return (mc_shared_tpld){._sptr_ = mongoc_atomic_shared_ptr_load (&tpl->_shared_descr_._sptr_)};
+   return (mc_shared_tpld) {._sptr_ = mongoc_atomic_shared_ptr_load (&tpl->_shared_descr_._sptr_)};
 }
 
 /**

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -1992,7 +1992,7 @@ mc_tpld_modify_begin (mongoc_topology_t *tpl)
    prev_td = mc_tpld_take_ref (tpl);
    new_td = mongoc_topology_description_new_copy (prev_td.ptr);
    mc_tpld_drop_ref (&prev_td);
-   return (mc_tpld_modification){
+   return (mc_tpld_modification) {
       .new_td = new_td,
       .topology = tpl,
    };

--- a/src/libmongoc/src/mongoc/service-gcp.c
+++ b/src/libmongoc/src/mongoc/service-gcp.c
@@ -56,7 +56,7 @@ gcp_request_destroy (gcp_request *req)
    bson_free (req->_owned_headers);
    bson_free (req->_owned_host);
    bson_free (req->_owned_path);
-   *req = (gcp_request){
+   *req = (gcp_request) {
       .req = {0},
       ._owned_path = NULL,
       ._owned_host = NULL,
@@ -81,7 +81,7 @@ gcp_access_token_try_parse_from_json (gcp_service_account_token *out, const char
    bool okay = false;
 
    // Zero the output
-   *out = (gcp_service_account_token){0};
+   *out = (gcp_service_account_token) {0};
 
    // Parse the JSON data
    bson_t bson;
@@ -108,7 +108,7 @@ gcp_access_token_try_parse_from_json (gcp_service_account_token *out, const char
       goto done;
    }
 
-   *out = (gcp_service_account_token){
+   *out = (gcp_service_account_token) {
       .access_token = bson_strdup (access_token),
       .token_type = bson_strdup (token_type),
    };
@@ -130,7 +130,7 @@ gcp_access_token_from_gcp_server (gcp_service_account_token *out,
    bool okay = false;
 
    // Clear the output
-   *out = (gcp_service_account_token){0};
+   *out = (gcp_service_account_token) {0};
 
    mongoc_http_response_t resp;
    _mongoc_http_response_init (&resp);

--- a/src/libmongoc/tests/TestSuite.c
+++ b/src/libmongoc/tests/TestSuite.c
@@ -335,7 +335,7 @@ _TestSuite_AddMockServerTest (TestSuite *suite, const char *name, TestFunc func,
    Test *test;
    va_list ap;
    TestFnCtx *ctx = bson_malloc (sizeof (TestFnCtx));
-   *ctx = (TestFnCtx){.test_fn = func, .dtor = NULL};
+   *ctx = (TestFnCtx) {.test_fn = func, .dtor = NULL};
 
    va_start (ap, func);
    test = _V_TestSuite_AddFull (suite, name, TestSuite_AddHelper, _TestSuite_TestFnCtxDtor, ctx, ap);

--- a/src/libmongoc/tests/json-test.h
+++ b/src/libmongoc/tests/json-test.h
@@ -51,10 +51,7 @@ typedef struct _json_test_config_t {
 } json_test_config_t;
 
 
-#define JSON_TEST_CONFIG_INIT                                      \
-   {                                                               \
-      NULL, NULL, NULL, NULL, NULL, NULL, false, false, NULL, NULL \
-   }
+#define JSON_TEST_CONFIG_INIT {NULL, NULL, NULL, NULL, NULL, NULL, false, false, NULL, NULL}
 
 bson_t *
 get_bson_from_json_file (char *filename);

--- a/src/libmongoc/tests/test-conveniences.h
+++ b/src/libmongoc/tests/test-conveniences.h
@@ -296,6 +296,6 @@ semver_to_string (semver_t *str);
 /* An arbitrary traceable mongoc_ss_log_context_t for tests.
  * Logs the function name and file:line as the "operation". */
 #define TEST_SS_LOG_CONTEXT \
-   (&(mongoc_ss_log_context_t){.operation = tmp_str ("%s:%d: %s", __FILE__, (int) __LINE__, BSON_FUNC)})
+   (&(mongoc_ss_log_context_t) {.operation = tmp_str ("%s:%d: %s", __FILE__, (int) __LINE__, BSON_FUNC)})
 
 #endif /* TEST_CONVENIENCES_H */

--- a/src/libmongoc/tests/test-happy-eyeballs.c
+++ b/src/libmongoc/tests/test-happy-eyeballs.c
@@ -342,35 +342,17 @@ _testcase_run (he_testcase_t *testcase)
    _check_stream (node->stream, expected->conn_succeeds_to, "checking client's final connection");
 }
 
-#define CLIENT(client) \
-   {                   \
-      #client          \
-   }
+#define CLIENT(client) {#client}
 
-#define CLIENT_WITH_DNS_CACHE_TIMEOUT(type, timeout) \
-   {                                                 \
-      #type, timeout                                 \
-   }
+#define CLIENT_WITH_DNS_CACHE_TIMEOUT(type, timeout) {#type, timeout}
 #define HANGUP true
 #define LISTEN false
-#define SERVER(type, hangup) \
-   {                         \
-      #type, hangup          \
-   }
-#define DELAYED_SERVER(type, hangup, delay) \
-   {                                        \
-      #type, hangup, delay                  \
-   }
-#define SERVERS(...) \
-   {                 \
-      __VA_ARGS__    \
-   }
+#define SERVER(type, hangup) {#type, hangup}
+#define DELAYED_SERVER(type, hangup, delay) {#type, hangup, delay}
+#define SERVERS(...) {__VA_ARGS__}
 #define DELAY_MS(val) val
 #define DURATION_MS(min, max) (min), (max)
-#define EXPECT(type, num_acmds, duration) \
-   {                                      \
-      #type, num_acmds, duration          \
-   }
+#define EXPECT(type, num_acmds, duration) {#type, num_acmds, duration}
 #define NCMDS(n) (n)
 
 static void

--- a/src/libmongoc/tests/test-libmongoc-main.c
+++ b/src/libmongoc/tests/test-libmongoc-main.c
@@ -16,14 +16,14 @@ main (int argc, char *argv[])
 
    /* libbson */
 
-#define TEST_INSTALL(FuncName)                 \
-   if (1) {                                    \
-      mlib_diagnostic_push ();                 \
-      mlib_msvc_warning (disable : 4210);      \
-      extern void FuncName (TestSuite *suite); \
-      mlib_diagnostic_pop ();                  \
-      FuncName (&suite);                       \
-   } else                                      \
+#define TEST_INSTALL(FuncName)                  \
+   if (1) {                                     \
+      mlib_diagnostic_push ();                  \
+      mlib_msvc_warning (disable : 4210);       \
+      extern void FuncName (TestSuite * suite); \
+      mlib_diagnostic_pop ();                   \
+      FuncName (&suite);                        \
+   } else                                       \
       ((void) 0)
 
    TEST_INSTALL (test_bcon_basic_install);

--- a/src/libmongoc/tests/test-mcd-azure-imds.c
+++ b/src/libmongoc/tests/test-mcd-azure-imds.c
@@ -22,7 +22,7 @@ _test_oauth_parse (void)
    ASSERT (!mcd_azure_access_token_try_init_from_json_str (&token, RAW_STRING ({"access_token" : null}), -1, &error));
    ASSERT_ERROR_CONTAINS (error, MONGOC_ERROR_AZURE, MONGOC_ERROR_KMS_SERVER_BAD_JSON, "");
 
-   error = (bson_error_t){0};
+   error = (bson_error_t) {0};
    ASSERT (mcd_azure_access_token_try_init_from_json_str (
       &token,
       RAW_STRING ({"access_token" : "meow", "resource" : "something", "expires_in" : "1234", "token_type" : "Bearer"}),

--- a/src/libmongoc/tests/test-mongoc-change-stream.c
+++ b/src/libmongoc/tests/test-mongoc-change-stream.c
@@ -1170,10 +1170,7 @@ typedef struct {
    bson_t agg_reply;
 } resume_ctx_t;
 
-#define RESUME_INITIALIZER           \
-   {                                 \
-      false, false, BSON_INITIALIZER \
-   }
+#define RESUME_INITIALIZER {false, false, BSON_INITIALIZER}
 
 static void
 _resume_with_post_batch_resume_token_started (const mongoc_apm_command_started_t *event)

--- a/src/libmongoc/tests/test-mongoc-client-session.c
+++ b/src/libmongoc/tests/test-mongoc-client-session.c
@@ -2390,7 +2390,7 @@ test_unacknowledged_explicit_cs_explicit_wc (void *ctx)
 #define add_session_test(_suite, _name, _test_fn, _allow_read_concern)                      \
    if (1) {                                                                                 \
       session_test_helper_t *const helper = bson_malloc (sizeof (*helper));                 \
-      *helper = (session_test_helper_t){.test_fn = (_test_fn)};                             \
+      *helper = (session_test_helper_t) {.test_fn = (_test_fn)};                            \
       TestSuite_AddFull (_suite,                                                            \
                          _name,                                                             \
                          (_allow_read_concern) ? run_session_test : run_session_test_no_rc, \
@@ -2404,7 +2404,7 @@ test_unacknowledged_explicit_cs_explicit_wc (void *ctx)
 #define add_session_test_wc(_suite, _name, _test_fn, _allow_read_concern, ...)              \
    if (1) {                                                                                 \
       session_test_helper_t *const helper = bson_malloc (sizeof (*helper));                 \
-      *helper = (session_test_helper_t){.test_fn = (_test_fn)};                             \
+      *helper = (session_test_helper_t) {.test_fn = (_test_fn)};                            \
       TestSuite_AddFull (_suite,                                                            \
                          _name,                                                             \
                          (_allow_read_concern) ? run_session_test : run_session_test_no_rc, \
@@ -2419,7 +2419,7 @@ test_unacknowledged_explicit_cs_explicit_wc (void *ctx)
 #define add_unacknowledged_test(_suite, _name, _test_fn, _explicit_cs, _inherit_wc)                    \
    if (1) {                                                                                            \
       session_test_helper_t *const helper = bson_malloc (sizeof (*helper));                            \
-      *helper = (session_test_helper_t){.test_fn = (_test_fn)};                                        \
+      *helper = (session_test_helper_t) {.test_fn = (_test_fn)};                                       \
       TestSuite_AddFull (_suite,                                                                       \
                          _name,                                                                        \
                          (_explicit_cs) ? (_inherit_wc ? test_unacknowledged_explicit_cs_inherit_wc    \
@@ -2757,7 +2757,7 @@ test_session_install (TestSuite *suite)
    add_session_test (suite, "/Session/find_indexes", test_find_indexes, true);
    {
       session_test_helper_t *const helper = bson_malloc (sizeof (*helper));
-      *helper = (session_test_helper_t){.test_fn = test_bulk_set_session};
+      *helper = (session_test_helper_t) {.test_fn = test_bulk_set_session};
       TestSuite_AddFull (suite,
                          "/Session/bulk_set_session",
                          run_session_test_bulk_operation,
@@ -2768,7 +2768,7 @@ test_session_install (TestSuite *suite)
    }
    {
       session_test_helper_t *const helper = bson_malloc (sizeof (*helper));
-      *helper = (session_test_helper_t){.test_fn = test_bulk_set_client};
+      *helper = (session_test_helper_t) {.test_fn = test_bulk_set_client};
       TestSuite_AddFull (suite,
                          "/Session/bulk_set_client",
                          run_session_test_bulk_operation,

--- a/src/libmongoc/tests/test-mongoc-counters.c
+++ b/src/libmongoc/tests/test-mongoc-counters.c
@@ -480,7 +480,7 @@ typedef struct _rpc_op_egress_counters {
 static rpc_op_egress_counters
 rpc_op_egress_counters_current (void)
 {
-   return (rpc_op_egress_counters){
+   return (rpc_op_egress_counters) {
       .op_egress_compressed = mongoc_counter_op_egress_compressed_count (),
       .op_egress_delete = mongoc_counter_op_egress_delete_count (),
       .op_egress_getmore = mongoc_counter_op_egress_getmore_count (),

--- a/src/libmongoc/tests/test-mongoc-cursor.c
+++ b/src/libmongoc/tests/test-mongoc-cursor.c
@@ -416,7 +416,7 @@ _make_array_cursor (mongoc_collection_t *coll)
 #define TEST_CURSOR_FIND(prefix, fn)                                                          \
    if (1) {                                                                                   \
       make_cursor_helper_t *const helper = bson_malloc (sizeof (*helper));                    \
-      *helper = (make_cursor_helper_t){.ctor = _make_find_cursor};                            \
+      *helper = (make_cursor_helper_t) {.ctor = _make_find_cursor};                           \
       TestSuite_AddFull (suite, prefix "/find", fn, &bson_free, helper, TestSuite_CheckLive); \
    } else                                                                                     \
       ((void) 0)
@@ -424,7 +424,7 @@ _make_array_cursor (mongoc_collection_t *coll)
 #define TEST_CURSOR_CMD(prefix, fn)                                                          \
    if (1) {                                                                                  \
       make_cursor_helper_t *const helper = bson_malloc (sizeof (*helper));                   \
-      *helper = (make_cursor_helper_t){.ctor = _make_cmd_cursor};                            \
+      *helper = (make_cursor_helper_t) {.ctor = _make_cmd_cursor};                           \
       TestSuite_AddFull (suite, prefix "/cmd", fn, &bson_free, helper, TestSuite_CheckLive); \
    } else                                                                                    \
       ((void) 0)
@@ -433,7 +433,7 @@ _make_array_cursor (mongoc_collection_t *coll)
 #define TEST_CURSOR_ARRAY(prefix, fn)                                                          \
    if (1) {                                                                                    \
       make_cursor_helper_t *const helper = bson_malloc (sizeof (*helper));                     \
-      *helper = (make_cursor_helper_t){.ctor = _make_array_cursor};                            \
+      *helper = (make_cursor_helper_t) {.ctor = _make_array_cursor};                           \
       TestSuite_AddFull (suite, prefix "/array", fn, &bson_free, helper, TestSuite_CheckLive); \
    } else                                                                                      \
       ((void) 0)
@@ -441,7 +441,7 @@ _make_array_cursor (mongoc_collection_t *coll)
 #define TEST_CURSOR_AGG(prefix, fn)                                                          \
    if (1) {                                                                                  \
       make_cursor_helper_t *const helper = bson_malloc (sizeof (*helper));                   \
-      *helper = (make_cursor_helper_t){.ctor = _make_cmd_cursor_from_agg};                   \
+      *helper = (make_cursor_helper_t) {.ctor = _make_cmd_cursor_from_agg};                  \
       TestSuite_AddFull (suite, prefix "/agg", fn, &bson_free, helper, TestSuite_CheckLive); \
    } else                                                                                    \
       ((void) 0)

--- a/src/libmongoc/tests/test-mongoc-long-namespace.c
+++ b/src/libmongoc/tests/test-mongoc-long-namespace.c
@@ -446,7 +446,7 @@ unsupported_long_db (void)
 #define add_long_namespace_test(_name, _test_fn, ...)                              \
    if (1) {                                                                        \
       run_test_helper_t *const helper = bson_malloc (sizeof (*helper));            \
-      *helper = (run_test_helper_t){.test_fn = (_test_fn)};                        \
+      *helper = (run_test_helper_t) {.test_fn = (_test_fn)};                       \
       TestSuite_AddFull (suite, _name, run_test, &bson_free, helper, __VA_ARGS__); \
    } else                                                                          \
       ((void) 0)

--- a/src/libmongoc/tests/test-mongoc-opts.c
+++ b/src/libmongoc/tests/test-mongoc-opts.c
@@ -71,7 +71,7 @@ typedef struct {
 } func_ctx_t;
 
 
-typedef future_t *(func_with_opts_t) (func_ctx_t *ctx, bson_t *cmd);
+typedef future_t *(func_with_opts_t) (func_ctx_t * ctx, bson_t *cmd);
 
 
 typedef struct _opt_inheritance_test_t {
@@ -786,24 +786,15 @@ test_func_inherits_opts (void *ctx)
 
 
 /* commands that send one OP_MSG section */
-#define OPT_TEST(_opt_source, _func, _opt_type)                   \
-   {                                                              \
-      OPT_SOURCE_##_opt_source, _func, #_func, OPT_##_opt_type, 1 \
-   }
+#define OPT_TEST(_opt_source, _func, _opt_type) {OPT_SOURCE_##_opt_source, _func, #_func, OPT_##_opt_type, 1}
 
 
 /* write commands commands that send two OP_MSG sections */
-#define OPT_WRITE_TEST(_func)                              \
-   {                                                       \
-      OPT_SOURCE_COLL, _func, #_func, OPT_WRITE_CONCERN, 2 \
-   }
+#define OPT_WRITE_TEST(_func) {OPT_SOURCE_COLL, _func, #_func, OPT_WRITE_CONCERN, 2}
 
 
 /* mongoc_bulk_operation_t functions */
-#define OPT_BULK_TEST(_bulk_op)                                             \
-   {                                                                        \
-      OPT_SOURCE_COLL, bulk_exec, #_bulk_op, OPT_WRITE_CONCERN, 2, _bulk_op \
-   }
+#define OPT_BULK_TEST(_bulk_op) {OPT_SOURCE_COLL, bulk_exec, #_bulk_op, OPT_WRITE_CONCERN, 2, _bulk_op}
 
 
 static opt_inheritance_test_t gInheritanceTests[] = {

--- a/src/libmongoc/tests/test-mongoc-stream.c
+++ b/src/libmongoc/tests/test-mongoc-stream.c
@@ -1,4 +1,3 @@
-
 #include <fcntl.h>
 #include <mongoc/mongoc.h>
 #include <mongoc/mongoc-stream-private.h>

--- a/src/libmongoc/tests/test-mongoc-stream.c
+++ b/src/libmongoc/tests/test-mongoc-stream.c
@@ -182,7 +182,7 @@ _writev_timeout_stream_new (void)
 {
    writev_timeout_stream_t *const stream = bson_malloc (sizeof (writev_timeout_stream_t));
 
-   *stream = (writev_timeout_stream_t){
+   *stream = (writev_timeout_stream_t) {
       .vtable =
          {
             .type = 999, // For testing purposes.

--- a/src/libmongoc/tests/test-mongoc-ts-pool.c
+++ b/src/libmongoc/tests/test-mongoc-ts-pool.c
@@ -6,7 +6,7 @@
 static void
 test_ts_pool_empty (void)
 {
-   mongoc_ts_pool *pool = mongoc_ts_pool_new ((mongoc_ts_pool_params){.element_size = sizeof (int)});
+   mongoc_ts_pool *pool = mongoc_ts_pool_new ((mongoc_ts_pool_params) {.element_size = sizeof (int)});
    BSON_ASSERT (mongoc_ts_pool_is_empty (pool));
    mongoc_ts_pool_free (pool);
 }
@@ -15,7 +15,7 @@ test_ts_pool_empty (void)
 static void
 test_ts_pool_simple (void)
 {
-   mongoc_ts_pool *pool = mongoc_ts_pool_new ((mongoc_ts_pool_params){.element_size = sizeof (int)});
+   mongoc_ts_pool *pool = mongoc_ts_pool_new ((mongoc_ts_pool_params) {.element_size = sizeof (int)});
    int *item;
    int *item2;
 

--- a/src/libmongoc/tests/test-mongoc-uri.c
+++ b/src/libmongoc/tests/test-mongoc-uri.c
@@ -1400,7 +1400,7 @@ test_mongoc_uri_functions (void)
    mongoc_uri_destroy (uri);
 }
 
-#define BSON_ERROR_INIT ((bson_error_t){.code = 0u, .domain = 0u, .message = {0}, .reserved = 0u})
+#define BSON_ERROR_INIT ((bson_error_t) {.code = 0u, .domain = 0u, .message = {0}, .reserved = 0u})
 
 static void
 test_mongoc_uri_new_with_error (void)

--- a/src/libmongoc/tests/unified/operation.c
+++ b/src/libmongoc/tests/unified/operation.c
@@ -482,7 +482,7 @@ operation_client_bulkwrite (test_t *test, operation_t *op, result_t *result, bso
                // Return with a success (to not abort test runner) and propagate
                // the error as a result.
                ret = true;
-               *error = (bson_error_t){0};
+               *error = (bson_error_t) {0};
                bson_parser_destroy_with_parsed_fields (parser);
                goto done;
             }

--- a/uv.lock
+++ b/uv.lock
@@ -118,24 +118,25 @@ wheels = [
 
 [[package]]
 name = "clang-format"
-version = "17.0.6"
+version = "20.1.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/f5/0338054f3f749df62972445fa6ce3e303db27eac7aec4396fad6f67fc12b/clang-format-17.0.6.tar.gz", hash = "sha256:50f082840d2e013160355ed63add4502884344371dda5af12ec0abe68cbc5a36", size = 9623, upload-time = "2023-11-29T13:03:01.564Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/af/e138e1be1812ce0261ceaf5695e7d4299fa4d5085e1ed16e9157c4cda3ea/clang_format-20.1.7.tar.gz", hash = "sha256:2b0d76b9bf1f993bad33d2216b5fce4c407bc748fa31659ab7f51ca60df113c9", size = 11535, upload-time = "2025-06-26T12:57:25.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/52/43e0b6ffe0502deae7572b0e6381fbfd40d2ffcfd3aceaaa505d44958309/clang_format-17.0.6-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:2c7364a50c4fdb8ce9acc4e0c21627e52f4eebee98ff2d8a19b6d4302d0be23b", size = 1351137, upload-time = "2023-11-29T13:02:33.189Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/0a/d112aea9f0272e2c5558a2e9cf50229c846892dadf585f2a98fa0ba22385/clang_format-17.0.6-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:195014a589fde9e2bec447ee1f2efd31f8c9f773b10aa66b510beae6997e6bc5", size = 1303972, upload-time = "2023-11-29T13:02:37.989Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/a5/78fe6b7b6947a1d90dcb451caf9c63895fa84d7fc453865a64d770aae242/clang_format-17.0.6-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cda40badfb01818ece739509d9cde678fc02660180cc1a55156782ef203704d", size = 1626537, upload-time = "2023-11-29T13:02:39.999Z" },
-    { url = "https://files.pythonhosted.org/packages/07/9a/84366548453da7debc318cef0f1a58a7c29379307f48a9f23dbe90b6758f/clang_format-17.0.6-py2.py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:879e831c58a25a9b7527155032a6dc4758716ded69590911468a37629acb13d1", size = 1809392, upload-time = "2023-11-29T13:02:41.997Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/b5/8f84b52e2549d0058d37e06f2f3791bcab61fe88478a63417b5c44853105/clang_format-17.0.6-py2.py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:393f896db6155d6b8401ebae40df1f9a8cdf15d494d13fb775657c9ec609b586", size = 2485793, upload-time = "2023-11-29T13:02:45.026Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/1d/f814e4f95552270a59da694cdaac1701540f03c5d8fcc4d90fb2536b5f3d/clang_format-17.0.6-py2.py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ccb6f5ce90f24ed0bb314d041a8edcc94d1279c1469669d5855be004d9d6caff", size = 1613940, upload-time = "2023-11-29T13:02:46.568Z" },
-    { url = "https://files.pythonhosted.org/packages/89/df/5296c3eca534eedef32813cd38b3436c86f0eabcda2238060f73e45ef37d/clang_format-17.0.6-py2.py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2a1323ca5322e0dead521223155fe2ae1ba81d50abab8e20aaac28f6a94f23b9", size = 1630858, upload-time = "2023-11-29T13:02:48.572Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/a2/4f49923502938302a099317a431cc1bce7d6516f30d2940fa096d7a9da93/clang_format-17.0.6-py2.py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:5476f8fba40e4330a4704681386d78751ced0ecbd050bd0687817cca01d4e167", size = 2139740, upload-time = "2023-11-29T13:02:50.041Z" },
-    { url = "https://files.pythonhosted.org/packages/74/c0/be7647e1c965af6a3946d6936abe826a4bd4f186d74e1f6dc657eb170fd7/clang_format-17.0.6-py2.py3-none-musllinux_1_1_i686.whl", hash = "sha256:a0f744b056cb1595efdb7d2b83a7d73370e506e17fcaa68cd884c2ed029ae0fd", size = 2322503, upload-time = "2023-11-29T13:02:52.062Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/45/0bc5f9557e3518097d851baf336ad98d89741155130a9754444df9832e26/clang_format-17.0.6-py2.py3-none-musllinux_1_1_ppc64le.whl", hash = "sha256:2ddc8b6237520d26d78489e3bb876243d87c3629eb3cd40e1df0c8c6e355d949", size = 2493056, upload-time = "2023-11-29T13:02:53.596Z" },
-    { url = "https://files.pythonhosted.org/packages/22/82/fc884df02b5df4c045ac6c2e036080fade64c79fc7ce36c876ac7ce9feb0/clang_format-17.0.6-py2.py3-none-musllinux_1_1_s390x.whl", hash = "sha256:afc29c4413b5f2f885347f4bdbb7fe81f595faeceafa640c9e67a2d9aa2c7134", size = 2168110, upload-time = "2023-11-29T13:02:55.366Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/8d/46cf72600ea2cc9a34f98421102d180b9c1c1261dc8bb578611661edafef/clang_format-17.0.6-py2.py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:33c4f1975a6a0a76e5b85165c510c46ae1155f82477a5730e29799e43d78c83a", size = 2159932, upload-time = "2023-11-29T13:02:56.874Z" },
-    { url = "https://files.pythonhosted.org/packages/68/5c/58fd7a4e4191e41babc810f10ffbd2463f5fe6321e2ef02e0a72cacc3492/clang_format-17.0.6-py2.py3-none-win32.whl", hash = "sha256:edd55b840fa6edcdafb1651c3c24c6ea8d911e73be30373e7e8e5741cb585464", size = 1165073, upload-time = "2023-11-29T13:02:58.353Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/43/dd9dbd0191022ee1eeed7a48f3881f92abb68528f688f20a8659536ce8df/clang_format-17.0.6-py2.py3-none-win_amd64.whl", hash = "sha256:9407f0f4cb5a26b96af38bb2261f1c4015127f4d87ce46a61bb3a3c2a3d4f3cc", size = 1353600, upload-time = "2023-11-29T13:02:59.769Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c7/d6b6b2f37e559cefc07426170368ddb5951753b7a831668666c5d91d6b79/clang_format-20.1.7-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:70a904719a1bd6653d77ddc6d7b40418845912a1a2a419b9116b819a6b619f8c", size = 1436729, upload-time = "2025-06-26T12:57:02.479Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8c/ae7bc9122a2c7505506bba4aae9d9f38c01435b735a38c65985d30efc943/clang_format-20.1.7-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:e5257e8188569e4e47fceb3ba3317b0b44dc5ab5046c8cc2d58c626430c747a6", size = 1410576, upload-time = "2025-06-26T12:57:04.441Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c1/6777ef4eafa63d35dda0cda2803e818d17a0a9fe3216837eab1f169afbee/clang_format-20.1.7-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1dad1e6f9eb732b76046bf5810c6ee78b9e6cd6b3616cb75d9bde06ecd3222e6", size = 1794265, upload-time = "2025-06-26T12:57:05.722Z" },
+    { url = "https://files.pythonhosted.org/packages/54/8f/33a426e3b61cff30e4d8d7173508da277ece67296428b7657da681c821d5/clang_format-20.1.7-py2.py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27ed7fe674e8a77461c8d5b117ed96021aa18233917b3fe54b95391e0b22d04", size = 1968022, upload-time = "2025-06-26T12:57:07.03Z" },
+    { url = "https://files.pythonhosted.org/packages/da/1f/fc0fe12a27153370ca55490bedd29f11611b1a1336779472dec5f3d6af94/clang_format-20.1.7-py2.py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bd144f093b4a3ac8a0f0d0ebb9b013974884d9da0627b9905949c6f3213aa850", size = 2724211, upload-time = "2025-06-26T12:57:08.75Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/fd/7d7462d307d8827de0b8b183b3b467643e14c61e880b5485e7aa80a11db7/clang_format-20.1.7-py2.py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d79484ce2c8f621242046c4bb0aefd49445ec5c7bc3c404af97490289791b777", size = 1789853, upload-time = "2025-06-26T12:57:10.314Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/7f/55985595ffbf9bcec64ad36e9a0451cf8556ba0fb1a80781943de106cfa3/clang_format-20.1.7-py2.py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99cbfb99dab836027498190f55e543bed51bae33ae6dc256861e7aa91368de98", size = 1801091, upload-time = "2025-06-26T12:57:11.708Z" },
+    { url = "https://files.pythonhosted.org/packages/84/2e/04009020237243f8785188810ee33bc9ce0773e3ccba2599768381dac088/clang_format-20.1.7-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4c05114a10efe85c11fde518fe0fadc2977ce4a997a26ceaac88521daee83bbd", size = 2774653, upload-time = "2025-06-26T12:57:13.248Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/22/8f98cf57f54a06ff3a08dd79fba25617a4495614b6458bc69e46e81caa96/clang_format-20.1.7-py2.py3-none-musllinux_1_2_i686.whl", hash = "sha256:9cd4d64dc0e34b23badad0ce3a235fb5c8ac63651d9f91d1c806356212cbca6c", size = 3100264, upload-time = "2025-06-26T12:57:14.59Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/93/b5dc2959423b203f8a8db35ff7f19a114c50df265728714dcaf90d779d4f/clang_format-20.1.7-py2.py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:11431cb437ed22be85744ea47b3a6801bc61de7ac4b775bf1cb89ee190c992d4", size = 3186502, upload-time = "2025-06-26T12:57:16.176Z" },
+    { url = "https://files.pythonhosted.org/packages/da/a6/3ae4861b2fd3eba3b47d46e5c31b4dac0065a8048dc77825a85ac141e991/clang_format-20.1.7-py2.py3-none-musllinux_1_2_s390x.whl", hash = "sha256:29f5fe39e60579ca253d31c1122ce06a80716400ec7e5dc38833da80f88dbbd5", size = 3224655, upload-time = "2025-06-26T12:57:18.012Z" },
+    { url = "https://files.pythonhosted.org/packages/64/df/8668d80685b0556fead8ecc9ff221574d9f2b4011a68da155c54acab6dc6/clang_format-20.1.7-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:6db0b7271af8cbc2656b3b6b31e4276d5c6b8ceafb1981760f4738cfbe0a9e43", size = 2881843, upload-time = "2025-06-26T12:57:19.347Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e8/5f105c2195fe565b9b5203f533f6d727a73d98ef3b295e3f2f01ddf5d847/clang_format-20.1.7-py2.py3-none-win32.whl", hash = "sha256:7bd56bd0f519959488977dcddddba4e4fd07cba6225ed09ad658caa1f7286d1f", size = 1259337, upload-time = "2025-06-26T12:57:21.029Z" },
+    { url = "https://files.pythonhosted.org/packages/31/0d/a3685e3287d3ff3676297da331d7a05110dee049c773af2d6a1f5c8df0b0/clang_format-20.1.7-py2.py3-none-win_amd64.whl", hash = "sha256:4a9b909b1a9eb0b91aae51fdeeeb013ce20f9079d2e0fa8b8381e97c268dc889", size = 1444266, upload-time = "2025-06-26T12:57:22.37Z" },
+    { url = "https://files.pythonhosted.org/packages/88/93/5242ed23c0ec6b2e28509452b41c732789822c9e5aa4a899e406f9d15d64/clang_format-20.1.7-py2.py3-none-win_arm64.whl", hash = "sha256:d11c62d38b9144d30021b884b0f95e7270a6bcbf4f22bdd7dae94a531d82fbba", size = 1319591, upload-time = "2025-06-26T12:57:23.704Z" },
 ]
 
 [[package]]
@@ -309,7 +310,7 @@ format = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "clang-format", specifier = "~=17.0.6" },
+    { name = "clang-format", specifier = "~=20.1.0" },
     { name = "furo", specifier = ">=2023.5.20" },
     { name = "packaging", specifier = ">=14.0" },
     { name = "pydantic", specifier = ">=2.8" },
@@ -329,7 +330,7 @@ evg = [
     { name = "shrub-py", specifier = ">=3.7" },
     { name = "yamlloader", specifier = ">=1.5" },
 ]
-format = [{ name = "clang-format", specifier = "~=17.0.6" }]
+format = [{ name = "clang-format", specifier = "~=20.1.0" }]
 
 [[package]]
 name = "packaging"

--- a/uv.lock
+++ b/uv.lock
@@ -48,11 +48,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2025.4.26"
+version = "2025.6.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/9e/c05b3920a3b7d20d3d3310465f50348e5b3694f4f88c6daf736eef3024c4/certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6", size = 160705, upload-time = "2025-04-26T02:12:29.51Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/f7/f14b46d4bcd21092d7d3ccef689615220d8a08fb25e564b65d20738e672e/certifi-2025.6.15.tar.gz", hash = "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b", size = 158753, upload-time = "2025-06-15T02:45:51.329Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/7e/3db2bd1b1f9e95f7cddca6d6e75e2f2bd9f51b1246e546d88addca0106bd/certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3", size = 159618, upload-time = "2025-04-26T02:12:27.662Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ae/320161bd181fc06471eed047ecce67b693fd7515b16d495d8932db763426/certifi-2025.6.15-py3-none-any.whl", hash = "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057", size = 157650, upload-time = "2025-06-15T02:45:49.977Z" },
 ]
 
 [[package]]
@@ -343,7 +343,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.11.6"
+version = "2.11.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -351,9 +351,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/8f/9af0f46acc943b8c4592d06523f26a150acf6e6e37e8bd5f0ace925e996d/pydantic-2.11.6.tar.gz", hash = "sha256:12b45cfb4af17e555d3c6283d0b55271865fb0b43cc16dd0d52749dc7abf70e7", size = 787868, upload-time = "2025-06-13T09:00:29.595Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/dd/4325abf92c39ba8623b5af936ddb36ffcfe0beae70405d456ab1fb2f5b8c/pydantic-2.11.7.tar.gz", hash = "sha256:d989c3c6cb79469287b1569f7447a17848c998458d49ebe294e975b9baf0f0db", size = 788350, upload-time = "2025-06-14T08:33:17.137Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/11/7912a9a194ee4ea96520740d1534bc31a03a4a59d62e1d7cac9461d3f379/pydantic-2.11.6-py3-none-any.whl", hash = "sha256:a24478d2be1b91b6d3bc9597439f69ed5e87f68ebd285d86f7c7932a084b72e7", size = 444718, upload-time = "2025-06-13T09:00:27.134Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl", hash = "sha256:dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b", size = 444782, upload-time = "2025-06-14T08:33:14.905Z" },
 ]
 
 [[package]]
@@ -445,11 +445,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.1"
+version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
 ]
 
 [[package]]
@@ -778,11 +778,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.4.0"
+version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466", size = 390672, upload-time = "2025-04-10T15:23:39.232Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813", size = 128680, upload-time = "2025-04-10T15:23:37.377Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Raises the ClangFormat version used to format our codebase from 17.0.6 to 20.1.0 for better compatibility with recent versions of clangd (which embeds its own clang-format). See [ClangFormat 20.1 docs](https://releases.llvm.org/20.1.0/tools/clang/docs/ClangFormatStyleOptions.html) for reference.

---

The most significant change due to this upgrade is the formatting of list initializers, such as for compound literals, which does not seem to have a related configuration option (hence pre-ClangFormat 19 compatibility pains; it is not `SpaceAfterCStyleCast` or `SpaceBeforeCpp11BracedList`):

```c
// Before
(type){ ... }

// After
(type) { ... }
```

This upgrade also seems to insert a space after some `(paren)` which it may be (mis-)interpreting as as C-style cast. These changes are left as-is due to relatively minor impact (especially compared to the compound literal changes mentioned above).

```c
// Before
MONGOC_RPC_CONSUME (uint8_t, uint8_t, (uint8_t))

// After
MONGOC_RPC_CONSUME (uint8_t, uint8_t, (uint8_t) )
```

The last notable changes to mention are better handling of preprocessor macro definitions (e.g. applying existing rules, abbreviating to a single line, etc.). These changes are also left as-is due to relatively minor impact.

```c
// Before
#define BSON_INITIALIZER \
   {                     \
      3, 5,              \
      {                  \
         5               \
      }                  \
   }

// After
#define BSON_INITIALIZER {3, 5, {5}}
```

There is also this one particular change which confuses me, but I do not think it is worth going out of our way to address/prevent .

```c
// Before
typedef future_t *(func_with_opts_t) (func_ctx_t *ctx, bson_t *cmd);

// After (why?)
typedef future_t *(func_with_opts_t) (func_ctx_t * ctx, bson_t *cmd);
```

---

The ClangFormat configuration file is regenerated (via `--dump-config`) to explicitly address all new/changed/removed options. Notable changes (relative to the old ClangFormat 17 config or relative to ClangFormat 20 defaults) include:

- `AlwaysBreakAfterReturnType: All` is renamed to `BreakAfterReturnType: All`
- `AlwaysBreakTemplateDeclarations: Multiline` renamed to `BreakTemplateDeclarations: Multiline`
- `BinPackParameters` is set to `OnePerLine` (equivalent to former value of `false`).
- `IndentExportBlock` is set to `false` for consistency with other `Indent*` options (default is `true`).
- `KeepEmptyLinesAtTheStartOfBlocks: false` renamed to `KeepEmptyLines.AtStartOfBlock: false`.
- `KeepEmptyLinesAtEOF: false` is renamed to `KeepEmptyLines.AtEndOfFile: false`.
- `KeepEmptyLines.AtStartOfFile` is set to `false` for consistency with other `KeepEmptyLines` options (default is `true`).
    - Setting this new option modified a few files which had empty newlines at the start of the file.
- `MainIncludeChar` is set to `Any` (default is `Quote`).

All other options are left as their default values.