### PR TITLE
CDRIVER-6352 update CSE tests for server validation

### DIFF
--- a/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/encryptedFields-c10.json
+++ b/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/encryptedFields-c10.json
@@ -1,0 +1,30 @@
+{
+  "fields": [
+    {
+      "keyId": {
+        "$binary": {
+          "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+          "subType": "04"
+        }
+      },
+      "path": "encryptedIndexed",
+      "bsonType": "string",
+      "queries": {
+        "queryType": "equality",
+        "contention": {
+          "$numberLong": "10"
+        }
+      }
+    },
+    {
+      "keyId": {
+        "$binary": {
+          "base64": "q83vqxI0mHYSNBI0VniQEg==",
+          "subType": "04"
+        }
+      },
+      "path": "encryptedUnindexed",
+      "bsonType": "string"
+    }
+  ]
+}

--- a/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/encryptedFields-prefix-suffix.json
+++ b/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/encryptedFields-prefix-suffix.json
@@ -18,6 +18,9 @@
                     "strMaxQueryLength": {
                         "$numberInt": "10"
                     },
+                    "contention": {
+                        "$numberLong": "0"
+                    },
                     "caseSensitive": true,
                     "diacriticSensitive": true
                 },
@@ -28,6 +31,9 @@
                     },
                     "strMaxQueryLength": {
                         "$numberInt": "10"
+                    },
+                    "contention": {
+                        "$numberLong": "0"
                     },
                     "caseSensitive": true,
                     "diacriticSensitive": true

--- a/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/encryptedFields-substring.json
+++ b/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/encryptedFields-substring.json
@@ -21,6 +21,9 @@
                     "strMaxQueryLength": {
                         "$numberInt": "10"
                     },
+                    "contention": {
+                        "$numberLong": "0"
+                    },
                     "caseSensitive": true,
                     "diacriticSensitive": true
                 }

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -3302,6 +3302,7 @@ typedef struct {
    mongoc_client_encryption_t *clientEncryption;
    mongoc_client_t *encryptedClient;
    mongoc_collection_t *encryptedColl;
+   mongoc_collection_t *encryptedColl_c10;
 } ee_fixture;
 
 static ee_fixture *
@@ -3309,10 +3310,13 @@ explicit_encryption_setup(void)
 {
    char *encrypted_fields_path =
       "./src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/encryptedFields.json";
+   char *encrypted_fields_c10_path =
+      "./src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/encryptedFields-c10.json";
    char *key_path = "./src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/key1-document.json";
 
    ee_fixture *eef = (ee_fixture *)bson_malloc0(sizeof(ee_fixture));
    bson_t *encryptedFields = get_bson_from_json_file(encrypted_fields_path);
+   bson_t *encryptedFields_c10 = get_bson_from_json_file(encrypted_fields_c10_path);
    bson_t *key1Document = get_bson_from_json_file(key_path);
    mongoc_client_t *setupClient = test_framework_new_default_client();
 
@@ -3345,6 +3349,31 @@ explicit_encryption_setup(void)
       mongoc_collection_destroy(coll);
 
       coll = mongoc_database_create_collection(db, "explicit_encryption", opts, &error);
+      ASSERT_OR_PRINT(coll, error);
+
+      mongoc_collection_destroy(coll);
+      bson_destroy(opts);
+      mongoc_database_destroy(db);
+   }
+
+   /* Drop and create the collection ``db.explicit_encryption_c10`` using
+    * ``encryptedFields_c10`` as an option. */
+   {
+      mongoc_database_t *db = mongoc_client_get_database(setupClient, "db");
+      mongoc_collection_t *coll = mongoc_database_get_collection(db, "explicit_encryption_c10");
+      bson_error_t error;
+      bson_t *opts;
+
+      opts = BCON_NEW("encryptedFields", BCON_DOCUMENT(encryptedFields_c10));
+
+      if (!mongoc_collection_drop_with_opts(coll, opts, &error)) {
+         if (error.code != MONGOC_SERVER_ERR_NS_NOT_FOUND) {
+            test_error("unexpected error in drop: %s", error.message);
+         }
+      }
+      mongoc_collection_destroy(coll);
+
+      coll = mongoc_database_create_collection(db, "explicit_encryption_c10", opts, &error);
       ASSERT_OR_PRINT(coll, error);
 
       mongoc_collection_destroy(coll);
@@ -3416,10 +3445,12 @@ explicit_encryption_setup(void)
       bson_destroy(kms_providers);
       mongoc_auto_encryption_opts_destroy(aeOpts);
       eef->encryptedColl = mongoc_client_get_collection(eef->encryptedClient, "db", "explicit_encryption");
+      eef->encryptedColl_c10 = mongoc_client_get_collection(eef->encryptedClient, "db", "explicit_encryption_c10");
    }
 
    mongoc_client_destroy(setupClient);
    bson_destroy(key1Document);
