### PR TITLE
CDRIVER-6367 fix CMake 4.4.0 configure

### DIFF
--- a/.evergreen/scripts/compile-libmongocrypt.sh
+++ b/.evergreen/scripts/compile-libmongocrypt.sh
@@ -12,7 +12,18 @@ compile_libmongocrypt() {
   # `src/kms-message`.
   #
   # Run `.evergreen/scripts/kms-divergence-check.sh` to ensure that there is no divergence in the copied files.
-  declare -r version="1.20.0"
+  declare -r version="1.21.0-dev"
+
+  {
+    git clone -q https://github.com/mongodb/libmongocrypt || return
+    cd libmongocrypt || return
+    # Check out libmongocrypt commit that pins to CMake 4.3.4 to work around MONGOCRYPT-952 until libmongocrypt updates the C driver.
+    git checkout c2f80a7153da3537fe32916eef8ff1d4cc08bc67 || return
+    cd .. || return
+  }
+  # TODO: after libmongocrypt is updated to use C driver 1.21.0, update the above to:
+  # git clone --depth=1 -q https://github.com/mongodb/libmongocrypt --branch 1.21.0 || return
+
 
   git clone --depth=1 -q https://github.com/mongodb/libmongocrypt --branch "${version:?}" || return
 

--- a/.evergreen/scripts/compile-libmongocrypt.sh
+++ b/.evergreen/scripts/compile-libmongocrypt.sh
@@ -15,7 +15,9 @@ compile_libmongocrypt() {
   declare -r version="1.21.0-dev" # TODO: set to 1.21.0 once released and change `if true` to `if false`.
   if true; then
     git clone -q https://github.com/mongodb/libmongocrypt || return
-    git -C libmongocrypt checkout --detach "63fee9ff9e2748818bfe9204038e07d455777ab3" || return
+    cd libmongocrypt || return
+    git libmongocrypt checkout --detach "63fee9ff9e2748818bfe9204038e07d455777ab3" || return
+    cd .. || return
   else
     git clone --depth=1 -q https://github.com/mongodb/libmongocrypt --branch "${version:?}" || return
   fi

--- a/.evergreen/scripts/compile-libmongocrypt.sh
+++ b/.evergreen/scripts/compile-libmongocrypt.sh
@@ -16,7 +16,7 @@ compile_libmongocrypt() {
   if true; then
     git clone -q https://github.com/mongodb/libmongocrypt || return
     cd libmongocrypt || return
-    git libmongocrypt checkout --detach "63fee9ff9e2748818bfe9204038e07d455777ab3" || return
+    git checkout --detach "63fee9ff9e2748818bfe9204038e07d455777ab3" || return
     cd .. || return
   else
     git clone --depth=1 -q https://github.com/mongodb/libmongocrypt --branch "${version:?}" || return

--- a/.evergreen/scripts/compile-libmongocrypt.sh
+++ b/.evergreen/scripts/compile-libmongocrypt.sh
@@ -12,20 +12,13 @@ compile_libmongocrypt() {
   # `src/kms-message`.
   #
   # Run `.evergreen/scripts/kms-divergence-check.sh` to ensure that there is no divergence in the copied files.
-  declare -r version="1.21.0-dev"
-
-  {
+  declare -r version="1.21.0-dev" # TODO: set to 1.21.0 once released and change `if true` to `if false`.
+  if true; then
     git clone -q https://github.com/mongodb/libmongocrypt || return
-    cd libmongocrypt || return
-    # Check out libmongocrypt commit that pins to CMake 4.3.4 to work around MONGOCRYPT-952 until libmongocrypt updates the C driver.
-    git checkout c2f80a7153da3537fe32916eef8ff1d4cc08bc67 || return
-    cd .. || return
-  }
-  # TODO: after libmongocrypt is updated to use C driver 1.21.0, update the above to:
-  # git clone --depth=1 -q https://github.com/mongodb/libmongocrypt --branch 1.21.0 || return
-
-
-  git clone --depth=1 -q https://github.com/mongodb/libmongocrypt --branch "${version:?}" || return
+    git -C libmongocrypt checkout --detach "${version:?}" || return
+  else
+    git clone --depth=1 -q https://github.com/mongodb/libmongocrypt --branch "${version:?}" || return
+  fi
 
   declare -a crypt_cmake_flags=(
     "-DMONGOCRYPT_MONGOC_DIR=${mongoc_dir}"

--- a/.evergreen/scripts/compile-libmongocrypt.sh
+++ b/.evergreen/scripts/compile-libmongocrypt.sh
@@ -15,7 +15,7 @@ compile_libmongocrypt() {
   declare -r version="1.21.0-dev" # TODO: set to 1.21.0 once released and change `if true` to `if false`.
   if true; then
     git clone -q https://github.com/mongodb/libmongocrypt || return
-    git -C libmongocrypt checkout --detach "${version:?}" || return
+    git -C libmongocrypt checkout --detach "63fee9ff9e2748818bfe9204038e07d455777ab3" || return
   else
     git clone --depth=1 -q https://github.com/mongodb/libmongocrypt --branch "${version:?}" || return
   fi

--- a/Earthfile
+++ b/Earthfile
@@ -53,7 +53,7 @@ configure:
         -D ENABLE_SSL=$(echo $tls | __str upper) \
         -D ENABLE_COVERAGE=OFF \
         -D ENABLE_DEBUG_ASSERTIONS=ON \
-        -Werror \
+        -Werror=author \
         -B "$build_dir" -S "$source_dir"
 
 # build :

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -422,11 +422,12 @@ function (mongoc_get_accept_args ARG2 ARG3)
    }
    ")
 
-   TRY_COMPILE (RES ${CMAKE_CURRENT_BINARY_DIR}
-   ${CMAKE_CURRENT_BINARY_DIR}/accept_test${VAR}.c
-   COMPILE_DEFINITIONS "-Werror"
-   CMAKE_FLAGS "-DCMAKE_C_LINK_EXECUTABLE=echo not linking now..."
-   OUTPUT_VARIABLE LOG2)
+   TRY_COMPILE (RES
+      "${CMAKE_CURRENT_BINARY_DIR}"
+      SOURCES "${CMAKE_CURRENT_BINARY_DIR}/accept_test${VAR}.c"
+      CMAKE_FLAGS "-DCOMPILE_DEFINITIONS=-Werror" "-DCMAKE_CXX_LINK_EXECUTABLE='echo not linking now...'"
+      OUTPUT_VARIABLE LOG2
+   )
 
    if (RES)
       message (

--- a/src/libmongoc/CMakeLists.txt
+++ b/src/libmongoc/CMakeLists.txt
@@ -423,8 +423,10 @@ function (mongoc_get_accept_args ARG2 ARG3)
    ")
 
    TRY_COMPILE (RES ${CMAKE_CURRENT_BINARY_DIR}
-   ${CMAKE_CURRENT_BINARY_DIR}/accept_test${VAR}.c CMAKE_FLAGS
-   "-Werror -DCMAKE_CXX_LINK_EXECUTABLE='echo not linking now...'" OUTPUT_VARIABLE LOG2)
+   ${CMAKE_CURRENT_BINARY_DIR}/accept_test${VAR}.c
+   COMPILE_DEFINITIONS "-Werror"
+   CMAKE_FLAGS "-DCMAKE_C_LINK_EXECUTABLE=echo not linking now..."
+   OUTPUT_VARIABLE LOG2)
 
    if (RES)
       message (


### PR DESCRIPTION
To address a newly observed error in CMake 4.4.0:
```
CMake Error: The warning category "error -DCMAKE_CXX_LINK_EXECUTABLE='echo not linking now...'" is not known.
CMake Error at cmake-build/_deps/embedded_mcd-src/src/libmongoc/CMakeLists.txt:425 (TRY_COMPILE):
  Failed to configure test project build system.
Call Stack (most recent call first):
  cmake-build/_deps/embedded_mcd-src/src/libmongoc/CMakeLists.txt:449 (mongoc_get_accept_args)
```

The `-Werror` appears intended for the compiler (not `cmake`) so is moved from `CMAKE_FLAGS` to `COMPILE_DEFINITIONS`.

