### PR TITLE
Fix OpenSSL 4.0.0 compatibility issues (CDRIVER-6308, CDRIVER-6319)

### DIFF
--- a/.evergreen/config_generator/components/openssl_compat.py
+++ b/.evergreen/config_generator/components/openssl_compat.py
@@ -73,11 +73,8 @@ def tasks():
             commands = [
                 FetchSource.call(),
                 OpenSSLSetup.call(vars=vars),
+                FunctionCall(func='run auth tests'),
             ]
-
-            # CDRIVER-6319: Atlas test servers do not yet support connections with OpenSSL 4.0.0...?
-            if version not in ['4.0.0']:
-                commands.append(FunctionCall(func='run auth tests'))
 
             yield EvgTask(
                 name=f'{TAG}-{version}-{link_type}-{distro_str}',

--- a/.evergreen/config_generator/components/openssl_compat.py
+++ b/.evergreen/config_generator/components/openssl_compat.py
@@ -14,7 +14,7 @@ TAG = 'openssl-compat'
 # pylint: disable=line-too-long
 # fmt: off
 OPENSSL_MATRIX = [
-    ('ubuntu2404', 'gcc', ['shared', 'static'], ['1.0.2', '1.1.1', '3.0.9', '3.1.2', '3.2.5', '3.3.4', '3.4.2', '3.5.1']),
+    ('ubuntu2404', 'gcc', ['shared', 'static'], ['1.0.2', '1.1.1', '3.0.9', '3.1.2', '3.2.5', '3.3.4', '3.4.2', '3.5.1', '4.0.0']),
 ]
 # fmt: on
 
@@ -70,15 +70,20 @@ def tasks():
             if link_type == 'static':
                 vars |= {'OPENSSL_USE_STATIC_LIBS': 'ON'}
 
+            commands = [
+                FetchSource.call(),
+                OpenSSLSetup.call(vars=vars),
+            ]
+
+            # CDRIVER-6319: Atlas test servers do not yet support connections with OpenSSL 4.0.0...?
+            if version not in ['4.0.0']:
+                commands.append(FunctionCall(func='run auth tests'))
+
             yield EvgTask(
                 name=f'{TAG}-{version}-{link_type}-{distro_str}',
                 run_on=find_large_distro(distro_name).name,
                 tags=[TAG, f'openssl-{version}', f'openssl-{link_type}', distro_name, compiler],
-                commands=[
-                    FetchSource.call(),
-                    OpenSSLSetup.call(vars=vars),
-                    FunctionCall(func='run auth tests'),
-                ],
+                commands=commands,
             )
 
     for distro_name, compiler, link_types, versions in OPENSSL_FIPS_MATRIX:

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -6262,6 +6262,7 @@ tasks:
       - func: openssl-compat
         vars:
           OPENSSL_VERSION: 4.0.0
+      - func: run auth tests
   - name: openssl-compat-4.0.0-static-ubuntu2404-gcc
     run_on: ubuntu2404-large
     tags: [openssl-compat, openssl-4.0.0, openssl-static, ubuntu2404, gcc]
@@ -6271,6 +6272,7 @@ tasks:
         vars:
           OPENSSL_USE_STATIC_LIBS: "ON"
           OPENSSL_VERSION: 4.0.0
+      - func: run auth tests
   - name: openssl-compat-fips-3.0.9-shared-ubuntu2404-gcc
     run_on: ubuntu2404-large
     tags: [openssl-compat, openssl-fips-3.0.9, openssl-shared, ubuntu2404, gcc]

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -6254,6 +6254,23 @@ tasks:
           OPENSSL_USE_STATIC_LIBS: "ON"
           OPENSSL_VERSION: 3.5.1
       - func: run auth tests
+  - name: openssl-compat-4.0.0-shared-ubuntu2404-gcc
+    run_on: ubuntu2404-large
+    tags: [openssl-compat, openssl-4.0.0, openssl-shared, ubuntu2404, gcc]
+    commands:
+      - func: fetch-source
+      - func: openssl-compat
+        vars:
+          OPENSSL_VERSION: 4.0.0
+  - name: openssl-compat-4.0.0-static-ubuntu2404-gcc
+    run_on: ubuntu2404-large
+    tags: [openssl-compat, openssl-4.0.0, openssl-static, ubuntu2404, gcc]
+    commands:
+      - func: fetch-source
+      - func: openssl-compat
+        vars:
+          OPENSSL_USE_STATIC_LIBS: "ON"
+          OPENSSL_VERSION: 4.0.0
   - name: openssl-compat-fips-3.0.9-shared-ubuntu2404-gcc
     run_on: ubuntu2404-large
     tags: [openssl-compat, openssl-fips-3.0.9, openssl-shared, ubuntu2404, gcc]

--- a/.evergreen/scripts/openssl-downloader.sh
+++ b/.evergreen/scripts/openssl-downloader.sh
@@ -43,6 +43,7 @@ openssl_download() {
   declare openssl_checksum_3_3_4="8d1a5fc323d3fd351dc05458457fd48f78652d2a498e1d70ffea07b4d0eb3fa8"
   declare openssl_checksum_3_4_2="17b02459fc28be415470cccaae7434f3496cac1306b86b52c83886580e82834c"
   declare openssl_checksum_3_5_1="529043b15cffa5f36077a4d0af83f3de399807181d607441d734196d889b641f"
+  declare openssl_checksum_4_0_0="c32cf49a959c4f345f9606982dd36e7d28f7c58b19c2e25d75624d2b3d2f79ac"
 
   declare checksum_name
   checksum_name="openssl_checksum_$(echo "${version:?}" | perl -lpe 's|\.|_|g')" || return

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+libmongoc 2.3.1 [UNRELEASED]
+============================
+
+## Improvements
+
+* Improve forward compatibility with OpenSSL 4.0.0 when handling `EAGAIN` errors in old-style read callbacks where `BIO_FLAGS_AUTO_EOF` is enabled.
+
 libmongoc 2.3.0
 ===============
 
@@ -129,7 +136,7 @@ libmongoc 2.2.0
 
 ## Fixed
 
-* Do not try to resume when iterating a closed change stream. 
+* Do not try to resume when iterating a closed change stream.
 
 ## Notes
 

--- a/src/libmongoc/src/mongoc/mongoc-openssl.c
+++ b/src/libmongoc/src/mongoc/mongoc-openssl.c
@@ -40,7 +40,10 @@
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/ocsp.h>
+#include <openssl/opensslv.h>
+#include <openssl/safestack.h>
 #include <openssl/ssl.h>
+#include <openssl/x509.h>
 #include <openssl/x509v3.h>
 
 #include <limits.h>
@@ -471,14 +474,12 @@ _mongoc_openssl_setup_pem_file(SSL_CTX *ctx, const char *pem_file, const char *p
 static X509 *
 _get_issuer(X509 *cert, STACK_OF(X509) * chain)
 {
-   X509 *issuer = NULL, *candidate = NULL;
-   X509_NAME *issuer_name = NULL, *candidate_name = NULL;
-   int i;
+   X509 *issuer = NULL;
 
-   issuer_name = X509_get_issuer_name(cert);
-   for (i = 0; i < sk_X509_num(chain) && issuer == NULL; i++) {
-      candidate = sk_X509_value(chain, i);
-      candidate_name = X509_get_subject_name(candidate);
+   const X509_NAME *const issuer_name = X509_get_issuer_name(cert);
+   for (int i = 0; i < sk_X509_num(chain) && issuer == NULL; i++) {
+      X509 *const candidate = sk_X509_value(chain, i);
+      const X509_NAME *const candidate_name = X509_get_subject_name(candidate);
       if (0 == X509_NAME_cmp(candidate_name, issuer_name)) {
          issuer = candidate;
       }
@@ -602,25 +603,26 @@ _mongoc_tlsfeature_has_status_request(const uint8_t *data, int length)
 bool
 _get_must_staple(X509 *cert)
 {
-   const STACK_OF(X509_EXTENSION) *exts = NULL;
-   X509_EXTENSION *ext;
-   ASN1_STRING *ext_data;
-   int idx;
-
-   exts = _get_extensions(cert);
+   const STACK_OF(X509_EXTENSION) *const exts = _get_extensions(cert);
    if (!exts) {
       TRACE("%s", "certificate extensions not found");
       return false;
    }
 
-   idx = X509v3_get_ext_by_NID(exts, tlsfeature_nid, -1);
+   const int idx = X509v3_get_ext_by_NID(exts, tlsfeature_nid, -1);
    if (-1 == idx) {
       TRACE("%s", "tlsfeature extension not found");
       return false;
    }
 
-   ext = sk_X509_EXTENSION_value(exts, idx);
-   ext_data = X509_EXTENSION_get_data(ext);
+   X509_EXTENSION *const ext = sk_X509_EXTENSION_value(exts, idx);
+
+   // Pre-3.0.0 `ASN1_STRING_get0_data()` expects `T*`, but post-4.0.0 `X509_EXTENSION_get_data()` returns `const T*`.
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+   ASN1_STRING *const ext_data = X509_EXTENSION_get_data(ext);
+#else
+   const ASN1_STRING *const ext_data = X509_EXTENSION_get_data(ext);
+#endif
 
    /* Data is a DER encoded sequence of integers. */
    return _mongoc_tlsfeature_has_status_request(ASN1_STRING_get0_data(ext_data), ASN1_STRING_length(ext_data));
@@ -960,12 +962,16 @@ _mongoc_openssl_ctx_new(mongoc_ssl_opt_t *opt)
 /* only defined in special build, using:
  * --enable-system-crypto-profile (autotools)
  * -DENABLE_CRYPTO_SYSTEM_PROFILE:BOOL=ON (cmake)  */
-#ifndef MONGOC_ENABLE_CRYPTO_SYSTEM_PROFILE
+#if !defined(MONGOC_ENABLE_CRYPTO_SYSTEM_PROFILE)
    /* HIGH - Enable strong ciphers
     * !EXPORT - Disable export ciphers (40/56 bit)
     * !aNULL - Disable anonymous auth ciphers
     * @STRENGTH - Sort ciphers based on strength */
-   SSL_CTX_set_cipher_list(ctx, "HIGH:!EXPORT:!aNULL@STRENGTH");
+   if (!SSL_CTX_set_cipher_list(ctx, "HIGH:!EXPORT:!aNULL@STRENGTH")) {
+      MONGOC_ERROR("Could not set cipher list for TLSv1.2 and below: %s", ERR_STR);
+      SSL_CTX_free(ctx);
+      return NULL;
+   }
 #endif
 
    /* If renegotiation is needed, don't return from recv() or send() until it's

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl-bio.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls-openssl-bio.c
@@ -226,15 +226,18 @@ mongoc_stream_tls_openssl_bio_read(BIO *b, char *buf, int len)
    openssl = (mongoc_stream_tls_openssl_t *)tls->ctx;
 
    errno = 0;
-   const ssize_t ret = mongoc_stream_read(tls->base_stream, buf, (size_t)len, 0, (int32_t)tls->timeout_msec);
+   ssize_t ret = mongoc_stream_read(tls->base_stream, buf, (size_t)len, 0, (int32_t)tls->timeout_msec);
    BIO_clear_retry_flags(b);
 
    if ((ret <= 0) && MONGOC_ERRNO_IS_AGAIN(errno)) {
-      /* this BIO is not the same as "b", which openssl passed in to this func.
-       * set its retry flag, which we check with BIO_should_retry in
-       * mongoc-stream-tls-openssl.c
-       */
+      // Set the retry flag for the BIO used by functions in mongoc-stream-tls-openssl.c.
       BIO_set_retry_read(openssl->bio);
+
+      // Also set the retry flag for the BIO used by OpenSSL.
+      BIO_set_retry_read(b);
+
+      // EAGAIN is an error (negative value), not an EOF (zero).
+      ret = -1;
    }
 
    BSON_ASSERT(mlib_in_range(int, ret));

--- a/src/libmongoc/tests/ssl-test.c
+++ b/src/libmongoc/tests/ssl-test.c
@@ -195,6 +195,9 @@ static BSON_THREAD_FUN(ssl_test_client, ptr)
 
    sock_stream = mongoc_stream_socket_new(conn_sock);
    BSON_ASSERT(sock_stream);
+   if (data->client_stream_wrapper) {
+      sock_stream = data->client_stream_wrapper(sock_stream);
+   }
    ssl_stream = mongoc_stream_tls_new_with_hostname(sock_stream, data->host, data->client, 1);
    if (!ssl_stream) {
 #ifdef MONGOC_ENABLE_SSL_OPENSSL
@@ -263,13 +266,25 @@ static BSON_THREAD_FUN(ssl_test_client, ptr)
 }
 
 
-/** This is the testing function for the ssl-test lib
- *
- * The basic idea is that you spin up a client and server, which will
- * communicate over a mongoc-stream-tls, with varying mongoc_ssl_opt's.  The
- * client and server speak a simple echo protocol, so all we're really testing
- * here is that any given configuration succeeds or fails as it should
- */
+static void
+_ssl_test_run(ssl_test_data_t *data)
+{
+   bson_thread_t server;
+   bson_thread_t client;
+
+   bson_mutex_init(&data->cond_mutex);
+   mongoc_cond_init(&data->cond);
+
+   ASSERT_CMPINT(mcommon_thread_create(&server, &ssl_test_server, data), ==, 0);
+   ASSERT_CMPINT(mcommon_thread_create(&client, &ssl_test_client, data), ==, 0);
+
+   mcommon_thread_join(server);
+   mcommon_thread_join(client);
+
+   bson_mutex_destroy(&data->cond_mutex);
+   mongoc_cond_destroy(&data->cond);
+}
+
 void
 ssl_test(mongoc_ssl_opt_t *client,
          mongoc_ssl_opt_t *server,
@@ -277,30 +292,29 @@ ssl_test(mongoc_ssl_opt_t *client,
          ssl_test_result_t *client_result,
          ssl_test_result_t *server_result)
 {
-   ssl_test_data_t data = {0};
-   bson_thread_t threads[2];
-   int i, r;
+   _ssl_test_run(&(ssl_test_data_t){
+      .client = client,
+      .server = server,
+      .client_result = client_result,
+      .server_result = server_result,
+      .host = host,
+   });
+}
 
-   data.server = server;
-   data.client = client;
-   data.client_result = client_result;
-   data.server_result = server_result;
-   data.host = host;
-
-   bson_mutex_init(&data.cond_mutex);
-   mongoc_cond_init(&data.cond);
-
-   r = mcommon_thread_create(threads, &ssl_test_server, &data);
-   BSON_ASSERT(r == 0);
-
-   r = mcommon_thread_create(threads + 1, &ssl_test_client, &data);
-   BSON_ASSERT(r == 0);
-
-   for (i = 0; i < 2; i++) {
-      r = mcommon_thread_join(threads[i]);
-      BSON_ASSERT(r == 0);
-   }
-
-   bson_mutex_destroy(&data.cond_mutex);
-   mongoc_cond_destroy(&data.cond);
+void
+ssl_test_with_client_stream_wrapper(mongoc_ssl_opt_t *client,
+                                    mongoc_ssl_opt_t *server,
+                                    const char *host,
+                                    ssl_test_result_t *client_result,
+                                    ssl_test_result_t *server_result,
+                                    mongoc_stream_t *(*wrapper)(mongoc_stream_t *stream))
+{
+   _ssl_test_run(&(ssl_test_data_t){
+      .client = client,
+      .server = server,
+      .client_result = client_result,
+      .server_result = server_result,
+      .host = host,
+      .client_stream_wrapper = wrapper,
+   });
 }

--- a/src/libmongoc/tests/ssl-test.h
+++ b/src/libmongoc/tests/ssl-test.h
@@ -33,6 +33,7 @@ typedef struct ssl_test_data {
    bson_mutex_t cond_mutex;
    ssl_test_result_t *client_result;
    ssl_test_result_t *server_result;
+   mongoc_stream_t *(*client_stream_wrapper)(mongoc_stream_t *stream); /* optional */
 } ssl_test_data_t;
 
 void
@@ -41,3 +42,11 @@ ssl_test(mongoc_ssl_opt_t *client,
          const char *host,
          ssl_test_result_t *client_result,
          ssl_test_result_t *server_result);
+
+void
+ssl_test_with_client_stream_wrapper(mongoc_ssl_opt_t *client,
+                                    mongoc_ssl_opt_t *server,
+                                    const char *host,
+                                    ssl_test_result_t *client_result,
+                                    ssl_test_result_t *server_result,
+                                    mongoc_stream_t *(*wrapper)(mongoc_stream_t *stream));

--- a/src/libmongoc/tests/test-mongoc-stream-tls.c
+++ b/src/libmongoc/tests/test-mongoc-stream-tls.c
@@ -1,5 +1,11 @@
 #include <mongoc/mongoc.h>
 
+#include <bson/memory.h>
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+
 
 #ifdef MONGOC_ENABLE_SSL_OPENSSL
 #include <openssl/err.h>
@@ -387,6 +393,99 @@ test_mongoc_tls_trust_dir(void)
 }
 #endif
 
+#if defined(MONGOC_ENABLE_SSL_OPENSSL)
+typedef struct {
+   mongoc_stream_t base;
+   mongoc_stream_t *wrapped;
+   int eagain_remaining;
+} _eagain_stream_t;
+
+static ssize_t
+_eagain_readv(mongoc_stream_t *s, mongoc_iovec_t *iov, size_t iovcnt, size_t min_bytes, int32_t timeout_msec)
+{
+   _eagain_stream_t *const es = (_eagain_stream_t *)s;
+   if (es->eagain_remaining > 0) {
+      --es->eagain_remaining;
+      errno = EAGAIN;
+      return 0;
+   }
+   return mongoc_stream_readv(es->wrapped, iov, iovcnt, min_bytes, timeout_msec);
+}
+
+static ssize_t
+_eagain_writev(mongoc_stream_t *s, mongoc_iovec_t *iov, size_t iovcnt, int32_t timeout_msec)
+{
+   return mongoc_stream_writev(((_eagain_stream_t *)s)->wrapped, iov, iovcnt, timeout_msec);
+}
+
+static int
+_eagain_close(mongoc_stream_t *s)
+{
+   return mongoc_stream_close(((_eagain_stream_t *)s)->wrapped);
+}
+
+static int
+_eagain_flush(mongoc_stream_t *s)
+{
+   return mongoc_stream_flush(((_eagain_stream_t *)s)->wrapped);
+}
+
+static void
+_eagain_destroy(mongoc_stream_t *s)
+{
+   _eagain_stream_t *const es = (_eagain_stream_t *)s;
+   mongoc_stream_destroy(es->wrapped);
+   bson_free(es);
+}
+
+static bool
+_eagain_check_closed(mongoc_stream_t *s)
+{
+   return mongoc_stream_check_closed(((_eagain_stream_t *)s)->wrapped);
+}
+
+static mongoc_stream_t *
+_eagain_get_base_stream(mongoc_stream_t *s)
+{
+   return ((_eagain_stream_t *)s)->wrapped;
+}
+
+static mongoc_stream_t *
+_eagain_stream_new(mongoc_stream_t *base)
+{
+   _eagain_stream_t *const es = bson_malloc0(sizeof(*es));
+   es->base.type = base->type;
+   es->base.destroy = _eagain_destroy;
+   es->base.close = _eagain_close;
+   es->base.flush = _eagain_flush;
+   es->base.writev = _eagain_writev;
+   es->base.readv = _eagain_readv;
+   es->base.get_base_stream = _eagain_get_base_stream;
+   es->base.check_closed = _eagain_check_closed;
+   es->wrapped = base;
+   es->eagain_remaining = 3; // Return EAGAIN three times, then succeed.
+   return (mongoc_stream_t *)es;
+}
+
+static mongoc_stream_t *
+_eagain_stream_wrapper(mongoc_stream_t *s)
+{
+   return _eagain_stream_new(s);
+}
+
+static void
+test_mongoc_tls_eagain(void)
+{
+   mongoc_ssl_opt_t sopt = {.ca_file = CERT_CA, .pem_file = CERT_SERVER};
+   mongoc_ssl_opt_t copt = {.ca_file = CERT_CA, .pem_file = CERT_CLIENT};
+   ssl_test_result_t sr;
+   ssl_test_result_t cr;
+   ssl_test_with_client_stream_wrapper(&copt, &sopt, "localhost", &cr, &sr, _eagain_stream_wrapper);
+   ASSERT_CMPINT((int)cr.result, ==, SSL_TEST_SUCCESS);
+   ASSERT_CMPINT((int)sr.result, ==, SSL_TEST_SUCCESS);
+}
+#endif // defined(MONGOC_ENABLE_SSL_OPENSSL)
+
 #endif /* !MONGOC_ENABLE_SSL_SECURE_CHANNEL */
 
 void
@@ -437,6 +536,7 @@ test_stream_tls_install(TestSuite *suite)
    TestSuite_Add(suite, "/TLS/bad_password", test_mongoc_tls_bad_password);
    TestSuite_Add(suite, "/TLS/weak_cert_validation", test_mongoc_tls_weak_cert_validation);
    TestSuite_Add(suite, "/TLS/crl", test_mongoc_tls_crl);
+   TestSuite_Add(suite, "/TLS/eagain", test_mongoc_tls_eagain);
 #endif
 
 #if !defined(__APPLE__) && !defined(_WIN32) && defined(MONGOC_ENABLE_SSL_OPENSSL) && \
@@ -445,5 +545,6 @@ test_stream_tls_install(TestSuite *suite)
 #endif
 
    TestSuite_AddLive(suite, "/TLS/insecure_nowarning", test_mongoc_tls_insecure_nowarning);
-#endif
+
+#endif // !defined(MONGOC_ENABLE_SSL_SECURE_CHANNEL)
 }


### PR DESCRIPTION
Cherry-picks https://github.com/mongodb/mongo-c-driver/pull/2290 and https://github.com/mongodb/mongo-c-driver/pull/2297 onto the r2.3 branch targeting a 2.3.1 release.