### PR TITLE
CDRIVER-5945 mongoc_collection_create_indexes_with_opts does not apply write command behavior

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-collection.c
+++ b/src/libmongoc/src/mongoc/mongoc-collection.c
@@ -2635,8 +2635,7 @@ mongoc_collection_create_indexes_with_opts (mongoc_collection_t *collection,
    }
    BSON_ASSERT (bson_append_array_builder_end (&cmd, indexes));
 
-   ok = mongoc_client_command_with_opts (
-      collection->client, collection->db, &cmd, NULL /* read_prefs */, opts, reply_ptr, error);
+   ok = mongoc_collection_write_command_with_opts(collection, &cmd, opts, reply_ptr, error);
 
 fail:
    mongoc_server_stream_cleanup (server_stream);


### PR DESCRIPTION
`mongoc_collection_create_indexes_with_opts` uses `mongoc_client_command_with_opts` rather than `mongoc_collection_write_command_with_opts`. As a result, write command behavior is not applied:

- Write concern is not inherited from the parent mongoc_collection_t (contrary to [documentation](https://mongoc.org/libmongoc/1.30.2/mongoc_collection_create_indexes_with_opts.html))
- A server reply with a "writeConcernError" does not result in a failing return.

These changes now call `mongoc_collection_write_command_with_opts`.

A test was added to reproduce the errors in the original code and confirm that write command behavior is fixed with the correct call.