### PR TITLE
CDRIVER-6349 update tests for corporate Azure credentials

### DIFF
--- a/.evergreen/config_generator/components/funcs/csfle_setup.py
+++ b/.evergreen/config_generator/components/funcs/csfle_setup.py
@@ -38,6 +38,9 @@ class CSFLESetup(Function):
             command_type=command_type,
             working_dir='drivers-evergreen-tools/.evergreen/csfle',
             include_expansions_in_env=['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN'],
+            env={
+                'FLE_AZURE_USE_CORPORATE': 'YES'
+            },
             script='./setup.sh',  # Creates secrets-export.sh. Starts servers on ports 5698, 9000, 9001, 9002, and 9003.
         ),
     ]

--- a/.evergreen/generated_configs/functions.yml
+++ b/.evergreen/generated_configs/functions.yml
@@ -224,6 +224,8 @@ functions:
       params:
         binary: bash
         working_dir: drivers-evergreen-tools/.evergreen/csfle
+        env:
+          FLE_AZURE_USE_CORPORATE: "YES"
         include_expansions_in_env:
           - AWS_ACCESS_KEY_ID
           - AWS_SECRET_ACCESS_KEY

--- a/src/libmongoc/tests/client_side_encryption_prose/corpus/corpus-key-azure.json
+++ b/src/libmongoc/tests/client_side_encryption_prose/corpus/corpus-key-azure.json
@@ -7,7 +7,7 @@
     },
     "keyMaterial": {
         "$binary": {
-            "base64": "n+HWZ0ZSVOYA3cvQgP7inN4JSXfOH85IngmeQxRpQHjCCcqT3IFqEWNlrsVHiz3AELimHhX4HKqOLWMUeSIT6emUDDoQX9BAv8DR1+E1w4nGs/NyEneac78EYFkK3JysrFDOgl2ypCCTKAypkn9CkAx1if4cfgQE93LW4kczcyHdGiH36CIxrCDGv1UzAvERN5Qa47DVwsM6a+hWsF2AAAJVnF0wYLLJU07TuRHdMrrphPWXZsFgyV+lRqJ7DDpReKNO8nMPLV/mHqHBHGPGQiRdb9NoJo8CvokGz4+KE8oLwzKf6V24dtwZmRkrsDV4iOhvROAzz+Euo1ypSkL3mw==",
+            "base64": "Vlza0NjSsxbiJbHUM++3EWyhd5/m4QHv0ZaH87LsljVDltHNZyR9YBFOTDFE1RKeY/uGSW35IdOLVxpHvo1/qBz7E6Iv14obBmniRetWZq0wxerm72LlF+VPTHHmNn1sIv3TY/HsHSx7S1U/ILaKukD7hBKZ5/4A2tPOXtdnTzC4Rpc8bRjaM8heQSNEWbTBPqcQ9xD4YLi+uQlzbLZjQA+Ljr540QJEwa7RGw8J22eo1sb3vSeDAhR24GH6RPJ5v72yElGcOZrKCjxnbd4mrCtSHssfOzCnK2Dw3mHikSLeBFGjnlXydBWiTn2AlhOs+YpXdAJ6Zm3xjkdJOXKytg==",
             "subType": "00"
         }
     },
@@ -26,8 +26,8 @@
     },
     "masterKey": {
         "provider": "azure",
-        "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
-        "keyName": "key-name-csfle"
+        "keyVaultEndpoint": "drivers-3392-key-vault.vault.azure.net",
+        "keyName": "drivers-3392-keyname"
     },
     "keyAltNames": ["azure"]
 }

