### PR TITLE
CDRIVER-6343 check embedded length in `bson_new_from_buffer`

### DIFF
--- a/src/libbson/doc/bson_init_static.rst
+++ b/src/libbson/doc/bson_init_static.rst
@@ -25,6 +25,8 @@ The :symbol:`bson_init_static()` function shall initialize a read-only :symbol:`
 
 The resulting `bson_t` has internal references and therefore must not be copied to avoid dangling pointers in the copy.
 
+It is an error if ``length`` does not match the length embedded in the first four bytes of the BSON data in ``data``.
+
 Returns
 -------
 

--- a/src/libbson/doc/bson_new_from_buffer.rst
+++ b/src/libbson/doc/bson_new_from_buffer.rst
@@ -31,6 +31,8 @@ The ``realloc_func``, if provided, is called to resize ``buf`` if the document i
 
 If ``*buf`` is initially NULL then it is allocated, using ``realloc_func`` or the default allocator, and initialized with an empty BSON document, and ``*buf_len`` is set to 5, the size of an empty document.
 
+If ``*buf`` is initially non-NULL, ``*buf_len`` must be at least as large as the embedded length in the first four bytes of the BSON data in ``*buf``, but may exceed it. Remaining buffer capacity may be used to later grow the BSON document.
+
 Returns
 -------
 

--- a/src/libbson/doc/bson_new_from_data.rst
+++ b/src/libbson/doc/bson_new_from_data.rst
@@ -22,6 +22,8 @@ Description
 
 The :symbol:`bson_new_from_data()` function shall create a new :symbol:`bson_t` on the heap and copy the contents of ``data``. This may be helpful when working with language bindings but is generally expected to be slower.
 
+It is an error if ``length`` does not match the length embedded in the first four bytes of the BSON data in ``data``.
+
 Returns
 -------
 

--- a/src/libbson/src/bson/bson.c
+++ b/src/libbson/src/bson/bson.c
@@ -2041,7 +2041,7 @@ bson_new_from_buffer(uint8_t **buf, size_t *buf_len, bson_realloc_func realloc_f
          return NULL;
       }
       length = mlib_read_u32le(*buf);
-      if (length > *buf_len) {
+      if (length < 5 || length > *buf_len) {
          bson_free(bson);
          return NULL;
       }

--- a/src/libbson/tests/test-bson.c
+++ b/src/libbson/tests/test-bson.c
@@ -1105,6 +1105,17 @@ test_bson_new_from_buffer(void)
       bson_destroy(minimal);
       bson_free(buf);
    }
+
+   // Buffer embeds a zero document length. Must be rejected without underflowing.
+   {
+      size_t buf_len = 5;
+      uint8_t *buf = bson_malloc0(buf_len); // All zeroes.
+
+      bson_t *b = bson_new_from_buffer(&buf, &buf_len, realloc_func_never_called, NULL);
+
+      BSON_ASSERT(b == NULL);
+      bson_free(buf);
+   }
 }
 
 static void


### PR DESCRIPTION
Add an additional length check to `bson_new_from_buffer`. See CDRIVER-6343 for details.