### PR TITLE
update release branch protection rules step

### DIFF
--- a/docs/dev/releasing.rst
+++ b/docs/dev/releasing.rst
@@ -557,6 +557,13 @@ Click ``Edit`` on the hook for ``https://githook.mongodb.com/``.
 Add the new release branch to the ``Payload URL``. Remove unmaintained
 release branches.
 
+Update Branch Protection Rules
+******************************
+
+Notify a repository administrator that the previous stable release branch (which will no longer recieve any further
+updates) may now be "locked" by removing the exclude rule from the "Restrict Branch Updates" ruleset and adding an
+exclude rule for the new branch.
+
 
 Comment on the Generated DOCSP Ticket
 *************************************


### PR DESCRIPTION
Similar to https://github.com/mongodb/mongo-cxx-driver/pull/1633/, this PR is in response to discovering the "Restrict Updates (Branches)" ruleset was referencing old branches.

The ruleset "Target branches" is updated to follow the pattern of the C++ driver: apply to all branches matching release branch patterns, then exclude the most recent release branch:

<img width="809" height="361" alt="Screenshot 2026-05-12 at 3 25 06 PM" src="https://github.com/user-attachments/assets/55bfd311-473f-44ee-bda4-c7e2107d67e7" />

