### PR TITLE
CDRIVER-6319 Improve handling `EAGAIN` errors in OpenSSL BIO read callbacks

### DIFF
--- a/.evergreen/config_generator/components/openssl_compat.py
+++ b/.evergreen/config_generator/components/openssl_compat.py
@@ -73,11 +73,8 @@ def tasks():
             commands = [
                 FetchSource.call(),
                 OpenSSLSetup.call(vars=vars),
+                FunctionCall(func='run auth tests'),
             ]
-
-            # CDRIVER-6319: Atlas test servers do not yet support connections with OpenSSL 4.0.0...?
-            if version not in ['4.0.0']:
-                commands.append(FunctionCall(func='run auth tests'))
 
             yield EvgTask(
                 name=f'{TAG}-{version}-{link_type}-{distro_str}',

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -6262,6 +6262,7 @@ tasks:
       - func: openssl-compat
         vars:
           OPENSSL_VERSION: 4.0.0
+      - func: run auth tests
   - name: openssl-compat-4.0.0-static-ubuntu2404-gcc
     run_on: ubuntu2404-large
     tags: [openssl-compat, openssl-4.0.0, openssl-static, ubuntu2404, gcc]
@@ -6271,6 +6272,7 @@ tasks:
         vars:
           OPENSSL_USE_STATIC_LIBS: "ON"
           OPENSSL_VERSION: 4.0.0
+      - func: run auth tests
   - name: openssl-compat-fips-3.0.9-shared-ubuntu2404-gcc
     run_on: ubuntu2404-large
     tags: [openssl-compat, openssl-fips-3.0.9, openssl-shared, ubuntu2404, gcc]

--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,10 @@ libmongoc 2.4.0 [UNRELEASED]
 * Raise required version of libmongocrypt from 1.15.1 to 1.18.0 to support In-Use Encryption (corresponds to the CMake option: `ENABLE_CLIENT_SIDE_ENCRYPTION`).
 * In a future minor release the minimum supported MongoDB Server version will be raised from 4.2 to 4.4. This is in accordance with [MongoDB Software Lifecycle Schedules](https://www.mongodb.com/legal/support-policy/lifecycles).
 
+## Improvements
+
+* Improve forward compatibility with OpenSSL 4.0.0 when handling `EAGAIN` errors in old-style read callbacks where `BIO_FLAGS_AUTO_EOF` is enabled.
+
 libmongoc 2.3.0
 ===============
 
@@ -141,7 +145,7 @@ libmongoc 2.2.0
 
 ## Fixed
 
-* Do not try to resume when iterating a closed change stream. 
+* Do not try to resume when iterating a closed change stream.
 
 ## Notes
 

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl-bio.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl-bio.c
@@ -226,15 +226,18 @@ mongoc_stream_tls_openssl_bio_read(BIO *b, char *buf, int len)
    openssl = (mongoc_stream_tls_openssl_t *)tls->ctx;
 
    errno = 0;
-   const ssize_t ret = mongoc_stream_read(tls->base_stream, buf, (size_t)len, 0, (int32_t)tls->timeout_msec);
+   ssize_t ret = mongoc_stream_read(tls->base_stream, buf, (size_t)len, 0, (int32_t)tls->timeout_msec);
    BIO_clear_retry_flags(b);
 
    if ((ret <= 0) && MONGOC_ERRNO_IS_AGAIN(errno)) {
-      /* this BIO is not the same as "b", which openssl passed in to this func.
-       * set its retry flag, which we check with BIO_should_retry in
-       * mongoc-stream-tls-openssl.c
-       */
+      // Set the retry flag for the BIO used by functions in mongoc-stream-tls-openssl.c.
       BIO_set_retry_read(openssl->bio);
+
+      // Also set the retry flag for the BIO used by OpenSSL.
+      BIO_set_retry_read(b);
+
+      // EAGAIN is an error (negative value), not an EOF (zero).
+      ret = -1;
    }
 
    BSON_ASSERT(mlib_in_range(int, ret));

--- a/src/libmongoc/tests/ssl-test.c
+++ b/src/libmongoc/tests/ssl-test.c
@@ -195,6 +195,9 @@ static BSON_THREAD_FUN(ssl_test_client, ptr)
 
    sock_stream = mongoc_stream_socket_new(conn_sock);
    BSON_ASSERT(sock_stream);
+   if (data->client_stream_wrapper) {
+      sock_stream = data->client_stream_wrapper(sock_stream);
+   }
    ssl_stream = mongoc_stream_tls_new_with_hostname(sock_stream, data->host, data->client, 1);
    if (!ssl_stream) {
 #ifdef MONGOC_ENABLE_SSL_OPENSSL
@@ -263,13 +266,25 @@ static BSON_THREAD_FUN(ssl_test_client, ptr)
 }
 
 
-/** This is the testing function for the ssl-test lib
- *
- * The basic idea is that you spin up a client and server, which will
- * communicate over a mongoc-stream-tls, with varying mongoc_ssl_opt's.  The
- * client and server speak a simple echo protocol, so all we're really testing
- * here is that any given configuration succeeds or fails as it should
- */
+static void
+_ssl_test_run(ssl_test_data_t *data)
+{
+   bson_thread_t server;
+   bson_thread_t client;
+
+   bson_mutex_init(&data->cond_mutex);
+   mongoc_cond_init(&data->cond);
+
+   ASSERT_CMPINT(mcommon_thread_create(&server, &ssl_test_server, data), ==, 0);
+   ASSERT_CMPINT(mcommon_thread_create(&client, &ssl_test_client, data), ==, 0);
+
+   mcommon_thread_join(server);
+   mcommon_thread_join(client);
+
+   bson_mutex_destroy(&data->cond_mutex);
+   mongoc_cond_destroy(&data->cond);
+}
+
 void
 ssl_test(mongoc_ssl_opt_t *client,
          mongoc_ssl_opt_t *server,
@@ -277,30 +292,29 @@ ssl_test(mongoc_ssl_opt_t *client,
          ssl_test_result_t *client_result,
          ssl_test_result_t *server_result)
 {
-   ssl_test_data_t data = {0};
-   bson_thread_t threads[2];
-   int i, r;
+   _ssl_test_run(&(ssl_test_data_t){
+      .client = client,
+      .server = server,
+      .client_result = client_result,
+      .server_result = server_result,
+      .host = host,
+   });
+}
 
-   data.server = server;
-   data.client = client;
-   data.client_result = client_result;
-   data.server_result = server_result;
-   data.host = host;
-
-   bson_mutex_init(&data.cond_mutex);
-   mongoc_cond_init(&data.cond);
-
-   r = mcommon_thread_create(threads, &ssl_test_server, &data);
-   BSON_ASSERT(r == 0);
-
-   r = mcommon_thread_create(threads + 1, &ssl_test_client, &data);
-   BSON_ASSERT(r == 0);
-
-   for (i = 0; i < 2; i++) {
-      r = mcommon_thread_join(threads[i]);
-      BSON_ASSERT(r == 0);
-   }
-
-   bson_mutex_destroy(&data.cond_mutex);
-   mongoc_cond_destroy(&data.cond);
+void
+ssl_test_with_client_stream_wrapper(mongoc_ssl_opt_t *client,
+                                    mongoc_ssl_opt_t *server,
+                                    const char *host,
+                                    ssl_test_result_t *client_result,
+                                    ssl_test_result_t *server_result,
+                                    mongoc_stream_t *(*wrapper)(mongoc_stream_t *stream))
+{
+   _ssl_test_run(&(ssl_test_data_t){
+      .client = client,
+      .server = server,
+      .client_result = client_result,
+      .server_result = server_result,
+      .host = host,
+      .client_stream_wrapper = wrapper,
+   });
 }

--- a/src/libmongoc/tests/ssl-test.h
+++ b/src/libmongoc/tests/ssl-test.h
@@ -33,6 +33,7 @@ typedef struct ssl_test_data {
    bson_mutex_t cond_mutex;
    ssl_test_result_t *client_result;
    ssl_test_result_t *server_result;
+   mongoc_stream_t *(*client_stream_wrapper)(mongoc_stream_t *stream); /* optional */
 } ssl_test_data_t;
 
 void
@@ -41,3 +42,11 @@ ssl_test(mongoc_ssl_opt_t *client,
          const char *host,
          ssl_test_result_t *client_result,
          ssl_test_result_t *server_result);
+
+void
+ssl_test_with_client_stream_wrapper(mongoc_ssl_opt_t *client,
+                                    mongoc_ssl_opt_t *server,
+                                    const char *host,
+                                    ssl_test_result_t *client_result,
+                                    ssl_test_result_t *server_result,
+                                    mongoc_stream_t *(*wrapper)(mongoc_stream_t *stream));

--- a/src/libmongoc/tests/test-mongoc-stream-tls.c
+++ b/src/libmongoc/tests/test-mongoc-stream-tls.c
@@ -1,5 +1,11 @@
 #include <mongoc/mongoc.h>
 
+#include <bson/memory.h>
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+
 
 #ifdef MONGOC_ENABLE_SSL_OPENSSL
 #include <openssl/err.h>
@@ -387,6 +393,99 @@ test_mongoc_tls_trust_dir(void)
 }
 #endif
 
+#if defined(MONGOC_ENABLE_SSL_OPENSSL)
+typedef struct {
+   mongoc_stream_t base;
+   mongoc_stream_t *wrapped;
+   int eagain_remaining;
+} _eagain_stream_t;
+
+static ssize_t
+_eagain_readv(mongoc_stream_t *s, mongoc_iovec_t *iov, size_t iovcnt, size_t min_bytes, int32_t timeout_msec)
+{
+   _eagain_stream_t *const es = (_eagain_stream_t *)s;
+   if (es->eagain_remaining > 0) {
+      --es->eagain_remaining;
+      errno = EAGAIN;
+      return 0;
+   }
+   return mongoc_stream_readv(es->wrapped, iov, iovcnt, min_bytes, timeout_msec);
+}
+
+static ssize_t
+_eagain_writev(mongoc_stream_t *s, mongoc_iovec_t *iov, size_t iovcnt, int32_t timeout_msec)
+{
+   return mongoc_stream_writev(((_eagain_stream_t *)s)->wrapped, iov, iovcnt, timeout_msec);
+}
+
+static int
+_eagain_close(mongoc_stream_t *s)
+{
+   return mongoc_stream_close(((_eagain_stream_t *)s)->wrapped);
+}
+
+static int
+_eagain_flush(mongoc_stream_t *s)
+{
+   return mongoc_stream_flush(((_eagain_stream_t *)s)->wrapped);
+}
+
+static void
+_eagain_destroy(mongoc_stream_t *s)
+{
+   _eagain_stream_t *const es = (_eagain_stream_t *)s;
+   mongoc_stream_destroy(es->wrapped);
+   bson_free(es);
+}
+
+static bool
+_eagain_check_closed(mongoc_stream_t *s)
+{
+   return mongoc_stream_check_closed(((_eagain_stream_t *)s)->wrapped);
+}
+
+static mongoc_stream_t *
+_eagain_get_base_stream(mongoc_stream_t *s)
+{
+   return ((_eagain_stream_t *)s)->wrapped;
+}
+
+static mongoc_stream_t *
+_eagain_stream_new(mongoc_stream_t *base)
+{
+   _eagain_stream_t *const es = bson_malloc0(sizeof(*es));
+   es->base.type = base->type;
+   es->base.destroy = _eagain_destroy;
+   es->base.close = _eagain_close;
+   es->base.flush = _eagain_flush;
+   es->base.writev = _eagain_writev;
+   es->base.readv = _eagain_readv;
+   es->base.get_base_stream = _eagain_get_base_stream;
+   es->base.check_closed = _eagain_check_closed;
+   es->wrapped = base;
+   es->eagain_remaining = 3; // Return EAGAIN three times, then succeed.
+   return (mongoc_stream_t *)es;
+}
+
+static mongoc_stream_t *
+_eagain_stream_wrapper(mongoc_stream_t *s)
+{
+   return _eagain_stream_new(s);
+}
+
+static void
+test_mongoc_tls_eagain(void)
+{
+   mongoc_ssl_opt_t sopt = {.ca_file = CERT_CA, .pem_file = CERT_SERVER};
+   mongoc_ssl_opt_t copt = {.ca_file = CERT_CA, .pem_file = CERT_CLIENT};
+   ssl_test_result_t sr;
+   ssl_test_result_t cr;
+   ssl_test_with_client_stream_wrapper(&copt, &sopt, "localhost", &cr, &sr, _eagain_stream_wrapper);
+   ASSERT_CMPINT((int)cr.result, ==, SSL_TEST_SUCCESS);
+   ASSERT_CMPINT((int)sr.result, ==, SSL_TEST_SUCCESS);
+}
+#endif // defined(MONGOC_ENABLE_SSL_OPENSSL)
+
 #endif /* !MONGOC_ENABLE_SSL_SECURE_CHANNEL */
 
 void
@@ -437,6 +536,7 @@ test_stream_tls_install(TestSuite *suite)
    TestSuite_Add(suite, "/TLS/bad_password", test_mongoc_tls_bad_password);
    TestSuite_Add(suite, "/TLS/weak_cert_validation", test_mongoc_tls_weak_cert_validation);
    TestSuite_Add(suite, "/TLS/crl", test_mongoc_tls_crl);
+   TestSuite_Add(suite, "/TLS/eagain", test_mongoc_tls_eagain);
 #endif
 
 #if !defined(__APPLE__) && !defined(_WIN32) && defined(MONGOC_ENABLE_SSL_OPENSSL) && \
@@ -445,5 +545,6 @@ test_stream_tls_install(TestSuite *suite)
 #endif
 
    TestSuite_AddLive(suite, "/TLS/insecure_nowarning", test_mongoc_tls_insecure_nowarning);
-#endif
+
+#endif // !defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
 }


### PR DESCRIPTION
Resolves CDRIVER-6319 and ongoing task failures on `windows-2022-latest` EVG distros. Re-enables the "run auth tests" step that were skipped in https://github.com/mongodb/mongo-c-driver/pull/2290.

Quoting Claude Code's diagnosis (version 2.1.139, Opus 1M with high effort):

> OpenSSL 4.0.0 introduced new auto-EOF detection in its legacy `BIO_read` compatibility shim (`bread_conv` in `crypto/bio/bio_meth.c`):
> 
> ```c
> // OpenSSL 4.0.0 — new logic absent in 3.6.2
> ret = bio->method->bread_old(bio, data, (int)datal);
> bio->flags &= ~BIO_FLAGS_AUTO_EOF;
> if (ret == 0) {
>     if (BIO_ctrl(bio, BIO_CTRL_EOF, 0, NULL) == 0)
>         bio->flags |= BIO_FLAGS_AUTO_EOF;   // <-- new
>     ...
> }
> ```
> 
> And `BIO_eof()` in 4.0.0 short-circuits on this flag, so the record layer sees `OSSL_RECORD_RETURN_EOF` and aborts the handshake with `SSL_R_UNEXPECTED_EOF_WHILE_READING`.
> 
> mongoc's custom BIO read (`mongoc_stream_tls_openssl_bio_read`) hit this because:
> 1. `_mongoc_stream_socket_readv` with `min_bytes=0` returns `0` (not `-1`) on `EAGAIN`.
> 2. mongoc's ctrl handler returns `0` for everything except `BIO_CTRL_FLUSH`, so `BIO_CTRL_EOF` returns `0`.
> 3. mongoc set the retry flag on the wrong BIO (`openssl->bio`, the SSL filter BIO), not on `b` (the network BIO OpenSSL is asking about).
> 
> The trio triggered `AUTO_EOF` in 4.0.0. In 3.6.2, `BIO_eof` was a plain ctrl wrapper, so a `0`-returning ctrl meant "not EOF" and the issue was masked.

Quoting OpenSSL 4.0.0 docs for [BIO_meth_new](https://docs.openssl.org/4.0/man3/BIO_meth_new/):

> Older code may call BIO_meth_get_read() and BIO_meth_set_read() instead to set an old-style read function. The parameters for the function have the same meaning as for BIO_read() and it must return values as described for BIO_read(). \[...\] Functions set by BIO_meth_set_read_ex() and BIO_meth_set_read() must call BIO_set_flags() to set the BIO_FLAGS_SHOULD_RETRY flag in relevant situations.

and [BIO_read](https://docs.openssl.org/4.0/man3/BIO_read/):

> A return value of 0 indicates that end-of-file was reached, or that a read of zero bytes was requested. A negative return value indicates an error condition.

The referenced code was introduced in [this commit](https://github.com/openssl/openssl/commit/be42447469dcccc68b7e115c7947e3c25124f3f2#diff-d34b4f116098efaead6681b47a5f3b96b7ed54fbcbebe57905335f7e0ece9c4dR134-R140), which is part of a series of (ongoing) improvements to EOF-handling by BIO read functions. Our "old-style" read callback function implementation violates the updated wording in the OpenSSL 4.0.0 function contract, which (now) explicitly documents and enforces better EOF-handling behavior, which in turn changes how _non-EOF_ behavior is handled, which thus affects the handling of `EAGAIN` errors.

---

A new regression test `/TLS/eagain` is added by this PR. To support this new test, the `ssl_test` API is extended to support wrapping the client stream. This wrapper is used to create a stream (in a manner similar to `debug_stream`) that deliberately returns `EAGAIN` errors (up to three times) before eventually succeeding.

Without setting `ret = -1`, which is required to indicate to OpenSSL 4.0.0 that the result is an error, the test failures with the originally observed error (paraphrased for brevity):

```
ERROR: mongoc: ERRORED (line: 227): TLS handshake failed: error:0A000126:SSL routines::unexpected eof while reading
ERROR: mongoc: ERRORED (line: 104): TLS handshake failed: error:0A00010B:SSL routines::wrong version number
ERROR: mongoc: msg: error:0A000139:SSL routines::record layer failure
FAIL
Assert Failure: 3 == 1 (SSL_TEST_SSL_HANDSHAKE == SSL_TEST_SUCCESS)
```

Without the `BIO_set_retry_read(b)`, which is required to indicate to OpenSSL 4.0.0 that the read operation will be retried at a later time, the test also fails (paraphrased for brevity):

```
ERROR: mongoc: ERRORED (line: 227): TLS handshake failed: Connection timed out
ERROR: mongoc: ERRORED (line: 104): TLS handshake failed: Connection timed out
ERROR: mongoc: msg: error:0A000139:SSL routines::record layer failure
FAIL
Assert Failure: 3 == 1 (SSL_TEST_SSL_HANDSHAKE == SSL_TEST_SUCCESS)
```

With both additions to `mongoc_stream_tls_openssl_bio_read()`, the test passes.