### PR TITLE
Update mingw-windows2016 to use "CC=gcc" for mingw-w64

### DIFF
--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -10273,7 +10273,7 @@ buildvariants:
 - name: mingw-windows2016
   display_name: MinGW-W64 (Windows Server 2016)
   expansions:
-    CC: mingw
+    CC: gcc
   run_on: windows-vsCurrent-large
   tasks:
   - debug-compile-nosasl-nossl

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -219,7 +219,7 @@ all_variants = [
         "MinGW-W64 (Windows Server 2016)",
         "windows-vsCurrent-large",
         ["debug-compile-nosasl-nossl", ".latest .nossl .nosasl .server"],
-        {"CC": "mingw"},
+        {"CC": "gcc"},
     ),
     Variant(
         "rhel8-power",


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-c-driver/pull/2070 which overlooked the `mingw-windows2016` variant in the legacy config generator.

> The `CC` env var is also updated to correctly indicate the compiler to use (`gcc`, not `mingw`), since we are only really interested in testing compilation of our libraries with the mingw-w64 compiler on Windows, not the particulars of the build system of choice.