### PR TITLE
CDRIVER-5998 import persisted private keys for SChannel

### DIFF
--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -204,7 +204,7 @@ endfunction()
 # Per-backend link libs/options:
 set(SecureTransport/LINK_LIBRARIES "-framework CoreFoundation" "-framework Security")
 set(SecureTransport/pkg_config_LIBS -framework Corefoundation -framework Security)
-set(SecureChannel/LINK_LIBRARIES secur32.lib crypt32.lib Bcrypt.lib)
+set(SecureChannel/LINK_LIBRARIES secur32.lib crypt32.lib Bcrypt.lib ncrypt.lib)
 set(SecureChannel/pkg_config_LIBS ${SecureChannel/LINK_LIBRARIES})
 set(OpenSSL/LINK_LIBRARIES OpenSSL::SSL OpenSSL::Crypto $<$<PLATFORM_ID:Windows>:crypt32.lib>)
 set(OpenSSL/pkg_config_LIBS -lssl -lcrypto $<$<PLATFORM_ID:Windows>:crypt32.lib>)

--- a/src/libmongoc/src/mongoc/mongoc-util-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-util-private.h
@@ -250,7 +250,7 @@ uint8_t *
 hex_to_bin (const char *hex, uint32_t *len);
 
 char *
-bin_to_hex (const uint8_t *bin, uint32_t len);
+bin_to_hex (const uint8_t *bin, uint32_t len, bool uppercase);
 
 typedef struct {
    bool set;

--- a/src/libmongoc/src/mongoc/mongoc-util.c
+++ b/src/libmongoc/src/mongoc/mongoc-util.c
@@ -1014,13 +1014,18 @@ hex_to_bin (const char *hex, uint32_t *len)
 }
 
 char *
