### PR TITLE
CDRIVER-6313 Improve decompressed message length constraints using maxMessageSizeBytes (#2292)

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-async-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-async-cmd.c
@@ -450,7 +450,8 @@ _mongoc_async_cmd_phase_recv_rpc(mongoc_async_cmd_t *acmd)
       void *decompressed_data;
       size_t decompressed_data_len;
 
-      if (!mcd_rpc_message_decompress_if_necessary(acmd->rpc, &decompressed_data, &decompressed_data_len)) {
+      if (!mcd_rpc_message_decompress_if_necessary(
+             acmd->rpc, &decompressed_data, &decompressed_data_len, MONGOC_DEFAULT_MAX_MSG_SIZE)) {
          _mongoc_set_error(&acmd->error,
                            MONGOC_ERROR_PROTOCOL,
                            MONGOC_ERROR_PROTOCOL_INVALID_REPLY,

--- a/src/libmongoc/src/mongoc/mongoc-cluster-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-private.h
@@ -269,10 +269,10 @@ mcd_rpc_message_compress(mcd_rpc_message *rpc,
                          bson_error_t *error);
 
 bool
-mcd_rpc_message_decompress(mcd_rpc_message *rpc, void **data, size_t *data_len);
+mcd_rpc_message_decompress(mcd_rpc_message *rpc, void **data, size_t *data_len, int32_t max_msg_size);
 
 bool
-mcd_rpc_message_decompress_if_necessary(mcd_rpc_message *rpc, void **data, size_t *data_len);
+mcd_rpc_message_decompress_if_necessary(mcd_rpc_message *rpc, void **data, size_t *data_len, int32_t max_msg_size);
 
 BSON_END_DECLS
 

--- a/src/libmongoc/src/mongoc/mongoc-cluster.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster.c
@@ -27,8 +27,12 @@
 #include <mongoc/mongoc-config.h>
 #include <mongoc/mongoc-log.h>
 
+#include <bson/macros.h>
+#include <bson/memory.h>
+
 #include <mlib/intencode.h>
 
+#include <stdint.h>
 #include <string.h>
 #ifdef MONGOC_ENABLE_SSL
 #include <mongoc/mongoc-ssl-private.h>
@@ -438,9 +442,10 @@ _mongoc_cluster_run_command_opquery_recv(
       goto done;
    }
 
+   const int32_t max_msg_size = mongoc_cluster_get_max_msg_size(cluster);
    const int32_t message_length = mlib_read_i32le(buffer.data);
 
-   if (message_length < message_header_length || message_length > MONGOC_DEFAULT_MAX_MSG_SIZE) {
+   if (message_length < message_header_length || message_length > max_msg_size) {
       RUN_CMD_ERR(MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "invalid message length");
       _handle_network_error(cluster, cmd, reply, error);
       goto done;
@@ -461,7 +466,7 @@ _mongoc_cluster_run_command_opquery_recv(
 
    mcd_rpc_message_ingress(rpc);
 
-   if (!mcd_rpc_message_decompress_if_necessary(rpc, &decompressed_data, &decompressed_data_len)) {
+   if (!mcd_rpc_message_decompress_if_necessary(rpc, &decompressed_data, &decompressed_data_len, max_msg_size)) {
       RUN_CMD_ERR(MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "could not decompress server reply");
       goto done;
    }
@@ -3228,15 +3233,16 @@ _mongoc_cluster_run_opmsg_recv(
       goto done;
    }
 
+   const int32_t max_msg_size = mongoc_cluster_get_max_msg_size(cluster);
    const int32_t message_length = mlib_read_i32le(buffer.data);
 
-   if (message_length < message_header_length || message_length > server_stream->sd->max_msg_size) {
+   if (message_length < message_header_length || message_length > max_msg_size) {
       RUN_CMD_ERR(MONGOC_ERROR_PROTOCOL,
                   MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
                   "message length %" PRId32 " is not within valid range of %" PRId32 "-%" PRId32 " bytes",
-                  message_header_length,
                   message_length,
-                  server_stream->sd->max_msg_size);
+                  message_header_length,
+                  max_msg_size);
       _handle_network_error(cluster, cmd, reply, error);
       server_stream->stream = NULL;
       goto done;
@@ -3263,7 +3269,7 @@ _mongoc_cluster_run_opmsg_recv(
    void *decompressed_data = NULL;
    size_t decompressed_data_len = 0u;
 
-   if (!mcd_rpc_message_decompress_if_necessary(rpc, &decompressed_data, &decompressed_data_len)) {
+   if (!mcd_rpc_message_decompress_if_necessary(rpc, &decompressed_data, &decompressed_data_len, max_msg_size)) {
       _mongoc_set_error(
          error, MONGOC_ERROR_PROTOCOL, MONGOC_ERROR_PROTOCOL_INVALID_REPLY, "could not decompress message from server");
       _handle_network_error(cluster, cmd, reply, error);
@@ -3472,33 +3478,35 @@ fail:
 }
 
 bool
-mcd_rpc_message_decompress(mcd_rpc_message *rpc, void **data, size_t *data_len)
+mcd_rpc_message_decompress(mcd_rpc_message *rpc, void **data, size_t *data_len, int32_t max_msg_size)
 {
    BSON_ASSERT_PARAM(rpc);
    BSON_ASSERT_PARAM(data);
    BSON_ASSERT_PARAM(data_len);
 
-   BSON_ASSERT(mcd_rpc_header_get_op_code(rpc) == MONGOC_OP_CODE_COMPRESSED);
+   // Precondition: `maxMessageSizeBytes` must always be greater than the minimum message size.
+   BSON_ASSERT(max_msg_size > message_header_length);
 
-   const int32_t uncompressed_size_raw = mcd_rpc_op_compressed_get_uncompressed_size(rpc);
-
-   // Malformed message: invalid uncompressedSize.
-   if (BSON_UNLIKELY(uncompressed_size_raw < 0)) {
+   // Runtime invariant: `maxMessageSizeBytes` must not exceed the default maximum message size.
+   if (BSON_UNLIKELY(max_msg_size > MONGOC_DEFAULT_MAX_MSG_SIZE)) {
       return false;
    }
 
-   const size_t uncompressed_size = (size_t)uncompressed_size_raw;
+   BSON_ASSERT(mcd_rpc_header_get_op_code(rpc) == MONGOC_OP_CODE_COMPRESSED);
 
-   // Malformed message: original message length is not representable.
-   if (BSON_UNLIKELY(uncompressed_size > SIZE_MAX - message_header_length)) {
+   // Does NOT include the message header length.
+   const int32_t uncompressed_size = mcd_rpc_op_compressed_get_uncompressed_size(rpc);
+
+   // Malformed message: invalid uncompressedSize.
+   if (BSON_UNLIKELY(uncompressed_size < 0 || mlib_cmp(uncompressed_size, >, max_msg_size - message_header_length))) {
       return false;
    }
 
    // uncompressedSize does not include msgHeader fields.
-   const size_t original_message_length = message_header_length + uncompressed_size;
+   const size_t original_message_length = (size_t)(message_header_length + uncompressed_size);
    uint8_t *const ptr = bson_malloc(original_message_length);
 
-   const int32_t message_length = original_message_length;
+   const int32_t message_length = (int32_t)original_message_length;
    const int32_t request_id = mcd_rpc_header_get_request_id(rpc);
    const int32_t response_to = mcd_rpc_header_get_response_to(rpc);
    const int32_t op_code = mcd_rpc_op_compressed_get_original_opcode(rpc);
@@ -3512,7 +3520,7 @@ mcd_rpc_message_decompress(mcd_rpc_message *rpc, void **data, size_t *data_len)
 
    // This value may be passed as an argument to an in-out parameter depending
    // on the compressor, not just an out-parameter.
-   size_t actual_uncompressed_size = uncompressed_size;
+   size_t actual_uncompressed_size = (size_t)uncompressed_size;
 
    // Populate the rest of the uncompressed message.
    if (!mongoc_uncompress(mcd_rpc_op_compressed_get_compressor_id(rpc),
@@ -3525,7 +3533,7 @@ mcd_rpc_message_decompress(mcd_rpc_message *rpc, void **data, size_t *data_len)
    }
 
    // Malformed message: size inconsistency.
-   if (BSON_UNLIKELY(uncompressed_size != actual_uncompressed_size)) {
+   if (BSON_UNLIKELY(mlib_cmp(uncompressed_size, !=, actual_uncompressed_size))) {
       bson_free(ptr);
       return false;
    }
@@ -3539,7 +3547,7 @@ mcd_rpc_message_decompress(mcd_rpc_message *rpc, void **data, size_t *data_len)
 }
 
 bool
-mcd_rpc_message_decompress_if_necessary(mcd_rpc_message *rpc, void **data, size_t *data_len)
+mcd_rpc_message_decompress_if_necessary(mcd_rpc_message *rpc, void **data, size_t *data_len, int32_t max_msg_size)
 {
    BSON_ASSERT_PARAM(rpc);
    BSON_ASSERT_PARAM(data);
@@ -3552,7 +3560,7 @@ mcd_rpc_message_decompress_if_necessary(mcd_rpc_message *rpc, void **data, size_
       return true;
    }
 
-   return mcd_rpc_message_decompress(rpc, data, data_len);
+   return mcd_rpc_message_decompress(rpc, data, data_len, max_msg_size);
 }
 
 typedef struct {

--- a/src/libmongoc/src/mongoc/mongoc-server-monitor.c
+++ b/src/libmongoc/src/mongoc/mongoc-server-monitor.c
@@ -19,6 +19,7 @@
 #include <mongoc/mongoc-client-private.h>
 #include <mongoc/mongoc-error-private.h>
 #include <mongoc/mongoc-handshake-private.h>
+#include <mongoc/mongoc-rpc-private.h>
 #include <mongoc/mongoc-server-monitor-private.h>
 #include <mongoc/mongoc-ssl-private.h>
 #include <mongoc/mongoc-stream-private.h>
@@ -29,10 +30,14 @@
 
 #include <mongoc/mcd-rpc.h>
 
+#include <bson/macros.h>
+
 #include <mlib/config.h>
 #include <mlib/intencode.h>
 
 #include <inttypes.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #undef MONGOC_LOG_DOMAIN
 #define MONGOC_LOG_DOMAIN "monitor"
@@ -308,7 +313,9 @@ _server_monitor_send_and_recv_hello_opmsg(mongoc_server_monitor_t *server_monito
    // msgHeader consists of four int32 fields.
    const int32_t message_header_length = 4u * sizeof(int32_t);
 
-   if (message_length < message_header_length) {
+   // Malformed message.
+   if (BSON_UNLIKELY(message_length < message_header_length ||
+                     message_length > server_monitor->description->max_msg_size)) {
       _mongoc_set_error(error,
                         MONGOC_ERROR_PROTOCOL,
                         MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
@@ -334,7 +341,8 @@ _server_monitor_send_and_recv_hello_opmsg(mongoc_server_monitor_t *server_monito
 
    mcd_rpc_message_ingress(rpc);
 
-   if (!mcd_rpc_message_decompress_if_necessary(rpc, &decompressed_data, &decompressed_data_len)) {
+   if (!mcd_rpc_message_decompress_if_necessary(
+          rpc, &decompressed_data, &decompressed_data_len, server_monitor->description->max_msg_size)) {
       _mongoc_set_error(error,
                         MONGOC_ERROR_PROTOCOL,
                         MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
@@ -421,7 +429,8 @@ _server_monitor_send_and_recv_opquery(mongoc_server_monitor_t *server_monitor,
    // msgHeader consists of four int32 fields.
    const int32_t message_header_length = 4u * sizeof(int32_t);
 
-   if (message_length < message_header_length) {
+   if (BSON_UNLIKELY(message_length < message_header_length ||
+                     message_length > server_monitor->description->max_msg_size)) {
       _mongoc_set_error(error,
                         MONGOC_ERROR_PROTOCOL,
                         MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
@@ -447,7 +456,8 @@ _server_monitor_send_and_recv_opquery(mongoc_server_monitor_t *server_monitor,
 
    mcd_rpc_message_ingress(rpc);
 
-   if (!mcd_rpc_message_decompress_if_necessary(rpc, &decompressed_data, &decompressed_data_len)) {
+   if (!mcd_rpc_message_decompress_if_necessary(
+          rpc, &decompressed_data, &decompressed_data_len, server_monitor->description->max_msg_size)) {
       _mongoc_set_error(error,
                         MONGOC_ERROR_PROTOCOL,
                         MONGOC_ERROR_PROTOCOL_INVALID_REPLY,
@@ -717,7 +727,8 @@ _server_monitor_awaitable_hello_recv(mongoc_server_monitor_t *server_monitor,
 
    mcd_rpc_message_ingress(rpc);
 
-   if (!mcd_rpc_message_decompress_if_necessary(rpc, &decompressed_data, &decompressed_data_len)) {
+   if (!mcd_rpc_message_decompress_if_necessary(
+          rpc, &decompressed_data, &decompressed_data_len, server_monitor->description->max_msg_size)) {
       _mongoc_set_error(error, MONGOC_ERROR_PROTOCOL, MONGOC_ERROR_PROTOCOL_INVALID_REPLY, "decompression failure");
       GOTO(fail);
    }

--- a/src/libmongoc/tests/test-mongoc-cluster.c
+++ b/src/libmongoc/tests/test-mongoc-cluster.c
@@ -5,7 +5,11 @@
 #include <mongoc/mongoc-uri-private.h>
 #include <mongoc/mongoc-util-private.h>
 
+#include <mongoc/mcd-rpc.h>
 #include <mongoc/mongoc.h>
+
+#include <bson/macros.h>
+#include <bson/memory.h>
 
 #include <mlib/duration.h>
 #include <mlib/time_point.h>
@@ -18,6 +22,8 @@
 #include <test-libmongoc.h>
 
 #include <inttypes.h>
+#include <stddef.h>
+#include <stdint.h>
 
 
 #undef MONGOC_LOG_DOMAIN
@@ -112,6 +118,83 @@ test_get_max_msg_size(void)
 
    mongoc_client_pool_push(pool, client);
    mongoc_client_pool_destroy(pool);
+}
+
+// clang-format off
+#define TEST_DATA_OP_COMPRESSED                                              \
+   /*    */ /* header (16 bytes) */                                          \
+   /*  0 */ 0x2d, 0x00, 0x00, 0x00, /* messageLength (45)           */       \
+   /*  4 */ 0x04, 0x03, 0x02, 0x01, /* requestID (16909060)         */       \
+   /*  8 */ 0x08, 0x07, 0x06, 0x05, /* responseTo (84281096)        */       \
+   /* 12 */ 0xdc, 0x07, 0x00, 0x00, /* opCode (2012: OP_COMPRESSED) */       \
+   /*    */                                                                  \
+   /*    */ /* OP_COMPRESSED fields (9 bytes) */                             \
+   /* 16 */ 0xdd, 0x07, 0x00, 0x00, /* originalOpcode (2013: OP_MSG) */      \
+   /* 20 */ 0x14, 0x00, 0x00, 0x00, /* uncompressedSize (20)         */      \
+   /* 24 */ 0x00,                   /* compressorId (0: noop)        */      \
+   /*    */                                                                  \
+   /*    */ /* compressedMessage (20 bytes) */                               \
+   /* 25 */ 0x00, 0x00, 0x00, 0x00, /* flagBits (MONGOC_OP_MSG_FLAG_NONE) */ \
+   /* 29 */ 0x00,                   /* Kind 0: Body */                       \
+   /* 30 */ 0x0f, 0x00, 0x00, 0x00,           /* (15 bytes) { */             \
+   /* 34 */   0x10,                           /*   (int32)    */             \
+   /* 35 */     0x6b, 0x69, 0x6e, 0x64, 0x00, /*     'kind':  */             \
+   /* 40 */     0x00, 0x00, 0x00, 0x00,       /*      0       */             \
+   /* 44 */ 0x00                              /* }            */             \
+   /* 45 */
+// clang-format on
+
+static void
+test_decompress_max_msg_size_valid(void)
+{
+   uint8_t data[] = {TEST_DATA_OP_COMPRESSED};
+   mcd_rpc_message *const rpc = mcd_rpc_message_from_data(data, sizeof(data), NULL);
+   ASSERT(rpc);
+
+   // message header (16) + uncompressedSize (20) = 36 bytes
+   const int32_t max_msg_size = 36;
+
+   void *decompressed = NULL;
+   size_t decompressed_len = 0u;
+   ASSERT(mcd_rpc_message_decompress(rpc, &decompressed, &decompressed_len, max_msg_size));
+
+   mcd_rpc_message_destroy(rpc);
+   bson_free(decompressed);
+}
+
+static void
+test_decompress_max_msg_size_invalid(void)
+{
+   uint8_t data[] = {TEST_DATA_OP_COMPRESSED};
+   mcd_rpc_message *const rpc = mcd_rpc_message_from_data(data, sizeof(data), NULL);
+   ASSERT(rpc);
+
+   // message header (16) + uncompressed message (20) = 36 bytes
+   // Subtract one to trigger invalid uncompressedSize failure.
+   const int32_t max_msg_size = 36 - 1;
+
+   void *decompressed = NULL;
+   size_t decompressed_len = 0u;
+   ASSERT(!mcd_rpc_message_decompress(rpc, &decompressed, &decompressed_len, max_msg_size));
+
+   mcd_rpc_message_destroy(rpc);
+}
+
+static void
+test_decompress_max_msg_size_invariant(void)
+{
+   uint8_t data[] = {TEST_DATA_OP_COMPRESSED};
+   mcd_rpc_message *const rpc = mcd_rpc_message_from_data(data, sizeof(data), NULL);
+   ASSERT(rpc);
+
+   // `maxMessageSizeBytes` returned by server must never be greater than `MONGOC_DEFAULT_MAX_MSG_SIZE`.
+   const int32_t max_msg_size = MONGOC_DEFAULT_MAX_MSG_SIZE + 1;
+
+   void *decompressed = NULL;
+   size_t decompressed_len = 0u;
+   ASSERT(!mcd_rpc_message_decompress(rpc, &decompressed, &decompressed_len, max_msg_size));
+
+   mcd_rpc_message_destroy(rpc);
 }
 
 
@@ -1833,6 +1916,9 @@ test_cluster_install(TestSuite *suite)
 {
    TestSuite_AddLive(suite, "/Cluster/test_get_max_bson_obj_size", test_get_max_bson_obj_size);
    TestSuite_AddLive(suite, "/Cluster/test_get_max_msg_size", test_get_max_msg_size);
+   TestSuite_Add(suite, "/Cluster/decompress/max_msg_size_valid", test_decompress_max_msg_size_valid);
+   TestSuite_Add(suite, "/Cluster/decompress/max_msg_size_invalid", test_decompress_max_msg_size_invalid);
+   TestSuite_Add(suite, "/Cluster/decompress/max_msg_size_invariant", test_decompress_max_msg_size_invariant);
    TestSuite_AddFull(suite,
                      "/Cluster/disconnect/single [timeout:30]",
                      test_cluster_node_disconnect_single,


### PR DESCRIPTION
Cherry-picks https://github.com/mongodb/mongo-c-driver/pull/2292 onto the r2.3 branch targeting the 2.3.1 release.