### PR TITLE
CDRIVER-6010 use `ec2.assume_role` for Azure KMS task

### DIFF
--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -16147,8 +16147,15 @@ task_groups:
 - name: testazurekms_task_group
   setup_group:
   - func: fetch-det
+  - command: ec2.assume_role
+    params:
+      role_arn: ${aws_test_secrets_role}
   - command: shell.exec
     params:
+      include_expansions_in_env:
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
       shell: bash
       script: |-
         set -o errexit

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/testazurekms.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/testazurekms.py
@@ -18,8 +18,6 @@
 from collections import OrderedDict as OD
 from typing import MutableSequence
 
-from config_generator.components.funcs.find_cmake_latest import FindCMakeLatest
-
 from evergreen_config_generator.functions import shell_exec, func
 from evergreen_config_generator.tasks import NamedTask
 from evergreen_config_generator.variants import Variant

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/testazurekms.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/testazurekms.py
@@ -117,6 +117,13 @@ def _create_task_group():
     task_group.setup_group_timeout_secs = 1800  # 30 minutes
     task_group.setup_group = [
         func("fetch-det"),
+        # Assume role to get AWS secrets.
+        {
+            "command": "ec2.assume_role",
+            "params": {
+                "role_arn": "${aws_test_secrets_role}"
+            }
+        },
         shell_exec(
             r"""
             DRIVERS_TOOLS=$(pwd)/drivers-evergreen-tools
@@ -136,6 +143,7 @@ def _create_task_group():
             $DRIVERS_TOOLS/.evergreen/csfle/azurekms/create-and-setup-vm.sh
             """,
             test=False,
+            include_expansions_in_env=[ "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN" ]
         ),
         # Load the AZUREKMS_VMNAME expansion.
         OD(


### PR DESCRIPTION
Apply fix from https://github.com/mongodb/mongo-c-driver/pull/2025 to `testazurekms-task`. Intended to fix [on-going failure](https://spruce.mongodb.com/task/mongo_c_driver_testazurekms_variant_testazurekms_task_30ac9bf0d8b2677a1a1e92a4fe5a13584845f30e_25_06_26_17_37_40/logs?execution=2) logging:

```
An error occurred (AccessDenied) when calling the AssumeRole operation
```

Verified with this patch build: https://spruce.mongodb.com/version/6862e5f5778aa400072b85d3
