### PR TITLE
CDRIVER-5901 update error assert in localSchema.json

### DIFF
--- a/src/libmongoc/tests/json/client_side_encryption/unified/localSchema.json
+++ b/src/libmongoc/tests/json/client_side_encryption/unified/localSchema.json
@@ -327,7 +327,8 @@
             }
           },
           "expectError": {
-            "isClientError": true
+            "isError": true,
+            "errorContains": "JSON schema keyword 'required' is only allowed with a remote schema"
           }
         }
       ]


### PR DESCRIPTION
Applies test change proposed in DRIVERS-3106. The entire test is not copied, since the test runner does not support the `sessionToken` placeholder (pending CDRIVER-5779).

Tested with this [patch build](https://spruce.mongodb.com/version/6876971272e2810007950140)