### PR TITLE
CDRIVER-4812 Single-threaded monitoring commands may include saslSupportedMechs beyond initial handshake

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
@@ -191,6 +191,13 @@ _reset_hello(mongoc_topology_scanner_t *ts)
    _add_hello(ts);
 }
 
+void
+_mongoc_topology_scanner_node_parse_sasl_supported_mechs(const bson_t *hello, mongoc_topology_scanner_node_t *node)
+{
+   _mongoc_handshake_parse_sasl_supported_mechs(hello, &node->sasl_supported_mechs);
+   node->negotiated_sasl_supported_mechs = true;
+}
+
 const char *
 _mongoc_topology_scanner_get_speculative_auth_mechanism(const mongoc_uri_t *uri)
 {
@@ -727,7 +734,7 @@ _async_success(mongoc_async_cmd_t *acmd, const bson_t *hello_response, mlib_dura
    }
 
    if (ts->negotiate_sasl_supported_mechs && !node->negotiated_sasl_supported_mechs) {
-      _mongoc_handshake_parse_sasl_supported_mechs(hello_response, &node->sasl_supported_mechs);
+      _mongoc_topology_scanner_node_parse_sasl_supported_mechs(hello_response, node);
    }
 
    if (ts->speculative_authentication) {


### PR DESCRIPTION
### Summary
See [CDRIVER-4812](https://jira.mongodb.org/browse/CDRIVER-4812) for full details. In summary, the flag `negotiated_sasl_supported_mechs` stored by topology scanner nodes is never set to true after parsing saslSupportedMechs from the server's hello_response, causing saslSupportedMechs to be continuously appended to all outgoing hellos. This seems to have caused extraneous log output for customers.

### Changes
This PR adds a wrapper to `_mongoc_handshake_parse_sasl_supported_mechs` which allows for `node->negotiated_sasl_supported_mechs` to be set to true upon successful parsing. This ensures saslSupportedMechs are not appended to outgoing hellos after the initial hello response from the server. 

### Validation
To replicate the issue found in [mongodb/mongo-php-driver#1506](https://github.com/mongodb/mongo-php-driver/issues/1506), I created a simple [test](https://gist.github.com/Julia-Garland/95d90c4c11298cf3385b0e26820a563e) that creates a user for a  test database, then has that user indefinitely send hello commands to the server.

When I ran the test on the original codebase, AuthenticationAbandoned errors appeared after approximately 60 seconds of runtime and continued to repeat every 60 seconds. Print statements confirmed that saslSupportedMechs continue to be appended unecessarily:


```
[mongoc_async_cmd_new] { "hello" : { "$numberInt" : "1" }, "helloOk" : true, "saslSupportedMechs" : "test.username", "$clusterTime" : { "clusterTime" : { "$timestamp" : { "t" : 1756919138, "i" : 1 } }, "signature" : { "hash" : { "$binary" : { "base64" : "Iq0n7Kc4Fvw66Wxq1tcQx3VBSXM=", "subType" : "00" } }, "keyId" : { "$numberLong" : "7545579002958708741" } } } }
```

```json
{"t":{"$date":"2025-09-03T13:05:46.866-04:00"},"s":"I",  "c":"ACCESS",   "id":5286307, "ctx":"conn989","msg":"Failed to authenticate","attr":{"client":"127.0.0.1:51481","isSpeculative":false,"isClusterMember":false,"mechanism":"","user":"","db":"","error":"AuthenticationAbandoned: Overridden by new authentication session","result":337,"metrics":{"conversation_duration":{"micros":60002249,"summary":{}}},"extraInfo":{}}}
```

```json
{"t":{"$date":"2025-09-03T13:05:55.024-04:00"},"s":"I",  "c":"ACCESS",   "id":5286307, "ctx":"conn989","msg":"Failed to authenticate","attr":{"client":"127.0.0.1:51481","isSpeculative":false,"isClusterMember":false,"mechanism":"","user":"","db":"","error":"AuthenticationAbandoned: Authentication session abandoned, client has likely disconnected","result":337,"metrics":{"conversation_duration":{"micros":8155577,"summary":{}}},"extraInfo":{}}}
```

These log entries did not emerge after running for an extended period of time with the updated logic.