### PR TITLE
[CDRIVER-5705] Add a new documentation for versioning, API, and ABI guarantees

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,10 +74,9 @@ and the existing codes or domains are inappropriate.
                               
 ### Adding a new symbol
 
-This should be done rarely but there are several things that you need to do
-when adding a new symbol.
-
- - Add documentation for the new symbol in `doc/mongoc_your_new_symbol_name.rst`
+See the *Adding New Symbols* section of the [API and ABI Policy](docs/dev/api-abi-policy.rst)
+for the full procedure (header declaration, `MONGOC_EXPORT`/`BSON_EXPORT`
+annotation, documentation, and ABI compliance check).
 
 ### Documentation
 

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,9 @@ mongo-c-driver is a project that includes two libraries:
 
 If libmongoc is not needed, it is possible to build and install only libbson.
 
-This project uses `Semantic Versioning <https://semver.org/>`_.
+This project uses `Semantic Versioning <https://semver.org/>`_. See
+`docs/dev/api-abi-policy.rst <docs/dev/api-abi-policy.rst>`_ for the project's
+full API and ABI stability policy.
 
 Documentation / Support / Feedback
 ==================================

--- a/docs/dev/api-abi-policy.rst
+++ b/docs/dev/api-abi-policy.rst
@@ -1,0 +1,257 @@
+##################
+API and ABI Policy
+##################
+
+This page describes the stability guarantees that the C driver project makes
+about its public API and ABI across releases, how deprecation works, and what
+is explicitly *not* covered by these guarantees.
+
+.. note::
+
+   This policy applies to both **libmongoc** and **libbson**.
+
+
+.. _api-abi-policy.versioning:
+
+Versioning Scheme
+#################
+
+The C libraries use a ``<major>.<minor>.<micro>`` versioning scheme that is
+based on `Semantic Versioning <https://semver.org>`_. Prerelease and development
+versions include a suffix to indicate that the contents of the libraries are
+unstable and subject to change.
+
+- A **major** version indicates overall breaking changes. Different major
+  versions offer very few compatibility guarantees in their API and ABI.
+- A **minor** version indicates the addition of new APIs and features to the
+  libraries, or possible deprecation of APIs. Programs written against earlier
+  minor versions should continue to compile and link with a newer minor version
+  with minimal or no changes.
+- A **micro** (also known as "patch") version indicates bugfixes and tweaks and
+  will not deprecate or add any major features to libraries. Programs written
+  against earlier micro versions should compile and link against newer micro
+  with no changes unless security considerations require API or ABI changes.
+
+
+.. _api-abi-policy.public-api:
+
+What Is the Public API?
+#######################
+
+The public API consists of:
+
+* Every symbol (function, type, macro, constant) declared in a **public header**
+  — a header that is installed alongside the library and has no ``-private``
+  suffix in its name (e.g. ``mongoc/mongoc-client.h``, ``bson/bson.h``), except
+  for those noted below.
+* Every function annotated with ``MONGOC_EXPORT(...)`` or ``BSON_EXPORT(...)``.
+
+The following are **not** part of the public API and carry **no stability
+guarantee**:
+
+* Headers with a ``-private.h`` suffix (e.g. ``mongoc-client-private.h``) and
+  the contents thereof.
+* Anything under ``src/common/`` (the internal shared utility library).
+* Symbols prefixed with an underscore or otherwise documented as internal.
+* The layout of any struct whose definition lives in a ``-private.h`` header,
+  even when the opaque ``typedef`` is public.
+* The content of ``src/kms-message/``, a vendored library with its own
+  versioning.
+
+
+Header Inclusion
+****************
+
+All library header ``#include`` directives should use the ``bson/`` or
+``mongoc/`` directory prefix. Including unqualified header filenames by
+modifying the header search paths is unsupported.
+
+Header files that have the ``bson/bson-*`` or ``mongoc/mongoc-*`` (with the
+hyphen) prefix should never be included directly, despite being part of the
+public API. Only their contents are part of the public API, not the filename or
+the physical location of the entities contained within. The content of these
+headers may be moved in any version, or those headers may be removed entirely.
+Instead, users should include the umbrella headers
+``<bson/bson.h>``/``<mongoc/mongoc.h>`` or they may directly include one of the
+headers without the ``bson-`` or ``mongoc-`` prefix in its filename.
+
+
+.. _api-abi-policy.api:
+
+API Stability
+#############
+
+Within a **major** version series the project guarantees source-level backward
+compatibility: a program that compiles cleanly against version ``X.Y.Z`` using
+only the public API is expected to compile without modification against any later
+``X.Y'.Z'`` release in the same major series. Specifically:
+
+* **No removal** of public symbols — functions, types, macros, and constants
+  present in a release remain available in all subsequent releases within the
+  same major version.
+* **No rename** of a public symbol without providing a compatibility alias for
+  the original name.
+* **No incompatible signature changes** — the parameter and return types of
+  public functions do not change in ways that require callers to be updated.
+  Note that cv-qualifiers may be added or removed from parameter or return types
+  in ways that do not affect existing callers.
+* **No change in documented contract** — the observable behavior, preconditions,
+  postconditions, and error semantics of a public function do not change in a way
+  that causes a previously-correct caller to misbehave.
+* **No change in the values** of public constants or enum members in a way that
+  alters the semantics of existing programs.
+
+As a result, a program that compiles cleanly against version ``X.Y.Z`` is
+expected to compile and link without modification against any later ``X.Y'.Z'``
+release in the same major series, provided the program only uses the public API.
+
+Within a **minor** release, new public symbols may be added (see
+:ref:`api-abi-policy.additions`). Within a **micro** release, no new public
+symbols are introduced and existing behavior changes only to correct bugs.
+
+Deprecation (see :ref:`api-abi-policy.deprecation`) is the only mechanism by
+which a public symbol can eventually be removed; removal only occurs at a
+**major** release boundary. Until a symbol is actually removed it remains fully
+functional — not merely a stub.
+
+.. rubric:: Bug fixes and behavior
+
+A change that corrects a function's behavior to match its documented contract is
+not an API break, even if some callers relied on the erroneous behavior.
+Undocumented or incorrect behavior carries no stability guarantee.
+
+.. rubric:: Macros
+
+The observable behavior of a public macro is stable within a major version
+series. The specific token sequence of a macro's expansion is not guaranteed and
+may change between releases — for example, to replace a function-like macro with
+an inline function or to add internal casts. Code that depends on a specific
+expansion rather than on the macro's documented behavior is unsupported.
+
+.. rubric:: Error codes
+
+New error codes and domain values may be introduced in any **minor** release.
+Callers should handle unknown error codes gracefully rather than treating the set
+of possible values as exhaustive.
+
+
+.. _api-abi-policy.abi:
+
+ABI Stability
+#############
+
+Within a **major** version series the project guarantees:
+
+* **No removal** of exported symbols, and no change to an exported symbol's
+  link name or DLL ordinal.
+* **No signature changes** to exported functions (parameter types, return type,
+  calling convention), except for the possible addition of cv-qualifiers to
+  pointer parameters or removal of cv-qualifiers from pointer return types.
+* **No breaking changes** to the size or layout of any completely-defined struct
+  reachable in the public API, even if the contents of that struct are not
+  themselves part of the API. Where feasible, structs are kept opaque (accessed
+  only through accessor functions) to preserve this freedom.
+
+As a result, a program compiled against version ``X.Y.Z`` is expected to load
+and run correctly against any later ``X.Y'.Z'`` shared library, provided the
+program only uses the public API.
+
+.. rubric:: Incomplete types
+
+Many types (e.g. ``mongoc_client_t``) are intentionally incomplete in the public
+API and are only passed/returned by address. Callers should never rely on the
+size, alignment, or fields of such a type. Adding, removing, or rearranging the
+content of such types is not an ABI break.
+
+.. rubric:: Public aggregate types
+
+A small number of structs expose their fields in public headers as part of their
+public API (e.g. ``bson_iter_t``). Changes to these structs **are** ABI breaks
+and are therefore prohibited within a **major** version series.
+
+.. rubric:: Compilation settings
+
+Certain preprocessor macros and CMake configure-time build parameters may affect
+the ABI of the resulting build. When possible, programs should not attempt to
+link translation units together that are not compiled with the same set of
+preprocessor definitions.
+
+Users should not manually define preprocessor macros during their compilation
+that could affect the content of the exposed library APIs. Instead, users should
+rely on the CMake imported targets or pkg-config definitions to set the
+appropriate compile/link settings for their program.
+
+.. note::
+
+   The project runs an ABI compliance check in CI (the ``abi-compliance-check``
+   Evergreen task) that compares the current branch against the most recent
+   stable release. Any unexpected breakage should be caught before merge.
+
+
+.. _api-abi-policy.deprecation:
+
+Deprecation Policy
+##################
+
+Symbols that need to be removed follow a two-step cycle:
+
+1. **Mark deprecated.** Annotate the declaration with ``BSON_DEPRECATED("…")``
+   or ``BSON_DEPRECATED_FOR(replacement)`` and update the documentation to note
+   the deprecation and its replacement. This is a non-breaking change that may
+   land in any **minor** release. **mongoc** also uses the ``BSON_DEPRECATED``
+   macros (there is no ``MONGOC_DEPRECATED`` equivalent).
+
+2. **Remove.** The symbol is removed no earlier than the *next major release*
+   after it was deprecated, giving users at least one full major-version cycle
+   to migrate.
+
+A deprecated symbol must remain present and functional (not just a stub) until
+it is removed.
+
+
+.. _api-abi-policy.additions:
+
+Adding New Symbols
+##################
+
+New public symbols may be added in any **minor** release. When adding a symbol:
+
+1. Declare it in the appropriate public header.
+2. For functions, annotate it with ``MONGOC_EXPORT`` or ``BSON_EXPORT``.
+3. Add a ``.rst`` documentation page in ``src/libmongoc/doc/`` or
+   ``src/libbson/doc/``.
+4. Verify it appears in the ABI compliance report under *Added Symbols* (see
+   the ``abi-compliance-check`` Evergreen task artifact).
+
+Adding new symbols is **not** an ABI break. However, a new symbol that clashes
+with a name a downstream project already defines privately can cause linker
+confusion; prefer descriptive, namespaced names (``mongoc_`` or ``bson_``
+prefix).
+
+
+Other Notes
+###########
+
+Pre-release versions
+********************
+
+Any release with a pre-release label (e.g. ``2.0.0-alpha1``) carries **no
+stability guarantee**. Any changes that are part of a prerelease may be removed
+or modified without notice between pre-release versions.
+
+
+Experimental APIs
+*****************
+
+APIs that are documented as **experimental** may change or be removed in any
+release, including patch releases, regardless of the usual policy. Such APIs
+will be clearly marked in the documentation.
+
+
+CMake integration API
+*********************
+
+The CMake targets (``mongoc::shared``, ``bson::static``, etc.) and the
+properties they expose are considered public and follow the same versioning
+rules as the C API. However, the internal CMake helper modules under
+``build/cmake/`` are not public and may change without notice.

