### PR TITLE
CDRIVER-5945 mongoc_collection_create_indexes_with_opts does not apply write command behavior

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-collection.c
+++ b/src/libmongoc/src/mongoc/mongoc-collection.c
@@ -2634,8 +2634,7 @@ mongoc_collection_create_indexes_with_opts(mongoc_collection_t *collection,
    }
    BSON_ASSERT(bson_append_array_builder_end(&cmd, indexes));
 
-   ok = mongoc_client_command_with_opts(
-      collection->client, collection->db, &cmd, NULL /* read_prefs */, opts, reply_ptr, error);
+   ok = mongoc_collection_write_command_with_opts(collection, &cmd, opts, reply_ptr, error);
 
 fail:
    mongoc_server_stream_cleanup(server_stream);

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -4910,7 +4910,7 @@ test_create_indexes_acts_as_write_command(void *unused)
          bool ok =
             mongoc_collection_create_indexes_with_opts(coll, &im, 1, NULL /* options */, NULL /* reply */, &error);
          ASSERT(!ok);
-         ASSERT_ERROR_CONTAINS(error, 5, 9, "w has to be a non-negative number and not greater than 50; found: -1");
+         ASSERT_ERROR_CONTAINS(error, 5, 9, "w has to be a non-negative number and not greater than 50");
          mongoc_index_model_destroy(im);
       }
    }

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -4898,7 +4898,7 @@ test_create_indexes_acts_as_write_command(void *unused)
       // Set a non-default write concern on collection:
       {
          mongoc_write_concern_t *wc = mongoc_write_concern_new();
-         mongoc_write_concern_set_w(wc, 99); // Set a write concern that fails.
+         mongoc_write_concern_set_w(wc, -1); // Set a write concern that fails.
          mongoc_collection_set_write_concern(coll, wc);
          mongoc_write_concern_destroy(wc);
       }
@@ -4910,7 +4910,7 @@ test_create_indexes_acts_as_write_command(void *unused)
          bool ok =
             mongoc_collection_create_indexes_with_opts(coll, &im, 1, NULL /* options */, NULL /* reply */, &error);
          ASSERT(!ok);
-         ASSERT_ERROR_CONTAINS(error, 5, 9, "w has to be a non-negative number and not greater than 50");
+         ASSERT_ERROR_CONTAINS(error, 5, 9, "w has to be a non-negative number and not greater than 50; found: -1");
          mongoc_index_model_destroy(im);
       }
    }

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -4936,6 +4936,7 @@ test_create_indexes_acts_as_write_command(void *unused)
          bool ok = mongoc_client_command_simple(client, "admin", failpoint_cmd, NULL /* read_prefs */, &reply, &error);
          ASSERT_OR_PRINT(ok, error);
          bson_destroy(failpoint_cmd);
+         bson_destroy(&reply);
       }
 
       {
@@ -4945,6 +4946,7 @@ test_create_indexes_acts_as_write_command(void *unused)
          ASSERT(!ok);
          ASSERT_ERROR_CONTAINS(error, MONGOC_ERROR_WRITE_CONCERN, 123, "foo");
          mongoc_index_model_destroy(im);
+         bson_destroy(&reply);
       }
    }
 

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -4883,6 +4883,75 @@ test_insert_one_reports_id(void)
 
 #undef ASSERT_INDEX_EXISTS
 
