### PR TITLE
CDRIVER-6291 verify retry behavior with mixed overload and non-overload errors

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-jitter-source-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-jitter-source-private.h
@@ -38,4 +38,10 @@ _mongoc_jitter_source_generate(mongoc_jitter_source_t *source);
 double
 _mongoc_jitter_source_generate_default(mongoc_jitter_source_t *source);
 
+void
+_mongoc_jitter_source_set_context(mongoc_jitter_source_t *source, void *ctx);
+
+void *
+_mongoc_jitter_source_get_context(mongoc_jitter_source_t *source);
+
 #endif

--- a/src/libmongoc/src/mongoc/mongoc-jitter-source.c
+++ b/src/libmongoc/src/mongoc/mongoc-jitter-source.c
@@ -19,6 +19,7 @@
 
 struct _mongoc_jitter_source_t {
    mongoc_jitter_source_generate_fn_t generate;
+   void *ctx;
 };
 
 mongoc_jitter_source_t *
@@ -54,4 +55,20 @@ _mongoc_jitter_source_generate_default(mongoc_jitter_source_t *source)
    BSON_UNUSED(source);
 
    return (double)_mongoc_simple_rand_uint32_t() / (double)UINT32_MAX;
+}
+
+void
+_mongoc_jitter_source_set_context(mongoc_jitter_source_t *source, void *ctx)
+{
+   BSON_ASSERT_PARAM(source);
+
+   source->ctx = ctx;
+}
+
+void *
+_mongoc_jitter_source_get_context(mongoc_jitter_source_t *source)
+{
+   BSON_ASSERT_PARAM(source);
+
+   return source->ctx;
 }

--- a/src/libmongoc/tests/test-mongoc-retryable-reads.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-reads.c
@@ -827,6 +827,10 @@ test_retryable_reads_prose_4(void *unused)
    mongoc_client_destroy(client);
 }
 
+// Prose test 5 requires some means of detecting how many times backoff is applied during the execution of a command.
+// Since the C Driver lacks a formal mechanism for this, we use a global counter that is incremented every time
+// `prose_test_5_jitter_source_generate` is called. Since jitter is generated only when backoff is calculated, this
+// effectively counts the number of times backoff is applied.
 static int gProseTest5BackoffCount;
 
 static double

--- a/src/libmongoc/tests/test-mongoc-retryable-reads.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-reads.c
@@ -827,17 +827,15 @@ test_retryable_reads_prose_4(void *unused)
    mongoc_client_destroy(client);
 }
 
-// Prose test 5 requires some means of detecting how many times backoff is applied during the execution of a command.
-// Since the C Driver lacks a formal mechanism for this, we use a global counter that is incremented every time
-// `prose_test_5_jitter_source_generate` is called. Since jitter is generated only when backoff is calculated, this
-// effectively counts the number of times backoff is applied.
-static int gProseTest5BackoffCount;
+typedef struct {
+   int count;
+} backoff_counter_t;
 
 static double
-prose_test_5_jitter_source_generate(mongoc_jitter_source_t *source)
+backoff_counting_jitter_source_generate(mongoc_jitter_source_t *source)
 {
-   BSON_UNUSED(source);
-   ++gProseTest5BackoffCount;
+   backoff_counter_t *const counter = (backoff_counter_t *)_mongoc_jitter_source_get_context(source);
+   ++counter->count;
    return 0.0;
 }
 
@@ -871,7 +869,12 @@ test_retryable_reads_prose_5(void *unused)
    // Step 1: Create a client.
    mongoc_client_t *const client = test_framework_new_default_client();
 
-   _mongoc_client_set_jitter_source(client, _mongoc_jitter_source_new(prose_test_5_jitter_source_generate));
+   backoff_counter_t backoff_counter = {0};
+   {
+      mongoc_jitter_source_t *const jitter_source = _mongoc_jitter_source_new(backoff_counting_jitter_source_generate);
+      _mongoc_jitter_source_set_context(jitter_source, &backoff_counter);
+      _mongoc_client_set_jitter_source(client, jitter_source);
+   }
 
    // Step 3: Via the command monitoring CommandFailedEvent, configure a fail point with error code 91
    // (`ShutdownInProgress`) and the `RetryableError` label. Configure the second fail point command only if the failed
@@ -900,9 +903,8 @@ test_retryable_reads_prose_5(void *unused)
          {"failCommands" : ["find"], "errorLabels" : [ "RetryableError", "SystemOverloadedError" ], "errorCode" : 91}
    }));
 