--- a/docs/dev/api-abi-policy.rst
+++ b/docs/dev/api-abi-policy.rst
@@ -16,21 +16,22 @@ is explicitly *not* covered by these guarantees.
 Versioning Scheme
 #################
 
-The C libraries use a ``<major>.<minor>.<micro>`` versioning scheme that is
+The C libraries use a ``<major>.<minor>.<patch>`` versioning scheme that is
 based on `Semantic Versioning <https://semver.org>`_. Prerelease and development
 versions include a suffix to indicate that the contents of the libraries are
 unstable and subject to change.
 
 - A **major** version indicates overall breaking changes. Different major
-  versions offer very few compatibility guarantees in their API and ABI.
+  versions offer no compatibility guarantees in their API and ABI.
 - A **minor** version indicates the addition of new APIs and features to the
   libraries, or possible deprecation of APIs. Programs written against earlier
   minor versions should continue to compile and link with a newer minor version
   with minimal or no changes.
-- A **micro** (also known as "patch") version indicates bugfixes and tweaks and
-  will not deprecate or add any major features to libraries. Programs written
-  against earlier micro versions should compile and link against newer micro
-  with no changes unless security considerations require API or ABI changes.
+- A **patch** version (also known as the "micro" version at some locations in
+  the source code) indicates bugfixes and tweaks and will not deprecate or add
+  any major features to libraries. Programs written against earlier patch
+  versions should compile and link against newer patch versions with no changes
+  unless security considerations require API or ABI changes.
 
 
 .. _api-abi-policy.public-api:
