### PR TITLE
CDRIVER-6276 add initial AGENTS.md and testing skill

### DIFF
--- a/.agents/skills/running-test-libmongoc/SKILL.md
+++ b/.agents/skills/running-test-libmongoc/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: running-test-libmongoc
+description: Use when running, filtering, or debugging tests in the test-libmongoc executable of the MongoDB C Driver — the custom TestSuite framework in src/libmongoc/tests/TestSuite.h with its own flags (-l, -d, -f), test-naming rules, and JSON spec tests.
+---
+
+# Running `test-libmongoc`
+
+## Overview
+
+`test-libmongoc` is the executable holding most `libmongoc` and `libbson` tests. It uses a **custom** test framework (`src/libmongoc/tests/TestSuite.h`), not a mainstream one, so its invocation, filtering, and test-naming rules are unique. This skill explains how to run and select tests with it.
+
+The executable is excluded from the CMake `ALL` target. Build it first with the `--target` flag:
+
+```bash
+cmake --build cmake-build --target test-libmongoc
+```
+
+## Running tests
+
+Typical invocation:
+
+```bash
+./cmake-build/src/libmongoc/test-libmongoc -d -f -l "<test-name-or-pattern>"
+```
+
+| Flag | Meaning |
+|------|---------|
+| `-l` | Run tests matching a name or pattern. **Repeatable** — pass `-l` multiple times to select several tests in one run. |
+| `-d` | Print debug output. Useful when a test hangs. |
+| `-f` | Do not fork a process per test; abort on the first error. |
+
+Run `./cmake-build/src/libmongoc/test-libmongoc --help` for the full flag list.
+
+### `-l` matching rules
+
+Matching against a test's name (`TestSuite_TestMatchesName` in `TestSuite.c`) is **exact string**, with one exception: a **trailing** `*` makes it a prefix match. There is no other wildcard support.
+
+- `-l "*aggregate"` does **not** work — a `*` is only special as the last character.
+- A trailing `*` is a *prefix* match and over-matches siblings: `-l "/crud/unified/aggregate*"` also matches `/crud/unified/aggregate-let`, `-merge`, etc. To run exactly one test, pass its full name without a `*` (e.g. `-l "/crud/unified/aggregate"`).
+
+## Finding a test's name
+
+A test's registration string may bundle a name and one or more space-separated `[...]` tags. At registration (`_V_TestSuite_AddFull`) the string is **split on the first space**: everything before it is the test's name, and the bracketed tags are stored separately as metadata. **`-l` matches the name only — never include a tag in the pattern.** Names come from one of two places:
+
+1. **The second argument to a `TestSuite_Add*` call.** In `/loadbalanced/connect/single [lock:live-server]`,
+   the name is `/loadbalanced/connect/single` and `[lock:live-server]` is a tag indicating the
+   test needs a live MongoDB server. Match it with `-l "/loadbalanced/connect/single"`.
+2. **A JSON spec test.** Its name is the path starting at (and including) the `/` after
+   `src/libmongoc/tests/json`, with `.json` removed. Spec tests installed via
+   `install_json_test_suite` also get a ` [lock:live-server]` tag appended and a
+   `TestSuite_CheckLive` check, so they require a live server. Example:
+   `src/libmongoc/tests/json/crud/unified/aggregate.json` has the name
+   `/crud/unified/aggregate` (leading `/`, no tag) — match it with `-l "/crud/unified/aggregate"`.
+
+Tip: `test-libmongoc --list-tests` prints every registered test name (all tests, unfiltered; tags are not shown). Pipe it through `grep` to find the exact name to pass to `-l`.
+
+## Registration functions (server requirements)
+
+Tests register with the suite through these functions; which one is used tells you whether a live server is required:
+
+| Function | Requires live server? | Notes |
+|----------|----------------------|-------|
+| `TestSuite_Add` | No | Basic test. |
+| `TestSuite_AddLive` | Yes | Needs a live MongoDB server. |
+| `TestSuite_AddFull` | Depends | May use a context object or skip conditions. |
+
+## Common mistakes
+
+- **Including a `[...]` tag in the `-l` pattern** — tags are metadata, not part of the name; `-l` matches the name only. Use `-l "/crud/unified/aggregate"`, not `-l "/crud/unified/aggregate [lock:live-server]"`.
+- **Dropping the leading `/` from a spec-test name** — the name is `/crud/unified/aggregate`, not `crud/unified/aggregate`. The leading slash is part of the name.
+- **Assuming a trailing `*` matches exactly one test** — it is a prefix match and catches siblings. See the matching rules above.
+- **Using a leading or interior wildcard** — `-l "*aggregate"` will not work; only a trailing `*` is supported.
+- **Forgetting to build the target first** — `test-libmongoc` is not built by the default `ALL` target.
+- **Expecting a fork-per-test by default when debugging** — add `-f` so the run aborts on the first failure instead of continuing, and `-d` to see where a hang occurs.

