### PR TITLE
Add default EVG config_generator Function.call() and update uv lockfile

### DIFF
--- a/.evergreen/config_generator/components/abi_compliance_check.py
+++ b/.evergreen/config_generator/components/abi_compliance_check.py
@@ -48,10 +48,6 @@ class CheckABICompliance(Function):
         ),
     ]
 
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)
-
 
 def functions():
     return CheckABICompliance.defn()

--- a/.evergreen/config_generator/components/c_std_compile.py
+++ b/.evergreen/config_generator/components/c_std_compile.py
@@ -59,10 +59,6 @@ class StdCompile(Function):
         ),
     ]
 
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)
-
 
 def functions():
     return StdCompile.defn()

--- a/.evergreen/config_generator/components/check_mongoc_public_headers.py
+++ b/.evergreen/config_generator/components/check_mongoc_public_headers.py
@@ -20,10 +20,6 @@ class CheckMongocPublicHeaders(Function):
         ),
     ]
 
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)
-
 
 def functions():
     return CheckMongocPublicHeaders.defn()

--- a/.evergreen/config_generator/components/clang_format.py
+++ b/.evergreen/config_generator/components/clang_format.py
@@ -24,10 +24,6 @@ class ClangFormat(Function):
         ),
     ]
 
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)
-
 
 def functions():
     return ClangFormat.defn()

