### PR TITLE
CDRIVER-6242 remove skipped X509 test

### DIFF
--- a/.evergreen/scripts/run-auth-tests.sh
+++ b/.evergreen/scripts/run-auth-tests.sh
@@ -155,12 +155,6 @@ maybe_skip() {
 }
 
 if [[ "${ssl}" != "OFF" ]]; then
-  # FIXME: CDRIVER-2008 for the cygwin check
-  if [[ "${OSTYPE}" != "cygwin" ]]; then
-    # TODO: uncomment test when resolving CDRIVER-6242:
-    echo "Authenticating using X.509 - Skipped pending DEVPROD-28037"
-    # maybe_skip "${mongoc_ping:?}" "mongodb://CN=client,OU=kerneluser,O=10Gen,L=New York City,ST=New York,C=US@${auth_host:?}/?ssl=true&authMechanism=MONGODB-X509&sslClientCertificateKeyFile=src/libmongoc/tests/x509gen/ldaptest-client-key-and-cert.pem&sslCertificateAuthorityFile=src/libmongoc/tests/x509gen/ldaptest-ca-cert.crt&sslAllowInvalidHostnames=true&${c_timeout:?}"
-  fi
   echo "Connecting to Atlas Free Tier"
   "${mongoc_ping:?}" "${atlas_free:?}&${c_timeout:?}"
   echo "Connecting to Atlas Free Tier with SRV"


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/mongo-c-driver/pull/2221 to remove skipped X509 test.

This X509 auth test was skipped due to certificate expiration (see DEVPROD-28037). However, since there is already X509 test coverage against [Atlas dev and prod](https://github.com/mongodb/mongo-c-driver/blob/19640e91788a72ef6b3f8e6dfbfd84d9e655cfa6/.evergreen/scripts/run-auth-tests.sh#L187-L191). Other drivers do not appear to test this server with X509:
- [Node](https://github.com/mongodb/node-mongodb-native/blob/16a899daa378a2c55aac75b1040159b5de8ee647/.evergreen/run-x509-tests.sh) connects to `ATLAS_X509_DEV`
- [Java](https://github.com/mongodb/mongo-java-driver/blob/ccca236378b84805a45bf11b6dfbc36bdb3043cf/.evergreen/run-x509-auth-tests.sh) connects to `ATLAS_X509_DEV`
- [Rust](https://github.com/mongodb/mongo-rust-driver/blob/960e176d89077711c20f0c3fe7153ac716b87e66/.evergreen/run-atlas-tests.sh) connects `ATLAS_X509_DEV`
- [Python](https://github.com/mongodb/mongo-python-driver/blob/912ef337f90852b58eaf6318e59f97206b281980/.evergreen/scripts/setup_tests.py#L427) sets up `ATLAS_X509_DEV_WITH_CERT`
- [Ruby](https://github.com/mongodb/mongo-ruby-driver/blob/1f8e13978e0c03b8da15d2fbf10cda2f5e3b3632/spec/atlas/atlas_connectivity_spec.rb#L49) tests both `ATLAS_X509_URI` and `ATLAS_X509_DEV_URI`

This PR proposes removing this skipped test.