+static void
+test_create_indexes_acts_as_write_command(void *unused)
+{
+   BSON_UNUSED(unused);
+
+   mongoc_client_t *client = test_framework_new_default_client();
+   mongoc_collection_t *coll = get_test_collection(client, "test_create_indexes_with_opts");
+   bson_error_t error;
+   bson_t reply;
+
+   // Test write concern is inherited from collection:
+   {
+      // Set a non-default write concern on collection:
+      {
+         mongoc_write_concern_t *wc = mongoc_write_concern_new();
+         mongoc_write_concern_set_w(wc, 99); // Set a write concern that fails.
+         mongoc_collection_set_write_concern(coll, wc);
+         mongoc_write_concern_destroy(wc);
+      }
+
+      // Create index:
+      {
+         const bson_t *keys = tmp_bson("{'x': 1}");
+         mongoc_index_model_t *im = mongoc_index_model_new(keys, NULL);
+         bool ok =
+            mongoc_collection_create_indexes_with_opts(coll, &im, 1, NULL /* options */, NULL /* reply */, &error);
+         ASSERT(!ok);
+         ASSERT_ERROR_CONTAINS(error, 5, 9, "w has to be a non-negative number and not greater than 50");
+         mongoc_index_model_destroy(im);
+      }
+   }
+
+   // Test a server reply with "writeConcernError" is considered an error:
+   {
+      // Set the default write concern on collection:
+      {
+         mongoc_write_concern_t *wc = mongoc_write_concern_new(); // Default write concern.
+         mongoc_collection_set_write_concern(coll, wc);
+         mongoc_write_concern_destroy(wc);
+      }
+
+      // Set a failpoint to fail with "writeConcernError":
+      {
+         const char *cmd_str = BSON_STR({
+            "configureFailPoint" : "failCommand",
+            "mode" : {"times" : 1},
+            "data" : {"failCommands" : ["createIndexes"], "writeConcernError" : {"code" : 123, "errmsg" : "foo"}}
+         });
+         bson_t *failpoint_cmd = bson_new_from_json((const uint8_t *)cmd_str, -1, &error);
+         ASSERT_OR_PRINT(failpoint_cmd, error);
+         bool ok = mongoc_client_command_simple(client, "admin", failpoint_cmd, NULL /* read_prefs */, &reply, &error);
+         ASSERT_OR_PRINT(ok, error);
+         bson_destroy(failpoint_cmd);
+      }
+
+      {
+         const bson_t *keys = tmp_bson("{'x': 1}");
+         mongoc_index_model_t *im = mongoc_index_model_new(keys, NULL);
+         bool ok = mongoc_collection_create_indexes_with_opts(coll, &im, 1, NULL /* opts */, &reply, &error);
+         ASSERT(!ok);
+         ASSERT_ERROR_CONTAINS(error, MONGOC_ERROR_WRITE_CONCERN, 123, "foo");
+         mongoc_index_model_destroy(im);
+      }
+   }
+
+   mongoc_collection_destroy(coll);
+   mongoc_client_destroy(client);
+}
+
 
 void
 test_collection_install(TestSuite *suite)
@@ -5016,4 +5085,12 @@ test_collection_install(TestSuite *suite)
                      // requires failpoint
                      test_framework_skip_if_no_failpoint);
    TestSuite_AddLive(suite, "/Collection/insert_one_reports_id", test_insert_one_reports_id);
+
+   TestSuite_AddFull(suite,
+                     "/Collection/test_create_indexes_acts_as_write_command",
+                     test_create_indexes_acts_as_write_command,
+                     NULL /* _dtor */,
+                     NULL /* _ctx */,
+                     // requires failpoint
+                     test_framework_skip_if_no_failpoint);
 }

--- a/src/libmongoc/tests/test-mongoc-collection.c
+++ b/src/libmongoc/tests/test-mongoc-collection.c
@@ -4942,11 +4942,10 @@ test_create_indexes_acts_as_write_command(void *unused)
       {
          const bson_t *keys = tmp_bson("{'x': 1}");
          mongoc_index_model_t *im = mongoc_index_model_new(keys, NULL);
-         bool ok = mongoc_collection_create_indexes_with_opts(coll, &im, 1, NULL /* opts */, &reply, &error);
+         bool ok = mongoc_collection_create_indexes_with_opts(coll, &im, 1, NULL /* opts */, NULL /* reply */, &error);
          ASSERT(!ok);
          ASSERT_ERROR_CONTAINS(error, MONGOC_ERROR_WRITE_CONCERN, 123, "foo");
          mongoc_index_model_destroy(im);
-         bson_destroy(&reply);
       }
    }
 
@@ -5094,5 +5093,7 @@ test_collection_install(TestSuite *suite)
                      NULL /* _dtor */,
                      NULL /* _ctx */,
                      // requires failpoint
-                     test_framework_skip_if_no_failpoint);
+                     test_framework_skip_if_no_failpoint,
+                     // Server Version 4.4 has Wire Version 9 - w < 0 does not error on earlier versions.
+                     test_framework_skip_if_max_wire_version_less_than_9);
 }


### PR DESCRIPTION
### Summary
`mongoc_collection_create_indexes_with_opts` uses `mongoc_client_command_with_opts` rather than `mongoc_collection_write_command_with_opts`. As a result, write command behavior is not applied:

- Write concern is not inherited from the parent mongoc_collection_t (contrary to [documentation](https://mongoc.org/libmongoc/1.30.2/mongoc_collection_create_indexes_with_opts.html))
- A server reply with a "writeConcernError" does not result in a failing return.

These changes now call `mongoc_collection_write_command_with_opts`. 

A test was added to reproduce the errors in the original code and confirm that write command behavior is fixed with the correct call.
