### PR TITLE
Fix -Wdiscarded-qualifiers warning in kms_request.c

### DIFF
--- a/src/kms-message/src/kms_request.c
+++ b/src/kms-message/src/kms_request.c
@@ -32,12 +32,12 @@ parse_query_params (kms_request_str_t *q)
    kms_request_str_t *k, *v;
 
    do {
-      equals = strchr ((const char *) p, '=');
+      equals = strchr (p, '=');
       if (!equals) {
          kms_kv_list_destroy (lst);
          return NULL;
       }
-      amp = strchr ((const char *) equals, '&');
+      amp = strchr (equals, '&');
       if (!amp) {
          amp = end;
       }


### PR DESCRIPTION
This fixes a (problematic) `-Wdiscarded-qualifiers` warning that we get in the R bindings on `gcc-16`:

```
kms/kms_request.c: In function 'parse_query_params':
kms/kms_request.c:35:14: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
   35 |       equals = strchr ((const char *) p, '=');
      |              ^
kms/kms_request.c:40:11: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
   40 |       amp = strchr ((const char *) equals, '&');
      |           ^
```

AI summary: In C23 (the default language standard for GCC 15), `strchr` is const-generic: when passed a `const char *` it returns a `const char *`. The explicit `(const char *)` casts in `parse_query_params` therefore make the result unassignable to the non-const `equals` and `amp` pointers.

Since `p` and `equals` are already plain `char *`, the casts serve no purpose; removing them is warning-free on both old and new compilers.
