### PR TITLE
Remove comment reference to NPS survey

### DIFF
--- a/build/sphinx/mongoc_common.py
+++ b/build/sphinx/mongoc_common.py
@@ -81,7 +81,7 @@ def add_ga_javascript(app: Sphinx, pagename: str, templatename: str, context: Di
     if not app.env.config.analytics:
         return
 
-    # Add google analytics and NPS survey.
+    # Add google analytics.
     context["metatags"] = (
         context.get("metatags", "")
         + """


### PR DESCRIPTION
Minor followup to https://github.com/mongodb/mongo-c-driver/pull/2121 which overlooked a descriptive comment mentioning the NPS survey script (that is now removed).