### PR TITLE
CDRIVER-6373: update copied kms-message

### DIFF
--- a/.evergreen/scripts/kms-divergence-check.sh
+++ b/.evergreen/scripts/kms-divergence-check.sh
@@ -13,7 +13,7 @@ LIBMONGOCRYPT_DIR="$MONGOC_DIR/libmongocrypt-for-kms-divergence-check"
 
 # LIBMONGOCRYPT_GITREF is expected to refer to the version of libmongocrypt
 # where kms-message was last copied.
-LIBMONGOCRYPT_GITREF="6d6bc38254a07bd47dbd0e665cffd67adf8746a9"
+LIBMONGOCRYPT_GITREF="e692af569c41d2d4feb55152426cec4e632cd2cf"
 
 cleanup() {
   if [ -d "$LIBMONGOCRYPT_DIR" ]; then

--- a/src/kms-message/src/hexlify.c
+++ b/src/kms-message/src/hexlify.c
@@ -20,6 +20,7 @@
 
 #include "kms_message_private.h"
 
+#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -50,8 +51,8 @@ unhexlify (const char *in, size_t len)
 {
    int i;
    int byte;
-   int total = 0;
-   int multiplier = 1;
+   int64_t total = 0;
+   int64_t multiplier = 1;
 
    for (i = (int) len - 1; i >= 0; i--) {
       char c = *(in + i);
@@ -66,8 +67,11 @@ unhexlify (const char *in, size_t len)
          return -1;
       }
 
-      total += byte * multiplier;
+      total += (int64_t) byte * multiplier;
+      if (total > INT_MAX) {
+         return -1;
+      }
       multiplier *= 16;
    }
-   return total;
+   return (int) total;
 }

--- a/src/kms-message/src/kms_kmip_reader_writer.c
+++ b/src/kms-message/src/kms_kmip_reader_writer.c
@@ -451,6 +451,7 @@ kmip_reader_find (kmip_reader_t *reader,
       if (read_tag == search_tag && read_type == type) {
          *pos = reader->pos;
          *length = read_length;
+         CHECK_REMAINING_BUFFER_AND_RET (compute_padded_length(read_length));
          return true;
       }
 
@@ -477,6 +478,10 @@ kmip_reader_find_and_recurse (kmip_reader_t *reader, kmip_tag_type_t tag)
    }
 
    reader->pos = 0;
+
+   if (pos + compute_padded_length (length) > reader->len) {
+      return false;
+   }
    reader->ptr = reader->ptr + pos;
    reader->len = length;
    return true;

--- a/src/kms-message/src/kms_kmip_response_parser.c
+++ b/src/kms-message/src/kms_kmip_response_parser.c
@@ -91,6 +91,12 @@ kms_kmip_response_parser_feed (kms_kmip_response_parser_t *parser,
                                const uint8_t *buf,
                                uint32_t len)
 {
+   // As a precaution, limit the maximum size KMS response:
+   if (len > KMS_PARSER_MAX_RESPONSE_LEN || parser->buf->len > KMS_PARSER_MAX_RESPONSE_LEN - len) {
+      KMS_ERROR (parser, "KMS response too large");
+      return false;
+   }
+
    kms_request_str_append_chars (parser->buf, (char *) buf, len);
    parser->bytes_fed += len;
 
@@ -105,6 +111,10 @@ kms_kmip_response_parser_feed (kms_kmip_response_parser_t *parser,
       uint32_t temp;
       memcpy (&temp, parser->buf->str + FIRST_LENGTH_OFFSET, sizeof (uint32_t));
       parser->first_len = KMS_UINT32_FROM_BE (temp);
+      if (parser->first_len > KMS_PARSER_MAX_RESPONSE_LEN) {
+         KMS_ERROR (parser, "KMS KMIP response too large");
+         return false;
+      }
    }
    return true;
 }