@@ -44,7 +45,8 @@ The public API consists of:
   — a header that is installed alongside the library and has no ``-private``
   suffix in its name (e.g. ``mongoc/mongoc-client.h``, ``bson/bson.h``), except
   for those noted below.
-* Every function annotated with ``MONGOC_EXPORT(...)`` or ``BSON_EXPORT(...)``.
+* Every symbol annotated with ``MONGOC_EXPORT`` or ``BSON_EXPORT``.
+* The *documented* behavior of any API function.
 
 The following are **not** part of the public API and carry **no stability
 guarantee**:
@@ -57,6 +59,7 @@ guarantee**:
   even when the opaque ``typedef`` is public.
 * The content of ``src/kms-message/``, a vendored library with its own
   versioning.
+* The *undocumented, incidental* behavior of any function.
 
 
 Header Inclusion
@@ -75,16 +78,20 @@ Instead, users should include the umbrella headers
 ``<bson/bson.h>``/``<mongoc/mongoc.h>`` or they may directly include one of the
 headers without the ``bson-`` or ``mongoc-`` prefix in its filename.
 
+By default, libbson and libmongoc headers are not installed as direct children
+of the platform's default header include-search-path directory, and live in a
+subdirectory that is qualified by the library version. Users should never use
+this intermediate directory in their include directives, and should rely on
+CMake or pkg-config to set the appropriate flags to update their
+include-search-path to find the relevant headers in this versioned subdirectory.
+
 
 .. _api-abi-policy.api:
 
 API Stability
 #############
 
