### PR TITLE
CDRIVER-6080 fix stream tracking in `/Client/exhaust_cursor/pool`

### DIFF
--- a/.evergreen/scripts/run-tests.sh
+++ b/.evergreen/scripts/run-tests.sh
@@ -136,8 +136,6 @@ declare -a test_args=(
   "test-results.json"
   "--skip-tests"
   ".evergreen/etc/skip-tests.txt"
-  "--match"
-  "/Client/exhaust_cursor/pool"
 )
 
 # TODO (CDRIVER-4045): consolidate DNS tests into regular test tasks.
@@ -284,9 +282,7 @@ cygwin)
     openssl_lib_prefix="${openssl_install_dir}/lib:${openssl_lib_prefix:-}"
   fi
 
-  for i in {1..10}; do
-    LD_LIBRARY_PATH="${openssl_lib_prefix}" LD_PRELOAD="${ld_preload:-}" ./cmake-build/src/libmongoc/test-libmongoc --no-fork "${test_args[@]}"
-  done
+  LD_LIBRARY_PATH="${openssl_lib_prefix}" LD_PRELOAD="${ld_preload:-}" ./cmake-build/src/libmongoc/test-libmongoc --no-fork "${test_args[@]}"
   ;;
 esac
 

--- a/.evergreen/scripts/run-tests.sh
+++ b/.evergreen/scripts/run-tests.sh
@@ -136,6 +136,8 @@ declare -a test_args=(
   "test-results.json"
   "--skip-tests"
   ".evergreen/etc/skip-tests.txt"
+  "--match"
+  "/Client/exhaust_cursor/pool"
 )
 
 # TODO (CDRIVER-4045): consolidate DNS tests into regular test tasks.
@@ -282,7 +284,9 @@ cygwin)
     openssl_lib_prefix="${openssl_install_dir}/lib:${openssl_lib_prefix:-}"
   fi
 
-  LD_LIBRARY_PATH="${openssl_lib_prefix}" LD_PRELOAD="${ld_preload:-}" ./cmake-build/src/libmongoc/test-libmongoc --no-fork "${test_args[@]}"
+  for i in {1..10}; do
+    LD_LIBRARY_PATH="${openssl_lib_prefix}" LD_PRELOAD="${ld_preload:-}" ./cmake-build/src/libmongoc/test-libmongoc --no-fork "${test_args[@]}"
+  done
   ;;
 esac
 

--- a/src/libmongoc/tests/test-mongoc-exhaust.c
+++ b/src/libmongoc/tests/test-mongoc-exhaust.c
@@ -115,6 +115,9 @@ test_exhaust_cursor(bool pooled)
       pool = test_framework_new_default_client_pool();
       stream_tracker_track_pool(st, pool);
       client = mongoc_client_pool_pop(pool);
+      // Server 4.4 added support for streaming monitoring and has 2 monitoring connections.
+      int monitor_count = test_framework_get_server_version() >= test_framework_str_to_version("4.4") ? 2 : 1;
+      stream_tracker_assert_eventual_active_count(st, "localhost:27017", monitor_count);
    } else {
       client = test_framework_new_default_client();
       stream_tracker_track_client(st, client);


### PR DESCRIPTION
Follow-up to #2095 intended to fix observed test failures on macOS replica sets. [Example](https://spruce.mongodb.com/task/mongo_c_driver_sasl_matrix_darwinssl_sasl_cyrus_darwinssl_macos_14_arm64_clang_test_6.0_replica_auth_patch_bd58f9df2029955cb1564557ab5403198b1ce650_68bb4bca9fc72c00079c4923_25_09_05_20_45_01/logs?execution=0):

```
test error in: /Users/ec2-user/data/mci/c4f6b76328d456c45e1a0f91c797f34d/mongoc/src/libmongoc/tests/test-mongoc-exhaust.c 202:test_exhaust_cursor()
Got unexpected total stream count to localhost:27018:
    Expected 3, got 4
```

I reproduced the error by running test in repeat 100x: https://spruce.mongodb.com/version/68bb4bca9fc72c00079c4923
Tests pass with this fix applied: https://spruce.mongodb.com/version/68bb4f4fe5543500071df4fc

I expect the extra observed connection is due to the monitoring connections taking time to establish. This fix awaits monitoring connections before proceeding with the test.