### PR TITLE
[r1.30] CDRIVER-6112 fix ownership transfer of `mongoc_write_command_t`

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-array-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-array-private.h
@@ -25,6 +25,9 @@
 BSON_BEGIN_DECLS
 
 
+// mongoc_array_t stores an array of objects of type T.
+//
+// T must be trivially relocatable. In particular, `bson_t` is not trivially relocatable (CDRIVER-6113).
 typedef struct _mongoc_array_t mongoc_array_t;
 
 

--- a/src/libmongoc/src/mongoc/mongoc-write-command-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-write-command-private.h
@@ -61,7 +61,7 @@ typedef struct {
    uint32_t n_documents;
    mongoc_bulk_write_flags_t flags;
    int64_t operation_id;
-   bson_t cmd_opts;
+   bson_t *cmd_opts;
 } mongoc_write_command_t;
 
 

--- a/src/libmongoc/src/mongoc/mongoc-write-command.c
+++ b/src/libmongoc/src/mongoc/mongoc-write-command.c
@@ -143,9 +143,9 @@ _mongoc_write_command_init_bulk (
    command->flags = flags;
    command->operation_id = operation_id;
    if (!bson_empty0 (opts)) {
-      bson_copy_to (opts, &command->cmd_opts);
+      command->cmd_opts = bson_copy (opts);
    } else {
-      bson_init (&command->cmd_opts);
+      command->cmd_opts = bson_new ();
    }
 
    _mongoc_buffer_init (&command->payload, NULL, 0, NULL, NULL);
@@ -671,7 +671,7 @@ _mongoc_write_opmsg (mongoc_write_command_t *command,
                                ? MONGOC_CMD_PARTS_ALLOW_TXN_NUMBER_NO
                                : MONGOC_CMD_PARTS_ALLOW_TXN_NUMBER_YES;
 
-   BSON_ASSERT (bson_iter_init (&iter, &command->cmd_opts));
+   BSON_ASSERT (bson_iter_init (&iter, command->cmd_opts));
    if (!mongoc_cmd_parts_append_opts (&parts, &iter, error)) {
       bson_destroy (&cmd);
       mongoc_cmd_parts_cleanup (&parts);
@@ -944,7 +944,7 @@ _mongoc_write_command_destroy (mongoc_write_command_t *command)
    ENTRY;
 
    if (command) {
-      bson_destroy (&command->cmd_opts);
+      bson_destroy (command->cmd_opts);
       _mongoc_buffer_destroy (&command->payload);
    }
 


### PR DESCRIPTION
Applies changes from https://github.com/mongodb/mongo-c-driver/pull/2132 to r1.30 branch to include in 1.30.6 release.

[ac38749](https://github.com/mongodb/mongo-c-driver/commit/ac38749127feec6c85745132853468bbc203115e) was cherry-picked and manually fixed to match formatting on r1.30 (6ccc0ae7b5ce30559853cc53f3a8938010fde332 changed formatting on master, and is not on r1.30).