--- a/src/libmongoc/tests/json/client_side_encryption/unified/accessToken-azure.json
+++ b/src/libmongoc/tests/json/client_side_encryption/unified/accessToken-azure.json
@@ -101,7 +101,7 @@
           ],
           "keyMaterial": {
             "$binary": {
-              "base64": "n+HWZ0ZSVOYA3cvQgP7inN4JSXfOH85IngmeQxRpQHjCCcqT3IFqEWNlrsVHiz3AELimHhX4HKqOLWMUeSIT6emUDDoQX9BAv8DR1+E1w4nGs/NyEneac78EYFkK3JysrFDOgl2ypCCTKAypkn9CkAx1if4cfgQE93LW4kczcyHdGiH36CIxrCDGv1UzAvERN5Qa47DVwsM6a+hWsF2AAAJVnF0wYLLJU07TuRHdMrrphPWXZsFgyV+lRqJ7DDpReKNO8nMPLV/mHqHBHGPGQiRdb9NoJo8CvokGz4+KE8oLwzKf6V24dtwZmRkrsDV4iOhvROAzz+Euo1ypSkL3mw==",
+              "base64": "Vlza0NjSsxbiJbHUM++3EWyhd5/m4QHv0ZaH87LsljVDltHNZyR9YBFOTDFE1RKeY/uGSW35IdOLVxpHvo1/qBz7E6Iv14obBmniRetWZq0wxerm72LlF+VPTHHmNn1sIv3TY/HsHSx7S1U/ILaKukD7hBKZ5/4A2tPOXtdnTzC4Rpc8bRjaM8heQSNEWbTBPqcQ9xD4YLi+uQlzbLZjQA+Ljr540QJEwa7RGw8J22eo1sb3vSeDAhR24GH6RPJ5v72yElGcOZrKCjxnbd4mrCtSHssfOzCnK2Dw3mHikSLeBFGjnlXydBWiTn2AlhOs+YpXdAJ6Zm3xjkdJOXKytg==",
               "subType": "00"
             }
           },
@@ -120,8 +120,8 @@
           },
           "masterKey": {
             "provider": "azure",
-            "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
-            "keyName": "key-name-csfle"
+            "keyVaultEndpoint": "drivers-3392-key-vault.vault.azure.net",
+            "keyName": "drivers-3392-keyname"
           }
         }
       ]

--- a/src/libmongoc/tests/json/client_side_encryption/unified/azureKMS.json
+++ b/src/libmongoc/tests/json/client_side_encryption/unified/azureKMS.json
@@ -158,7 +158,7 @@
           },
           "keyMaterial": {
             "$binary": {
-              "base64": "n+HWZ0ZSVOYA3cvQgP7inN4JSXfOH85IngmeQxRpQHjCCcqT3IFqEWNlrsVHiz3AELimHhX4HKqOLWMUeSIT6emUDDoQX9BAv8DR1+E1w4nGs/NyEneac78EYFkK3JysrFDOgl2ypCCTKAypkn9CkAx1if4cfgQE93LW4kczcyHdGiH36CIxrCDGv1UzAvERN5Qa47DVwsM6a+hWsF2AAAJVnF0wYLLJU07TuRHdMrrphPWXZsFgyV+lRqJ7DDpReKNO8nMPLV/mHqHBHGPGQiRdb9NoJo8CvokGz4+KE8oLwzKf6V24dtwZmRkrsDV4iOhvROAzz+Euo1ypSkL3mw==",
+              "base64": "Vlza0NjSsxbiJbHUM++3EWyhd5/m4QHv0ZaH87LsljVDltHNZyR9YBFOTDFE1RKeY/uGSW35IdOLVxpHvo1/qBz7E6Iv14obBmniRetWZq0wxerm72LlF+VPTHHmNn1sIv3TY/HsHSx7S1U/ILaKukD7hBKZ5/4A2tPOXtdnTzC4Rpc8bRjaM8heQSNEWbTBPqcQ9xD4YLi+uQlzbLZjQA+Ljr540QJEwa7RGw8J22eo1sb3vSeDAhR24GH6RPJ5v72yElGcOZrKCjxnbd4mrCtSHssfOzCnK2Dw3mHikSLeBFGjnlXydBWiTn2AlhOs+YpXdAJ6Zm3xjkdJOXKytg==",
               "subType": "00"
             }
           },
@@ -177,8 +177,8 @@
           },
           "masterKey": {
             "provider": "azure",
-            "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
-            "keyName": "key-name-csfle"
+            "keyVaultEndpoint": "drivers-3392-key-vault.vault.azure.net",
+            "keyName": "drivers-3392-keyname"
           },
           "keyAltNames": [
             "altname",

--- a/src/libmongoc/tests/json/client_side_encryption/unified/createDataKey.json
+++ b/src/libmongoc/tests/json/client_side_encryption/unified/createDataKey.json
@@ -159,8 +159,8 @@
             "kmsProvider": "azure",
             "opts": {
               "masterKey": {
-                "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
-                "keyName": "key-name-csfle"
+                "keyVaultEndpoint": "drivers-3392-key-vault.vault.azure.net",
+                "keyName": "drivers-3392-keyname"
               }
             }
           },
