### PR TITLE
CDRIVER-6292: migrate VS 2022 C standard tasks

### DIFF
--- a/.evergreen/config_generator/components/c_std_compile.py
+++ b/.evergreen/config_generator/components/c_std_compile.py
@@ -34,9 +34,9 @@ MATRIX = [
 
     ('macos-14-arm64', 'clang', None, [99, 11, 17, 23]), # Apple Clang
 
-    ('windows-vsCurrent', 'vs2017x64', None, [99, 11,   ]), # Max: C11
-    ('windows-vsCurrent', 'vs2019x64', None, [99, 11, 17]), # Max: C17
-    ('windows-vsCurrent', 'vs2022x64', None, [99, 11, 17]), # Max: C17
+    ('windows-vsCurrent',   'vs2017x64', None, [99, 11,   ]), # Max: C11
+    ('windows-vsCurrent',   'vs2019x64', None, [99, 11, 17]), # Max: C17
+    ('windows-2022-latest', 'vs2022x64', None, [99, 11, 17]), # Max: C17
 ]
 # fmt: on
 # pylint: enable=line-too-long

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -8794,9 +8794,9 @@ tasks:
           CMAKE_GENERATOR: Visual Studio 16 2019
           CMAKE_GENERATOR_PLATFORM: x64
           C_STD_VERSION: 11
-  - name: std-c11-windows-2019-vs2022-x64-compile
-    run_on: windows-vsCurrent-large
-    tags: [std-matrix, windows-vsCurrent, vs2022x64, compile, std-c11]
+  - name: std-c11-windows-2022-latest-vs2022x64-compile
+    run_on: windows-2022-latest-large
+    tags: [std-matrix, windows-2022-latest, vs2022x64, compile, std-c11]
     commands:
       - func: std-compile
         vars:
@@ -8974,9 +8974,9 @@ tasks:
           CMAKE_GENERATOR: Visual Studio 16 2019
           CMAKE_GENERATOR_PLATFORM: x64
           C_STD_VERSION: 17
-  - name: std-c17-windows-2019-vs2022-x64-compile
-    run_on: windows-vsCurrent-large
-    tags: [std-matrix, windows-vsCurrent, vs2022x64, compile, std-c17]
+  - name: std-c17-windows-2022-latest-vs2022x64-compile
+    run_on: windows-2022-latest-large
+    tags: [std-matrix, windows-2022-latest, vs2022x64, compile, std-c17]
     commands:
       - func: std-compile
         vars:
@@ -9307,9 +9307,9 @@ tasks:
           CMAKE_GENERATOR: Visual Studio 16 2019
           CMAKE_GENERATOR_PLATFORM: x64
           C_STD_VERSION: 99
-  - name: std-c99-windows-2019-vs2022-x64-compile
-    run_on: windows-vsCurrent-large
-    tags: [std-matrix, windows-vsCurrent, vs2022x64, compile, std-c99]
+  - name: std-c99-windows-2022-latest-vs2022x64-compile
+    run_on: windows-2022-latest-large
+    tags: [std-matrix, windows-2022-latest, vs2022x64, compile, std-c99]
     commands:
       - func: std-compile
         vars:

--- a/.evergreen/scripts/compile-std.sh
+++ b/.evergreen/scripts/compile-std.sh
@@ -108,8 +108,8 @@ CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
 if [[ "${CMAKE_GENERATOR:-}" =~ "Visual Studio" ]]; then
   # MSBuild needs additional assistance.
   # https://devblogs.microsoft.com/cppblog/improved-parallelism-in-msbuild/
-  export UseMultiToolTask=1
-  export EnforceProcessCountAcrossBuilds=1
+  export UseMultiToolTask=true
+  export EnforceProcessCountAcrossBuilds=true
 fi
 
 echo "Checking requested C standard is supported..."


### PR DESCRIPTION
[skip ci] Evergreen: https://spruce.corp.mongodb.com/version/69dfab9213ca000007620731
# Summary

- Migrate C standard tasks on VS 2022 from `windows-vsCurrent` to `windows-2022-latest`
- Change "1" to "true" to fix an [observed error](https://spruce.corp.mongodb.com/task/mongo_c_driver_std_matrix_std_c11_windows_2022_latest_vs2022x64_compile_patch_d0b080e2fa973480f4c2f025416ec4ca91b6c8ef_69de9cdac6b83b00078d3511_26_04_14_20_00_29/logs?execution=0):
```
error MSB4030: "1" is an invalid value for the "EnforceProcessCountAcrossBuilds" parameter of the "SetModuleDependencies" task. The "EnforceProcessCountAcrossBuilds" parameter is of type "System.Boolean".
```

# Background & Motivation

The removal of newer Windows SDKs on `windows-vsCurrent` (DEVPROD-31175) appears to break [a workaround](https://github.com/mongodb/mongo-c-driver/blob/6da116d3993e4c715d5bf8bbec5e1896a4a85c78/.evergreen/scripts/compile-std.sh#L66-L68) in C driver builds testing C11 / C17 conformance.

The SDK removal was reported in [slack](https://mongodb.slack.com/archives/CR8SNBY0N/p1776264930543269) and also appears to impact Compass.



