### PR TITLE
Apply post-2.3.2 changes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,21 @@ libmongoc 2.4.0 [UNRELEASED]
   * The `prefixPreview`, `suffixPreview`, and `substringPreview` query types remains experimental.
 
 
+libmongoc 2.3.2
+===============
+
+## Fixes
+
+* Fix possible abort on failed `killCursors` (introduced in 2.3.0).
+* Fix error handling in SCRAM authentication.
+
+Thanks to everyone who contributed to the development of this release.
+
+  * Connor MacDonald
+  * Ezra Chung
+  * Kevin Albertson
+
+
 libmongoc 2.3.1
 ===============
 

--- a/etc/third_party_vulnerabilities.md
+++ b/etc/third_party_vulnerabilities.md
@@ -32,20 +32,6 @@ information that was available at that time.
 
 ## `Zlib`
 
-### CVE-2023-45853 - Integer Overflow or Wraparound
-
-- **Date Detected**: 2024-06-24
-- **CVE Number**: [CVE-2023-45853](https://www.cve.org/CVERecord?id=CVE-2023-45853)
-- **Snyk Entry**: [SNYK-UNMANAGED-MADLERZLIB-5969359](https://security.snyk.io/vuln/SNYK-UNMANAGED-MADLERZLIB-5969359)
-- **Severity**: High
-- **Description**: Affected versions of this package are vulnerable to Integer
-  Overflow or Wraparound via the `MiniZip` function in `zlib`, by providing a
-  long filename, comment, or extra field.
-- **Upstream Fix Status**: Fix available (1.3.1, 2024-01-22)
-- **mongo-c-driver Fix Status**: Fix available (1.27.3, 2024-06-26)
-- **Notes**: This issue was related to Zip file handling, which was not used by
-  mongo-c-driver. This errant code was never reachable via the C driver APIs.
-
 ## `jsonsl`, `utf8proc`, and `uthash`
 
 These bundled dependencies are present within the release archive, but are not

--- a/etc/third_party_vulnerabilities.md
+++ b/etc/third_party_vulnerabilities.md
@@ -31,6 +31,16 @@ information that was available at that time.
 > appear in this document.
 
 ## `Zlib`
+### CVE-2026-27171 - Infinite loop
+
+- **Date Detected**: 2026-07-07
+- **CVE Number**: [CVE-2026-27171](https://www.cve.org/CVERecord?id=CVE-2026-27171)
+- **Snyk Entry**: [SNYK-UNMANAGED-MADLERZLIB-15317565](https://security.snyk.io/vuln/SNYK-UNMANAGED-MADLERZLIB-15317565)
+- **Severity**: Low
+- **Description**: Affected versions of this package are vulnerable to Infinite loop in the `crc32_combine_gen64()` function. An attacker can cause excessive CPU consumption by providing negative argument that triggers a loop with no termination condition.
+- **Upstream Fix Status**: Fix available (1.3.2, 2026-02-17)
+- **mongo-c-driver Fix Status**: Fix pending
+- **Notes**: This issue is related to APIs not used by mongo-c-driver.
 
 ## `jsonsl`, `utf8proc`, and `uthash`
 

--- a/src/libbson/NEWS
+++ b/src/libbson/NEWS
@@ -1,3 +1,8 @@
+libbson 2.3.2
+=============
+
+No changes since 2.3.2. Version incremented to match the libmongoc version.
+
 libbson 2.3.1
 =============
 


### PR DESCRIPTION
- Update `NEWS`.
- Update `third_party_vulnerabilities.md`:
  - Delete CVE-2023-45853 following [release instructions](https://github.com/mongodb/mongo-c-driver/blob/d802d8c16ecb3d3eb3c7ce79002f9952bc00f982/docs/dev/deps.rst#updating-the-vulnerability-report) as it is "no longer part of any supported release version"
  - Add CVE-2026-27171. This does not impact the C driver, but is reported in Snyk.