### PR TITLE
CDRIVER-6053 do not buffer pooled streams

### DIFF
--- a/src/libmongoc/doc/mongoc_stream_buffered_new.rst
+++ b/src/libmongoc/doc/mongoc_stream_buffered_new.rst
@@ -9,8 +9,7 @@ Synopsis
 .. code-block:: c
 
   mongoc_stream_t *
-  mongoc_stream_buffered_new (mongoc_stream_t *base_stream,
-                          size_t buffer_size);
+  mongoc_stream_buffered_new (mongoc_stream_t *base_stream, size_t buffer_size);
 
 Parameters
 ----------
@@ -21,6 +20,10 @@ Parameters
 This function shall create a new :symbol:`mongoc_stream_t` that buffers bytes to and from the underlying ``base_stream``.
 
 ``buffer_size`` will be used as the initial buffer size. It may grow past this size.
+
+.. warning::
+  
+  The internal buffer does not reduce in size once grown. Receiving a large message may result in a large allocation that persists until the returned :symbol:`mongoc_stream_t` is freed with :symbol:`mongoc_stream_destroy()`. The allocation strategy of the internal buffer is subject to change.
 
 Returns
 -------

--- a/src/libmongoc/doc/mongoc_stream_buffered_new.rst
+++ b/src/libmongoc/doc/mongoc_stream_buffered_new.rst
@@ -23,7 +23,7 @@ This function shall create a new :symbol:`mongoc_stream_t` that buffers bytes to
 
 .. warning::
   
-  The internal buffer does not reduce in size once grown. Receiving a large message may result in a large allocation that persists until the returned :symbol:`mongoc_stream_t` is freed with :symbol:`mongoc_stream_destroy()`. The allocation strategy of the internal buffer is subject to change.
+  The internal buffer does not reduce in size once grown. Receiving a large message may result in a large allocation that persists until the returned :symbol:`mongoc_stream_t` is freed with :symbol:`mongoc_stream_destroy()`.
 
 Returns
 -------

--- a/src/libmongoc/src/mongoc/mongoc-client-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-private.h
@@ -209,8 +209,7 @@ mongoc_stream_t *
 mongoc_client_connect_tcp (int32_t connecttimeoutms, const mongoc_host_list_t *host, bson_error_t *error);
 
 mongoc_stream_t *
-mongoc_client_connect (bool buffered,
-                       bool use_ssl,
+mongoc_client_connect (bool use_ssl,
                        void *ssl_opts_void,
                        const mongoc_uri_t *uri,
                        const mongoc_host_list_t *host,

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -761,8 +761,7 @@ mongoc_client_connect_unix (const mongoc_host_list_t *host, bson_error_t *error)
 }
 
 mongoc_stream_t *
-mongoc_client_connect (bool buffered,
-                       bool use_ssl,
+mongoc_client_connect (bool use_ssl,
                        void *ssl_opts_void,
                        const mongoc_uri_t *uri,
                        const mongoc_host_list_t *host,
@@ -851,9 +850,6 @@ mongoc_client_connect (bool buffered,
    if (!base_stream) {
       return NULL;
    }
-   if (buffered) {
-      return mongoc_stream_buffered_new (base_stream, 1024);
-   }
    return base_stream;
 }
 
@@ -897,13 +893,12 @@ mongoc_client_default_stream_initiator (const mongoc_uri_t *uri,
 
 #if defined(MONGOC_ENABLE_SSL_OPENSSL) && OPENSSL_VERSION_NUMBER >= 0x10100000L
    SSL_CTX *ssl_ctx = client->topology->scanner->openssl_ctx;
-   return mongoc_client_connect (
-      false, use_ssl, ssl_opts_void, uri, host, (void *) ssl_ctx, MONGOC_SHARED_PTR_NULL, error);
+   return mongoc_client_connect (use_ssl, ssl_opts_void, uri, host, (void *) ssl_ctx, MONGOC_SHARED_PTR_NULL, error);
 #elif defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
    return mongoc_client_connect (
-      false, use_ssl, ssl_opts_void, uri, host, NULL, client->topology->scanner->secure_channel_cred_ptr, error);
+      use_ssl, ssl_opts_void, uri, host, NULL, client->topology->scanner->secure_channel_cred_ptr, error);
 #else
-   return mongoc_client_connect (false, use_ssl, ssl_opts_void, uri, host, NULL, MONGOC_SHARED_PTR_NULL, error);
+   return mongoc_client_connect (use_ssl, ssl_opts_void, uri, host, NULL, MONGOC_SHARED_PTR_NULL, error);
 #endif
 }
 

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -898,12 +898,12 @@ mongoc_client_default_stream_initiator (const mongoc_uri_t *uri,
 #if defined(MONGOC_ENABLE_SSL_OPENSSL) && OPENSSL_VERSION_NUMBER >= 0x10100000L
    SSL_CTX *ssl_ctx = client->topology->scanner->openssl_ctx;
    return mongoc_client_connect (
-      true, use_ssl, ssl_opts_void, uri, host, (void *) ssl_ctx, MONGOC_SHARED_PTR_NULL, error);
+      false, use_ssl, ssl_opts_void, uri, host, (void *) ssl_ctx, MONGOC_SHARED_PTR_NULL, error);
 #elif defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
    return mongoc_client_connect (
-      true, use_ssl, ssl_opts_void, uri, host, NULL, client->topology->scanner->secure_channel_cred_ptr, error);
+      false, use_ssl, ssl_opts_void, uri, host, NULL, client->topology->scanner->secure_channel_cred_ptr, error);
 #else
-   return mongoc_client_connect (true, use_ssl, ssl_opts_void, uri, host, NULL, MONGOC_SHARED_PTR_NULL, error);
+   return mongoc_client_connect (false, use_ssl, ssl_opts_void, uri, host, NULL, MONGOC_SHARED_PTR_NULL, error);
 #endif
 }
 

