### PR TITLE
 CDRIVER-6075 fix and update EVG task coverage on MacOS distros

### DIFF
--- a/.evergreen/config_generator/components/c_std_compile.py
+++ b/.evergreen/config_generator/components/c_std_compile.py
@@ -39,6 +39,8 @@ MATRIX = [
     ('rhel95',       'gcc',    None, [99, 11, 17, 23]), # GCC 11.5 (max: C2x)
     ('ubuntu2404',   'gcc-13', None, [99, 11, 17, 23]), # GCC 13.3 (max: C2x)
 
+    ('macos-14-arm64', 'clang', None, [99, 11, 17, 23]), # Apple Clang
+
     ('windows-vsCurrent', 'vs2015x64', None, [99, 11,   ]), # Max: C11
     ('windows-vsCurrent', 'vs2017x64', None, [99, 11,   ]), # Max: C11
     ('windows-vsCurrent', 'vs2019x64', None, [99, 11, 17]), # Max: C17

--- a/.evergreen/config_generator/components/cse/darwinssl.py
+++ b/.evergreen/config_generator/components/cse/darwinssl.py
@@ -14,21 +14,17 @@ TAG = f'cse-matrix-{SSL}'
 # pylint: disable=line-too-long
 # fmt: off
 COMPILE_MATRIX = [
-    ('macos-14', 'clang', None, ['cyrus']),
-
-    ('macos-11-arm64', 'clang', None, ['cyrus']),
     ('macos-14-arm64', 'clang', None, ['cyrus']),
+    ('macos-14',       'clang', None, ['cyrus']),
 ]
 
 # TODO (CDRIVER-3789): test cse with the 'sharded' topology.
 TEST_MATRIX = [
-    ('macos-14', 'clang', None, 'cyrus', ['auth'], ['server'], ['4.2', '4.4', '5.0']),
-
-    ('macos-11-arm64', 'clang', None, 'cyrus', ['auth'], ['server'], ['6.0']),
-    ('macos-14-arm64', 'clang', None, 'cyrus', ['auth'], ['server'], ['6.0']),
-
     # Test 7.0+ with a replica set since Queryable Encryption does not support the 'server' topology. Queryable Encryption tests require 7.0+.
-    ('macos-14-arm64', 'clang', None, 'cyrus', ['auth'], ['server', 'replica' ], ['7.0', '8.0', 'latest']),
+    ('macos-14-arm64', 'clang', None, 'cyrus', ['auth'], ['replica'], ['6.0', '7.0', '8.0', 'latest']),
+
+    # Resource-limited: use sparingly.
+    ('macos-14', 'clang', None, 'cyrus', ['auth'], ['replica'], ['4.2', 'latest']),
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/components/sasl/darwinssl.py
+++ b/.evergreen/config_generator/components/sasl/darwinssl.py
@@ -15,17 +15,15 @@ TAG = f'sasl-matrix-{SSL}'
 # pylint: disable=line-too-long
 # fmt: off
 COMPILE_MATRIX = [
-    ('macos-14', 'clang', None, ['cyrus']),
-
-    ('macos-11-arm64', 'clang', None, ['cyrus']),
     ('macos-14-arm64', 'clang', None, ['cyrus']),
+    ('macos-14',       'clang', None, ['cyrus']),
 ]
 
 TEST_MATRIX = [
-    ('macos-14', 'clang', None, 'cyrus', ['auth'], ['server'], ['4.2', '4.4', '5.0']),
+    ('macos-14-arm64', 'clang', None, 'cyrus', ['auth'], ['replica'], ['6.0', '7.0', '8.0', 'latest']),
 
-    ('macos-11-arm64', 'clang', None, 'cyrus', ['auth'], ['server'], ['6.0', '7.0',                ]),
-    ('macos-14-arm64', 'clang', None, 'cyrus', ['auth'], ['server'], ['6.0', '7.0', '8.0', 'latest']),
+    # Resource-limited: use sparingly.
+    ('macos-14', 'clang', None, 'cyrus', ['auth'], ['replica'], ['4.2', 'latest']),
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/config_generator/etc/distros.py
+++ b/.evergreen/config_generator/etc/distros.py
@@ -55,7 +55,6 @@ MACOS_DISTROS = [
 ]
 
 MACOS_ARM64_DISTROS = [
-    Distro(name='macos-11-arm64', os='macos', os_type='macos', os_ver='11', arch='arm64'),
     Distro(name='macos-14-arm64', os='macos', os_type='macos', os_ver='14', arch='arm64'),
 ]
 

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -1644,37 +1644,6 @@ tasks:
     tags: [clang-format]
     commands:
       - func: clang-format
-  - name: cse-sasl-cyrus-darwinssl-macos-11-arm64-clang-compile
-    run_on: macos-11-arm64
-    tags: [cse-matrix-darwinssl, compile, macos-11-arm64, clang, cse, sasl-cyrus]
-    commands:
-      - func: find-cmake-latest
-      - func: cse-sasl-cyrus-darwinssl-compile
-        vars:
-          CC: clang
-          CXX: clang++
-      - func: upload-build
-  - name: cse-sasl-cyrus-darwinssl-macos-11-arm64-clang-test-6.0-server-auth
-    run_on: macos-11-arm64
-    tags: [cse-matrix-darwinssl, test, macos-11-arm64, clang, sasl-cyrus, cse, auth, server, "6.0", darwinssl]
-    depends_on: [{ name: cse-sasl-cyrus-darwinssl-macos-11-arm64-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: cse-sasl-cyrus-darwinssl-macos-11-arm64-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: CXX, value: clang++ }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "6.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: darwinssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-mock-kms-servers
-      - func: run-tests
   - name: cse-sasl-cyrus-darwinssl-macos-14-arm64-clang-compile
     run_on: macos-14-arm64
     tags: [cse-matrix-darwinssl, compile, macos-14-arm64, clang, cse, sasl-cyrus]
@@ -1685,9 +1654,9 @@ tasks:
           CC: clang
           CXX: clang++
       - func: upload-build
-  - name: cse-sasl-cyrus-darwinssl-macos-14-arm64-clang-test-6.0-server-auth
+  - name: cse-sasl-cyrus-darwinssl-macos-14-arm64-clang-test-6.0-replica-auth
     run_on: macos-14-arm64
-    tags: [cse-matrix-darwinssl, test, macos-14-arm64, clang, sasl-cyrus, cse, auth, server, "6.0", darwinssl]
+    tags: [cse-matrix-darwinssl, test, macos-14-arm64, clang, sasl-cyrus, cse, auth, replica, "6.0", darwinssl]
     depends_on: [{ name: cse-sasl-cyrus-darwinssl-macos-14-arm64-clang-compile }]
     commands:
       - func: fetch-build
@@ -1700,7 +1669,7 @@ tasks:
             - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
-            - { key: TOPOLOGY, value: server }
+            - { key: TOPOLOGY, value: replica_set }
             - { key: SSL, value: darwinssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
@@ -1727,27 +1696,6 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-mock-kms-servers
       - func: run-tests
-  - name: cse-sasl-cyrus-darwinssl-macos-14-arm64-clang-test-7.0-server-auth
-    run_on: macos-14-arm64
-    tags: [cse-matrix-darwinssl, test, macos-14-arm64, clang, sasl-cyrus, cse, auth, server, "7.0", darwinssl]
-    depends_on: [{ name: cse-sasl-cyrus-darwinssl-macos-14-arm64-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: cse-sasl-cyrus-darwinssl-macos-14-arm64-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: CXX, value: clang++ }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "7.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: darwinssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-mock-kms-servers
-      - func: run-tests
   - name: cse-sasl-cyrus-darwinssl-macos-14-arm64-clang-test-8.0-replica-auth
     run_on: macos-14-arm64
     tags: [cse-matrix-darwinssl, test, macos-14-arm64, clang, sasl-cyrus, cse, auth, replica, "8.0", darwinssl]
@@ -1764,27 +1712,6 @@ tasks:
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
             - { key: TOPOLOGY, value: replica_set }
-            - { key: SSL, value: darwinssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-mock-kms-servers
-      - func: run-tests
-  - name: cse-sasl-cyrus-darwinssl-macos-14-arm64-clang-test-8.0-server-auth
-    run_on: macos-14-arm64
-    tags: [cse-matrix-darwinssl, test, macos-14-arm64, clang, sasl-cyrus, cse, auth, server, "8.0", darwinssl]
-    depends_on: [{ name: cse-sasl-cyrus-darwinssl-macos-14-arm64-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: cse-sasl-cyrus-darwinssl-macos-14-arm64-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: CXX, value: clang++ }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "8.0" }
-            - { key: TOPOLOGY, value: server }
             - { key: SSL, value: darwinssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
@@ -1811,27 +1738,6 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-mock-kms-servers
       - func: run-tests
-  - name: cse-sasl-cyrus-darwinssl-macos-14-arm64-clang-test-latest-server-auth
-    run_on: macos-14-arm64
-    tags: [cse-matrix-darwinssl, test, macos-14-arm64, clang, sasl-cyrus, cse, auth, server, latest, darwinssl]
-    depends_on: [{ name: cse-sasl-cyrus-darwinssl-macos-14-arm64-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: cse-sasl-cyrus-darwinssl-macos-14-arm64-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: CXX, value: clang++ }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: latest }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: darwinssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-mock-kms-servers
-      - func: run-tests
   - name: cse-sasl-cyrus-darwinssl-macos-14-clang-compile
     run_on: macos-14
     tags: [cse-matrix-darwinssl, compile, macos-14, clang, cse, sasl-cyrus]
@@ -1842,9 +1748,9 @@ tasks:
           CC: clang
           CXX: clang++
       - func: upload-build
-  - name: cse-sasl-cyrus-darwinssl-macos-14-clang-test-4.2-server-auth
+  - name: cse-sasl-cyrus-darwinssl-macos-14-clang-test-4.2-replica-auth
     run_on: macos-14
-    tags: [cse-matrix-darwinssl, test, macos-14, clang, sasl-cyrus, cse, auth, server, "4.2", darwinssl]
+    tags: [cse-matrix-darwinssl, test, macos-14, clang, sasl-cyrus, cse, auth, replica, "4.2", darwinssl]
     depends_on: [{ name: cse-sasl-cyrus-darwinssl-macos-14-clang-compile }]
     commands:
       - func: fetch-build
@@ -1857,15 +1763,15 @@ tasks:
             - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.2" }
-            - { key: TOPOLOGY, value: server }
+            - { key: TOPOLOGY, value: replica_set }
             - { key: SSL, value: darwinssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
       - func: run-mock-kms-servers
       - func: run-tests
-  - name: cse-sasl-cyrus-darwinssl-macos-14-clang-test-4.4-server-auth
+  - name: cse-sasl-cyrus-darwinssl-macos-14-clang-test-latest-replica-auth
     run_on: macos-14
-    tags: [cse-matrix-darwinssl, test, macos-14, clang, sasl-cyrus, cse, auth, server, "4.4", darwinssl]
+    tags: [cse-matrix-darwinssl, test, macos-14, clang, sasl-cyrus, cse, auth, replica, latest, darwinssl]
     depends_on: [{ name: cse-sasl-cyrus-darwinssl-macos-14-clang-compile }]
     commands:
       - func: fetch-build
@@ -1877,29 +1783,8 @@ tasks:
             - { key: CC, value: clang }
             - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.4" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: darwinssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-mock-kms-servers
-      - func: run-tests
-  - name: cse-sasl-cyrus-darwinssl-macos-14-clang-test-5.0-server-auth
-    run_on: macos-14
-    tags: [cse-matrix-darwinssl, test, macos-14, clang, sasl-cyrus, cse, auth, server, "5.0", darwinssl]
-    depends_on: [{ name: cse-sasl-cyrus-darwinssl-macos-14-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: cse-sasl-cyrus-darwinssl-macos-14-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: CXX, value: clang++ }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "5.0" }
-            - { key: TOPOLOGY, value: server }
+            - { key: MONGODB_VERSION, value: latest }
+            - { key: TOPOLOGY, value: replica_set }
             - { key: SSL, value: darwinssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
@@ -3860,58 +3745,6 @@ tasks:
           OPENSSL_USE_STATIC_LIBS: "ON"
           OPENSSL_VERSION: 3.1.2
       - func: run auth tests
-  - name: sasl-cyrus-darwinssl-macos-11-arm64-clang-compile
-    run_on: macos-11-arm64
-    tags: [sasl-matrix-darwinssl, compile, macos-11-arm64, clang, sasl-cyrus]
-    commands:
-      - func: find-cmake-latest
-      - func: sasl-cyrus-darwinssl-compile
-        vars:
-          CC: clang
-          CXX: clang++
-      - func: upload-build
-  - name: sasl-cyrus-darwinssl-macos-11-arm64-clang-test-6.0-server-auth
-    run_on: macos-11-arm64
-    tags: [sasl-matrix-darwinssl, test, macos-11-arm64, clang, sasl-cyrus, auth, server, "6.0", darwinssl]
-    depends_on: [{ name: sasl-cyrus-darwinssl-macos-11-arm64-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-cyrus-darwinssl-macos-11-arm64-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: CXX, value: clang++ }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "6.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: darwinssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-cyrus-darwinssl-macos-11-arm64-clang-test-7.0-server-auth
-    run_on: macos-11-arm64
-    tags: [sasl-matrix-darwinssl, test, macos-11-arm64, clang, sasl-cyrus, auth, server, "7.0", darwinssl]
-    depends_on: [{ name: sasl-cyrus-darwinssl-macos-11-arm64-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-cyrus-darwinssl-macos-11-arm64-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: CXX, value: clang++ }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "7.0" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: darwinssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
   - name: sasl-cyrus-darwinssl-macos-14-arm64-clang-compile
     run_on: macos-14-arm64
     tags: [sasl-matrix-darwinssl, compile, macos-14-arm64, clang, sasl-cyrus]
@@ -3922,9 +3755,9 @@ tasks:
           CC: clang
           CXX: clang++
       - func: upload-build
-  - name: sasl-cyrus-darwinssl-macos-14-arm64-clang-test-6.0-server-auth
+  - name: sasl-cyrus-darwinssl-macos-14-arm64-clang-test-6.0-replica-auth
     run_on: macos-14-arm64
-    tags: [sasl-matrix-darwinssl, test, macos-14-arm64, clang, sasl-cyrus, auth, server, "6.0", darwinssl]
+    tags: [sasl-matrix-darwinssl, test, macos-14-arm64, clang, sasl-cyrus, auth, replica, "6.0", darwinssl]
     depends_on: [{ name: sasl-cyrus-darwinssl-macos-14-arm64-clang-compile }]
     commands:
       - func: fetch-build
@@ -3937,15 +3770,15 @@ tasks:
             - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "6.0" }
-            - { key: TOPOLOGY, value: server }
+            - { key: TOPOLOGY, value: replica_set }
             - { key: SSL, value: darwinssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: sasl-cyrus-darwinssl-macos-14-arm64-clang-test-7.0-server-auth
+  - name: sasl-cyrus-darwinssl-macos-14-arm64-clang-test-7.0-replica-auth
     run_on: macos-14-arm64
-    tags: [sasl-matrix-darwinssl, test, macos-14-arm64, clang, sasl-cyrus, auth, server, "7.0", darwinssl]
+    tags: [sasl-matrix-darwinssl, test, macos-14-arm64, clang, sasl-cyrus, auth, replica, "7.0", darwinssl]
     depends_on: [{ name: sasl-cyrus-darwinssl-macos-14-arm64-clang-compile }]
     commands:
       - func: fetch-build
@@ -3958,15 +3791,15 @@ tasks:
             - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "7.0" }
-            - { key: TOPOLOGY, value: server }
+            - { key: TOPOLOGY, value: replica_set }
             - { key: SSL, value: darwinssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: sasl-cyrus-darwinssl-macos-14-arm64-clang-test-8.0-server-auth
+  - name: sasl-cyrus-darwinssl-macos-14-arm64-clang-test-8.0-replica-auth
     run_on: macos-14-arm64
-    tags: [sasl-matrix-darwinssl, test, macos-14-arm64, clang, sasl-cyrus, auth, server, "8.0", darwinssl]
+    tags: [sasl-matrix-darwinssl, test, macos-14-arm64, clang, sasl-cyrus, auth, replica, "8.0", darwinssl]
     depends_on: [{ name: sasl-cyrus-darwinssl-macos-14-arm64-clang-compile }]
     commands:
       - func: fetch-build
@@ -3979,15 +3812,15 @@ tasks:
             - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "8.0" }
-            - { key: TOPOLOGY, value: server }
+            - { key: TOPOLOGY, value: replica_set }
             - { key: SSL, value: darwinssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: sasl-cyrus-darwinssl-macos-14-arm64-clang-test-latest-server-auth
+  - name: sasl-cyrus-darwinssl-macos-14-arm64-clang-test-latest-replica-auth
     run_on: macos-14-arm64
-    tags: [sasl-matrix-darwinssl, test, macos-14-arm64, clang, sasl-cyrus, auth, server, latest, darwinssl]
+    tags: [sasl-matrix-darwinssl, test, macos-14-arm64, clang, sasl-cyrus, auth, replica, latest, darwinssl]
     depends_on: [{ name: sasl-cyrus-darwinssl-macos-14-arm64-clang-compile }]
     commands:
       - func: fetch-build
@@ -4000,7 +3833,7 @@ tasks:
             - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: latest }
-            - { key: TOPOLOGY, value: server }
+            - { key: TOPOLOGY, value: replica_set }
             - { key: SSL, value: darwinssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
@@ -4016,9 +3849,9 @@ tasks:
           CC: clang
           CXX: clang++
       - func: upload-build
-  - name: sasl-cyrus-darwinssl-macos-14-clang-test-4.2-server-auth
+  - name: sasl-cyrus-darwinssl-macos-14-clang-test-4.2-replica-auth
     run_on: macos-14
-    tags: [sasl-matrix-darwinssl, test, macos-14, clang, sasl-cyrus, auth, server, "4.2", darwinssl]
+    tags: [sasl-matrix-darwinssl, test, macos-14, clang, sasl-cyrus, auth, replica, "4.2", darwinssl]
     depends_on: [{ name: sasl-cyrus-darwinssl-macos-14-clang-compile }]
     commands:
       - func: fetch-build
@@ -4031,15 +3864,15 @@ tasks:
             - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
             - { key: MONGODB_VERSION, value: "4.2" }
-            - { key: TOPOLOGY, value: server }
+            - { key: TOPOLOGY, value: replica_set }
             - { key: SSL, value: darwinssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
       - func: run-simple-http-server
       - func: run-tests
-  - name: sasl-cyrus-darwinssl-macos-14-clang-test-4.4-server-auth
+  - name: sasl-cyrus-darwinssl-macos-14-clang-test-latest-replica-auth
     run_on: macos-14
-    tags: [sasl-matrix-darwinssl, test, macos-14, clang, sasl-cyrus, auth, server, "4.4", darwinssl]
+    tags: [sasl-matrix-darwinssl, test, macos-14, clang, sasl-cyrus, auth, replica, latest, darwinssl]
     depends_on: [{ name: sasl-cyrus-darwinssl-macos-14-clang-compile }]
     commands:
       - func: fetch-build
@@ -4051,29 +3884,8 @@ tasks:
             - { key: CC, value: clang }
             - { key: CXX, value: clang++ }
             - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "4.4" }
-            - { key: TOPOLOGY, value: server }
-            - { key: SSL, value: darwinssl }
-      - func: fetch-det
-      - func: bootstrap-mongo-orchestration
-      - func: run-simple-http-server
-      - func: run-tests
-  - name: sasl-cyrus-darwinssl-macos-14-clang-test-5.0-server-auth
-    run_on: macos-14
-    tags: [sasl-matrix-darwinssl, test, macos-14, clang, sasl-cyrus, auth, server, "5.0", darwinssl]
-    depends_on: [{ name: sasl-cyrus-darwinssl-macos-14-clang-compile }]
-    commands:
-      - func: fetch-build
-        vars:
-          BUILD_NAME: sasl-cyrus-darwinssl-macos-14-clang-compile
-      - command: expansions.update
-        params:
-          updates:
-            - { key: CC, value: clang }
-            - { key: CXX, value: clang++ }
-            - { key: AUTH, value: auth }
-            - { key: MONGODB_VERSION, value: "5.0" }
-            - { key: TOPOLOGY, value: server }
+            - { key: MONGODB_VERSION, value: latest }
+            - { key: TOPOLOGY, value: replica_set }
             - { key: SSL, value: darwinssl }
       - func: fetch-det
       - func: bootstrap-mongo-orchestration
@@ -5650,6 +5462,16 @@ tasks:
           CC: gcc-10
           CXX: g++-10
           C_STD_VERSION: 11
+  - name: std-c11-macos-14-arm64-clang-compile
+    run_on: macos-14-arm64
+    tags: [std-matrix, macos-14-arm64, clang, compile, std-c11]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 11
   - name: std-c11-rhel7-latest-gcc-compile
     run_on: rhel7-latest-large
     tags: [std-matrix, rhel7-latest, gcc, compile, std-c11]
@@ -5890,6 +5712,16 @@ tasks:
           CC: gcc-10
           CXX: g++-10
           C_STD_VERSION: 17
+  - name: std-c17-macos-14-arm64-clang-compile
+    run_on: macos-14-arm64
+    tags: [std-matrix, macos-14-arm64, clang, compile, std-c17]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 17
   - name: std-c17-rhel80-clang-compile
     run_on: rhel80-large
     tags: [std-matrix, rhel80, clang, compile, std-c17]
@@ -6100,6 +5932,16 @@ tasks:
           CC: gcc-10
           CXX: g++-10
           C_STD_VERSION: 23
+  - name: std-c23-macos-14-arm64-clang-compile
+    run_on: macos-14-arm64
+    tags: [std-matrix, macos-14-arm64, clang, compile, std-c23]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
+          C_STD_VERSION: 23
   - name: std-c23-rhel84-clang-compile
     run_on: rhel84-large
     tags: [std-matrix, rhel84, clang, compile, std-c23]
@@ -6259,6 +6101,16 @@ tasks:
         vars:
           CC: gcc-10
           CXX: g++-10
+          C_STD_VERSION: 99
+  - name: std-c99-macos-14-arm64-clang-compile
+    run_on: macos-14-arm64
+    tags: [std-matrix, macos-14-arm64, clang, compile, std-c99]
+    commands:
+      - func: find-cmake-latest
+      - func: std-compile
+        vars:
+          CC: clang
+          CXX: clang++
           C_STD_VERSION: 99
   - name: std-c99-rhel7-latest-gcc-compile
     run_on: rhel7-latest-large

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+libmongoc 2.2.0 (Unreleased)
+============================
+
+## Deprecated
+
+- Support for macOS 11 (EOL since September 2023) and macOS 12 (EOL since September 2024).
+
 libmongoc 2.1.0
 ===============
 

--- a/src/libbson/NEWS
+++ b/src/libbson/NEWS
@@ -1,3 +1,10 @@
+libmongoc 2.2.0 (Unreleased)
+============================
+
+## Deprecated
+
+- Support for macOS 11 (EOL since September 2023) and macOS 12 (EOL since September 2024).
+
 libbson 2.1.0
 =============
 
@@ -39,7 +46,7 @@ Fixes:
 libbson 1.30.5
 ==============
 
-Fixes:
+Fixes: (Unreleased)
 
 * Various fixes have been applied to the `bson_validate` family of functions,
   with some minor behavioral changes.


### PR DESCRIPTION
Resolves CDRIVER-6075.

Per DevProd's [EVG Distro Guidelines for MacOS](https://wiki.corp.mongodb.com/spaces/DBDEVPROD/pages/296299060/Guidelines+for+MacOS+Distros+in+Evergreen):

> MacOS 10.14 and 11 are long EOL'd operating systems. While Apple doesn't publish exact information on what they support, the rule of thumb is they will support the "current" release and the two previous releases.  Any release prior no longer receives security updates. If something is not working for you on an older, EOL'd operating system, we will likely not be able to modify it anymore and you should try to migrate your project to a newer, supported OS.

[CDRIVER-6075](https://jira.mongodb.org/browse/CDRIVER-6075) (this PR) announces deprecation targeting the 2.2.0 release in advance of [CDRIVER-6076](https://jira.mongodb.org/browse/CDRIVER-6076) targeting the 2.3.0 release (per Client Libraries policy). However, this PR applies EVG configuration updates in advance to address ongoing MacOS 11 task failures caused by [inconsistent and sometimes _ancient_](/mongodb-labs/drivers-evergreen-tools/pull/678#issuecomment-3184224609) `uv` version being provided by the system which DET scripts do not expect (this seems to be a regression sometime [after August 1](https://spruce.mongodb.com/task/mongo_c_driver_cse_matrix_darwinssl_cse_sasl_cyrus_darwinssl_macos_11_arm64_clang_test_6.0_server_auth_1f756d6e3fc89fa554f2afb0d9e9521ed7d1c741_25_08_12_20_30_02/history?execution=1)...?).

---

This PR takes this opportunity to also update the task matrices for MacOS: C standard compatibility coverage (specifically for better Apple Clang libc++ coverage) is extended to MacOS 14 arm64. The resource-limited MacOS 14 x86_64 tasks are updated+minimized to test against "minimum" (available) and "latest" server versions only. The MacOS tasks are updated to use "replica" topology by default for better test suite coverage, as "server" (single) is likely not providing much value here (and there is plenty of equivalent single topology coverage on other distros).

> Try to use these distros more sparingly.

This PR attempted to extend coverage to sharded topologies, but encountered too many unexpected task failures, prompting [CDRIVER-6078](https://jira.mongodb.org/browse/CDRIVER-6078).