### PR TITLE
CDRIVER-5901 sync and run `poc-queryable-encryption.json`

### DIFF
--- a/.evergreen/scripts/run-tests.sh
+++ b/.evergreen/scripts/run-tests.sh
@@ -214,7 +214,7 @@ if [[ "${CLIENT_SIDE_ENCRYPTION}" == "on" ]]; then
 
   # Limit tests executed to CSE tests.
   test_args+=("-l" "/client_side_encryption/*")
-  test_args+=("-l" "/unified/poc-queryable-encryption")
+  test_args+=("-l" "/unified/*") # Includes PoC tests for CSFLE/QE.
 fi
 
 if [[ "${LOADBALANCED}" != "noloadbalanced" ]]; then

--- a/.evergreen/scripts/run-tests.sh
+++ b/.evergreen/scripts/run-tests.sh
@@ -214,6 +214,7 @@ if [[ "${CLIENT_SIDE_ENCRYPTION}" == "on" ]]; then
 
   # Limit tests executed to CSE tests.
   test_args+=("-l" "/client_side_encryption/*")
+  test_args+=("-l" "/unified/poc-queryable-encryption")
 fi
 
 if [[ "${LOADBALANCED}" != "noloadbalanced" ]]; then

--- a/src/libmongoc/tests/json/unified/poc-queryable-encryption.json
+++ b/src/libmongoc/tests/json/unified/poc-queryable-encryption.json
@@ -4,7 +4,12 @@
   "runOnRequirements": [
     {
       "minServerVersion": "7.0",
-      "csfle": true
+      "csfle": true,
+      "topologies": [
+        "replicaset",
+        "load-balanced",
+        "sharded"
+      ]
     }
   ],
   "createEntities": [


### PR DESCRIPTION
Sync test from 

The test was missing a requirement to skip on standalone. QE does not support standalone.

`poc-queryable-encryption` was not running on the encryption tasks (with names matching `*-cse-*`). This PR adds a glob to include tests from the unified directory (corresponding to the [valid-pass tests](https://github.com/mongodb/specifications/tree/62b9114bba9437c2c073d7e4e3b1090591ff01d2/source/unified-test-format/tests/valid-pass))