### PR TITLE
Add "ignore" paths to EVG config

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -9,6 +9,18 @@ exec_timeout_secs: 3600
 #   - system: after test (purple).
 command_type: system
 
+# Do not (automatically) trigger builds for changes irrelevant to regular test coverage.
+ignore:
+  - ".gdb*"
+  - ".git*"
+  - "**/*.md"
+  - "**/*.rst"
+  - "COPYING"
+  - "lldb*"
+  - "NEWS"
+  - "THIRD_PARTY_NOTICES"
+  - "!docs/**/*.rst"
+
 # Ensure Evergreen tests earlier commits when a task fails.
 stepback: true
 


### PR DESCRIPTION
Followup to https://github.com/mongodb/mongo-cxx-driver/pull/1634 for the C driver.

Notable difference is also ignoring ReST files in addition to Markdown, _but_ not ignoring those under `docs` which are tested in EVG by the `make-docs` task. Similarly, files under `build`, `etc`, and `tools` are not ignored due to being referenced by EVG tasks.