-Within a **major** version series the project guarantees source-level backward
-compatibility: a program that compiles cleanly against version ``X.Y.Z`` using
-only the public API is expected to compile without modification against any later
-``X.Y'.Z'`` release in the same major series. Specifically:
+Within a **major** version series, the project makes the following guarantees:
 
 * **No removal** of public symbols — functions, types, macros, and constants
   present in a release remain available in all subsequent releases within the
@@ -93,8 +100,8 @@ only the public API is expected to compile without modification against any late
   the original name.
 * **No incompatible signature changes** — the parameter and return types of
   public functions do not change in ways that require callers to be updated.
-  Note that cv-qualifiers may be added or removed from parameter or return types
-  in ways that do not affect existing callers.
+  Note that type-qualifiers may be added or removed from parameter or return
+  types in ways that do not affect existing callers.
 * **No change in documented contract** — the observable behavior, preconditions,
   postconditions, and error semantics of a public function do not change in a way
   that causes a previously-correct caller to misbehave.
@@ -106,7 +113,7 @@ expected to compile and link without modification against any later ``X.Y'.Z'``
 release in the same major series, provided the program only uses the public API.
 
 Within a **minor** release, new public symbols may be added (see
-:ref:`api-abi-policy.additions`). Within a **micro** release, no new public
+:ref:`api-abi-policy.additions`). Within a **patch** release, no new public
 symbols are introduced and existing behavior changes only to correct bugs.
 
 Deprecation (see :ref:`api-abi-policy.deprecation`) is the only mechanism by
@@ -128,6 +135,16 @@ may change between releases — for example, to replace a function-like macro wi
 an inline function or to add internal casts. Code that depends on a specific
 expansion rather than on the macro's documented behavior is unsupported.
 
+.. note::
+
+  Whether an API function is implemented as a preprocessor macro is an
+  implementation detail unless documented otherwise. Relying on whether an API
+  function name is a macro is not supported.
+
+  Do not attempt to take the address of an API function or perform an ``#ifdef``
+  on an API function name, unless such an operation is said to be supported in
+  the documentation.
+
 .. rubric:: Error codes
 
 New error codes and domain values may be introduced in any **minor** release.
@@ -140,13 +157,14 @@ of possible values as exhaustive.
 ABI Stability
 #############
 
-Within a **major** version series the project guarantees:
+Except in the case of security patches, within a **major** version series, the
+project guarantees the following:
 
 * **No removal** of exported symbols, and no change to an exported symbol's