-   // Step 4: Attempt a `findOne` operation on any record for any database and collection. Expect the `findOne` to fail
-   // with a server error.
-   gProseTest5BackoffCount = 0;
+   // Step 4: Attempt a findOne operation on any record for any database and collection. Expect the findOne to fail with
+   // a server error.
    {
       mongoc_collection_t *const coll = get_test_collection(client, "retryable_reads");
       mongoc_cursor_t *const cursor = mongoc_collection_find_with_opts(coll, tmp_bson("{}"), NULL, NULL);
@@ -919,7 +921,7 @@ test_retryable_reads_prose_5(void *unused)
    // Assert that backoff was applied only once for the initial overload error and not for the subsequent non-overload
    // retryable errors. The jitter source is only invoked when backoff is actually applied (via
    // _mongoc_retry_backoff_generator_next), not when it is skipped (via _mongoc_retry_backoff_generator_skip).
-   ASSERT_CMPINT(gProseTest5BackoffCount, ==, 1);
+   ASSERT_CMPINT(backoff_counter.count, ==, 1);
 
    // Step 5: Disable the fail point.
    run_admin_command(BSON_STR({"configureFailPoint" : "failCommand", "mode" : "off"}));

--- a/src/libmongoc/tests/test-mongoc-retryable-reads.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-reads.c
@@ -1,4 +1,5 @@
 #include <mongoc/mongoc-collection-private.h>
+#include <mongoc/mongoc-uri-private.h>
 
 #include <mongoc/mongoc.h>
 
@@ -730,6 +731,101 @@ test_retryable_reads_prose_3_3(void *ctx)
    ASSERT(apm_ctx.server_id_failed.id == apm_ctx.server_id_succeeded.id);
 }
 
+typedef struct {
+   const char *second_failpoint_cmd;
+   int find_commands_started_count;
+} prose_test_4_ctx_t;
+
+static void
+prose_test_4_on_command_started(const mongoc_apm_command_started_t *event)
+{
+   prose_test_4_ctx_t *const ctx = (prose_test_4_ctx_t *)mongoc_apm_command_started_get_context(event);
+
+   if (0 == strcmp(mongoc_apm_command_started_get_command_name(event), "find")) {
+      ctx->find_commands_started_count++;
+   }
+}
+
+static void
+prose_test_4_on_command_failed(const mongoc_apm_command_failed_t *event)
+{
+   prose_test_4_ctx_t *const ctx = (prose_test_4_ctx_t *)mongoc_apm_command_failed_get_context(event);
+
+   if (0 != strcmp(mongoc_apm_command_failed_get_command_name(event), "find")) {
+      return;
+   }
+
+   // Configure the second fail point command only if the failed event is for the first error configured in step 2.
+   if (ctx->second_failpoint_cmd) {
+      run_admin_command(ctx->second_failpoint_cmd);
+      ctx->second_failpoint_cmd = NULL;
+   }
+}
+
+// Test that drivers set the maximum number of retries for all retryable read errors when an overload error is
+// encountered.
+static void
+test_retryable_reads_prose_4(void *unused)
+{
+   BSON_UNUSED(unused);
+
+   // Step 1: Create a client.
+   mongoc_client_t *const client = test_framework_new_default_client();
+
+   // Step 2: Configure a fail point with error code 91 (`ShutdownInProgress`) with the `RetryableError` and
+   // `SystemOverloadedError` error labels.
+   run_admin_command(BSON_STR({
+      "configureFailPoint" : "failCommand",
+      "mode" : {"times" : 1},
+      "data" :
+         {"failCommands" : ["find"], "errorLabels" : [ "RetryableError", "SystemOverloadedError" ], "errorCode" : 91}
+   }));
+
+   // Step 3: Via the command monitoring CommandFailedEvent, configure a fail point with error code 91
+   // (`ShutdownInProgress`) and the `RetryableError` label. Configure the second fail point command only if the failed
+   // event is for the first error configured in step 2.
+   prose_test_4_ctx_t apm_ctx = {
+      .second_failpoint_cmd = BSON_STR({
+         "configureFailPoint" : "failCommand",
+         "mode" : "alwaysOn",
+         "data" : {"failCommands" : ["find"], "errorLabels" : ["RetryableError"], "errorCode" : 91}
+      }),
+      .find_commands_started_count = 0,
+   };
+
+   {
+      mongoc_apm_callbacks_t *const callbacks = mongoc_apm_callbacks_new();
+      mongoc_apm_set_command_started_cb(callbacks, prose_test_4_on_command_started);
+      mongoc_apm_set_command_failed_cb(callbacks, prose_test_4_on_command_failed);
+      mongoc_client_set_apm_callbacks(client, callbacks, &apm_ctx);
+      mongoc_apm_callbacks_destroy(callbacks);
+   }
+
+   // Step 4: Attempt a `findOne` operation on any record for any database and collection. Expect the `findOne` to fail
+   // with a server error.
+   {
+      mongoc_collection_t *const coll = get_test_collection(client, "retryable_reads");
+      mongoc_cursor_t *const cursor = mongoc_collection_find_with_opts(coll, tmp_bson("{}"), NULL, NULL);
+
+      const bson_t *doc;
+      ASSERT(!mongoc_cursor_next(cursor, &doc));
+
+      bson_error_t error;
+      ASSERT(mongoc_cursor_error(cursor, &error));
+
+      mongoc_cursor_destroy(cursor);
+      mongoc_collection_destroy(coll);
+   }
+
+   // Assert that `MONGOC_DEFAULT_MAXADAPTIVERETRIES + 1` attempts were made.
+   ASSERT_CMPINT(apm_ctx.find_commands_started_count, ==, MONGOC_DEFAULT_MAXADAPTIVERETRIES + 1);
+
+   // Step 5: Disable the fail point.
+   run_admin_command(BSON_STR({"configureFailPoint" : "failCommand", "mode" : "off"}));
+
+   mongoc_client_destroy(client);
+}
+
 /*
  *-----------------------------------------------------------------------
  *
@@ -801,5 +897,11 @@ test_retryable_reads_install(TestSuite *suite)
                      NULL,
                      NULL,
                      test_framework_skip_if_not_replset_with_secondary,
+                     test_framework_skip_if_max_wire_version_less_than_9 /* require 4.4+ */);
+   TestSuite_AddFull(suite,
+                     "/retryable_reads/prose_test_4",
+                     test_retryable_reads_prose_4,
+                     NULL,
+                     NULL,
                      test_framework_skip_if_max_wire_version_less_than_9 /* require 4.4+ */);
 }