--- a/src/kms-message/src/kms_message/kms_response_parser.h
+++ b/src/kms-message/src/kms_message/kms_response_parser.h
@@ -28,6 +28,8 @@
 extern "C" {
 #endif
 
+#define KMS_PARSER_MAX_RESPONSE_LEN 16 * 1024 * 1024 /* 16 MiB */
+
 typedef struct _kms_response_parser_t kms_response_parser_t;
 
 KMS_MSG_EXPORT (kms_response_parser_t *)

--- a/src/kms-message/src/kms_request.c
+++ b/src/kms-message/src/kms_request.c
@@ -32,12 +32,12 @@ parse_query_params (kms_request_str_t *q)
    kms_request_str_t *k, *v;
 
    do {
-      equals = strchr ((const char *) p, '=');
+      equals = strchr (p, '=');
       if (!equals) {
          kms_kv_list_destroy (lst);
          return NULL;
       }
-      amp = strchr ((const char *) equals, '&');
+      amp = strchr (equals, '&');
       if (!amp) {
          amp = end;
       }

--- a/src/kms-message/src/kms_response_parser.c
+++ b/src/kms-message/src/kms_response_parser.c
@@ -234,7 +234,7 @@ _parse_line (kms_response_parser_t *parser, int end)
       /* if we have *not* read the Content-Length yet, check. */
       if (parser->content_length == -1 &&
           strcmp (key->str, "Content-Length") == 0) {
-         if (!_parse_int (val->str, &parser->content_length)) {
+         if (!_parse_int (val->str, &parser->content_length) || parser->content_length > KMS_PARSER_MAX_RESPONSE_LEN || parser->content_length < 0) {
             KMS_ERROR (parser, "Could not parse Content-Length header.");
             kms_request_str_destroy (key);
             kms_request_str_destroy (val);
@@ -258,7 +258,7 @@ _parse_line (kms_response_parser_t *parser, int end)
    } else if (parser->state == PARSING_CHUNK_LENGTH) {
       int result = 0;
 
-      if (!_parse_hex_from_view (raw + i, end - i, &result)) {
+      if (!_parse_hex_from_view (raw + i, end - i, &result) || result > KMS_PARSER_MAX_RESPONSE_LEN || result < 0) {
          KMS_ERROR (parser, "Failed to parse hex chunk length.");
          return PARSING_DONE;
       }
@@ -280,6 +280,12 @@ kms_response_parser_feed (kms_response_parser_t *parser,
       return kms_kmip_response_parser_feed (parser->kmip, buf, len);
    }
 
+   // As a precaution, limit the maximum size KMS response:
+   if (len > KMS_PARSER_MAX_RESPONSE_LEN || raw->len > KMS_PARSER_MAX_RESPONSE_LEN - len) {
+      KMS_ERROR (parser, "KMS response too large");
+      return false;
+   }
+
    curr = (int) raw->len;
    kms_request_str_append_chars (raw, (char *) buf, len);
    /* process the new data appended. */
@@ -291,6 +297,9 @@ kms_response_parser_feed (kms_response_parser_t *parser,
          /* find the next \r\n. */
          if (curr && strncmp (raw->str + (curr - 1), "\r\n", 2) == 0) {
             parser->state = _parse_line (parser, curr - 1);
+            if (parser->failed) {
+               return false;
+            }
             parser->start = curr + 1;
          }
          curr++;

--- a/src/kms-message/test/test_kmip_reader_writer.c
+++ b/src/kms-message/test/test_kmip_reader_writer.c
@@ -443,6 +443,26 @@ kms_kmip_reader_find_and_recurse_test (void)
    free (data);
 }
 
+void kms_kmip_reader_find_and_recurse_invalid_test (void); // -Wmissing-prototypes: for testing only.
+void
+kms_kmip_reader_find_and_recurse_invalid_test (void)
+{
+   uint8_t *data;
+   size_t datalen;
+   kmip_reader_t *reader;
+
+   // Structure with overly large length:
+   data = hex_to_data (
+      "42 00 20 | 01 | 00 00 00 FF", // Struct with bad length
+      &datalen);
+
+   reader = kmip_reader_new (data, datalen);
+   // Expect error:
+   ASSERT (!kmip_reader_find_and_recurse (reader, KMIP_TAG_CompromiseDate));
+   kmip_reader_destroy (reader);
+   free (data);
+}
+
 void kms_kmip_reader_find_and_read_enum_test (void); // -Wmissing-prototypes: for testing only.
 void
 kms_kmip_reader_find_and_read_enum_test (void)

--- a/src/kms-message/test/test_kms_kmip_response_parser.c
+++ b/src/kms-message/test/test_kms_kmip_response_parser.c
@@ -199,3 +199,53 @@ kms_kmip_response_parser_notenough_test (void)
    kms_response_parser_destroy (parser);
    free (data);
 }
+
+
+void kms_response_parser_response_too_big_test (void); // -Wmissing-prototypes: for testing only.
+void
+kms_response_parser_response_too_big_test (void)
+{
+   uint8_t *data = (uint8_t*) malloc(KMS_PARSER_MAX_RESPONSE_LEN); // 16 MiB
+   memset(data, 0, KMS_PARSER_MAX_RESPONSE_LEN);
+
+   // Test HTTP parser:
+   {
+      kms_response_parser_t *parser = kms_response_parser_new ();
+
+      // Feed max length:
+      {
+         bool ok = kms_response_parser_feed (parser, data, KMS_PARSER_MAX_RESPONSE_LEN);
+         ASSERT (ok);
+      }
+
+      // Feed one more byte:
+      {
+         bool ok = kms_response_parser_feed (parser, data, 1);
+         ASSERT_PARSER_ERROR (parser, "KMS response too large");
+         ASSERT (!ok);
+      }
+
+      kms_response_parser_destroy (parser);
+   }
+
+   // Test KMIP parser:
+   {
+      kms_response_parser_t *parser = kms_kmip_response_parser_new (NULL);
+
+      // Feed max length:
+      {
+         bool ok = kms_response_parser_feed (parser, data, KMS_PARSER_MAX_RESPONSE_LEN);
+         ASSERT (ok);
+      }
+
+      // Feed one more byte:
+      {
+         bool ok = kms_response_parser_feed (parser, data, 1);
+         ASSERT_PARSER_ERROR (parser, "KMS response too large");
+         ASSERT (!ok);
+      }
+
+      kms_response_parser_destroy (parser);
+   }
+   free (data);
+}

--- a/src/kms-message/test/test_kms_request.c
+++ b/src/kms-message/test/test_kms_request.c
@@ -1216,6 +1216,7 @@ extern void kms_kmip_reader_test (void);
 extern void kms_kmip_reader_negative_int_test (void);
 extern void kms_kmip_reader_find_test (void);
 extern void kms_kmip_reader_find_and_recurse_test (void);
+extern void kms_kmip_reader_find_and_recurse_invalid_test (void);
 extern void kms_kmip_reader_find_and_read_enum_test (void);
 extern void kms_kmip_reader_find_and_read_bytes_test (void);
 extern void kms_kmip_request_register_secretdata_test (void);
@@ -1229,6 +1230,7 @@ extern void kms_kmip_response_get_secretdata_notfound_test (void);
 extern void kms_kmip_response_parser_reuse_test (void);
 extern void kms_kmip_response_parser_excess_test (void);
 extern void kms_kmip_response_parser_notenough_test (void);
+extern void kms_response_parser_response_too_big_test (void);
 
 int
 main (int argc, char *argv[])
@@ -1280,6 +1282,7 @@ main (int argc, char *argv[])
    RUN_TEST (kms_kmip_reader_negative_int_test);
    RUN_TEST (kms_kmip_reader_test);
    RUN_TEST (kms_kmip_reader_find_and_recurse_test);
+   RUN_TEST (kms_kmip_reader_find_and_recurse_invalid_test);
    RUN_TEST (kms_kmip_reader_find_and_read_enum_test);
    RUN_TEST (kms_kmip_reader_find_and_read_bytes_test);
    RUN_TEST (kms_kmip_request_register_secretdata_test);
@@ -1294,6 +1297,7 @@ main (int argc, char *argv[])
    RUN_TEST (kms_kmip_response_parser_reuse_test);
    RUN_TEST (kms_kmip_response_parser_excess_test);
    RUN_TEST (kms_kmip_response_parser_notenough_test);
+   RUN_TEST (kms_response_parser_response_too_big_test);
    RUN_TEST (test_request_newlines);
    RUN_TEST (test_kms_util);
 


### PR DESCRIPTION
To include fix to gcc-16 (https://github.com/mongodb/libmongocrypt/pull/1206) identified by https://github.com/mongodb/mongo-c-driver/pull/2354.