### PR TITLE
Fix /Client/recovering test to use valid read mode enumerators

### DIFF
--- a/src/libmongoc/tests/test-mongoc-client.c
+++ b/src/libmongoc/tests/test-mongoc-client.c
@@ -1684,7 +1684,6 @@ test_recovering(void *ctx)
    mock_server_t *server;
    mongoc_uri_t *uri;
    mongoc_client_t *client;
-   mongoc_read_mode_t read_mode;
    mongoc_read_prefs_t *prefs;
    bson_error_t error;
 
@@ -1712,9 +1711,20 @@ test_recovering(void *ctx)
    prefs = mongoc_read_prefs_new(MONGOC_READ_PRIMARY);
 
    /* recovering member matches no read mode */
-   for (read_mode = MONGOC_READ_PRIMARY; read_mode <= MONGOC_READ_NEAREST; read_mode++) {
-      mongoc_read_prefs_set_mode(prefs, read_mode);
-      BSON_ASSERT(!mongoc_topology_select(client->topology, MONGOC_SS_READ, TEST_SS_LOG_CONTEXT, prefs, NULL, &error));
+   const mongoc_read_mode_t read_modes[] = {
+      MONGOC_READ_PRIMARY,
+      MONGOC_READ_SECONDARY,
+      MONGOC_READ_PRIMARY_PREFERRED,
+      MONGOC_READ_SECONDARY_PREFERRED,
+      MONGOC_READ_NEAREST,
+   };
+
+   for (size_t i = 0u; i < sizeof(read_modes) / sizeof(read_modes[0]); i++) {
+      mongoc_read_prefs_set_mode(prefs, read_modes[i]);
+      ASSERT_WITH_MSG(
+         !mongoc_topology_select(client->topology, MONGOC_SS_READ, TEST_SS_LOG_CONTEXT, prefs, NULL, &error),
+         "read mode %d should not match any member",
+         (int)read_modes[i]);
    }
 
    mongoc_read_prefs_destroy(prefs);


### PR DESCRIPTION
Following https://github.com/mongodb/mongo-c-driver/pull/2203, preconditions to internal function calls are [more strictly asserted](https://github.com/mongodb/mongo-c-driver/blob/4d043b66d0b38955a5d5fb67cec1f8241f087c6c/src/libmongoc/src/mongoc/mongoc-topology-description.c#L1030). Consequently, the [/Client/recovering](https://github.com/mongodb/mongo-c-driver/blob/4d043b66d0b38955a5d5fb67cec1f8241f087c6c/src/libmongoc/tests/test-mongoc-client.c#L1715-L1718) test case is no longer valid, as it passes integral values of `read_mode` which are not valid enumerators (bit flags), triggering the "invalid read_mode" assertion. This PR replaces the integer increments with array element traversal instead.

This test was being skipped in EVG due to `MONGOC_TEST_SKIP_SLOW=ON` in [run-mock-server-tests.sh](https://github.com/mongodb/mongo-c-driver/blob/4d043b66d0b38955a5d5fb67cec1f8241f087c6c/.evergreen/scripts/run-mock-server-tests.sh#L34).  Local tests suggest no other mock server tests have latent failures that are being skipped. We may need to revisit this script at another time to ensure proper test coverage.