### PR TITLE
CDRIVER-3492 mongoc_client_reset should do nothing if passed a multi-threaded client

### DIFF
--- a/src/libmongoc/doc/mongoc_client_reset.rst
+++ b/src/libmongoc/doc/mongoc_client_reset.rst
@@ -20,6 +20,10 @@ Calling :symbol:`mongoc_client_reset()` prevents resource cleanup in the child p
 
 This method causes the client to clear its session pool without sending endSessions. It also increments an internal generation counter on the given client. After this method is called, cursors from previous generations will not issue a killCursors command when they are destroyed. Client sessions from previous generations cannot be used and should be destroyed.
 
+.. warning::
+
+This method should only be called on single threaded clients. Calling :symbol:`mongoc_client_reset()` on a multi threaded client is a no-op and will result in a warning.
+
 Parameters
 ----------
 

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -2617,6 +2617,11 @@ mongoc_client_reset(mongoc_client_t *client)
 {
    BSON_ASSERT_PARAM(client);
 
+   if (!client->topology->single_threaded) {
+      MONGOC_WARNING("mongoc_client_reset called on a pooled client, this is a no-op.");
+      return;
+   }
+
    client->generation++;
 
    /* Client sessions are owned and destroyed by the user, but we keep


### PR DESCRIPTION
- `mongoc_client_reset` will warn and return without doing anything if given a multi-threaded client
- Added a note to documentation for `mongoc_client_reset` 