### PR TITLE
CDRIVER-6308 Fix OpenSSL 4.0.0 forward compatibility issues

### DIFF
--- a/.evergreen/config_generator/components/openssl_compat.py
+++ b/.evergreen/config_generator/components/openssl_compat.py
@@ -14,7 +14,7 @@ TAG = 'openssl-compat'
 # pylint: disable=line-too-long
 # fmt: off
 OPENSSL_MATRIX = [
-    ('ubuntu2404', 'gcc', ['shared', 'static'], ['1.0.2', '1.1.1', '3.0.9', '3.1.2', '3.2.5', '3.3.4', '3.4.2', '3.5.1']),
+    ('ubuntu2404', 'gcc', ['shared', 'static'], ['1.0.2', '1.1.1', '3.0.9', '3.1.2', '3.2.5', '3.3.4', '3.4.2', '3.5.1', '4.0.0']),
 ]
 # fmt: on
 
@@ -70,15 +70,20 @@ def tasks():
             if link_type == 'static':
                 vars |= {'OPENSSL_USE_STATIC_LIBS': 'ON'}
 
+            commands = [
+                FetchSource.call(),
+                OpenSSLSetup.call(vars=vars),
+            ]
+
+            # CDRIVER-6319: Atlas test servers do not yet support connections with OpenSSL 4.0.0...?
+            if version not in ['4.0.0']:
+                commands.append(FunctionCall(func='run auth tests'))
+
             yield EvgTask(
                 name=f'{TAG}-{version}-{link_type}-{distro_str}',
                 run_on=find_large_distro(distro_name).name,
                 tags=[TAG, f'openssl-{version}', f'openssl-{link_type}', distro_name, compiler],
-                commands=[
-                    FetchSource.call(),
-                    OpenSSLSetup.call(vars=vars),
-                    FunctionCall(func='run auth tests'),
-                ],
+                commands=commands,
             )
 
     for distro_name, compiler, link_types, versions in OPENSSL_FIPS_MATRIX:

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -6210,6 +6210,23 @@ tasks:
           OPENSSL_USE_STATIC_LIBS: "ON"
           OPENSSL_VERSION: 3.5.1
       - func: run auth tests
+  - name: openssl-compat-4.0.0-shared-ubuntu2404-gcc
+    run_on: ubuntu2404-large
+    tags: [openssl-compat, openssl-4.0.0, openssl-shared, ubuntu2404, gcc]
+    commands:
+      - func: fetch-source
+      - func: openssl-compat
+        vars:
+          OPENSSL_VERSION: 4.0.0
+  - name: openssl-compat-4.0.0-static-ubuntu2404-gcc
+    run_on: ubuntu2404-large
+    tags: [openssl-compat, openssl-4.0.0, openssl-static, ubuntu2404, gcc]
+    commands:
+      - func: fetch-source
+      - func: openssl-compat
+        vars:
+          OPENSSL_USE_STATIC_LIBS: "ON"
+          OPENSSL_VERSION: 4.0.0
   - name: openssl-compat-fips-3.0.9-shared-ubuntu2404-gcc
     run_on: ubuntu2404-large
     tags: [openssl-compat, openssl-fips-3.0.9, openssl-shared, ubuntu2404, gcc]

