### PR TITLE
update Earthly version from 0.8.3 to 0.8.16

### DIFF
--- a/tools/earthly.sh
+++ b/tools/earthly.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-: "${EARTHLY_VERSION:=0.8.3}"
+: "${EARTHLY_VERSION:=0.8.16}"
 
 # Calc the arch of the executable we want
 case "$ARCHNAME" in


### PR DESCRIPTION
To fix `no such host` error logs observed after the Earthly cloud shutdown. [Example](https://parsley.mongodb.com/evergreen/mongo_c_driver_alpine3.16_gcc_check:sasl=Cyrus%C2%A0%E2%80%A2%C2%A0tls=OpenSSL%C2%A0%E2%80%A2%C2%A0test_mongocxx_ref=master_a3ba342a03df26f59b0427c921b8b727264b4f64_25_07_24_17_48_47/0/task?bookmarks=0,1419&shareLine=354):

```
retrying http request due to unexpected error Get "https://api.earthly.dev/api/v0/account/auth-challenge": dial tcp: lookup api.earthly.dev on 10.122.0.2:53: no such host {reqID: 6ebdff5e-e702-4953-b775-88ed20c8c031}
```

https://github.com/earthly/earthly/releases/tag/v0.8.16 notes:

> v0.8.16 does not emit log messages after the cloud shutdown