--- a/src/libmongoc/tests/test-mongoc-retryable-reads.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-reads.c
@@ -1,3 +1,4 @@
+#include <mongoc/mongoc-client-private.h>
 #include <mongoc/mongoc-collection-private.h>
 #include <mongoc/mongoc-uri-private.h>
 
@@ -826,6 +827,102 @@ test_retryable_reads_prose_4(void *unused)
    mongoc_client_destroy(client);
 }
 
+static int gProseTest5BackoffCount;
+
+static double
+prose_test_5_jitter_source_generate(mongoc_jitter_source_t *source)
+{
+   BSON_UNUSED(source);
+   ++gProseTest5BackoffCount;
+   return 0.0;
+}
+
+typedef struct {
+   const char *second_failpoint_cmd;
+} prose_test_5_ctx_t;
+
+static void
+prose_test_5_on_command_failed(const mongoc_apm_command_failed_t *event)
+{
+   prose_test_5_ctx_t *const ctx = (prose_test_5_ctx_t *)mongoc_apm_command_failed_get_context(event);
+
+   if (0 != strcmp(mongoc_apm_command_failed_get_command_name(event), "find")) {
+      return;
+   }
+
+   // Configure the second fail point command only if the failed event is for the first error configured in step 2.
+   if (ctx->second_failpoint_cmd) {
+      run_admin_command(ctx->second_failpoint_cmd);
+      ctx->second_failpoint_cmd = NULL;
+   }
+}
+
+// Test that drivers do not apply backoff to non-overload errors.
+static void
+test_retryable_reads_prose_5(void *unused)
+{
+   BSON_UNUSED(unused);
+
+
+   // Step 1: Create a client.
+   mongoc_client_t *const client = test_framework_new_default_client();
+
+   _mongoc_client_set_jitter_source(client, _mongoc_jitter_source_new(prose_test_5_jitter_source_generate));
+
+   // Step 3: Via the command monitoring CommandFailedEvent, configure a fail point with error code 91
+   // (`ShutdownInProgress`) and the `RetryableError` label. Configure the second fail point command only if the failed
+   // event is for the first error configured in step 2.
+   prose_test_5_ctx_t ctx = {
+      .second_failpoint_cmd = BSON_STR({
+         "configureFailPoint" : "failCommand",
+         "mode" : "alwaysOn",
+         "data" : {"failCommands" : ["find"], "errorLabels" : ["RetryableError"], "errorCode" : 91}
+      }),
+   };
+
+   {
+      mongoc_apm_callbacks_t *const callbacks = mongoc_apm_callbacks_new();
+      mongoc_apm_set_command_failed_cb(callbacks, prose_test_5_on_command_failed);
+      mongoc_client_set_apm_callbacks(client, callbacks, &ctx);
+      mongoc_apm_callbacks_destroy(callbacks);
+   }
+
+   // Step 2: Configure a fail point with error code 91 (`ShutdownInProgress`) with the `RetryableError` and
+   // `SystemOverloadedError` error labels.
+   run_admin_command(BSON_STR({
+      "configureFailPoint" : "failCommand",
+      "mode" : {"times" : 1},
+      "data" :
+         {"failCommands" : ["find"], "errorLabels" : [ "RetryableError", "SystemOverloadedError" ], "errorCode" : 91}
+   }));
+
+   // Step 4: Attempt a `findOne` operation on any record for any database and collection. Expect the `findOne` to fail
+   // with a server error.
+   gProseTest5BackoffCount = 0;
+   {
+      mongoc_collection_t *const coll = get_test_collection(client, "retryable_reads");
+      mongoc_cursor_t *const cursor = mongoc_collection_find_with_opts(coll, tmp_bson("{}"), NULL, NULL);
+
+      const bson_t *doc;
+      ASSERT(!mongoc_cursor_next(cursor, &doc));
+
+      bson_error_t error;
+      ASSERT(mongoc_cursor_error(cursor, &error));
+
+      mongoc_cursor_destroy(cursor);
+      mongoc_collection_destroy(coll);
+   }
+   // Assert that backoff was applied only once for the initial overload error and not for the subsequent non-overload
+   // retryable errors. The jitter source is only invoked when backoff is actually applied (via
+   // _mongoc_retry_backoff_generator_next), not when it is skipped (via _mongoc_retry_backoff_generator_skip).
+   ASSERT_CMPINT(gProseTest5BackoffCount, ==, 1);
+
+   // Step 5: Disable the fail point.
+   run_admin_command(BSON_STR({"configureFailPoint" : "failCommand", "mode" : "off"}));
+
+   mongoc_client_destroy(client);
+}
+
 /*
  *-----------------------------------------------------------------------
  *
@@ -901,6 +998,12 @@ test_retryable_reads_install(TestSuite *suite)
    TestSuite_AddFull(suite,
                      "/retryable_reads/prose_test_4",
                      test_retryable_reads_prose_4,
+                     NULL,
+                     NULL,
+                     test_framework_skip_if_max_wire_version_less_than_9 /* require 4.4+ */);
+   TestSuite_AddFull(suite,
+                     "/retryable_reads/prose_test_5",
+                     test_retryable_reads_prose_5,
                      NULL,
                      NULL,
                      test_framework_skip_if_max_wire_version_less_than_9 /* require 4.4+ */);

