### PR TITLE
CDRIVER-6055 Audit array allocations

### DIFF
--- a/src/common/src/common-bson-dsl-private.h
+++ b/src/common/src/common-bson-dsl-private.h
@@ -659,24 +659,24 @@ BSON_IF_GNU_LIKE(_Pragma("GCC diagnostic ignored \"-Wshadow\""))
       }                                      \
    } while (0);
 
-#define _bsonParseMarkVisited(Index)                                                                \
-   if (1) {                                                                                         \
-      const size_t nth_int = Index / 64u;                                                           \
-      const size_t nth_bit = Index % 64u;                                                           \
-      while (nth_int >= _bpNumVisitBitInts) {                                                       \
-         /* Say that five times, fast: */                                                           \
-         size_t new_num_visit_bit_ints = _bpNumVisitBitInts * 2u;                                   \
+#define _bsonParseMarkVisited(Index)                                                                 \
+   if (1) {                                                                                          \
+      const size_t nth_int = Index / 64u;                                                            \
+      const size_t nth_bit = Index % 64u;                                                            \
+      while (nth_int >= _bpNumVisitBitInts) {                                                        \
+         /* Say that five times, fast: */                                                            \
+         size_t new_num_visit_bit_ints = _bpNumVisitBitInts * 2u;                                    \
          uint64_t *new_visit_bit_ints = bson_array_alloc0(sizeof(uint64_t), new_num_visit_bit_ints); \
-         memcpy(new_visit_bit_ints, _bpVisitBits, sizeof(uint64_t) * _bpNumVisitBitInts);           \
-         if (_bpVisitBits != _bpVisitBits_static) {                                                 \
-            bson_free(_bpVisitBits);                                                                \
-         }                                                                                          \
-         _bpVisitBits = new_visit_bit_ints;                                                         \
-         _bpNumVisitBitInts = new_num_visit_bit_ints;                                               \
-      }                                                                                             \
-                                                                                                    \
-      _bpVisitBits[nth_int] |= (UINT64_C(1) << nth_bit);                                            \
-   } else                                                                                           \
+         memcpy(new_visit_bit_ints, _bpVisitBits, sizeof(uint64_t) * _bpNumVisitBitInts);            \
+         if (_bpVisitBits != _bpVisitBits_static) {                                                  \
+            bson_free(_bpVisitBits);                                                                 \
+         }                                                                                           \
+         _bpVisitBits = new_visit_bit_ints;                                                          \
+         _bpNumVisitBitInts = new_num_visit_bit_ints;                                                \
+      }                                                                                              \
+                                                                                                     \
+      _bpVisitBits[nth_int] |= (UINT64_C(1) << nth_bit);                                             \
+   } else                                                                                            \
       ((void)0)
 
 #define _bsonParseDidVisitNth(Index) _bsonParseDidVisitNth_1(Index / 64u, Index % 64u)

--- a/src/common/src/common-bson-dsl-private.h
+++ b/src/common/src/common-bson-dsl-private.h
@@ -659,24 +659,24 @@ BSON_IF_GNU_LIKE(_Pragma("GCC diagnostic ignored \"-Wshadow\""))
       }                                      \
    } while (0);
 
-#define _bsonParseMarkVisited(Index)                                                                 \
-   if (1) {                                                                                          \
-      const size_t nth_int = Index / 64u;                                                            \
-      const size_t nth_bit = Index % 64u;                                                            \
-      while (nth_int >= _bpNumVisitBitInts) {                                                        \
-         /* Say that five times, fast: */                                                            \
-         size_t new_num_visit_bit_ints = _bpNumVisitBitInts * 2u;                                    \
-         uint64_t *new_visit_bit_ints = bson_array_alloc0(sizeof(uint64_t), new_num_visit_bit_ints); \
-         memcpy(new_visit_bit_ints, _bpVisitBits, sizeof(uint64_t) * _bpNumVisitBitInts);            \
-         if (_bpVisitBits != _bpVisitBits_static) {                                                  \
-            bson_free(_bpVisitBits);                                                                 \
-         }                                                                                           \
-         _bpVisitBits = new_visit_bit_ints;                                                          \
-         _bpNumVisitBitInts = new_num_visit_bit_ints;                                                \
-      }                                                                                              \
-                                                                                                     \
-      _bpVisitBits[nth_int] |= (UINT64_C(1) << nth_bit);                                             \
-   } else                                                                                            \
+#define _bsonParseMarkVisited(Index)                                                         \
+   if (1) {                                                                                  \
+      const size_t nth_int = Index / 64u;                                                    \
+      const size_t nth_bit = Index % 64u;                                                    \
+      while (nth_int >= _bpNumVisitBitInts) {                                                \
+         /* Say that five times, fast: */                                                    \
+         size_t new_num_visit_bit_ints = _bpNumVisitBitInts * 2u;                            \
+         uint64_t *new_visit_bit_ints = BSON_ARRAY_ALLOC0(new_num_visit_bit_ints, uint64_t); \
+         memcpy(new_visit_bit_ints, _bpVisitBits, sizeof(uint64_t) * _bpNumVisitBitInts);    \
+         if (_bpVisitBits != _bpVisitBits_static) {                                          \
+            bson_free(_bpVisitBits);                                                         \
+         }                                                                                   \
+         _bpVisitBits = new_visit_bit_ints;                                                  \
+         _bpNumVisitBitInts = new_num_visit_bit_ints;                                        \
+      }                                                                                      \
+                                                                                             \
+      _bpVisitBits[nth_int] |= (UINT64_C(1) << nth_bit);                                     \
+   } else                                                                                    \
       ((void)0)
 
 #define _bsonParseDidVisitNth(Index) _bsonParseDidVisitNth_1(Index / 64u, Index % 64u)

--- a/src/common/src/common-bson-dsl-private.h
+++ b/src/common/src/common-bson-dsl-private.h
@@ -666,7 +666,7 @@ BSON_IF_GNU_LIKE(_Pragma("GCC diagnostic ignored \"-Wshadow\""))
       while (nth_int >= _bpNumVisitBitInts) {                                                       \
          /* Say that five times, fast: */                                                           \
          size_t new_num_visit_bit_ints = _bpNumVisitBitInts * 2u;                                   \
-         uint64_t *new_visit_bit_ints = bson_array_alloc(sizeof(uint64_t), new_num_visit_bit_ints); \
+         uint64_t *new_visit_bit_ints = bson_array_alloc0(sizeof(uint64_t), new_num_visit_bit_ints); \
          memcpy(new_visit_bit_ints, _bpVisitBits, sizeof(uint64_t) * _bpNumVisitBitInts);           \
          if (_bpVisitBits != _bpVisitBits_static) {                                                 \
             bson_free(_bpVisitBits);                                                                \

--- a/src/common/src/common-bson-dsl-private.h
+++ b/src/common/src/common-bson-dsl-private.h
@@ -659,24 +659,24 @@ BSON_IF_GNU_LIKE(_Pragma("GCC diagnostic ignored \"-Wshadow\""))
       }                                      \
    } while (0);
 
-#define _bsonParseMarkVisited(Index)                                                             \
-   if (1) {                                                                                      \
-      const size_t nth_int = Index / 64u;                                                        \
-      const size_t nth_bit = Index % 64u;                                                        \
-      while (nth_int >= _bpNumVisitBitInts) {                                                    \
-         /* Say that five times, fast: */                                                        \
-         size_t new_num_visit_bit_ints = _bpNumVisitBitInts * 2u;                                \
-         uint64_t *new_visit_bit_ints = bson_malloc0(sizeof(uint64_t) * new_num_visit_bit_ints); \
-         memcpy(new_visit_bit_ints, _bpVisitBits, sizeof(uint64_t) * _bpNumVisitBitInts);        \
-         if (_bpVisitBits != _bpVisitBits_static) {                                              \
-            bson_free(_bpVisitBits);                                                             \
-         }                                                                                       \
-         _bpVisitBits = new_visit_bit_ints;                                                      \
-         _bpNumVisitBitInts = new_num_visit_bit_ints;                                            \
-      }                                                                                          \
-                                                                                                 \
-      _bpVisitBits[nth_int] |= (UINT64_C(1) << nth_bit);                                         \
-   } else                                                                                        \
+#define _bsonParseMarkVisited(Index)                                                                \
+   if (1) {                                                                                         \
+      const size_t nth_int = Index / 64u;                                                           \
+      const size_t nth_bit = Index % 64u;                                                           \
+      while (nth_int >= _bpNumVisitBitInts) {                                                       \
+         /* Say that five times, fast: */                                                           \
+         size_t new_num_visit_bit_ints = _bpNumVisitBitInts * 2u;                                   \
+         uint64_t *new_visit_bit_ints = bson_array_alloc(sizeof(uint64_t), new_num_visit_bit_ints); \
+         memcpy(new_visit_bit_ints, _bpVisitBits, sizeof(uint64_t) * _bpNumVisitBitInts);           \
+         if (_bpVisitBits != _bpVisitBits_static) {                                                 \
+            bson_free(_bpVisitBits);                                                                \
+         }                                                                                          \
+         _bpVisitBits = new_visit_bit_ints;                                                         \
+         _bpNumVisitBitInts = new_num_visit_bit_ints;                                               \
+      }                                                                                             \
+                                                                                                    \
+      _bpVisitBits[nth_int] |= (UINT64_C(1) << nth_bit);                                            \
+   } else                                                                                           \
       ((void)0)
 
 #define _bsonParseDidVisitNth(Index) _bsonParseDidVisitNth_1(Index / 64u, Index % 64u)

--- a/src/libbson/doc/bson_aligned_alloc.rst
+++ b/src/libbson/doc/bson_aligned_alloc.rst
@@ -22,8 +22,6 @@ Description
 
 This is a portable ``aligned_alloc()`` wrapper.
 
-In general, this function will return an allocation at least ``sizeof(void*)`` bytes or bigger with an alignment of at least ``alignment``.
-
 If there was a failure to allocate ``num_bytes`` bytes aligned to ``alignment``, the process will be aborted.
 
 .. warning::

--- a/src/libbson/doc/bson_aligned_alloc0.rst
+++ b/src/libbson/doc/bson_aligned_alloc0.rst
@@ -22,8 +22,6 @@ Description
 
 This is a portable ``aligned_alloc()`` wrapper that also sets the memory to zero.
 
-In general, this function will return an allocation at least ``sizeof(void*)`` bytes or bigger with an alignment of at least ``alignment``.
-
 If there was a failure to allocate ``num_bytes`` bytes aligned to ``alignment``, the process will be aborted.
 
 .. warning::

--- a/src/libbson/doc/bson_alloc_array.rst
+++ b/src/libbson/doc/bson_alloc_array.rst
@@ -1,7 +1,7 @@
 :man_page: bson_alloc_array
 
 bson_alloc_array()
-=============
+==================
 
 Synopsis
 --------

