### PR TITLE
CDRIVER-6290 bump maxWireVersion for server 9.0

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-client-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-client-private.h
@@ -85,12 +85,14 @@ BSON_BEGIN_DECLS
 #define WIRE_VERSION_MONGOS_EXHAUST 22
 /* version corresponding to server 8.0 release */
 #define WIRE_VERSION_8_0 25
+/* version corresponding to server 9.0 release */
+#define WIRE_VERSION_9_0 29
 
 /* Range of wire protocol versions this driver supports. Bumping
  * WIRE_VERSION_MAX must be accompanied by an update to
  * `_mongoc_wire_version_to_server_version`. */
 #define WIRE_VERSION_MIN WIRE_VERSION_4_2 /* a.k.a. minWireVersion */
-#define WIRE_VERSION_MAX WIRE_VERSION_8_0 /* a.k.a. maxWireVersion */
+#define WIRE_VERSION_MAX WIRE_VERSION_9_0 /* a.k.a. maxWireVersion */
 
 #define MONGOC_DEFAULT_ENABLEOVERLOADRETARGETING false
 

--- a/src/libmongoc/src/mongoc/mongoc-util.c
+++ b/src/libmongoc/src/mongoc/mongoc-util.c
@@ -314,6 +314,8 @@ _mongoc_wire_version_to_server_version(int32_t version)
       return "7.0";
    case WIRE_VERSION_8_0:
       return "8.0";
+   case WIRE_VERSION_9_0:
+      return "9.0";
    default:
       return "Unknown";
    }


### PR DESCRIPTION
Bump maxWireVersion from 25 (server 8.0) to 29 (server 9.0).

I compared this diff against corresponding changes for server 8.0: https://github.com/mongodb/mongo-c-driver/pull/1672