-  link name or DLL ordinal.
+  link name.
 * **No signature changes** to exported functions (parameter types, return type,
-  calling convention), except for the possible addition of cv-qualifiers to
-  pointer parameters or removal of cv-qualifiers from pointer return types.
+  calling convention), except for the possible addition of type-qualifiers to
+  pointer parameters or removal of type-qualifiers from pointer return types.
 * **No breaking changes** to the size or layout of any completely-defined struct
   reachable in the public API, even if the contents of that struct are not
   themselves part of the API. Where feasible, structs are kept opaque (accessed
@@ -155,6 +173,23 @@ Within a **major** version series the project guarantees:
 As a result, a program compiled against version ``X.Y.Z`` is expected to load
 and run correctly against any later ``X.Y'.Z'`` shared library, provided the
 program only uses the public API.
+
+Additionally, the ``soname`` of a built dynamic library is part of the ABI and
+guaranteed stable within a major version. The ``soname`` of the resulting
+libraries includes the major version of the library, preventing collisions
+between major versions. The CMake ``SOVERSION`` property of resulting dynamic
+library artifacts is always equivalent to the major API version of the library.
+(The ``soname`` and ``SOVERSION`` are not applicable to Windows DLLs.)
+
+In the uncommon case that a security patch requires breaking any of the above
+guarantees, it will be noted in the release notes for the corresponding version.
+
+.. rubric:: Exported symbols
+
+The ``BSON_EXPORT`` and ``MONGOC_EXPORT`` macros are used to add appropriate
+attributes to external-linkage symbols that are visible in a dynamic library
+build. The presence of such symbols in a built artifact is part of the ABI of
+that artifact.
 
 .. rubric:: Incomplete types
 
@@ -173,7 +208,7 @@ and are therefore prohibited within a **major** version series.
 
 Certain preprocessor macros and CMake configure-time build parameters may affect
 the ABI of the resulting build. When possible, programs should not attempt to
-link translation units together that are not compiled with the same set of
+combine translation units together that are not compiled with the same set of
 preprocessor definitions.
 
 Users should not manually define preprocessor macros during their compilation
@@ -232,6 +267,17 @@ prefix).
 Other Notes
 ###########
 
+Build configuration compatibility
+*********************************
+
+The build parameters are themselves subject to the same stability guarantees as
+the C API, and follow the same deprecation policy.
+
+The C API and ABI guarantees only hold within the same build configuration.
+Attempting to mix build configurations is unsupported, as build settings may
+affect the API or ABI of the resulting artifacts.
+
+
 Pre-release versions
 ********************
 
@@ -248,10 +294,15 @@ release, including patch releases, regardless of the usual policy. Such APIs
 will be clearly marked in the documentation.
 
 
-CMake integration API
-*********************
+Build system integration API
+****************************
 
+The CMake config-file packages are the recommended way to import the project.
 The CMake targets (``mongoc::shared``, ``bson::static``, etc.) and the
 properties they expose are considered public and follow the same versioning
 rules as the C API. However, the internal CMake helper modules under
 ``build/cmake/`` are not public and may change without notice.
+
+The pkg-config files are also supported for building against the libraries, and
+will ensure that the compilation settings match the ABI of the corresponding
+binaries.

--- a/docs/dev/api-abi-policy.rst
+++ b/docs/dev/api-abi-policy.rst
@@ -41,22 +41,19 @@ What Is the Public API?
 
 The public API consists of:
 
-* Every symbol (function, type, macro, constant) declared in a **public header**
-  — a header that is installed alongside the library and has no ``-private``
-  suffix in its name (e.g. ``mongoc/mongoc-client.h``, ``bson/bson.h``), except
-  for those noted below.
-* Every symbol annotated with ``MONGOC_EXPORT`` or ``BSON_EXPORT``.
-* The *documented* behavior of any API function.
+* Every entity (function, type, macro, constant) declared in a **public header**
+  (a header that is installed alongside the library), except for those noted
+  below.
+* The *documented* behavior of any API function or macro.
 
 The following are **not** part of the public API and carry **no stability
 guarantee**:
 
-* Headers with a ``-private.h`` suffix (e.g. ``mongoc-client-private.h``) and
-  the contents thereof.
 * Anything under ``src/common/`` (the internal shared utility library).
-* Symbols prefixed with an underscore or otherwise documented as internal.
-* The layout of any struct whose definition lives in a ``-private.h`` header,
-  even when the opaque ``typedef`` is public.
+* Symbols prefixed with an underscore or otherwise documented as internal or
+  experimental.
+* The layout of any struct whose definition lives in a private header, even when
+  the opaque ``typedef`` is public.
 * The content of ``src/kms-message/``, a vendored library with its own
   versioning.
 * The *undocumented, incidental* behavior of any function.
@@ -114,7 +111,8 @@ release in the same major series, provided the program only uses the public API.
 
 Within a **minor** release, new public symbols may be added (see
 :ref:`api-abi-policy.additions`). Within a **patch** release, no new public
-symbols are introduced and existing behavior changes only to correct bugs.
+symbols are introduced and existing behavior changes only to correct bugs or
+security issues.
 
 Deprecation (see :ref:`api-abi-policy.deprecation`) is the only mechanism by
 which a public symbol can eventually be removed; removal only occurs at a
