### PR TITLE
CDRIVER-6339 Replace Google Tag Manager with Mixpanel

### DIFF
--- a/build/sphinx/_templates/base.html
+++ b/build/sphinx/_templates/base.html
@@ -1,0 +1,12 @@
+{% extends "!base.html" %}
+{%- block extrahead %}
+{{ super() }}
+<script type="text/javascript">
+  (function(e,c){if(!c.__SV){var l,h;window.mixpanel=c;c._i=[];c.init=function(q,r,f){function t(d,a){var g=a.split(".");2==g.length&&(d=d[g[0]],a=g[1]);d[a]=function(){d.push([a].concat(Array.prototype.slice.call(arguments,0)))}}var b=c;"undefined"!==typeof f?b=c[f]=[]:f="mixpanel";b.people=b.people||[];b.toString=function(d){var a="mixpanel";"mixpanel"!==f&&(a+="."+f);d||(a+=" (stub)");return a};b.people.toString=function(){return b.toString(1)+".people (stub)"};l="disable time_event track track_pageview track_links track_forms track_with_groups add_group set_group remove_group register register_once alias unregister identify name_tag set_config reset opt_in_tracking opt_out_tracking has_opted_in_tracking has_opted_out_tracking clear_opt_in_out_tracking start_batch_senders start_session_recording stop_session_recording people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user people.remove".split(" ");
+  for(h=0;h<l.length;h++)t(b,l[h]);var n="set set_once union unset remove delete".split(" ");b.get_group=function(){function d(p){a[p]=function(){b.push([g,[p].concat(Array.prototype.slice.call(arguments,0))])}}for(var a={},g=["get_group"].concat(Array.prototype.slice.call(arguments,0)),m=0;m<n.length;m++)d(n[m]);return a};c._i.push([q,r,f])};c.__SV=1.2;var k=e.createElement("script");k.type="text/javascript";k.async=!0;k.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?MIXPANEL_CUSTOM_LIB_URL:"file:"===
+  e.location.protocol&&"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)?"https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js":"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";e=e.getElementsByTagName("script")[0];e.parentNode.insertBefore(k,e)}})(document,window.mixpanel||[]); mixpanel.init('f2a38f26e5cc0eee429a9276f296c118', {
+    autocapture: true,
+    record_sessions_percent: 0,
+  })
+</script>
+{% endblock %}

--- a/build/sphinx/mongoc_common.py
+++ b/build/sphinx/mongoc_common.py
@@ -68,27 +68,6 @@ man_pages: List[Tuple[str, str, str, List[str], int]] = []
 # -- Sphinx customization ---------------------------------------
 
 
-def add_ga_javascript(app: Sphinx, pagename: str, templatename: str, context: Dict[str, Any], doctree: document):
-    if not app.env.config.analytics:
-        return
-
-    # Add google analytics.
-    context['metatags'] = (
-        context.get('metatags', '')
-        + """
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-56KD6L3MDX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-56KD6L3MDX');
-</script>
-"""
-    )
-
-
 class VersionList(Directive):
     """Custom directive to generate the version list from an environment variable"""
 
@@ -131,7 +110,6 @@ class VersionList(Directive):
 
 def mongoc_common_setup(app: Sphinx):
     _collect_man(app)
-    app.connect('html-page-context', add_ga_javascript)
-    # Run sphinx-build -D analytics=1 to enable Google Analytics.
     app.add_config_value('analytics', False, 'html')
     app.add_directive('versionlist', VersionList)
+    app.config.templates_path += [str(Path(__file__).parent / '_templates')]


### PR DESCRIPTION
Resolves CDRIVER-6339 by using Sphinx's support for [templating](https://www.sphinx-doc.org/en/master/development/html_themes/templating.html) to extend the `<head>` contents via the [extrahead](https://www.sphinx-doc.org/en/master/development/html_themes/templating.html#working-with-the-builtin-templates) block.

An unexpected quirk is that `base.html` is required instead of `layout.html` due to use of the Furo theme, which implements its own extension to the Sphinx templates and places the `extrahead` block in `base.html` instead of `layout.html`. This appears to be a quirk specific to the Furo theme, as per Furo [docs](https://pradyunsg.me/furo/customisation/injecting/):

> This customisation considered “unstable” under Furo’s [Stability Policy](https://pradyunsg.me/furo/stability/). Customisations done directly with CSS/JS/HTML are unbounded. Furo is not designed to accommodate for custom CSS/JS/HTML in any meaningful way, and no effort is made to stay compatible with such customisations.

Otherwise, the changes are fairly straightforward.

Note that these changes do not add the Mixpanel tracker to dev docs; only pages which invoke `mongoc_common_setup()` during HTML generation (home page, bson, and mongoc).