### PR TITLE
CDRIVER-6059 set CMake max policy version to 4.0

### DIFF
--- a/.evergreen/scripts/compile-std.sh
+++ b/.evergreen/scripts/compile-std.sh
@@ -119,7 +119,7 @@ fi
 echo "Checking requested C standard is supported..."
 pushd "$(mktemp -d)"
 cat >CMakeLists.txt <<DOC
-cmake_minimum_required(VERSION 3.30)
+cmake_minimum_required(VERSION 3.30...4.0)
 project(c_standard_latest LANGUAGES C)
 set(c_std_version "${C_STD_VERSION:?}")
 if(c_std_version STREQUAL "latest") # Special-case MSVC's /std:clatest flag.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.15)
+cmake_minimum_required (VERSION 3.15...4.0)
 
 list (INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_LIST_DIR}/build/cmake")
 # Defines BUILD_VERSION, which we use throughout:
@@ -347,11 +347,6 @@ set (CMAKE_MACOSX_RPATH ON)
 if(WIN32)
    set (CMAKE_IMPORT_LIBRARY_SUFFIX .dll.lib)
 endif()
-
-# https://cmake.org/cmake/help/v3.11/policy/CMP0042.html
-# Enable a CMake 3.0+ policy that sets CMAKE_MACOSX_RPATH by default, and
-# silence a CMake 3.11 warning that the old behavior is deprecated.
-cmake_policy (SET CMP0042 NEW)
 
 # By default, ensure conformance with a minimum C standard.
 # Required extensions to the language (i.e. POSIX) are (re)enabled further below.

--- a/NEWS
+++ b/NEWS
@@ -7,7 +7,9 @@ libmongoc 2.1.0 (Unreleased)
 
 ## Changes
 
-Removed:
+* The CMake project now sets a CMake policy max version of `4.0` (previously unset).
+
+## Removed
 
 * Support for Debian 9 and Debian 10.
 

--- a/build/cmake/GenerateUninstaller.cmake
+++ b/build/cmake/GenerateUninstaller.cmake
@@ -1,5 +1,3 @@
-cmake_policy(VERSION 3.15)
-
 if(NOT CMAKE_SCRIPT_MODE_FILE)
     # We are being included from within a project, so we should generate the install rules
     # The script name is "uninstall" by default:

--- a/src/libbson/CMakeLists.txt
+++ b/src/libbson/CMakeLists.txt
@@ -11,7 +11,7 @@
 #                                     888
 #                                     888
 
-cmake_minimum_required (VERSION 3.15)
+cmake_minimum_required (VERSION 3.15...4.0)
 
 project (libbson
    LANGUAGES C

--- a/src/libbson/NEWS
+++ b/src/libbson/NEWS
@@ -1,6 +1,10 @@
 libbson 2.1.0 (Unreleased)
 ==========================
 
+Changed:
+
+* The CMake project now sets a CMake policy max version of `4.0` (previously unset).
+
 Removed:
 
 * Support for Debian 9 and Debian 10.

--- a/src/libbson/examples/cmake/find_package/CMakeLists.txt
+++ b/src/libbson/examples/cmake/find_package/CMakeLists.txt
@@ -15,7 +15,7 @@
 # Demonstrates how to use the CMake 'find_package' mechanism to locate
 # and build against libbson.
 
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.15...4.0)
 
 project (hello_bson LANGUAGES C)
 

--- a/src/libbson/examples/cmake/find_package_static/CMakeLists.txt
+++ b/src/libbson/examples/cmake/find_package_static/CMakeLists.txt
@@ -15,7 +15,7 @@
 # Demonstrates how to use the CMake 'find_package' mechanism to locate
 # and build against libbson.
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.15...4.0)
 
 project (hello_bson LANGUAGES C)
 

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.15)
+cmake_minimum_required (VERSION 3.15...4.0)
 
 project (libmongoc
    LANGUAGES C

--- a/src/libmongoc/examples/cmake/find_package/CMakeLists.txt
+++ b/src/libmongoc/examples/cmake/find_package/CMakeLists.txt
@@ -15,7 +15,7 @@
 # Demonstrates how to use the CMake 'find_package' mechanism to locate
 # and build against libmongoc.
 
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.15...4.0)
 
 project (hello_mongoc LANGUAGES C)
 

