### PR TITLE
CDRIVER-6103 AIX build failure fix

### DIFF
--- a/src/libbson/tests/test-json.c
+++ b/src/libbson/tests/test-json.c
@@ -1933,9 +1933,9 @@ test_bson_json_double(void)
    BSON_ASSERT(BSON_ITER_HOLDS_DOUBLE(&iter));
    ASSERT_CMPDOUBLE(bson_iter_double(&iter), ==, 0.0);
 
-/* check that "x" is -0.0. signbit not available on FreeBSD or VS 2010
+/* check that "x" is -0.0. signbit not available on FreeBSD or VS 2010 or AIX
  */
-#if !defined(__FreeBSD__) && (!defined(_MSC_VER) || (_MSC_VER >= 1800))
+#if !defined(__FreeBSD__) && (!defined(_MSC_VER) || (_MSC_VER >= 1800)) || (!defined(_AIX))
    BSON_ASSERT(signbit(bson_iter_double(&iter)));
 #endif
 

--- a/src/libbson/tests/test-json.c
+++ b/src/libbson/tests/test-json.c
@@ -1935,7 +1935,7 @@ test_bson_json_double(void)
 
 /* check that "x" is -0.0. signbit not available on FreeBSD or VS 2010 or AIX
  */
-#if !defined(__FreeBSD__) && (!defined(_MSC_VER) || (_MSC_VER >= 1800)) || (!defined(_AIX))
+#if !defined(__FreeBSD__) && (!defined(_MSC_VER) || (_MSC_VER >= 1800)) && (!defined(_AIX))
    BSON_ASSERT(signbit(bson_iter_double(&iter)));
 #endif
 


### PR DESCRIPTION
This PR fixes the signbit symbol missing issue.

Below is the issue URL.

https://jira.mongodb.org/browse/CDRIVER-6103