--- a/.evergreen/scripts/openssl-downloader.sh
+++ b/.evergreen/scripts/openssl-downloader.sh
@@ -43,6 +43,7 @@ openssl_download() {
   declare openssl_checksum_3_3_4="8d1a5fc323d3fd351dc05458457fd48f78652d2a498e1d70ffea07b4d0eb3fa8"
   declare openssl_checksum_3_4_2="17b02459fc28be415470cccaae7434f3496cac1306b86b52c83886580e82834c"
   declare openssl_checksum_3_5_1="529043b15cffa5f36077a4d0af83f3de399807181d607441d734196d889b641f"
+  declare openssl_checksum_4_0_0="c32cf49a959c4f345f9606982dd36e7d28f7c58b19c2e25d75624d2b3d2f79ac"
 
   declare checksum_name
   checksum_name="openssl_checksum_$(echo "${version:?}" | perl -lpe 's|\.|_|g')" || return

--- a/src/libmongoc/src/mongoc/mongoc-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-openssl.c
@@ -40,7 +40,10 @@
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/ocsp.h>
+#include <openssl/opensslv.h>
+#include <openssl/safestack.h>
 #include <openssl/ssl.h>
+#include <openssl/x509.h>
 #include <openssl/x509v3.h>
 
 #include <limits.h>
@@ -471,14 +474,12 @@ _mongoc_openssl_setup_pem_file(SSL_CTX *ctx, const char *pem_file, const char *p
 static X509 *
 _get_issuer(X509 *cert, STACK_OF(X509) * chain)
 {
-   X509 *issuer = NULL, *candidate = NULL;
-   X509_NAME *issuer_name = NULL, *candidate_name = NULL;
-   int i;
+   X509 *issuer = NULL;
 
-   issuer_name = X509_get_issuer_name(cert);
-   for (i = 0; i < sk_X509_num(chain) && issuer == NULL; i++) {
-      candidate = sk_X509_value(chain, i);
-      candidate_name = X509_get_subject_name(candidate);
+   const X509_NAME *const issuer_name = X509_get_issuer_name(cert);
+   for (int i = 0; i < sk_X509_num(chain) && issuer == NULL; i++) {
+      X509 *const candidate = sk_X509_value(chain, i);
+      const X509_NAME *const candidate_name = X509_get_subject_name(candidate);
       if (0 == X509_NAME_cmp(candidate_name, issuer_name)) {
          issuer = candidate;
       }
@@ -602,25 +603,26 @@ _mongoc_tlsfeature_has_status_request(const uint8_t *data, int length)
 bool
 _get_must_staple(X509 *cert)
 {
-   const STACK_OF(X509_EXTENSION) *exts = NULL;
-   X509_EXTENSION *ext;
-   ASN1_STRING *ext_data;
-   int idx;
-
-   exts = _get_extensions(cert);
+   const STACK_OF(X509_EXTENSION) *const exts = _get_extensions(cert);
    if (!exts) {
       TRACE("%s", "certificate extensions not found");
       return false;
    }
 
-   idx = X509v3_get_ext_by_NID(exts, tlsfeature_nid, -1);
+   const int idx = X509v3_get_ext_by_NID(exts, tlsfeature_nid, -1);
    if (-1 == idx) {
       TRACE("%s", "tlsfeature extension not found");
       return false;
    }
 
-   ext = sk_X509_EXTENSION_value(exts, idx);
-   ext_data = X509_EXTENSION_get_data(ext);
+   X509_EXTENSION *const ext = sk_X509_EXTENSION_value(exts, idx);
+
+   // Pre-3.0.0 `ASN1_STRING_get0_data()` expects `T*`, but post-4.0.0 `X509_EXTENSION_get_data()` returns `const T*`.
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+   ASN1_STRING *const ext_data = X509_EXTENSION_get_data(ext);
+#else
+   const ASN1_STRING *const ext_data = X509_EXTENSION_get_data(ext);
+#endif
 
    /* Data is a DER encoded sequence of integers. */
    return _mongoc_tlsfeature_has_status_request(ASN1_STRING_get0_data(ext_data), ASN1_STRING_length(ext_data));

--- a/src/libmongoc/src/mongoc/mongoc-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-openssl.c
@@ -962,12 +962,16 @@ _mongoc_openssl_ctx_new(mongoc_ssl_opt_t *opt)
 /* only defined in special build, using:
  * --enable-system-crypto-profile (autotools)
  * -DENABLE_CRYPTO_SYSTEM_PROFILE:BOOL=ON (cmake)  */
-#ifndef MONGOC_ENABLE_CRYPTO_SYSTEM_PROFILE
+#if !defined(MONGOC_ENABLE_CRYPTO_SYSTEM_PROFILE)
    /* HIGH - Enable strong ciphers
     * !EXPORT - Disable export ciphers (40/56 bit)
     * !aNULL - Disable anonymous auth ciphers
     * @STRENGTH - Sort ciphers based on strength */
-   SSL_CTX_set_cipher_list(ctx, "HIGH:!EXPORT:!aNULL@STRENGTH");
+   if (!SSL_CTX_set_cipher_list(ctx, "HIGH:!EXPORT:!aNULL@STRENGTH")) {
+      MONGOC_ERROR("Could not set cipher list for TLSv1.2 and below: %s", ERR_STR);
+      SSL_CTX_free(ctx);
+      return NULL;
+   }
 #endif
 
    /* If renegotiation is needed, don't return from recv() or send() until it's


### PR DESCRIPTION
Resolves CDRIVER-6308 by addressing OpenSSL 4.0.0 compatibility issues, primarily concerning [improved const-correctness](https://docs.openssl.org/4.0/man7/ossl-guide-migration/#constification-of-x509-functions):

> A large number of public API functions that access an `X509 *` object have been constified. This change has been made to allow for future improvements to the `X509` layer to reduce the number of memory allocations and copies that are made. These changes can impact code which uses these functions if a returned pointer value which was not const in previous versions of OpenSSL has now been made const. When such a value is assigned to a non-const pointer variable you will get a compiler warning.

No other breaking changes appear to affect _building_ the mongoc library at this time. However, "run auth tests" fails when _executed_ with OpenSSL 4.0.0 with the following error:

```
TLS handshake failed: error:0A000126:SSL routines::unexpected eof while reading calling hello on '(...).mongodb-dev.net:27017'
```

OpenSSL on the `windows-2022-latest` distro was updated to 4.0.0 in April, causing [build failures](https://spruce.corp.mongodb.com/task/mongo_c_driver_sasl_matrix_openssl_sasl_sspi_openssl_windows_2022_latest_vs2022x64_compile_027a936c68a34dde38cb13e552cd941f92f27c97_26_04_22_18_30_17/logs?execution=0) due to the forward compatibility issues addressed by this PR. These tasks now appear to fail with the same "unexpected eof" error as above. Filed CDRIVER-6319 to investigate this issue later. See ticket description for details.

As a drive-by improvement, added error-handling for the call to `SSL_CTX_set_cipher_list()` (prompted by attempted resolutions to CDRIVER-6319) with a descriptive message indicating its relevance to TLSv1.2-or-lower only (notably, not TLSv1.3).