### PR TITLE
Update generated EVG config for verify-headers

### DIFF
--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -6786,5 +6786,9 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          include_expansions_in_env:
+            - DOCKER_CONFIG
           args:
+            - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +verify-headers
+            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/2053 which missed config regeneration changes for the new verify-headers task to account for https://github.com/mongodb/mongo-c-driver/pull/2058.