### PR TITLE
CDRIVER-6100 Remove Delighted NPS script (CDRIVER-3445)

### DIFF
--- a/build/sphinx/mongoc_common.py
+++ b/build/sphinx/mongoc_common.py
@@ -94,12 +94,6 @@ def add_ga_javascript(app: Sphinx, pagename: str, templatename: str, context: Di
 
   gtag('config', 'G-56KD6L3MDX');
 </script>
-<!--  NPS survey -->
-<script type="text/javascript">
-  !function(e,t,r,n,a){if(!e[a]){for(var i=e[a]=[],s=0;s<r.length;s++){var c=r[s];i[c]=i[c]||function(e){return function(){var t=Array.prototype.slice.call(arguments);i.push([e,t])}}(c)}i.SNIPPET_VERSION="1.0.1";var o=t.createElement("script");o.type="text/javascript",o.async=!0,o.src="https://d2yyd1h5u9mauk.cloudfront.net/integrations/web/v1/library/"+n+"/"+a+".js";var l=t.getElementsByTagName("script")[0];l.parentNode.insertBefore(o,l)}}(window,document,["survey","reset","config","init","set","get","event","identify","track","page","screen","group","alias"],"Dk30CC86ba0nATlK","delighted");
-
-  delighted.survey();
-</script>
 """
     )
 


### PR DESCRIPTION
Resolves CDRIVER-6100 (for future releases). See ticket for details. Reverts [CDRIVER-3445](https://jira.mongodb.org/browse/CDRIVER-3445) which was added as part of https://github.com/mongodb/mongo-c-driver/commit/eebc738efd2a976cd1014ba1dc6edf5045f0af04. The current page deployment will need to be updated manually separately from this PR.