### PR TITLE
CDRIVER-6076 note macOS 13 and older is not tested or supported

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,10 @@ libmongoc 2.3.0 [UNRELEASED]
         - If not upgrading, custom application retry logic may need to be adjusted to handle higher rates of overload errors.
     - Set the URI option `adaptiveRetry=true` limit retries with a token bucket system.
 
+## Removed
+
+* Support for macOS versions 13 and older. These versions are EOL and not tested. Use macOS version 14 or newer.
+
 libmongoc 2.2.4
 ===============
 


### PR DESCRIPTION
# Summary

Document support for macOS 13 and older is dropped

# Background & Motivation

As of https://github.com/mongodb/mongo-c-driver/pull/2088, only macOS 14+ is tested. The NEWS only documented dropping macOS 11 and 12. But macOS 13 has also [become EOL](https://endoflife.date/macos). Since macOS 13 is no longer tested, this PR proposes documenting that macOS 13 support is also dropped.

There are no changes to the Evergreen config. The NEWS entry might not be strictly necessary, but it communicates the intent of not supporting macOS 13 and older.