### PR TITLE
Remove the `Language: Cpp` setting for formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,7 @@
 ---
-Language:        Cpp
+# Note: The "Lanugage" option is omitted, as we want to apply the same formatting
+# to all files, otherwise clang-format may (sometimes) apply the default format
+# to other languages.
 AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
 AlignArrayOfStructures: None

--- a/src/libbson/tests/test-bson.c
+++ b/src/libbson/tests/test-bson.c
@@ -1952,8 +1952,8 @@ test_bson_regex_lengths (void)
       &new, "0_________1_________2_________3___4", -1, "0_________1_________2_________3_________4_________5___4", "i");
 
    ASSERT (new.len == 121);
-   ASSERT (new.flags &BSON_FLAG_STATIC);
-   ASSERT (!(new.flags &BSON_FLAG_INLINE));
+   ASSERT (new.flags & BSON_FLAG_STATIC);
+   ASSERT (!(new.flags & BSON_FLAG_INLINE));
 
    bson_destroy (&new);
 }
@@ -2328,12 +2328,12 @@ test_bson_dsl_predicate (void)
       require (key ("string"), //
                require (type (utf8)),
                require (strEqual ("hello")),
-               require (not(strEqual ("goodbye"))),
+               require (not (strEqual ("goodbye"))),
                require (iStrEqual ("HELLO")),
-               require (not(iStrEqual ("GOODBYE")))),
+               require (not (iStrEqual ("GOODBYE")))),
       require (key ("doc"),
                require (type (doc)),
-               require (not(empty)),
+               require (not (empty)),
                visitEach (require (key ("hello")), require (type (null)))),
       require (key ("null"), require (type (null))),
       require (key ("empty_string"), require (type (utf8))),

