### PR TITLE
CDRIVER-5998 share `SCHANNEL_CRED`

### DIFF
--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -1075,6 +1075,7 @@ set (test-libmongoc-sources
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-scram.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-sdam-monitoring.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-sdam.c
+   ${PROJECT_SOURCE_DIR}/tests/test-mongoc-secure-channel.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-server-description.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-server-selection-errors.c
    ${PROJECT_SOURCE_DIR}/tests/test-mongoc-server-selection.c

--- a/src/libmongoc/src/mongoc/mongoc-client-pool.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-pool.c
@@ -87,9 +87,7 @@ mongoc_client_pool_set_ssl_opts (mongoc_client_pool_t *pool, const mongoc_ssl_op
 #if defined(MONGOC_ENABLE_SSL_OPENSSL) && OPENSSL_VERSION_NUMBER >= 0x10100000L
       SSL_CTX_free (pool->topology->scanner->openssl_ctx);
       pool->topology->scanner->openssl_ctx = _mongoc_openssl_ctx_new (&pool->ssl_opts);
-#endif
-
-#if defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
+#elif defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
       // Access to secure_channel_cred_ptr does not need the thread-safe `mongoc_atomic_*` functions.
       // secure_channel_cred_ptr is not expected to be modified by multiple threads.
       // mongoc_client_pool_set_ssl_opts documentation prohibits calling after threads start.

--- a/src/libmongoc/src/mongoc/mongoc-client-pool.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-pool.c
@@ -39,6 +39,10 @@
 #include <mongoc/mongoc-openssl-private.h>
 #endif
 
+#if defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
+#include <mongoc/mongoc-stream-tls-secure-channel-private.h>
+#endif
+
 struct _mongoc_client_pool_t {
    bson_mutex_t mutex;
    mongoc_cond_t cond;
@@ -83,6 +87,15 @@ mongoc_client_pool_set_ssl_opts (mongoc_client_pool_t *pool, const mongoc_ssl_op
 #if defined(MONGOC_ENABLE_SSL_OPENSSL) && OPENSSL_VERSION_NUMBER >= 0x10100000L
       SSL_CTX_free (pool->topology->scanner->openssl_ctx);
       pool->topology->scanner->openssl_ctx = _mongoc_openssl_ctx_new (&pool->ssl_opts);
+#endif
+
+#if defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
+      // Access to secure_channel_cred_ptr does not need the thread-safe `mongoc_atomic_*` functions.
+      // secure_channel_cred_ptr is not expected to be modified by multiple threads.
+      // mongoc_client_pool_set_ssl_opts documentation prohibits calling after threads start.
+      mongoc_shared_ptr_reset (&pool->topology->scanner->secure_channel_cred_ptr,
+                               mongoc_secure_channel_cred_new (&pool->ssl_opts),
+                               mongoc_secure_channel_cred_deleter);
 #endif
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-client-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-private.h
@@ -38,6 +38,7 @@
 #include <mongoc/mongoc-topology-private.h>
 #include <mongoc/mongoc-write-concern.h>
 #include <mongoc/mongoc-crypt-private.h>
+#include <mongoc/mongoc-shared-private.h>
 
 BSON_BEGIN_DECLS
 
@@ -212,6 +213,7 @@ mongoc_client_connect (bool buffered,
                        const mongoc_uri_t *uri,
                        const mongoc_host_list_t *host,
                        void *openssl_ctx_void,
+                       mongoc_shared_ptr secure_channel_cred_ptr,
                        bson_error_t *error);
 
 

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -70,6 +70,11 @@
 #include <mongoc/mongoc-stream-tls-private.h>
 #endif
 
+#if defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
+#include <mongoc/mongoc-stream-tls-secure-channel-private.h>
+#include <mongoc/mongoc-stream-tls-private.h>
+#endif
+
 #include <common-string-private.h>
 #include <mlib/cmp.h>
 
@@ -756,6 +761,7 @@ mongoc_client_connect (bool buffered,
                        const mongoc_uri_t *uri,
                        const mongoc_host_list_t *host,
                        void *openssl_ctx_void,
+                       mongoc_shared_ptr secure_channel_cred_ptr,
                        bson_error_t *error)
 {
    mongoc_stream_t *base_stream = NULL;
@@ -765,6 +771,7 @@ mongoc_client_connect (bool buffered,
    BSON_ASSERT (host);
 
    BSON_UNUSED (openssl_ctx_void);
+   BSON_UNUSED (secure_channel_cred_ptr);
 
 #ifndef MONGOC_ENABLE_SSL
    if (ssl_opts_void || mongoc_uri_get_tls (uri)) {
@@ -814,6 +821,9 @@ mongoc_client_connect (bool buffered,
          // Use shared OpenSSL context.
          base_stream = mongoc_stream_tls_new_with_hostname_and_openssl_context (
             base_stream, host->host, ssl_opts, true, (SSL_CTX *) openssl_ctx_void);
+#elif defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
+         // Use shared Secure Channel credentials.
+         base_stream = mongoc_stream_tls_new_with_secure_channel_cred (base_stream, ssl_opts, secure_channel_cred_ptr);
 #else
          base_stream = mongoc_stream_tls_new_with_hostname (base_stream, host->host, ssl_opts, true);
 #endif
@@ -881,9 +891,13 @@ mongoc_client_default_stream_initiator (const mongoc_uri_t *uri,
 
 #if defined(MONGOC_ENABLE_SSL_OPENSSL) && OPENSSL_VERSION_NUMBER >= 0x10100000L
    SSL_CTX *ssl_ctx = client->topology->scanner->openssl_ctx;
-   return mongoc_client_connect (true, use_ssl, ssl_opts_void, uri, host, (void *) ssl_ctx, error);
+   return mongoc_client_connect (
+      true, use_ssl, ssl_opts_void, uri, host, (void *) ssl_ctx, MONGOC_SHARED_PTR_NULL, error);
+#elif defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
+   mongoc_shared_ptr cred_ptr = client->topology->scanner->secure_channel_cred_ptr;
+   return mongoc_client_connect (true, use_ssl, ssl_opts_void, uri, host, NULL, cred_ptr, error);
 #else
-   return mongoc_client_connect (true, use_ssl, ssl_opts_void, uri, host, NULL, error);
+   return mongoc_client_connect (true, use_ssl, ssl_opts_void, uri, host, NULL, MONGOC_SHARED_PTR_NULL, error);
 #endif
 }
 
@@ -1027,6 +1041,12 @@ _mongoc_client_set_ssl_opts_for_single_or_pooled (mongoc_client_t *client, const
 #if defined(MONGOC_ENABLE_SSL_OPENSSL) && OPENSSL_VERSION_NUMBER >= 0x10100000L
       SSL_CTX_free (client->topology->scanner->openssl_ctx);
       client->topology->scanner->openssl_ctx = _mongoc_openssl_ctx_new (&client->ssl_opts);
+#endif
+
+#if defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
+      mongoc_shared_ptr_reset (&client->topology->scanner->secure_channel_cred_ptr,
+                               mongoc_secure_channel_cred_new (&client->ssl_opts),
+                               mongoc_secure_channel_cred_deleter);
 #endif
    }
 }

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -894,8 +894,8 @@ mongoc_client_default_stream_initiator (const mongoc_uri_t *uri,
    return mongoc_client_connect (
       true, use_ssl, ssl_opts_void, uri, host, (void *) ssl_ctx, MONGOC_SHARED_PTR_NULL, error);
 #elif defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
-   mongoc_shared_ptr cred_ptr = client->topology->scanner->secure_channel_cred_ptr;
-   return mongoc_client_connect (true, use_ssl, ssl_opts_void, uri, host, NULL, cred_ptr, error);
+   return mongoc_client_connect (
+      true, use_ssl, ssl_opts_void, uri, host, NULL, client->topology->scanner->secure_channel_cred_ptr, error);
 #else
    return mongoc_client_connect (true, use_ssl, ssl_opts_void, uri, host, NULL, MONGOC_SHARED_PTR_NULL, error);
 #endif

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel-private.h
@@ -33,10 +33,10 @@
 BSON_BEGIN_DECLS
 
 bool
-mongoc_secure_channel_setup_ca (mongoc_ssl_opt_t *opt);
+mongoc_secure_channel_setup_ca (const mongoc_ssl_opt_t *opt);
 
 bool
-mongoc_secure_channel_setup_crl (mongoc_ssl_opt_t *opt);
+mongoc_secure_channel_setup_crl (const mongoc_ssl_opt_t *opt);
 
 // mongoc_secure_channel_load_crl is used in tests.
 PCCRL_CONTEXT
@@ -49,7 +49,7 @@ ssize_t
 mongoc_secure_channel_write (mongoc_stream_tls_t *tls, const void *data, size_t data_length);
 
 PCCERT_CONTEXT
-mongoc_secure_channel_setup_certificate (mongoc_ssl_opt_t *opt);
+mongoc_secure_channel_setup_certificate (const mongoc_ssl_opt_t *opt);
 
 
 /* it may require 16k + some overhead to hold one decryptable block of data - do

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -671,18 +671,18 @@ mongoc_secure_channel_handshake_step_1 (mongoc_stream_tls_t *tls, char *hostname
    secure_channel->ctxt = (mongoc_secure_channel_ctxt *) bson_malloc0 (sizeof (mongoc_secure_channel_ctxt));
 
    /* https://msdn.microsoft.com/en-us/library/windows/desktop/aa375924.aspx */
-   sspi_status = InitializeSecurityContext (&secure_channel->cred->cred_handle, /* phCredential */
-                                            NULL,                               /* phContext */
-                                            hostname,                           /* pszTargetName */
-                                            secure_channel->req_flags,          /* fContextReq */
-                                            0,                                  /* Reserved1, must be 0 */
-                                            0,                                  /* TargetDataRep, unused */
-                                            NULL,                               /* pInput */
-                                            0,                                  /* Reserved2, must be 0 */
-                                            &secure_channel->ctxt->ctxt_handle, /* phNewContext OUT param */
-                                            &outbuf_desc,                       /* pOutput OUT param */
-                                            &secure_channel->ret_flags,         /* pfContextAttr OUT param */
-                                            &secure_channel->ctxt->time_stamp   /* ptsExpiry OUT param */
+   sspi_status = InitializeSecurityContext (&secure_channel->cred_handle->cred_handle, /* phCredential */
+                                            NULL,                                      /* phContext */
+                                            hostname,                                  /* pszTargetName */
+                                            secure_channel->req_flags,                 /* fContextReq */
+                                            0,                                         /* Reserved1, must be 0 */
+                                            0,                                         /* TargetDataRep, unused */
+                                            NULL,                                      /* pInput */
+                                            0,                                         /* Reserved2, must be 0 */
+                                            &secure_channel->ctxt->ctxt_handle,        /* phNewContext OUT param */
+                                            &outbuf_desc,                              /* pOutput OUT param */
+                                            &secure_channel->ret_flags,                /* pfContextAttr OUT param */
+                                            &secure_channel->ctxt->time_stamp          /* ptsExpiry OUT param */
    );
    if (sspi_status != SEC_I_CONTINUE_NEEDED) {
       // Cast signed SECURITY_STATUS to unsigned DWORD. FormatMessage expects DWORD.
@@ -739,7 +739,7 @@ mongoc_secure_channel_handshake_step_2 (mongoc_stream_tls_t *tls, char *hostname
 
    TRACE ("%s", "SSL/TLS connection with endpoint (step 2/3)");
 
-   if (!secure_channel->cred || !secure_channel->ctxt) {
+   if (!secure_channel->cred_handle || !secure_channel->ctxt) {
       MONGOC_LOG_AND_SET_ERROR (
          error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "required TLS credentials or context not provided");
 
@@ -809,7 +809,7 @@ mongoc_secure_channel_handshake_step_2 (mongoc_stream_tls_t *tls, char *hostname
 
       /* https://msdn.microsoft.com/en-us/library/windows/desktop/aa375924.aspx
        */
-      sspi_status = InitializeSecurityContext (&secure_channel->cred->cred_handle,
+      sspi_status = InitializeSecurityContext (&secure_channel->cred_handle->cred_handle,
                                                &secure_channel->ctxt->ctxt_handle,
                                                hostname,
                                                secure_channel->req_flags,
@@ -989,7 +989,7 @@ mongoc_secure_channel_handshake_step_3 (mongoc_stream_tls_t *tls, char *hostname
 
    TRACE ("SSL/TLS connection with %s (step 3/3)", hostname);
 
-   if (!secure_channel->cred) {
+   if (!secure_channel->cred_handle) {
       MONGOC_LOG_AND_SET_ERROR (
          error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "required TLS credentials not provided");
       return false;

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -379,14 +379,14 @@ fail:
 }
 
 PCCERT_CONTEXT
-mongoc_secure_channel_setup_certificate (mongoc_ssl_opt_t *opt)
+mongoc_secure_channel_setup_certificate (const mongoc_ssl_opt_t *opt)
 {
    return mongoc_secure_channel_setup_certificate_from_file (opt->pem_file);
 }
 
 
 bool
-mongoc_secure_channel_setup_ca (mongoc_ssl_opt_t *opt)
+mongoc_secure_channel_setup_ca (const mongoc_ssl_opt_t *opt)
 {
    bool ok = false;
    char *pem = NULL;
@@ -496,7 +496,7 @@ fail:
 }
 
 bool
-mongoc_secure_channel_setup_crl (mongoc_ssl_opt_t *opt)
+mongoc_secure_channel_setup_crl (const mongoc_ssl_opt_t *opt)
 {
    HCERTSTORE cert_store = NULL;
    bool ok = false;

--- a/src/libmongoc/src/mongoc/mongoc-server-monitor.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-monitor.c
@@ -933,6 +933,7 @@ _server_monitor_setup_connection (mongoc_server_monitor_t *server_monitor,
    } else {
       void *ssl_opts_void = NULL;
       void *openssl_ctx_void = NULL;
+      mongoc_shared_ptr secure_channel_cred_ptr = MONGOC_SHARED_PTR_NULL;
 
 #ifdef MONGOC_ENABLE_SSL
       ssl_opts_void = server_monitor->ssl_opts;
@@ -942,12 +943,17 @@ _server_monitor_setup_connection (mongoc_server_monitor_t *server_monitor,
       openssl_ctx_void = server_monitor->topology->scanner->openssl_ctx;
 #endif
 
+#if defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
+      secure_channel_cred_ptr = server_monitor->topology->scanner->secure_channel_cred_ptr;
+#endif
+
       server_monitor->stream = mongoc_client_connect (false,
                                                       ssl_opts_void != NULL,
                                                       ssl_opts_void,
                                                       server_monitor->uri,
                                                       &server_monitor->description->host,
                                                       openssl_ctx_void,
+                                                      secure_channel_cred_ptr,
                                                       error);
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-private.h
@@ -28,6 +28,8 @@
 #include <openssl/ssl.h>
 #endif
 
+#include <mongoc/mongoc-shared-private.h>
+
 BSON_BEGIN_DECLS
 
 /**
@@ -54,6 +56,13 @@ mongoc_stream_tls_new_with_hostname_and_openssl_context (mongoc_stream_t *base_s
                                                          int client,
                                                          SSL_CTX *ssl_ctx) BSON_GNUC_WARN_UNUSED_RESULT;
 #endif
+
+#if defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
+mongoc_stream_t *
+mongoc_stream_tls_new_with_secure_channel_cred (mongoc_stream_t *base_stream,
+                                                mongoc_ssl_opt_t *opt,
+                                                mongoc_shared_ptr secure_channel_cred_ptr) BSON_GNUC_WARN_UNUSED_RESULT;
+#endif // MONGOC_ENABLE_SSL_SECURE_CHANNEL
 
 BSON_END_DECLS
 

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-private.h
@@ -55,9 +55,7 @@ mongoc_stream_tls_new_with_hostname_and_openssl_context (mongoc_stream_t *base_s
                                                          mongoc_ssl_opt_t *opt,
                                                          int client,
                                                          SSL_CTX *ssl_ctx) BSON_GNUC_WARN_UNUSED_RESULT;
-#endif
-
-#if defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
+#elif defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
 mongoc_stream_t *
 mongoc_stream_tls_new_with_secure_channel_cred (mongoc_stream_t *base_stream,
                                                 mongoc_ssl_opt_t *opt,

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel-private.h
@@ -45,7 +45,7 @@ typedef struct {
    CredHandle cred_handle;
    TimeStamp time_stamp;
    PCCERT_CONTEXT cert; /* Owning. Optional client cert. */
-} mongoc_secure_channel_cred;
+} mongoc_secure_channel_cred_handle;
 
 typedef struct {
    CtxtHandle ctxt_handle;
@@ -59,7 +59,7 @@ typedef struct {
  */
 typedef struct {
    ssl_connect_state connecting_state;
-   mongoc_secure_channel_cred *cred;
+   mongoc_secure_channel_cred_handle *cred;
    mongoc_secure_channel_ctxt *ctxt;
    SecPkgContext_StreamSizes stream_sizes;
    size_t encdata_length, decdata_length;

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel-private.h
@@ -93,7 +93,7 @@ mongoc_secure_channel_cred_deleter (void *cred_void);
 
 struct _mongoc_stream_t *
 mongoc_stream_tls_secure_channel_new_with_creds (struct _mongoc_stream_t *base_stream,
-                                                 struct _mongoc_ssl_opt_t *opt,
+                                                 const struct _mongoc_ssl_opt_t *opt,
                                                  mongoc_shared_ptr cred_ptr /* optional */);
 
 BSON_END_DECLS

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel-private.h
@@ -22,9 +22,12 @@
 #ifdef MONGOC_ENABLE_SSL_SECURE_CHANNEL
 #include <bson/bson.h>
 
+#include <mongoc/mongoc-shared-private.h>
+
 /* Its mandatory to indicate to Windows who is compiling the code */
 #define SECURITY_WIN32
 #include <security.h>
+#include <schannel.h>
 
 
 BSON_BEGIN_DECLS
@@ -44,8 +47,13 @@ typedef enum {
 typedef struct {
    CredHandle cred_handle;
    TimeStamp time_stamp;
-   PCCERT_CONTEXT cert; /* Owning. Optional client cert. */
 } mongoc_secure_channel_cred_handle;
+
+// `mongoc_secure_channel_cred` may be shared on multiple connections.
+typedef struct _mongoc_secure_channel_cred {
+   PCCERT_CONTEXT cert; /* Owning. Optional client cert. */
+   SCHANNEL_CRED cred;  // TODO: switch to SCH_CREDENTIALS to support TLS v1.3
+} mongoc_secure_channel_cred;
 
 typedef struct {
    CtxtHandle ctxt_handle;
@@ -59,7 +67,8 @@ typedef struct {
  */
 typedef struct {
    ssl_connect_state connecting_state;
-   mongoc_secure_channel_cred_handle *cred;
+   mongoc_shared_ptr cred_ptr; // Manages a mongoc_secure_channel_cred.
+   mongoc_secure_channel_cred_handle *cred_handle;
    mongoc_secure_channel_ctxt *ctxt;
    SecPkgContext_StreamSizes stream_sizes;
    size_t encdata_length, decdata_length;
@@ -72,6 +81,20 @@ typedef struct {
    bool recv_connection_closed; /* true if connection closed, regardless how */
 } mongoc_stream_tls_secure_channel_t;
 
+struct _mongoc_ssl_opt_t; // Forward declare. Defined in mongoc-ssl.h.
+struct _mongoc_stream_t;  // Forward declare. Defined in mongoc-stream.h.
+
+mongoc_secure_channel_cred *
+mongoc_secure_channel_cred_new (const struct _mongoc_ssl_opt_t *opt);
+
+// mongoc_secure_channel_cred_deleter is useful as a deleter for mongoc_shared_t.
+void
+mongoc_secure_channel_cred_deleter (void *cred_void);
+
+struct _mongoc_stream_t *
+mongoc_stream_tls_secure_channel_new_with_creds (struct _mongoc_stream_t *base_stream,
+                                                 struct _mongoc_ssl_opt_t *opt,
+                                                 mongoc_shared_ptr cred_ptr /* optional */);
 
 BSON_END_DECLS
 

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
@@ -993,6 +993,9 @@ mongoc_stream_tls_secure_channel_new_with_creds (mongoc_stream_t *base_stream,
       char *msg = mongoc_winerr_to_string ((DWORD) sspi_status);
       MONGOC_ERROR ("Failed to initialize security context: %s", msg);
       bson_free (msg);
+      // Detach the base stream so caller can free.
+      tls->base_stream = NULL;
+      mongoc_stream_destroy ((mongoc_stream_t *) tls);
       RETURN (NULL);
    }
 

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
@@ -919,7 +919,7 @@ mongoc_stream_tls_secure_channel_new (mongoc_stream_t *base_stream, const char *
 
 mongoc_stream_t *
 mongoc_stream_tls_secure_channel_new_with_creds (mongoc_stream_t *base_stream,
-                                                 mongoc_ssl_opt_t *opt,
+                                                 const mongoc_ssl_opt_t *opt,
                                                  mongoc_shared_ptr cred_ptr)
 {
    SECURITY_STATUS sspi_status = SEC_E_OK;

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-secure-channel.c
@@ -937,7 +937,8 @@ mongoc_stream_tls_secure_channel_new (mongoc_stream_t *base_stream, const char *
 
    schannel_cred.grbitEnabledProtocols = SP_PROT_TLS1_1_CLIENT | SP_PROT_TLS1_2_CLIENT;
 
-   secure_channel->cred = (mongoc_secure_channel_cred *) bson_malloc0 (sizeof (mongoc_secure_channel_cred));
+   secure_channel->cred =
+      (mongoc_secure_channel_cred_handle *) bson_malloc0 (sizeof (mongoc_secure_channel_cred_handle));
    if (cert) {
       // Store client cert to free later.
       secure_channel->cred->cert = cert;

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls.c
@@ -143,7 +143,7 @@ mongoc_stream_tls_handshake_block (mongoc_stream_t *stream, const char *host, in
  *       NULL on failure, otherwise a mongoc_stream_t.
  *
  * Side effects:
- *       None.
+ *       May set opt->allow_invalid_hostname to true.
  *
  *--------------------------------------------------------------------------
  */
@@ -226,5 +226,19 @@ mongoc_stream_tls_new_with_hostname_and_openssl_context (
    return mongoc_stream_tls_openssl_new_with_context (base_stream, host, opt, client, ssl_ctx);
 }
 #endif
+
+#if defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
+mongoc_stream_t *
+mongoc_stream_tls_new_with_secure_channel_cred (mongoc_stream_t *base_stream,
+                                                mongoc_ssl_opt_t *opt,
+                                                mongoc_shared_ptr secure_channel_cred_ptr)
+{
+   if (opt->weak_cert_validation) {
+      // For compatibility with `mongoc_stream_tls_new_with_hostname`, modify `opt` directly:
+      opt->allow_invalid_hostname = true;
+   }
+   return mongoc_stream_tls_secure_channel_new_with_creds (base_stream, opt, secure_channel_cred_ptr);
+}
+#endif // MONGOC_ENABLE_SSL_SECURE_CHANNEL
 
 #endif

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls.c
@@ -121,37 +121,22 @@ mongoc_stream_tls_handshake_block (mongoc_stream_t *stream, const char *host, in
    return false;
 }
 
-
-/*
- *--------------------------------------------------------------------------
- *
- * mongoc_stream_tls_new_with_hostname --
- *
- *       Creates a new mongoc_stream_tls_t to communicate with a remote
- *       server using a TLS stream.
- *
- *       @host the hostname we are connected to and to verify the
- *       server certificate against
- *
- *       @base_stream should be a stream that will become owned by the
- *       resulting tls stream. It will be used for raw I/O.
- *
- *       @trust_store_dir should be a path to the SSL cert db to use for
- *       verifying trust of the remote server.
- *
- * Returns:
- *       NULL on failure, otherwise a mongoc_stream_t.
- *
- * Side effects:
- *       May set opt->allow_invalid_hostname to true.
- *
- *--------------------------------------------------------------------------
- */
-
+// mongoc_stream_tls_new_with_hostname creates a TLS stream.
+//
+// base_stream: underlying data stream. Ownership is transferred to the returned stream on success.
+// host: hostname used to verify the the server certificate.
+// opt: TLS options.
+// client: indicates a client or server stream. Secure Channel implementation does not support server streams.
+//
+// Side effect: May set opt->allow_invalid_hostname to true.
+//
+// Returns a new stream on success. Returns `NULL` on failure.
 mongoc_stream_t *
 mongoc_stream_tls_new_with_hostname (mongoc_stream_t *base_stream, const char *host, mongoc_ssl_opt_t *opt, int client)
 {
-   BSON_ASSERT (base_stream);
+   BSON_ASSERT_PARAM (base_stream);
+   BSON_OPTIONAL_PARAM (host);
+   BSON_ASSERT_PARAM (opt);
 
    /* !client is only used for testing,
     * when the streams are pretending to be the server */
@@ -178,37 +163,27 @@ mongoc_stream_tls_new_with_hostname (mongoc_stream_t *base_stream, const char *h
 }
 
 #if defined(MONGOC_ENABLE_SSL_OPENSSL) && OPENSSL_VERSION_NUMBER >= 0x10100000L
-/*
- *--------------------------------------------------------------------------
- *
- * mongoc_stream_tls_new_with_hostname_and_openssl_context --
- *
- *       Creates a new mongoc_stream_tls_t to communicate with a remote
- *       server using a TLS stream, using an existing OpenSSL context.
- *
- *       @ssl_ctx is the global OpenSSL context for the mongoc_client_t
- *       associated with this function call.
- *
- *       @host the hostname we are connected to and to verify the
- *       server certificate against
- *
- *       @base_stream should be a stream that will become owned by the
- *       resulting tls stream. It will be used for raw I/O.
- *
- * Returns:
- *       NULL on failure, otherwise a mongoc_stream_t.
- *
- * Side effects:
- *       None.
- *
- *--------------------------------------------------------------------------
- */
-
+// Create an OpenSSL TLS stream with a shared context.
+//
+// This is an internal extension to mongoc_stream_tls_new_with_hostname.
+//
+// base_stream: underlying data stream. Ownership is transferred to the returned stream on success.
+// host: hostname used to verify the the server certificate.
+// opt: TLS options.
+// client: indicates a client or server stream.
+// ssl_ctx: shared context.
+//
+// Side effect: May set opt->allow_invalid_hostname to true for compatibility with mongoc_stream_tls_new_with_hostname.
+//
+// Returns a new stream on success. Returns `NULL` on failure.
 mongoc_stream_t *
 mongoc_stream_tls_new_with_hostname_and_openssl_context (
    mongoc_stream_t *base_stream, const char *host, mongoc_ssl_opt_t *opt, int client, SSL_CTX *ssl_ctx)
 {
-   BSON_ASSERT (base_stream);
+   BSON_ASSERT_PARAM (base_stream);
+   BSON_OPTIONAL_PARAM (host);
+   BSON_ASSERT_PARAM (opt);
+   BSON_OPTIONAL_PARAM (ssl_ctx);
 
    /* !client is only used for testing,
     * when the streams are pretending to be the server */
@@ -228,11 +203,25 @@ mongoc_stream_tls_new_with_hostname_and_openssl_context (
 #endif
 
 #if defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
+// Create a Secure Channel TLS stream with shared credentials.
+//
+// This is an internal extension to mongoc_stream_tls_new_with_hostname.
+//
+// base_stream: underlying data stream. Ownership is transferred to the returned stream on success.
+// opt: TLS options.
+// secure_channel_cred_ptr: optional shared credentials. May be MONGOC_SHARED_PTR_NULL.
+//
+// Side effect: May set opt->allow_invalid_hostname to true for compatibility with mongoc_stream_tls_new_with_hostname.
+//
+// Returns a new stream on success. Returns `NULL` on failure.
 mongoc_stream_t *
 mongoc_stream_tls_new_with_secure_channel_cred (mongoc_stream_t *base_stream,
                                                 mongoc_ssl_opt_t *opt,
                                                 mongoc_shared_ptr secure_channel_cred_ptr)
 {
+   BSON_ASSERT_PARAM (base_stream);
+   BSON_ASSERT_PARAM (opt);
+
    if (opt->weak_cert_validation) {
       // For compatibility with `mongoc_stream_tls_new_with_hostname`, modify `opt` directly:
       opt->allow_invalid_hostname = true;

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner-private.h
@@ -35,6 +35,7 @@
 #include <mongoc/mongoc-crypto-private.h>
 #include <mongoc/mongoc-server-description-private.h>
 #include <common-thread-private.h>
+#include <mongoc/mongoc-shared-private.h>
 
 BSON_BEGIN_DECLS
 
@@ -133,6 +134,8 @@ typedef struct mongoc_topology_scanner {
 
 #if defined(MONGOC_ENABLE_SSL_OPENSSL) && OPENSSL_VERSION_NUMBER >= 0x10100000L
    SSL_CTX *openssl_ctx;
+#elif defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
+   mongoc_shared_ptr secure_channel_cred_ptr; // Manages a mongoc_secure_channel_cred.
 #endif
 
    int64_t dns_cache_timeout_ms;

--- a/src/libmongoc/tests/test-libmongoc-main.c
+++ b/src/libmongoc/tests/test-libmongoc-main.c
@@ -161,6 +161,7 @@ main (int argc, char *argv[])
    TEST_INSTALL (test_mcd_nsinfo_install);
    TEST_INSTALL (test_bulkwrite_install);
    TEST_INSTALL (test_mongoc_oidc_callback_install);
+   TEST_INSTALL (test_secure_channel_install);
 
    const int ret = TestSuite_Run (&suite);
 

--- a/src/libmongoc/tests/test-mongoc-secure-channel.c
+++ b/src/libmongoc/tests/test-mongoc-secure-channel.c
@@ -9,7 +9,7 @@
 #include <mongoc/mongoc-client-private.h>    // mongoc_client_connect_tcp
 #include <mongoc/mongoc-log-private.h>       // _mongoc_log_get_handler
 #include <test-conveniences.h>
-
+#include <mlib/test.h>
 
 static bool
 connect_with_secure_channel_cred (mongoc_ssl_opt_t *ssl_opt, mongoc_shared_ptr cred_ptr, bson_error_t *error)
@@ -154,7 +154,7 @@ test_secure_channel_shared_creds_client (void *unused)
       }
 
       // Expect exactly one attempt to load the client cert:
-      ASSERT_CMPSIZE_T (1, ==, cf.failures);
+      mlib_check (1, eq, cf.failures);
       mongoc_client_destroy (client);
    }
 
@@ -182,7 +182,7 @@ test_secure_channel_shared_creds_client (void *unused)
       mongoc_client_pool_push (pool, client);
 
       // Expect exactly one attempt to load the client cert:
-      ASSERT_CMPSIZE_T (1, ==, cf.failures);
+      mlib_check (1, eq, cf.failures);
 
       mongoc_client_pool_destroy (pool);
    }
@@ -209,8 +209,8 @@ test_secure_channel_shared_creds_client (void *unused)
       }
 
       // Expect exactly one attempt to load the client cert:
-      ASSERT_CMPSIZE_T (1, ==, cf.failures);
-      ASSERT_CMPSIZE_T (0, ==, cf.failures2);
+      mlib_check (1, eq, cf.failures);
+      mlib_check (0, eq, cf.failures2);
 
       // Change the client cert:
       {
@@ -226,8 +226,8 @@ test_secure_channel_shared_creds_client (void *unused)
       }
 
       // Expect an attempt to load the new cert:
-      ASSERT_CMPSIZE_T (1, ==, cf.failures); // Unchanged.
-      ASSERT_CMPSIZE_T (1, ==, cf.failures2);
+      mlib_check (1, eq, cf.failures); // Unchanged.
+      mlib_check (1, eq, cf.failures2);
 
       mongoc_client_destroy (client);
    }

--- a/src/libmongoc/tests/test-mongoc-secure-channel.c
+++ b/src/libmongoc/tests/test-mongoc-secure-channel.c
@@ -68,6 +68,18 @@ test_secure_channel_shared_creds_stream (void *unused)
       ASSERT_OR_PRINT (ok, error);
       mongoc_shared_ptr_reset_null (&cred_ptr);
    }
+
+   // Test with bad SCHANNEL_CRED to exercise error path:
+   {
+      mongoc_secure_channel_cred *cred = mongoc_secure_channel_cred_new (&ssl_opt);
+      mongoc_shared_ptr cred_ptr = mongoc_shared_ptr_create (cred, mongoc_secure_channel_cred_deleter);
+      cred->cred.dwVersion = 0; // Invalid version.
+      capture_logs (true);
+      ok = connect_with_secure_channel_cred (&ssl_opt, cred_ptr, &error);
+      ASSERT (!ok);
+      ASSERT_CAPTURED_LOG ("schannel", MONGOC_LOG_LEVEL_ERROR, "Failed to initialize security context");
+      mongoc_shared_ptr_reset_null (&cred_ptr);
+   }
 }
 
 typedef struct {

--- a/src/libmongoc/tests/test-mongoc-secure-channel.c
+++ b/src/libmongoc/tests/test-mongoc-secure-channel.c
@@ -155,6 +155,7 @@ test_secure_channel_shared_creds_client (void *unused)
 
       // Expect exactly one attempt to load the client cert:
       ASSERT_CMPSIZE_T (1, ==, cf.failures);
+      mongoc_client_destroy (client);
    }
 
    cf = (cert_failures) {0};

--- a/src/libmongoc/tests/test-mongoc-secure-channel.c
+++ b/src/libmongoc/tests/test-mongoc-secure-channel.c
@@ -75,7 +75,7 @@ typedef struct {
    size_t failures2;
 } cert_failures;
 
-void
+static void
 count_cert_failures (mongoc_log_level_t log_level, const char *log_domain, const char *message, void *user_data)
 {
    cert_failures *cf = user_data;

--- a/src/libmongoc/tests/test-mongoc-secure-channel.c
+++ b/src/libmongoc/tests/test-mongoc-secure-channel.c
@@ -78,6 +78,8 @@ typedef struct {
 static void
 count_cert_failures (mongoc_log_level_t log_level, const char *log_domain, const char *message, void *user_data)
 {
+   BSON_UNUSED (log_level);
+   BSON_UNUSED (log_domain);
    cert_failures *cf = user_data;
    if (strstr (message, "Failed to open file: 'does-not-exist.pem'")) {
       cf->failures++;

--- a/src/libmongoc/tests/test-mongoc-secure-channel.c
+++ b/src/libmongoc/tests/test-mongoc-secure-channel.c
@@ -49,7 +49,6 @@ test_secure_channel_shared_creds_stream (void *unused)
    BSON_UNUSED (unused);
 
    mongoc_stream_t *stream;
-   mongoc_stream_tls_secure_channel_t *schannel_stream_view;
    bson_error_t error;
    mongoc_ssl_opt_t ssl_opt = {.ca_file = CERT_TEST_DIR "/ca.pem", .pem_file = CERT_TEST_DIR "/client.pem"};
    // Test with no sharing:

--- a/src/libmongoc/tests/test-mongoc-secure-channel.c
+++ b/src/libmongoc/tests/test-mongoc-secure-channel.c
@@ -1,0 +1,262 @@
+#include <mongoc/mongoc.h>
+
+#include "TestSuite.h"
+#include "test-libmongoc.h"
+
+#if defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
+#include <mongoc/mongoc-stream-tls-secure-channel-private.h>
+#include <mongoc/mongoc-host-list-private.h> // _mongoc_host_list_from_string_with_err
+#include <mongoc/mongoc-client-private.h>    // mongoc_client_connect_tcp
+#include <mongoc/mongoc-log-private.h>       // _mongoc_log_get_handler
+#include <test-conveniences.h>
+
+
+static bool
+connect_with_secure_channel_cred (mongoc_ssl_opt_t *ssl_opt, mongoc_shared_ptr cred_ptr, bson_error_t *error)
+{
+   mongoc_host_list_t host;
+   const int32_t connect_timout_ms = 10000;
+
+   *error = (bson_error_t) {0};
+
+   if (!_mongoc_host_list_from_string_with_err (&host, "localhost:27017", error)) {
+      return false;
+   }
+   mongoc_stream_t *tcp_stream = mongoc_client_connect_tcp (connect_timout_ms, &host, error);
+   if (!tcp_stream) {
+      return false;
+   }
+
+   mongoc_stream_t *tls_stream = mongoc_stream_tls_secure_channel_new_with_creds (tcp_stream, ssl_opt, cred_ptr);
+   if (!tls_stream) {
+      mongoc_stream_destroy (tcp_stream);
+      return false;
+   }
+
+   if (!mongoc_stream_tls_handshake_block (tls_stream, host.host, connect_timout_ms, error)) {
+      mongoc_stream_destroy (tls_stream);
+      return false;
+   }
+
+   mongoc_stream_destroy (tls_stream);
+   return true;
+}
+
+// Test a TLS stream can be create with shared Secure Channel credentials.
+static void
+test_secure_channel_shared_creds_stream (void *unused)
+{
+   BSON_UNUSED (unused);
+
+   bool ok;
+   bson_error_t error;
+   mongoc_ssl_opt_t ssl_opt = {.ca_file = CERT_TEST_DIR "/ca.pem", .pem_file = CERT_TEST_DIR "/client.pem"};
+   // Test with no sharing:
+   {
+      ok = connect_with_secure_channel_cred (&ssl_opt, MONGOC_SHARED_PTR_NULL, &error);
+      ASSERT_OR_PRINT (ok, error);
+   }
+
+   // Test with sharing:
+   {
+      mongoc_shared_ptr cred_ptr =
+         mongoc_shared_ptr_create (mongoc_secure_channel_cred_new (&ssl_opt), mongoc_secure_channel_cred_deleter);
+      ok = connect_with_secure_channel_cred (&ssl_opt, cred_ptr, &error);
+      ASSERT_OR_PRINT (ok, error);
+      // Use again.
+      ok = connect_with_secure_channel_cred (&ssl_opt, cred_ptr, &error);
+      ASSERT_OR_PRINT (ok, error);
+      mongoc_shared_ptr_reset_null (&cred_ptr);
+   }
+}
+
+typedef struct {
+   size_t failures;
+   size_t failures2;
+} cert_failures;
+
+void
+count_cert_failures (mongoc_log_level_t log_level, const char *log_domain, const char *message, void *user_data)
+{
+   cert_failures *cf = user_data;
+   if (strstr (message, "Failed to open file: 'does-not-exist.pem'")) {
+      cf->failures++;
+   }
+   if (strstr (message, "Failed to open file: 'does-not-exist-2.pem'")) {
+      cf->failures2++;
+   }
+}
+
+static bool
+try_ping (mongoc_client_t *client, bson_error_t *error)
+{
+   return mongoc_client_command_simple (client, "admin", tmp_bson (BSON_STR ({"ping" : 1})), NULL, NULL, error);
+}
+
+static bool
+try_ping_with_reconnect (mongoc_client_t *client, bson_error_t *error)
+{
+   // Force a connection error with a failpoint:
+   if (!mongoc_client_command_simple (client,
+                                      "admin",
+                                      tmp_bson (BSON_STR ({
+                                         "configureFailPoint" : "failCommand",
+                                         "mode" : {"times" : 1},
+                                         "data" : {"closeConnection" : true, "failCommands" : ["ping"]}
+                                      })),
+                                      NULL,
+                                      NULL,
+                                      error)) {
+      return false;
+   }
+
+   // Expect first ping to fail:
+   if (try_ping (client, error)) {
+      bson_set_error (error, 0, 0, "unexpected: ping succeeded, but expected to fail");
+      return false;
+   }
+
+   // Ping again:
+   return try_ping (client, error);
+}
+
+static void
+test_secure_channel_shared_creds_client (void *unused)
+{
+   BSON_UNUSED (unused);
+
+   bson_error_t error;
+
+   // Save log function:
+   mongoc_log_func_t saved_log_func;
+   void *saved_log_data;
+   _mongoc_log_get_handler (&saved_log_func, &saved_log_data);
+
+   // Set log function to count failed attempts to load client cert:
+   cert_failures cf = {0};
+   mongoc_log_set_handler (count_cert_failures, &cf);
+
+   // Test client:
+   {
+      mongoc_client_t *client = test_framework_new_default_client ();
+
+      // Set client cert to a bad path:
+      {
+         mongoc_ssl_opt_t ssl_opt = *test_framework_get_ssl_opts ();
+         ssl_opt.pem_file = "does-not-exist.pem";
+         mongoc_client_set_ssl_opts (client, &ssl_opt);
+      }
+
+      // Expect insert OK. Cert fails to load, but server configured with --tlsAllowConnectionsWithoutCertificates:
+      {
+         bool ok = try_ping (client, &error);
+         ASSERT_OR_PRINT (ok, error);
+      }
+
+      // Expect exactly one attempt to load the client cert:
+      ASSERT_CMPSIZE_T (1, ==, cf.failures);
+   }
+
+   cf = (cert_failures) {0};
+
+   // Test pool:
+   {
+      mongoc_client_pool_t *pool = test_framework_new_default_client_pool ();
+
+      // Set client cert to a bad path:
+      {
+         mongoc_ssl_opt_t ssl_opt = *test_framework_get_ssl_opts ();
+         ssl_opt.pem_file = "does-not-exist.pem";
+         mongoc_client_pool_set_ssl_opts (pool, &ssl_opt);
+      }
+
+      mongoc_client_t *client = mongoc_client_pool_pop (pool);
+
+      // Expect insert OK. Cert fails to load, but server configured with --tlsAllowConnectionsWithoutCertificates:
+      {
+         bool ok = try_ping (client, &error);
+         ASSERT_OR_PRINT (ok, error);
+      }
+
+      mongoc_client_pool_push (pool, client);
+
+      // Expect exactly one attempt to load the client cert:
+      ASSERT_CMPSIZE_T (1, ==, cf.failures);
+
+      mongoc_client_pool_destroy (pool);
+   }
+
+   cf = (cert_failures) {0};
+
+   // Test client changing TLS options after connecting:
+   {
+      // Changing TLS options after connecting is prohibited on a client pool, but not on a single-threaded client.
+      // It is not a documented feature, but is tested for OpenSSL.
+      mongoc_client_t *client = test_framework_new_default_client ();
+
+      // Set client cert to a bad path:
+      {
+         mongoc_ssl_opt_t ssl_opt = *test_framework_get_ssl_opts ();
+         ssl_opt.pem_file = "does-not-exist.pem";
+         mongoc_client_set_ssl_opts (client, &ssl_opt);
+      }
+
+      // Expect insert OK. Cert fails to load, but server configured with --tlsAllowConnectionsWithoutCertificates:
+      {
+         bool ok = try_ping (client, &error);
+         ASSERT_OR_PRINT (ok, error);
+      }
+
+      // Expect exactly one attempt to load the client cert:
+      ASSERT_CMPSIZE_T (1, ==, cf.failures);
+      ASSERT_CMPSIZE_T (0, ==, cf.failures2);
+
+      // Change the client cert:
+      {
+         mongoc_ssl_opt_t ssl_opt = *test_framework_get_ssl_opts ();
+         ssl_opt.pem_file = "does-not-exist-2.pem";
+         mongoc_client_set_ssl_opts (client, &ssl_opt);
+      }
+
+      // Force a reconnect.
+      {
+         bool ok = try_ping_with_reconnect (client, &error);
+         ASSERT_OR_PRINT (ok, error);
+      }
+
+      // Expect an attempt to load the new cert:
+      ASSERT_CMPSIZE_T (1, ==, cf.failures); // Unchanged.
+      ASSERT_CMPSIZE_T (1, ==, cf.failures2);
+
+      mongoc_client_destroy (client);
+   }
+
+   // Restore log handler:
+   mongoc_log_set_handler (saved_log_func, saved_log_data);
+}
+
+void
+test_secure_channel_install (TestSuite *suite)
+{
+   TestSuite_AddFull (suite,
+                      "/secure_channel/shared_creds/stream",
+                      test_secure_channel_shared_creds_stream,
+                      NULL,
+                      NULL,
+                      test_framework_skip_if_no_server_ssl);
+
+   TestSuite_AddFull (suite,
+                      "/secure_channel/shared_creds/client",
+                      test_secure_channel_shared_creds_client,
+                      NULL,
+                      NULL,
+                      test_framework_skip_if_no_server_ssl);
+}
+
+#else  // MONGOC_ENABLE_SSL_SECURE_CHANNEL
+void
+test_secure_channel_install (TestSuite *suite)
+{
+   BSON_UNUSED (suite);
+}
+#endif // MONGOC_ENABLE_SSL_SECURE_CHANNEL

--- a/src/libmongoc/tests/test-mongoc-secure-channel.c
+++ b/src/libmongoc/tests/test-mongoc-secure-channel.c
@@ -13,7 +13,7 @@
 #include <mlib/test.h>
 
 static mongoc_stream_t *
-connect_with_secure_channel_cred (mongoc_ssl_opt_t *ssl_opt, mongoc_shared_ptr cred_ptr, bson_error_t *error)
+connect_with_secure_channel_cred (const mongoc_ssl_opt_t *ssl_opt, mongoc_shared_ptr cred_ptr, bson_error_t *error)
 {
    mongoc_host_list_t host;
    const int32_t connect_timout_ms = 10000;
@@ -50,7 +50,7 @@ test_secure_channel_shared_creds_stream (void *unused)
 
    mongoc_stream_t *stream;
    bson_error_t error;
-   mongoc_ssl_opt_t ssl_opt = {.ca_file = CERT_TEST_DIR "/ca.pem", .pem_file = CERT_TEST_DIR "/client.pem"};
+   const mongoc_ssl_opt_t ssl_opt = {.ca_file = CERT_TEST_DIR "/ca.pem", .pem_file = CERT_TEST_DIR "/client.pem"};
    // Test with no sharing:
    {
       mongoc_stream_t *stream = connect_with_secure_channel_cred (&ssl_opt, MONGOC_SHARED_PTR_NULL, &error);

--- a/src/libmongoc/tests/test-mongoc-x509.c
+++ b/src/libmongoc/tests/test-mongoc-x509.c
@@ -346,15 +346,13 @@ test_x509_auth (void *unused)
       bson_error_t error = {0};
       bool ok;
       {
-         mongoc_client_t *client = test_framework_client_new_from_uri (uri, NULL);
          capture_logs (true);
+         mongoc_client_t *client = test_framework_client_new_from_uri (uri, NULL);
          ok = try_insert (client, &error);
-#if defined(MONGOC_ENABLE_SSL_SECURE_TRANSPORT)
+#if defined(MONGOC_ENABLE_SSL_SECURE_TRANSPORT) || defined(MONGOC_ENABLE_SSL_OPENSSL)
          ASSERT_CAPTURED_LOG ("tls", MONGOC_LOG_LEVEL_ERROR, "Cannot find certificate");
 #elif defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
          ASSERT_CAPTURED_LOG ("tls", MONGOC_LOG_LEVEL_ERROR, "Failed to open file");
-#elif defined(MONGOC_ENABLE_SSL_OPENSSL)
-         ASSERT_NO_CAPTURED_LOGS ("tls");
 #endif
          mongoc_client_destroy (client);
       }


### PR DESCRIPTION
# Summary

Share `SCHANNEL_CRED` across connections.

Verified with this patch: https://spruce.mongodb.com/version/686298d51b4881000729652b/

# Background & Motivation

Sharing the `SCHANNEL_CRED` is motivated by an upcoming fix for CDRIVER-5998. The private key for a client certificate is currently imported as an ephemeral key stored in-process (via [call to CryptImportKey](https://github.com/mongodb/mongo-c-driver/blob/31c13b6080a8a153be9c849b7c4138bfa1cbc6d8/src/libmongoc/src/mongoc/mongoc-secure-channel.c#L320)). Supporting SHA2 signatures appears to require importing a persisted private key stored on the file-system (with a unique name). This will be described further in a follow-up PR. But to avoid importing many duplicate keys, I want to change the current behavior from "import key per connection" to "import key per client/pool and share". 

Though improving performance was not the main goal of this PR, it reduces file-reading from per-connection to per-client/per-pool. Sharing the credentials showed an improvement in a [one-off benchmark](https://parsley.mongodb.com/evergreen/mongo_c_driver_sasl_matrix_winssl_sasl_sspi_winssl_windows_2019_vs2017_x64_test_8.0_server_auth_patch_30ac9bf0d8b2677a1a1e92a4fe5a13584845f30e_68627721ab51140007ba7d44_25_06_30_11_38_11/0/task?bookmarks=0,7110&shareLine=5324) creating 100 connections in 10 threads:
```
No sharing took: 8766.00ms
Sharing took: 8093.00ms
```

Sharing `SCHANNEL_CRED` follows a similar pattern to the shared OpenSSL context implemented in https://github.com/mongodb/mongo-c-driver/pull/1673.

Microsoft documentation does not appear to document thread-safety of sharing `SCHANNEL_CRED`. However, mongod shares the same `SCHANNEL_CRED` for client connections (via [_clientCred](https://github.com/10gen/mongo/blob/43c23fb8f8c8de17fd6eed61124f5e0a5714a948/src/mongo/util/net/ssl_manager_windows.cpp#L1481-L1482)). I expect the TLS handshake only needs to read `SCHANNEL_CRED`.

`SCHANNEL_CRED` is documented as [deprecated](https://learn.microsoft.com/en-us/windows/win32/api/schannel/ns-schannel-schannel_cred). This is not addressed in this PR, but I expect can be replaced when adding support for TLS v1.3 (CDRIVER-6045).

## Shared pointer

A `mongoc_shared_ptr` is used to manage `SCHANNEL_CRED`. This is to support changing the SSL options after creating connections (may have a use case for rotating certificates?). This behavior is [tested](https://github.com/mongodb/mongo-c-driver/blob/c63bb91fcecffd101ce2f620dc8d25aa7c3b7f5c/src/libmongoc/tests/test-mongoc-client.c#L2070-L2080) in the OpenSSL implementation:

```c
/* any operation - ping the server */
ret = mongoc_client_command_simple (client, "admin", tmp_bson ("{'ping': 1}"), NULL, NULL, &error);
ASSERT_OR_PRINT (ret, error);

/* change ssl opts before a second connection */
ssl_opts = test_framework_get_ssl_opts ();
mongoc_client_set_ssl_opts (client, ssl_opts);

/* any operation - ping the server */
ret = mongoc_client_command_simple (client, "admin", tmp_bson ("{'ping': 1}"), NULL, NULL, &error);
ASSERT_OR_PRINT (ret, error);
```

`mongoc_client_pool_t` however [documents](https://mongoc.org/libmongoc/2.0.2/mongoc_client_pool_set_ssl_opts.html):

> This function can only be called once on a pool, and must be called before the first call to `mongoc_client_pool_pop()`.

Therefore, the updates to the `mongoc_shared_ptr` are assumed to not require thread-safety.
