### PR TITLE
CDRIVER-5971 Use Amazon ECR to obtain all OCI images

### DIFF
--- a/.evergreen/config_generator/components/earthly.py
+++ b/.evergreen/config_generator/components/earthly.py
@@ -5,8 +5,17 @@ import re
 from typing import Iterable, Literal, Mapping, NamedTuple, TypeVar
 
 from shrub.v3.evg_build_variant import BuildVariant
-from shrub.v3.evg_command import BuiltInCommand, EvgCommandType, subprocess_exec
+from shrub.v3.evg_command import (
+    BuiltInCommand,
+    EvgCommandType,
+    KeyValueParam,
+    ec2_assume_role,
+    expansions_update,
+    subprocess_exec,
+)
 from shrub.v3.evg_task import EvgTask, EvgTaskRef
+
+from config_generator.etc.function import Function
 
 from ..etc.utils import all_possible
 
@@ -38,7 +47,7 @@ SASLOption = Literal["Cyrus", "off"]
 "Valid options for the SASL configuration parameter"
 TLSOption = Literal["OpenSSL", "off"]
 "Options for the TLS backend configuration parameter (AKA 'ENABLE_SSL')"
-CxxVersion = Literal["none"] # TODO: Once CXX-3103 is released, add latest C++ release tag.
+CxxVersion = Literal["none"]  # TODO: Once CXX-3103 is released, add latest C++ release tag.
 "C++ driver refs that are under CI test"
 
 # A separator character, since we cannot use whitespace
@@ -136,6 +145,34 @@ class Configuration(NamedTuple):
         return _SEPARATOR.join(f"{k}={v}" for k, v in self._asdict().items())
 
 
