### PR TITLE
Add DockerLoginAmazonECR to verify-headers task

### DIFF
--- a/.evergreen/config_generator/components/earthly.py
+++ b/.evergreen/config_generator/components/earthly.py
@@ -310,7 +310,10 @@ def tasks() -> Iterable[EvgTask]:
 
     yield EvgTask(
         name="verify-headers",
-        commands=[earthly_exec(kind="test", target="verify-headers")],
+        commands=[
+            DockerLoginAmazonECR.call(),
+            earthly_exec(kind="test", target="verify-headers"),
+        ],
         tags=["pr-merge-gate"],
         run_on=CONTAINER_RUN_DISTROS,
     )

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -6781,6 +6781,7 @@ tasks:
       - ubuntu2404-large
     tags: [pr-merge-gate]
     commands:
+      - func: docker-login-amazon-ecr
       - command: subprocess.exec
         type: test
         params:


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/2071, which overlooked that in addition to the EVG generated config being out-of-date, it was also missing the required call to `DockerLoginAmazonECR` to authenticate with Amazon ECR prior to running the `verify-headers` Earthly command.