-bin_to_hex (const uint8_t *bin, uint32_t len)
+bin_to_hex (const uint8_t *bin, uint32_t len, bool uppercase)
 {
    char *out = bson_malloc0 (2u * len + 1u);
 
    for (uint32_t i = 0u; i < len; i++) {
+      int req;
+      if (uppercase) {
+         req = bson_snprintf (out + (2u * i), 3, "%02X", bin[i]);
+      } else {
+         req = bson_snprintf (out + (2u * i), 3, "%02x", bin[i]);
+      }
       // Expect no truncation.
-      int req = bson_snprintf (out + (2u * i), 3, "%02x", bin[i]);
       BSON_ASSERT (req < 3);
    }
 

--- a/src/libmongoc/tests/bsonutil/bson-match.c
+++ b/src/libmongoc/tests/bsonutil/bson-match.c
@@ -259,8 +259,8 @@ special_matches_hex_bytes (const bson_matcher_context_t *context,
 
    expected_bytes = hex_to_bin (bson_iter_utf8 (&iter, NULL), &expected_bytes_len);
    actual_bytes = bson_val_to_binary (actual, &actual_bytes_len);
-   expected_bytes_string = bin_to_hex (expected_bytes, expected_bytes_len);
-   actual_bytes_string = bin_to_hex (actual_bytes, actual_bytes_len);
+   expected_bytes_string = bin_to_hex (expected_bytes, expected_bytes_len, false);
+   actual_bytes_string = bin_to_hex (actual_bytes, actual_bytes_len, false);
 
    if (expected_bytes_len != actual_bytes_len) {
       MATCH_ERR ("expected %" PRIu32 " (%s) but got %" PRIu32 " (%s) bytes",

--- a/src/libmongoc/tests/test-mongoc-util.c
+++ b/src/libmongoc/tests/test-mongoc-util.c
@@ -97,7 +97,7 @@ test_bin_to_hex (void)
    const char *bin = "foobar";
    const char *expect = "666f6f626172";
 
-   char *got = bin_to_hex ((const uint8_t *) bin, (uint32_t) strlen (bin));
+   char *got = bin_to_hex ((const uint8_t *) bin, (uint32_t) strlen (bin), false);
    ASSERT_CMPSTR (got, expect);
    bson_free (got);
 }

--- a/src/libmongoc/tests/test-mongoc-x509.c
+++ b/src/libmongoc/tests/test-mongoc-x509.c
@@ -136,6 +136,113 @@ try_insert (mongoc_client_t *client, bson_error_t *error)
    return ok;
 }
 
+#ifdef MONGOC_ENABLE_SSL_SECURE_CHANNEL
+// Define utilities check and delete imported keys for Secure Channel:
+
+// pkcs8_key_name is the deterministic name for the key: client-pkcs8-unencrypted.pem
+static LPCWSTR pkcs8_key_name = L"libmongoc-6659E73980D0FB4EB315CF600E0B10CCBB8C3B74FD3ED94DEAF6DC2D2B6B8317-pkcs8";
+
+static void
+delete_imported_pkcs8_key (void)
+{
+   // Open the software key storage provider:
+   NCRYPT_PROV_HANDLE hProv = 0;
+   SECURITY_STATUS status = NCryptOpenStorageProvider (&hProv, MS_KEY_STORAGE_PROVIDER, 0);
+   ASSERT_WITH_MSG (status == SEC_E_OK, "Failed to open key storage provider: %s", mongoc_winerr_to_string (status));
+
+   // Open the key handle:
+   NCRYPT_PROV_HANDLE keyHandle = 0;
+   status = NCryptOpenKey (hProv, &keyHandle, pkcs8_key_name, 0, 0);
+   ASSERT_WITH_MSG (status == SEC_E_OK, "Failed to open key: %s", mongoc_winerr_to_string (status));
+
+   // Delete key:
+   status = NCryptDeleteKey (keyHandle, 0); // Also frees handle.
+   ASSERT_WITH_MSG (status == SEC_E_OK, "Failed to delete key: %s", mongoc_winerr_to_string (status));
+
+   // NCryptDeleteKey freed handle.
+   NCryptFreeObject (hProv);
+}
+
+static bool
+has_imported_pkcs8_key (void)
+{
+   // Open the software key storage provider:
+   NCRYPT_PROV_HANDLE hProv = 0;
+   SECURITY_STATUS status = NCryptOpenStorageProvider (&hProv, MS_KEY_STORAGE_PROVIDER, 0);
+   ASSERT_WITH_MSG (status == SEC_E_OK, "Failed to open key storage provider: %s", mongoc_winerr_to_string (status));
+
+   // Open the key handle:
+   NCRYPT_PROV_HANDLE keyHandle = 0;
+   status = NCryptOpenKey (hProv, &keyHandle, pkcs8_key_name, 0, 0);
+   ASSERT_WITH_MSG (
+      status == SEC_E_OK || status == NTE_BAD_KEYSET, "Failed to open key: %s", mongoc_winerr_to_string (status));
+   bool found = (keyHandle != 0);
+
+   NCryptFreeObject (keyHandle);
+   NCryptFreeObject (hProv);
+   return found;
+}
+
+// pkcs1_key_name is the deterministic name for the key: client.pem
+static LPCWSTR pkcs1_key_name = L"libmongoc-6659E73980D0FB4EB315CF600E0B10CCBB8C3B74FD3ED94DEAF6DC2D2B6B8317-pkcs1";
+
+static void
+delete_imported_pkcs1_key (void)
+{
+   HCRYPTPROV provider;
+   bool success = CryptAcquireContextW (&provider,                          /* phProv */
+                                        pkcs1_key_name,                     /* pszContainer */
+                                        MS_ENHANCED_PROV_W,                 /* pszProvider */
+                                        PROV_RSA_FULL,                      /* dwProvType */
+                                        CRYPT_DELETEKEYSET | CRYPT_SILENT); /* dwFlags */
+   ASSERT_WITH_MSG (success, "Failed to delete key: %s", mongoc_winerr_to_string (GetLastError ()));
+   CryptReleaseContext (provider, 0);
+}
+
+static bool
+has_imported_pkcs1_key (void)
+{
+   HCRYPTPROV provider = 0;
+   bool success = CryptAcquireContextW (&provider,          /* phProv */
+                                        pkcs1_key_name,     /* pszContainer */
+                                        MS_ENHANCED_PROV_W, /* pszProvider */
+                                        PROV_RSA_FULL,      /* dwProvType */
+                                        CRYPT_SILENT);      /* dwFlags */
+   if (!success) {
+      DWORD lastError = GetLastError ();
+      ASSERT_WITH_MSG (
+         lastError = NTE_BAD_KEYSET, "Unexpected error in acquiring context: %s", mongoc_winerr_to_string (lastError));
+      CryptReleaseContext (provider, 0);
+      return false;
+   }
+
+   CryptReleaseContext (provider, 0);
+   return true;
+}
+
+#define SCHANNEL_ASSERT_PKCS8_KEY_IMPORTED() ASSERT (has_imported_pkcs8_key ())
+#define SCHANNEL_ASSERT_PKCS8_KEY_NOT_IMPORTED() ASSERT (!has_imported_pkcs8_key ())
+#define SCHANNEL_DELETE_PKCS8_KEY() \
+   if (has_imported_pkcs8_key ())   \
+      delete_imported_pkcs8_key (); \
+   else                             \
+      (void) 0
+#define SCHANNEL_ASSERT_PKCS1_KEY_IMPORTED() ASSERT (has_imported_pkcs1_key ())
+#define SCHANNEL_ASSERT_PKCS1_KEY_NOT_IMPORTED() ASSERT (!has_imported_pkcs1_key ())
+#define SCHANNEL_DELETE_PKCS1_KEY() \
+   if (has_imported_pkcs1_key ())   \
+      delete_imported_pkcs1_key (); \
+   else                             \
+      (void) 0
+#else
+#define SCHANNEL_ASSERT_PKCS8_KEY_IMPORTED() (void) 0
+#define SCHANNEL_ASSERT_PKCS8_KEY_NOT_IMPORTED() (void) 0
+#define SCHANNEL_DELETE_PKCS8_KEY() (void) 0
+#define SCHANNEL_ASSERT_PKCS1_KEY_IMPORTED() (void) 0
+#define SCHANNEL_ASSERT_PKCS1_KEY_NOT_IMPORTED() (void) 0
+#define SCHANNEL_DELETE_PKCS1_KEY() (void) 0
+#endif // MONGOC_ENABLE_SSL_SECURE_CHANNEL
+
 static void
 test_x509_auth (void *unused)
 {
@@ -158,7 +265,17 @@ test_x509_auth (void *unused)
       bson_error_t error = {0};
       bool ok;
       {
+         SCHANNEL_DELETE_PKCS8_KEY ();
+         SCHANNEL_ASSERT_PKCS8_KEY_NOT_IMPORTED ();
+
          mongoc_client_t *client = test_framework_client_new_from_uri (uri, NULL);
+         SCHANNEL_ASSERT_PKCS8_KEY_IMPORTED (); // Imported.
+         ok = try_insert (client, &error);
+         mongoc_client_destroy (client);
+
+         // Auth again with key still imported on Secure Channel:
+         SCHANNEL_ASSERT_PKCS8_KEY_IMPORTED (); // Still imported.
+         client = test_framework_client_new_from_uri (uri, NULL);
          ok = try_insert (client, &error);
          mongoc_client_destroy (client);
       }
@@ -167,8 +284,11 @@ test_x509_auth (void *unused)
       mongoc_uri_destroy (uri);
    }
 
-   // Test auth works:
+   // Test auth works with a PKCS1 key:
    {
+      SCHANNEL_DELETE_PKCS1_KEY ();
+      SCHANNEL_ASSERT_PKCS1_KEY_NOT_IMPORTED ();
+
       // Create URI:
       mongoc_uri_t *uri = get_x509_uri ();
       {
@@ -181,6 +301,13 @@ test_x509_auth (void *unused)
       bool ok;
       {
          mongoc_client_t *client = test_framework_client_new_from_uri (uri, NULL);
+         SCHANNEL_ASSERT_PKCS1_KEY_IMPORTED (); // Imported.
+         ok = try_insert (client, &error);
+         mongoc_client_destroy (client);
+
+         // Auth again with key still imported on Secure Channel:
+         SCHANNEL_ASSERT_PKCS1_KEY_IMPORTED (); // Still imported.
+         client = test_framework_client_new_from_uri (uri, NULL);
          ok = try_insert (client, &error);
          mongoc_client_destroy (client);
       }


### PR DESCRIPTION
# Summary

Import private keys as persisted (not ephemeral) for Secure Channel.

# Background & Motivation

This PR is intended to address an error sending a client certificate to servers that do not support the SHA1 client certificate signature:
```
The client and server cannot communicate, because they do not possess a common algorithm.
```

See [comment](https://jira.mongodb.org/browse/CDRIVER-5998?focusedCommentId=7279125&focusedId=7279125&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-7279125) for details. In particular, this prevents MONGODB-X509 auth (which authenticates with a client certificate).

Importing a persisted key appears required to support the SHA2 signature (and TLS 1.3, but that is planned in CDRIVER-6045). Experiments and references suggest persisting keys is relevant:

Quoting [.NET runtime](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs#L261-L262):
> on Windows we do not support ephemeral keys.

Quoting [Private Key Lifetime on Windows and the January 2021 .NET Framework Security and Quality Rollup](https://support.microsoft.com/en-us/topic/private-key-lifetime-on-windows-and-the-january-2021-net-framework-security-and-quality-rollup-3f097a10-f798-4ffd-8511-4757ebaf2c70):
> The default behavior is that the private key gets loaded into a persisted (named) key via one of the system cryptography libraries

Quoting https://stackoverflow.com/a/72101855:
> The TLS layer on Windows requires that the private key be written to disk

Quoting [PFXImportCertStore](https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-pfximportcertstore):
> if the handshake is performed externally to the calling process in LSASS.exe, it is not possible to use PKCS12_NO_PERSIST_KEY

## Key names

Some deprecated calls in CryptoAPI (CAPI) are migrated to Cryptography API: Next Generation (CNG). Quoting [About CNG](https://learn.microsoft.com/en-us/windows/win32/seccng/about-cng):
> Cryptography API: Next Generation (CNG) is the long-term replacement for the CryptoAPI

PKCS#8 keys now use CNG (`NCryptImportKey`). PKCS#1 keys still use CAPI (`CryptImportKey`) since CNG APIs do not appear to support PKCS#1. Atlas gives PKCS#8 certificates.

Keys are imported with a deterministic name. The imported key name has the form `libmongoc-<SHA256 thumbprint>-<pkcs1|pkcs8>`. The `<SHA256 thumbprint>` was chosen to be easily computable by a user (via `openssl x509` command). The `<pkcs1|pkcs8>` suffix is to distinguish the same key imported via PKCS#1 and PKCS#8 files (will end up in different providers). Since the key name is chosen by the C driver, I want to document the key name so users can identify and delete if desired. If merged, I plan to request [this documentation](https://docs.google.com/document/d/1JbwrNgHwC_ISuHXeEm03TvicKDLvyBxZEdnJReNtJSw/edit?tab=t.0) be added.

## Rejected Alternative: Import with GUID

Importing the key with GUID key name was considered. Each client/pool would import with a unique GUID and delete in the destructor. This appears to match the .NET runtime behavior, but I am concerned that a C application is more likely to abort early:
```c
const char* uri = "mongodb://localhost:27017/?tlsCertificateKeyFile=client.pem";
mongoc_client_t *client = mongoc_client_new(uri); // imports key with GUID name.
assert (returns_false()); // exits and does not delete imported key!
mongoc_client_destroy (client);
```
Each key "leak" could result in a build-up of orphaned imported keys.