### PR TITLE
CDRIVER-5874 Drop Debian 10 EVG task coverage

### DIFF
--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -123,7 +123,7 @@ functions:
           DRYRUN: "1"
         args:
           - -c
-          - uv run --frozen --only-group format tools/format.py --mode=check
+          - uv run --frozen --only-group=format tools/format.py --mode=check
   cse-sasl-cyrus-darwinssl-compile:
     - command: expansions.update
       params:

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -16293,7 +16293,7 @@ buildvariants:
   - debug-compile-with-warnings
   - name: build-and-test-with-toolchain
     distros:
-    - debian10-small
+    - debian11-small
   - install-libmongoc-after-libbson
   tags:
   - pr-merge-gate
@@ -16339,15 +16339,6 @@ buildvariants:
   - debug-compile-nosasl-openssl
   - debug-compile-sasl-openssl
   - .authentication-tests .openssl
-  - .latest .nossl
-- name: gcc83
-  display_name: GCC 8.3 (Debian 10.0)
-  expansions:
-    CC: gcc
-  run_on: debian10-test
-  tasks:
-  - release-compile
-  - debug-compile-nosasl-nossl
   - .latest .nossl
 - name: gcc102
   display_name: GCC 10.2 (Debian 11.0)
@@ -16587,7 +16578,7 @@ buildvariants:
   - .versioned-api .8.0
 - name: testazurekms-variant
   display_name: Azure KMS
-  run_on: debian10-small
+  run_on: debian11-small
   tasks:
   - testazurekms_task_group
   - testazurekms-fail-task

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/testazurekms.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/testazurekms.py
@@ -103,7 +103,7 @@ def _create_variant():
         name="testazurekms-variant",
         display_name="Azure KMS",
         # Azure Virtual Machine created is Debian 10.
-        run_on="debian10-small",
+        run_on="debian11-small",
         tasks=["testazurekms_task_group", "testazurekms-fail-task"],
         batchtime=20160,
     )  # Use a batchtime of 14 days as suggested by the CSFLE test README

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -67,7 +67,7 @@ all_variants = [
             OD([("name", "install-uninstall-check-mingw"), ("distros", ["windows-vsCurrent-large"])]),
             OD([("name", "install-uninstall-check-msvc"), ("distros", ["windows-vsCurrent-large"])]),
             "debug-compile-with-warnings",
-            OD([("name", "build-and-test-with-toolchain"), ("distros", ["debian10-small"])]),
+            OD([("name", "build-and-test-with-toolchain"), ("distros", ["debian11-small"])]),
             "install-libmongoc-after-libbson",
         ],
         {
@@ -126,13 +126,6 @@ all_variants = [
             ".authentication-tests .openssl",
             ".latest .nossl",
         ],
-        {"CC": "gcc"},
-    ),
-    Variant(
-        "gcc83",
-        "GCC 8.3 (Debian 10.0)",
-        "debian10-test",
-        ["release-compile", "debug-compile-nosasl-nossl", ".latest .nossl"],
         {"CC": "gcc"},
     ),
     Variant(


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/2044 which overlooked usage of the `debian10` distro in the legacy config. The `build-and-test-with-toolchain` and `testazurekms-variant` tasks are moved to Debian 11. The `gcc83` build variant is dropped in favor of existing and comparable compilation with the `gcc102` build variant.