--- a/.agents/skills/running-test-libmongoc/SKILL.md
+++ b/.agents/skills/running-test-libmongoc/SKILL.md
@@ -36,7 +36,7 @@ Run `./cmake-build/src/libmongoc/test-libmongoc --help` for the full flag list.
 Matching against a test's name (`TestSuite_TestMatchesName` in `TestSuite.c`) is **exact string**, with one exception: a **trailing** `*` makes it a prefix match. There is no other wildcard support.
 
 - `-l "*aggregate"` does **not** work — a `*` is only special as the last character.
-- A trailing `*` is a *prefix* match and over-matches siblings: `-l "/crud/unified/aggregate*"` also matches `/crud/unified/aggregate-let`, `-merge`, etc. To run exactly one test, pass its full name without a `*` (e.g. `-l "/crud/unified/aggregate"`).
+- A trailing `*` is a *prefix* match and over-matches siblings: `-l "/crud/unified/aggregate*"` also matches `/crud/unified/aggregate-let`, `/crud/unified/aggregate-merge`, etc. To run exactly one test, pass its full name without a `*` (e.g. `-l "/crud/unified/aggregate"`).
 
 ## Finding a test's name
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,152 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents working with code in this repository.
+
+## Build System
+
+This project uses CMake.
+
+Use `cmake-build/` as the CMake binary directory unless otherwise specified by the user. When the user specifies a custom binary directory, always use that directory - do not fall back to `cmake-build/`.
+
+> [!IMPORTANT]
+> Despite `build/` being a common choice for a CMake binary directory name, that is not recommended in this repository because the `build/` directory is tracked by Git.
+
+The typical configure and build steps (for release and installation):
+
+```bash
+cmake -D CMAKE_BUILD_TYPE=RelWithDebInfo -B cmake-build
+cmake --build cmake-build
+```
+
+The optional install step:
+
+```bash
+cmake --install cmake-build
+```
+
+> [!IMPORTANT]
+> For multi-configuration generators (e.g. "Visual Studio *", "Ninja Multi-Config", etc.), use `--config <config>` during the build, install, and test steps instead of `CMAKE_BUILD_TYPE=<config>`.
+> The `CMAKE_BUILD_TYPE` option will be ignored by the configuration step.
+> Only use `CMAKE_BUILD_TYPE` with single-configuration generators (e.g. Makefile Generators, Ninja, etc.).
+
+Key CMake configuration options (given `option=(default|alternatives...)`):
+
+- `-G <generator-name>`: specify a build system generator.
+- `-D CMAKE_PREFIX_PATH:PATH=<libmongocrypt-prefix>`: specify installation prefixes to search with `find_*()` CMake commands (e.g., to link with `libmongocrypt`).
+- `-D CMAKE_INSTALL_PREFIX:PATH=<install-prefix>`: install directory used by `install()`. Defaults to:
+  - The `CMAKE_INSTALL_PREFIX` environment variable when set (with CMake 3.29 or newer).
+  - `/usr/local` on UNIX platforms.
+  - `C:/Program Files/${PROJECT_NAME}` on Windows.
+  - Use `cmake-build/install/` as the custom install prefix when system modification is undesirable or disallowed by the user.
+- `-D CMAKE_BUILD_TYPE:STRING=<config>`: specify the build type on single-configuration generators.
+- `-D BUILD_SHARED_LIBS:BOOL=(ON|OFF)`: specify whether to build shared (`ON`) or static (`OFF`) libraries.
+
+**Build performance:** Ninja parallelizes builds across all available cores by default; to cap the job count, set `CMAKE_BUILD_PARALLEL_LEVEL=<N>` in the environment before running `cmake --build`.
+
+> [!NOTE]
+> `.evergreen/scripts/compile.sh` is the authoritative reference for CI configure-build-install routines. Consult it for details on Ninja generator selection, ccache integration, sanitizer flags (`MONGO_SANITIZE`), client-side encryption (`ENABLE_CLIENT_SIDE_ENCRYPTION`), and other platform-specific options.
+
+## Running Tests
+
+The typical configure and build steps for testing:
+
+```bash
+cmake -D CMAKE_BUILD_TYPE=Debug -B cmake-build
+cmake --build cmake-build --target test-libmongoc
+```
+
+> [!IMPORTANT]
+> The "Debug" config type is recommended for local testing and development.
+> If the project was already built with a different build type and the user has not requested a change, preserve the existing `CMAKE_BUILD_TYPE` rather than switching to `Debug`, and advise the user that switching to `Debug` is recommended for local testing and development.
+> This configure step replaces the release/installation configure above - running both is unnecessary when developing.
+
+Test executables are excluded from the `ALL` CMake target, so it is necessary to specify a target with the `--target` flag when building tests. The target `test-libmongoc` contains the majority of the test cases. The target `mongo_c_driver_tests` is a custom CMake target that can be used to build all test executables.
+
+Most tests require a live MongoDB server. Server-dependent tests are skipped when no server is available.
+
+Test executables include:
+
+- `test-libmongoc`: Most of the tests for `libmongoc` and `libbson`. Uses a custom test framework; see the `running-test-libmongoc` skill in `.agents/skills/` for how to build, run, filter, and debug these tests.
+- `test-mongoc-gssapi`: GSSAPI / Kerberos authentication tests. Requires a configured Kerberos environment (via `MONGOC_TEST_GSSAPI_HOST` / `MONGOC_TEST_GSSAPI_USER`) and connects concurrently from multiple threads.
+- `test-sfp`: Connectivity tests against the Atlas Secure Front-End Processor (SFP), exercising unauthenticated, SCRAM, and X.509 auth across baseline, compressed, and Server API variants.
+- `test-mongoc-cache`: End-to-end test for the OCSP response cache (Linux only). Confirms a revoked certificate stays revoked (TLS handshake keeps failing) from the cached OCSP response even after the OCSP responder is replaced with a valid one; it pauses itself with `SIGSTOP` so the harness can swap responders between connection attempts.
+- `test-azurekms`: Client-Side Field Level Encryption (CSFLE) test for automatic Azure KMS credentials. Creates a data key with an empty `azure` KMS provider so credentials are obtained from the Azure VM-assigned managed identity. Must run on a configured Azure VM.
+- `test-gcpkms`: CSFLE test for automatic GCP KMS credentials. Creates a data key with an empty `gcp` KMS provider so credentials are obtained from a GCP attached service account. Must run on a configured GCP VM.
+- `test-awsauth`: `MONGODB-AWS` authentication mechanism tests, intended to run within an AWS ECS task or EC2 instance.
+
+## Architecture
+
+The repository provides several public, private, and vendored libraries, each under `src/`:
+
+### Public Libraries
+
+#### `libbson`
+
+A public standalone BSON document library with no MongoDB dependency.
+
+#### `libmongoc`
+
+The public MongoDB C Driver. Depends on the `libbson` library.
+
+#### `kms-message`
+
+A library used to generate requests for Amazon Web Services Key Management Service (KMS) and Azure Key Vault.
+
+### Private Libraries
+
+#### `mlib` (found under `src/common/src/mlib`)
+
+Facilities for checked arithmetic, macros, date/time, integer utilities, OS headers, strings, testing, and vector containers. Used by both `libbson` and `libmongoc`. Header only.
+
+#### `common`
+
+Provides various utilities such as concurrency primitives and JSON serialization. Technically not a library, but a collection of private headers and source files that are compiled with both `libbson` and `libmongoc`.
+
+### Vendored Third-Party Libraries
+
+There are several third-party libraries in the repository source tree to enable self-contained builds:
+
+| Repository | Source Tree Location (where `<version>` is a placeholder for the version number) |
+|---|---|
+| https://github.com/mnunberg/jsonsl | `src/libbson/src/jsonsl` |
+| https://github.com/JuliaStrings/utf8proc | `src/utf8proc-<version>` |
+| https://github.com/troydhanson/uthash | `src/uthash/uthash-<version>` |
+| https://github.com/madler/zlib | `src/zlib-<version>` |
+
+### C Standard
+
+Uses C99. Contributions shall not use features from newer standards.
+
+## Documentation
+
+Documentation is authored as separate `.rst` files under `src/libbson/doc` and `src/libmongoc/doc`, and generated with Sphinx. There is a document for each public API type (e.g., `src/libmongoc/doc/mongoc_client_t.rst`) and function (e.g., `src/libmongoc/doc/mongoc_client_new.rst`).
+
+To build `libmongoc` documentation from a fresh environment with warnings treated as errors:
+
+```bash
+uv run --frozen sphinx-build -WEn src/libmongoc/doc src/libmongoc/doc/html
+```
+
+Replace `libmongoc` with `libbson` in the above command for `libbson` documentation.
+
+## Before Committing
+
+Always format before committing:
+
+```bash
+uv run --frozen tools/format.py           # C/C++ source files.
+uv run --frozen tools/ruff-format-all.sh  # Python scripts.
+uv run --frozen tools/shfmt-format-all.sh # Shell scripts.
+```
+
+`--frozen` ensures the pinned lockfile is used; if it fails with a lockfile error, update it with `uv sync`.
+
+## Contributing
+
+See `CONTRIBUTING.md` for guidance on:
+
+- Indentation
+- Error codes and domains
+- API/ABI policy
+- Documentation
+- In-depth testing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,7 @@ Documentation is authored as separate `.rst` files under `src/libbson/doc` and `
 To build `libmongoc` documentation from a fresh environment with warnings treated as errors:
 
 ```bash