--- a/src/libmongoc/src/mongoc/mongoc-server-monitor.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-monitor.c
@@ -948,8 +948,7 @@ _server_monitor_setup_connection (mongoc_server_monitor_t *server_monitor,
       secure_channel_cred_ptr = server_monitor->topology->scanner->secure_channel_cred_ptr;
 #endif
 
-      server_monitor->stream = mongoc_client_connect (false,
-                                                      ssl_opts_void != NULL,
+      server_monitor->stream = mongoc_client_connect (ssl_opts_void != NULL,
                                                       ssl_opts_void,
                                                       server_monitor->uri,
                                                       &server_monitor->description->host,


### PR DESCRIPTION
# Summary

Remove buffered stream on pooled connections

# Background & Motivation

See CDRIVER-6053 for a description of the problem. In short: long-lived buffered streams can significantly increase memory usage.

I initially thought buffering was intended to reduce allocations. But it actually increases allocations. When using a buffered stream to read, the caller still [allocates](https://github.com/mongodb/mongo-c-driver/blob/017cf329d7c9bf705cfa1d88eca15e884d13f7dc/src/libmongoc/src/mongoc/mongoc-buffer.c#L185) for the result, then [copies from the buffered stream](https://github.com/mongodb/mongo-c-driver/blob/017cf329d7c9bf705cfa1d88eca15e884d13f7dc/src/libmongoc/src/mongoc/mongoc-stream-buffered.c#L251).

[Comments](https://github.com/mongodb/mongo-c-driver/blob/017cf329d7c9bf705cfa1d88eca15e884d13f7dc/src/libmongoc/src/mongoc/mongoc-stream-buffered.c#L205-L209) indicate the original motivation for buffered streams:

> This isn't actually a huge savings since we never have more than one reply waiting for us, but perhaps someday that will be different. It should help for small replies, however that will reduce our read() syscalls by 50%.

I ran three patch builds of the `Parallel/Pool/*` performance tests to compare with buffering disabled. `Parallel/Pool/*` tests `mongoc_client_pool_t` running a `ping` command repeatedly. The performance [comparison against the stable baseline](https://performance-analyzer.server-tig.prod.corp.mongodb.com/perf-analyzer-viz/?comparison_id=687e4585eac28993fec65fbc&selected_tab=data-table&percent_filter=0%7C%7C100&z_filter=0%7C%7C10&filter_type=Default), summarized here:

| Test                      | Average Percent Change   |
|---------------------------|--------------------------|
| Parallel/Pool/Threads:1   | 0.39%                    |
| Parallel/Pool/Threads:10  | 0.31%                    |
| Parallel/Pool/Threads:100 | 4.29%                    |

Disabling buffering did not appear significant (and maybe slightly improved?). This PR proposes simply disabling buffered streams on `mongoc_client_pool_t`.

Additionally, single-threaded `mongoc_client_t` does not [enable buffered streams](https://github.com/mongodb/mongo-c-driver/blob/017cf329d7c9bf705cfa1d88eca15e884d13f7dc/src/libmongoc/src/mongoc/mongoc-topology-scanner.c#L835-L852) by default. A stream initiator could be set with `mongoc_client_set_stream_initiator` to create a buffered stream (though I expect this is rare). Regardless, documentation is added to warn about the behavior of buffered stream allocation.