@@ -197,8 +197,8 @@
                       },
                       "masterKey": {
                         "provider": "azure",
-                        "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
-                        "keyName": "key-name-csfle"
+                        "keyVaultEndpoint": "drivers-3392-key-vault.vault.azure.net",
+                        "keyName": "drivers-3392-keyname"
                       }
                     }
                   ],

--- a/src/libmongoc/tests/json/client_side_encryption/unified/namedKMS-createDataKey.json
+++ b/src/libmongoc/tests/json/client_side_encryption/unified/namedKMS-createDataKey.json
@@ -159,8 +159,8 @@
             "kmsProvider": "azure:name1",
             "opts": {
               "masterKey": {
-                "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
-                "keyName": "key-name-csfle"
+                "keyVaultEndpoint": "drivers-3392-key-vault.vault.azure.net",
+                "keyName": "drivers-3392-keyname"
               }
             }
           },
@@ -197,8 +197,8 @@
                       },
                       "masterKey": {
                         "provider": "azure:name1",
-                        "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
-                        "keyName": "key-name-csfle"
+                        "keyVaultEndpoint": "drivers-3392-key-vault.vault.azure.net",
+                        "keyName": "drivers-3392-keyname"
                       }
                     }
                   ],

--- a/src/libmongoc/tests/json/client_side_encryption/unified/namedKMS-rewrapManyDataKey.json
+++ b/src/libmongoc/tests/json/client_side_encryption/unified/namedKMS-rewrapManyDataKey.json
@@ -139,7 +139,7 @@
           ],
           "keyMaterial": {
             "$binary": {
-              "base64": "pr01l7qDygUkFE/0peFwpnNlv3iIy8zrQK38Q9i12UCN2jwZHDmfyx8wokiIKMb9kAleeY+vnt3Cf1MKu9kcDmI+KxbNDd+V3ytAAGzOVLDJr77CiWjF9f8ntkXRHrAY9WwnVDANYkDwXlyU0Y2GQFTiW65jiQhUtYLYH63Tk48SsJuQvnWw1Q+PzY8ga+QeVec8wbcThwtm+r2IHsCFnc72Gv73qq7weISw+O4mN08z3wOp5FOS2ZM3MK7tBGmPdBcktW7F8ODGsOQ1FU53OrWUnyX2aTi2ftFFFMWVHqQo7EYuBZHru8RRODNKMyQk0BFfKovAeTAVRv9WH9QU7g==",
+              "base64": "d8y3DLFGseaTkfoPSjGUkRnCl/bLiq83USDDmKU+d9ZQmvrSPDnF7T4G4g9z2YL/mlNlgjMn/oObkh/OIlDgZLUfSQTTo1U2pOKDG1m/wCi0CaSfyxoWy8mespl9SHmngDauWKeJYs1p8zFrrK/WyzzWTyhkVeSTYmf3Zev4zAO7cTc1NMkvCL7UZQ6ODAAV6KNgEr2iETls00bOG/7KMVWXKmH5+tlmXdplnBohb1w0m+M5LUnSO0t7Q45dgGl4kfp4KMat2d7ooS5sUIDY5ynUpSiRcDGMj4MFt5ACM5XdwRWQNs5D863B1bHeTpLH2fPr1eZTcCprSyPhqOtIQA==",
               "subType": "00"
             }
           },
@@ -156,8 +156,8 @@
           "status": 1,
           "masterKey": {
             "provider": "azure:name1",
-            "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
-            "keyName": "key-name-csfle"
+            "keyVaultEndpoint": "drivers-3392-key-vault.vault.azure.net",
+            "keyName": "drivers-3392-keyname"
           }
         },
         {
@@ -462,8 +462,8 @@
             "opts": {
               "provider": "azure:name1",
               "masterKey": {
-                "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
-                "keyName": "key-name-csfle"
+                "keyVaultEndpoint": "drivers-3392-key-vault.vault.azure.net",
+                "keyName": "drivers-3392-keyname"
               }
             }
           },