--- a/src/libmongoc/tests/test-mongoc-retryable-writes.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-writes.c
@@ -1,3 +1,4 @@
+#include <mongoc/mongoc-client-private.h>
 #include <mongoc/mongoc-collection-private.h>
 #include <mongoc/mongoc-uri-private.h>
 
@@ -1530,6 +1531,88 @@ retryable_writes_prose_test_6_case_4(void *ctx)
    mongoc_client_destroy(client);
 }
 
+static int gProseTest6Case5BackoffCount;
+
+static double
+prose_test_6_case_5_jitter_source_generate(mongoc_jitter_source_t *source)
+{
+   BSON_UNUSED(source);
+   ++gProseTest6Case5BackoffCount;
+   return 0.0;
+}
+
+typedef struct {
+   const char *second_fail_point_cmd_str;
+} prose_test_6_case_5_ctx_t;
+
+static void
+prose_test_6_case_5_on_command_failed(const mongoc_apm_command_failed_t *event)
+{
+   prose_test_6_case_5_ctx_t *const ctx = (prose_test_6_case_5_ctx_t *)mongoc_apm_command_failed_get_context(event);
+
+   if (0 != strcmp(mongoc_apm_command_failed_get_command_name(event), "insert")) {
+      return;
+   }
+
+   // Configure the second fail point command only if the failed event is for the first error configured in step 2.
+   if (ctx->second_fail_point_cmd_str) {
+      run_admin_command(ctx->second_fail_point_cmd_str);
+      ctx->second_fail_point_cmd_str = NULL;
+   }
+}
+
+// Case 5: Test that drivers do not apply backoff to non-overload errors.
+void
+retryable_writes_prose_test_6_case_5(void *ctx)
+{
+   BSON_UNUSED(ctx);
+
+   // Step 1: Create a client with `retryWrites=true`.
+   mongoc_client_t *const client = prose_test_6_create_client();
+
+   _mongoc_client_set_jitter_source(client, _mongoc_jitter_source_new(prose_test_6_case_5_jitter_source_generate));
+
+   // Step 2: Configure a fail point with error code 91 (`ShutdownInProgress`) with the `RetryableError` and
+   // `SystemOverloadedError` error labels.
+   run_admin_command(BSON_STR({
+      "configureFailPoint" : "failCommand",
+      "mode" : {"times" : 1},
+      "data" :
+         {"failCommands" : ["insert"], "errorLabels" : [ "RetryableError", "SystemOverloadedError" ], "errorCode" : 91}
+   }));
+
+   // Step 3: Via the command monitoring CommandFailedEvent, configure a fail point with error code 91
+   // (`ShutdownInProgress`) and the `RetryableWriteError` and `RetryableError` labels. Configure the second fail point
+   // command only if the failed event is for the first error configured in step 2.
+   prose_test_6_case_5_ctx_t apm_ctx = {
+      .second_fail_point_cmd_str = BSON_STR({
+         "configureFailPoint" : "failCommand",
+         "mode" : "alwaysOn",
+         "data" :
+            {"failCommands" : ["insert"], "errorLabels" : [ "RetryableError", "RetryableWriteError" ], "errorCode" : 91}
+      }),
+   };
+
+   {
+      mongoc_apm_callbacks_t *const callbacks = mongoc_apm_callbacks_new();
+      mongoc_apm_set_command_failed_cb(callbacks, prose_test_6_case_5_on_command_failed);
+      mongoc_client_set_apm_callbacks(client, callbacks, &apm_ctx);
+      mongoc_apm_callbacks_destroy(callbacks);
+   }
+
+   // Step 4: Attempt an `insertOne` operation on any record for any database and collection. Expect the `insertOne` to
+   // fail with a server error. Assert that backoff was applied only once for the initial overload error and not for the
+   // subsequent non-overload retryable errors.
+   gProseTest6Case5BackoffCount = 0;
+   prose_test_6_attempt_insert(client, 91u, NULL);
+   ASSERT_CMPINT(gProseTest6Case5BackoffCount, ==, 1);
+
+   // Step 5: Disable the fail point.
+   disable_fail_point();
+
+   mongoc_client_destroy(client);
+}
+
 void
 test_retryable_writes_install(TestSuite *suite)
 {
@@ -1667,6 +1750,14 @@ test_retryable_writes_install(TestSuite *suite)
    TestSuite_AddFull(suite,
                      "/retryable_writes/prose_test_6_case_4",
                      retryable_writes_prose_test_6_case_4,
+                     NULL,
+                     NULL,
+                     test_framework_skip_if_not_replset, /* only run against replica sets as mongos does not propagate
+                                                            the NoWritesPerformed label to the drivers */
+                     test_framework_skip_if_max_wire_version_less_than_9 /* require 4.4+ for errorLabels */);
+   TestSuite_AddFull(suite,
+                     "/retryable_writes/prose_test_6_case_5",
+                     retryable_writes_prose_test_6_case_5,
                      NULL,
                      NULL,
                      test_framework_skip_if_not_replset, /* only run against replica sets as mongos does not propagate

--- a/src/libmongoc/tests/test-mongoc-retryable-writes.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-writes.c
@@ -1531,6 +1531,10 @@ retryable_writes_prose_test_6_case_4(void *ctx)
    mongoc_client_destroy(client);
 }
 
+// Prose test 6 case 5 requires some means of detecting how many times backoff is applied during the execution of a
+// command. Since the C Driver lacks a formal mechanism for this, we use a global counter that is incremented every time
+// `prose_test_6_case_5_jitter_source_generate` is called. Since jitter is generated only when backoff is calculated,
+// this effectively counts the number of times backoff is applied.
 static int gProseTest6Case5BackoffCount;
 
 static double

--- a/src/libmongoc/tests/test-mongoc-retryable-writes.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-writes.c
@@ -1,4 +1,5 @@
 #include <mongoc/mongoc-collection-private.h>
+#include <mongoc/mongoc-uri-private.h>
 
 #include <mongoc/mongoc.h>
 
@@ -1258,12 +1259,13 @@ run_admin_command(const char *cmd_str)
 typedef struct {
    uint32_t first_fail_point_error_code;
    const char *second_fail_point_cmd_str;
-} prose_test_6_apm_ctx_t;
+} prose_test_6_case_1_to_3_apm_ctx_t;
 
 static void
-prose_test_6_on_command_failed(const mongoc_apm_command_failed_t *event)
+prose_test_6_case_1_to_3_on_command_failed(const mongoc_apm_command_failed_t *event)
 {
-   prose_test_6_apm_ctx_t *const ctx = (prose_test_6_apm_ctx_t *)mongoc_apm_command_failed_get_context(event);
+   prose_test_6_case_1_to_3_apm_ctx_t *const ctx =
+      (prose_test_6_case_1_to_3_apm_ctx_t *)mongoc_apm_command_failed_get_context(event);
 
    bson_error_t error;
    mongoc_apm_command_failed_get_error(event, &error);
@@ -1274,10 +1276,10 @@ prose_test_6_on_command_failed(const mongoc_apm_command_failed_t *event)
 }
 
 static void
-prose_test_6_set_apm_callbacks(mongoc_client_t *client, prose_test_6_apm_ctx_t *ctx)
+prose_test_6_case_1_to_3_set_apm_callbacks(mongoc_client_t *client, prose_test_6_case_1_to_3_apm_ctx_t *ctx)
 {
    mongoc_apm_callbacks_t *const callbacks = mongoc_apm_callbacks_new();
-   mongoc_apm_set_command_failed_cb(callbacks, prose_test_6_on_command_failed);
+   mongoc_apm_set_command_failed_cb(callbacks, prose_test_6_case_1_to_3_on_command_failed);
 
    mongoc_client_set_apm_callbacks(client, callbacks, ctx);
 
@@ -1323,17 +1325,17 @@ retryable_writes_prose_test_6_case_1(void *ctx)
    // Step 3: Via the command monitoring CommandFailedEvent, configure a fail point with error code `10107`
    // (NotWritablePrimary). Configure the `10107` fail point command only if the the failed event is for the `91` error
    // configured in step 2.
-   prose_test_6_apm_ctx_t apm_ctx = {.first_fail_point_error_code = 91u,
-                                     .second_fail_point_cmd_str = BSON_STR({
-                                        "configureFailPoint" : "failCommand",
-                                        "mode" : "alwaysOn",
-                                        "data" : {
-                                           "failCommands" : ["insert"],
-                                           "errorCode" : 10107,
-                                           "errorLabels" : [ "RetryableError", "SystemOverloadedError" ]
-                                        }
-                                     })};
-   prose_test_6_set_apm_callbacks(client, &apm_ctx);
+   prose_test_6_case_1_to_3_apm_ctx_t apm_ctx = {.first_fail_point_error_code = 91u,
+                                                 .second_fail_point_cmd_str = BSON_STR({
+                                                    "configureFailPoint" : "failCommand",
+                                                    "mode" : "alwaysOn",
+                                                    "data" : {
+                                                       "failCommands" : ["insert"],
+                                                       "errorCode" : 10107,
+                                                       "errorLabels" : [ "RetryableError", "SystemOverloadedError" ]
+                                                    }
+                                                 })};
+   prose_test_6_case_1_to_3_set_apm_callbacks(client, &apm_ctx);
 
    // Step 4: Attempt an `insertOne` operation on any record for any database and collection. Expect the `insertOne` to
    // fail with a server error. Assert that the error code of the server error is `10107`.
@@ -1369,7 +1371,7 @@ retryable_writes_prose_test_6_case_2(void *ctx)
    // Step 3: Via the command monitoring CommandFailedEvent, configure a fail point with error code `10107`
    // (NotWritablePrimary) and a NoWritesPerformed label. Configure the `10107` fail point command only if the the
    // failed event is for the `91` error configured in step 2.
-   prose_test_6_apm_ctx_t apm_ctx = {
+   prose_test_6_case_1_to_3_apm_ctx_t apm_ctx = {
       .first_fail_point_error_code = 91u,
       .second_fail_point_cmd_str = BSON_STR({
          "configureFailPoint" : "failCommand",
@@ -1380,7 +1382,7 @@ retryable_writes_prose_test_6_case_2(void *ctx)
             "errorLabels" : [ "RetryableError", "SystemOverloadedError", "NoWritesPerformed" ]
          }
       })};
-   prose_test_6_set_apm_callbacks(client, &apm_ctx);
+   prose_test_6_case_1_to_3_set_apm_callbacks(client, &apm_ctx);
 
    // Step 4: Attempt an `insertOne` operation on any record for any database and collection. Expect the `insertOne` to
    // fail with a server error. Assert that the error code of the server error is 91.
@@ -1404,17 +1406,17 @@ retryable_writes_prose_test_6_case_3(void *ctx)
 
    // Step 2: Configure a fail point with error code `91` (ShutdownInProgress) with the `RetryableError` and
    // `SystemOverloadedError` error labels.
-   prose_test_6_apm_ctx_t apm_ctx = {.first_fail_point_error_code = 91u,
-                                     .second_fail_point_cmd_str = BSON_STR({
-                                        "configureFailPoint" : "failCommand",
-                                        "mode" : {"times" : 1},
-                                        "data" : {
-                                           "failCommands" : ["insert"],
-                                           "errorLabels" : [ "RetryableError", "SystemOverloadedError" ],
-                                           "errorCode" : 91
-                                        }
-                                     })};
-   prose_test_6_set_apm_callbacks(client, &apm_ctx);
+   prose_test_6_case_1_to_3_apm_ctx_t apm_ctx = {.first_fail_point_error_code = 91u,
+                                                 .second_fail_point_cmd_str = BSON_STR({
+                                                    "configureFailPoint" : "failCommand",
+                                                    "mode" : {"times" : 1},
+                                                    "data" : {
+                                                       "failCommands" : ["insert"],
+                                                       "errorLabels" : [ "RetryableError", "SystemOverloadedError" ],
+                                                       "errorCode" : 91
+                                                    }
+                                                 })};
+   prose_test_6_case_1_to_3_set_apm_callbacks(client, &apm_ctx);
 
    // Step 3: Via the command monitoring CommandFailedEvent, configure a fail point with error code `91`
    // (ShutdownInProgress) and the `NoWritesPerformed`, `RetryableError` and `SystemOverloadedError` labels.
@@ -1440,6 +1442,88 @@ retryable_writes_prose_test_6_case_3(void *ctx)
 
       bson_destroy(&reply);
    }
+
+   // Step 5: Disable the fail point.
+   disable_fail_point();
+
+   mongoc_client_destroy(client);
+}
+
+typedef struct {
+   const char *second_fail_point_cmd_str;
+   int insert_commands_started_count;
+} prose_test_6_case_4_ctx_t;
+
+static void
+prose_test_6_case_4_on_command_started(const mongoc_apm_command_started_t *event)
+{
+   prose_test_6_case_4_ctx_t *const ctx = (prose_test_6_case_4_ctx_t *)mongoc_apm_command_started_get_context(event);
+
+   if (0 == strcmp(mongoc_apm_command_started_get_command_name(event), "insert")) {
+      ctx->insert_commands_started_count++;
+   }
+}
+
+static void
+prose_test_6_case_4_on_command_failed(const mongoc_apm_command_failed_t *event)
+{
+   prose_test_6_case_4_ctx_t *const ctx = (prose_test_6_case_4_ctx_t *)mongoc_apm_command_failed_get_context(event);
+
+   if (0 != strcmp(mongoc_apm_command_failed_get_command_name(event), "insert")) {
+      return;
+   }
+
+   // Configure the second fail point command only if the failed event is for the first error configured in step 2.
+   if (ctx->second_fail_point_cmd_str) {
+      run_admin_command(ctx->second_fail_point_cmd_str);
+      ctx->second_fail_point_cmd_str = NULL;
+   }
+}
+
+// Case 4: Test that drivers set the maximum number of retries for all retryable write errors when an overload error is
+// encountered.
+void
+retryable_writes_prose_test_6_case_4(void *ctx)
+{
+   BSON_UNUSED(ctx);
+
+   // Step 1: Create a client with `retryWrites=true`.
+   mongoc_client_t *const client = prose_test_6_create_client();
+
+   // Step 2: Configure a fail point with error code 91 (`ShutdownInProgress`) with the `RetryableError` and
+   // `SystemOverloadedError` error labels.
+   run_admin_command(BSON_STR({
+      "configureFailPoint" : "failCommand",
+      "mode" : {"times" : 1},
+      "data" :
+         {"failCommands" : ["insert"], "errorLabels" : [ "RetryableError", "SystemOverloadedError" ], "errorCode" : 91}
+   }));
+
+   // Step 3: Via the command monitoring CommandFailedEvent, configure a fail point with error code 91
+   // (`ShutdownInProgress`) and the `RetryableWriteError` and `RetryableError` labels. Configure the second fail point
+   // command only if the failed event is for the first error configured in step 2.
+   prose_test_6_case_4_ctx_t apm_ctx = {
+      .second_fail_point_cmd_str = BSON_STR({
+         "configureFailPoint" : "failCommand",
+         "mode" : "alwaysOn",
+         "data" :
+            {"failCommands" : ["insert"], "errorLabels" : [ "RetryableError", "RetryableWriteError" ], "errorCode" : 91}
+      }),
+      .insert_commands_started_count = 0,
+   };
+
+   {
+      mongoc_apm_callbacks_t *const callbacks = mongoc_apm_callbacks_new();
+      mongoc_apm_set_command_started_cb(callbacks, prose_test_6_case_4_on_command_started);
+      mongoc_apm_set_command_failed_cb(callbacks, prose_test_6_case_4_on_command_failed);
+      mongoc_client_set_apm_callbacks(client, callbacks, &apm_ctx);
+      mongoc_apm_callbacks_destroy(callbacks);
+   }
+
+   // Step 4: Attempt an `insertOne` operation on any record for any database and collection. Expect the `insertOne` to
+   // fail with a server error. Assert that `MONGOC_DEFAULT_MAXADAPTIVERETRIES + 1` attempts were made.
+   prose_test_6_attempt_insert(client, 91u, NULL);
+   ASSERT_CMPINT(apm_ctx.insert_commands_started_count, ==, MONGOC_DEFAULT_MAXADAPTIVERETRIES + 1);
 
    // Step 5: Disable the fail point.
    disable_fail_point();
@@ -1581,4 +1665,12 @@ test_retryable_writes_install(TestSuite *suite)
       test_framework_skip_if_not_replset, /* only run against replica sets as mongos does not propagate
                                              the NoWritesPerformed label to the drivers */
       test_framework_skip_if_max_wire_version_less_than_17 /* run against server versions 6.0 and above */);
+   TestSuite_AddFull(suite,
+                     "/retryable_writes/prose_test_6_case_4",
+                     retryable_writes_prose_test_6_case_4,
+                     NULL,
+                     NULL,
+                     test_framework_skip_if_not_replset, /* only run against replica sets as mongos does not propagate
+                                                            the NoWritesPerformed label to the drivers */
+                     test_framework_skip_if_max_wire_version_less_than_9 /* require 4.4+ for errorLabels */);
 }

