### PR TITLE
add step to check tickets in commit messages

### DIFF
--- a/docs/dev/releasing.rst
+++ b/docs/dev/releasing.rst
@@ -305,15 +305,19 @@ Install the Python requirements for the driver tools::
    $ pip install -r $CDRIVER_TOOLS/requirements.txt
 
 
-**For Patch Releases**: Check Consistency with the Jira Release
-***************************************************************
+Check Consistency with the Jira Release
+***************************************
 
-**If we are releasing a patch version**, we must check that the Jira release
+We must check that the Jira release
 matches the content of the branch to be released. Open
-`the releases page on Jira <Jira releases_>`_ and open the release page for the new patch
-release. Verify that the changes for all tickets in the Jira release have been
-cherry-picked onto the release branch (not including the "Release x.y.z" ticket
-that is part of every Jira release).
+`the releases page on Jira <Jira releases_>`_ and open the release page for the new
+release.
+
+**If we are releasing a patch version**, verify that the changes for all tickets in the Jira release have been
+cherry-picked onto the release branch (not including the "Release x.y.z" ticket that is part of every Jira release).
+
+Check tickets referenced in commit messages (e.g. "CDRIVER-1234 fix foo") are in the expected state.
+Expect most tickets to be in the "Closed" state with the ``fixVersion`` of the upcoming release.
 
 .. _Jira releases:
 .. _jira-releases: https://jira.mongodb.org/projects/CDRIVER?selectedItem=com.atlassian.jira.jira-projects-plugin%3Arelease-page&status=unreleased

--- a/docs/dev/releasing.rst
+++ b/docs/dev/releasing.rst
@@ -38,7 +38,7 @@ process.
    - [ ] Do the Release:
        - [ ] Start a Release Stopwatch (start time: HH:MM)
        - [ ] Clone the Driver Tools
-       - [ ] If patch release: Check consistency with [the Jira release](https://jira.mongodb.org/projects/CDRIVER/versions/XXXXXX)
+       - [ ] Check Consistency with [the Jira release](https://jira.mongodb.org/projects/CDRIVER/versions/XXXXXX)
        - [ ] Run the Release Script
        - [ ] Fixup the `NEWS` Pages
        - [ ] Signed & Upload the Release


### PR DESCRIPTION
Motivated by a [slack conversation](https://mongodb.slack.com/archives/GMY98JS86/p1756493343064969) about CDRIVER-4153. The ticket originally had commits in 2.1.0 but was left open. Prefer closing tickets with commits in a release to simplify consistency with Jira.