### PR TITLE
Reduce use of write concern timeout in tests

### DIFF
--- a/src/libmongoc/examples/client-side-encryption-server-schema.c
+++ b/src/libmongoc/examples/client-side-encryption-server-schema.c
@@ -178,7 +178,7 @@ main(void)
    /* Create the collection with the encryption JSON Schema. */
    create_cmd = BCON_NEW("create", ENCRYPTED_COLL, "validator", "{", "$jsonSchema", BCON_DOCUMENT(schema), "}");
    wc = mongoc_write_concern_new();
-   mongoc_write_concern_set_wmajority(wc, 0);
+   mongoc_write_concern_set_w(wc, MONGOC_WRITE_CONCERN_W_MAJORITY);
    create_cmd_opts = bson_new();
    mongoc_write_concern_append(wc, create_cmd_opts);
    ret = mongoc_client_command_with_opts(

--- a/src/libmongoc/src/mongoc/mongoc-write-concern.c
+++ b/src/libmongoc/src/mongoc/mongoc-write-concern.c
@@ -463,9 +463,7 @@ _mongoc_write_concern_new_from_iter(const bson_iter_t *iter, bson_error_t *error
             mongoc_write_concern_set_w(write_concern, w);
          } else if (BSON_ITER_HOLDS_UTF8(&inner)) {
             if (!strcmp(bson_iter_utf8(&inner, NULL), "majority")) {
-               /* mongoc_write_concern_set_wmajority() only assigns wtimeout if
-                * it is >= 0. Since we set wtimeout below, pass -1 here. */
-               mongoc_write_concern_set_wmajority(write_concern, -1);
+               mongoc_write_concern_set_w(write_concern, MONGOC_WRITE_CONCERN_W_MAJORITY);
             } else {
                mongoc_write_concern_set_wtag(write_concern, bson_iter_utf8(&inner, NULL));
             }

--- a/src/libmongoc/tests/test-conveniences.c
+++ b/src/libmongoc/tests/test-conveniences.c
@@ -392,7 +392,7 @@ bson_lookup_write_concern(const bson_t *b, const char *key)
    if (BSON_ITER_HOLDS_NUMBER(&w)) {
       mongoc_write_concern_set_w(wc, (int32_t)bson_iter_as_int64(&w));
    } else if (!strcmp(bson_iter_utf8(&w, NULL), "majority")) {
-      mongoc_write_concern_set_wmajority(wc, 0);
+      mongoc_write_concern_set_w(wc, MONGOC_WRITE_CONCERN_W_MAJORITY);
    } else {
       mongoc_write_concern_set_wtag(wc, bson_iter_utf8(&w, NULL));
    }

--- a/src/libmongoc/tests/test-mongoc-change-stream.c
+++ b/src/libmongoc/tests/test-mongoc-change-stream.c
@@ -309,7 +309,7 @@ test_change_stream_live_track_resume_token(void *test_ctx)
 
    /* Insert a few docs to listen for. Use write concern majority, so subsequent
     * call to watch will be guaranteed to retrieve them. */
-   mongoc_write_concern_set_wmajority(wc, 30000);
+   mongoc_write_concern_set_w(wc, MONGOC_WRITE_CONCERN_W_MAJORITY);
    mongoc_write_concern_append(wc, &opts);
    ASSERT_OR_PRINT(mongoc_collection_insert_one(coll, tmp_bson("{'_id': 0}"), &opts, NULL, &error), error);
 
@@ -428,7 +428,7 @@ test_change_stream_live_batch_size(void *test_ctx)
 
    ctx.expected_getmore_batch_size = 1;
 
-   mongoc_write_concern_set_wmajority(wc, 30000);
+   mongoc_write_concern_set_w(wc, MONGOC_WRITE_CONCERN_W_MAJORITY);
    mongoc_write_concern_append(wc, &opts);
    for (i = 0; i < 10; i++) {
       bson_t *doc = BCON_NEW("_id", BCON_INT32(i));
@@ -486,7 +486,7 @@ _test_resume_token_error(const char *id_projection)
    ASSERT(stream);
    ASSERT_OR_PRINT(!mongoc_change_stream_error_document(stream, &err, NULL), err);
 
-   mongoc_write_concern_set_wmajority(wc, 30000);
+   mongoc_write_concern_set_w(wc, MONGOC_WRITE_CONCERN_W_MAJORITY);
    mongoc_write_concern_append(wc, &opts);
    ASSERT_OR_PRINT(mongoc_collection_insert_one(coll, tmp_bson("{'_id': 2}"), &opts, NULL, &err), err);
 
@@ -888,7 +888,7 @@ test_change_stream_live_watch(void *test_ctx)
 
    BSON_UNUSED(test_ctx);
 
-   mongoc_write_concern_set_wmajority(wc, 30000);
+   mongoc_write_concern_set_w(wc, MONGOC_WRITE_CONCERN_W_MAJORITY);
 
    coll = drop_and_get_coll(client, "db", "coll_watch");
    ASSERT(coll);
@@ -1610,7 +1610,7 @@ prose_test_11(void *ctx)
    post_batch_expected = (_data_change_stream_t *)stream->cursor->impl.data;
    ASSERT(bson_compare(resume_token, &post_batch_expected->post_batch_resume_token) == 0);
 
-   mongoc_write_concern_set_wmajority(wc, 30000);
+   mongoc_write_concern_set_w(wc, MONGOC_WRITE_CONCERN_W_MAJORITY);
    mongoc_write_concern_append(wc, &opts);
    ASSERT_OR_PRINT(mongoc_collection_insert_one(coll, tmp_bson("{'_id': 0}"), &opts, NULL, &error), error);
 
@@ -1661,7 +1661,7 @@ prose_test_13(void *ctx)
 
    /* Insert a few docs to listen for. Use write concern majority, so subsequent
     * call to watch will be guaranteed to retrieve them. */
-   mongoc_write_concern_set_wmajority(wc, 30000);
+   mongoc_write_concern_set_w(wc, MONGOC_WRITE_CONCERN_W_MAJORITY);
    mongoc_write_concern_append(wc, &opts);
    ASSERT_OR_PRINT(mongoc_collection_insert_one(coll, tmp_bson("{'_id': 0}"), &opts, NULL, &error), error);
 

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -53,7 +53,7 @@ _before_test(json_test_ctx_t *ctx, const bson_t *test)
    /* Insert data into the key vault. */
    client = test_framework_new_default_client();
    wc = mongoc_write_concern_new();
-   mongoc_write_concern_set_wmajority(wc, 1000);
+   mongoc_write_concern_set_w(wc, MONGOC_WRITE_CONCERN_W_MAJORITY);
    bson_init(&insert_opts);
    mongoc_write_concern_append(wc, &insert_opts);
 
@@ -397,7 +397,7 @@ test_bson_size_limits_and_batch_splitting(void *unused)
       (void)mongoc_collection_drop(coll, NULL);
       datakey = get_bson_from_json_file("./src/libmongoc/tests/client_side_encryption_prose/limits-key.json");
       wc = mongoc_write_concern_new();
-      mongoc_write_concern_set_wmajority(wc, 1000);
+      mongoc_write_concern_set_w(wc, MONGOC_WRITE_CONCERN_W_MAJORITY);
       mongoc_collection_set_write_concern(coll, wc);
       ASSERT_OR_PRINT(mongoc_collection_insert_one(coll, datakey, NULL /* opts */, NULL /* reply */, &error), error);
       mongoc_write_concern_destroy(wc);
@@ -951,7 +951,7 @@ _test_key_vault(bool with_external_key_vault)
 
    /* Insert the document external-key.json into ``keyvault.datakeys``. */
    wc = mongoc_write_concern_new();
-   mongoc_write_concern_set_wmajority(wc, 1000);
+   mongoc_write_concern_set_w(wc, MONGOC_WRITE_CONCERN_W_MAJORITY);
    mongoc_collection_set_write_concern(coll, wc);
    datakey = get_bson_from_json_file("./src/libmongoc/tests/"
                                      "client_side_encryption_prose/external/"
@@ -1725,7 +1725,7 @@ _test_corpus(bool local_schema)
    coll = mongoc_client_get_collection(client, "keyvault", "datakeys");
    (void)mongoc_collection_drop(coll, NULL);
    wc = mongoc_write_concern_new();
-   mongoc_write_concern_set_wmajority(wc, 1000);
+   mongoc_write_concern_set_w(wc, MONGOC_WRITE_CONCERN_W_MAJORITY);
    mongoc_collection_set_write_concern(coll, wc);
    _insert_from_file(coll,
                      "./src/libmongoc/tests/client_side_encryption_prose/"
@@ -1898,7 +1898,7 @@ _reset(mongoc_client_pool_t **pool,
       coll = mongoc_client_get_collection(*singled_threaded_client, "db", "keyvault");
       (void)mongoc_collection_drop(coll, NULL);
       wc = mongoc_write_concern_new();
-      mongoc_write_concern_set_wmajority(wc, 1000);
+      mongoc_write_concern_set_w(wc, MONGOC_WRITE_CONCERN_W_MAJORITY);
       mongoc_collection_set_write_concern(coll, wc);
       datakey = get_bson_from_json_file("./src/libmongoc/tests/client_side_encryption_prose/limits-key.json");
       BSON_ASSERT(datakey);
@@ -2129,7 +2129,7 @@ _test_multi_threaded(bool external_key_vault)
    datakey = get_bson_from_json_file("./src/libmongoc/tests/client_side_encryption_prose/limits-key.json");
    BSON_ASSERT(datakey);
    wc = mongoc_write_concern_new();
-   mongoc_write_concern_set_wmajority(wc, 1000);
+   mongoc_write_concern_set_w(wc, MONGOC_WRITE_CONCERN_W_MAJORITY);
    mongoc_collection_set_write_concern(coll, wc);
    ASSERT_OR_PRINT(mongoc_collection_insert_one(coll, datakey, NULL /* opts */, NULL /* reply */, &error), error);
 

--- a/src/libmongoc/tests/test-mongoc-primary-stepdown.c
+++ b/src/libmongoc/tests/test-mongoc-primary-stepdown.c
@@ -62,7 +62,7 @@ _setup_test_with_client(mongoc_client_t *client)
 
       {
          mongoc_write_concern_t *const wc = mongoc_write_concern_new();
-         mongoc_write_concern_set_wmajority(wc, -1);
+         mongoc_write_concern_set_w(wc, MONGOC_WRITE_CONCERN_W_MAJORITY);
          ASSERT(mongoc_write_concern_append(wc, &opts));
          mongoc_write_concern_destroy(wc);
       }
@@ -158,7 +158,7 @@ test_getmore_iteration(mongoc_client_t *client, stream_tracker_t *st)
 
       {
          mongoc_write_concern_t *const wc = mongoc_write_concern_new();
-         mongoc_write_concern_set_wmajority(wc, -1);
+         mongoc_write_concern_set_w(wc, MONGOC_WRITE_CONCERN_W_MAJORITY);
          ASSERT(mongoc_write_concern_append(wc, &opts));
          mongoc_write_concern_destroy(wc);
       }

--- a/src/libmongoc/tests/test-mongoc-sample-commands.c
+++ b/src/libmongoc/tests/test-mongoc-sample-commands.c
@@ -3933,7 +3933,7 @@ with_transaction_example(bson_error_t *error)
     * concern by default.
     */
    wc = mongoc_write_concern_new();
-   mongoc_write_concern_set_wmajority(wc, 0);
+   mongoc_write_concern_set_wmajority(wc, 1000);
    insert_opts = bson_new();
    mongoc_write_concern_append(wc, insert_opts);
    coll = mongoc_client_get_collection(client, "mydb1", "foo");


### PR DESCRIPTION
# Summary
Do not set write concern timeout in most tests executing server operations.

# Background & Motivation

Intended to fix recent observed failures in Evergreen. [Example](https://spruce.mongodb.com/task/mongo_c_driver_cse_matrix_darwinssl_cse_sasl_cyrus_darwinssl_macos_14_clang_test_4.4_sharded_auth_0540e9929d6af9cb32086292db61fda78247ec1a_25_09_26_16_54_36/logs?execution=0):

```
FAIL:/Users/ec2-user/data/mci/ffb7ebf283ddea39b3d6257ed6eff9b4/mongoc/src/libmongoc/tests/test-mongoc-client-side-encryption.c:76  _before_test()
  ret
  waiting for replication timed out; Error details: { wtimeout: true, writeConcern: { w: "majority", wtimeout: 1000, provenance: "clientSupplied" } } at sh01
```

I expect the 1 second timeout is sometimes too short (IIRC servers on macOS Evergreen hosts generally run slower).

Removing `wTimeout` is expected to mean "no timeout". Quoting [docs](https://www.mongodb.com/docs/manual/reference/write-concern/#std-label-wc-wtimeout):

> If you do not specify the `wtimeout` option and the level of write concern is unachievable, the write operation will block indefinitely. Specifying a `wtimeout` value of 0 is equivalent to a write concern without the `wtimeout` option.

**Exceptions**:
- Two tests in test-mongoc-sample-commands.c keep their `wTimeout`. These are used as documentation examples and intended to match the descriptions of DRIVERS-547 and DRIVERS-655.
- Files in `src/libmongoc/examples` are left as-is. The examples are not run in Evergreen.

**References**:
- PyMongo tests for CSFLE [do not use a `wTimeout`](https://github.com/mongodb/mongo-python-driver/blob/e0767cf5a1ae47474889680685046e2866317900/test/test_encryption.py#L708).