-uv run --frozen sphinx-build -WEn src/libmongoc/doc src/libmongoc/doc/html
+uv run --frozen sphinx-build -j auto -WEn src/libmongoc/doc src/libmongoc/doc/html
 ```
 
 Replace `libmongoc` with `libbson` in the above command for `libbson` documentation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ The public MongoDB C Driver. Depends on the `libbson` library.
 
 #### `kms-message`
 
-A library used to generate requests for Amazon Web Services Key Management Service (KMS) and Azure Key Vault.
+A library used to create signed Amazon Web Services (AWS) requests for the `MONGODB-AWS` auth mechanism.
 
 #### `mlib` (found under `src/common/src/mlib`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ cmake --build cmake-build --target test-libmongoc
 > This configure step replaces the release/installation configure above - running both is unnecessary when developing.
 
 > [!IMPORTANT]
-> For multi-configuration generators (e.g. "Visual Studio *", "Ninja Multi-Config"), executables appear under a `<config>/` subdirectory (e.g. `cmake-build/src/bsoncxx/test/Debug/test-libmongoc`).
+> For multi-configuration generators (e.g., "Visual Studio *", "Ninja Multi-Config"), executables appear under a `<config>/` subdirectory (e.g., `cmake-build/src/bsoncxx/test/Debug/test-libmongoc`).
 
 Test executables are excluded from the `ALL` CMake target, so it is necessary to specify a target with the `--target` flag when building tests. The target `test-libmongoc` contains the majority of the test cases. The target `mongo_c_driver_tests` is a custom CMake target that can be used to build all test executables.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,8 +139,6 @@ uv run --frozen tools/ruff-format-all.sh  # Python scripts.
 uv run --frozen tools/shfmt-format-all.sh # Shell scripts.
 ```
 