--- a/src/libmongoc/tests/test-mongoc-retryable-writes.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-writes.c
@@ -1531,17 +1531,15 @@ retryable_writes_prose_test_6_case_4(void *ctx)
    mongoc_client_destroy(client);
 }
 
-// Prose test 6 case 5 requires some means of detecting how many times backoff is applied during the execution of a
-// command. Since the C Driver lacks a formal mechanism for this, we use a global counter that is incremented every time
-// `prose_test_6_case_5_jitter_source_generate` is called. Since jitter is generated only when backoff is calculated,
-// this effectively counts the number of times backoff is applied.
-static int gProseTest6Case5BackoffCount;
+typedef struct {
+   int count;
+} backoff_counter_t;
 
 static double
-prose_test_6_case_5_jitter_source_generate(mongoc_jitter_source_t *source)
+backoff_counting_jitter_source_generate(mongoc_jitter_source_t *source)
 {
-   BSON_UNUSED(source);
-   ++gProseTest6Case5BackoffCount;
+   backoff_counter_t *const counter = (backoff_counter_t *)_mongoc_jitter_source_get_context(source);
+   ++counter->count;
    return 0.0;
 }
 
@@ -1574,7 +1572,12 @@ retryable_writes_prose_test_6_case_5(void *ctx)
    // Step 1: Create a client with `retryWrites=true`.
    mongoc_client_t *const client = prose_test_6_create_client();
 
