### PR TITLE
ClangFormat

### DIFF
--- a/src/libmongoc/tests/test-libmongoc.c
+++ b/src/libmongoc/tests/test-libmongoc.c
@@ -1951,7 +1951,7 @@ test_framework_skip_if_windows(void)
 
 
 int
-test_framework_skip_if_macos (void)
+test_framework_skip_if_macos(void)
 {
 #ifdef __APPLE__
    return 0;


### PR DESCRIPTION
Overlooked a ClangFormat error in https://github.com/mongodb/mongo-c-driver/pull/2088.