--- a/src/libbson/doc/bson_alloc_array.rst
+++ b/src/libbson/doc/bson_alloc_array.rst
@@ -1,0 +1,36 @@
+:man_page: bson_alloc_array
+
+bson_alloc_array()
+=============
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  void *
+  bson_alloc_array (size_t type_size, size_t num_elems);
+
+Parameters
+----------
+
+* ``type_size``: A size_t containing the size in bytes of a single object in the array. 
+* ``num_elems``: A size_t containing the number of objects to be stored in the array.
+
+Description
+-----------
+
+This is a portable ``malloc()`` wrapper to allocate an array of objects.
+
+In general, this function will return an allocation at least ``sizeof(void*)`` bytes or bigger.
+
+If there was a failure to allocate ``type_size * num_elems`` bytes, the process will be aborted.
+
+.. warning::
+
+  This function will abort on failure to allocate memory.
+
+Returns
+-------
+
+A pointer to a memory region which *HAS NOT* been zeroed.

--- a/src/libbson/doc/bson_alloc_array0.rst
+++ b/src/libbson/doc/bson_alloc_array0.rst
@@ -1,7 +1,7 @@
 :man_page: bson_alloc_array0
 
 bson_alloc_array0()
-=============
+===================
 
 Synopsis
 --------

--- a/src/libbson/doc/bson_alloc_array0.rst
+++ b/src/libbson/doc/bson_alloc_array0.rst
@@ -1,0 +1,36 @@
+:man_page: bson_alloc_array0
+
+bson_alloc_array0()
+=============
+
+Synopsis
+--------
+
+.. code-block:: c
+
+  void *
+  bson_alloc_array0 (size_t type_size, size_t num_elems);
+
+Parameters
+----------
+
+* ``type_size``: A size_t containing the size in bytes of a single object in the array. 
+* ``num_elems``: A size_t containing the number of objects to be stored in the array.
+
+Description
+-----------
+
+This is a portable ``malloc()`` wrapper to allocate an array of objects that also sets the memory to zero.
+
+In general, this function will return an allocation at least ``sizeof(void*)`` bytes or bigger.
+
+If there was a failure to allocate ``type_size * num_elems`` bytes, the process will be aborted.
+
+.. warning::
+
+  This function will abort on failure to allocate memory.
+
+Returns
+-------
+
+A pointer to a memory region which *HAS* been zeroed.

--- a/src/libbson/doc/bson_array_alloc.rst
+++ b/src/libbson/doc/bson_array_alloc.rst
@@ -25,7 +25,7 @@ Description
 
 This is a portable ``malloc()`` wrapper to allocate an array of objects.
 
-If there was a failure to allocate ``num_elems * elem_size`` bytes, the process will be aborted.
+If ``num_elems * elem_size`` cannot be represented in a size_t or there was a failure to allocate ``num_elems * elem_size`` bytes, the process will be aborted.
 
 .. warning::
 

--- a/src/libbson/doc/bson_array_alloc.rst
+++ b/src/libbson/doc/bson_array_alloc.rst
@@ -8,14 +8,17 @@ Synopsis
 
 .. code-block:: c
 
+  #define BSON_ARRAY_ALLOC(Count, Type) \
+     (Type*) bson_array_alloc (Count, sizeof (Type))
+
   void *
-  bson_array_alloc (size_t type_size, size_t num_elems);
+  bson_array_alloc (size_t num_elems, size_t elem_size);
 
 Parameters
 ----------
 
-* ``type_size``: A size_t containing the size in bytes of a single object in the array. 
-* ``num_elems``: A size_t containing the number of objects to be stored in the array.
+* ``num_elems``: A size_t containing the number of objects to allocate.
+* ``elem_size``: A size_t containing the size of each object in bytes.
 
 Description
 -----------
@@ -24,7 +27,7 @@ This is a portable ``malloc()`` wrapper to allocate an array of objects.
 
 In general, this function will return an allocation at least ``sizeof(void*)`` bytes or bigger.
 
-If there was a failure to allocate ``type_size * num_elems`` bytes, the process will be aborted.
+If there was a failure to allocate ``num_elems * elem_size`` bytes, the process will be aborted.
 
 .. warning::
 

--- a/src/libbson/doc/bson_array_alloc.rst
+++ b/src/libbson/doc/bson_array_alloc.rst
@@ -25,8 +25,6 @@ Description
 
 This is a portable ``malloc()`` wrapper to allocate an array of objects.
 
-In general, this function will return an allocation at least ``sizeof(void*)`` bytes or bigger.
-
 If there was a failure to allocate ``num_elems * elem_size`` bytes, the process will be aborted.
 
 .. warning::

--- a/src/libbson/doc/bson_array_alloc.rst
+++ b/src/libbson/doc/bson_array_alloc.rst
@@ -1,7 +1,7 @@
-:man_page: bson_alloc_array0
+:man_page: bson_array_alloc
 
-bson_alloc_array0()
-===================
+bson_array_alloc()
+==================
 
 Synopsis
 --------
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   void *
-  bson_alloc_array0 (size_t type_size, size_t num_elems);
+  bson_array_alloc (size_t type_size, size_t num_elems);
 
 Parameters
 ----------
@@ -20,7 +20,7 @@ Parameters
 Description
 -----------
 
-This is a portable ``malloc()`` wrapper to allocate an array of objects that also sets the memory to zero.
+This is a portable ``malloc()`` wrapper to allocate an array of objects.
 
 In general, this function will return an allocation at least ``sizeof(void*)`` bytes or bigger.
 
@@ -33,4 +33,4 @@ If there was a failure to allocate ``type_size * num_elems`` bytes, the process 
 Returns
 -------
 
-A pointer to a memory region which *HAS* been zeroed.
+A pointer to a memory region which *HAS NOT* been zeroed.

--- a/src/libbson/doc/bson_array_alloc0.rst
+++ b/src/libbson/doc/bson_array_alloc0.rst
@@ -25,7 +25,7 @@ Description
 
 This is a portable ``calloc()`` wrapper to allocate an array of objects that also sets the memory to zero.
 
-If there was a failure to allocate ``num_elems * elem_size`` bytes, the process will be aborted.
+If ``num_elems * elem_size`` cannot be represented in a size_t or there was a failure to allocate ``num_elems * elem_size`` bytes, the process will be aborted.
 
 .. warning::
 

--- a/src/libbson/doc/bson_array_alloc0.rst
+++ b/src/libbson/doc/bson_array_alloc0.rst
@@ -25,8 +25,6 @@ Description
 
 This is a portable ``calloc()`` wrapper to allocate an array of objects that also sets the memory to zero.
 
-In general, this function will return an allocation at least ``sizeof(void*)`` bytes or bigger.
-
 If there was a failure to allocate ``num_elems * elem_size`` bytes, the process will be aborted.
 
 .. warning::

--- a/src/libbson/doc/bson_array_alloc0.rst
+++ b/src/libbson/doc/bson_array_alloc0.rst
@@ -1,7 +1,7 @@
-:man_page: bson_alloc_array
+:man_page: bson_array_alloc0
 
-bson_alloc_array()
-==================
+bson_array_alloc0()
+===================
 
 Synopsis
 --------
@@ -9,7 +9,7 @@ Synopsis
 .. code-block:: c
 
   void *
-  bson_alloc_array (size_t type_size, size_t num_elems);
+  bson_array_alloc0 (size_t type_size, size_t num_elems);
 
 Parameters
 ----------
@@ -20,7 +20,7 @@ Parameters
 Description
 -----------
 
-This is a portable ``malloc()`` wrapper to allocate an array of objects.
+This is a portable ``malloc()`` wrapper to allocate an array of objects that also sets the memory to zero.
 
 In general, this function will return an allocation at least ``sizeof(void*)`` bytes or bigger.
 
@@ -33,4 +33,4 @@ If there was a failure to allocate ``type_size * num_elems`` bytes, the process 
 Returns
 -------
 
-A pointer to a memory region which *HAS NOT* been zeroed.
+A pointer to a memory region which *HAS* been zeroed.

--- a/src/libbson/doc/bson_array_alloc0.rst
+++ b/src/libbson/doc/bson_array_alloc0.rst
@@ -8,23 +8,26 @@ Synopsis
 
 .. code-block:: c
 
+  #define BSON_ARRAY_ALLOC0(Count, Type) \
+     (Type*) bson_array_alloc0 (Count, sizeof (Type))
+
   void *
-  bson_array_alloc0 (size_t type_size, size_t num_elems);
+  bson_array_alloc0 (size_t num_elems, size_t elem_size);
 
 Parameters
 ----------
 
-* ``type_size``: A size_t containing the size in bytes of a single object in the array. 
-* ``num_elems``: A size_t containing the number of objects to be stored in the array.
+* ``num_elems``: A size_t containing the number of objects to allocate.
+* ``elem_size``: A size_t containing the size of each object in bytes.
 
 Description
 -----------
 
-This is a portable ``malloc()`` wrapper to allocate an array of objects that also sets the memory to zero.
+This is a portable ``calloc()`` wrapper to allocate an array of objects that also sets the memory to zero.
 
 In general, this function will return an allocation at least ``sizeof(void*)`` bytes or bigger.
 
-If there was a failure to allocate ``type_size * num_elems`` bytes, the process will be aborted.
+If there was a failure to allocate ``num_elems * elem_size`` bytes, the process will be aborted.
 
 .. warning::
 

--- a/src/libbson/doc/bson_malloc.rst
+++ b/src/libbson/doc/bson_malloc.rst
@@ -21,8 +21,6 @@ Description
 
 This is a portable ``malloc()`` wrapper.
 
-In general, this function will return an allocation at least ``sizeof(void*)`` bytes or bigger.
-
 If there was a failure to allocate ``num_bytes`` bytes, the process will be aborted.
 
 .. warning::

--- a/src/libbson/doc/bson_malloc0.rst
+++ b/src/libbson/doc/bson_malloc0.rst
@@ -21,8 +21,6 @@ Description
 
 This is a portable ``malloc()`` wrapper that also sets the memory to zero. Similar to ``calloc()``.
 
-In general, this function will return an allocation at least ``sizeof(void*)`` bytes or bigger.
-
 If there was a failure to allocate ``num_bytes`` bytes, the process will be aborted.
 
 .. warning::

--- a/src/libbson/doc/bson_memory.rst
+++ b/src/libbson/doc/bson_memory.rst
@@ -26,6 +26,8 @@ To aid in language binding integration, Libbson allows for setting a custom memo
     bson_malloc0
     bson_aligned_alloc
     bson_aligned_alloc0
+    bson_array_alloc
+    bson_array_alloc0
     bson_mem_restore_vtable
     bson_mem_set_vtable
     bson_realloc

--- a/src/libbson/doc/bson_realloc.rst
+++ b/src/libbson/doc/bson_realloc.rst
@@ -22,7 +22,7 @@ Description
 
 This is a portable ``realloc()`` wrapper.
 
