### PR TITLE
check for new "too-large" error code

### DIFF
--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -486,7 +486,17 @@ test_bson_size_limits_and_batch_splitting(void *unused)
    bson_append_utf8(docs[0], "_id", -1, "under_16mib", -1);
    bson_append_utf8(docs[0], "unencrypted", -1, as, exceeds_16mib_after_encryption);
    BSON_ASSERT(!mongoc_collection_insert_one(coll, docs[0], NULL /* opts */, NULL /* reply */, &error));
-   ASSERT_ERROR_CONTAINS(error, MONGOC_ERROR_SERVER, 2, "too large");
+   {
+      const uint32_t too_large = 10334;
+      // SERVER-104405 changed the expected error code from 2 to 10334:
+      const uint32_t too_large_old = 2;
+      ASSERT_CMPUINT32(error.domain, ==, (uint32_t)MONGOC_ERROR_SERVER);
+      if (error.code != too_large && error.code != too_large_old) {
+         test_error(
+            "Unexpected error: %" PRIu32 ". Expected %" PRIu32 " or %" PRIu32, error.code, too_large, too_large_old);
+      }
+      ASSERT_CONTAINS(error.message, "too large");
+   }
    bson_destroy(docs[0]);
 
    bson_free(as);


### PR DESCRIPTION
Intended to fix failing [C driver tasks](https://spruce.mongodb.com/task/mongo_c_driver_sanitizers_matrix_asan_asan_cse_sasl_cyrus_openssl_rhel8_latest_clang_test_latest_replica_auth_patch_d77a79e4b83bbcc4bc48a02cf443e4879fb36161_68b70664262fa0000703c44d_25_09_02_14_59_52/logs?execution=0) on latest servers:
```
test-mongoc-client-side-encryption.c:489 test_bson_size_limits_and_batch_splitting(): error code 10334 doesn't match expected 2
```

Changes from SERVER-104405 resulted in a different error code returned for a too-large document.