-   _mongoc_client_set_jitter_source(client, _mongoc_jitter_source_new(prose_test_6_case_5_jitter_source_generate));
+   backoff_counter_t backoff_counter = {0};
+   {
+      mongoc_jitter_source_t *const jitter_source = _mongoc_jitter_source_new(backoff_counting_jitter_source_generate);
+      _mongoc_jitter_source_set_context(jitter_source, &backoff_counter);
+      _mongoc_client_set_jitter_source(client, jitter_source);
+   }
 
    // Step 2: Configure a fail point with error code 91 (`ShutdownInProgress`) with the `RetryableError` and
    // `SystemOverloadedError` error labels.
@@ -1607,9 +1610,8 @@ retryable_writes_prose_test_6_case_5(void *ctx)
    // Step 4: Attempt an `insertOne` operation on any record for any database and collection. Expect the `insertOne` to
    // fail with a server error. Assert that backoff was applied only once for the initial overload error and not for the
    // subsequent non-overload retryable errors.
-   gProseTest6Case5BackoffCount = 0;
    prose_test_6_attempt_insert(client, 91u, NULL);
-   ASSERT_CMPINT(gProseTest6Case5BackoffCount, ==, 1);
+   ASSERT_CMPINT(backoff_counter.count, ==, 1);
 
    // Step 5: Disable the fail point.
    disable_fail_point();