-`--frozen` ensures the pinned lockfile is used; if it fails with a lockfile error, update it with `uv sync`.
-
 ## Contributing
 
 See `CONTRIBUTING.md` for guidance on:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,9 @@ cmake --build cmake-build --target test-libmongoc
 > If the project was already built with a different build type and the user has not requested a change, preserve the existing `CMAKE_BUILD_TYPE` rather than switching to `Debug`, and advise the user that switching to `Debug` is recommended for local testing and development.
 > This configure step replaces the release/installation configure above - running both is unnecessary when developing.
 
+> [!IMPORTANT]
+> For multi-configuration generators (e.g. "Visual Studio *", "Ninja Multi-Config"), executables appear under a `<config>/` subdirectory (e.g. `cmake-build/src/bsoncxx/test/Debug/test-libmongoc`).
+
 Test executables are excluded from the `ALL` CMake target, so it is necessary to specify a target with the `--target` flag when building tests. The target `test-libmongoc` contains the majority of the test cases. The target `mongo_c_driver_tests` is a custom CMake target that can be used to build all test executables.
 
 Most tests require a live MongoDB server. Server-dependent tests are skipped when no server is available.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,11 +91,11 @@ A public standalone BSON document library with no MongoDB dependency.
 
 The public MongoDB C Driver. Depends on the `libbson` library.
 
