### PR TITLE
Use "default_quay_registry" for quay.io images

### DIFF
--- a/.evergreen/config_generator/components/earthly.py
+++ b/.evergreen/config_generator/components/earthly.py
@@ -86,6 +86,8 @@ def from_container_image(img: EnvImage) -> str:
 
     NOTE: This will be potentially unnecessary pending the completion of DEVPROD-21478
     """
+    if img.startswith('quay.io/'):
+        return f'{_ECR_HOST}/quay/{img.removeprefix("quay.io/")}'
     if '/' in img or img.startswith('+'):
         return img
     return f'{_ECR_HOST}/dockerhub/library/{img}'
@@ -231,6 +233,8 @@ def earthly_exec(
             f'+{target}',
             # Use Amazon ECR as pull-through cache for DockerHub to avoid rate limits.
             f'--default_docker_registry={_ECR_HOST}/dockerhub/library',
+            # Use Amazon ECR as pull-through cache for Quay to avoid spurious network failures.
+            f'--default_quay_registry={_ECR_HOST}/quay',
             *(f'--{arg}={val}' for arg, val in (args or {}).items()),
         ],
         command_type=EvgCommandType(kind),

--- a/.evergreen/config_generator/components/earthly.py
+++ b/.evergreen/config_generator/components/earthly.py
@@ -50,7 +50,7 @@ SASLOption = Literal['Cyrus', 'off']
 TLSOption = Literal['OpenSSL', 'off']
 "Options for the TLS backend configuration parameter (AKA 'ENABLE_SSL')"
 # TODO: restore C++ driver tests after CXX-3503 to update for API renames.
-CxxVersion = Literal['none'] # Literal['master', 'r4.1.0', 'none']
+CxxVersion = Literal['none']  # Literal['master', 'r4.1.0', 'none']
 'C++ driver refs that are under CI test'
 SnappyOption = Literal['false', 'true']
 """Should we enable Snappy compression in this build?"""
@@ -230,7 +230,7 @@ def earthly_exec(
             *([f'--platform={platform}'] if platform else ()),
             f'+{target}',
             # Use Amazon ECR as pull-through cache for DockerHub to avoid rate limits.
-            f'--default_search_registry={_ECR_HOST}/dockerhub/library',
+            f'--default_docker_registry={_ECR_HOST}/dockerhub/library',
             *(f'--{arg}={val}' for arg, val in (args or {}).items()),
         ],
         command_type=EvgCommandType(kind),

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -1358,6 +1358,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
             - --sasl=Cyrus
             - --tls=OpenSSL
             - --test_mongocxx_ref=none
@@ -1376,6 +1377,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
             - --sasl=Cyrus
             - --tls=OpenSSL
             - --test_mongocxx_ref=none
@@ -1394,6 +1396,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +run
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
             - --targets=test-example
             - --sasl=Cyrus
             - --tls=OpenSSL
@@ -1425,6 +1428,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
             - --sasl=Cyrus
             - --tls=OpenSSL
             - --test_mongocxx_ref=none
@@ -1443,6 +1447,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
             - --sasl=Cyrus
             - --tls=OpenSSL
             - --test_mongocxx_ref=none
@@ -1461,6 +1466,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +run
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
             - --targets=test-example
             - --sasl=Cyrus
             - --tls=OpenSSL
@@ -1492,6 +1498,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
             - --sasl=Cyrus
             - --tls=off
             - --test_mongocxx_ref=none
@@ -1510,6 +1517,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
             - --sasl=Cyrus
             - --tls=off
             - --test_mongocxx_ref=none
@@ -1528,6 +1536,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +run
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
             - --targets=test-example
             - --sasl=Cyrus
             - --tls=off
@@ -1559,6 +1568,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
             - --sasl=Cyrus
             - --tls=off
             - --test_mongocxx_ref=none
@@ -1577,6 +1587,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
             - --sasl=Cyrus
             - --tls=off
             - --test_mongocxx_ref=none
@@ -1595,6 +1606,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +run
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
             - --targets=test-example
             - --sasl=Cyrus
             - --tls=off
@@ -1626,6 +1638,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
             - --sasl=off
             - --tls=OpenSSL
             - --test_mongocxx_ref=none
@@ -1644,6 +1657,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
             - --sasl=off
             - --tls=OpenSSL
             - --test_mongocxx_ref=none
@@ -1662,6 +1676,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +run
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
             - --targets=test-example
             - --sasl=off
             - --tls=OpenSSL
@@ -1693,6 +1708,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
             - --sasl=off
             - --tls=OpenSSL
             - --test_mongocxx_ref=none
@@ -1711,6 +1727,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
             - --sasl=off
             - --tls=OpenSSL
             - --test_mongocxx_ref=none
@@ -1729,6 +1746,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +run
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
             - --targets=test-example
             - --sasl=off
             - --tls=OpenSSL
@@ -1760,6 +1778,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
             - --sasl=off
             - --tls=off
             - --test_mongocxx_ref=none
@@ -1778,6 +1797,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
             - --sasl=off
             - --tls=off
             - --test_mongocxx_ref=none
@@ -1796,6 +1816,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +run
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
             - --targets=test-example
             - --sasl=off
             - --tls=off
@@ -1827,6 +1848,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
             - --sasl=off
             - --tls=off
             - --test_mongocxx_ref=none
@@ -1845,6 +1867,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
             - --sasl=off
             - --tls=off
             - --test_mongocxx_ref=none
@@ -1863,6 +1886,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +run
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
             - --targets=test-example
             - --sasl=off
             - --tls=off
@@ -4548,6 +4572,7 @@ tasks:
             - --platform=linux/amd64
             - +deb.test
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
   - name: debian-package-i386
     run_on:
       - amazon2
@@ -4570,6 +4595,7 @@ tasks:
             - --platform=linux/i386
             - +deb.test
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay
   - name: kms-divergence-check
     commands:
       - func: kms-divergence-check
@@ -8865,3 +8891,4 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +verify-headers
             - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_quay_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/quay

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -1357,7 +1357,7 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --sasl=Cyrus
             - --tls=OpenSSL
             - --test_mongocxx_ref=none
@@ -1375,7 +1375,7 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --sasl=Cyrus
             - --tls=OpenSSL
             - --test_mongocxx_ref=none
@@ -1393,7 +1393,7 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +run
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --targets=test-example
             - --sasl=Cyrus
             - --tls=OpenSSL
@@ -1424,7 +1424,7 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --sasl=Cyrus
             - --tls=OpenSSL
             - --test_mongocxx_ref=none
@@ -1442,7 +1442,7 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --sasl=Cyrus
             - --tls=OpenSSL
             - --test_mongocxx_ref=none
@@ -1460,7 +1460,7 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +run
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --targets=test-example
             - --sasl=Cyrus
             - --tls=OpenSSL
@@ -1491,7 +1491,7 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --sasl=Cyrus
             - --tls=off
             - --test_mongocxx_ref=none
@@ -1509,7 +1509,7 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --sasl=Cyrus
             - --tls=off
             - --test_mongocxx_ref=none
@@ -1527,7 +1527,7 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +run
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --targets=test-example
             - --sasl=Cyrus
             - --tls=off
@@ -1558,7 +1558,7 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --sasl=Cyrus
             - --tls=off
             - --test_mongocxx_ref=none
@@ -1576,7 +1576,7 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --sasl=Cyrus
             - --tls=off
             - --test_mongocxx_ref=none
@@ -1594,7 +1594,7 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +run
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --targets=test-example
             - --sasl=Cyrus
             - --tls=off
@@ -1625,7 +1625,7 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --sasl=off
             - --tls=OpenSSL
             - --test_mongocxx_ref=none
@@ -1643,7 +1643,7 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --sasl=off
             - --tls=OpenSSL
             - --test_mongocxx_ref=none
@@ -1661,7 +1661,7 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +run
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --targets=test-example
             - --sasl=off
             - --tls=OpenSSL
@@ -1692,7 +1692,7 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --sasl=off
             - --tls=OpenSSL
             - --test_mongocxx_ref=none
@@ -1710,7 +1710,7 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --sasl=off
             - --tls=OpenSSL
             - --test_mongocxx_ref=none
@@ -1728,7 +1728,7 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +run
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --targets=test-example
             - --sasl=off
             - --tls=OpenSSL
@@ -1759,7 +1759,7 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --sasl=off
             - --tls=off
             - --test_mongocxx_ref=none
@@ -1777,7 +1777,7 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --sasl=off
             - --tls=off
             - --test_mongocxx_ref=none
@@ -1795,7 +1795,7 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +run
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --targets=test-example
             - --sasl=off
             - --tls=off
@@ -1826,7 +1826,7 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +build-environment
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --sasl=off
             - --tls=off
             - --test_mongocxx_ref=none
@@ -1844,7 +1844,7 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +configure
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --sasl=off
             - --tls=off
             - --test_mongocxx_ref=none
@@ -1862,7 +1862,7 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +run
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
             - --targets=test-example
             - --sasl=off
             - --tls=off
@@ -4547,7 +4547,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - --platform=linux/amd64
             - +deb.test
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
   - name: debian-package-i386
     run_on:
       - amazon2
@@ -4569,7 +4569,7 @@ tasks:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - --platform=linux/i386
             - +deb.test
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
   - name: kms-divergence-check
     commands:
       - func: kms-divergence-check
@@ -8864,4 +8864,4 @@ tasks:
           args:
             - --buildkit-image=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/earthly/buildkitd:v0.8.3
             - +verify-headers
-            - --default_search_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library
+            - --default_docker_registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -250,28 +250,28 @@ buildvariants:
     display_name: CentOS 10 (LLVM/Clang)
     expansions:
       MONGOC_EARTHLY_C_COMPILER: clang
-      MONGOC_EARTHLY_FROM: quay.io/centos/centos:stream10
+      MONGOC_EARTHLY_FROM: 901841024863.dkr.ecr.us-east-1.amazonaws.com/quay/centos/centos:stream10
     tasks:
       - name: .quay.io/centos/centos:stream10-clang
   - name: quay.io/centos/centos:stream10-gcc
     display_name: CentOS 10 (GCC)
     expansions:
       MONGOC_EARTHLY_C_COMPILER: gcc
-      MONGOC_EARTHLY_FROM: quay.io/centos/centos:stream10
+      MONGOC_EARTHLY_FROM: 901841024863.dkr.ecr.us-east-1.amazonaws.com/quay/centos/centos:stream10
     tasks:
       - name: .quay.io/centos/centos:stream10-gcc
   - name: quay.io/centos/centos:stream9-clang
     display_name: CentOS 9 (LLVM/Clang)
     expansions:
       MONGOC_EARTHLY_C_COMPILER: clang
-      MONGOC_EARTHLY_FROM: quay.io/centos/centos:stream9
+      MONGOC_EARTHLY_FROM: 901841024863.dkr.ecr.us-east-1.amazonaws.com/quay/centos/centos:stream9
     tasks:
       - name: .quay.io/centos/centos:stream9-clang
   - name: quay.io/centos/centos:stream9-gcc
     display_name: CentOS 9 (GCC)
     expansions:
       MONGOC_EARTHLY_C_COMPILER: gcc
-      MONGOC_EARTHLY_FROM: quay.io/centos/centos:stream9
+      MONGOC_EARTHLY_FROM: 901841024863.dkr.ecr.us-east-1.amazonaws.com/quay/centos/centos:stream9
     tasks:
       - name: .quay.io/centos/centos:stream9-gcc
   - name: sanitizers-matrix-asan

--- a/Earthfile
+++ b/Earthfile
@@ -6,11 +6,11 @@ VERSION --arg-scope-and-set --pass-args --use-function-keyword 0.7
 # For more detailed documentation, use to the "devdocs" target in this file (ctrl+f "devdocs:"),
 # and read the resulting "Earthly" page that is generated.
 
-# Allow setting the "default" container image registry to use for image short names (e.g. to Amazon ECR).
-ARG --global default_search_registry=docker.io
+# Allow setting the "default" container image registries to use for image short names (e.g. to Amazon ECR).
+ARG --global default_docker_registry=docker.io
 
 # Set a base container image at the root so that this project can be imported
-FROM $default_search_registry/alpine:3.20
+FROM $default_docker_registry/alpine:3.20
 
 # Not intended to be overridden, but provide some defaults used across targets
 ARG --global __source_dir = "/opt/mcd/source"
@@ -132,7 +132,7 @@ test-cxx-driver:
 # release-archive :
 #   Create a release archive of the source tree. (Refer to dev docs)
 release-archive:
-    FROM $default_search_registry/alpine:3.20
+    FROM $default_docker_registry/alpine:3.20
     RUN apk add git bash
     ARG --required prefix
     ARG --required ref
@@ -177,7 +177,7 @@ release-archive:
 
 # Obtain the signing public key. Exported as an artifact /c-driver.pub
 signing-pubkey:
-    FROM +init --from=$default_search_registry/alpine:3.20 --uv_version=none
+    FROM +init --from=$default_docker_registry/alpine:3.20 --uv_version=none
     RUN __download --from="https://pgp.mongodb.com/c-driver.pub" --to=/c-driver.pub --hash=unchecked
     SAVE ARTIFACT /c-driver.pub
 
@@ -206,7 +206,7 @@ sign-file:
 #   Generate a signed release artifact. Refer to the "Earthly" page of our dev docs for more information.
 #   (Refer to dev docs)
 signed-release:
-    FROM $default_search_registry/alpine:3.20
+    FROM $default_docker_registry/alpine:3.20
     RUN apk add git
     # The version of the release. This affects the filepaths of the output and is the default for --ref
     ARG --required version
@@ -295,7 +295,7 @@ sbom-validate:
             --exclude jira
 
 snyk:
-    FROM --platform=linux/amd64 +init --from=$default_search_registry/ubuntu:24.04
+    FROM --platform=linux/amd64 +init --from=$default_docker_registry/ubuntu:24.04
     RUN __download --from=https://github.com/snyk/cli/releases/download/v1.1291.1/snyk-linux \
         --to=/usr/local/bin/snyk \
         --hash=md5sum=1dafaff658906ca3d0656dcd838cc09b
@@ -368,7 +368,7 @@ test-vcpkg-manifest-mode:
         make test-manifest-mode
 
 vcpkg-base:
-    FROM $default_search_registry/alpine:3.18
+    FROM $default_docker_registry/alpine:3.18
     RUN apk add cmake curl gcc g++ musl-dev ninja-is-really-ninja zip unzip tar \
                 build-base git pkgconf perl bash linux-headers
     ENV VCPKG_ROOT=/opt/vcpkg-git
@@ -382,7 +382,7 @@ vcpkg-base:
 
 deb.packages:
     ARG debian_version=unstable
-    FROM $default_search_registry/debian:$debian_version
+    FROM $default_docker_registry/debian:$debian_version
     # Prepare the packaging environment
     COPY etc/deb/prep-env.sh /tmp/prep-env.sh
     RUN bash /tmp/prep-env.sh
@@ -410,7 +410,7 @@ deb.packages:
 
 deb.test:
     ARG debian_version = "unstable"
-    FROM $default_search_registry/debian:$debian_version
+    FROM $default_docker_registry/debian:$debian_version
     # Basics for building
     RUN apt-get update && apt-get -y install pkgconf gcc
     # Install the packages built by the packaging step
@@ -432,9 +432,9 @@ verify-headers:
     # need to specify. In the future, it is possible that we will need to test
     # other environments and build settings.
     BUILD +do-verify-headers-impl \
-        --from $default_search_registry/alpine:3.19 \
-        --from $default_search_registry/almalinux:8 \
-        --from $default_search_registry/ubuntu:20.04 \
+        --from $default_docker_registry/alpine:3.19 \
+        --from $default_docker_registry/almalinux:8 \
+        --from $default_docker_registry/ubuntu:20.04 \
         --from quay.io/centos/centos:stream10 \
         --sasl=off --tls=off --compiler=gcc --with_cxx=true --snappy=off
 

--- a/Earthfile
+++ b/Earthfile
@@ -8,6 +8,7 @@ VERSION --arg-scope-and-set --pass-args --use-function-keyword 0.7
 
 # Allow setting the "default" container image registries to use for image short names (e.g. to Amazon ECR).
 ARG --global default_docker_registry=docker.io
+ARG --global default_quay_registry=quay.io
 
 # Set a base container image at the root so that this project can be imported
 FROM $default_docker_registry/alpine:3.20
@@ -435,7 +436,7 @@ verify-headers:
         --from $default_docker_registry/alpine:3.19 \
         --from $default_docker_registry/almalinux:8 \
         --from $default_docker_registry/ubuntu:20.04 \
-        --from quay.io/centos/centos:stream10 \
+        --from $default_quay_registry/centos/centos:stream10 \
         --sasl=off --tls=off --compiler=gcc --with_cxx=true --snappy=off
 
 do-verify-headers-impl:


### PR DESCRIPTION
Following [DEVPROD-32961](https://jira.mongodb.org/browse/DEVPROD-32961), Amazon ECR pull-through cache now supports Quay images. This should improve the reliability of Earthly tasks when pulling CentOS Stream images. A new `default_quay_registry` is used to specify Quay images due to Amazon ECR requiring a different format than DockerHub images. The old `default_search_registry` was renamed to `default_docker_registry` for disambiguation.