### PR TITLE
Suppress -Wpoison-system-directories for Apple Clang

### DIFF
--- a/.evergreen/config_generator/components/earthly.py
+++ b/.evergreen/config_generator/components/earthly.py
@@ -27,16 +27,16 @@ _CC_PARAM_NAME = "MONGOC_EARTHLY_C_COMPILER"
 
 
 EnvKey = Literal[
-    "u16",
-    "u18",
     "u20",
     "u22",
-    "alpine3.16",
-    "alpine3.17",
-    "alpine3.18",
+    "u22",
     "alpine3.19",
+    "alpine3.20",
+    "alpine3.21",
+    "alpine3.22",
     "archlinux",
-    "centos7",
+    "centos9",
+    "centos10",
 ]
 "Identifiers for environments. These correspond to special 'env.*' targets in the Earthfile."
 CompilerName = Literal["gcc", "clang"]
@@ -65,12 +65,11 @@ def os_split(env: EnvKey) -> tuple[str, None | str]:
         # Match 'u22', 'u20', 'u71' etc.
         case ubu if mat := re.match(r"u(\d\d)", ubu):
             return "Ubuntu", f"{mat[1]}.04"
-        case "centos7":
-            return "CentOS", "7.0"
+        # Match 'centos9', 'centos10', etc.
+        case cent if mat := re.match(r"centos(\d+)", cent):
+            return "CentOS", f"{mat[1]}"
         case _:
-            raise ValueError(
-                f"Failed to split OS env key {env=} into a name+version pair (unrecognized)"
-            )
+            raise ValueError(f"Failed to split OS env key {env=} into a name+version pair (unrecognized)")
 
 
 class EarthlyVariant(NamedTuple):
