### PR TITLE
Update bypass_dlclose.sh to permit fancy Clang paths

### DIFF
--- a/.evergreen/scripts/bypass-dlclose.sh
+++ b/.evergreen/scripts/bypass-dlclose.sh
@@ -30,20 +30,20 @@ bypass_dlclose() (
     fi
 
     echo "int dlclose (void *handle) {(void) handle; return 0; }" \
-      >|"${tmp}/bypass_dlclose.c" || return
+      >|"${tmp:?}/bypass_dlclose.c" || return
 
-    "${CC}" -o "${tmp}/bypass_dlclose.so" \
-      -shared "${tmp}/bypass_dlclose.c" || return
+    "${CC:?}" -o "${tmp:?}/bypass_dlclose.so" \
+      -shared "${tmp:?}/bypass_dlclose.c" || return
 
-    ld_preload="${tmp}/bypass_dlclose.so"
+    ld_preload="${tmp:?}/bypass_dlclose.so"
 
     # Clang uses its own libasan.so; do not preload it!
-    if [ "${CC}" != "clang" ]; then
+    if [[ ! "${CC:?}" =~ clang ]]; then
       declare asan_path
-      asan_path="$(${CC} -print-file-name=libasan.so)" || return
-      ld_preload="${asan_path}:${ld_preload}"
+      asan_path="$("${CC:?}" -print-file-name=libasan.so)" || return
+      ld_preload="${asan_path:?}:${ld_preload:?}"
     fi
   } 1>&2
 
-  printf "%s" "${ld_preload}"
+  printf "%s" "${ld_preload:?}"
 )


### PR DESCRIPTION
Related to https://github.com/mongodb/mongo-cxx-driver/pull/1453. Syncs the relative changes in the script required to allow for fancy paths to the Clang compiler (e.g. `/opt/mongodbtoolchain/v4/bin/clang`) rather than comparing only against the trivial pathless `clang`.