### PR TITLE
CDRIVER-5998 remove extra `mongoc_stream_t*` declaration

### DIFF
--- a/src/libmongoc/tests/test-mongoc-secure-channel.c
+++ b/src/libmongoc/tests/test-mongoc-secure-channel.c
@@ -48,7 +48,6 @@ test_secure_channel_shared_creds_stream (void *unused)
 {
    BSON_UNUSED (unused);
 
-   mongoc_stream_t *stream;
    bson_error_t error;
    const mongoc_ssl_opt_t ssl_opt = {.ca_file = CERT_TEST_DIR "/ca.pem", .pem_file = CERT_TEST_DIR "/client.pem"};
    // Test with no sharing:


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/mongo-c-driver/pull/2052 to fix error in MinGW compile ([example task](https://spruce.mongodb.com/task/mongo_c_driver_sasl_matrix_winssl_sasl_sspi_winssl_windows_2019_mingw_compile_bc14d6cf0c02c2cba5557de98df0df4e99a83308_25_07_03_20_27_45/logs?execution=0)):
```
C:\data\mci\88e4\mongoc\src\libmongoc\tests\test-mongoc-secure-channel.c:56:24: error: declaration of 'stream' shadows a previous local [-Werror=shadow]
```

Verified with this patch build: https://spruce.mongodb.com/version/686bc6123d10c50007e18aad