-In general, this function will return an allocation at least ``sizeof(void*)`` bytes or bigger. If ``num_bytes`` is 0, then the allocation will be freed.
+If ``num_bytes`` is 0, then the allocation will be freed.
 
 If there was a failure to allocate ``num_bytes`` bytes, the process will be aborted.
 

--- a/src/libbson/src/bson/memory.c
+++ b/src/libbson/src/bson/memory.c
@@ -257,7 +257,7 @@ void *
 bson_array_alloc(size_t num_elems /* IN */, size_t elem_size /* IN */)
 {
    void *mem = NULL;
-   size_t num_bytes;
+   size_t num_bytes = 0;
    BSON_ASSERT(!mlib_mul(&num_bytes, num_elems, elem_size));
 
    if (BSON_LIKELY(num_bytes)) {
@@ -292,7 +292,7 @@ void *
 bson_array_alloc0(size_t num_elems /* IN */, size_t elem_size /* IN */)
 {
    void *mem = NULL;
-   size_t num_bytes;
+   size_t num_bytes = 0;
    BSON_ASSERT(!mlib_mul(&num_bytes, num_elems, elem_size));
 
    if (BSON_LIKELY(num_bytes)) {

--- a/src/libbson/src/bson/memory.c
+++ b/src/libbson/src/bson/memory.c
@@ -22,6 +22,7 @@
 #include <bson/config.h>
 
 #include <mlib/config.h>
+#include <mlib/timer.h>
 
 #include <errno.h>
 #include <stdio.h>
@@ -247,8 +248,7 @@ bson_aligned_alloc0(size_t alignment /* IN */, size_t num_bytes /* IN */)
  *
  * Returns:
  *       A pointer if successful; otherwise abort() is called and this
- *       function will never return. In the cases of num_elems = 0 or
- *       integer overflow in num_elems * elem_size, NULL is returned.
+ *       function will never return.
  *
  *--------------------------------------------------------------------------
  */
@@ -257,9 +257,10 @@ void *
 bson_array_alloc(size_t num_elems /* IN */, size_t elem_size /* IN */)
 {
    void *mem = NULL;
-   size_t num_bytes = num_elems * elem_size;
+   size_t num_bytes;
+   BSON_ASSERT(!mlib_mul(&num_bytes, num_elems, elem_size));
 
-   if (BSON_LIKELY(num_bytes) && BSON_LIKELY(num_elems == num_bytes / elem_size)) {
+   if (BSON_LIKELY(num_bytes)) {
       mem = bson_malloc(num_bytes);
    }
    return mem;
@@ -279,8 +280,7 @@ bson_array_alloc(size_t num_elems /* IN */, size_t elem_size /* IN */)
  *
  * Returns:
  *       A pointer if successful; otherwise abort() is called and this
- *       function will never return. In the cases of num_elems = 0 or
- *       integer overflow in num_elems * elem_size, NULL is returned.
+ *       function will never return.
  *
  * Side effects:
  *       None.
@@ -292,9 +292,10 @@ void *
 bson_array_alloc0(size_t num_elems /* IN */, size_t elem_size /* IN */)
 {
    void *mem = NULL;
-   size_t num_bytes = num_elems * elem_size;
+   size_t num_bytes;
+   BSON_ASSERT(!mlib_mul(&num_bytes, num_elems, elem_size));
 
-   if (BSON_LIKELY(num_bytes) && BSON_LIKELY(num_elems == num_bytes / elem_size)) {
+   if (BSON_LIKELY(num_bytes)) {
       if (BSON_UNLIKELY(!(mem = gMemVtable.calloc(num_elems, elem_size)))) {
          fprintf(stderr, "Failure to allocate memory in bson_array_alloc0(). errno: %d.\n", errno);
          abort();

--- a/src/libbson/src/bson/memory.c
+++ b/src/libbson/src/bson/memory.c
@@ -261,7 +261,7 @@ bson_array_alloc(size_t type_size /* IN */, size_t len /* IN */)
    size_t num_bytes = type_size * len;
 
    if (BSON_LIKELY(num_bytes) && BSON_LIKELY(type_size == num_bytes / len)) {
-      mem = bson_aligned_alloc0(BSON_ALIGN_OF(type_size), num_bytes);
+      mem = bson_aligned_alloc0(BSON_ALIGNOF(type_size), num_bytes);
    }
    return mem;
 }

--- a/src/libbson/src/bson/memory.c
+++ b/src/libbson/src/bson/memory.c
@@ -236,8 +236,8 @@ bson_aligned_alloc0(size_t alignment /* IN */, size_t num_bytes /* IN */)
  *
  * bson_array_alloc --
  *
- *       Allocates memory for an array of objects, checking for cases of 
- *       n = 0 and integer overflow in type_size * len, in which case NULL 
+ *       Allocates memory for an array of objects, checking for cases of
+ *       n = 0 and integer overflow in type_size * len, in which case NULL
  *       is returned.
  *
  * Parameters:
@@ -288,7 +288,7 @@ bson_array_alloc(size_t type_size /* IN */, size_t num_elems /* IN */)
  *--------------------------------------------------------------------------
  */
 
- void *
+void *
 bson_array_alloc0(size_t type_size /* IN */, size_t num_elems /* IN */)
 {
    void *mem = NULL;

--- a/src/libbson/src/bson/memory.c
+++ b/src/libbson/src/bson/memory.c
@@ -236,13 +236,13 @@ bson_aligned_alloc0(size_t alignment /* IN */, size_t num_bytes /* IN */)
  *
  * bson_array_alloc --
  *
- *       Allocates zero-filled, aligned memory for an array of objects,
- *       checking for cases of n = 0 and integer overflow in type_size * len,
- *       in which case NULL is returned.
+ *       Allocates memory for an array of objects, checking for cases of 
+ *       n = 0 and integer overflow in type_size * len, in which case NULL 
+ *       is returned.
  *
  * Parameters:
  *       @type_size: The size of each object's type in bytes.
- *       @len: The number of objects to allocate.
+ *       @num_elems: The number of objects to allocate.
  *
  * Returns:
  *       A pointer if successful; otherwise abort() is called and this
@@ -255,13 +255,47 @@ bson_aligned_alloc0(size_t alignment /* IN */, size_t num_bytes /* IN */)
  */
 
 void *
-bson_array_alloc(size_t type_size /* IN */, size_t len /* IN */)
+bson_array_alloc(size_t type_size /* IN */, size_t num_elems /* IN */)
 {
    void *mem = NULL;
-   size_t num_bytes = type_size * len;
+   size_t num_bytes = type_size * num_elems;
 
-   if (BSON_LIKELY(num_bytes) && BSON_LIKELY(type_size == num_bytes / len)) {
-      mem = bson_aligned_alloc0(BSON_ALIGNOF(type_size), num_bytes);
+   if (BSON_LIKELY(num_bytes) && BSON_LIKELY(num_elems == num_bytes / type_size)) {
+      mem = bson_malloc(num_bytes);
+   }
+   return mem;
+}
+
+/*
+ *--------------------------------------------------------------------------
+ *
+ * bson_array_alloc0 --
+ *
+ *       Like bson_array_alloc() except the memory is zeroed after allocation
+ *       for convenience.
+ *
+ * Parameters:
+ *       @type_size: The size of each object's type in bytes.
+ *       @num_elems: The number of objects to allocate.
+ *
+ * Returns:
+ *       A pointer if successful; otherwise abort() is called and this
+ *       function will never return.
+ *
+ * Side effects:
+ *       None.
+ *
+ *--------------------------------------------------------------------------
+ */
+
+ void *
+bson_array_alloc0(size_t type_size /* IN */, size_t num_elems /* IN */)
+{
+   void *mem = NULL;
+   size_t num_bytes = type_size * num_elems;
+
+   if (BSON_LIKELY(num_bytes) && BSON_LIKELY(num_elems == num_bytes / type_size)) {
+      mem = bson_malloc0(num_bytes);
    }
    return mem;
 }

--- a/src/libbson/src/bson/memory.c
+++ b/src/libbson/src/bson/memory.c
@@ -21,8 +21,8 @@
 
 #include <bson/config.h>
 
+#include <mlib/ckdint.h>
 #include <mlib/config.h>
-#include <mlib/timer.h>
 
 #include <errno.h>
 #include <stdio.h>

--- a/src/libbson/src/bson/memory.c
+++ b/src/libbson/src/bson/memory.c
@@ -234,6 +234,42 @@ bson_aligned_alloc0(size_t alignment /* IN */, size_t num_bytes /* IN */)
 /*
  *--------------------------------------------------------------------------
  *
+ * bson_array_alloc --
+ *
+ *       Allocates zero-filled, aligned memory for an array of objects,
+ *       checking for cases of n = 0 and integer overflow in type_size * len,
+ *       in which case NULL is returned.
+ *
+ * Parameters:
+ *       @type_size: The size of each object's type in bytes.
+ *       @len: The number of objects to allocate.
+ *
+ * Returns:
+ *       A pointer if successful; otherwise abort() is called and this
+ *       function will never return.
+ *
+ * Side effects:
+ *       None.
+ *
+ *--------------------------------------------------------------------------
+ */
+
+void *
+bson_array_alloc(size_t type_size /* IN */, size_t len /* IN */)
+{
+   void *mem = NULL;
+   size_t num_bytes = type_size * len;
+
+   if (BSON_LIKELY(num_bytes) && BSON_LIKELY(type_size == num_bytes / len)) {
+      mem = bson_aligned_alloc0(BSON_ALIGN_OF(type_size), num_bytes);
+   }
+   return mem;
+}
+
+
+/*
+ *--------------------------------------------------------------------------
+ *
  * bson_realloc --
  *
  *       This function behaves similar to realloc() except that if there is

--- a/src/libbson/src/bson/memory.h
+++ b/src/libbson/src/bson/memory.h
@@ -48,7 +48,9 @@ bson_aligned_alloc(size_t alignment, size_t num_bytes);
 BSON_EXPORT(void *)
 bson_aligned_alloc0(size_t alignment, size_t num_bytes);
 BSON_EXPORT(void *)
-bson_array_alloc(size_t type_size, size_t len);
+bson_array_alloc(size_t type_size, size_t num_elems);
+BSON_EXPORT(void *)
+bson_array_alloc0(size_t type_size, size_t num_elems);
 BSON_EXPORT(void *)
 bson_realloc(void *mem, size_t num_bytes);
 BSON_EXPORT(void *)

--- a/src/libbson/src/bson/memory.h
+++ b/src/libbson/src/bson/memory.h
@@ -48,9 +48,9 @@ bson_aligned_alloc(size_t alignment, size_t num_bytes);
 BSON_EXPORT(void *)
 bson_aligned_alloc0(size_t alignment, size_t num_bytes);
 BSON_EXPORT(void *)
-bson_array_alloc(size_t type_size, size_t num_elems);
+bson_array_alloc(size_t num_elems, size_t elem_size);
 BSON_EXPORT(void *)
-bson_array_alloc0(size_t type_size, size_t num_elems);
+bson_array_alloc0(size_t num_elems, size_t elem_size);
 BSON_EXPORT(void *)
 bson_realloc(void *mem, size_t num_bytes);
 BSON_EXPORT(void *)
@@ -63,6 +63,8 @@ bson_zero_free(void *mem, size_t size);
 
 #define BSON_ALIGNED_ALLOC(T) ((T *)(bson_aligned_alloc(BSON_ALIGNOF(T), sizeof(T))))
 #define BSON_ALIGNED_ALLOC0(T) ((T *)(bson_aligned_alloc0(BSON_ALIGNOF(T), sizeof(T))))
+#define BSON_ARRAY_ALLOC(N, T) ((T *)(bson_array_alloc(N, sizeof(T))))
+#define BSON_ARRAY_ALLOC0(N, T) ((T *)(bson_array_alloc0(N, sizeof(T))))
 
 BSON_END_DECLS
 

--- a/src/libbson/src/bson/memory.h
+++ b/src/libbson/src/bson/memory.h
@@ -48,6 +48,8 @@ bson_aligned_alloc(size_t alignment, size_t num_bytes);
 BSON_EXPORT(void *)
 bson_aligned_alloc0(size_t alignment, size_t num_bytes);
 BSON_EXPORT(void *)
+bson_array_alloc(size_t type_size, size_t len);
+BSON_EXPORT(void *)
 bson_realloc(void *mem, size_t num_bytes);
 BSON_EXPORT(void *)
 bson_realloc_ctx(void *mem, size_t num_bytes, void *ctx);

--- a/src/libbson/src/jsonsl/jsonsl.c
+++ b/src/libbson/src/jsonsl/jsonsl.c
@@ -1052,9 +1052,9 @@ void jsonsl_jpr_match_state_init(jsonsl_t jsn,
     if (njprs == 0) {
         return;
     }
-    jsn->jprs = (jsonsl_jpr_t *) bson_malloc (sizeof (jsonsl_jpr_t) * njprs);
+    jsn->jprs = (jsonsl_jpr_t *) bson_array_alloc (sizeof (jsonsl_jpr_t), njprs);
     jsn->jpr_count = njprs;
-    jsn->jpr_root = (size_t *) bson_malloc0 (sizeof (size_t) * njprs * jsn->levels_max);
+    jsn->jpr_root = (size_t *) bson_array_alloc (sizeof (size_t), njprs * jsn->levels_max);
     memcpy(jsn->jprs, jprs, sizeof(jsonsl_jpr_t) * njprs);
     /* Set the initial jump table values */
 

--- a/src/libbson/src/jsonsl/jsonsl.c
+++ b/src/libbson/src/jsonsl/jsonsl.c
@@ -1052,9 +1052,9 @@ void jsonsl_jpr_match_state_init(jsonsl_t jsn,
     if (njprs == 0) {
         return;
     }
-    jsn->jprs = (jsonsl_jpr_t *) bson_array_alloc (sizeof (jsonsl_jpr_t), njprs);
+    jsn->jprs = BSON_ARRAY_ALLOC(njprs, jsonsl_jpr_t);
     jsn->jpr_count = njprs;
-    jsn->jpr_root = (size_t *) bson_array_alloc0 (sizeof (size_t), njprs * jsn->levels_max);
+    jsn->jpr_root = BSON_ARRAY_ALLOC0(njprs * jsn->levels_max, size_t);
     memcpy(jsn->jprs, jprs, sizeof(jsonsl_jpr_t) * njprs);
     /* Set the initial jump table values */
 

--- a/src/libbson/src/jsonsl/jsonsl.c
+++ b/src/libbson/src/jsonsl/jsonsl.c
@@ -1054,7 +1054,7 @@ void jsonsl_jpr_match_state_init(jsonsl_t jsn,
     }
     jsn->jprs = (jsonsl_jpr_t *) bson_array_alloc (sizeof (jsonsl_jpr_t), njprs);
     jsn->jpr_count = njprs;
-    jsn->jpr_root = (size_t *) bson_array_alloc (sizeof (size_t), njprs * jsn->levels_max);
+    jsn->jpr_root = (size_t *) bson_array_alloc0 (sizeof (size_t), njprs * jsn->levels_max);
     memcpy(jsn->jprs, jprs, sizeof(jsonsl_jpr_t) * njprs);
     /* Set the initial jump table values */
 

--- a/src/libbson/tests/test-bson-vector.c
+++ b/src/libbson/tests/test-bson-vector.c
@@ -920,8 +920,8 @@ test_bson_vector_view_api_fuzz_int8(void)
 {
    size_t current_length = 0;
    bson_t vector_doc = BSON_INITIALIZER;
-   int8_t *expected_elements = bson_malloc(MAX_TESTED_VECTOR_LENGTH * sizeof *expected_elements);
-   int8_t *actual_elements = bson_malloc(MAX_TESTED_VECTOR_LENGTH * sizeof *actual_elements);
+   int8_t *expected_elements = bson_array_alloc(sizeof *expected_elements, MAX_TESTED_VECTOR_LENGTH);
+   int8_t *actual_elements = bson_array_alloc(sizeof *actual_elements, MAX_TESTED_VECTOR_LENGTH);
    for (int fuzz_iter = 0; fuzz_iter < FUZZ_TEST_ITERS; fuzz_iter++) {
       unsigned r = (unsigned)rand();
       unsigned r_operation = r & 0xFu;
@@ -974,8 +974,8 @@ test_bson_vector_view_api_fuzz_float32(void)
 {
    size_t current_length = 0;
    bson_t vector_doc = BSON_INITIALIZER;
-   float *expected_elements = bson_malloc(MAX_TESTED_VECTOR_LENGTH * sizeof *expected_elements);
-   float *actual_elements = bson_malloc(MAX_TESTED_VECTOR_LENGTH * sizeof *actual_elements);
+   float *expected_elements = bson_array_alloc(sizeof *expected_elements, MAX_TESTED_VECTOR_LENGTH);
+   float *actual_elements = bson_array_alloc(sizeof *actual_elements, MAX_TESTED_VECTOR_LENGTH);
    for (int fuzz_iter = 0; fuzz_iter < FUZZ_TEST_ITERS; fuzz_iter++) {
       unsigned r = (unsigned)rand();
       unsigned r_operation = r & 0xFu;
@@ -1028,8 +1028,8 @@ test_bson_vector_view_api_fuzz_packed_bit(void)
 {
    size_t current_length = 0;
    bson_t vector_doc = BSON_INITIALIZER;
-   bool *expected_elements = bson_malloc(MAX_TESTED_VECTOR_LENGTH * sizeof *expected_elements);
-   bool *actual_elements = bson_malloc(MAX_TESTED_VECTOR_LENGTH * sizeof *actual_elements);
+   bool *expected_elements = bson_array_alloc(sizeof *expected_elements, MAX_TESTED_VECTOR_LENGTH);
+   bool *actual_elements = bson_array_alloc(sizeof *actual_elements, MAX_TESTED_VECTOR_LENGTH);
    uint8_t *packed_buffer = bson_malloc((MAX_TESTED_VECTOR_LENGTH + 7) / 8);
    for (int fuzz_iter = 0; fuzz_iter < FUZZ_TEST_ITERS; fuzz_iter++) {
       unsigned r = (unsigned)rand();
@@ -1392,7 +1392,7 @@ test_bson_vector_edge_cases_int8(void)
    // Test some read and write boundaries.
    {
       size_t values_size = 100;
-      int8_t *values = bson_malloc0(values_size * sizeof *values);
+      int8_t *values = bson_array_alloc(sizeof *values, values_size);
       TEST_BSON_VECTOR_EDGE_CASES_RW_COMMON(
          view, max_alloc_elements, values, values_size, bson_vector_int8_view_read, bson_vector_int8_view_write);
       bson_free(values);
@@ -1439,7 +1439,7 @@ test_bson_vector_edge_cases_float32(void)
    // Test some read and write boundaries.
    {
       size_t values_size = 100;
-      float *values = bson_malloc0(values_size * sizeof *values);
+      float *values = bson_array_alloc(sizeof *values, values_size);
       TEST_BSON_VECTOR_EDGE_CASES_RW_COMMON(
          view, max_alloc_elements, values, values_size, bson_vector_float32_view_read, bson_vector_float32_view_write);
       bson_free(values);
@@ -1506,7 +1506,7 @@ test_bson_vector_edge_cases_packed_bit(void)
    // Only tests one length, but it's chosen to be greater than 8 and not a multiple of 8.
    {
       size_t values_size = 190;
-      bool *values = bson_malloc0(values_size * sizeof *values);
+      bool *values = bson_array_alloc(sizeof *values, values_size);
       TEST_BSON_VECTOR_EDGE_CASES_RW_COMMON(view,
                                             max_alloc_elements,
                                             values,

--- a/src/libbson/tests/test-bson-vector.c
+++ b/src/libbson/tests/test-bson-vector.c
@@ -920,8 +920,8 @@ test_bson_vector_view_api_fuzz_int8(void)
 {
    size_t current_length = 0;
    bson_t vector_doc = BSON_INITIALIZER;
-   int8_t *expected_elements = bson_array_alloc(sizeof *expected_elements, MAX_TESTED_VECTOR_LENGTH);
-   int8_t *actual_elements = bson_array_alloc(sizeof *actual_elements, MAX_TESTED_VECTOR_LENGTH);
+   int8_t *expected_elements = BSON_ARRAY_ALLOC(MAX_TESTED_VECTOR_LENGTH, int8_t);
+   int8_t *actual_elements = BSON_ARRAY_ALLOC(MAX_TESTED_VECTOR_LENGTH, int8_t);
    for (int fuzz_iter = 0; fuzz_iter < FUZZ_TEST_ITERS; fuzz_iter++) {
       unsigned r = (unsigned)rand();
       unsigned r_operation = r & 0xFu;
@@ -974,8 +974,8 @@ test_bson_vector_view_api_fuzz_float32(void)
 {
    size_t current_length = 0;
    bson_t vector_doc = BSON_INITIALIZER;
-   float *expected_elements = bson_array_alloc(sizeof *expected_elements, MAX_TESTED_VECTOR_LENGTH);
-   float *actual_elements = bson_array_alloc(sizeof *actual_elements, MAX_TESTED_VECTOR_LENGTH);
+   float *expected_elements = BSON_ARRAY_ALLOC(MAX_TESTED_VECTOR_LENGTH, float);
+   float *actual_elements = BSON_ARRAY_ALLOC(MAX_TESTED_VECTOR_LENGTH, float);
    for (int fuzz_iter = 0; fuzz_iter < FUZZ_TEST_ITERS; fuzz_iter++) {
       unsigned r = (unsigned)rand();
       unsigned r_operation = r & 0xFu;
@@ -1028,8 +1028,8 @@ test_bson_vector_view_api_fuzz_packed_bit(void)
 {
    size_t current_length = 0;
    bson_t vector_doc = BSON_INITIALIZER;
-   bool *expected_elements = bson_array_alloc(sizeof *expected_elements, MAX_TESTED_VECTOR_LENGTH);
-   bool *actual_elements = bson_array_alloc(sizeof *actual_elements, MAX_TESTED_VECTOR_LENGTH);
+   bool *expected_elements = BSON_ARRAY_ALLOC(MAX_TESTED_VECTOR_LENGTH, bool);
+   bool *actual_elements = BSON_ARRAY_ALLOC(MAX_TESTED_VECTOR_LENGTH, bool);
    uint8_t *packed_buffer = bson_malloc((MAX_TESTED_VECTOR_LENGTH + 7) / 8);
    for (int fuzz_iter = 0; fuzz_iter < FUZZ_TEST_ITERS; fuzz_iter++) {
       unsigned r = (unsigned)rand();
@@ -1392,7 +1392,7 @@ test_bson_vector_edge_cases_int8(void)
    // Test some read and write boundaries.
    {
       size_t values_size = 100;
-      int8_t *values = bson_array_alloc0(sizeof *values, values_size);
+      int8_t *values = BSON_ARRAY_ALLOC0(values_size, int8_t);
       TEST_BSON_VECTOR_EDGE_CASES_RW_COMMON(
          view, max_alloc_elements, values, values_size, bson_vector_int8_view_read, bson_vector_int8_view_write);
       bson_free(values);
@@ -1439,7 +1439,7 @@ test_bson_vector_edge_cases_float32(void)
    // Test some read and write boundaries.
    {
       size_t values_size = 100;
-      float *values = bson_array_alloc0(sizeof *values, values_size);
+      float *values = BSON_ARRAY_ALLOC0(values_size, float);
       TEST_BSON_VECTOR_EDGE_CASES_RW_COMMON(
          view, max_alloc_elements, values, values_size, bson_vector_float32_view_read, bson_vector_float32_view_write);
       bson_free(values);
@@ -1506,7 +1506,7 @@ test_bson_vector_edge_cases_packed_bit(void)
    // Only tests one length, but it's chosen to be greater than 8 and not a multiple of 8.
    {
       size_t values_size = 190;
-      bool *values = bson_array_alloc0(sizeof *values, values_size);
+      bool *values = BSON_ARRAY_ALLOC0(values_size, bool);
       TEST_BSON_VECTOR_EDGE_CASES_RW_COMMON(view,
                                             max_alloc_elements,
                                             values,

--- a/src/libbson/tests/test-bson-vector.c
+++ b/src/libbson/tests/test-bson-vector.c
@@ -1392,7 +1392,7 @@ test_bson_vector_edge_cases_int8(void)
    // Test some read and write boundaries.
    {
       size_t values_size = 100;
-      int8_t *values = bson_array_alloc(sizeof *values, values_size);
+      int8_t *values = bson_array_alloc0(sizeof *values, values_size);
       TEST_BSON_VECTOR_EDGE_CASES_RW_COMMON(
          view, max_alloc_elements, values, values_size, bson_vector_int8_view_read, bson_vector_int8_view_write);
       bson_free(values);
@@ -1439,7 +1439,7 @@ test_bson_vector_edge_cases_float32(void)
    // Test some read and write boundaries.
    {
       size_t values_size = 100;
-      float *values = bson_array_alloc(sizeof *values, values_size);
+      float *values = bson_array_alloc0(sizeof *values, values_size);
       TEST_BSON_VECTOR_EDGE_CASES_RW_COMMON(
          view, max_alloc_elements, values, values_size, bson_vector_float32_view_read, bson_vector_float32_view_write);
       bson_free(values);
@@ -1506,7 +1506,7 @@ test_bson_vector_edge_cases_packed_bit(void)
    // Only tests one length, but it's chosen to be greater than 8 and not a multiple of 8.
    {
       size_t values_size = 190;
-      bool *values = bson_array_alloc(sizeof *values, values_size);
+      bool *values = bson_array_alloc0(sizeof *values, values_size);
       TEST_BSON_VECTOR_EDGE_CASES_RW_COMMON(view,
                                             max_alloc_elements,
                                             values,

--- a/src/libbson/tests/test-bson.c
+++ b/src/libbson/tests/test-bson.c
@@ -125,6 +125,25 @@ test_bson_alloc(void)
 
 
 static void
+test_bson_array_alloc(void) 
+{
+   // Can allocate an array of items:
+   {
+      int *arr = BSON_ARRAY_ALLOC(2, int);
+      arr[0] = 1;
+      arr[1] = 2;
+      bson_free(arr);
+   }
+
+   // Allocating with overflow in byte size aborts:
+   mlib_assert_aborts () {
+      int *arr = BSON_ARRAY_ALLOC(SIZE_MAX, int);
+      bson_free(arr);
+   }
+}
+
+
+static void
 BSON_ASSERT_BSON_EQUAL(const bson_t *a, const bson_t *b)
 {
    const uint8_t *data1 = bson_get_data(a);
@@ -2971,6 +2990,7 @@ test_bson_install(TestSuite *suite)
    TestSuite_Add(suite, "/bson/init", test_bson_init);
    TestSuite_Add(suite, "/bson/init_static", test_bson_init_static);
    TestSuite_Add(suite, "/bson/basic", test_bson_alloc);
+   TestSuite_Add(suite, "/bson/basic_array_alloc", test_bson_array_alloc);
    TestSuite_Add(suite, "/bson/append_overflow", test_bson_append_overflow);
    TestSuite_Add(suite, "/bson/append_array", test_bson_append_array);
    TestSuite_Add(suite, "/bson/append_binary", test_bson_append_binary);

--- a/src/libmongoc/src/mongoc/mcd-rpc.c
+++ b/src/libmongoc/src/mongoc/mcd-rpc.c
@@ -957,7 +957,7 @@ _append_iovec_reserve_space_for(mongoc_iovec_t **iovecs,
    BSON_ASSERT(*capacity == 4u);
 
    *capacity += additional_capacity;
-   *iovecs = bson_array_alloc(sizeof(mongoc_iovec_t), *capacity);
+   *iovecs = BSON_ARRAY_ALLOC(*capacity, mongoc_iovec_t);
    memcpy(*iovecs, header_iovecs, 4u * sizeof(mongoc_iovec_t));
 }
 

--- a/src/libmongoc/src/mongoc/mcd-rpc.c
+++ b/src/libmongoc/src/mongoc/mcd-rpc.c
@@ -957,7 +957,7 @@ _append_iovec_reserve_space_for(mongoc_iovec_t **iovecs,
    BSON_ASSERT(*capacity == 4u);
 
    *capacity += additional_capacity;
-   *iovecs = bson_malloc(*capacity * sizeof(mongoc_iovec_t));
+   *iovecs = bson_array_alloc(sizeof(mongoc_iovec_t), *capacity);
    memcpy(*iovecs, header_iovecs, 4u * sizeof(mongoc_iovec_t));
 }
 

--- a/src/libmongoc/src/mongoc/mongoc-async-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-async-cmd.c
@@ -339,7 +339,7 @@ _mongoc_async_cmd_phase_send(mongoc_async_cmd_t *acmd)
 
       /* create a new iovec with the remaining data to be written. */
       niovec = acmd->niovec - i;
-      iovec = bson_array_alloc(sizeof(mongoc_iovec_t), niovec);
+      iovec = BSON_ARRAY_ALLOC(niovec, mongoc_iovec_t);
       memcpy(iovec, acmd->iovec + i, niovec * sizeof(mongoc_iovec_t));
       iovec[0].iov_base = (char *)iovec[0].iov_base + offset;
       iovec[0].iov_len -= offset;

--- a/src/libmongoc/src/mongoc/mongoc-async-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-async-cmd.c
@@ -339,7 +339,7 @@ _mongoc_async_cmd_phase_send(mongoc_async_cmd_t *acmd)
 
       /* create a new iovec with the remaining data to be written. */
       niovec = acmd->niovec - i;
-      iovec = bson_malloc(niovec * sizeof(mongoc_iovec_t));
+      iovec = bson_array_alloc(sizeof(mongoc_iovec_t), niovec);
       memcpy(iovec, acmd->iovec + i, niovec * sizeof(mongoc_iovec_t));
       iovec[0].iov_base = (char *)iovec[0].iov_base + offset;
       iovec[0].iov_len -= offset;

--- a/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
@@ -409,7 +409,7 @@ mongoc_client_encryption_datakey_opts_set_keyaltnames(mongoc_client_encryption_d
    BSON_ASSERT(!opts->keyaltnames);
 
    if (keyaltnames_count) {
-      opts->keyaltnames = bson_array_alloc(sizeof(char *), keyaltnames_count);
+      opts->keyaltnames = BSON_ARRAY_ALLOC(keyaltnames_count, char *);
       for (uint32_t i = 0u; i < keyaltnames_count; i++) {
          opts->keyaltnames[i] = bson_strdup(keyaltnames[i]);
       }
@@ -1601,7 +1601,7 @@ _spawn_mongocryptd(const char *mongocryptd_spawn_path, const bson_t *mongocryptd
       num_args++;
    }
 
-   args = (char **)bson_array_alloc(sizeof(char *), num_args);
+   args = BSON_ARRAY_ALLOC(num_args, char *);
    i = 0;
    args[i++] = "mongocryptd";
 

--- a/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-side-encryption.c
@@ -409,7 +409,7 @@ mongoc_client_encryption_datakey_opts_set_keyaltnames(mongoc_client_encryption_d
    BSON_ASSERT(!opts->keyaltnames);
 
    if (keyaltnames_count) {
-      opts->keyaltnames = bson_malloc(sizeof(char *) * keyaltnames_count);
+      opts->keyaltnames = bson_array_alloc(sizeof(char *), keyaltnames_count);
       for (uint32_t i = 0u; i < keyaltnames_count; i++) {
          opts->keyaltnames[i] = bson_strdup(keyaltnames[i]);
       }
@@ -1601,7 +1601,7 @@ _spawn_mongocryptd(const char *mongocryptd_spawn_path, const bson_t *mongocryptd
       num_args++;
    }
 
-   args = (char **)bson_malloc(sizeof(char *) * num_args);
+   args = (char **)bson_array_alloc(sizeof(char *), num_args);
    i = 0;
    args[i++] = "mongocryptd";
 

--- a/src/libmongoc/src/mongoc/mongoc-cluster-sspi.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-sspi.c
@@ -65,7 +65,7 @@ _mongoc_cluster_sspi_new(mongoc_uri_t *uri, mongoc_stream_t *stream, const char 
    service_ascii_len = strlen(service_ascii);
 
    /* this is donated to the sspi */
-   service = bson_array_alloc(sizeof(WCHAR), (service_ascii_len + 1));
+   service = bson_array_alloc0(sizeof(WCHAR), (service_ascii_len + 1));
    service_len =
       MultiByteToWideChar(CP_UTF8, 0, service_ascii, (int)service_ascii_len, service, (int)service_ascii_len);
    service[service_len] = L'\0';
@@ -75,7 +75,7 @@ _mongoc_cluster_sspi_new(mongoc_uri_t *uri, mongoc_stream_t *stream, const char 
       tmp_creds_len = strlen(state->sasl.pass);
 
       /* this is donated to the sspi */
-      pass = bson_array_alloc(sizeof(WCHAR), (tmp_creds_len + 1));
+      pass = bson_array_alloc0(sizeof(WCHAR), (tmp_creds_len + 1));
       pass_len = MultiByteToWideChar(CP_UTF8, 0, state->sasl.pass, (int)tmp_creds_len, pass, (int)tmp_creds_len);
       pass[pass_len] = L'\0';
    }
@@ -84,7 +84,7 @@ _mongoc_cluster_sspi_new(mongoc_uri_t *uri, mongoc_stream_t *stream, const char 
       tmp_creds_len = strlen(state->sasl.user);
 
       /* this is donated to the sspi */
-      user = bson_array_alloc(sizeof(WCHAR), (tmp_creds_len + 1));
+      user = bson_array_alloc0(sizeof(WCHAR), (tmp_creds_len + 1));
       user_len = MultiByteToWideChar(CP_UTF8, 0, state->sasl.user, (int)tmp_creds_len, user, (int)tmp_creds_len);
       user[user_len] = L'\0';
    }

--- a/src/libmongoc/src/mongoc/mongoc-cluster-sspi.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-sspi.c
@@ -65,7 +65,7 @@ _mongoc_cluster_sspi_new(mongoc_uri_t *uri, mongoc_stream_t *stream, const char 
    service_ascii_len = strlen(service_ascii);
 
    /* this is donated to the sspi */
-   service = bson_array_alloc0(sizeof(WCHAR), (service_ascii_len + 1));
+   service = BSON_ARRAY_ALLOC0((service_ascii_len + 1), WCHAR);
    service_len =
       MultiByteToWideChar(CP_UTF8, 0, service_ascii, (int)service_ascii_len, service, (int)service_ascii_len);
    service[service_len] = L'\0';
@@ -75,7 +75,7 @@ _mongoc_cluster_sspi_new(mongoc_uri_t *uri, mongoc_stream_t *stream, const char 
       tmp_creds_len = strlen(state->sasl.pass);
 
       /* this is donated to the sspi */
-      pass = bson_array_alloc0(sizeof(WCHAR), (tmp_creds_len + 1));
+      pass = BSON_ARRAY_ALLOC0((tmp_creds_len + 1), WCHAR);
       pass_len = MultiByteToWideChar(CP_UTF8, 0, state->sasl.pass, (int)tmp_creds_len, pass, (int)tmp_creds_len);
       pass[pass_len] = L'\0';
    }
@@ -84,7 +84,7 @@ _mongoc_cluster_sspi_new(mongoc_uri_t *uri, mongoc_stream_t *stream, const char 
       tmp_creds_len = strlen(state->sasl.user);
 
       /* this is donated to the sspi */
-      user = bson_array_alloc0(sizeof(WCHAR), (tmp_creds_len + 1));
+      user = BSON_ARRAY_ALLOC0((tmp_creds_len + 1), WCHAR);
       user_len = MultiByteToWideChar(CP_UTF8, 0, state->sasl.user, (int)tmp_creds_len, user, (int)tmp_creds_len);
       user[user_len] = L'\0';
    }
@@ -222,7 +222,7 @@ _mongoc_cluster_auth_node_sspi(mongoc_cluster_t *cluster,
 
       tmpstr = bson_iter_utf8(&iter, &buflen);
       bson_free(buf);
-      buf = bson_array_alloc(sizeof(SEC_CHAR), (buflen + 1));
+      buf = BSON_ARRAY_ALLOC((buflen + 1), SEC_CHAR);
       memcpy(buf, tmpstr, buflen);
       buf[buflen] = (SEC_CHAR)0;
 

--- a/src/libmongoc/src/mongoc/mongoc-cluster-sspi.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-sspi.c
@@ -65,7 +65,7 @@ _mongoc_cluster_sspi_new(mongoc_uri_t *uri, mongoc_stream_t *stream, const char 
    service_ascii_len = strlen(service_ascii);
 
    /* this is donated to the sspi */
-   service = bson_malloc0((service_ascii_len + 1) * sizeof(WCHAR));
+   service = bson_array_alloc(sizeof(WCHAR), (service_ascii_len + 1));
    service_len =
       MultiByteToWideChar(CP_UTF8, 0, service_ascii, (int)service_ascii_len, service, (int)service_ascii_len);
    service[service_len] = L'\0';
@@ -75,7 +75,7 @@ _mongoc_cluster_sspi_new(mongoc_uri_t *uri, mongoc_stream_t *stream, const char 
       tmp_creds_len = strlen(state->sasl.pass);
 
       /* this is donated to the sspi */
-      pass = bson_malloc0((tmp_creds_len + 1) * sizeof(WCHAR));
+      pass = bson_array_alloc(sizeof(WCHAR), (tmp_creds_len + 1));
       pass_len = MultiByteToWideChar(CP_UTF8, 0, state->sasl.pass, (int)tmp_creds_len, pass, (int)tmp_creds_len);
       pass[pass_len] = L'\0';
    }
@@ -84,7 +84,7 @@ _mongoc_cluster_sspi_new(mongoc_uri_t *uri, mongoc_stream_t *stream, const char 
       tmp_creds_len = strlen(state->sasl.user);
 
       /* this is donated to the sspi */
-      user = bson_malloc0((tmp_creds_len + 1) * sizeof(WCHAR));
+      user = bson_array_alloc(sizeof(WCHAR), (tmp_creds_len + 1));
       user_len = MultiByteToWideChar(CP_UTF8, 0, state->sasl.user, (int)tmp_creds_len, user, (int)tmp_creds_len);
       user[user_len] = L'\0';
    }
@@ -222,7 +222,7 @@ _mongoc_cluster_auth_node_sspi(mongoc_cluster_t *cluster,
 
       tmpstr = bson_iter_utf8(&iter, &buflen);
       bson_free(buf);
-      buf = bson_malloc(sizeof(SEC_CHAR) * (buflen + 1));
+      buf = bson_array_alloc(sizeof(SEC_CHAR), (buflen + 1));
       memcpy(buf, tmpstr, buflen);
       buf[buflen] = (SEC_CHAR)0;
 

--- a/src/libmongoc/src/mongoc/mongoc-scram.c
+++ b/src/libmongoc/src/mongoc/mongoc-scram.c
@@ -1026,7 +1026,7 @@ _mongoc_sasl_prep_impl(const char *name, const char *in_utf8, bson_error_t *err)
 
    /* convert to unicode. */
    BSON_ASSERT(mlib_cmp(num_chars, <=, SIZE_MAX / sizeof(uint32_t) - 1));
-   utf8_codepoints = bson_array_alloc(sizeof(uint32_t), ((size_t)num_chars + 1u)); /* add one for trailing 0 value. */
+   utf8_codepoints = BSON_ARRAY_ALLOC(((size_t)num_chars + 1u), uint32_t); /* add one for trailing 0 value. */
    const char *c = in_utf8;
 
    mlib_foreach_irange (i, num_chars) {
@@ -1083,7 +1083,7 @@ _mongoc_sasl_prep_impl(const char *name, const char *in_utf8, bson_error_t *err)
          utf8_pre_norm_len += len;
       }
    }
-   char *utf8_pre_norm = (char *)bson_array_alloc(sizeof(char), (utf8_pre_norm_len + 1));
+   char *utf8_pre_norm = BSON_ARRAY_ALLOC((utf8_pre_norm_len + 1), char);
 
    char *loc = utf8_pre_norm;
    mlib_foreach_irange (i, num_chars) {

--- a/src/libmongoc/src/mongoc/mongoc-scram.c
+++ b/src/libmongoc/src/mongoc/mongoc-scram.c
@@ -1026,7 +1026,7 @@ _mongoc_sasl_prep_impl(const char *name, const char *in_utf8, bson_error_t *err)
 
    /* convert to unicode. */
    BSON_ASSERT(mlib_cmp(num_chars, <=, SIZE_MAX / sizeof(uint32_t) - 1));
-   utf8_codepoints = bson_malloc(sizeof(uint32_t) * ((size_t)num_chars + 1u)); /* add one for trailing 0 value. */
+   utf8_codepoints = bson_array_alloc(sizeof(uint32_t), ((size_t)num_chars + 1u)); /* add one for trailing 0 value. */
    const char *c = in_utf8;
 
    mlib_foreach_irange (i, num_chars) {
@@ -1083,7 +1083,7 @@ _mongoc_sasl_prep_impl(const char *name, const char *in_utf8, bson_error_t *err)
          utf8_pre_norm_len += len;
       }
    }
-   char *utf8_pre_norm = (char *)bson_malloc(sizeof(char) * (utf8_pre_norm_len + 1));
+   char *utf8_pre_norm = (char *)bson_array_alloc(sizeof(char), (utf8_pre_norm_len + 1));
 
    char *loc = utf8_pre_norm;
    mlib_foreach_irange (i, num_chars) {

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -233,7 +233,7 @@ utf8_to_wide(const char *utf8)
    }
 
    // Since -1 was passed as the input length, the returned character count includes space for the null character.
-   WCHAR *wide_chars = bson_malloc(sizeof(WCHAR) * required_wide_chars);
+   WCHAR *wide_chars = bson_array_alloc(sizeof(WCHAR), required_wide_chars);
    if (0 == MultiByteToWideChar(CP_UTF8, 0, utf8, -1 /* NULL terminated */, wide_chars, required_wide_chars)) {
       bson_free(wide_chars);
       return NULL;

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -233,7 +233,7 @@ utf8_to_wide(const char *utf8)
    }
 
    // Since -1 was passed as the input length, the returned character count includes space for the null character.
-   WCHAR *wide_chars = bson_array_alloc(sizeof(WCHAR), required_wide_chars);
+   WCHAR *wide_chars = BSON_ARRAY_ALLOC(required_wide_chars, WCHAR);
    if (0 == MultiByteToWideChar(CP_UTF8, 0, utf8, -1 /* NULL terminated */, wide_chars, required_wide_chars)) {
       bson_free(wide_chars);
       return NULL;

--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -987,7 +987,7 @@ mongoc_server_description_filter_tags(const mongoc_server_description_t **descri
       return;
    }
 
-   sd_matched = (bool *)bson_array_alloc0(sizeof(bool), description_len);
+   sd_matched = BSON_ARRAY_ALLOC0(description_len, bool);
 
    bson_iter_init(&rp_tagset_iter, rp_tags);
 

--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -987,7 +987,7 @@ mongoc_server_description_filter_tags(const mongoc_server_description_t **descri
       return;
    }
 
-   sd_matched = (bool *)bson_array_alloc(sizeof(bool), description_len);
+   sd_matched = (bool *)bson_array_alloc0(sizeof(bool), description_len);
 
    bson_iter_init(&rp_tagset_iter, rp_tags);
 

--- a/src/libmongoc/src/mongoc/mongoc-server-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-description.c
@@ -987,7 +987,7 @@ mongoc_server_description_filter_tags(const mongoc_server_description_t **descri
       return;
    }
 
-   sd_matched = (bool *)bson_malloc0(sizeof(bool) * description_len);
+   sd_matched = (bool *)bson_array_alloc(sizeof(bool), description_len);
 
    bson_iter_init(&rp_tagset_iter, rp_tags);
 

--- a/src/libmongoc/src/mongoc/mongoc-set.c
+++ b/src/libmongoc/src/mongoc/mongoc-set.c
@@ -27,7 +27,7 @@ mongoc_set_new(size_t nitems, mongoc_set_item_dtor dtor, void *dtor_ctx)
    mongoc_set_t *set = (mongoc_set_t *)bson_malloc(sizeof(*set));
 
    set->items_allocated = BSON_MAX(nitems, 1);
-   set->items = (mongoc_set_item_t *)bson_malloc(sizeof(*set->items) * set->items_allocated);
+   set->items = (mongoc_set_item_t *)bson_array_alloc(sizeof(*set->items), set->items_allocated);
    set->items_len = 0;
 
    set->dtor = dtor;
@@ -208,7 +208,7 @@ mongoc_set_for_each_with_id(mongoc_set_t *set, mongoc_set_for_each_with_id_cb_t 
       return;
    }
 
-   mongoc_set_item_t *const old_set = bson_malloc(sizeof(*old_set) * items_len);
+   mongoc_set_item_t *const old_set = bson_array_alloc(sizeof(*old_set), items_len);
    memcpy(old_set, set->items, sizeof(*old_set) * items_len);
 
    for (uint32_t i = 0u; i < items_len; i++) {
@@ -237,7 +237,7 @@ mongoc_set_for_each_with_id_const(const mongoc_set_t *set, mongoc_set_for_each_w
       return;
    }
 
-   mongoc_set_item_t *const old_set = bson_malloc(sizeof(*old_set) * items_len);
+   mongoc_set_item_t *const old_set = bson_array_alloc(sizeof(*old_set), items_len);
    memcpy(old_set, set->items, sizeof(*old_set) * items_len);
 
    for (uint32_t i = 0u; i < items_len; i++) {

--- a/src/libmongoc/src/mongoc/mongoc-set.c
+++ b/src/libmongoc/src/mongoc/mongoc-set.c
@@ -27,7 +27,7 @@ mongoc_set_new(size_t nitems, mongoc_set_item_dtor dtor, void *dtor_ctx)
    mongoc_set_t *set = (mongoc_set_t *)bson_malloc(sizeof(*set));
 
    set->items_allocated = BSON_MAX(nitems, 1);
-   set->items = (mongoc_set_item_t *)bson_array_alloc(sizeof(*set->items), set->items_allocated);
+   set->items = BSON_ARRAY_ALLOC(set->items_allocated, mongoc_set_item_t);
    set->items_len = 0;
 
    set->dtor = dtor;
@@ -208,7 +208,7 @@ mongoc_set_for_each_with_id(mongoc_set_t *set, mongoc_set_for_each_with_id_cb_t 
       return;
    }
 
-   mongoc_set_item_t *const old_set = bson_array_alloc(sizeof(*old_set), items_len);
+   mongoc_set_item_t *const old_set = BSON_ARRAY_ALLOC(items_len, mongoc_set_item_t);
    memcpy(old_set, set->items, sizeof(*old_set) * items_len);
 
    for (uint32_t i = 0u; i < items_len; i++) {
@@ -237,7 +237,7 @@ mongoc_set_for_each_with_id_const(const mongoc_set_t *set, mongoc_set_for_each_w
       return;
    }
 
-   mongoc_set_item_t *const old_set = bson_array_alloc(sizeof(*old_set), items_len);
+   mongoc_set_item_t *const old_set = BSON_ARRAY_ALLOC(items_len, mongoc_set_item_t);
    memcpy(old_set, set->items, sizeof(*old_set) * items_len);
 
    for (uint32_t i = 0u; i < items_len; i++) {

--- a/src/libmongoc/src/mongoc/mongoc-socket.c
+++ b/src/libmongoc/src/mongoc/mongoc-socket.c
@@ -336,7 +336,7 @@ mongoc_socket_poll(mongoc_socket_poll_t *sds, /* IN */
       }
    }
 #else
-   pfds = (struct pollfd *)bson_array_alloc(sizeof(*pfds), nsds);
+   pfds = BSON_ARRAY_ALLOC(nsds, struct pollfd);
 
    for (size_t i = 0u; i < nsds; i++) {
       pfds[i].fd = sds[i].socket->sd;
@@ -1349,7 +1349,7 @@ mongoc_socket_sendv(mongoc_socket_t *sock,  /* IN */
    BSON_ASSERT(in_iov);
    BSON_ASSERT(iovcnt);
 
-   iov = bson_array_alloc(sizeof(*iov), iovcnt);
+   iov = BSON_ARRAY_ALLOC(iovcnt, mongoc_iovec_t);
    memcpy(iov, in_iov, sizeof(*iov) * iovcnt);
 
    for (;;) {

--- a/src/libmongoc/src/mongoc/mongoc-socket.c
+++ b/src/libmongoc/src/mongoc/mongoc-socket.c
@@ -336,7 +336,7 @@ mongoc_socket_poll(mongoc_socket_poll_t *sds, /* IN */
       }
    }
 #else
-   pfds = (struct pollfd *)bson_malloc(sizeof(*pfds) * nsds);
+   pfds = (struct pollfd *)bson_array_alloc(sizeof(*pfds), nsds);
 
    for (size_t i = 0u; i < nsds; i++) {
       pfds[i].fd = sds[i].socket->sd;
@@ -1349,7 +1349,7 @@ mongoc_socket_sendv(mongoc_socket_t *sock,  /* IN */
    BSON_ASSERT(in_iov);
    BSON_ASSERT(iovcnt);
 
-   iov = bson_malloc(sizeof(*iov) * iovcnt);
+   iov = bson_array_alloc(sizeof(*iov), iovcnt);
    memcpy(iov, in_iov, sizeof(*iov) * iovcnt);
 
    for (;;) {

--- a/src/libmongoc/src/mongoc/mongoc-sspi.c
+++ b/src/libmongoc/src/mongoc/mongoc-sspi.c
@@ -69,7 +69,7 @@ _mongoc_sspi_base64_encode(const SEC_CHAR *value, DWORD vlen)
    DWORD len;
    /* Get the correct size for the out buffer. */
    if (CryptBinaryToStringA((BYTE *)value, vlen, CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, NULL, &len)) {
-      out = (SEC_CHAR *)bson_array_alloc(sizeof(SEC_CHAR), len);
+      out = BSON_ARRAY_ALLOC(len, SEC_CHAR);
       if (out) {
          /* Encode to the out buffer. */
          if (CryptBinaryToStringA((BYTE *)value, vlen, CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, out, &len)) {
@@ -89,7 +89,7 @@ _mongoc_sspi_base64_decode(const SEC_CHAR *value, DWORD *rlen)
    SEC_CHAR *out = NULL;
    /* Get the correct size for the out buffer. */
    if (CryptStringToBinaryA(value, 0, CRYPT_STRING_BASE64, NULL, rlen, NULL, NULL)) {
-      out = (SEC_CHAR *)bson_array_alloc(sizeof(SEC_CHAR), *rlen);
+      out = BSON_ARRAY_ALLOC(*rlen, SEC_CHAR);
       if (out) {
          /* Decode to the out buffer. */
          if (CryptStringToBinaryA(value, 0, CRYPT_STRING_BASE64, (BYTE *)out, rlen, NULL, NULL)) {
@@ -109,7 +109,7 @@ _mongoc_sspi_wide_to_utf8(WCHAR *value)
    CHAR *out;
    int len = WideCharToMultiByte(CP_UTF8, 0, value, -1, NULL, 0, NULL, NULL);
    if (len) {
-      out = (CHAR *)bson_array_alloc(sizeof(CHAR), len);
+      out = BSON_ARRAY_ALLOC(len, CHAR);
       if (WideCharToMultiByte(CP_UTF8, 0, value, -1, out, len, NULL, NULL)) {
          return out;
       } else {
@@ -438,7 +438,7 @@ _mongoc_sspi_auth_sspi_client_wrap(
    }
 
    outbufSize = wrapBufs[0].cbBuffer + wrapBufs[1].cbBuffer + wrapBufs[2].cbBuffer;
-   outbuf = (SEC_CHAR *)bson_array_alloc(sizeof(SEC_CHAR), outbufSize);
+   outbuf = BSON_ARRAY_ALLOC(outbufSize, SEC_CHAR);
    memcpy_s(outbuf, outbufSize, wrapBufs[0].pvBuffer, wrapBufs[0].cbBuffer);
    memcpy_s(
       outbuf + wrapBufs[0].cbBuffer, outbufSize - wrapBufs[0].cbBuffer, wrapBufs[1].pvBuffer, wrapBufs[1].cbBuffer);

--- a/src/libmongoc/src/mongoc/mongoc-sspi.c
+++ b/src/libmongoc/src/mongoc/mongoc-sspi.c
@@ -69,7 +69,7 @@ _mongoc_sspi_base64_encode(const SEC_CHAR *value, DWORD vlen)
    DWORD len;
    /* Get the correct size for the out buffer. */
    if (CryptBinaryToStringA((BYTE *)value, vlen, CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, NULL, &len)) {
-      out = (SEC_CHAR *)bson_malloc(sizeof(SEC_CHAR) * len);
+      out = (SEC_CHAR *)bson_array_alloc(sizeof(SEC_CHAR), len);
       if (out) {
          /* Encode to the out buffer. */
          if (CryptBinaryToStringA((BYTE *)value, vlen, CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, out, &len)) {
@@ -89,7 +89,7 @@ _mongoc_sspi_base64_decode(const SEC_CHAR *value, DWORD *rlen)
    SEC_CHAR *out = NULL;
    /* Get the correct size for the out buffer. */
    if (CryptStringToBinaryA(value, 0, CRYPT_STRING_BASE64, NULL, rlen, NULL, NULL)) {
-      out = (SEC_CHAR *)bson_malloc(sizeof(SEC_CHAR) * *rlen);
+      out = (SEC_CHAR *)bson_array_alloc(sizeof(SEC_CHAR), *rlen);
       if (out) {
          /* Decode to the out buffer. */
          if (CryptStringToBinaryA(value, 0, CRYPT_STRING_BASE64, (BYTE *)out, rlen, NULL, NULL)) {
@@ -109,7 +109,7 @@ _mongoc_sspi_wide_to_utf8(WCHAR *value)
    CHAR *out;
    int len = WideCharToMultiByte(CP_UTF8, 0, value, -1, NULL, 0, NULL, NULL);
    if (len) {
-      out = (CHAR *)bson_malloc(sizeof(CHAR) * len);
+      out = (CHAR *)bson_array_alloc(sizeof(CHAR), len);
       if (WideCharToMultiByte(CP_UTF8, 0, value, -1, out, len, NULL, NULL)) {
          return out;
       } else {
@@ -438,7 +438,7 @@ _mongoc_sspi_auth_sspi_client_wrap(
    }
 
    outbufSize = wrapBufs[0].cbBuffer + wrapBufs[1].cbBuffer + wrapBufs[2].cbBuffer;
-   outbuf = (SEC_CHAR *)bson_malloc(sizeof(SEC_CHAR) * outbufSize);
+   outbuf = (SEC_CHAR *)bson_array_alloc(sizeof(SEC_CHAR), outbufSize);
    memcpy_s(outbuf, outbufSize, wrapBufs[0].pvBuffer, wrapBufs[0].cbBuffer);
    memcpy_s(
       outbuf + wrapBufs[0].cbBuffer, outbufSize - wrapBufs[0].cbBuffer, wrapBufs[1].pvBuffer, wrapBufs[1].cbBuffer);

--- a/src/libmongoc/src/mongoc/mongoc-stream-socket.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-socket.c
@@ -214,7 +214,7 @@ _mongoc_stream_socket_poll(mongoc_stream_poll_t *streams, size_t nstreams, int32
 
    ENTRY;
 
-   sds = (mongoc_socket_poll_t *)bson_array_alloc(sizeof(*sds), nstreams);
+   sds = BSON_ARRAY_ALLOC(nstreams, mongoc_socket_poll_t);
 
    for (size_t i = 0u; i < nstreams; i++) {
       ss = (mongoc_stream_socket_t *)streams[i].stream;

--- a/src/libmongoc/src/mongoc/mongoc-stream-socket.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-socket.c
@@ -214,7 +214,7 @@ _mongoc_stream_socket_poll(mongoc_stream_poll_t *streams, size_t nstreams, int32
 
    ENTRY;
 
-   sds = (mongoc_socket_poll_t *)bson_malloc(sizeof(*sds) * nstreams);
+   sds = (mongoc_socket_poll_t *)bson_array_alloc(sizeof(*sds), nstreams);
 
    for (size_t i = 0u; i < nstreams; i++) {
       ss = (mongoc_stream_socket_t *)streams[i].stream;

--- a/src/libmongoc/src/mongoc/mongoc-stream.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream.c
@@ -335,7 +335,7 @@ mongoc_stream_poll(mongoc_stream_poll_t *streams, size_t nstreams, int32_t timeo
 ssize_t
 _mongoc_stream_poll_internal(mongoc_stream_poll_t *streams, size_t nstreams, mlib_timer until)
 {
-   mongoc_stream_poll_t *poller = (mongoc_stream_poll_t *)bson_malloc(sizeof(*poller) * nstreams);
+   mongoc_stream_poll_t *poller = (mongoc_stream_poll_t *)bson_array_alloc(sizeof(*poller), nstreams);
 
    int last_type = 0;
    ssize_t rval = -1;

--- a/src/libmongoc/src/mongoc/mongoc-stream.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream.c
@@ -335,7 +335,7 @@ mongoc_stream_poll(mongoc_stream_poll_t *streams, size_t nstreams, int32_t timeo
 ssize_t
 _mongoc_stream_poll_internal(mongoc_stream_poll_t *streams, size_t nstreams, mlib_timer until)
 {
-   mongoc_stream_poll_t *poller = (mongoc_stream_poll_t *)bson_array_alloc(sizeof(*poller), nstreams);
+   mongoc_stream_poll_t *poller = BSON_ARRAY_ALLOC(nstreams, mongoc_stream_poll_t);
 
    int last_type = 0;
    ssize_t rval = -1;

--- a/src/libmongoc/src/mongoc/mongoc-topology-background-monitoring.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-background-monitoring.c
@@ -183,7 +183,7 @@ _remove_orphaned_server_monitors(mongoc_set_t *server_monitors, mongoc_set_t *se
 
    /* Signal shutdown to server monitors no longer in the topology description.
     */
-   server_monitor_ids_to_remove = bson_array_alloc(sizeof(uint32_t), server_monitors->items_len);
+   server_monitor_ids_to_remove = bson_array_alloc0(sizeof(uint32_t), server_monitors->items_len);
    for (size_t i = 0u; i < server_monitors->items_len; i++) {
       mongoc_server_monitor_t *server_monitor;
       uint32_t id;

--- a/src/libmongoc/src/mongoc/mongoc-topology-background-monitoring.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-background-monitoring.c
@@ -183,7 +183,7 @@ _remove_orphaned_server_monitors(mongoc_set_t *server_monitors, mongoc_set_t *se
 
    /* Signal shutdown to server monitors no longer in the topology description.
     */
-   server_monitor_ids_to_remove = bson_malloc0(sizeof(uint32_t) * server_monitors->items_len);
+   server_monitor_ids_to_remove = bson_array_alloc(sizeof(uint32_t), server_monitors->items_len);
    for (size_t i = 0u; i < server_monitors->items_len; i++) {
       mongoc_server_monitor_t *server_monitor;
       uint32_t id;

--- a/src/libmongoc/src/mongoc/mongoc-topology-background-monitoring.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-background-monitoring.c
@@ -183,7 +183,7 @@ _remove_orphaned_server_monitors(mongoc_set_t *server_monitors, mongoc_set_t *se
 
    /* Signal shutdown to server monitors no longer in the topology description.
     */
-   server_monitor_ids_to_remove = bson_array_alloc0(sizeof(uint32_t), server_monitors->items_len);
+   server_monitor_ids_to_remove = BSON_ARRAY_ALLOC0(server_monitors->items_len, uint32_t);
    for (size_t i = 0u; i < server_monitors->items_len; i++) {
       mongoc_server_monitor_t *server_monitor;
       uint32_t id;

--- a/src/libmongoc/src/mongoc/mongoc-topology-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description.c
@@ -798,7 +798,7 @@ mongoc_topology_description_suitable_servers(mongoc_array_t *set, /* OUT */
       .topology_type = topology->type,
       .has_secondary = false,
       .candidates_len = 0,
-      .candidates = bson_array_alloc0(sizeof(mongoc_server_description_t *), td_servers->items_len),
+      .candidates = BSON_ARRAY_ALLOC0(td_servers->items_len, const mongoc_server_description_t *),
    };
 
    /* The "effective" read mode is the read mode that we should behave for, and
@@ -2370,7 +2370,7 @@ mongoc_topology_description_get_servers(const mongoc_topology_description_t *td,
 {
    const mongoc_set_t *const set = mc_tpld_servers_const(BSON_ASSERT_PTR_INLINE(td));
    /* enough room for all descriptions, even if some are unknown  */
-   mongoc_server_description_t **sds = bson_array_alloc0(sizeof(mongoc_server_description_t *), set->items_len);
+   mongoc_server_description_t **sds = BSON_ARRAY_ALLOC0(set->items_len, mongoc_server_description_t *);
 
    BSON_ASSERT_PARAM(n);
 

--- a/src/libmongoc/src/mongoc/mongoc-topology-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description.c
@@ -798,7 +798,7 @@ mongoc_topology_description_suitable_servers(mongoc_array_t *set, /* OUT */
       .topology_type = topology->type,
       .has_secondary = false,
       .candidates_len = 0,
-      .candidates = bson_array_alloc(sizeof(mongoc_server_description_t *), td_servers->items_len),
+      .candidates = bson_array_alloc0(sizeof(mongoc_server_description_t *), td_servers->items_len),
    };
 
    /* The "effective" read mode is the read mode that we should behave for, and
@@ -2370,7 +2370,7 @@ mongoc_topology_description_get_servers(const mongoc_topology_description_t *td,
 {
    const mongoc_set_t *const set = mc_tpld_servers_const(BSON_ASSERT_PTR_INLINE(td));
    /* enough room for all descriptions, even if some are unknown  */
-   mongoc_server_description_t **sds = bson_array_alloc(sizeof(mongoc_server_description_t *), set->items_len);
+   mongoc_server_description_t **sds = bson_array_alloc0(sizeof(mongoc_server_description_t *), set->items_len);
 
    BSON_ASSERT_PARAM(n);
 

--- a/src/libmongoc/src/mongoc/mongoc-topology-description.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-description.c
@@ -798,7 +798,7 @@ mongoc_topology_description_suitable_servers(mongoc_array_t *set, /* OUT */
       .topology_type = topology->type,
       .has_secondary = false,
       .candidates_len = 0,
-      .candidates = bson_malloc0(sizeof(mongoc_server_description_t *) * td_servers->items_len),
+      .candidates = bson_array_alloc(sizeof(mongoc_server_description_t *), td_servers->items_len),
    };
 
    /* The "effective" read mode is the read mode that we should behave for, and
@@ -2370,7 +2370,7 @@ mongoc_topology_description_get_servers(const mongoc_topology_description_t *td,
 {
    const mongoc_set_t *const set = mc_tpld_servers_const(BSON_ASSERT_PTR_INLINE(td));
    /* enough room for all descriptions, even if some are unknown  */
-   mongoc_server_description_t **sds = bson_malloc0(sizeof(mongoc_server_description_t *) * set->items_len);
+   mongoc_server_description_t **sds = bson_array_alloc(sizeof(mongoc_server_description_t *), set->items_len);
 
    BSON_ASSERT_PARAM(n);
 

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -268,7 +268,7 @@ _mongoc_apply_srv_max_hosts(const mongoc_host_list_t *hl, size_t max_hosts, size
       return NULL;
    }
 
-   hl_array = bson_array_alloc(sizeof(mongoc_host_list_t *), hl_size);
+   hl_array = BSON_ARRAY_ALLOC(hl_size, const mongoc_host_list_t *);
 
    for (size_t idx = 0u; hl; hl = hl->next) {
       hl_array[idx++] = hl;

--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -268,7 +268,7 @@ _mongoc_apply_srv_max_hosts(const mongoc_host_list_t *hl, size_t max_hosts, size
       return NULL;
    }
 
-   hl_array = bson_malloc(hl_size * sizeof(mongoc_host_list_t *));
+   hl_array = bson_array_alloc(sizeof(mongoc_host_list_t *), hl_size);
 
    for (size_t idx = 0u; hl; hl = hl->next) {
       hl_array[idx++] = hl;


### PR DESCRIPTION
### Motivation

"There are several points in the codebase that use `bson_malloc(sizeof(T) * N) `to allocate arrays of objects. This should not do an in-situ multiplication, since a large value of N will cause integer overflow and result in either an allocation failure or a bogus allocation size. Also, N = 0 can cause issues since malloc(0) is undefined/unspecified."

### Summary
Array allocations of the form `bson_malloc(sizeof(T) * N) ` now use a new function `bson_array_alloc()` which handles multiplication of the two terms internally.  Likewise, equivalent calls to `bson_malloc0(sizeof(T) * N)` now use `bson_array_alloc0()`.