### PR TITLE
CDRIVER-4738 Do not resume after change stream cursor is closed

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-change-stream.c
+++ b/src/libmongoc/src/mongoc/mongoc-change-stream.c
@@ -497,6 +497,15 @@ mongoc_change_stream_next(mongoc_change_stream_t *stream, const bson_t **bson)
          goto end;
       }
 
+      /* the cursor is closed. */
+      if (stream->cursor->cursor_id == 0) {
+         _mongoc_set_error(&stream->err,
+                           MONGOC_ERROR_CURSOR,
+                           MONGOC_ERROR_CURSOR_INVALID_CURSOR,
+                           "Cannot advance a closed change stream.");
+         goto end;
+      }
+
       resumable = _is_resumable_error(stream, err_doc);
       while (resumable) {
          /* recreate the cursor. */

--- a/src/libmongoc/tests/test-mongoc-change-stream.c
+++ b/src/libmongoc/tests/test-mongoc-change-stream.c
@@ -1932,12 +1932,14 @@ prose_test_18(void)
 
 // Test that a resume does not occur after an "invalidate" event.
 static void
-iterate_after_invalidate(void)
+iterate_after_invalidate(void *test_ctx)
 {
    mongoc_client_t *client = test_framework_new_default_client();
    mongoc_collection_t *coll = mongoc_client_get_collection(client, "db", "coll");
    bson_error_t error;
    int64_t start_time = bson_get_monotonic_time();
+
+   BSON_UNUSED(test_ctx);
 
    // Insert a document into the collection to ensure the collection is created.
    bool ok = mongoc_collection_insert_one(coll, tmp_bson("{'foo': 'bar'}"), NULL /* opts */, NULL /* reply */, &error);
@@ -2246,7 +2248,12 @@ test_change_stream_install(TestSuite *suite)
                      test_framework_skip_if_not_replset);
    TestSuite_AddMockServerTest(suite, "/change_streams/prose_test_17", prose_test_17);
    TestSuite_AddMockServerTest(suite, "/change_streams/prose_test_18", prose_test_18);
-   TestSuite_AddLive(suite, "/change_streams/iterate_after_invalidate", iterate_after_invalidate);
+   TestSuite_AddFull(suite,
+                     "/change_streams/iterate_after_invalidate",
+                     iterate_after_invalidate,
+                     NULL,
+                     NULL,
+                     test_framework_skip_if_not_replset);
    TestSuite_AddFull(suite,
                      "/change_stream/batchSize0",
                      test_change_stream_batchSize0,


### PR DESCRIPTION
- Attempting to iterate a closed change stream with `mongoc_change_stream_next` will now return the error "Cannot advance a closed change stream."
- Added a [test](https://github.com/mongodb/mongo-c-driver/compare/master...kevinAlbs:mongo-c-driver:changestream) that reproduced the issue.