### PR TITLE
CDRIVER-6346 Fix calls to Windows APIs when UNICODE defined

### DIFF
--- a/.evergreen/config_generator/components/unicode_compile.py
+++ b/.evergreen/config_generator/components/unicode_compile.py
@@ -1,0 +1,44 @@
+from shrub.v3.evg_build_variant import BuildVariant
+from shrub.v3.evg_command import EvgCommandType
+from shrub.v3.evg_task import EvgTask, EvgTaskRef
+
+from config_generator.etc.distros import compiler_to_vars, find_large_distro
+from config_generator.etc.utils import bash_exec
+
+# Compile-only task for CDRIVER-6346: build on Windows with UNICODE/_UNICODE defined.
+
+# Enable C4133 as error to identify string pointer mismatch.
+_UNICODE_FLAGS = "/we4133 /DUNICODE /D_UNICODE"
+
+
+def tasks():
+    return [
+        EvgTask(
+            name='unicode-compile',
+            run_on=find_large_distro('windows-2022-latest').name,
+            tags=['unicode-compile', 'compile'],
+            commands=[
+                bash_exec(
+                    command_type=EvgCommandType.TEST,
+                    add_expansions_to_env=True,
+                    working_dir='mongoc',
+                    script='.evergreen/scripts/compile.sh',
+                ),
+            ],
+        )
+    ]
+
+
+def variants():
+    return [
+        BuildVariant(
+            name='unicode-compile',
+            display_name='UNICODE Compile',
+            tasks=[EvgTaskRef(name='unicode-compile')],
+            expansions={
+                **compiler_to_vars('vs2022x64'),
+                'CFLAGS': _UNICODE_FLAGS,
+                'CXXFLAGS': _UNICODE_FLAGS,
+            },
+        ),
+    ]

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -8844,6 +8844,19 @@ tasks:
       - func: run-simple-http-server
       - func: run-tests
       - func: csfle-teardown
+  - name: unicode-compile
+    run_on: windows-2022-latest-large
+    tags: [unicode-compile, compile]
+    commands:
+      - command: subprocess.exec
+        type: test
+        params:
+          binary: bash
+          working_dir: mongoc
+          add_expansions_to_env: true
+          args:
+            - -c
+            - .evergreen/scripts/compile.sh
   - name: verify-headers
     run_on:
       - amazon2

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -431,3 +431,12 @@ buildvariants:
       MONGOC_EARTHLY_FROM: 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/ubuntu:24.04
     tasks:
       - name: .ubuntu:24.04-gcc