+### Private Libraries
+
 #### `kms-message`
 
 A library used to generate requests for Amazon Web Services Key Management Service (KMS) and Azure Key Vault.
-
-### Private Libraries
 
 #### `mlib` (found under `src/common/src/mlib`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ cmake --build cmake-build --target test-libmongoc
 > This configure step replaces the release/installation configure above - running both is unnecessary when developing.
 
 > [!IMPORTANT]
-> For multi-configuration generators (e.g., "Visual Studio *", "Ninja Multi-Config"), executables appear under a `<config>/` subdirectory (e.g., `cmake-build/src/bsoncxx/test/Debug/test-libmongoc`).
+> For multi-configuration generators (e.g., "Visual Studio *", "Ninja Multi-Config"), executables appear under a `<config>/` subdirectory (e.g., `cmake-build/src/libmongoc/Debug/test-libmongoc`).
 
 Test executables are excluded from the `ALL` CMake target, so it is necessary to specify a target with the `--target` flag when building tests. The target `test-libmongoc` contains the majority of the test cases. The target `mongo_c_driver_tests` is a custom CMake target that can be used to build all test executables.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ cmake --build cmake-build --target test-libmongoc
 
 Test executables are excluded from the `ALL` CMake target, so it is necessary to specify a target with the `--target` flag when building tests. The target `test-libmongoc` contains the majority of the test cases. The target `mongo_c_driver_tests` is a custom CMake target that can be used to build all test executables.
 
-Most tests require a live MongoDB server. Server-dependent tests are skipped when no server is available.
+Most tests require a live MongoDB server. Server-dependent tests may be skipped with the environment variable `MONGOC_TEST_SKIP_LIVE`.
 
 Test executables include:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -337,7 +337,7 @@ Though Evergreen logs are private, avoid logging any sensitive data. This is int
 
 #### Configuring the test runner
 
-The test runner can be configured with command-line options. Run `test-libmongoc --help` for details. Agents should refer to to the `running-test-libmongoc` skill under `.agents/skills` for more details on how to build, run, filter, and debug tests.
+The test runner can be configured with command-line options. Run `test-libmongoc --help` for details. Agents should refer to the `running-test-libmongoc` skill under `.agents/skills` for more details on how to build, run, filter, and debug tests.
 
 To run just a specific portion of the test suite use the -l option like so:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -337,8 +337,7 @@ Though Evergreen logs are private, avoid logging any sensitive data. This is int
 
 #### Configuring the test runner
 