+# Use DevProd-provided Amazon ECR instance to obtain earthly-buildkitd in advance.
+class DockerLoginAmazonECR(Function):
+    name = 'docker-login-amazon-ecr'
+    commands = [
+        # Avoid inadvertently using a pre-existing and potentially conflicting Docker config.
+        expansions_update(updates=[KeyValueParam(key='DOCKER_CONFIG', value='${workdir}/.docker')]),
+        ec2_assume_role(role_arn="arn:aws:iam::901841024863:role/ecr-role-evergreen-ro"),
+        subprocess_exec(
+            binary="bash",
+            command_type=EvgCommandType.SETUP,
+            include_expansions_in_env=[
+                "AWS_ACCESS_KEY_ID",
+                "AWS_SECRET_ACCESS_KEY",
+                "AWS_SESSION_TOKEN",
+                "DOCKER_CONFIG",
+            ],
+            args=[
+                "-c",
+                'aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 901841024863.dkr.ecr.us-east-1.amazonaws.com',
+            ],
+        ),
+    ]
+
+    @classmethod
+    def call(cls, **kwargs):
+        return cls.default_call(**kwargs)
+
+
 def task_filter(env: EarthlyVariant, conf: Configuration) -> bool:
     """
     Control which tasks are actually defined by matching on the platform and
@@ -175,6 +212,7 @@ def earthly_exec(
             *(f"--{arg}={val}" for arg, val in (args or {}).items()),
         ],
         command_type=EvgCommandType(kind),
+        include_expansions_in_env=["DOCKER_CONFIG"],
         env=env if env else None,
         working_dir="mongoc",
     )
@@ -209,10 +247,12 @@ def earthly_task(
     return EvgTask(
         name=name,
         commands=[
+            DockerLoginAmazonECR.call(),
             # Ensure subsequent Docker commands are authenticated.
             subprocess_exec(
                 binary="bash",
                 command_type=EvgCommandType.SETUP,
+                include_expansions_in_env=["DOCKER_CONFIG"],
                 args=[
                     "-c",
                     r'docker login -u "${artifactory_username}" --password-stdin artifactory.corp.mongodb.com <<<"${artifactory_password}"',
@@ -247,6 +287,10 @@ CONTAINER_RUN_DISTROS = [
     "ubuntu2204-large",
     "ubuntu2404-large",
 ]
+
+
+def functions():
+    return DockerLoginAmazonECR.defn()
 
 
 def tasks() -> Iterable[EvgTask]:

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -123,7 +123,7 @@ functions:
           DRYRUN: "1"
         args:
           - -c
-          - uv run --frozen --only-group format tools/format.py --mode=check
+          - uv run --frozen --only-group=format tools/format.py --mode=check
   cse-sasl-cyrus-darwinssl-compile:
     - command: expansions.update
       params:
@@ -175,6 +175,26 @@ functions:
         args:
           - -c
           - EXTRA_CONFIGURE_FLAGS="-DENABLE_PIC=ON ${EXTRA_CONFIGURE_FLAGS}" .evergreen/scripts/compile.sh
+  docker-login-amazon-ecr:
+    - command: expansions.update
+      params:
+        updates:
+          - { key: DOCKER_CONFIG, value: "${workdir}/.docker" }
+    - command: ec2.assume_role
+      params:
+        role_arn: arn:aws:iam::901841024863:role/ecr-role-evergreen-ro
+    - command: subprocess.exec
+      type: setup
+      params:
+        binary: bash
+        include_expansions_in_env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+          - DOCKER_CONFIG
+        args:
+          - -c
+          - aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 901841024863.dkr.ecr.us-east-1.amazonaws.com
   fetch-build:
     - command: subprocess.exec
       type: setup

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -1133,10 +1133,13 @@ tasks:
       - ubuntu2404-large
     tags: [earthly, pr-merge-gate, alpine3.16-clang, alpine3.16-gcc, alpine3.17-clang, alpine3.17-gcc, alpine3.18-clang, alpine3.18-gcc, alpine3.19-clang, alpine3.19-gcc, archlinux-clang, archlinux-gcc, centos7-clang, centos7-gcc, u16-clang, u16-gcc, u18-clang, u18-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
     commands:
+      - func: docker-login-amazon-ecr
       - command: subprocess.exec
         type: setup
         params:
           binary: bash
+          include_expansions_in_env:
+            - DOCKER_CONFIG
           args:
             - -c
             - docker login -u "${artifactory_username}" --password-stdin artifactory.corp.mongodb.com <<<"${artifactory_password}"
@@ -1145,6 +1148,8 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          include_expansions_in_env:
+            - DOCKER_CONFIG
           args:
             - +env-warmup
             - --sasl=Cyrus
@@ -1157,6 +1162,8 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          include_expansions_in_env:
+            - DOCKER_CONFIG
           args:
             - +run
             - --targets=test-example
@@ -1174,10 +1181,13 @@ tasks:
       - ubuntu2404-large
     tags: [earthly, pr-merge-gate, alpine3.16-clang, alpine3.16-gcc, alpine3.17-clang, alpine3.17-gcc, alpine3.18-clang, alpine3.18-gcc, alpine3.19-clang, alpine3.19-gcc, archlinux-clang, archlinux-gcc, centos7-clang, centos7-gcc, u16-clang, u16-gcc, u18-clang, u18-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
     commands:
+      - func: docker-login-amazon-ecr
       - command: subprocess.exec
         type: setup
         params:
           binary: bash
+          include_expansions_in_env:
+            - DOCKER_CONFIG
           args:
             - -c
             - docker login -u "${artifactory_username}" --password-stdin artifactory.corp.mongodb.com <<<"${artifactory_password}"
@@ -1186,6 +1196,8 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          include_expansions_in_env:
+            - DOCKER_CONFIG
           args:
             - +env-warmup
             - --sasl=Cyrus
@@ -1198,6 +1210,8 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          include_expansions_in_env:
+            - DOCKER_CONFIG
           args:
             - +run
             - --targets=test-example
@@ -1215,10 +1229,13 @@ tasks:
       - ubuntu2404-large
     tags: [earthly, pr-merge-gate, alpine3.16-clang, alpine3.16-gcc, alpine3.17-clang, alpine3.17-gcc, alpine3.18-clang, alpine3.18-gcc, alpine3.19-clang, alpine3.19-gcc, archlinux-clang, archlinux-gcc, centos7-clang, centos7-gcc, u16-clang, u16-gcc, u18-clang, u18-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
     commands:
+      - func: docker-login-amazon-ecr
       - command: subprocess.exec
         type: setup
         params:
           binary: bash
+          include_expansions_in_env:
+            - DOCKER_CONFIG
           args:
             - -c
             - docker login -u "${artifactory_username}" --password-stdin artifactory.corp.mongodb.com <<<"${artifactory_password}"
@@ -1227,6 +1244,8 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          include_expansions_in_env:
+            - DOCKER_CONFIG
           args:
             - +env-warmup
             - --sasl=off
@@ -1239,6 +1258,8 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          include_expansions_in_env:
+            - DOCKER_CONFIG
           args:
             - +run
             - --targets=test-example
@@ -1256,10 +1277,13 @@ tasks:
       - ubuntu2404-large
     tags: [earthly, pr-merge-gate, alpine3.16-clang, alpine3.16-gcc, alpine3.17-clang, alpine3.17-gcc, alpine3.18-clang, alpine3.18-gcc, alpine3.19-clang, alpine3.19-gcc, archlinux-clang, archlinux-gcc, centos7-clang, centos7-gcc, u16-clang, u16-gcc, u18-clang, u18-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
     commands:
+      - func: docker-login-amazon-ecr
       - command: subprocess.exec
         type: setup
         params:
           binary: bash
+          include_expansions_in_env:
+            - DOCKER_CONFIG
           args:
             - -c
             - docker login -u "${artifactory_username}" --password-stdin artifactory.corp.mongodb.com <<<"${artifactory_password}"
@@ -1268,6 +1292,8 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          include_expansions_in_env:
+            - DOCKER_CONFIG
           args:
             - +env-warmup
             - --sasl=off
@@ -1280,6 +1306,8 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          include_expansions_in_env:
+            - DOCKER_CONFIG
           args:
             - +run
             - --targets=test-example

--- a/Earthfile
+++ b/Earthfile
@@ -1,4 +1,4 @@
-VERSION --arg-scope-and-set --pass-args 0.7
+VERSION --arg-scope-and-set --pass-args --use-function-keyword 0.7
 LOCALLY
 
 IMPORT ./tools/ AS tools
@@ -114,7 +114,7 @@ test-cxx-driver:
 
 # PREP_CMAKE "warms up" the CMake installation cache for the current environment
 PREP_CMAKE:
-    COMMAND
+    FUNCTION
     LET scratch=/opt/mongoc-cmake
     # Copy the minimal amount that we need, as to avoid cache invalidation
     COPY tools/use.sh tools/platform.sh tools/paths.sh tools/base.sh tools/download.sh \
@@ -462,7 +462,7 @@ env.centos7:
     DO --pass-args +CENTOS_ENV --version=7
 
 ALPINE_ENV:
-    COMMAND
+    FUNCTION
     ARG --required version
     FROM --pass-args tools+init-env --from alpine:$version
     # XXX: On Alpine, we just use the system's CMake. At time of writing, it is
@@ -484,7 +484,7 @@ ALPINE_ENV:
     DO --pass-args tools+ADD_C_COMPILER --clang_pkg="gcc clang compiler-rt"
 
 UBUNTU_ENV:
-    COMMAND
+    FUNCTION
     ARG --required version
     FROM --pass-args tools+init-env --from ubuntu:$version
     RUN __install curl build-essential
@@ -502,7 +502,7 @@ UBUNTU_ENV:
     DO +PREP_CMAKE
 
 CENTOS_ENV:
-    COMMAND
+    FUNCTION
     ARG --required version
     FROM --pass-args tools+init-env --from centos:$version
     # Update repositories to use vault.centos.org

--- a/Earthfile
+++ b/Earthfile
@@ -148,7 +148,7 @@ multibuild:
 # release-archive :
 #   Create a release archive of the source tree. (Refer to dev docs)
 release-archive:
-    FROM alpine:3.20
+    FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/alpine:3.20
     RUN apk add git bash
     ARG --required prefix
     ARG --required ref
@@ -193,7 +193,7 @@ release-archive:
 
 # Obtain the signing public key. Exported as an artifact /c-driver.pub
 signing-pubkey:
-    FROM alpine:3.20
+    FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/alpine:3.20
     RUN apk add curl
     RUN curl --location --silent --fail "https://pgp.mongodb.com/c-driver.pub" -o /c-driver.pub
     SAVE ARTIFACT /c-driver.pub
@@ -203,7 +203,7 @@ signing-pubkey:
 #   to be used to access them. (Refer to dev docs)
 sign-file:
     # Pull from Garasign:
-    FROM artifactory.corp.mongodb.com/release-tools-container-registry-local/garasign-gpg
+    FROM artifactory.corp.mongodb.com/release-infrastructure/garasign-gpg
     # Copy the file to be signed
     ARG --required file
     COPY $file /s/file
@@ -223,7 +223,7 @@ sign-file:
 #   Generate a signed release artifact. Refer to the "Earthly" page of our dev docs for more information.
 #   (Refer to dev docs)
 signed-release:
-    FROM alpine:3.20
+    FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/alpine:3.20
     RUN apk add git
     # The version of the release. This affects the filepaths of the output and is the default for --ref
     ARG --required version
@@ -312,7 +312,7 @@ sbom-validate:
             --exclude jira
 
 snyk:
-    FROM --platform=linux/amd64 ubuntu:24.04
+    FROM --platform=linux/amd64 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/ubuntu:24.04
     RUN apt-get update && apt-get -y install curl
     RUN curl --location https://github.com/snyk/cli/releases/download/v1.1291.1/snyk-linux -o /usr/local/bin/snyk
     RUN chmod a+x /usr/local/bin/snyk
@@ -384,7 +384,7 @@ test-vcpkg-manifest-mode:
         make test-manifest-mode
 
 vcpkg-base:
-    FROM alpine:3.18
+    FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/alpine:3.18
     RUN apk add cmake curl gcc g++ musl-dev ninja-is-really-ninja zip unzip tar \
                 build-base git pkgconf perl bash linux-headers
     ENV VCPKG_ROOT=/opt/vcpkg-git
@@ -443,7 +443,7 @@ env.alpine3.19:
     DO --pass-args +ALPINE_ENV --version=3.19
 
 env.archlinux:
-    FROM --pass-args tools+init-env --from archlinux
+    FROM --pass-args tools+init-env --from 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/archlinux
     RUN pacman-key --init
     ARG --required purpose
 
@@ -464,7 +464,7 @@ env.centos7:
 ALPINE_ENV:
     FUNCTION
     ARG --required version
-    FROM --pass-args tools+init-env --from alpine:$version
+    FROM --pass-args tools+init-env --from 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/alpine:$version
     # XXX: On Alpine, we just use the system's CMake. At time of writing, it is
     # very up-to-date and much faster than building our own from source (since
     # Kitware does not (yet) provide libmuslc builds of CMake)
@@ -486,7 +486,7 @@ ALPINE_ENV:
 UBUNTU_ENV:
     FUNCTION
     ARG --required version
-    FROM --pass-args tools+init-env --from ubuntu:$version
+    FROM --pass-args tools+init-env --from 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/ubuntu:$version
     RUN __install curl build-essential
     ARG --required purpose
 
@@ -504,7 +504,7 @@ UBUNTU_ENV:
 CENTOS_ENV:
     FUNCTION
     ARG --required version
-    FROM --pass-args tools+init-env --from centos:$version
+    FROM --pass-args tools+init-env --from 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/centos:$version
     # Update repositories to use vault.centos.org
     RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
         sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*

--- a/Earthfile
+++ b/Earthfile
@@ -508,7 +508,7 @@ CENTOS_ENV:
     # Update repositories to use vault.centos.org
     RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
         sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-    RUN yum -y install epel-release && yum -y update
+    RUN yum -y --enablerepo=extras install epel-release && yum -y update
     RUN yum -y install curl gcc gcc-c++ make
     ARG --required purpose
 

--- a/docs/dev/earthly.rst
+++ b/docs/dev/earthly.rst
@@ -149,8 +149,7 @@ enumerated using ``earthly ls`` or ``earthly doc`` in the root of the repository
 .. earthly-target:: +sign-file
 
    Signs a file using Garasign. Use of this target requires authenticating
-   against the MongoDB Artifactory installation! (Refer to:
-   `earthly.artifactory-auth`)
+   against MongoDB's AWS ECR instance! (Refer to: `earthly.aws-ecr`)
 
    .. earthly-artifact:: +sign-file/signature.asc
 
@@ -175,23 +174,34 @@ enumerated using ``earthly ls`` or ``earthly doc`` in the root of the repository
 
       .. seealso:: `earthly.secrets`
 
-   .. _earthly.artifactory-auth:
+   .. _earthly.aws-ecr:
 
-   Authenticating with Artifactory
-   ===============================
+   Authenticating with AWS ECR
+   ===========================
 
    In order to run `+sign-file` or any target that depends upon it, the
    container engine client\ [#oci]_ will need to be authenticated with the
-   MongoDB Artifactory instance.
+   MongoDB's AWS ECR pull-through cache using AWS CLI v2::
 
-   Authenticating can be done using the container engine's command-line
-   interface. For example, with Podman::
+      # Forward the short-term AWS credentials to the container engine client.
+      $ aws ecr get-login-password --profile <profile> | podman login --username AWS --password-stdin 901841024863.dkr.ecr.us-east-1.amazonaws.com
 
-      $ podman login "artifactory.corp.mongodb.com"
+   Configure the AWS profile using ``aws configure sso`` or modifying the
+   ``$HOME/.aws/config`` file such that:
 
-   Which will prompt you for a username and password if you are not already
-   authenticated with the host.\ [#creds]_ If you are already authenticated, this
-   command will have no effect.
+   - The SSO start URL is ``https://d-9067613a84.awsapps.com/start#/``.
+   - The SSO and client region are ``us-east-1``.
+   - The SSO registration scope is ``sso:account:access`` (default).
+   - The SSO account ID is ``901841024863`` (aka ``devprod-platforms-ecr``).
+   - The SSO role name is ``ECRScopedAccess`` (default).
+
+   To refresh short-term credentials when they have expired, run
+   ``aws sso login --profile <profile>`` followed by the same
+   ``aws ecr get-login-password ... | podman login ...`` command described
+   above.
+
+   .. seealso:: `"DevProd Platforms Container Registry"
+   <https://docs.devprod.prod.corp.mongodb.com/devprod-platforms-ecr>`_ and `"Configuring IAM Identity Center authentication with the AWS CLI" <https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html>_`.
 
 .. earthly-target:: +sbom-generate
 

--- a/tools/earthly.sh
+++ b/tools/earthly.sh
@@ -36,7 +36,7 @@ if ! is-file "$EARTHLY_EXE"; then
 fi
 
 run-earthly() {
-    "$EARTHLY_EXE" "$@"
+    "$EARTHLY_EXE" --buildkit-image 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3 "$@"
 }
 
 if is-main; then


### PR DESCRIPTION
Resolves CDRIVER-5971. These changes should improve the performance and reliability of Earthly tasks on Evergreen by avoiding both DockerHub rate limits and Artifactory's limited bandwidth.

@mdb-ad and @rcsanchez97: even if not review-requested, I recommended attempting the documented instructions to authenticate with Amazon ECR and pull images on your local machine and verify if it works as expected, since these changes and instructions are meant to preserve/support the ability to run Earthly tasks locally (not Evergreen only).

---

DevProd plans to decommission the Artifactory instance currently providing DevProd Release Tools images (e.g. garasign-gpg, silkbomb, etc.). We temporarily used Artifactory as a workaround for DockerHub rate limits (https://github.com/mongodb/mongo-c-driver/pull/1794) but reverted shortly after (https://github.com/mongodb/mongo-c-driver/pull/1927). The new [DevProd-provided Amazon ECR instance](https://docs.devprod.prod.corp.mongodb.com/devprod-platforms-ecr/DockerHub) is intended to the proper long-term solution going forward.

The Amazon ECR instance is both a host for internal images (e.g. DevProd Release Tools) as well as a pull-through cache for DockerHub images. Therefore, it serves all our present OCI image acquisition needs. However, using this Amazon ECR instance requires performing [IAM Identity Center authentication](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html) with the `devprod-platforms-ecr` AWS account. This is simple in Evergreen using `ec2.assume_role`, but the steps are a bit more involved on local developer machines. These steps are documented in `earthly.rst`, but reiterated below for locality.

---

DockerHub images `<name>` and `<orgname>/<name>` are specified as `library/<name>` and `<orgname>/<name>` respectively. DevProd Release Tools images `release-tools-container-registry-local/<name>` are specified as `release-infrastructure/<name>`.

Using Amazon ECR requires authenticating with the `devprod-platforms-ecr` AWS account. Before pulling any OCI images (via `docker`, `podman`, or `earthly`), you must obtain AWS short-term credentials using SSO authentication with AWS CLI v2 (note: _not_ v1, which does not support `aws configure sso`). AWS CLI v2 can be obtained by running `snap install awscli --classic` (see: [install docs](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)). Initial configuration can be done by running `aws configure sso` or directly setting `$HOME/.aws/config` to the following:

```
[profile <profile>]
sso_session = <session_name>
sso_account_id = 901841024863
sso_role_name = ECRScopedAccess
region = us-east-1
[sso-session <session_name>]
sso_start_url = https://d-9067613a84.awsapps.com/start#/
sso_region = us-east-1
sso_registration_scopes = sso:account:access
```

> [!NOTE]
> "\<profile>" is the AWS account, role, etc. "\<session_name>" is the short-term credentials. I recommend setting them to something like "amazon-ecr" and "\<your username>" respectively.

To modify an existing configuration, run `aws configure sso --profile <profile>`.

When short-term credentials expire, the following error is emitted:

```
denied: Your authorization token has expired. Reauthenticate and try again.
```

The expired credentials be refreshed by running either one of:

```bash
aws sso login --profile <profile>
aws sso login --sso-session <session_name>
```

The AWS credentials must be passed to `podman` and/or `docker` after (re)authentication by running:

```bash
aws ecr get-login-password --profile <profile> | podman login --username AWS --password-stdin 901841024863.dkr.ecr.us-east-1.amazonaws.com
```

At this point, you should be able to pull images from Amazon ECR, e.g. by running `podman pull 901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/garasign-gpg`.

> [!NOTE]
> I was unable to find a method of [configuring the default container image registry](https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md) that preserves the use of short-names (e.g. `alpine:3.20`), but which _doesn't_ involve system-level or user-level configuration, which would conflict with Evergreen task reproducibility. I am open to suggestions or a followup PR; otherwise, all images require the `901841024863.dkr.ecr.us-east-1.amazonaws.com/` prefix to be pulled from Amazon ECR. This is not necessary when manually running `pull` commands on local machines (such as to pre-pull images from DockerHub prior to their use by Earthly), e.g. `podman pull alpine` should resolve to DockerHub (by default) whereas `podman pull garasign-gpg` should resolve to Amazon ECR (when authenticated).