--- a/src/libmongoc/tests/test-mongoc-retryable-writes.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-writes.c
@@ -1406,30 +1406,29 @@ retryable_writes_prose_test_6_case_3(void *ctx)
 
    // Step 2: Configure a fail point with error code `91` (ShutdownInProgress) with the `RetryableError` and
    // `SystemOverloadedError` error labels.
-   prose_test_6_case_1_to_3_apm_ctx_t apm_ctx = {.first_fail_point_error_code = 91u,
-                                                 .second_fail_point_cmd_str = BSON_STR({
-                                                    "configureFailPoint" : "failCommand",
-                                                    "mode" : {"times" : 1},
-                                                    "data" : {
-                                                       "failCommands" : ["insert"],
-                                                       "errorLabels" : [ "RetryableError", "SystemOverloadedError" ],
-                                                       "errorCode" : 91
-                                                    }
-                                                 })};
-   prose_test_6_case_1_to_3_set_apm_callbacks(client, &apm_ctx);
+   run_admin_command(BSON_STR({
+      "configureFailPoint" : "failCommand",
+      "mode" : {"times" : 1},
+      "data" :
+         {"failCommands" : ["insert"], "errorLabels" : [ "RetryableError", "SystemOverloadedError" ], "errorCode" : 91}
+   }));
 
    // Step 3: Via the command monitoring CommandFailedEvent, configure a fail point with error code `91`
    // (ShutdownInProgress) and the `NoWritesPerformed`, `RetryableError` and `SystemOverloadedError` labels.
    // Configure the second fail point command only if the failed event is for the first error configured in step 2.
