### PR TITLE
Bump libmongocrypt to 1.14.0 in CI scripts only

### DIFF
--- a/.evergreen/scripts/compile-libmongocrypt.sh
+++ b/.evergreen/scripts/compile-libmongocrypt.sh
@@ -9,9 +9,7 @@ compile_libmongocrypt() {
   # libmongocrypt's kms-message in `src/kms-message`. Run
   # `.evergreen/scripts/kms-divergence-check.sh` to ensure that there is no
   # divergence in the copied files.
-
-  # Clone libmongocrypt and check-out 1.13.0.
-  git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.13.0 || return
+  git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.14.0 || return
 
   declare -a crypt_cmake_flags=(
     "-DMONGOCRYPT_MONGOC_DIR=${mongoc_dir}"

--- a/.evergreen/scripts/compile-libmongocrypt.sh
+++ b/.evergreen/scripts/compile-libmongocrypt.sh
@@ -9,7 +9,7 @@ compile_libmongocrypt() {
   # libmongocrypt's kms-message in `src/kms-message`. Run
   # `.evergreen/scripts/kms-divergence-check.sh` to ensure that there is no
   # divergence in the copied files.
-  git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch 1.14.0 || return
+  git clone -q --depth=1 https://github.com/mongodb/libmongocrypt --branch "${COMPILE_LIBMONGOCRYPT_VERSION:-"1.14.0"}" || return
 
   declare -a crypt_cmake_flags=(
     "-DMONGOCRYPT_MONGOC_DIR=${mongoc_dir}"


### PR DESCRIPTION
To address the error described in https://github.com/mongodb/libmongocrypt/pull/1052:

```
CMake Error at cmake-build/_deps/embedded_mcd-src/src/libbson/CMakeLists.txt:37 (cmake_policy):
  Policy CMP0042 may not be set to OLD behavior because this version of CMake
  no longer supports it.  The policy was introduced in CMake version 3.0.0,
  and use of NEW behavior is now required.
  Please either update your CMakeLists.txt files to conform to the new
  behavior or use an older version of CMake that still supports the old
  behavior.  Run cmake --help-policy CMP0042 for more information.
```

libmongocrypt 1.14.0 bumps its required libbson version to 1.30.3, which contains the [backported fix](https://github.com/mongodb/mongo-c-driver/commit/23440389b76dad06ac11640f06e6e5682e5e4b35) in the bson project's CMake configuration. I expect a proper libmongocrypt minimum required version bump (to obtain upcoming QE features) will follow soon; for now, this PR bumps it to 1.14.0 and adds support for overriding the requested libmongocrypt version using the `COMPILE_LIBMONGOCRYPT_VERSION` environment variable (to unblock the C++ Driver whose CMake compatibility tasks are what revealed the error above, so that going forward C++ Driver EVG scripts can override without depending on C Driver commits). The [actual minimum version requirement](https://github.com/mongodb/mongo-c-driver/blob/3385ba9c2251ec184e23c12559796ce49d667c88/src/libmongoc/CMakeLists.txt#L492) is left as-is (libmongocrypt 1.13.0).