@@ -157,8 +155,8 @@ of possible values as exhaustive.
 ABI Stability
 #############
 
-Except in the case of security patches, within a **major** version series, the
-project guarantees the following:
+Except in the case of security patches, the project guarantees the following
+within a **major** version series:
 
 * **No removal** of exported symbols, and no change to an exported symbol's
   link name.
@@ -270,8 +268,9 @@ Other Notes
 Build configuration compatibility
 *********************************
 
-The build parameters are themselves subject to the same stability guarantees as
-the C API, and follow the same deprecation policy.
+The build parameters that affect the API/ABI of built artifacts are themselves
+subject to the same stability guarantees as the C API, and follow the same
+deprecation policy.
 
 The C API and ABI guarantees only hold within the same build configuration.
 Attempting to mix build configurations is unsupported, as build settings may

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -19,6 +19,7 @@ the mongo-c-driver project directory:
 
 .. toctree::
 
+   api-abi-policy
    debian
    earthly
    deps


### PR DESCRIPTION
Refer: CDRIVER-5705

# Summary

This changeset introduces a developer+user documentation page that describes the compatibility guarantees of the libraries. For now, it lives in `docs/dev/`, but it can be migrated to anywhere as needed.

I won't detail its contents as it speaks for itself, but I did find the process interesting enough to note here.

## Adding Documentation with LLM Assistance

I took this task as an opportunity to explore Claude's technical prose and source-processing abilities in combination, and found it exceptionally helpful in accelerating the workflow significantly, potentially saving many hours of work.

**First,** I asked it to consider existing information, including existing documentation and source code contents, preexisting knowledge of semantic versioning, and knowledge about software in general, to write a basic draft of the initial document.

The initial draft appeared decent at a high level, but needed some significant work. For example: it hallucinated the existence of `BSON_EXPERIMENTAL` and `MONGOC_EXPERIMENTAL` preprocessor macros to control experimental features, it referenced deprecated CMake export target names rather than the new target names, and seemed to be unfocused on what parts of the document were intended for end users versus project contributors. There were many smaller revisions needed to make it satisfactory for me.

Overall, about three quarters of the document needed to be rewritten or revised in some way. Despite this, it was able to infer a lot of information from our existing codebase and gave me a good basis for what needed to be done to be completed.

**Second,** after hand-revising the document, I asked it to proofread the document for spelling and grammar issues, semantic issues, ambiguities, and open questions. It found several basic editorial problems, but also found potentially conflicting information or poor phrasing.

I performed this step several times until I was satisfied that there were no more notable issues. Example Claude output:

<img width="683" height="819" alt="Screenshot 2026-06-02 163559" src="https://github.com/user-attachments/assets/98704324-795b-45b6-98d8-1c98b88447e8" />

**Third,** I asked it to verify that the new document does not conflict with existing documentation in the repository. This is what it found:

<img width="682" height="519" alt="Screenshot 2026-06-02 164003" src="https://github.com/user-attachments/assets/ed695b8c-77e5-4f1b-a3f7-58731122d2fb" />

I hadn't noticed it, but we do in fact use the term "micro" and "patch" interchangeably throughout the codebase when "patch" is the more common term. I updated the document to note this synonym. It was also able to verify that the suspected misspelled CMake target name `mongo::shared` was inconsistent with what was found in the `CMakeLists.txt`.

**Fourth,** I was unhappy with a structural issue in the document: We had an "ABI Stability" section but no "API Stability" section. This felt like an annoying asymmetry. Claude had also created a "What Constitutes a Breaking Change?" section that detailed the API stability guarantees, which was somewhat redundant with the versioning and ABI stability section. I asked it to add an "API Stability" section and to remove the "Breaking Change" section, consolidating redundant information between everything. It did this very well, retaining all of my existing revisions and added details without introducing any new information.

Finally, I asked it to: "Find possible redundancies between the contents of this document and other documentation in the repository." I am wary when adding new documentation of duplicating existing documentation, as they can quickly become out-of-sync or contradictory. It found the following:

<img width="692" height="677" alt="Screenshot 2026-06-02 165033" src="https://github.com/user-attachments/assets/273a049d-2f94-4bc4-8a6e-f1e074b634d4" />

I asked it to apply the suggested changes, resulting in commit 3848ce3d.