-   run_admin_command(BSON_STR({
-      "configureFailPoint" : "failCommand",
-      "mode" : "alwaysOn",
-      "data" : {
-         "failCommands" : ["insert"],
-         "errorLabels" : [ "RetryableError", "SystemOverloadedError", "NoWritesPerformed" ],
-         "errorCode" : 91
-      }
-   }));
+   prose_test_6_case_1_to_3_apm_ctx_t apm_ctx = {
+      .first_fail_point_error_code = 91u,
+      .second_fail_point_cmd_str = BSON_STR({
+
+         "configureFailPoint" : "failCommand",
+         "mode" : "alwaysOn",
+         "data" : {
+            "failCommands" : ["insert"],
+            "errorLabels" : [ "RetryableError", "SystemOverloadedError", "NoWritesPerformed" ],
+            "errorCode" : 91
+         }
+      })};
+   prose_test_6_case_1_to_3_set_apm_callbacks(client, &apm_ctx);
 
    // Step 4: Attempt an `insertOne` operation on any record for any database and collection. Expect the `insertOne` to
    // fail with a server error. Assert that the error code of the server error is 91. Assert that the error does not


### PR DESCRIPTION
CDRIVER-6291
DRIVERS-3446

# Summary

Implement the prose tests added by DRIVERS-3446:

- Retryable Reads prose tests 4 and 5
- Retryable Writes prose test 6 cases 4 and 5

Additionally, there is a drive-by fix to Retryable Writes prose test 6 case 3.

## Use of global variables in Retryable Reads prose test 5 and Retryable Writes prose test 6 case 5

Both of these prose tests require some mechanism to detect how many times backoff was applied during the execution of a command. In the Python implementation, they replace the internal `RetryPolicy` type with a mock that counts the number of times the relevant function is called. While we could implement a similar customization point in the C Driver, I was concerned about having enough time for verification and code review before the April 17 release. 

For expediency, I chose to use a global counter for each test that is incremented every time the jitter source generate function is called. Since jitter is generated only when we calculate backoff, this effectively counts the number of times backoff is applied. Globals are obviously not ideal, so I am open to alternative solutions.