### PR TITLE
Restrict setting CMP0147 OLD to Visual Studio generators

### DIFF
--- a/build/cmake/GenerateUninstaller.cmake
+++ b/build/cmake/GenerateUninstaller.cmake
@@ -2,7 +2,7 @@
 cmake_policy(VERSION 3.15...4.0)
 
 # Avoid CMake Issue 26678: https://gitlab.kitware.com/cmake/cmake/-/issues/26678
-if("${CMAKE_VERSION}" VERSION_GREATER_EQUAL "3.27")
+if("${CMAKE_VERSION}" VERSION_GREATER_EQUAL "3.27" AND CMAKE_GENERATOR MATCHES "Visual Studio")
     cmake_policy(SET CMP0147 OLD)
 endif()
 


### PR DESCRIPTION
A minor CMake improvement which addresses the following warning during the config step:

```
CMake Deprecation Warning at build/cmake/GenerateUninstaller.cmake:6 (cmake_policy):
  The OLD behavior for policy CMP0147 will be removed from a future version
  of CMake.

  The cmake-policies(7) manual explains that the OLD behaviors of all
  policies are deprecated and that a policy should be set to OLD only under
  specific short-term circumstances.  Projects should be ported to the NEW
  behavior and not rely on setting a policy to OLD.
```

This warning is correct for Visual Studio generators, but not for others. The relevant [CMake issue](http://cmake/cmake#26678) is still unresolved, so the workaround (added in https://github.com/mongodb/mongo-c-driver/pull/2070) is still necessary. However, this PR restricts this workaround to apply only to VS generators, since it is not applicable to other generators. Note `CMAKE_GENERATOR MATCHES "Visual Studio"` is used instead of `CMAKE_<LANG>_COMPILER_ID` or `STREQUAL` because this concerns the build system (e.g. GNU Make vs. Ninja vs. Visual Studio), not the compiler (e.g. GCC vs. Clang vs. MSVC), and VS generators use the naming scheme "Visual Studio N YYYY" (e.g. "Visual Studio 17 2022" for VS 2022).