--- a/.evergreen/config_generator/components/earthly.py
+++ b/.evergreen/config_generator/components/earthly.py
@@ -168,10 +168,6 @@ class DockerLoginAmazonECR(Function):
         ),
     ]
 
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)
-
 
 def task_filter(env: EarthlyVariant, conf: Configuration) -> bool:
     """

--- a/.evergreen/config_generator/components/funcs/backtrace.py
+++ b/.evergreen/config_generator/components/funcs/backtrace.py
@@ -11,10 +11,6 @@ class Backtrace(Function):
         ),
     ]
 
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)
-
 
 def functions():
     return Backtrace.defn()

--- a/.evergreen/config_generator/components/funcs/bootstrap_mongo_orchestration.py
+++ b/.evergreen/config_generator/components/funcs/bootstrap_mongo_orchestration.py
@@ -21,10 +21,6 @@ class BootstrapMongoOrchestration(Function):
         ),
     ]
 
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)
-
 
 def functions():
     return BootstrapMongoOrchestration.defn()

--- a/.evergreen/config_generator/components/funcs/fetch_det.py
+++ b/.evergreen/config_generator/components/funcs/fetch_det.py
@@ -40,10 +40,6 @@ class FetchDET(Function):
         ),
     ]
 
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)
-
 
 def functions():
     return FetchDET.defn()

--- a/.evergreen/config_generator/components/funcs/fetch_source.py
+++ b/.evergreen/config_generator/components/funcs/fetch_source.py
@@ -39,10 +39,6 @@ class FetchSource(Function):
         ),
     ]
 
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)
-
 
 def functions():
     return FetchSource.defn()

--- a/.evergreen/config_generator/components/funcs/restore_instance_profile.py
+++ b/.evergreen/config_generator/components/funcs/restore_instance_profile.py
@@ -34,10 +34,6 @@ class RestoreInstanceProfile(Function):
         ),
     ]
 
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)
-
 
 def functions():
     return RestoreInstanceProfile.defn()

--- a/.evergreen/config_generator/components/funcs/run_mock_kms_servers.py
+++ b/.evergreen/config_generator/components/funcs/run_mock_kms_servers.py
@@ -55,10 +55,6 @@ class RunMockKMSServers(Function):
         ),
     ]
 
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)
-
 
 def functions():
     return RunMockKMSServers.defn()

--- a/.evergreen/config_generator/components/funcs/run_simple_http_server.py
+++ b/.evergreen/config_generator/components/funcs/run_simple_http_server.py
@@ -22,10 +22,6 @@ class RunSimpleHTTPServer(Function):
         ),
     ]
 
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)
-
 
 def functions():
     return RunSimpleHTTPServer.defn()

--- a/.evergreen/config_generator/components/funcs/run_tests.py
+++ b/.evergreen/config_generator/components/funcs/run_tests.py
@@ -15,10 +15,6 @@ class RunTests(Function):
         ),
     ]
 
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)
-
 
 def functions():
     return RunTests.defn()

--- a/.evergreen/config_generator/components/funcs/stop_load_balancer.py
+++ b/.evergreen/config_generator/components/funcs/stop_load_balancer.py
@@ -19,10 +19,6 @@ class StopLoadBalancer(Function):
         ),
     ]
 
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)
-
 
 def functions():
     return StopLoadBalancer.defn()

--- a/.evergreen/config_generator/components/funcs/stop_mongo_orchestration.py
+++ b/.evergreen/config_generator/components/funcs/stop_mongo_orchestration.py
@@ -14,10 +14,6 @@ class StopMongoOrchestration(Function):
         ),
     ]
 
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)
-
 
 def functions():
     return StopMongoOrchestration.defn()

--- a/.evergreen/config_generator/components/funcs/upload_build.py
+++ b/.evergreen/config_generator/components/funcs/upload_build.py
@@ -22,10 +22,6 @@ class UploadBuild(Function):
         ),
     ]
 
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)
-
 
 def functions():
     return UploadBuild.defn()

--- a/.evergreen/config_generator/components/funcs/upload_mo_artifacts.py
+++ b/.evergreen/config_generator/components/funcs/upload_mo_artifacts.py
@@ -87,10 +87,6 @@ class UploadMOArtifacts(Function):
         ),
     ]
 
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)
-
 
 def functions():
     return UploadMOArtifacts.defn()

--- a/.evergreen/config_generator/components/funcs/upload_test_results.py
+++ b/.evergreen/config_generator/components/funcs/upload_test_results.py
@@ -19,10 +19,6 @@ class UploadTestResults(Function):
         ),
     ]
 
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)
-
 
 def functions():
     return UploadTestResults.defn()

--- a/.evergreen/config_generator/components/kms_divergence_check.py
+++ b/.evergreen/config_generator/components/kms_divergence_check.py
@@ -16,10 +16,6 @@ class KmsDivergenceCheck(Function):
         ),
     ]
 
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)
-
 
 def functions():
     return KmsDivergenceCheck.defn()

--- a/.evergreen/config_generator/components/make_docs.py
+++ b/.evergreen/config_generator/components/make_docs.py
@@ -23,10 +23,6 @@ class MakeDocs(Function):
         ),
     ]
 
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)
-
 
 class UploadDocs(Function):
     name = "upload-docs"
@@ -69,10 +65,6 @@ class UploadDocs(Function):
         ),
     ]
 
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)
-
 
 class UploadManPages(Function):
     name = "upload-man-pages"
@@ -113,10 +105,6 @@ class UploadManPages(Function):
             remote_file="${project}/man-pages/libmongoc/${CURRENT_VERSION}/index.html",
         ),
     ]
-
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)
 
 
 def functions():

--- a/.evergreen/config_generator/components/openssl_static_compile.py
+++ b/.evergreen/config_generator/components/openssl_static_compile.py
@@ -38,10 +38,6 @@ class StaticOpenSSLCompile(Function):
         ),
     ]
 
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)
-
 
 def functions():
     return StaticOpenSSLCompile.defn()

--- a/.evergreen/config_generator/components/sbom.py
+++ b/.evergreen/config_generator/components/sbom.py
@@ -92,10 +92,6 @@ class SBOM(Function):
         ),
     ]
 
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)
-
 
 def functions():
     return merge_defns(

--- a/.evergreen/config_generator/components/scan_build.py
+++ b/.evergreen/config_generator/components/scan_build.py
@@ -38,10 +38,6 @@ class ScanBuild(Function):
         ),
     ]
 
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)
-
 
 def functions():
     return ScanBuild.defn()

--- a/.evergreen/config_generator/etc/cse/compile.py
+++ b/.evergreen/config_generator/etc/cse/compile.py
@@ -35,7 +35,3 @@ class CompileCommon(Function):
                 },
             ),
         ]
-
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)

--- a/.evergreen/config_generator/etc/function.py
+++ b/.evergreen/config_generator/etc/function.py
@@ -18,6 +18,10 @@ class Function:
     def default_call(cls, **kwargs) -> FunctionCall:
         return FunctionCall(func=cls.name, **kwargs)
 
+    @classmethod
+    def call(cls, **kwargs) -> FunctionCall:
+        return cls.default_call(**kwargs)
+
 
 def merge_defns(*args):
     return ChainMap(*args)

--- a/.evergreen/config_generator/etc/sasl/compile.py
+++ b/.evergreen/config_generator/etc/sasl/compile.py
@@ -30,7 +30,3 @@ class CompileCommon(Function):
                 script='.evergreen/scripts/compile.sh',
             ),
         ]
-
-    @classmethod
-    def call(cls, **kwargs):
-        return cls.default_call(**kwargs)

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,18 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "accessible-pygments"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c1/bbac6a50d02774f91572938964c582fff4270eee73ab822a4aeea4d8b11b/accessible_pygments-0.0.5.tar.gz", hash = "sha256:40918d3e6a2b619ad424cb91e556bd3bd8865443d9f22f1dcdf79e33c8046872", size = 1377899, upload-time = "2024-05-10T11:23:10.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/3f/95338030883d8c8b91223b4e21744b04d11b161a3ef117295d8241f50ab4/accessible_pygments-0.0.5-py3-none-any.whl", hash = "sha256:88ae3211e68a1d0b011504b2ffc1691feafce124b845bd072ab6f9f66f34d4b7", size = 1395903, upload-time = "2024-05-10T11:23:08.421Z" },
+]
+
+[[package]]
 name = "alabaster"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -48,11 +60,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2025.6.15"
+version = "2025.7.14"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/f7/f14b46d4bcd21092d7d3ccef689615220d8a08fb25e564b65d20738e672e/certifi-2025.6.15.tar.gz", hash = "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b", size = 158753, upload-time = "2025-06-15T02:45:51.329Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/76/52c535bcebe74590f296d6c77c86dabf761c41980e1347a2422e4aa2ae41/certifi-2025.7.14.tar.gz", hash = "sha256:8ea99dbdfaaf2ba2f9bac77b9249ef62ec5218e7c2b2e903378ed5fccf765995", size = 163981, upload-time = "2025-07-14T03:29:28.449Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/ae/320161bd181fc06471eed047ecce67b693fd7515b16d495d8932db763426/certifi-2025.6.15-py3-none-any.whl", hash = "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057", size = 157650, upload-time = "2025-06-15T02:45:49.977Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/52/34c6cf5bb9285074dc3531c437b3919e825d976fde097a7a73f79e726d03/certifi-2025.7.14-py3-none-any.whl", hash = "sha256:6b31f564a415d79ee77df69d757bb49a5bb53bd9f756cbbe24394ffd6fc1f4b2", size = 162722, upload-time = "2025-07-14T03:29:26.863Z" },
 ]
 
 [[package]]
@@ -118,25 +130,27 @@ wheels = [
 
 [[package]]
 name = "clang-format"
-version = "20.1.7"
+version = "20.1.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a7/af/e138e1be1812ce0261ceaf5695e7d4299fa4d5085e1ed16e9157c4cda3ea/clang_format-20.1.7.tar.gz", hash = "sha256:2b0d76b9bf1f993bad33d2216b5fce4c407bc748fa31659ab7f51ca60df113c9", size = 11535, upload-time = "2025-06-26T12:57:25.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/e5/6560d6466378597f76292a6f54702dcf8a3746edfbd5fbdcb54b12e9ac46/clang_format-20.1.8.tar.gz", hash = "sha256:8ebd717257d8c7daf6bb1f703a4024f009a58941723eeb0d92ec493ce26aa520", size = 11500, upload-time = "2025-07-10T11:40:06.899Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/c7/d6b6b2f37e559cefc07426170368ddb5951753b7a831668666c5d91d6b79/clang_format-20.1.7-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:70a904719a1bd6653d77ddc6d7b40418845912a1a2a419b9116b819a6b619f8c", size = 1436729, upload-time = "2025-06-26T12:57:02.479Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/8c/ae7bc9122a2c7505506bba4aae9d9f38c01435b735a38c65985d30efc943/clang_format-20.1.7-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:e5257e8188569e4e47fceb3ba3317b0b44dc5ab5046c8cc2d58c626430c747a6", size = 1410576, upload-time = "2025-06-26T12:57:04.441Z" },
-    { url = "https://files.pythonhosted.org/packages/19/c1/6777ef4eafa63d35dda0cda2803e818d17a0a9fe3216837eab1f169afbee/clang_format-20.1.7-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1dad1e6f9eb732b76046bf5810c6ee78b9e6cd6b3616cb75d9bde06ecd3222e6", size = 1794265, upload-time = "2025-06-26T12:57:05.722Z" },
-    { url = "https://files.pythonhosted.org/packages/54/8f/33a426e3b61cff30e4d8d7173508da277ece67296428b7657da681c821d5/clang_format-20.1.7-py2.py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27ed7fe674e8a77461c8d5b117ed96021aa18233917b3fe54b95391e0b22d04", size = 1968022, upload-time = "2025-06-26T12:57:07.03Z" },
-    { url = "https://files.pythonhosted.org/packages/da/1f/fc0fe12a27153370ca55490bedd29f11611b1a1336779472dec5f3d6af94/clang_format-20.1.7-py2.py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bd144f093b4a3ac8a0f0d0ebb9b013974884d9da0627b9905949c6f3213aa850", size = 2724211, upload-time = "2025-06-26T12:57:08.75Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/fd/7d7462d307d8827de0b8b183b3b467643e14c61e880b5485e7aa80a11db7/clang_format-20.1.7-py2.py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d79484ce2c8f621242046c4bb0aefd49445ec5c7bc3c404af97490289791b777", size = 1789853, upload-time = "2025-06-26T12:57:10.314Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/7f/55985595ffbf9bcec64ad36e9a0451cf8556ba0fb1a80781943de106cfa3/clang_format-20.1.7-py2.py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99cbfb99dab836027498190f55e543bed51bae33ae6dc256861e7aa91368de98", size = 1801091, upload-time = "2025-06-26T12:57:11.708Z" },
-    { url = "https://files.pythonhosted.org/packages/84/2e/04009020237243f8785188810ee33bc9ce0773e3ccba2599768381dac088/clang_format-20.1.7-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4c05114a10efe85c11fde518fe0fadc2977ce4a997a26ceaac88521daee83bbd", size = 2774653, upload-time = "2025-06-26T12:57:13.248Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/22/8f98cf57f54a06ff3a08dd79fba25617a4495614b6458bc69e46e81caa96/clang_format-20.1.7-py2.py3-none-musllinux_1_2_i686.whl", hash = "sha256:9cd4d64dc0e34b23badad0ce3a235fb5c8ac63651d9f91d1c806356212cbca6c", size = 3100264, upload-time = "2025-06-26T12:57:14.59Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/93/b5dc2959423b203f8a8db35ff7f19a114c50df265728714dcaf90d779d4f/clang_format-20.1.7-py2.py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:11431cb437ed22be85744ea47b3a6801bc61de7ac4b775bf1cb89ee190c992d4", size = 3186502, upload-time = "2025-06-26T12:57:16.176Z" },
-    { url = "https://files.pythonhosted.org/packages/da/a6/3ae4861b2fd3eba3b47d46e5c31b4dac0065a8048dc77825a85ac141e991/clang_format-20.1.7-py2.py3-none-musllinux_1_2_s390x.whl", hash = "sha256:29f5fe39e60579ca253d31c1122ce06a80716400ec7e5dc38833da80f88dbbd5", size = 3224655, upload-time = "2025-06-26T12:57:18.012Z" },
-    { url = "https://files.pythonhosted.org/packages/64/df/8668d80685b0556fead8ecc9ff221574d9f2b4011a68da155c54acab6dc6/clang_format-20.1.7-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:6db0b7271af8cbc2656b3b6b31e4276d5c6b8ceafb1981760f4738cfbe0a9e43", size = 2881843, upload-time = "2025-06-26T12:57:19.347Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/e8/5f105c2195fe565b9b5203f533f6d727a73d98ef3b295e3f2f01ddf5d847/clang_format-20.1.7-py2.py3-none-win32.whl", hash = "sha256:7bd56bd0f519959488977dcddddba4e4fd07cba6225ed09ad658caa1f7286d1f", size = 1259337, upload-time = "2025-06-26T12:57:21.029Z" },
-    { url = "https://files.pythonhosted.org/packages/31/0d/a3685e3287d3ff3676297da331d7a05110dee049c773af2d6a1f5c8df0b0/clang_format-20.1.7-py2.py3-none-win_amd64.whl", hash = "sha256:4a9b909b1a9eb0b91aae51fdeeeb013ce20f9079d2e0fa8b8381e97c268dc889", size = 1444266, upload-time = "2025-06-26T12:57:22.37Z" },
-    { url = "https://files.pythonhosted.org/packages/88/93/5242ed23c0ec6b2e28509452b41c732789822c9e5aa4a899e406f9d15d64/clang_format-20.1.7-py2.py3-none-win_arm64.whl", hash = "sha256:d11c62d38b9144d30021b884b0f95e7270a6bcbf4f22bdd7dae94a531d82fbba", size = 1319591, upload-time = "2025-06-26T12:57:23.704Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/cd/6dab2c15bb2f13ad13015fb92eda0b49b3bd866153072e4d9796f7b220e4/clang_format-20.1.8-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:e9422bc81b3bea6c0ee773662fbe3bfd8a9479ae70e59008095dfae7001c5a84", size = 1429486, upload-time = "2025-07-10T11:39:38.665Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/4c/3efe4fe6910e1e00dcec0c8d9ef715164500f043e9911bdf253370ff917b/clang_format-20.1.8-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:c0cf62720247a7dd1e2d610816a2f7d7016433f9c2869880cba655449bd09616", size = 1400840, upload-time = "2025-07-10T11:39:40.516Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c3/af601563d3bfa4c514406347c13dc639f984df7c9e13df3a0adf3a650fc9/clang_format-20.1.8-py2.py3-none-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4f998e5c19e10f69b87af6991ccb14db934b5fa36fd28c7dbfc17dee957007f4", size = 1777504, upload-time = "2025-07-10T11:39:42.266Z" },
+    { url = "https://files.pythonhosted.org/packages/06/60/7c2ff3019599ad985d0a61f74ba8226d538c72485b0e3d25b1899601a9f5/clang_format-20.1.8-py2.py3-none-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34de32fe53452a07497793d5faf3fd03f7cf8b960b915417471ae81227461a39", size = 1692081, upload-time = "2025-07-10T11:39:43.67Z" },
+    { url = "https://files.pythonhosted.org/packages/99/74/956bc5455ce102767805b2eafcada0de003c391adb8299222432091af309/clang_format-20.1.8-py2.py3-none-manylinux_2_27_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1397b1b700ee78af73b14c5d65ad777c570c79a175c220768056fbcb7afed113", size = 1987169, upload-time = "2025-07-10T11:39:45.465Z" },
+    { url = "https://files.pythonhosted.org/packages/70/3f/0c141c391a0d4bd4012758f68a27ddc1db8b48814f96eb459417e197124a/clang_format-20.1.8-py2.py3-none-manylinux_2_27_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e195b5f6b79d89d42d4094d103f0a4f47ff3997d6474811622b95ab596f01fd2", size = 2005960, upload-time = "2025-07-10T11:39:47.163Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/77/786aa0fc8a75d8ce94966bb33e44c63fec1964cbf343ee862ed6a5be38c1/clang_format-20.1.8-py2.py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c6bcb7e01ba4f05a4c980fda147b330f7e4833c2aea8c92a0c2df9573ae7afe", size = 1777063, upload-time = "2025-07-10T11:39:48.962Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/0b/79cc55d7a64f3798a044c1f12c288048c6551af834700ac2ed1204c1181d/clang_format-20.1.8-py2.py3-none-manylinux_2_31_armv7l.whl", hash = "sha256:d99a5f3d7a252ab762ed79bc2a271a63fe593ae2e2565ce287835c00ce13c37e", size = 1626598, upload-time = "2025-07-10T11:39:50.468Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a2/913509f0e845b2beb0d298a9ec78c230a3a1f659c6928f990e84b842da4a/clang_format-20.1.8-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0a687c6efd7708227eafec37e98143e0b4b7dbeca82ff8e1de110d434f4e63ac", size = 2689936, upload-time = "2025-07-10T11:39:52.08Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/29/7cb26c5884040d4cb2f1e3ece6d37ebaf318d7cd281339affc94d1a9803c/clang_format-20.1.8-py2.py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d6491195d8edc788de8abfaea30b78ff74ad3f5ee89653cd0a27a4af4feb1317", size = 2462082, upload-time = "2025-07-10T11:39:53.73Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/55/11ba71667856abfc7872c33e71b15c551d2d0fc3ef86ef73f92a46b2749c/clang_format-20.1.8-py2.py3-none-musllinux_1_2_i686.whl", hash = "sha256:9ceae6a1fbd594ec2a31157997378b70df42273795a0177be0725a4e96336231", size = 2927834, upload-time = "2025-07-10T11:39:55.264Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/71/496d2bafcb03b16a6fff25e73dcbe5aedcf68dd138580022b3114a3f7a84/clang_format-20.1.8-py2.py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:941396455b529ca130fae24d6d95bdf9a236d2ad22318991090d0b7ae53d236a", size = 3054954, upload-time = "2025-07-10T11:39:56.823Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/b9/8e5595a8d301c9695802664e4e00548a4c88a9fb6e434aac43e4778f06e1/clang_format-20.1.8-py2.py3-none-musllinux_1_2_s390x.whl", hash = "sha256:8dbbdfce85bdde675dee98fdbcddee445e6a9492b2a2b04afabfd33525be5642", size = 3159351, upload-time = "2025-07-10T11:39:58.95Z" },
+    { url = "https://files.pythonhosted.org/packages/51/50/d385c1eb678061a18ab1de198e8400bb8c69003ec54fd4220f1c34ea6c46/clang_format-20.1.8-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:abc1b72f42db5db695d539b0a1b3cc3c125dfaa9c5baea0a94a3a2d6d1e50c1f", size = 2809188, upload-time = "2025-07-10T11:40:00.797Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/2d/e02502cd8c845f0b3e17c556648fd481aca0d77935adf8684cda5e4293e5/clang_format-20.1.8-py2.py3-none-win32.whl", hash = "sha256:635b57361fa3caeb9449aa62584d7cd38fbee81dbf3addd6b1d7c377eb34e766", size = 1261819, upload-time = "2025-07-10T11:40:02.194Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/ee/656287efdf58dccc7a7299fab547fe1313b49ca1ea1607ea475b262d640f/clang_format-20.1.8-py2.py3-none-win_amd64.whl", hash = "sha256:346ac8cab571eaba4d6b89dfa30fdbbc512db82a66ab0eeb1763cacc5977e325", size = 1414174, upload-time = "2025-07-10T11:40:03.701Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/27/71cd96599d47229bd819dcc0c688a859764bb1b4960a23b8a75f8558c044/clang_format-20.1.8-py2.py3-none-win_arm64.whl", hash = "sha256:d18b7b69697e97b6917a69f4bf48bf94e3827b016b491c90dd0f6ab917e37cf9", size = 1319592, upload-time = "2025-07-10T11:40:05.441Z" },
 ]
 
 [[package]]
@@ -171,18 +185,19 @@ wheels = [
 
 [[package]]
 name = "furo"
-version = "2024.8.6"
+version = "2025.7.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "accessible-pygments" },
     { name = "beautifulsoup4" },
     { name = "pygments" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-basic-ng" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/e2/d351d69a9a9e4badb4a5be062c2d0e87bd9e6c23b5e57337fef14bef34c8/furo-2024.8.6.tar.gz", hash = "sha256:b63e4cee8abfc3136d3bc03a3d45a76a850bada4d6374d24c1716b0e01394a01", size = 1661506, upload-time = "2024-08-06T08:07:57.567Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/69/312cd100fa45ddaea5a588334d2defa331ff427bcb61f5fe2ae61bdc3762/furo-2025.7.19.tar.gz", hash = "sha256:4164b2cafcf4023a59bb3c594e935e2516f6b9d35e9a5ea83d8f6b43808fe91f", size = 1662054, upload-time = "2025-07-19T10:52:09.754Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/48/e791a7ed487dbb9729ef32bb5d1af16693d8925f4366befef54119b2e576/furo-2024.8.6-py3-none-any.whl", hash = "sha256:6cd97c58b47813d3619e63e9081169880fbe331f0ca883c871ff1f3f11814f5c", size = 341333, upload-time = "2024-08-06T08:07:54.44Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/34/2b07b72bee02a63241d654f5d8af87a2de977c59638eec41ca356ab915cd/furo-2025.7.19-py3-none-any.whl", hash = "sha256:bdea869822dfd2b494ea84c0973937e35d1575af088b6721a29c7f7878adc9e3", size = 342175, upload-time = "2025-07-19T10:52:02.399Z" },
 ]
 
 [[package]]
@@ -757,11 +772,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.14.0"
+version = "4.14.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d1/bc/51647cd02527e87d05cb083ccc402f93e441606ff1f01739a62c8ad09ba5/typing_extensions-4.14.0.tar.gz", hash = "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4", size = 107423, upload-time = "2025-06-02T14:52:11.399Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36", size = 107673, upload-time = "2025-07-04T13:28:34.16Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/e0/552843e0d356fbb5256d21449fa957fa4eff3bbc135a74a691ee70c7c5da/typing_extensions-4.14.0-py3-none-any.whl", hash = "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af", size = 43839, upload-time = "2025-06-02T14:52:10.026Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76", size = 43906, upload-time = "2025-07-04T13:28:32.743Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Minor maintenance updates to the EVG configuration and uv lockfile by running `uv lock -U` and applying the "default call" pattern that was applied for the C++ Driver's EVG config_generator in [mongodb/mongo-cxx-driver#1244](/mongodb/mongo-cxx-driver/pull/1244). Python dependencies are updated as follows:

```
Added accessible-pygments v0.0.5
Updated certifi v2025.6.15 -> v2025.7.14
Updated clang-format v20.1.7 -> v20.1.8
Updated furo v2024.8.6 -> v2025.7.19
Updated typing-extensions v4.14.0 -> v4.14.1
```

The `accessible-pygments` package is a new requirement by `furo`.