### PR TITLE
CDRIVER-6291 require crypto for test

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-topology.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology.c
@@ -403,8 +403,9 @@ mongoc_topology_new(const mongoc_uri_t *uri, bool single_threaded)
 
 #ifndef MONGOC_ENABLE_CRYPTO
    if (mongoc_uri_get_option_as_bool(uri, MONGOC_URI_RETRYWRITES, MONGOC_DEFAULT_RETRYWRITES)) {
-      /* retryWrites requires sessions, which require crypto - just warn */
-      MONGOC_WARNING("retryWrites not supported without an SSL crypto library");
+      // retryWrites needs crypto to retry server errors that require sessions. (See Retryable Writes spec)
+      // retryWrites does not need crypto to retry server overload errors. (See Client Backpressure spec)
+      MONGOC_WARNING("retryWrites is not fully supported without an SSL crypto library");
    }
 #endif
 

--- a/src/libmongoc/tests/test-mongoc-retryable-writes.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-writes.c
@@ -452,7 +452,7 @@ test_retry_no_crypto(void *ctx)
    BSON_ASSERT(client);
    ASSERT_CAPTURED_LOG("test_framework_client_new and retryWrites=true",
                        MONGOC_LOG_LEVEL_WARNING,
-                       "retryWrites not supported without an SSL crypto library");
+                       "retryWrites is not fully supported without an SSL crypto library");
    mongoc_client_destroy(client);
 
    clear_captured_logs();
@@ -464,7 +464,7 @@ test_retry_no_crypto(void *ctx)
    BSON_ASSERT(client);
    ASSERT_CAPTURED_LOG("test_framework_client_new_from_uri and retryWrites=true",
                        MONGOC_LOG_LEVEL_WARNING,
-                       "retryWrites not supported without an SSL crypto library");
+                       "retryWrites is not fully supported without an SSL crypto library");
    mongoc_client_destroy(client);
 
    clear_captured_logs();
@@ -473,7 +473,7 @@ test_retry_no_crypto(void *ctx)
    BSON_ASSERT(pool);
    ASSERT_CAPTURED_LOG("test_framework_client_pool_new_from_uri and retryWrites=true",
                        MONGOC_LOG_LEVEL_WARNING,
-                       "retryWrites not supported without an SSL crypto library");
+                       "retryWrites is not fully supported without an SSL crypto library");
    mongoc_client_pool_destroy(pool);
 
    mongoc_uri_destroy(uri);

--- a/src/libmongoc/tests/test-mongoc-retryable-writes.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-writes.c
@@ -1760,7 +1760,8 @@ test_retryable_writes_install(TestSuite *suite)
                      NULL,
                      test_framework_skip_if_not_replset, /* only run against replica sets as mongos does not propagate
                                                             the NoWritesPerformed label to the drivers */
-                     test_framework_skip_if_max_wire_version_less_than_9 /* require 4.4+ for errorLabels */);
+                     test_framework_skip_if_max_wire_version_less_than_9, /* require 4.4+ for errorLabels */
+                     test_framework_skip_if_no_crypto /* require crypto for sessions */);
    TestSuite_AddFull(suite,
                      "/retryable_writes/prose_test_6_case_5",
                      retryable_writes_prose_test_6_case_5,


### PR DESCRIPTION
Minor follow-up to https://github.com/mongodb/mongo-c-driver/pull/2273 to skip test requiring crypto and revise a driver warning. This fixes some failing "nossl" tasks.

No crypto means no sessions are available. Sessions are needed to retry non-overload errors (checked in [_is_retryable_write](https://github.com/mongodb/mongo-c-driver/blob/92d14879426cd54704492a62cbd94c6a936245ae/src/libmongoc/src/mongoc/mongoc-cmd.c#L620-L622)).

Retryable Writes prose test 4 expects the driver to do a non-overload retry in addition to overload retry. This test is now skipped if crypto is not available.

If `retryWrites=true` and crypto is not available, libmongoc warns. This warning is updated to note the behavior is "not fully supported" since overload errors are still enabled with `retryWrites=true`.

Evergreen patch: https://spruce.corp.mongodb.com/version/69e0ef97cc5c2b00074dcf6a