### PR TITLE
CDRIVER-6305 Sync change streams unified spec tests with 0f48bb56

### DIFF
--- a/src/libmongoc/tests/json/change_streams/unified/change-streams-nsType.json
+++ b/src/libmongoc/tests/json/change_streams/unified/change-streams-nsType.json
@@ -64,47 +64,6 @@
       ]
     },
     {
-      "description": "nsType is present when creating timeseries",
-      "operations": [
-        {
-          "name": "dropCollection",
-          "object": "database0",
-          "arguments": {
-            "collection": "foo"
-          }
-        },
-        {
-          "name": "createChangeStream",
-          "object": "database0",
-          "arguments": {
-            "pipeline": [],
-            "showExpandedEvents": true
-          },
-          "saveResultAsEntity": "changeStream0"
-        },
-        {
-          "name": "createCollection",
-          "object": "database0",
-          "arguments": {
-            "collection": "foo",
-            "timeseries": {
-              "timeField": "time",
-              "metaField": "meta",
-              "granularity": "minutes"
-            }
-          }
-        },
-        {
-          "name": "iterateUntilDocumentOrError",
-          "object": "changeStream0",
-          "expectResult": {
-            "operationType": "create",
-            "nsType": "timeseries"
-          }
-        }
-      ]
-    },
-    {
       "description": "nsType is present when creating views",
       "operations": [
         {


### PR DESCRIPTION
Resolves CDRIVER-6305 and ongoing EVG task failures (timeouts) due to the `/change_streams/unified/change-streams-nsType` spec test when testing against latest server builds. See [DRIVERS-3458](https://jira.mongodb.org/browse/DRIVERS-3458) for details.