### PR TITLE
CDRIVER-6367 pin ABI base to CMake < 4.4.0

### DIFF
--- a/.evergreen/scripts/abi-compliance-check.sh
+++ b/.evergreen/scripts/abi-compliance-check.sh
@@ -52,8 +52,13 @@ git checkout "tags/${base:?}" -f
 declare compile_script
 compile_script=".evergreen/scripts/compile.sh"
 
+# TODO: remove "UV_CONSTRAINT" of CMake after the base release is 2.3.3+ to include fix of CDRIVER-6367.
+constraint_file="$(mktemp)"
+echo "cmake<4.4" > "${constraint_file:?}"
+
 # build the base release
 env \
+  UV_CONSTRAINT="${constraint_file:?}" \
   CFLAGS="-g -Og" \
   EXTRA_CONFIGURE_FLAGS="-DCMAKE_INSTALL_PREFIX=./abi-compliance/base-install ${cmake_configure_flags[*]:?}" \
   bash "${compile_script}"


### PR DESCRIPTION
# Summary

Pin `abi-compliance-check` task base builds to CMake < 4.4.0.

Evergreen: https://spruce.corp.mongodb.com/version/6a5a5aaf6099aa0007a633c6

# Details

Intended to address Evergreen failures of the abi-compliance-check task ([example](https://spruce.corp.mongodb.com/task/mongo_c_driver_latest_release_abi_compliance_check_abi_compliance_check_466e96cd37c91af23e50df33889b474d6ee46f4e_26_04_17_10_26_56/logs?execution=0)).

I used `UV_CONSTRAINT` mentioned in [in slack](https://mongodb.slack.com/archives/C72LB5RPV/p1783976105148729?thread_ts=1783721546.503609&cid=C72LB5RPV) with a tweak. I used a temporary file, rather than `<(echo "cmake<4.4")` substitution to avoid assuming the `UV_CONSTRAINT` is only read once. The substitution is emptied on first read. Example:

```bash
# cat-twice.sh
cat $UV_CONSTRAINT
cat $UV_CONSTRAINT
```

Using the substitution only prints once:
```bash
UV_CONSTRAINT=<(echo "foo") ./cat-twice.sh
foo
```