### PR TITLE
retry `build-environment` Earthly step with delay

### DIFF
--- a/.evergreen/config_generator/components/earthly.py
+++ b/.evergreen/config_generator/components/earthly.py
@@ -214,10 +214,12 @@ def earthly_exec(
     platform: str | None = None,
     secrets: Mapping[str, str] | None = None,
     args: Mapping[str, str] | None = None,
-    retry_on_failure: Optional[bool] = None,
+    retry_with_delay: bool = False,
 ) -> BuiltInCommandWithRetry:
     """Create a subprocess_exec command that runs Earthly with the given arguments"""
     env: dict[str, str] = {k: v for k, v in (secrets or {}).items()}
+    if retry_with_delay:
+        env['EARTHLY_RETRY_WITH_DELAY'] = '1'
     return subprocess_exec_with_retry(
         './tools/earthly.sh',
         args=[
@@ -234,7 +236,6 @@ def earthly_exec(
         include_expansions_in_env=['DOCKER_CONFIG'],
         env=env if env else None,
         working_dir='mongoc',
-        retry_on_failure=retry_on_failure,
     )
 
 
@@ -274,8 +275,8 @@ def earthly_task(
             # This won't generate any output, but allows EVG to track it as a separate build step
             # for timing and logging purposes. The subequent build step will cache-hit the
             # warmed-up build environments.
-            earthly_exec(kind='setup', target='build-environment', args=earthly_args, retry_on_failure=True),
-            earthly_exec(kind='setup', target='configure', args=earthly_args, retry_on_failure=True),
+            earthly_exec(kind='setup', target='build-environment', args=earthly_args, retry_with_delay=True),
+            earthly_exec(kind='setup', target='configure', args=earthly_args),
             # Now execute the main tasks:
             earthly_exec(
                 kind='test',

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -1350,9 +1350,10 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          env:
+            EARTHLY_RETRY_WITH_DELAY: "1"
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
@@ -1371,7 +1372,6 @@ tasks:
           working_dir: mongoc
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
@@ -1417,9 +1417,10 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          env:
+            EARTHLY_RETRY_WITH_DELAY: "1"
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
@@ -1438,7 +1439,6 @@ tasks:
           working_dir: mongoc
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
@@ -1484,9 +1484,10 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          env:
+            EARTHLY_RETRY_WITH_DELAY: "1"
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
@@ -1505,7 +1506,6 @@ tasks:
           working_dir: mongoc
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
@@ -1551,9 +1551,10 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          env:
+            EARTHLY_RETRY_WITH_DELAY: "1"
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
@@ -1572,7 +1573,6 @@ tasks:
           working_dir: mongoc
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
@@ -1618,9 +1618,10 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          env:
+            EARTHLY_RETRY_WITH_DELAY: "1"
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
@@ -1639,7 +1640,6 @@ tasks:
           working_dir: mongoc
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
@@ -1685,9 +1685,10 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          env:
+            EARTHLY_RETRY_WITH_DELAY: "1"
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
@@ -1706,7 +1707,6 @@ tasks:
           working_dir: mongoc
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
@@ -1752,9 +1752,10 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          env:
+            EARTHLY_RETRY_WITH_DELAY: "1"
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
@@ -1773,7 +1774,6 @@ tasks:
           working_dir: mongoc
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
@@ -1819,9 +1819,10 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          env:
+            EARTHLY_RETRY_WITH_DELAY: "1"
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
@@ -1840,7 +1841,6 @@ tasks:
           working_dir: mongoc
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
@@ -1886,9 +1886,10 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          env:
+            EARTHLY_RETRY_WITH_DELAY: "1"
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
@@ -1907,7 +1908,6 @@ tasks:
           working_dir: mongoc
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
@@ -1953,9 +1953,10 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          env:
+            EARTHLY_RETRY_WITH_DELAY: "1"
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
@@ -1974,7 +1975,6 @@ tasks:
           working_dir: mongoc
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
@@ -2020,9 +2020,10 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          env:
+            EARTHLY_RETRY_WITH_DELAY: "1"
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
@@ -2041,7 +2042,6 @@ tasks:
           working_dir: mongoc
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
@@ -2087,9 +2087,10 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          env:
+            EARTHLY_RETRY_WITH_DELAY: "1"
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
@@ -2108,7 +2109,6 @@ tasks:
           working_dir: mongoc
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
@@ -2154,9 +2154,10 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          env:
+            EARTHLY_RETRY_WITH_DELAY: "1"
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
@@ -2175,7 +2176,6 @@ tasks:
           working_dir: mongoc
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
@@ -2221,9 +2221,10 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          env:
+            EARTHLY_RETRY_WITH_DELAY: "1"
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
@@ -2242,7 +2243,6 @@ tasks:
           working_dir: mongoc
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
@@ -2288,9 +2288,10 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          env:
+            EARTHLY_RETRY_WITH_DELAY: "1"
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
@@ -2309,7 +2310,6 @@ tasks:
           working_dir: mongoc
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
@@ -2355,9 +2355,10 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          env:
+            EARTHLY_RETRY_WITH_DELAY: "1"
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
@@ -2376,7 +2377,6 @@ tasks:
           working_dir: mongoc
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
@@ -2422,9 +2422,10 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          env:
+            EARTHLY_RETRY_WITH_DELAY: "1"
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
@@ -2443,7 +2444,6 @@ tasks:
           working_dir: mongoc
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
@@ -2489,9 +2489,10 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          env:
+            EARTHLY_RETRY_WITH_DELAY: "1"
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
@@ -2510,7 +2511,6 @@ tasks:
           working_dir: mongoc
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
@@ -2556,9 +2556,10 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          env:
+            EARTHLY_RETRY_WITH_DELAY: "1"
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
@@ -2577,7 +2578,6 @@ tasks:
           working_dir: mongoc
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
@@ -2623,9 +2623,10 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          env:
+            EARTHLY_RETRY_WITH_DELAY: "1"
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
@@ -2644,7 +2645,6 @@ tasks:
           working_dir: mongoc
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
@@ -2690,9 +2690,10 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          env:
+            EARTHLY_RETRY_WITH_DELAY: "1"
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
@@ -2711,7 +2712,6 @@ tasks:
           working_dir: mongoc
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
@@ -2757,9 +2757,10 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          env:
+            EARTHLY_RETRY_WITH_DELAY: "1"
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
@@ -2778,7 +2779,6 @@ tasks:
           working_dir: mongoc
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
@@ -2824,9 +2824,10 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          env:
+            EARTHLY_RETRY_WITH_DELAY: "1"
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
@@ -2845,7 +2846,6 @@ tasks:
           working_dir: mongoc
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
@@ -2891,9 +2891,10 @@ tasks:
         params:
           binary: ./tools/earthly.sh
           working_dir: mongoc
+          env:
+            EARTHLY_RETRY_WITH_DELAY: "1"
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
@@ -2912,7 +2913,6 @@ tasks:
           working_dir: mongoc
           include_expansions_in_env:
             - DOCKER_CONFIG
-          retry_on_failure: true
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure

--- a/tools/earthly.sh
+++ b/tools/earthly.sh
@@ -45,5 +45,14 @@ run-earthly() {
 }
 
 if is-main; then
+  if [[ "${EARTHLY_RETRY_WITH_DELAY:-}" == "1" ]]; then
+    for _delay in 1 10 30; do
+      if run-earthly "$@"; then
+        exit 0
+      fi
+      echo "Earthly failed. Retrying in ${_delay}s..." >&2
+      sleep "$_delay"
+    done
+  fi
   run-earthly "$@"
 fi


### PR DESCRIPTION
# Summary

Retry the `build-environment` task on failure up to three times with an increasing delay.

# Background & Motivation

Earthly tasks frequently fail in the `build-environment` step, even after enabling the [retry_on_failure](https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Project-Configuration-Files#auto-restarting-tasks-upon-failure) Evergreen option (which retries once). Here is a sample of three recent failures:


[1](https://spruce.corp.mongodb.com/task/mongo_c_driver_archlinux_gcc_check:sasl=off%C2%A0%E2%80%A2%C2%A0tls=OpenSSL%C2%A0%E2%80%A2%C2%A0test_mongocxx_ref=master%C2%A0%E2%80%A2%C2%A0snappy=false_081a2d23955230c856a7fe6f72e745a5c70292d0_26_05_08_19_24_27/logs?execution=0):

```
[2026/05/08 15:37:03.660]   +build-environment | apply build +base: earthfile2llb for +base: Earthfile:13:0 apply FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/alpine:3.20: resolve image config for 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/alpine:3.20: failed to copy: httpReadSeeker: failed open: unexpected status code https://901841024863.dkr.ecr.us-east-1.amazonaws.com/v2/dockerhub/library/alpine/blobs/sha256:bf8527eb54c3680e728d5b4b383a8ba730d72dae7236fbc8dff97ed6b224a731: 500 Internal Server Error
```

[2](https://spruce.corp.mongodb.com/task/mongo_c_driver_alpine:3.22_gcc_check:sasl=off%C2%A0%E2%80%A2%C2%A0tls=off%C2%A0%E2%80%A2%C2%A0test_mongocxx_ref=r4.1.0%C2%A0%E2%80%A2%C2%A0snappy=false_deab4ed0c98e1b31c5148cdd1e111948455ecba3_26_05_12_16_05_01/logs?execution=0):

```
[2026/05/12 12:16:45.649]   +build-environment | apply build +base: earthfile2llb for +base: Earthfile:13:0 apply FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/alpine:3.20: resolve image config for 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/alpine:3.20: failed to copy: httpReadSeeker: failed open: unexpected status code https://901841024863.dkr.ecr.us-east-1.amazonaws.com/v2/dockerhub/library/alpine/blobs/sha256:bf8527eb54c3680e728d5b4b383a8ba730d72dae7236fbc8dff97ed6b224a731: 500 Internal Server Error
```

[3](https://spruce.corp.mongodb.com/task/mongo_c_driver_alpine:3.20_gcc_check:sasl=off%C2%A0%E2%80%A2%C2%A0tls=OpenSSL%C2%A0%E2%80%A2%C2%A0test_mongocxx_ref=master%C2%A0%E2%80%A2%C2%A0snappy=true_e5e1aa14e18e363324f8230f55e1837fee004724_26_04_28_18_15_55/logs?execution=0):
```
[2026/04/28 14:22:42.035]                +init *failed* | wget: server returned error: HTTP/1.1 502 Bad Gateway or Proxy Error
[2026/04/28 14:22:42.035]                +init *failed* | failed to download https://github.com/astral-sh/uv/releases/download/0.8.15/uv-x86_64-unknown-linux-musl.tar.gz
```

This PR adds three retries with delays.