@@ -519,8 +519,8 @@
                         "$set": {
                           "masterKey": {
                             "provider": "azure:name1",
-                            "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
-                            "keyName": "key-name-csfle"
+                            "keyVaultEndpoint": "drivers-3392-key-vault.vault.azure.net",
+                            "keyName": "drivers-3392-keyname"
                           },
                           "keyMaterial": {
                             "$$type": "binData"
@@ -547,8 +547,8 @@
                         "$set": {
                           "masterKey": {
                             "provider": "azure:name1",
-                            "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
-                            "keyName": "key-name-csfle"
+                            "keyVaultEndpoint": "drivers-3392-key-vault.vault.azure.net",
+                            "keyName": "drivers-3392-keyname"
                           },
                           "keyMaterial": {
                             "$$type": "binData"
@@ -575,8 +575,8 @@
                         "$set": {
                           "masterKey": {
                             "provider": "azure:name1",
-                            "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
-                            "keyName": "key-name-csfle"
+                            "keyVaultEndpoint": "drivers-3392-key-vault.vault.azure.net",
+                            "keyName": "drivers-3392-keyname"
                           },
                           "keyMaterial": {
                             "$$type": "binData"
@@ -603,8 +603,8 @@
                         "$set": {
                           "masterKey": {
                             "provider": "azure:name1",
-                            "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
-                            "keyName": "key-name-csfle"
+                            "keyVaultEndpoint": "drivers-3392-key-vault.vault.azure.net",
+                            "keyName": "drivers-3392-keyname"
                           },
                           "keyMaterial": {
                             "$$type": "binData"

--- a/src/libmongoc/tests/json/client_side_encryption/unified/rewrapManyDataKey.json
+++ b/src/libmongoc/tests/json/client_side_encryption/unified/rewrapManyDataKey.json
@@ -128,7 +128,7 @@
           ],
           "keyMaterial": {
             "$binary": {
-              "base64": "pr01l7qDygUkFE/0peFwpnNlv3iIy8zrQK38Q9i12UCN2jwZHDmfyx8wokiIKMb9kAleeY+vnt3Cf1MKu9kcDmI+KxbNDd+V3ytAAGzOVLDJr77CiWjF9f8ntkXRHrAY9WwnVDANYkDwXlyU0Y2GQFTiW65jiQhUtYLYH63Tk48SsJuQvnWw1Q+PzY8ga+QeVec8wbcThwtm+r2IHsCFnc72Gv73qq7weISw+O4mN08z3wOp5FOS2ZM3MK7tBGmPdBcktW7F8ODGsOQ1FU53OrWUnyX2aTi2ftFFFMWVHqQo7EYuBZHru8RRODNKMyQk0BFfKovAeTAVRv9WH9QU7g==",
+              "base64": "d8y3DLFGseaTkfoPSjGUkRnCl/bLiq83USDDmKU+d9ZQmvrSPDnF7T4G4g9z2YL/mlNlgjMn/oObkh/OIlDgZLUfSQTTo1U2pOKDG1m/wCi0CaSfyxoWy8mespl9SHmngDauWKeJYs1p8zFrrK/WyzzWTyhkVeSTYmf3Zev4zAO7cTc1NMkvCL7UZQ6ODAAV6KNgEr2iETls00bOG/7KMVWXKmH5+tlmXdplnBohb1w0m+M5LUnSO0t7Q45dgGl4kfp4KMat2d7ooS5sUIDY5ynUpSiRcDGMj4MFt5ACM5XdwRWQNs5D863B1bHeTpLH2fPr1eZTcCprSyPhqOtIQA==",
               "subType": "00"
             }
           },
@@ -145,8 +145,8 @@
           "status": 1,
           "masterKey": {
             "provider": "azure",
-            "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
-            "keyName": "key-name-csfle"
+            "keyVaultEndpoint": "drivers-3392-key-vault.vault.azure.net",
+            "keyName": "drivers-3392-keyname"
           }
         },
         {
@@ -552,8 +552,8 @@
             "opts": {
               "provider": "azure",
               "masterKey": {
-                "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
-                "keyName": "key-name-csfle"
+                "keyVaultEndpoint": "drivers-3392-key-vault.vault.azure.net",
+                "keyName": "drivers-3392-keyname"
               }
             }
           },
@@ -609,8 +609,8 @@
                         "$set": {
                           "masterKey": {
                             "provider": "azure",
-                            "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
-                            "keyName": "key-name-csfle"
+                            "keyVaultEndpoint": "drivers-3392-key-vault.vault.azure.net",
+                            "keyName": "drivers-3392-keyname"
                           },
                           "keyMaterial": {
                             "$$type": "binData"
@@ -637,8 +637,8 @@
                         "$set": {
                           "masterKey": {
                             "provider": "azure",
-                            "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
-                            "keyName": "key-name-csfle"
+                            "keyVaultEndpoint": "drivers-3392-key-vault.vault.azure.net",
+                            "keyName": "drivers-3392-keyname"
                           },
                           "keyMaterial": {
                             "$$type": "binData"
@@ -665,8 +665,8 @@
                         "$set": {
                           "masterKey": {
                             "provider": "azure",
-                            "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
-                            "keyName": "key-name-csfle"
+                            "keyVaultEndpoint": "drivers-3392-key-vault.vault.azure.net",
+                            "keyName": "drivers-3392-keyname"
                           },
                           "keyMaterial": {
                             "$$type": "binData"
@@ -693,8 +693,8 @@
                         "$set": {
                           "masterKey": {
                             "provider": "azure",
-                            "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
-                            "keyName": "key-name-csfle"
+                            "keyVaultEndpoint": "drivers-3392-key-vault.vault.azure.net",
+                            "keyName": "drivers-3392-keyname"
                           },
                           "keyMaterial": {
                             "$$type": "binData"
@@ -721,8 +721,8 @@
                         "$set": {
                           "masterKey": {
                             "provider": "azure",
-                            "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
-                            "keyName": "key-name-csfle"
+                            "keyVaultEndpoint": "drivers-3392-key-vault.vault.azure.net",
+                            "keyName": "drivers-3392-keyname"
                           },
                           "keyMaterial": {
                             "$$type": "binData"
@@ -1668,8 +1668,8 @@
               },
               "masterKey": {
                 "provider": "azure",
-                "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
-                "keyName": "key-name-csfle"
+                "keyVaultEndpoint": "drivers-3392-key-vault.vault.azure.net",
+                "keyName": "drivers-3392-keyname"
               }
             },
             {

--- a/src/libmongoc/tests/test-mongoc-client-side-encryption.c
+++ b/src/libmongoc/tests/test-mongoc-client-side-encryption.c
@@ -245,7 +245,7 @@ _make_kms_masterkey(char const *provider)
    }
 
    if (strcmp(provider, "azure") == 0) {
-      return BCON_NEW("keyVaultEndpoint", "key-vault-csfle.vault.azure.net", "keyName", "key-name-csfle");
+      return BCON_NEW("keyVaultEndpoint", "drivers-3392-key-vault.vault.azure.net", "keyName", "drivers-3392-keyname");
    }
 
    if (strcmp(provider, "gcp") == 0) {
@@ -578,8 +578,8 @@ test_datakey_and_double_encryption_creating_and_using(mongoc_client_encryption_t
    } else if (0 == strcmp(kms_provider, "azure")) {
       mongoc_client_encryption_datakey_opts_set_masterkey(
          opts,
-         tmp_bson("{'keyVaultEndpoint': 'key-vault-csfle.vault.azure.net', "
-                  "'keyName': 'key-name-csfle'}"));
+         tmp_bson("{'keyVaultEndpoint': 'drivers-3392-key-vault.vault.azure.net', "
+                  "'keyName': 'drivers-3392-keyname'}"));
    } else if (0 == strcmp(kms_provider, "gcp")) {
       mongoc_client_encryption_datakey_opts_set_masterkey(opts,
                                                           tmp_bson("{'projectId': 'devprod-drivers','location': "
@@ -1362,7 +1362,8 @@ test_custom_endpoint(void *unused)
 
    /* Case 7: Azure successful case */
    _endpoint_setup(keyvault_client, &client_encryption, &client_encryption_invalid);
-   masterkey = BCON_NEW("keyVaultEndpoint", "key-vault-csfle.vault.azure.net", "keyName", "key-name-csfle");
+   masterkey =
+      BCON_NEW("keyVaultEndpoint", "drivers-3392-key-vault.vault.azure.net", "keyName", "drivers-3392-keyname");
    mongoc_client_encryption_datakey_opts_set_masterkey(datakey_opts, masterkey);
    res = mongoc_client_encryption_create_datakey(client_encryption, "azure", datakey_opts, &keyid, &error);
    ASSERT_OR_PRINT(res, error);


### PR DESCRIPTION
# Summary

Update CSFLE tests to use new corporate Azure credentials

Tests files updated in https://github.com/mongodb/specifications/pull/1955

# Background & Motivation

Setting the environment variable `FLE_AZURE_USE_CORPORATE=YES` switches drivers-evergreen-tools to use corporate credentials.

Switching the corporate credentials requires an update to test data. The Azure Key Encryption Key (KEK) cannot be exported between Azure accounts (by design), so the Data Encryption Key (DEK) ("keyMaterial" in test files) require re-encryption. The key vault endpoint and key names have also been updated to refer to the new account.