### PR TITLE
[CDRIVER-6043] Modify definitions in `intutil` to avoid compound-literals

### DIFF
--- a/src/common/src/mlib/ckdint.h
+++ b/src/common/src/mlib/ckdint.h
@@ -196,11 +196,11 @@ mlib_extern_c_begin ();
 // Generates an 0b01111 bit pattern for the two's complement max value:
 #define _mlibMaxofSigned(V) \
    /* NOLINTNEXTLINE(bugprone-sizeof-expression) */ \
-   mlib_bits(mlib_bitsizeof(V) - 1, 0)
+   mlib_bits(mlib_bitsizeof(V) - 1u, 0)
 // Generates an 0b10000... bit pattern for the two's complement min value:
 #define _mlibMinofSigned(V) \
    /* NOLINTNEXTLINE(bugprone-sizeof-expression) */ \
-   (0 - mlib_bits(1, mlib_bitsizeof(V) - 1))
+   (0 - mlib_bits(1, mlib_bitsizeof(V) - 1u))
 // For completeness:
 #define _mlibMinofUnsigned(V) 0
 // Yields true iff the operand expression has a signed type, but requires that
@@ -263,7 +263,7 @@ static inline bool (mlib_add) (uintmax_t *dst, bool dst_signed, bool a_signed, u
    // Perform regular wrapping arithmetic on the unsigned value. The bit pattern
    // is equivalent if there is two's complement signed arithmetic.
    const uintmax_t sum = *dst = a + b;
-   const uintmax_t signbit = mlib_bits (1, mlib_bitsizeof (uintmax_t) - 1);
+   const uintmax_t signbit = mlib_bits (1, mlib_bitsizeof (uintmax_t) - 1u);
    // Now we check whether that overflowed according to the sign configuration.
    // We use some bit fiddling magic that treat the signbit as a boolean for
    // "is this number negative?" or "is this number “large” (i.e. bigger than signed-max)?"
@@ -357,7 +357,7 @@ static inline bool (mlib_sub) (uintmax_t *dst, bool dst_signed, bool a_signed, u
 {
    // Perform the subtraction using regular wrapping arithmetic
    const uintmax_t diff = *dst = a - b;
-   const uintmax_t signbit = mlib_bits (1, mlib_bitsizeof (uintmax_t) - 1);
+   const uintmax_t signbit = mlib_bits (1, mlib_bitsizeof (uintmax_t) - 1u);
    // Test whether the operation overflowed for the given sign configuration
    // (See mlib_add for more details on why we do this bit fiddling)
    if (dst_signed) {
@@ -458,7 +458,7 @@ static inline bool (mlib_mul) (uintmax_t *dst, bool dst_signed, bool a_signed, u
    mlib_noexcept
 {
    // Multiplication is a lot more subtle
-   const uintmax_t signbit = mlib_bits (1, mlib_bitsizeof (uintmax_t) - 1);
+   const uintmax_t signbit = mlib_bits (1, mlib_bitsizeof (uintmax_t) - 1u);
    if (dst_signed) {
       if (a_signed) {
          if (b_signed) {

--- a/src/common/src/mlib/ckdint.test.cpp
+++ b/src/common/src/mlib/ckdint.test.cpp
@@ -15,9 +15,6 @@
 #endif // __has_builtin
 #endif
 
-static_assert (mlib_upsize_integer (42ll).is_signed, "mlib_upsize_integer yielded the wrong answer");
-static_assert (!mlib_upsize_integer (42ull).is_signed, "mlib_upsize_integer yielded the wrong answer");
-
 template <typename... Ts> struct typelist {
 };
 using integer_types = typelist<char,

--- a/src/common/src/mlib/cmp.h
+++ b/src/common/src/mlib/cmp.h
@@ -77,32 +77,32 @@ mlib_always_inline static enum mlib_cmp_result (mlib_cmp) (struct mlib_upsized_i
    if (x.is_signed) {
       if (y.is_signed) {
          // Both signed
-         if (x.i.s < y.i.s) {
+         if (x.bits.as_signed < y.bits.as_signed) {
             return mlib_less;
-         } else if (x.i.s > y.i.s) {
+         } else if (x.bits.as_signed > y.bits.as_signed) {
             return mlib_greater;
          }
       } else {
          // X signed, Y unsigned
-         if (x.i.s < 0 || (uintmax_t) x.i.s < y.i.u) {
+         if (x.bits.as_signed < 0 || (uintmax_t) x.bits.as_signed < y.bits.as_unsigned) {
             return mlib_less;
-         } else if ((uintmax_t) x.i.s > y.i.u) {
+         } else if ((uintmax_t) x.bits.as_signed > y.bits.as_unsigned) {
             return mlib_greater;
          }
       }
    } else {
       if (!y.is_signed) {
          // Both unsigned
-         if (x.i.u < y.i.u) {
+         if (x.bits.as_unsigned < y.bits.as_unsigned) {
             return mlib_less;
-         } else if (x.i.u > y.i.u) {
+         } else if (x.bits.as_unsigned > y.bits.as_unsigned) {
             return mlib_greater;
          }
       } else {
          // X unsigned, Y signed
-         if (y.i.s < 0 || x.i.u > (uintmax_t) y.i.s) {
+         if (y.bits.as_signed < 0 || x.bits.as_unsigned > (uintmax_t) y.bits.as_signed) {
             return mlib_greater;
-         } else if (x.i.u < (uintmax_t) y.i.s) {
+         } else if (x.bits.as_unsigned < (uintmax_t) y.bits.as_signed) {
             return mlib_less;
          }
       }
@@ -123,9 +123,9 @@ mlib_always_inline static enum mlib_cmp_result (mlib_cmp) (struct mlib_upsized_i
 static inline bool (mlib_in_range) (intmax_t min_, uintmax_t max_, struct mlib_upsized_integer val) mlib_noexcept
 {
    if (val.is_signed) {
-      return mlib_cmp (val.i.s, >=, min_) && mlib_cmp (val.i.s, <=, max_);
+      return mlib_cmp (val.bits.as_signed, >=, min_) && mlib_cmp (val.bits.as_signed, <=, max_);
    } else {
-      return mlib_cmp (val.i.u, >=, min_) && mlib_cmp (val.i.u, <=, max_);
+      return mlib_cmp (val.bits.as_unsigned, >=, min_) && mlib_cmp (val.bits.as_unsigned, <=, max_);
    }
 }
 

--- a/src/common/src/mlib/intutil.h
+++ b/src/common/src/mlib/intutil.h
@@ -35,7 +35,7 @@
 /**
  * @brief Like `sizeof`, but returns the number of bits in the object representation
  */
-#define mlib_bitsizeof(T) ((sizeof (T)) * CHAR_BIT)
+#define mlib_bitsizeof(T) ((sizeof (T)) * ((size_t) CHAR_BIT))
 
 // clang-format off
 /**
@@ -78,8 +78,8 @@
  */
 #define mlib_maxof(T) \
    ((T) (mlib_is_signed (T) \
-        ? ((T) mlib_bits(mlib_bitsizeof(T) - 1, 0)) \
-        : ((T) mlib_bits(mlib_bitsizeof(T),     0))))
+        ? ((T) mlib_bits(mlib_bitsizeof(T) - 1u, 0)) \
+        : ((T) mlib_bits(mlib_bitsizeof(T),      0))))
 
 /**
  * @brief Given an integral type, yield an integral constant value for the
@@ -88,7 +88,7 @@
 #define mlib_minof(T) \
    ((T) (!mlib_is_signed (T) \
         ? (T) 0 \
-        : (T) mlib_bits(1, mlib_bitsizeof(T) - 1)))
+        : (T) mlib_bits(1, mlib_bitsizeof(T) - 1u)))
 // clang-format on
 
 /**

--- a/src/common/src/mlib/intutil.h
+++ b/src/common/src/mlib/intutil.h
@@ -41,8 +41,8 @@
 /**
  * @brief Generate a mask of contiguous bits.
  *
- * @param NumOnes The number of contiguous 1 bits
- * @param NumZeros The number of contiguous 0 bits to set in the low position
+ * @param NumOnes The non-negative number of contiguous 1 bits
+ * @param NumZeros The non-negative number of contiguous 0 bits to set in the low position
  *
  * The generated mask is of the form:
  *
@@ -63,14 +63,10 @@
  * 3. `res  = tmp  << NumZeros` : Add the 0s in the low position
  */
 #define mlib_bits(NumOnes, NumZeros) ( \
-      /* Create a set of N 1 bits */ \
-      (/* Create a mask of all 0b1111... */ \
-         ~UINTMAX_C(0) \
-         /* Shift down the chop off to only the number of 1 bits we want */ \
-         >> (mlib_bitsizeof(uintmax_t) - (uintmax_t)(NumOnes))) \
-      /* Shift left to add the low zeros */\
-      << ((uintmax_t)(NumZeros)) \
-   )
+   ((NumOnes) \
+      ? (~UINTMAX_C(0) >> ((mlib_bitsizeof(uintmax_t) - (uintmax_t)(NumOnes)))) \
+      : 0) \
+   << ((uintmax_t)(NumZeros)))
 
 /**
  * @brief Given an integral type, yield an integral constant value representing

--- a/src/common/src/mlib/str.h
+++ b/src/common/src/mlib/str.h
@@ -276,15 +276,16 @@ _mstr_adjust_index (mstr_view s, mlib_upsized_integer pos, bool clamp_to_length)
       // We want to clamp to the length, and the given value is greater than the string length.
       return s.len;
    }
-   if (pos.is_signed && pos.i.s < 0) {
+   if (pos.is_signed && pos.bits.as_signed < 0) {
       // This will add the negative value to the length of the string. If such
       // an operation would result a negative value, this will terminate the
       // program.
-      return mlib_assert_add (size_t, s.len, pos.i.s);
+      return mlib_assert_add (size_t, s.len, pos.bits.as_signed);
    }
    // No special behavior, just assert that the given position is in-bounds for the string
-   mlib_check (pos.i.u <= s.len, because, "the string position index must not be larger than the string length");
-   return pos.i.u;
+   mlib_check (
+      pos.bits.as_unsigned <= s.len, because, "the string position index must not be larger than the string length");
+   return pos.bits.as_unsigned;
 }
 
 /**

--- a/src/common/src/mlib/test.h
+++ b/src/common/src/mlib/test.h
@@ -179,16 +179,16 @@ _mlibCheckIntCmp (enum mlib_cmp_result cres, // The cmp result to check
                right_expr);
       fprintf (stderr, "    ");
       if (left.is_signed) {
-         fprintf (stderr, "%lld", (long long) left.i.s);
+         fprintf (stderr, "%lld", (long long) left.bits.as_signed);
       } else {
-         fprintf (stderr, "%llu", (unsigned long long) left.i.u);
+         fprintf (stderr, "%llu", (unsigned long long) left.bits.as_unsigned);
       }
       fprintf (stderr, " ⟨%s⟩\n", left_expr);
       fprintf (stderr, "    ");
       if (right.is_signed) {
-         fprintf (stderr, "%lld", (long long) right.i.s);
+         fprintf (stderr, "%lld", (long long) right.bits.as_signed);
       } else {
-         fprintf (stderr, "%llu", (unsigned long long) right.i.u);
+         fprintf (stderr, "%llu", (unsigned long long) right.bits.as_unsigned);
       }
       fprintf (stderr, " ⟨%s⟩\n", right_expr);
       fflush (stderr);

--- a/src/common/tests/test-mlib.c
+++ b/src/common/tests/test-mlib.c
@@ -47,6 +47,17 @@ _test_checks (void)
 }
 
 static void
+_test_bits (void)
+{
+   mlib_static_assert (mlib_bits (0, 0) == 0);           // 0b000
+   mlib_static_assert (mlib_bits (1, 0) == 1);           // 0b001
+   mlib_static_assert (mlib_bits (2, 0) == 3);           // 0b011
+   mlib_static_assert (mlib_bits (1, 1) == 2);           // 0b010
+   mlib_static_assert (mlib_bits (5, 3) == 248);         // 0b11111000
+   mlib_static_assert (mlib_bits (64, 0) == UINT64_MAX); // 0b111...
+}
+
+static void
 _test_minmax (void)
 {
    mlib_static_assert (mlib_minof (unsigned) == 0);
@@ -662,6 +673,7 @@ void
 test_mlib_install (TestSuite *suite)
 {
    TestSuite_Add (suite, "/mlib/checks", _test_checks);
+   TestSuite_Add (suite, "/mlib/intutil/bits", _test_bits);
    TestSuite_Add (suite, "/mlib/intutil/minmax", _test_minmax);
    TestSuite_Add (suite, "/mlib/intutil/upsize", _test_upsize);
    TestSuite_Add (suite, "/mlib/cmp", _test_cmp);

--- a/src/common/tests/test-mlib.c
+++ b/src/common/tests/test-mlib.c
@@ -89,23 +89,23 @@ _test_upsize (void)
 {
    struct mlib_upsized_integer up;
    up = mlib_upsize_integer (31);
-   ASSERT (up.is_signed);
-   ASSERT (up.i.s == 31);
+   mlib_check (up.is_signed);
+   mlib_check (up.bits.as_signed == 31);
 
    // Casting from the max unsigned integer generates an unsigned upsized integer:
    up = mlib_upsize_integer ((uintmax_t) 1729);
-   ASSERT (!up.is_signed);
-   ASSERT (up.i.u == 1729);
+   mlib_check (!up.is_signed);
+   mlib_check (up.bits.as_unsigned == 1729);
 
    // Max signed integer makes a signed upsized integer:
    up = mlib_upsize_integer ((intmax_t) 1729);
-   ASSERT (up.is_signed);
-   ASSERT (up.i.s == 1729);
+   mlib_check (up.is_signed);
+   mlib_check (up.bits.as_signed == 1729);
 
    // From a literal:
    up = mlib_upsize_integer (UINTMAX_MAX);
-   ASSERT (!up.is_signed);
-   ASSERT (up.i.u == UINTMAX_MAX);
+   mlib_check (!up.is_signed);
+   mlib_check (up.bits.as_unsigned == UINTMAX_MAX);
 }
 
 static void

--- a/src/common/tests/test-mlib.c
+++ b/src/common/tests/test-mlib.c
@@ -49,12 +49,12 @@ _test_checks (void)
 static void
 _test_bits (void)
 {
-   mlib_static_assert (mlib_bits (0, 0) == 0);           // 0b000
-   mlib_static_assert (mlib_bits (1, 0) == 1);           // 0b001
-   mlib_static_assert (mlib_bits (2, 0) == 3);           // 0b011
-   mlib_static_assert (mlib_bits (1, 1) == 2);           // 0b010
-   mlib_static_assert (mlib_bits (5, 3) == 248);         // 0b11111000
-   mlib_static_assert (mlib_bits (64, 0) == UINT64_MAX); // 0b111...
+   mlib_check (mlib_bits (0, 0), eq, 0);           // 0b000
+   mlib_check (mlib_bits (1, 0), eq, 1);           // 0b001
+   mlib_check (mlib_bits (2, 0), eq, 3);           // 0b011
+   mlib_check (mlib_bits (1, 1), eq, 2);           // 0b010
+   mlib_check (mlib_bits (5, 3), eq, 248);         // 0b11111000
+   mlib_check (mlib_bits (64, 0), eq, UINT64_MAX); // 0b111...
 }
 
 static void


### PR DESCRIPTION
The following changes are made:

- We avoid compound literals expanded from macros. This is to avoid buggy compound-literal support in VS 2017 (See CDRIVER-6043).

  Instead, we pass the relevant argument to a function that initializes the new aggregate object.

  This has the downside that we cannot use the macros in constant expressions, but that was a minor feature that wasn't really used anywhere.
- Add a new macro to define bit masks. This simplifies the expressions that build bit patterns used for two's complement arithmetic.
- Rename the members of `mlib_upsized_integer` to give them meaningful names.

This doesn't fully fix CDRIVER-6043, but will avoid future subtle issues with VS 2017.