### PR TITLE
CDRIVER-6307 skip "prefixPreview" and "suffixPreview" on server 9.0.0+

### DIFF
--- a/src/libmongoc/tests/json/client_side_encryption/unified/QE-Text-cleanupStructuredEncryptionData.json
+++ b/src/libmongoc/tests/json/client_side_encryption/unified/QE-Text-cleanupStructuredEncryptionData.json
@@ -4,6 +4,7 @@
   "runOnRequirements": [
     {
       "minServerVersion": "8.2.0",
+      "maxServerVersion": "8.99.99",
       "topologies": [
         "replicaset",
         "sharded",

--- a/src/libmongoc/tests/json/client_side_encryption/unified/QE-Text-compactStructuredEncryptionData.json
+++ b/src/libmongoc/tests/json/client_side_encryption/unified/QE-Text-compactStructuredEncryptionData.json
@@ -4,6 +4,7 @@
   "runOnRequirements": [
     {
       "minServerVersion": "8.2.0",
+      "maxServerVersion": "8.99.99",
       "topologies": [
         "replicaset",
         "sharded",

--- a/src/libmongoc/tests/json/client_side_encryption/unified/QE-Text-prefixPreview.json
+++ b/src/libmongoc/tests/json/client_side_encryption/unified/QE-Text-prefixPreview.json
@@ -4,6 +4,7 @@
   "runOnRequirements": [
     {
       "minServerVersion": "8.2.0",
+      "maxServerVersion": "8.99.99",
       "topologies": [
         "replicaset",
         "sharded",

--- a/src/libmongoc/tests/json/client_side_encryption/unified/QE-Text-substringPreview.json
+++ b/src/libmongoc/tests/json/client_side_encryption/unified/QE-Text-substringPreview.json
@@ -126,7 +126,7 @@
   ],
   "tests": [
     {
-      "description": "Insert QE suffixPreview",
+      "description": "Insert QE substringPreview",
       "operations": [
         {
           "name": "insertOne",

--- a/src/libmongoc/tests/json/client_side_encryption/unified/QE-Text-suffixPreview.json
+++ b/src/libmongoc/tests/json/client_side_encryption/unified/QE-Text-suffixPreview.json
@@ -4,6 +4,7 @@
   "runOnRequirements": [
     {
       "minServerVersion": "8.2.0",
+      "maxServerVersion": "8.99.99",
       "topologies": [
         "replicaset",
         "sharded",

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -4725,6 +4725,10 @@ test_explicit_encryption_text_prefix_suffix(void *unused)
       mongoc_client_encryption_encrypt_text_opts_destroy(topts);
       mongoc_client_encryption_encrypt_opts_destroy(eo);
    }
+
+   mongoc_client_encryption_encrypt_text_suffix_opts_destroy(sopts);
+   mongoc_client_encryption_encrypt_text_prefix_opts_destroy(popts);
+   explicit_encryption_destroy(eef);
 }
 
 static void

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -4506,7 +4506,7 @@ test_explicit_encryption_case5(void *unused)
 }
 
 static void
-test_explicit_encryption_text(void *unused)
+test_explicit_encryption_text_prefix_suffix(void *unused)
 {
    bson_error_t error;
    bool ok;
@@ -4529,11 +4529,6 @@ test_explicit_encryption_text(void *unused)
    mongoc_client_encryption_encrypt_text_suffix_opts_t *sopts = mongoc_client_encryption_encrypt_text_suffix_opts_new();
    mongoc_client_encryption_encrypt_text_suffix_opts_set_str_max_query_length(sopts, 10);
    mongoc_client_encryption_encrypt_text_suffix_opts_set_str_min_query_length(sopts, 2);
-   mongoc_client_encryption_encrypt_text_substring_opts_t *ssopts =
-      mongoc_client_encryption_encrypt_text_substring_opts_new();
-   mongoc_client_encryption_encrypt_text_substring_opts_set_str_max_length(ssopts, 10);
-   mongoc_client_encryption_encrypt_text_substring_opts_set_str_max_query_length(ssopts, 10);
-   mongoc_client_encryption_encrypt_text_substring_opts_set_str_min_query_length(ssopts, 2);
 
    /* Prefix and suffix tests */
    /* Insert 'foobarbaz' with both prefix and suffix indexing */
@@ -4725,14 +4720,35 @@ test_explicit_encryption_text(void *unused)
       mongoc_client_encryption_encrypt_text_opts_destroy(topts);
       mongoc_client_encryption_encrypt_opts_destroy(eo);
    }
+}
+
+static void
+test_explicit_encryption_text_substring(void *unused)
+{
+   bson_error_t error;
+   bool ok;
+   bson_value_t plaintext = {0};
+
+   ee_fixture *eef =
+      explicit_encryption_setup_full("./src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/"
+                                     "encryptedFields-substring.json",
+                                     "./src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/"
+                                     "key1-document.json");
+
+   BSON_UNUSED(unused);
+
+   plaintext.value_type = BSON_TYPE_UTF8;
+   plaintext.value.v_utf8.str = "foobarbaz";
+   plaintext.value.v_utf8.len = (uint32_t)strlen(plaintext.value.v_utf8.str);
+
+   mongoc_client_encryption_encrypt_text_substring_opts_t *ssopts =
+      mongoc_client_encryption_encrypt_text_substring_opts_new();
+   mongoc_client_encryption_encrypt_text_substring_opts_set_str_max_length(ssopts, 10);
+   mongoc_client_encryption_encrypt_text_substring_opts_set_str_max_query_length(ssopts, 10);
+   mongoc_client_encryption_encrypt_text_substring_opts_set_str_min_query_length(ssopts, 2);
 
 
    /* Substring tests */
-   explicit_encryption_destroy(eef);
-   eef = explicit_encryption_setup_full("./src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/"
-                                        "encryptedFields-substring.json",
-                                        "./src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/"
-                                        "key1-document.json");
    /* Insert 'foobarbaz' with substring indexing */
    {
       bson_value_t insertPayload;
@@ -4843,8 +4859,6 @@ test_explicit_encryption_text(void *unused)
       mongoc_client_encryption_encrypt_text_opts_destroy(topts);
       mongoc_client_encryption_encrypt_opts_destroy(eo);
    }
-   mongoc_client_encryption_encrypt_text_prefix_opts_destroy(popts);
-   mongoc_client_encryption_encrypt_text_suffix_opts_destroy(sopts);
    mongoc_client_encryption_encrypt_text_substring_opts_destroy(ssopts);
    explicit_encryption_destroy(eef);
 }
@@ -7859,8 +7873,16 @@ test_client_side_encryption_install(TestSuite *suite)
                         test_framework_skip_if_single, /* QE not supported on standalone */
                         test_framework_skip_if_no_client_side_encryption);
       TestSuite_AddFull(suite,
-                        "/client_side_encryption/explicit_encryption/text",
-                        test_explicit_encryption_text,
+                        "/client_side_encryption/explicit_encryption/text/prefix_suffix",
+                        test_explicit_encryption_text_prefix_suffix,
+                        NULL,
+                        NULL,
+                        test_framework_skip_if_max_wire_version_less_than_27 /* require server > 8.2 for QE support */,
+                        test_framework_skip_if_single, /* QE not supported on standalone */
+                        test_framework_skip_if_no_client_side_encryption);
+      TestSuite_AddFull(suite,
+                        "/client_side_encryption/explicit_encryption/text/substring",
+                        test_explicit_encryption_text_substring,
                         NULL,
                         NULL,
                         test_framework_skip_if_max_wire_version_less_than_27 /* require server > 8.2 for QE support */,

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -4508,6 +4508,11 @@ test_explicit_encryption_case5(void *unused)
 static void
 test_explicit_encryption_text_prefix_suffix(void *unused)
 {
+   if (test_framework_get_server_version() >= test_framework_str_to_version("9.0.0")) {
+      MONGOC_DEBUG("skipping test because text prefix and suffix indexing is not supported on server versions >= 9.0");
+      return;
+   }
+
    bson_error_t error;
    bool ok;
    bson_value_t plaintext = {0};


### PR DESCRIPTION
Evergreen: https://spruce.corp.mongodb.com/version/69f1feea42ec9c0007ff696d

Skip QE tests of "prefixPreview" and "suffixPreview" on server 9.0.0+. 

Following [SERVER-123416](https://jira.mongodb.org/browse/SERVER-123416), creating a collection with "suffixPreview" and "prefixPreview" is rejected by 9.0.0-rc0 servers, resulting in an error:
```
Cannot create a collection with an encrypted field with query type prefixPreview, as it is deprecated
```

This is intended as a short-term test fix. Upcoming spec changes of DRIVERS-3321 will update to use and test "suffix" and "prefix".