--- a/src/libmongoc/src/mongoc/mongoc-client-session.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-session.c
@@ -240,7 +240,7 @@ retry:
        * actually apply the error label due to reply being NULL */
       _mongoc_client_session_unpin (session);
       if (reply) {
-         bsonBuildAppend (*reply, insert (reply_local, not(key ("errorLabels"))));
+         bsonBuildAppend (*reply, insert (reply_local, not (key ("errorLabels"))));
          _mongoc_error_copy_labels_and_upsert (&reply_local, reply, UNKNOWN_COMMIT_RESULT);
       }
    } else if (reply) {

--- a/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
@@ -2873,7 +2873,7 @@ mongoc_client_encryption_create_encrypted_collection (mongoc_client_encryption_t
    bsonVisitEach (in_encryptedFields,
                   case (
                      // We only care about the "fields" array
-                     when (not(key ("fields")), appendTo (new_encryptedFields)),
+                     when (not (key ("fields")), appendTo (new_encryptedFields)),
                      // Automaticall fill in the "keyId" no each field:
                      else (storeDocRef (fields_ref), do ({
                               bson_t new_fields = BSON_INITIALIZER;
@@ -2896,7 +2896,7 @@ mongoc_client_encryption_create_encrypted_collection (mongoc_client_encryption_t
    // We've successfully filled out all null keyIds. Now create the collection
    // with our new options:
    bsonBuild (*opt_out_options,
-              insert (*in_options, not(key ("encryptedFields"))),
+              insert (*in_options, not (key ("encryptedFields"))),
               kv ("encryptedFields", bson (new_encryptedFields)));
    if (bsonBuildError) {
       // Error while building the new options.
@@ -2935,7 +2935,7 @@ _init_1_encryptedField (
    BSON_OPTIONAL_PARAM (error);
    bsonVisitEach (*in_field,
                   // If it is not a "keyId":null element, just copy it to the output.
-                  if (not(keyWithType ("keyId", null)), then (appendTo (*out_field), continue)),
+                  if (not (keyWithType ("keyId", null)), then (appendTo (*out_field), continue)),
                   // Otherwise:
                   do ({
                      // Set up factory context
@@ -2971,7 +2971,7 @@ _init_encryptedFields (
    bsonVisitEach (
       *in_fields,
       // Each field must be a document element
-      if (not(type (doc)), then (error ("Each 'encryptedFields' element must be a document"))),
+      if (not (type (doc)), then (error ("Each 'encryptedFields' element must be a document"))),
       // Append a new element with the same name as the field:
       storeDocRef (cur_field),
       append (*out_fields,

--- a/src/libmongoc/src/mongoc/mongoc-collection.c
+++ b/src/libmongoc/src/mongoc/mongoc-collection.c
@@ -622,7 +622,7 @@ mongoc_collection_count_documents (mongoc_collection_t *coll,
    _make_aggregate_for_count (coll, filter, &cd_opts, &aggregate_cmd);
    bson_init (&aggregate_opts);
    if (opts) {
-      bsonBuildAppend (aggregate_opts, insert (*opts, not(key ("skip", "limit"))));
+      bsonBuildAppend (aggregate_opts, insert (*opts, not (key ("skip", "limit"))));
    }
 
    ret =
@@ -824,7 +824,7 @@ mongoc_collection_drop_with_opts (mongoc_collection_t *collection, const bson_t 
 
    // We've found the encryptedFields, so we need to do something different
    // to drop this collection:
-   bsonBuildAppend (opts_without_encryptedFields, if (opts, then (insert (*opts, not(key ("encryptedFields"))))));
+   bsonBuildAppend (opts_without_encryptedFields, if (opts, then (insert (*opts, not (key ("encryptedFields"))))));
    if (bsonBuildError) {
       _mongoc_set_error (
          error, MONGOC_ERROR_BSON, MONGOC_ERROR_BSON_INVALID, "Error while updating drop options: %s", bsonBuildError);

--- a/src/libmongoc/src/mongoc/mongoc-cursor-legacy.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor-legacy.c
@@ -109,7 +109,7 @@ _mongoc_cursor_monitor_legacy_query (mongoc_cursor_t *cursor,
    /* simulate a MongoDB 3.2+ "find" command */
    _mongoc_cursor_prepare_find_command (cursor, filter, &doc);
 
-   bsonBuildAppend (cursor->opts, insert (doc, not(key ("serverId", "maxAwaitTimeMS", "sessionId"))));
+   bsonBuildAppend (cursor->opts, insert (doc, not (key ("serverId", "maxAwaitTimeMS", "sessionId"))));
 
    r = _mongoc_cursor_monitor_command (cursor, server_stream, &doc, "find");
 

--- a/src/libmongoc/src/mongoc/mongoc-cursor.c
+++ b/src/libmongoc/src/mongoc/mongoc-cursor.c
@@ -332,9 +332,9 @@ _mongoc_cursor_new_with_opts (mongoc_client_t *client,
       // Selectively copy the options:
       bsonBuildAppend (cursor->opts,
                        insert (*opts,
-                               not(key ("serverId", "sessionId"),
-                                   // Drop bypassDocumentValidation if it isn't true:
-                                   allOf (key ("bypassDocumentValidation"), isFalse))));
+                               not (key ("serverId", "sessionId"),
+                                    // Drop bypassDocumentValidation if it isn't true:
+                                    allOf (key ("bypassDocumentValidation"), isFalse))));
    }
 
    if (_mongoc_client_session_in_txn (cursor->client_session)) {

--- a/src/libmongoc/src/mongoc/mongoc-database.c
+++ b/src/libmongoc/src/mongoc/mongoc-database.c
@@ -1136,7 +1136,7 @@ _mongoc_get_collection_encryptedFields (mongoc_client_t *client,
       bool found = false;
       bsonParse (*opts,
                  find (key ("encryptedFields"),
-                       if (not(type (doc)), then (error ("'encryptedFields' should be a document"))),
+                       if (not (type (doc)), then (error ("'encryptedFields' should be a document"))),
                        // Update encryptedFields to be a reference to the subdocument:
                        storeDocRef (*encryptedFields),
                        do (found = true)));
@@ -1194,7 +1194,7 @@ mongoc_database_create_collection (mongoc_database_t *database,
 
    if (!bson_empty (&encryptedFields)) {
       // Clone 'opts' without the encryptedFields element
-      bsonBuildDecl (opts_without_encryptedFields, if (opts, then (insert (*opts, not(key ("encryptedFields"))))));
+      bsonBuildDecl (opts_without_encryptedFields, if (opts, then (insert (*opts, not (key ("encryptedFields"))))));
 
       mongoc_collection_t *ret = create_collection_with_encryptedFields (
          database, name, &opts_without_encryptedFields, &encryptedFields, error);

--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -529,7 +529,7 @@ mongoc_server_description_handle_hello (mongoc_server_description_t *sd,
    }
 
    bson_destroy (&sd->last_hello_response);
-   bsonBuild (sd->last_hello_response, insert (*hello_response, not(key ("speculativeAuthenticate"))));
+   bsonBuild (sd->last_hello_response, insert (*hello_response, not (key ("speculativeAuthenticate"))));
    sd->has_hello_response = true;
 
    /* Only reinitialize the topology version if we have a hello response.

--- a/src/libmongoc/src/mongoc/mongoc-uri.c
+++ b/src/libmongoc/src/mongoc/mongoc-uri.c
@@ -2158,7 +2158,7 @@ mongoc_uri_set_mechanism_properties (mongoc_uri_t *uri, const bson_t *properties
    bsonBuildAppend (tmp,
                     // Copy the existing credentials, dropping the existing properties if
                     // present
-                    insert (uri->credentials, not(key (MONGOC_URI_AUTHMECHANISMPROPERTIES))),
+                    insert (uri->credentials, not (key (MONGOC_URI_AUTHMECHANISMPROPERTIES))),
                     // Append the new properties
                     kv (MONGOC_URI_AUTHMECHANISMPROPERTIES, bson (*properties)));
    bson_reinit (&uri->credentials);

--- a/src/libmongoc/tests/unified/entity-map.c
+++ b/src/libmongoc/tests/unified/entity-map.c
@@ -755,19 +755,19 @@ entity_client_new (entity_map_t *em, bson_t *bson, bson_error_t *error)
       else (error ("A client 'id' string is required")),
       // Optional 'uriOptions' for the client
       find (key ("uriOptions"),
-            if (not(type (doc)), then (error ("'uriOptions' must be a document value"))),
+            if (not (type (doc)), then (error ("'uriOptions' must be a document value"))),
             storeDocDupPtr (uri_options)),
       // Optional 'useMultipleMongoses' bool
       find (key ("useMultipleMongoses"),
-            if (not(type (boolean)), then (error ("'useMultipleMongoses' must be a bool value"))),
+            if (not (type (boolean)), then (error ("'useMultipleMongoses' must be a bool value"))),
             do (use_multiple_mongoses_set = true),
             storeBool (use_multiple_mongoses)),
       // Events to observe:
       find (key ("observeEvents"),
-            if (not(type (array)), then (error ("'observeEvents' must be an array"))),
+            if (not (type (array)), then (error ("'observeEvents' must be an array"))),
             visitEach (case (
                // Ensure all elements are strings:
-               when (not(type (utf8)), error ("Every 'observeEvents' element must be a string")),
+               when (not (type (utf8)), error ("Every 'observeEvents' element must be a string")),
                // Dispatch based on the event name:
                when (eval (is_supported_event_type (bson_iter_utf8 (&bsonVisitIter, NULL))), do ({
                         const char *const type = bson_iter_utf8 (&bsonVisitIter, NULL);
@@ -781,14 +781,14 @@ entity_client_new (entity_map_t *em, bson_t *bson, bson_error_t *error)
                else (do (test_error ("Unknown event type '%s'", bsonAs (cstr))))))),
       // Command events to ignore
       find (key ("ignoreCommandMonitoringEvents"),
-            if (not(type (array)), then (error ("'ignoreCommandMonitoringEvents' must be an array"))),
-            visitEach (if (not(type (utf8)),
+            if (not (type (array)), then (error ("'ignoreCommandMonitoringEvents' must be an array"))),
+            visitEach (if (not (type (utf8)),
                            then (error ("Every 'ignoreCommandMonitoringEvents' "
                                         "element must be a string")))),
             storeDocDupPtr (entity->ignore_command_monitoring_events)),
       // Parse the serverApi, if present
       find (key ("serverApi"),
-            if (not(type (doc)), then (error ("'serverApi' must be a document"))),
+            if (not (type (doc)), then (error ("'serverApi' must be a document"))),
             parse ( // The "version" string is required first:
                find (keyWithType ("version", utf8), do ({
                         mongoc_server_api_version_t ver;
@@ -801,22 +801,22 @@ entity_client_new (entity_map_t *em, bson_t *bson, bson_error_t *error)
                else (error ("Missing 'version' property in 'serverApi' object")),
                // Toggle strictness:
                find (key ("strict"),
-                     if (not(type (boolean)), then (error ("'serverApi.strict' must be a bool"))),
+                     if (not (type (boolean)), then (error ("'serverApi.strict' must be a bool"))),
                      do (mongoc_server_api_strict (api, bsonAs (boolean)))),
                // Toggle deprecation errors:
                find (key ("deprecationErrors"),
-                     if (not(type (boolean)), then (error ("serverApi.deprecationErrors must be a bool"))),
+                     if (not (type (boolean)), then (error ("serverApi.deprecationErrors must be a bool"))),
                      do (mongoc_server_api_deprecation_errors (api, bsonAs (boolean)))))),
       // Toggle observation of sensitive commands
       find (key ("observeSensitiveCommands"),
-            if (not(type (boolean)), then (error ("'observeSensitiveCommands' must be a bool"))),
+            if (not (type (boolean)), then (error ("'observeSensitiveCommands' must be a bool"))),
             do ({
                bool *p = entity->observe_sensitive_commands = bson_malloc (sizeof (bool));
                *p = bsonAs (boolean);
             })),
       // Which events should be available as entities:
       find (key ("storeEventsAsEntities"),
-            if (not(type (array)), then (error ("'storeEventsAsEntities' must be an array"))),
+            if (not (type (array)), then (error ("'storeEventsAsEntities' must be an array"))),
             visitEach (parse (
                find (keyWithType ("id", utf8), storeStrRef (store_entity_id), do ({
                         if (!entity_map_add_bson_array (em, store_entity_id, error)) {
@@ -827,7 +827,7 @@ entity_client_new (entity_map_t *em, bson_t *bson, bson_error_t *error)
                         }
                      })),
                find (keyWithType ("events", array),
-                     visitEach (case (when (not(type (utf8)),
+                     visitEach (case (when (not (type (utf8)),
                                             error ("Every 'storeEventsAsEntities.events' "
                                                    "element must be a string")),
                                       when (anyOf (iStrEqual ("commandStartedEvent"),
@@ -844,11 +844,11 @@ entity_client_new (entity_map_t *em, bson_t *bson, bson_error_t *error)
                visitOthers (
                   errorf (err, "Unexpected field '%s' in storeEventsAsEntities", bson_iter_key (&bsonVisitIter)))))),
       find (key ("autoEncryptOpts"),
-            if (not(type (doc)), then (error ("'autoEncryptOpts' must be a document value"))),
+            if (not (type (doc)), then (error ("'autoEncryptOpts' must be a document value"))),
             storeDocDupPtr (auto_encryption_opts)),
       // Log messages to observe:
       find (key ("observeLogMessages"),
-            if (not(type (doc)), then (error ("'observeLogMessages' must be a document"))),
+            if (not (type (doc)), then (error ("'observeLogMessages' must be a document"))),
             do ({
                // Initialize all components to the lowest available level, and install a handler.
                BSON_ASSERT (mongoc_structured_log_opts_set_max_level_for_all_components (
@@ -859,7 +859,7 @@ entity_client_new (entity_map_t *em, bson_t *bson, bson_error_t *error)
                mongoc_structured_log_opts_set_max_document_length (log_opts, 10000);
             }),
             visitEach (
-               if (not(type (utf8)), then (error ("Every value in 'observeLogMessages' must be a log level string"))),
+               if (not (type (utf8)), then (error ("Every value in 'observeLogMessages' must be a log level string"))),
                do ({
                   const char *const component_name = bson_iter_key (&bsonVisitIter);
                   mongoc_structured_log_component_t component;


### PR DESCRIPTION
It seems that the `Language: Cpp` setting in `.clang-format` changes Clang's behavior in Clang 20.x, and sometimes restricts it from formatting C files, instead falling back to the default format.

This PR removes `Language: Cpp` and allows clang-format to apply the same formatting to all source files. This seems to also have minor changes to the way it typesets the `not` identifier in C files (it looks like clang-format was previously treating C as C++, where `not` is a special prefix operator rather than a bare identifier).