-The test runner can be configured with command-line options. Run `test-libmongoc
---help` for details.
+The test runner can be configured with command-line options. Run `test-libmongoc --help` for details. Agents should refer to to the `running-test-libmongoc` skill under `.agents/skills` for more details on how to build, run, filter, and debug tests.
 
 To run just a specific portion of the test suite use the -l option like so:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ Set the user and password environment variables, then build and run the tests:
 ```
 $ export MONGOC_TEST_USER=bob
 $ export MONGOC_TEST_PASSWORD=pwd123
-$ ./test-libmongoc
+$ ./cmake-build/src/libmongoc/test-libmongoc
 ```
 
 Additional environment variables:
@@ -343,7 +343,7 @@ The test runner can be configured with command-line options. Run `test-libmongoc
 To run just a specific portion of the test suite use the -l option like so:
 
 ```
-$ ./test-libmongoc -l "/server_selection/*"
+$ ./cmake-build/src/libmongoc/test-libmongoc -l "/server_selection/*"
 ```
 
 The full list of tests is shown in the help.


### PR DESCRIPTION
CDRIVER-6276

# Summary

This PR adds an initial AGENTS.md, CLAUDE.md, and a skill for `test-libmongoc`.

## AGENTS.md

The AGENTS.md for this repo is based heavily on the AGENTS.md for the C++ Driver (CXX-3440). Some of the content is copied verbatim where applicable.

Some points of note, particularly in contrast to the AGENTS.md for the C++ Driver:

- Advises using the directory `cmake-build/` as a CMake binary directory by default since the `build/` directory is tracked by Git.
- Suggests using the `test-libmongoc` target by default rather than `mongo_c_driver_tests` (the custom CMake target that builds all tests) since the other tests are more niche and require specific environments.
- Refers to the newly added SKILL.md for `test-libmongoc`, keeping documentation in AGENTS.md minimal.
- Documents private and vendored libraries in the architecture section to clarify the potentially confusing structure of `src/`.
- Points to `CONTRIBUTING.md` for code guidelines since we lack a single coding guidelines document unlike the C++ Driver (though we may want to consider drafting a better document in the future).
- Includes a documentation section to briefly describe how to author and build public API docs.

### Evaluation

Similar to what was done for CXX-3440, evaluation was performed by asking agents (both Claude and OpenCode) to do some basic tasks involving exploration, development, building, and testing. Agents were generally able to understand the project, build it using the specific recommendations, and run tests by loading the `running-test-libmongoc` skill.

## CLAUDE.md

Claude does not automatically load AGENTS.md, so this PR adds a CLAUDE.md that simply points to AGENTS.md.

## SKILL.md: running-test-libmongoc

Agents can struggle to build and run tests in `test-libmongoc` due to the unique nature of the test runner. To better enable agents to work with our test suite, this PR adds a SKILL.md to instruct agents on how to build, run, filter, and debug tests. This skill was validated by Claude spawning subagents with and without the skill. The points in the "common mistakes" section come from Claude's own observations of mistakes made by subagents. The SKILL.md was partially written using the "superpowers:writing-skills" skill.

### Evaluation

Evaluation was performed by spawning agents to build and run certain tests, which included running:

- A spec test by only referring to its `.json` path relative to the project root to validate that the agent understands how spec test paths correspond to test names.
- A set of spec tests or non-spec tests (e.g., `/uri/*`) to validate that the agent understands how the limited wildcard matching works.
- A test that includes the live server tag to ensure the agent does not try to include the tag in the test name.
- Mulitple tests to verify the use of the `-l` (`--match`) argument more than once rather than misuing wildcard matching.

## CONTRIBUTING.md

This PR makes minor edits to CONTRIBUTING.md to refer to the new testing skill and maintain consistency with AGENTS.md.