--- a/src/libmongoc/examples/cmake/find_package_static/CMakeLists.txt
+++ b/src/libmongoc/examples/cmake/find_package_static/CMakeLists.txt
@@ -15,7 +15,7 @@
 # Demonstrates how to use the CMake 'find_package' mechanism to locate
 # and build against libmongoc.
 
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.15...4.0)
 
 project (hello_mongoc LANGUAGES C)
 

--- a/src/libmongoc/examples/cmake/vcpkg/CMakeLists.txt
+++ b/src/libmongoc/examples/cmake/vcpkg/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required (VERSION 3.15...4.0)
 project(vcpkg-example-project)
 
 find_package(mongoc CONFIG REQUIRED)

--- a/src/libmongoc/tests/cmake-import/CMakeLists.txt
+++ b/src/libmongoc/tests/cmake-import/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required (VERSION 3.15...4.0)
 project(ImportTestProject)
 
 include(CTest)

--- a/src/libmongoc/tests/pkg-config-import/CMakeLists.txt
+++ b/src/libmongoc/tests/pkg-config-import/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required (VERSION 3.15...4.0)
 project(pkg-config-import-test LANGUAGES C)
 
 # This is a test case that tries to build against bson/mongoc using pkg-config.


### PR DESCRIPTION
Resolves CDRIVER-6059.

Motivated by the following error when building example projects under `src/libmongoc/examples/cmake` with CMake 4.0, some of which have very-long-outdated calls to `cmake_minimum_required ()` with version `3.0` and even `2.8`:

```
CMake Error at CMakeLists.txt:18 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

Decided to take this opportunity to set the [CMake policy max version](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#policy-version) to `4.0`, the current latest CMake major release version, in advance of upcoming changes to the C Driver's EVG configuration to use `uv tool` to consistently obtain newer CMake binaries, including CMake v4 binaries (see: [mongodb/mongo-cxx-driver#1428](/mongodb/mongo-cxx-driver/pull/1428)).

Existing calls to `cmake_policy()` which are made redundant by the max policy version are removed accordingly. All calls to `cmake_minimum_required()` are updated to consistently use the same version range of `3.15...4.0`. Exceptions include calls which use a newer minimum required version (e.g. [here](https://github.com/mongodb/mongo-c-driver/blob/d2e6be2796013c9d077c46e03b41a6769d4b495e/build/cmake/TestProject.cmake#L264) and [here](https://github.com/mongodb/mongo-c-driver/blob/d2e6be2796013c9d077c46e03b41a6769d4b495e/.evergreen/scripts/compile-std.sh#L122)) and bundled libraries (e.g. [kms-message](src/kms-message/CMakeLists.txt) and [zlib](https://github.com/mongodb/mongo-c-driver/blob/d2e6be2796013c9d077c46e03b41a6769d4b495e/src/zlib-1.3.1/CMakeLists.txt#L1)).

Changelog entries are added to the bson and mongoc libraries' `NEWS` files, as these changes may cause observable differences in build system behavior depending on the CMake version and configurations being used. The full list of policies per CMake version are [listed here](https://cmake.org/cmake/help/latest/manual/cmake-policies.7.html). Setting the CMake policy max version to `4.0` effectively sets all CMake policies introduced from `3.15` (current CMake minimum required version) to `4.0` to select the `NEW` behavior by default. Note that similar updates were made to the C++ Driver's CMake project in [mongodb/mongo-cxx-driver#1379](/mongodb/mongo-cxx-driver/pull/1379) in the 4.1.0 release. This PR will make the CMake policy settings for the C Driver consistent with those for the C++ Driver.