@@ -152,12 +151,8 @@ class DockerLoginAmazonECR(Function):
     name = "docker-login-amazon-ecr"
     commands = [
         # Avoid inadvertently using a pre-existing and potentially conflicting Docker config.
-        expansions_update(
-            updates=[KeyValueParam(key="DOCKER_CONFIG", value="${workdir}/.docker")]
-        ),
-        ec2_assume_role(
-            role_arn="arn:aws:iam::901841024863:role/ecr-role-evergreen-ro"
-        ),
+        expansions_update(updates=[KeyValueParam(key="DOCKER_CONFIG", value="${workdir}/.docker")]),
+        ec2_assume_role(role_arn="arn:aws:iam::901841024863:role/ecr-role-evergreen-ro"),
         subprocess_exec(
             binary="bash",
             command_type=EvgCommandType.SETUP,
@@ -181,12 +176,6 @@ def task_filter(env: EarthlyVariant, conf: Configuration) -> bool:
     configuration values.
     """
     match env, conf:
-        # u16/u18/centos7 are not capable of building mongocxx
-        case e, (_sasl, _tls, cxx) if re.match(
-            r"^Ubuntu 16|^Ubuntu 18|^CentOS 7", e.display_name
-        ):
-            # Only build if C++ driver is test is disabled
-            return cxx == "none"
         # Anything else: Allow it to run:
         case _:
             return True

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -1131,7 +1131,7 @@ tasks:
       - debian12-large
       - ubuntu2204-large
       - ubuntu2404-large
-    tags: [earthly, pr-merge-gate, alpine3.16-clang, alpine3.16-gcc, alpine3.17-clang, alpine3.17-gcc, alpine3.18-clang, alpine3.18-gcc, alpine3.19-clang, alpine3.19-gcc, archlinux-clang, archlinux-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
+    tags: [earthly, pr-merge-gate, alpine3.19-clang, alpine3.19-gcc, alpine3.20-clang, alpine3.20-gcc, alpine3.21-clang, alpine3.21-gcc, alpine3.22-clang, alpine3.22-gcc, archlinux-clang, archlinux-gcc, centos10-clang, centos10-gcc, centos9-clang, centos9-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
     commands:
       - func: docker-login-amazon-ecr
       - command: subprocess.exec
@@ -1174,7 +1174,7 @@ tasks:
       - debian12-large
       - ubuntu2204-large
       - ubuntu2404-large
-    tags: [earthly, pr-merge-gate, alpine3.16-clang, alpine3.16-gcc, alpine3.17-clang, alpine3.17-gcc, alpine3.18-clang, alpine3.18-gcc, alpine3.19-clang, alpine3.19-gcc, archlinux-clang, archlinux-gcc, centos7-clang, centos7-gcc, u16-clang, u16-gcc, u18-clang, u18-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
+    tags: [earthly, pr-merge-gate, alpine3.19-clang, alpine3.19-gcc, alpine3.20-clang, alpine3.20-gcc, alpine3.21-clang, alpine3.21-gcc, alpine3.22-clang, alpine3.22-gcc, archlinux-clang, archlinux-gcc, centos10-clang, centos10-gcc, centos9-clang, centos9-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
     commands:
       - func: docker-login-amazon-ecr
       - command: subprocess.exec
@@ -1217,7 +1217,7 @@ tasks:
       - debian12-large
       - ubuntu2204-large
       - ubuntu2404-large
-    tags: [earthly, pr-merge-gate, alpine3.16-clang, alpine3.16-gcc, alpine3.17-clang, alpine3.17-gcc, alpine3.18-clang, alpine3.18-gcc, alpine3.19-clang, alpine3.19-gcc, archlinux-clang, archlinux-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
+    tags: [earthly, pr-merge-gate, alpine3.19-clang, alpine3.19-gcc, alpine3.20-clang, alpine3.20-gcc, alpine3.21-clang, alpine3.21-gcc, alpine3.22-clang, alpine3.22-gcc, archlinux-clang, archlinux-gcc, centos10-clang, centos10-gcc, centos9-clang, centos9-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
     commands:
       - func: docker-login-amazon-ecr
       - command: subprocess.exec
@@ -1260,7 +1260,7 @@ tasks:
       - debian12-large
       - ubuntu2204-large
       - ubuntu2404-large
-    tags: [earthly, pr-merge-gate, alpine3.16-clang, alpine3.16-gcc, alpine3.17-clang, alpine3.17-gcc, alpine3.18-clang, alpine3.18-gcc, alpine3.19-clang, alpine3.19-gcc, archlinux-clang, archlinux-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
+    tags: [earthly, pr-merge-gate, alpine3.19-clang, alpine3.19-gcc, alpine3.20-clang, alpine3.20-gcc, alpine3.21-clang, alpine3.21-gcc, alpine3.22-clang, alpine3.22-gcc, archlinux-clang, archlinux-gcc, centos10-clang, centos10-gcc, centos9-clang, centos9-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
     commands:
       - func: docker-login-amazon-ecr
       - command: subprocess.exec
@@ -1303,7 +1303,7 @@ tasks:
       - debian12-large
       - ubuntu2204-large
       - ubuntu2404-large
-    tags: [earthly, pr-merge-gate, alpine3.16-clang, alpine3.16-gcc, alpine3.17-clang, alpine3.17-gcc, alpine3.18-clang, alpine3.18-gcc, alpine3.19-clang, alpine3.19-gcc, archlinux-clang, archlinux-gcc, centos7-clang, centos7-gcc, u16-clang, u16-gcc, u18-clang, u18-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
+    tags: [earthly, pr-merge-gate, alpine3.19-clang, alpine3.19-gcc, alpine3.20-clang, alpine3.20-gcc, alpine3.21-clang, alpine3.21-gcc, alpine3.22-clang, alpine3.22-gcc, archlinux-clang, archlinux-gcc, centos10-clang, centos10-gcc, centos9-clang, centos9-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
     commands:
       - func: docker-login-amazon-ecr
       - command: subprocess.exec
@@ -1346,7 +1346,7 @@ tasks:
       - debian12-large
       - ubuntu2204-large
       - ubuntu2404-large
-    tags: [earthly, pr-merge-gate, alpine3.16-clang, alpine3.16-gcc, alpine3.17-clang, alpine3.17-gcc, alpine3.18-clang, alpine3.18-gcc, alpine3.19-clang, alpine3.19-gcc, archlinux-clang, archlinux-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
+    tags: [earthly, pr-merge-gate, alpine3.19-clang, alpine3.19-gcc, alpine3.20-clang, alpine3.20-gcc, alpine3.21-clang, alpine3.21-gcc, alpine3.22-clang, alpine3.22-gcc, archlinux-clang, archlinux-gcc, centos10-clang, centos10-gcc, centos9-clang, centos9-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
     commands:
       - func: docker-login-amazon-ecr
       - command: subprocess.exec
@@ -1389,7 +1389,7 @@ tasks:
       - debian12-large
       - ubuntu2204-large
       - ubuntu2404-large
-    tags: [earthly, pr-merge-gate, alpine3.16-clang, alpine3.16-gcc, alpine3.17-clang, alpine3.17-gcc, alpine3.18-clang, alpine3.18-gcc, alpine3.19-clang, alpine3.19-gcc, archlinux-clang, archlinux-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
+    tags: [earthly, pr-merge-gate, alpine3.19-clang, alpine3.19-gcc, alpine3.20-clang, alpine3.20-gcc, alpine3.21-clang, alpine3.21-gcc, alpine3.22-clang, alpine3.22-gcc, archlinux-clang, archlinux-gcc, centos10-clang, centos10-gcc, centos9-clang, centos9-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
     commands:
       - func: docker-login-amazon-ecr
       - command: subprocess.exec
@@ -1432,7 +1432,7 @@ tasks:
       - debian12-large
       - ubuntu2204-large
       - ubuntu2404-large
-    tags: [earthly, pr-merge-gate, alpine3.16-clang, alpine3.16-gcc, alpine3.17-clang, alpine3.17-gcc, alpine3.18-clang, alpine3.18-gcc, alpine3.19-clang, alpine3.19-gcc, archlinux-clang, archlinux-gcc, centos7-clang, centos7-gcc, u16-clang, u16-gcc, u18-clang, u18-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
+    tags: [earthly, pr-merge-gate, alpine3.19-clang, alpine3.19-gcc, alpine3.20-clang, alpine3.20-gcc, alpine3.21-clang, alpine3.21-gcc, alpine3.22-clang, alpine3.22-gcc, archlinux-clang, archlinux-gcc, centos10-clang, centos10-gcc, centos9-clang, centos9-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
     commands:
       - func: docker-login-amazon-ecr
       - command: subprocess.exec
@@ -1475,7 +1475,7 @@ tasks:
       - debian12-large
       - ubuntu2204-large
       - ubuntu2404-large
-    tags: [earthly, pr-merge-gate, alpine3.16-clang, alpine3.16-gcc, alpine3.17-clang, alpine3.17-gcc, alpine3.18-clang, alpine3.18-gcc, alpine3.19-clang, alpine3.19-gcc, archlinux-clang, archlinux-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
+    tags: [earthly, pr-merge-gate, alpine3.19-clang, alpine3.19-gcc, alpine3.20-clang, alpine3.20-gcc, alpine3.21-clang, alpine3.21-gcc, alpine3.22-clang, alpine3.22-gcc, archlinux-clang, archlinux-gcc, centos10-clang, centos10-gcc, centos9-clang, centos9-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
     commands:
       - func: docker-login-amazon-ecr
       - command: subprocess.exec
@@ -1518,7 +1518,7 @@ tasks:
       - debian12-large
       - ubuntu2204-large
       - ubuntu2404-large
-    tags: [earthly, pr-merge-gate, alpine3.16-clang, alpine3.16-gcc, alpine3.17-clang, alpine3.17-gcc, alpine3.18-clang, alpine3.18-gcc, alpine3.19-clang, alpine3.19-gcc, archlinux-clang, archlinux-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
+    tags: [earthly, pr-merge-gate, alpine3.19-clang, alpine3.19-gcc, alpine3.20-clang, alpine3.20-gcc, alpine3.21-clang, alpine3.21-gcc, alpine3.22-clang, alpine3.22-gcc, archlinux-clang, archlinux-gcc, centos10-clang, centos10-gcc, centos9-clang, centos9-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
     commands:
       - func: docker-login-amazon-ecr
       - command: subprocess.exec
@@ -1561,7 +1561,7 @@ tasks:
       - debian12-large
       - ubuntu2204-large
       - ubuntu2404-large
-    tags: [earthly, pr-merge-gate, alpine3.16-clang, alpine3.16-gcc, alpine3.17-clang, alpine3.17-gcc, alpine3.18-clang, alpine3.18-gcc, alpine3.19-clang, alpine3.19-gcc, archlinux-clang, archlinux-gcc, centos7-clang, centos7-gcc, u16-clang, u16-gcc, u18-clang, u18-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
+    tags: [earthly, pr-merge-gate, alpine3.19-clang, alpine3.19-gcc, alpine3.20-clang, alpine3.20-gcc, alpine3.21-clang, alpine3.21-gcc, alpine3.22-clang, alpine3.22-gcc, archlinux-clang, archlinux-gcc, centos10-clang, centos10-gcc, centos9-clang, centos9-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
     commands:
       - func: docker-login-amazon-ecr
       - command: subprocess.exec
@@ -1604,7 +1604,7 @@ tasks:
       - debian12-large
       - ubuntu2204-large
       - ubuntu2404-large
-    tags: [earthly, pr-merge-gate, alpine3.16-clang, alpine3.16-gcc, alpine3.17-clang, alpine3.17-gcc, alpine3.18-clang, alpine3.18-gcc, alpine3.19-clang, alpine3.19-gcc, archlinux-clang, archlinux-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
+    tags: [earthly, pr-merge-gate, alpine3.19-clang, alpine3.19-gcc, alpine3.20-clang, alpine3.20-gcc, alpine3.21-clang, alpine3.21-gcc, alpine3.22-clang, alpine3.22-gcc, archlinux-clang, archlinux-gcc, centos10-clang, centos10-gcc, centos9-clang, centos9-gcc, u20-clang, u20-gcc, u22-clang, u22-gcc]
     commands:
       - func: docker-login-amazon-ecr
       - command: subprocess.exec

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -1,46 +1,4 @@
 buildvariants:
-  - name: alpine3.16-clang
-    display_name: Alpine 3.16 (LLVM/Clang)
-    expansions:
-      MONGOC_EARTHLY_C_COMPILER: clang
-      MONGOC_EARTHLY_ENV: alpine3.16
-    tasks:
-      - name: .alpine3.16-clang
-  - name: alpine3.16-gcc
-    display_name: Alpine 3.16 (GCC)
-    expansions:
-      MONGOC_EARTHLY_C_COMPILER: gcc
-      MONGOC_EARTHLY_ENV: alpine3.16
-    tasks:
-      - name: .alpine3.16-gcc
-  - name: alpine3.17-clang
-    display_name: Alpine 3.17 (LLVM/Clang)
-    expansions:
-      MONGOC_EARTHLY_C_COMPILER: clang
-      MONGOC_EARTHLY_ENV: alpine3.17
-    tasks:
-      - name: .alpine3.17-clang
-  - name: alpine3.17-gcc
-    display_name: Alpine 3.17 (GCC)
-    expansions:
-      MONGOC_EARTHLY_C_COMPILER: gcc
-      MONGOC_EARTHLY_ENV: alpine3.17
-    tasks:
-      - name: .alpine3.17-gcc
-  - name: alpine3.18-clang
-    display_name: Alpine 3.18 (LLVM/Clang)
-    expansions:
-      MONGOC_EARTHLY_C_COMPILER: clang
-      MONGOC_EARTHLY_ENV: alpine3.18
-    tasks:
-      - name: .alpine3.18-clang
-  - name: alpine3.18-gcc
-    display_name: Alpine 3.18 (GCC)
-    expansions:
-      MONGOC_EARTHLY_C_COMPILER: gcc
-      MONGOC_EARTHLY_ENV: alpine3.18
-    tasks:
-      - name: .alpine3.18-gcc
   - name: alpine3.19-clang
     display_name: Alpine 3.19 (LLVM/Clang)
     expansions:
@@ -55,6 +13,48 @@ buildvariants:
       MONGOC_EARTHLY_ENV: alpine3.19
     tasks:
       - name: .alpine3.19-gcc
+  - name: alpine3.20-clang
+    display_name: Alpine 3.20 (LLVM/Clang)
+    expansions:
+      MONGOC_EARTHLY_C_COMPILER: clang
+      MONGOC_EARTHLY_ENV: alpine3.20
+    tasks:
+      - name: .alpine3.20-clang
+  - name: alpine3.20-gcc
+    display_name: Alpine 3.20 (GCC)
+    expansions:
+      MONGOC_EARTHLY_C_COMPILER: gcc
+      MONGOC_EARTHLY_ENV: alpine3.20
+    tasks:
+      - name: .alpine3.20-gcc
+  - name: alpine3.21-clang
+    display_name: Alpine 3.21 (LLVM/Clang)
+    expansions:
+      MONGOC_EARTHLY_C_COMPILER: clang
+      MONGOC_EARTHLY_ENV: alpine3.21
+    tasks:
+      - name: .alpine3.21-clang
+  - name: alpine3.21-gcc
+    display_name: Alpine 3.21 (GCC)
+    expansions:
+      MONGOC_EARTHLY_C_COMPILER: gcc
+      MONGOC_EARTHLY_ENV: alpine3.21
+    tasks:
+      - name: .alpine3.21-gcc
+  - name: alpine3.22-clang
+    display_name: Alpine 3.22 (LLVM/Clang)
+    expansions:
+      MONGOC_EARTHLY_C_COMPILER: clang
+      MONGOC_EARTHLY_ENV: alpine3.22
+    tasks:
+      - name: .alpine3.22-clang
+  - name: alpine3.22-gcc
+    display_name: Alpine 3.22 (GCC)
+    expansions:
+      MONGOC_EARTHLY_C_COMPILER: gcc
+      MONGOC_EARTHLY_ENV: alpine3.22
+    tasks:
+      - name: .alpine3.22-gcc
   - name: archlinux-clang
     display_name: ArchLinux (LLVM/Clang)
     expansions:
@@ -69,20 +69,34 @@ buildvariants:
       MONGOC_EARTHLY_ENV: archlinux
     tasks:
       - name: .archlinux-gcc
-  - name: centos7-clang
-    display_name: CentOS 7.0 (LLVM/Clang)
+  - name: centos10-clang
+    display_name: CentOS 10 (LLVM/Clang)
     expansions:
       MONGOC_EARTHLY_C_COMPILER: clang
-      MONGOC_EARTHLY_ENV: centos7
+      MONGOC_EARTHLY_ENV: centos10
     tasks:
-      - name: .centos7-clang
-  - name: centos7-gcc
-    display_name: CentOS 7.0 (GCC)
+      - name: .centos10-clang
+  - name: centos10-gcc
+    display_name: CentOS 10 (GCC)
     expansions:
       MONGOC_EARTHLY_C_COMPILER: gcc
-      MONGOC_EARTHLY_ENV: centos7
+      MONGOC_EARTHLY_ENV: centos10
     tasks:
-      - name: .centos7-gcc
+      - name: .centos10-gcc
+  - name: centos9-clang
+    display_name: CentOS 9 (LLVM/Clang)
+    expansions:
+      MONGOC_EARTHLY_C_COMPILER: clang
+      MONGOC_EARTHLY_ENV: centos9
+    tasks:
+      - name: .centos9-clang
+  - name: centos9-gcc
+    display_name: CentOS 9 (GCC)
+    expansions:
+      MONGOC_EARTHLY_C_COMPILER: gcc
+      MONGOC_EARTHLY_ENV: centos9
+    tasks:
+      - name: .centos9-gcc
   - name: clang-format
     display_name: clang-format
     run_on:
@@ -305,34 +319,6 @@ buildvariants:
     display_name: std-matrix
     tasks:
       - name: .std-matrix
-  - name: u16-clang
-    display_name: Ubuntu 16.04 (LLVM/Clang)
-    expansions:
-      MONGOC_EARTHLY_C_COMPILER: clang
-      MONGOC_EARTHLY_ENV: u16
-    tasks:
-      - name: .u16-clang
-  - name: u16-gcc
-    display_name: Ubuntu 16.04 (GCC)
-    expansions:
-      MONGOC_EARTHLY_C_COMPILER: gcc
-      MONGOC_EARTHLY_ENV: u16
-    tasks:
-      - name: .u16-gcc
-  - name: u18-clang
-    display_name: Ubuntu 18.04 (LLVM/Clang)
-    expansions:
-      MONGOC_EARTHLY_C_COMPILER: clang
-      MONGOC_EARTHLY_ENV: u18
-    tasks:
-      - name: .u18-clang
-  - name: u18-gcc
-    display_name: Ubuntu 18.04 (GCC)
-    expansions:
-      MONGOC_EARTHLY_C_COMPILER: gcc
-      MONGOC_EARTHLY_ENV: u18
-    tasks:
-      - name: .u18-gcc
   - name: u20-clang
     display_name: Ubuntu 20.04 (LLVM/Clang)
     expansions:

--- a/.evergreen/scripts/cmake.sh
+++ b/.evergreen/scripts/cmake.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -eu
-. "$(dirname "${BASH_SOURCE[0]}")/find-cmake-latest.sh"
-
-cmake=$(find_cmake_latest)
-
-$cmake "$@"

--- a/Earthfile
+++ b/Earthfile
@@ -135,19 +135,10 @@ test-cxx-driver:
 # PREP_CMAKE "warms up" the CMake installation cache for the current environment
 PREP_CMAKE:
     FUNCTION
-    LET scratch=/opt/mongoc-cmake
-    # Copy the minimal amount that we need, as to avoid cache invalidation
-    COPY tools/use.sh tools/platform.sh tools/paths.sh tools/base.sh tools/download.sh \
-        $scratch/tools/
-    COPY .evergreen/scripts/find-cmake-version.sh \
-        .evergreen/scripts/use-tools.sh \
-        .evergreen/scripts/find-cmake-latest.sh \
-        .evergreen/scripts/cmake.sh \
-        $scratch/.evergreen/scripts/
-    # "Install" a shim that runs our managed CMake executable:
-    RUN __alias cmake /opt/mongoc-cmake/.evergreen/scripts/cmake.sh
+    # Run all CMake commands using uvx:
+    RUN __alias cmake uvx cmake
     # Executing any CMake command will warm the cache:
-    RUN cmake --version
+    RUN cmake --version | head -n 1
 
 env-warmup:
     ARG --required env
@@ -157,8 +148,9 @@ env-warmup:
 # Simultaneously builds and tests multiple different platforms
 multibuild:
     BUILD +run --targets "test-example" \
-        --env=alpine3.16 --env=alpine3.17 --env=alpine3.18 --env=alpine3.19 \
-        --env=u16 --env=u18 --env=u20 --env=u22 --env=centos7 \
+        --env=alpine3.19 --env=alpine3.20 --env=alpine3.21 --env=alpine3.22 \
+        --env=u20 --env=u22 --env=u24 \
+        --env=centos9 --env=centos10 \
         --env=archlinux \
         --tls=OpenSSL --tls=off \
         --sasl=Cyrus --sasl=off \
@@ -427,7 +419,7 @@ verify-headers:
     BUILD +do-verify-headers-impl \
         --from +env.alpine3.19 \
         --from +env.u22 \
-        --from +env.centos7 \
+        --from +env.centos10 \
         --sasl=off --tls=off --cxx_compiler=gcc --c_compiler=gcc
 
 do-verify-headers-impl:
@@ -466,36 +458,12 @@ run:
 # 88.     88  V888  `8bd8'    .88.   88 `88. `8b  d8' 88  V888 88  88  88 88.     88  V888    88    db   8D
 # Y88888P VP   V8P    YP    Y888888P 88   YD  `Y88P'  VP   V8P YP  YP  YP Y88888P VP   V8P    YP    `8888Y'
 
-env.u16:
-    DO --pass-args +UBUNTU_ENV --version=16.04
-
-env.u18:
-    DO --pass-args +UBUNTU_ENV --version=18.04
-
-env.u20:
-    DO --pass-args +UBUNTU_ENV --version=20.04
-
-env.u22:
-    DO --pass-args +UBUNTU_ENV --version=22.04
-
-env.alpine3.16:
-    DO --pass-args +ALPINE_ENV --version=3.16
-
-env.alpine3.17:
-    DO --pass-args +ALPINE_ENV --version=3.17
-
-env.alpine3.18:
-    DO --pass-args +ALPINE_ENV --version=3.18
-
-env.alpine3.19:
-    DO --pass-args +ALPINE_ENV --version=3.19
-
 env.archlinux:
     FROM --pass-args tools+init-env --from $default_search_registry/library/archlinux
     RUN pacman-key --init
     ARG --required purpose
 
-    RUN __install ninja snappy
+    RUN __install ninja snappy uv
 
     IF test "$purpose" = build
         RUN __install ccache
@@ -506,18 +474,33 @@ env.archlinux:
     DO --pass-args tools+ADD_C_COMPILER
     DO +PREP_CMAKE
 
-env.centos7:
-    DO --pass-args +CENTOS_ENV --version=7
+env.alpine3.19:
+    DO --pass-args +ALPINE_ENV --version=3.19
+
+env.alpine3.20:
+    DO --pass-args +ALPINE_ENV --version=3.20
+
+env.alpine3.21:
+    DO --pass-args +ALPINE_ENV --version=3.21
+
+env.alpine3.22:
+    DO --pass-args +ALPINE_ENV --version=3.22
 
 ALPINE_ENV:
     FUNCTION
     ARG --required version
     FROM --pass-args tools+init-env --from $default_search_registry/library/alpine:$version
-    # XXX: On Alpine, we just use the system's CMake. At time of writing, it is
-    # very up-to-date and much faster than building our own from source (since
-    # Kitware does not (yet) provide libmuslc builds of CMake)
-    RUN __install bash curl cmake ninja musl-dev make
+    RUN __install bash curl ninja musl-dev make python3
     ARG --required purpose
+
+    IF test "$version" = "3.19" -o "$version" = "3.20"
+        # uv is not yet available. Install via pipx.
+        RUN __install pipx
+        RUN pipx install uv
+        ENV PATH="/root/.local/bin:$PATH"
+    ELSE
+        RUN __install uv
+    END
 
     IF test "$purpose" = "build"
         RUN __install snappy-dev ccache
@@ -530,6 +513,16 @@ ALPINE_ENV:
     # Add "gcc" when installing Clang, since it pulls in a lot of runtime libraries and
     # utils that are needed for linking with Clang
     DO --pass-args tools+ADD_C_COMPILER --clang_pkg="gcc clang compiler-rt"
+    DO +PREP_CMAKE
+
+env.u20:
+    DO --pass-args +UBUNTU_ENV --version=20.04
+
+env.u22:
+    DO --pass-args +UBUNTU_ENV --version=22.04
+
+env.u24:
+    DO --pass-args +UBUNTU_ENV --version=24.04
 
 UBUNTU_ENV:
     FUNCTION
@@ -537,6 +530,11 @@ UBUNTU_ENV:
     FROM --pass-args tools+init-env --from $default_search_registry/library/ubuntu:$version
     RUN __install curl build-essential
     ARG --required purpose
+
+    # uv is not available via apt. Avoid snapd (systemd) by using pipx instead.
+    RUN __install python3-venv pipx
+    RUN pipx install uv
+    ENV PATH="/root/.local/bin:$PATH"
 
     IF test "$purpose" = build
         RUN __install ninja-build gcc ccache libsnappy-dev zlib1g-dev
@@ -549,21 +547,28 @@ UBUNTU_ENV:
     DO --pass-args tools+ADD_C_COMPILER
     DO +PREP_CMAKE
 
+env.centos9:
+    DO --pass-args +CENTOS_ENV --version=9
+
+env.centos10:
+    DO --pass-args +CENTOS_ENV --version=10
+
 CENTOS_ENV:
     FUNCTION
     ARG --required version
-    FROM --pass-args tools+init-env --from $default_search_registry/library/centos:$version
-    # Update repositories to use vault.centos.org
-    RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
-        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-    RUN yum -y --enablerepo=extras install epel-release && yum -y update
-    RUN yum -y install curl gcc gcc-c++ make
+    FROM --pass-args tools+init-env --from quay.io/centos/centos:stream$version
+    RUN yum -y install epel-release && yum -y update
+    RUN yum -y install gcc gcc-c++ make pipx
     ARG --required purpose
 
+    # uv is not available via yum. Avoid snapd (systemd) by using pipx instead.
+    RUN pipx install uv
+    ENV PATH="/root/.local/bin:$PATH"
+
     IF test "$purpose" = build
-        RUN yum -y install ninja-build ccache snappy-devel zlib-devel
+        RUN yum -y --enablerepo=crb install ninja-build ccache snappy-devel zlib-devel
     ELSE IF test "$purpose" = test
-        RUN yum -y install ninja-build snappy
+        RUN yum -y --enablerepo=crb install ninja-build snappy
     END
 
     DO --pass-args tools+ADD_SASL --cyrus_dev_pkg="cyrus-sasl-devel" --cyrus_rt_pkg="cyrus-sasl-lib"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,7 @@ target_compile_options(public-header-warnings PRIVATE
   $<$<C_COMPILER_ID:AppleClang,Clang>:-Wno-reserved-identifier>
   $<$<C_COMPILER_ID:AppleClang,Clang>:-Wno-documentation-unknown-command>
   $<$<C_COMPILER_ID:AppleClang,Clang>:-Wno-unknown-warning-option>
+  $<$<C_COMPILER_ID:AppleClang>:-Wno-poison-system-directories>
   $<$<C_COMPILER_ID:MSVC>:/W4>
   $<$<C_COMPILER_ID:MSVC>:/WX>
   $<$<C_COMPILER_ID:MSVC>:/wd4324>


### PR DESCRIPTION
This PR replaces `find-cmake-latest.sh` with `uvx cmake` for Earthly tasks. To support `uvx cmake`, this PR also updates the Earthfile to migrate away from old/EOL/unsupported operating systems. A followup PR will migrate the rest of the EVG configuration to use `uv` to obtain preferred build tools as done in https://github.com/mongodb/mongo-cxx-driver/pull/1428.

---

First, concerning Earthly, the following operating system versions are removed due to being EOL:

- Alpine 3.16: EOL since May 2024.
- Alpine 3.17: EOL since Sep 2024.
- Alpine 3.18: EOL since Feb 2025.
- CentOS 7: EOL since June 2024.
- CentOS 8: EOL since May 2024. (Yes, it's [later than](https://wiki.centos.org/About(2f)Product.html) CentOS 7. ¯\\\_ (ツ)\_/¯)
- Ubuntu 16.04: EOL since Apr 2021 (ESM until Apr 2026).
- Ubuntu 18.04: EOL since May 2023 (ESM until Apr 2028).

> [!NOTE]
> Although we do not have our own [platform support policy document](https://docs.google.com/document/d/1SK2iCXJ1rE1PdJgEKrA9jnRSpRhYMjwNEqz6VIP1I6s/edit?tab=t.0#bookmark=id.r732ml8jz9ys), both [Evergreen](https://wiki.corp.mongodb.com/spaces/DBDEVPROD/pages/116563465/Guidelines+around+Evergreen+distros) and [Server](https://docs.google.com/spreadsheets/d/1-sZKW70HbVt2yHOWa18qwBwi-gBcn54tWmronnn89kI/edit?usp=sharing) do _not_ include "Extended Security Maintenance" mode in their range of support. Therefore, I do not think we should include them either.

Second, to avoid the need to copy mongo-c-driver scripts into the Earthly environment, to better test OS compatibility, and to take advantage of Earthly containerization, the OS' package managers are used to acquire `uv` instead of a `uv-installer.sh` script (which will be needed by EVG tasks). This leads to some [complications with using `snap`/`systemd` in containers](https://forum.snapcraft.io/t/please-remove-systemd-dependency/17580/5) (given `snap` is usually the OS-recommended alternative to obtain a missing or newer package than what is available with `apt`). However, `pipx` is available as the [second uv-recommended method](https://docs.astral.sh/uv/getting-started/installation/#pypi) to install `uv` (after `curl | sh`) on all relevant distros as a system package (when `uv` itself is not available via the system package manager), and so it is used instead when needed.

Third, Red Hat apparently [ended support for CentOS](https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux/centos-migration) in 2024 in favor of [CentOS Stream](https://www.redhat.com/en/topics/linux/what-is-centos-stream) (confusingly _not_ the same thing as CentOS, but more or less its equivalent successor). Red Hat strongly recommends against continuing to use CentOS as it is "now exposed to significant risks". As part of this migration, OCI images for CentOS Stream are now provided via [quay.io](https://quay.io/repository/centos/centos) rather than [DockerHub](https://hub.docker.com/_/centos). Therefore, the CentOS Stream images are specified using fully-qualified image names to `quay.io` instead of using `$default_search_registry` (at this time, the DevProd-provided Amazon ECR instance does _not_ seem to support pull-through caching of `quay.io` images, only DockerHub).

---

This PR also includes a drive-by addition of a `-Wpoison-system-directories` suppression with Apple Clang for the `public-header-warnings` target:

```
FAILED: src/CMakeFiles/public-header-warnings.dir/c-check.c.o
/usr/bin/clang -DBSON_STATIC -DMONGOC_STATIC -D_BSD_SOURCE -D_DARWIN_C_SOURCE -D_DEFAULT_SOURCE -D_MLIB_BUILD_CONFIG=Debug -D_XOPEN_SOURCE=700 -Icmake-build/src/libmongoc/src -Isrc/libmongoc/src -Isrc/common/src -Icmake-build/src -Icmake-build/src/common/src -Isrc/libbson/src -Icmake-build/src/libbson/src -m64 -march=x86-64 -Wno-unknown-pragmas -g -std=c99 -Weverything -Werror -Wno-declaration-after-statement -Wno-disabled-macro-expansion -Wno-c++98-compat-pedantic -Wno-pre-c11-compat -Wno-pre-c2x-compat -Wno-unsafe-buffer-usage -Wno-padded -Wno-reserved-identifier -Wno-documentation-unknown-command -Wno-unknown-warning-option -fPIC -MD -MT src/CMakeFiles/public-header-warnings.dir/c-check.c.o -MF src/CMakeFiles/public-header-warnings.dir/c-check.c.o.d -o src/CMakeFiles/public-header-warnings.dir/c-check.c.o -c src/c-check.c
error: include location '/usr/local/include' is unsafe for cross-compilation [-Werror,-Wpoison-system-directories]
1 error generated.
```

This warning is strange. I do not know why the changes in this PR (or the upcoming PR to apply `uv` to EVG scripts) seem to have triggered this false-positive warning. According to [this comment](/AOMediaCodec/libavif/issues/284#issuecomment-678717800), it may be related to the implicit use of the `--sysroot` flag on recent versions of macOS...? We are definitely not attempting any cross-compilation in our macOS EVG tasks (that I am aware of), so I've opted to treat this as a false-positive and disabled it.