+  - name: unicode-compile
+    display_name: UNICODE Compile
+    expansions:
+      CFLAGS: /we4133 /DUNICODE /D_UNICODE
+      CMAKE_GENERATOR: Visual Studio 17 2022
+      CMAKE_GENERATOR_PLATFORM: x64
+      CXXFLAGS: /we4133 /DUNICODE /D_UNICODE
+    tasks:
+      - name: unicode-compile

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -132,14 +132,13 @@ srv_callback(const char *hostname, PDNS_RECORD pdns, mongoc_rr_data_t *rr_data, 
     * PDNS_RECORD -> PDNS_RECORDW under UNICODE. Reinterpret the string pointer as
     * char* rather than treating it as wide.
     * https://learn.microsoft.com/en-us/windows/win32/api/windns/nf-windns-dnsquery_utf8 */
-   const char *name_target = (const char *) pdns->Data.SRV.pNameTarget;
+   const char *name_target = (const char *)pdns->Data.SRV.pNameTarget;
 
    if (rr_data && rr_data->hosts) {
       _mongoc_host_list_remove_host(&(rr_data->hosts), name_target, pdns->Data.SRV.wPort);
    }
 
-   if (!_mongoc_host_list_from_hostport_with_err(
-          &new_host, mstr_cstring(name_target), pdns->Data.SRV.wPort, error)) {
+   if (!_mongoc_host_list_from_hostport_with_err(&new_host, mstr_cstring(name_target), pdns->Data.SRV.wPort, error)) {
       return false;
    }
    _mongoc_host_list_upsert(&rr_data->hosts, &new_host);
@@ -162,7 +161,7 @@ txt_callback(const char *hostname, PDNS_RECORD pdns, mongoc_rr_data_t *rr_data, 
    for (i = 0; i < pdns->Data.TXT.dwStringCount; i++) {
       /* pStringArray holds UTF-8 char data from DnsQuery_UTF8, not wide strings
        * (see srv_callback for reference). */
-      mcommon_string_append(&txt, (const char *) pdns->Data.TXT.pStringArray[i]);
+      mcommon_string_append(&txt, (const char *)pdns->Data.TXT.pStringArray[i]);
    }
 
    rr_data->txt_record_opts = mcommon_string_from_append_destroy_with_steal(&txt);

--- a/src/libmongoc/src/mongoc/mongoc-client.c
+++ b/src/libmongoc/src/mongoc/mongoc-client.c
@@ -127,12 +127,19 @@ srv_callback(const char *hostname, PDNS_RECORD pdns, mongoc_rr_data_t *rr_data, 
 
    mongoc_host_list_t new_host;
 
+   /* DnsQuery_UTF8 returns records whose string fields are UTF-8-encoded (per its
+    * documented "for UTF-8 encoding" variant), even though the out-param is typed
+    * PDNS_RECORD -> PDNS_RECORDW under UNICODE. Reinterpret the string pointer as
+    * char* rather than treating it as wide.
+    * https://learn.microsoft.com/en-us/windows/win32/api/windns/nf-windns-dnsquery_utf8 */
+   const char *name_target = (const char *) pdns->Data.SRV.pNameTarget;
+
    if (rr_data && rr_data->hosts) {
-      _mongoc_host_list_remove_host(&(rr_data->hosts), pdns->Data.SRV.pNameTarget, pdns->Data.SRV.wPort);
+      _mongoc_host_list_remove_host(&(rr_data->hosts), name_target, pdns->Data.SRV.wPort);
    }
 
    if (!_mongoc_host_list_from_hostport_with_err(
-          &new_host, mstr_cstring(pdns->Data.SRV.pNameTarget), pdns->Data.SRV.wPort, error)) {
+          &new_host, mstr_cstring(name_target), pdns->Data.SRV.wPort, error)) {
       return false;
    }
    _mongoc_host_list_upsert(&rr_data->hosts, &new_host);
@@ -153,7 +160,9 @@ txt_callback(const char *hostname, PDNS_RECORD pdns, mongoc_rr_data_t *rr_data, 
    mcommon_string_new_with_capacity_as_append(&txt, pdns->wDataLength);
 
    for (i = 0; i < pdns->Data.TXT.dwStringCount; i++) {
-      mcommon_string_append(&txt, pdns->Data.TXT.pStringArray[i]);
+      /* pStringArray holds UTF-8 char data from DnsQuery_UTF8, not wide strings
+       * (see srv_callback for reference). */
+      mcommon_string_append(&txt, (const char *) pdns->Data.TXT.pStringArray[i]);
    }
 
    rr_data->txt_record_opts = mcommon_string_from_append_destroy_with_steal(&txt);

--- a/src/libmongoc/src/mongoc/mongoc-secure-channel.c
+++ b/src/libmongoc/src/mongoc/mongoc-secure-channel.c
@@ -834,24 +834,24 @@ mongoc_secure_channel_handshake_step_1(mongoc_stream_tls_t *tls, char *hostname,
    secure_channel->ctxt = (mongoc_secure_channel_ctxt *)bson_malloc0(sizeof(mongoc_secure_channel_ctxt));
 
    /* https://msdn.microsoft.com/en-us/library/windows/desktop/aa375924.aspx */
-   sspi_status = InitializeSecurityContext(&secure_channel->cred_handle->cred_handle, /* phCredential */
-                                           NULL,                                      /* phContext */
-                                           hostname,                                  /* pszTargetName */
-                                           secure_channel->req_flags,                 /* fContextReq */
-                                           0,                                         /* Reserved1, must be 0 */
-                                           0,                                         /* TargetDataRep, unused */
-                                           NULL,                                      /* pInput */
-                                           0,                                         /* Reserved2, must be 0 */
-                                           &secure_channel->ctxt->ctxt_handle,        /* phNewContext OUT param */
-                                           &outbuf_desc,                              /* pOutput OUT param */
-                                           &secure_channel->ret_flags,                /* pfContextAttr OUT param */
-                                           &secure_channel->ctxt->time_stamp          /* ptsExpiry OUT param */
+   sspi_status = InitializeSecurityContextA(&secure_channel->cred_handle->cred_handle, /* phCredential */
+                                            NULL,                                      /* phContext */
+                                            hostname,                                  /* pszTargetName */
+                                            secure_channel->req_flags,                 /* fContextReq */
+                                            0,                                         /* Reserved1, must be 0 */
+                                            0,                                         /* TargetDataRep, unused */
+                                            NULL,                                      /* pInput */
+                                            0,                                         /* Reserved2, must be 0 */
+                                            &secure_channel->ctxt->ctxt_handle,        /* phNewContext OUT param */
+                                            &outbuf_desc,                              /* pOutput OUT param */
+                                            &secure_channel->ret_flags,                /* pfContextAttr OUT param */
+                                            &secure_channel->ctxt->time_stamp          /* ptsExpiry OUT param */
    );
    if (sspi_status != SEC_I_CONTINUE_NEEDED) {
       // Cast signed SECURITY_STATUS to unsigned DWORD. FormatMessage expects DWORD.
       char *msg = mongoc_winerr_to_string((DWORD)sspi_status);
       MONGOC_LOG_AND_SET_ERROR(
-         error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "initial InitializeSecurityContext failed: %s", msg);
+         error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_SOCKET, "initial InitializeSecurityContextA failed: %s", msg);
       bson_free(msg);
       return false;
    }
@@ -972,18 +972,18 @@ mongoc_secure_channel_handshake_step_2(mongoc_stream_tls_t *tls, char *hostname,
 
       /* https://msdn.microsoft.com/en-us/library/windows/desktop/aa375924.aspx
        */
-      sspi_status = InitializeSecurityContext(&secure_channel->cred_handle->cred_handle,
-                                              &secure_channel->ctxt->ctxt_handle,
-                                              hostname,
-                                              secure_channel->req_flags,
-                                              0,
-                                              0,
-                                              &inbuf_desc,
-                                              0,
-                                              NULL,
-                                              &outbuf_desc,
-                                              &secure_channel->ret_flags,
-                                              &secure_channel->ctxt->time_stamp);
+      sspi_status = InitializeSecurityContextA(&secure_channel->cred_handle->cred_handle,
+                                               &secure_channel->ctxt->ctxt_handle,
+                                               hostname,
+                                               secure_channel->req_flags,
+                                               0,
+                                               0,
+                                               &inbuf_desc,
+                                               0,
+                                               NULL,
+                                               &outbuf_desc,
+                                               &secure_channel->ret_flags,
+                                               &secure_channel->ctxt->time_stamp);
 
       /* free buffer for received handshake data */
       bson_free(inbuf[0].pvBuffer);

--- a/src/libmongoc/src/mongoc/mongoc-socket.c
+++ b/src/libmongoc/src/mongoc/mongoc-socket.c
@@ -396,7 +396,7 @@ _mongoc_socket_setkeepalive_windows(SOCKET sd)
       /* https://technet.microsoft.com/en-us/library/cc957548.aspx */
       DWORD default_keepaliveinterval = 1000; /* 1 second */
 
-      if (RegQueryValueEx(hKey, "KeepAliveTime", NULL, &type, (LPBYTE)&data, &data_size) == ERROR_SUCCESS) {
+      if (RegQueryValueExA(hKey, "KeepAliveTime", NULL, &type, (LPBYTE)&data, &data_size) == ERROR_SUCCESS) {
          if (type == REG_DWORD && data < keepalive.keepalivetime) {
             keepalive.keepalivetime = data;
          }
@@ -404,7 +404,7 @@ _mongoc_socket_setkeepalive_windows(SOCKET sd)
          keepalive.keepalivetime = default_keepalivetime;
       }
 
-      if (RegQueryValueEx(hKey, "KeepAliveInterval", NULL, &type, (LPBYTE)&data, &data_size) == ERROR_SUCCESS) {
+      if (RegQueryValueExA(hKey, "KeepAliveInterval", NULL, &type, (LPBYTE)&data, &data_size) == ERROR_SUCCESS) {
          if (type == REG_DWORD && data < keepalive.keepaliveinterval) {
             keepalive.keepaliveinterval = data;
          }

--- a/src/libmongoc/tests/TestSuite.c
+++ b/src/libmongoc/tests/TestSuite.c
@@ -402,7 +402,7 @@ static int
 TestSuite_RunFuncInChild(TestSuite *suite, /* IN */
                          Test *test)       /* IN */
 {
-   STARTUPINFO si;
+   STARTUPINFOA si;
    PROCESS_INFORMATION pi;
    char *cmdline;
    DWORD exit_code = -1;
@@ -413,16 +413,16 @@ TestSuite_RunFuncInChild(TestSuite *suite, /* IN */
 
    cmdline = bson_strdup_printf("%s --silent --no-fork -l %.*s", suite->prgname, MSTR_FMT(test->name));
 
-   if (!CreateProcess(NULL,
-                      cmdline,
-                      NULL,  /* Process handle not inheritable  */
-                      NULL,  /* Thread handle not inheritable   */
-                      FALSE, /* Set handle inheritance to FALSE */
-                      0,     /* No creation flags               */
-                      NULL,  /* Use parent's environment block  */
-                      NULL,  /* Use parent's starting directory */
-                      &si,
-                      &pi)) {
+   if (!CreateProcessA(NULL,
+                       cmdline,
+                       NULL,  /* Process handle not inheritable  */
+                       NULL,  /* Thread handle not inheritable   */
+                       FALSE, /* Set handle inheritance to FALSE */
+                       0,     /* No creation flags               */
+                       NULL,  /* Use parent's environment block  */
+                       NULL,  /* Use parent's starting directory */
+                       &si,
+                       &pi)) {
       test_error("CreateProcess failed (%lu).", GetLastError());
       bson_free(cmdline);
 

--- a/src/libmongoc/tests/test-conveniences.h
+++ b/src/libmongoc/tests/test-conveniences.h
@@ -79,7 +79,7 @@ json_with_all_types(void);
 #endif
 
 #ifdef _WIN32
-#define realpath(path, expanded) GetFullPathName(path, PATH_MAX, expanded, NULL)
+#define realpath(path, expanded) GetFullPathNameA(path, PATH_MAX, expanded, NULL)
 #endif
 
 void


### PR DESCRIPTION
# Summary

Fix calls to Windows APIs when UNICODE defined.

# Details

A CI compile task is added on Windows with UNICODE macros defined and the MSVC "incompatible types" warning as an error (`/we4133`) to test for regressions.

A notably irregular case is `DnsQuery_UTF8`. The out-param of `DnsQuery_UTF8` is `PDNS_RECORD`. Though `PDNS_RECORD` is defined in terms of wide-character strings when `UNICODE` is defined, `DnsQuery_UTF8` [documents](https://learn.microsoft.com/en-us/windows/win32/api/windns/nf-windns-dnsquery_utf8): "for UTF-8 encoding". So explicit casts are used.