### PR TITLE
CDRIVER-4689 add a private `mongoc_oidc_callback_copy`

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-oidc-callback-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-oidc-callback-private.h
@@ -58,6 +58,6 @@ void
 mongoc_oidc_callback_params_set_cancelled_with_timeout(mongoc_oidc_callback_params_t *params, bool value);
 
 mongoc_oidc_callback_t *
-mongoc_oidc_callback_copy (const mongoc_oidc_callback_t *callback);
+mongoc_oidc_callback_copy(const mongoc_oidc_callback_t *callback);
 
 #endif // MONGOC_OIDC_CALLBACK_PRIVATE_H

--- a/src/libmongoc/src/mongoc/mongoc-oidc-callback-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-oidc-callback-private.h
@@ -57,4 +57,7 @@ mongoc_oidc_callback_params_get_cancelled_with_timeout(const mongoc_oidc_callbac
 void
 mongoc_oidc_callback_params_set_cancelled_with_timeout(mongoc_oidc_callback_params_t *params, bool value);
 
+mongoc_oidc_callback_t *
+mongoc_oidc_callback_copy (const mongoc_oidc_callback_t *callback);
+
 #endif // MONGOC_OIDC_CALLBACK_PRIVATE_H

--- a/src/libmongoc/src/mongoc/mongoc-oidc-callback.c
+++ b/src/libmongoc/src/mongoc/mongoc-oidc-callback.c
@@ -258,11 +258,11 @@ mongoc_oidc_credential_get_expires_in(const mongoc_oidc_credential_t *cred)
 }
 
 mongoc_oidc_callback_t *
-mongoc_oidc_callback_copy (const mongoc_oidc_callback_t *callback)
+mongoc_oidc_callback_copy(const mongoc_oidc_callback_t *callback)
 {
-   BSON_ASSERT_PARAM (callback);
-   mongoc_oidc_callback_t *const ret = mongoc_oidc_callback_new_with_user_data (
-      mongoc_oidc_callback_get_fn (callback), mongoc_oidc_callback_get_user_data (callback));
-   BSON_ASSERT (ret);
+   BSON_ASSERT_PARAM(callback);
+   mongoc_oidc_callback_t *const ret = mongoc_oidc_callback_new_with_user_data(
+      mongoc_oidc_callback_get_fn(callback), mongoc_oidc_callback_get_user_data(callback));
+   BSON_ASSERT(ret);
    return ret;
 }

--- a/src/libmongoc/src/mongoc/mongoc-oidc-callback.c
+++ b/src/libmongoc/src/mongoc/mongoc-oidc-callback.c
@@ -256,3 +256,13 @@ mongoc_oidc_credential_get_expires_in(const mongoc_oidc_credential_t *cred)
    BSON_ASSERT_PARAM(cred);
    return cred->expires_in_set ? &cred->expires_in : NULL;
 }
+
+mongoc_oidc_callback_t *
+mongoc_oidc_callback_copy (const mongoc_oidc_callback_t *callback)
+{
+   BSON_ASSERT_PARAM (callback);
+   mongoc_oidc_callback_t *const ret = mongoc_oidc_callback_new_with_user_data (
+      mongoc_oidc_callback_get_fn (callback), mongoc_oidc_callback_get_user_data (callback));
+   BSON_ASSERT (ret);
+   return ret;
+}

--- a/src/libmongoc/tests/test-mongoc-oidc-callback.c
+++ b/src/libmongoc/tests/test-mongoc-oidc-callback.c
@@ -64,6 +64,23 @@ test_oidc_callback_new(void)
 }
 
 static void
+test_oidc_callback_copy(void)
+{
+   int user_data = 0;
+
+   mongoc_oidc_callback_t *const callback = mongoc_oidc_callback_new(&_test_oidc_callback_fn_cb);
+   mongoc_oidc_callback_set_user_data(callback, &user_data);
+
+   mongoc_oidc_callback_t *callback_copy = mongoc_oidc_callback_copy(callback);
+
+   ASSERT(mongoc_oidc_callback_get_fn(callback_copy) == &_test_oidc_callback_fn_cb);
+   ASSERT(mongoc_oidc_callback_get_user_data(callback_copy) == &user_data);
+
+   mongoc_oidc_callback_destroy(callback_copy);
+   mongoc_oidc_callback_destroy(callback);
+}
+
+static void
 test_oidc_callback_params(void)
 {
    mongoc_oidc_callback_params_t *const params = mongoc_oidc_callback_params_new();
@@ -179,6 +196,7 @@ void
 test_mongoc_oidc_callback_install(TestSuite *suite)
 {
    TestSuite_Add(suite, "/oidc/callback/new", test_oidc_callback_new);
+   TestSuite_Add(suite, "/oidc/callback/copy", test_oidc_callback_copy);
    TestSuite_Add(suite, "/oidc/callback/params", test_oidc_callback_params);
    TestSuite_Add(suite, "/oidc/callback/credential", test_oidc_credential);
 }


### PR DESCRIPTION
# Summary

Add a private `mongoc_oidc_callback_copy`.

# Background & Motivation

This is a start towards resolving CDRIVER-4689. The copy function is expected to be used in soon-to-be-added setter functions:

```c
// Configure OIDC callback:
mongoc_oidc_callback_t *oidc_callback = mongoc_oidc_callback_new (oidc_callback_fn);
mongoc_client_set_oidc_callback (client, oidc_callback); // Copies callback.
```

Following patterns of other setters (e.g. `mongoc_client_set_write_concern`) a copy of the argument is stored.