### PR TITLE
CDRIVER-6055 format

### DIFF
--- a/src/libbson/tests/test-bson.c
+++ b/src/libbson/tests/test-bson.c
@@ -125,7 +125,7 @@ test_bson_alloc(void)
 
 
 static void
-test_bson_array_alloc(void) 
+test_bson_array_alloc(void)
 {
    // Can allocate an array of items:
    {


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/mongo-c-driver/commit/b2550825f1ca3eee796f950ee41ae7c8fb4caebb to fix the [clang-format task](https://spruce.mongodb.com/task/mongo_c_driver_clang_format_clang_format_78bdf533c2d2d708e5b30836999bf4435464eeb6_25_09_04_16_38_43/logs?execution=0). Formatted with: `uv run tools/format.py`