+   bson_destroy(encryptedFields_c10);
    bson_destroy(encryptedFields);
    return eef;
 }
@@ -3431,6 +3462,7 @@ explicit_encryption_destroy(ee_fixture *eef)
       return;
    }
 
+   mongoc_collection_destroy(eef->encryptedColl_c10);
    mongoc_collection_destroy(eef->encryptedColl);
    mongoc_client_destroy(eef->encryptedClient);
    mongoc_client_encryption_destroy(eef->clientEncryption);
@@ -4197,7 +4229,7 @@ test_explicit_encryption_case2(void *unused)
 
       ASSERT(BSON_APPEND_VALUE(&to_insert, "encryptedIndexed", &insertPayload));
 
-      ok = mongoc_collection_insert_one(eef->encryptedColl, &to_insert, NULL /* opts */, NULL /* reply */, &error);
+      ok = mongoc_collection_insert_one(eef->encryptedColl_c10, &to_insert, NULL /* opts */, NULL /* reply */, &error);
       ASSERT_OR_PRINT(ok, error);
 
       bson_value_destroy(&insertPayload);
@@ -4205,40 +4237,6 @@ test_explicit_encryption_case2(void *unused)
       mongoc_client_encryption_encrypt_opts_destroy(eopts);
    }
 
-   /* Find with contention factor of 0. Expect < 10 documents returned.
-    */
-   {
-      bson_value_t findPayload;
-      mongoc_cursor_t *cursor;
-      bson_t filter = BSON_INITIALIZER;
-      const bson_t *got;
-      int got_count = 0;
-
-      eopts = mongoc_client_encryption_encrypt_opts_new();
-      mongoc_client_encryption_encrypt_opts_set_keyid(eopts, &eef->key1ID);
-      mongoc_client_encryption_encrypt_opts_set_algorithm(eopts, MONGOC_ENCRYPT_ALGORITHM_INDEXED);
-      mongoc_client_encryption_encrypt_opts_set_query_type(eopts, MONGOC_ENCRYPT_QUERY_TYPE_EQUALITY);
-      mongoc_client_encryption_encrypt_opts_set_contention_factor(eopts, 0);
-
-      ok = mongoc_client_encryption_encrypt(eef->clientEncryption, &plaintext, eopts, &findPayload, &error);
-      ASSERT_OR_PRINT(ok, error);
-
-      ASSERT(BSON_APPEND_VALUE(&filter, "encryptedIndexed", &findPayload));
-
-      cursor = mongoc_collection_find_with_opts(eef->encryptedColl, &filter, NULL /* opts */, NULL /* read_prefs */);
-
-      while (mongoc_cursor_next(cursor, &got)) {
-         got_count++;
-         ASSERT_MATCH(got, "{ 'encryptedIndexed': 'encrypted indexed value' }");
-      }
-      ASSERT_OR_PRINT(!mongoc_cursor_error(cursor, &error), error);
-      ASSERT_CMPINT(got_count, <, 10);
-
-      bson_value_destroy(&findPayload);
-      mongoc_cursor_destroy(cursor);
-      mongoc_client_encryption_encrypt_opts_destroy(eopts);
-      bson_destroy(&filter);
-   }
 
    /* Find with contention factor of 10. Expect all 10 documents returned. */
    {
@@ -4259,7 +4257,8 @@ test_explicit_encryption_case2(void *unused)
 
       ASSERT(BSON_APPEND_VALUE(&filter, "encryptedIndexed", &findPayload));
 
-      cursor = mongoc_collection_find_with_opts(eef->encryptedColl, &filter, NULL /* opts */, NULL /* read_prefs */);
+      cursor =
+         mongoc_collection_find_with_opts(eef->encryptedColl_c10, &filter, NULL /* opts */, NULL /* read_prefs */);
 
       while (mongoc_cursor_next(cursor, &got)) {
          got_count++;


### PR DESCRIPTION
# Summary
Apply changes from DRIVERS-3547 to fix failing Client Side Encryption tests on latest servers. SERVER-91887 triggered test failures in tests using a different contention value from the server.

Evergreen patch: https://spruce.corp.mongodb.com/version/6a31652ab9645c0007dbbfe7

# Details
Explicit encryption test case 2 intentionally used a different contention value, and has been updated to only test the case where the contention value matches.

encryptedFields-prefix-suffix.json‎ and encryptedFields-substring.json unintentionally omitted the contention value, which applied the server [default](https://www.mongodb.com/docs/manual/core/queryable-encryption/fundamentals/encrypt-and-query/#mongodb-parameter-param.contention) of 8. The test used 0, so encryptedFields is updated to 0 to match.