### PR TITLE
Use tag debian/1.30.4-1 for building Debian packages in Evergreen

### DIFF
--- a/.evergreen/scripts/debian_package_build.sh
+++ b/.evergreen/scripts/debian_package_build.sh
@@ -23,6 +23,10 @@ trap on_exit EXIT
 git config user.email "evergreen-build@example.com"
 git config user.name "Evergreen Build"
 
+# Note that here, on the r1.30 branch, the tag debian/1.30.4-1 is used rather
+# than the branch debian/unstable. This is because the branch has advanced and
+# now contains updated packaging for the 2.x releases.
+
 if [ "${IS_PATCH}" = "true" ]; then
   git diff HEAD > ../upstream.patch
   git clean -fdx
@@ -30,9 +34,9 @@ if [ "${IS_PATCH}" = "true" ]; then
   git remote add upstream https://github.com/mongodb/mongo-c-driver
   git fetch upstream
   CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-  git checkout upstream/debian/unstable
+  git checkout debian/1.30.4-1
   git checkout ${CURRENT_BRANCH}
-  git checkout upstream/debian/unstable -- ./debian/
+  git checkout debian/1.30.4-1 -- ./debian/
   if [ -s ../upstream.patch ]; then
     [ -d debian/patches ] || mkdir debian/patches
     mv ../upstream.patch debian/patches/
@@ -59,9 +63,9 @@ sudo chroot ./unstable-chroot /bin/bash -c '(\
   git remote add upstream https://github.com/mongodb/mongo-c-driver && \
   git fetch upstream && \
   export CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)" && \
-  git checkout upstream/debian/unstable && \
+  git checkout debian/1.30.4-1 && \
   git checkout ${CURRENT_BRANCH} && \
-  git checkout upstream/debian/unstable -- ./debian/ && \
+  git checkout debian/1.30.4-1 -- ./debian/ && \
   git commit -m "fetch debian directory from the debian/unstable branch" && \
   LANG=C /bin/bash ./debian/build_snapshot.sh && \
   debc ../*.changes && \
@@ -91,9 +95,9 @@ sudo chroot ./unstable-i386-chroot /bin/bash -c '(\
   git remote add upstream https://github.com/mongodb/mongo-c-driver && \
   git fetch upstream && \
   export CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)" && \
-  git checkout upstream/debian/unstable && \
+  git checkout debian/1.30.4-1 && \
   git checkout ${CURRENT_BRANCH} && \
-  git checkout upstream/debian/unstable -- ./debian/ && \
+  git checkout debian/1.30.4-1 -- ./debian/ && \
   git commit -m "fetch debian directory from the debian/unstable branch" && \
   LANG=C /bin/bash ./debian/build_snapshot.sh && \
   debc ../*.changes && \


### PR DESCRIPTION
Evergreen patch build: https://spruce.mongodb.com/version/688bbbe50de93a0007007c04/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC