### PR TITLE
fix scan-build null pointer arithmetic findings

### DIFF
--- a/.evergreen/scripts/compile-scan-build.sh
+++ b/.evergreen/scripts/compile-scan-build.sh
@@ -165,6 +165,13 @@ fi
 # If scan-build emits warnings, continue the task and upload scan results before marking task as a failure.
 declare -r continue_command='{"status":"failed", "type":"test", "should_continue":true, "desc":"scan-build emitted one or more warnings or errors"}'
 
+# Exclude the vendored copy of utf8proc from the reported findings. Its "pass a null buffer to measure the required
+# size" idiom trips core.NullPointerArithm, and it is third-party code that we do not patch locally. The value is
+# matched as a regular expression against the directory of each report, so use a relative fragment: the analyzer
+# records paths under /Users/ec2-user/data, while the build runs from the equivalent /data path on macOS hosts.
+declare -r scan_build_excludes=("--exclude" 'src/utf8proc-2\.8\.0')
+
 # Put clang static analyzer results in scan/ and fail build if warnings found.
-"${scan_build_binary}" --use-cc="${CC}" --use-c++="${CXX}" -o scan --status-bugs cmake --build . -- -j "$(nproc)" ||
+"${scan_build_binary}" --use-cc="${CC}" --use-c++="${CXX}" -o scan --status-bugs "${scan_build_excludes[@]}" \
+  cmake --build . -- -j "$(nproc)" ||
   curl -sS -d "${continue_command}" -H "Content-Type: application/json" -X POST localhost:2285/task_status

--- a/.evergreen/scripts/compile-scan-build.sh
+++ b/.evergreen/scripts/compile-scan-build.sh
@@ -165,11 +165,10 @@ fi
 # If scan-build emits warnings, continue the task and upload scan results before marking task as a failure.
 declare -r continue_command='{"status":"failed", "type":"test", "should_continue":true, "desc":"scan-build emitted one or more warnings or errors"}'
 
-# Exclude the vendored copy of utf8proc from the reported findings. Its "pass a null buffer to measure the required
-# size" idiom trips core.NullPointerArithm, and it is third-party code that we do not patch locally. The value is
-# matched as a regular expression against the directory of each report, so use a relative fragment: the analyzer
-# records paths under /Users/ec2-user/data, while the build runs from the equivalent /data path on macOS hosts.
-declare -r scan_build_excludes=("--exclude" 'src/utf8proc-2\.8\.0')
+# Exclude the vendored copy of utf8proc from the reported findings. It is third-party code that we
+# do not patch locally. The value is matched as a regular expression against the directory of each
+# report, so use a relative fragment.
+declare -r scan_build_excludes=("--exclude" 'src/utf8proc-')
 
 # Put clang static analyzer results in scan/ and fail build if warnings found.
 "${scan_build_binary}" --use-cc="${CC}" --use-c++="${CXX}" -o scan --status-bugs "${scan_build_excludes[@]}" \

--- a/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
@@ -900,8 +900,7 @@ _mongoc_validate_and_derive_region(char *sts_fqdn, size_t sts_fqdn_len, char **r
    if (ptr) {
       second_part = ptr + 1;
    }
-   /* Compare the pointers rather than subtracting them: `ptr` is null when the host contains no ".", and pointer
-    * subtraction from a null pointer is undefined. */
+   // Check if `.` is the first character in the string, indicating an empty part to start
    if (ptr == sts_fqdn) {
       AUTH_ERROR_AND_FAIL("invalid STS host: empty part");
    }

--- a/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
@@ -900,7 +900,9 @@ _mongoc_validate_and_derive_region(char *sts_fqdn, size_t sts_fqdn_len, char **r
    if (ptr) {
       second_part = ptr + 1;
    }
-   if (0 == ptr - sts_fqdn) {
+   /* Compare the pointers rather than subtracting them: `ptr` is null when the host contains no ".", and pointer
+    * subtraction from a null pointer is undefined. */
+   if (ptr == sts_fqdn) {
       AUTH_ERROR_AND_FAIL("invalid STS host: empty part");
    }
    while (ptr) {

--- a/src/libmongoc/tests/test-mongoc-aws.c
+++ b/src/libmongoc/tests/test-mongoc-aws.c
@@ -214,6 +214,11 @@ test_derive_region(void *unused)
    ASSERT_ERROR_CONTAINS(error, MONGOC_ERROR_CLIENT, MONGOC_ERROR_CLIENT_AUTHENTICATE, "Invalid STS host: empty part");
    bson_free(region);
 
+   ret = _mongoc_validate_and_derive_region(WITH_LEN(".abc"), &region, &error);
+   ASSERT(!ret);
+   ASSERT_ERROR_CONTAINS(error, MONGOC_ERROR_CLIENT, MONGOC_ERROR_CLIENT_AUTHENTICATE, "Invalid STS host: empty part");
+   bson_free(region);
+
    ret = _mongoc_validate_and_derive_region(WITH_LEN("..."), &region, &error);
    ASSERT(!ret);
    ASSERT_ERROR_CONTAINS(error, MONGOC_ERROR_CLIENT, MONGOC_ERROR_CLIENT_AUTHENTICATE, "Invalid STS host: empty part");


### PR DESCRIPTION
## Problem

`scan-build-macos-14-arm64-clang` on the `scan-build-matrix` variant has been failing intermittently on `master` since ~2026-06-22, and on every run since 2026-07-17. It reports `scan-build: 3 bugs found`, all `core.NullPointerArithm`.

## Root cause: analyzer version drift, not a code change

No commit introduced this. The result correlates exactly with which Homebrew LLVM the macOS host happens to have installed:

| Version order | Revision | Analyzer | Result |
|---|---|---|---|
| 6133 (2026-07-21) | `fe6d8116d2` | `llvm/22.1.7_1/bin/clang-22` | 3 bugs |
| 6130 (2026-07-16) | `9655909e15` | `llvm/21.1.8/bin/clang-21` | No bugs found |
| 6110 (2026-06-22) | `8715412609` | `llvm/22.1.7_1/bin/clang-22` | same 3 bugs |

`core.NullPointerArithm` is new in clang 22, and `.evergreen/scripts/compile-scan-build.sh` resolves `scan-build` dynamically from `PATH`/Homebrew with no version pin.

## Changes

**1. Real bug — `_mongoc_validate_and_derive_region`.** `0 == ptr - sts_fqdn` subtracts from a null pointer whenever the STS host contains no `.` at all (`ptr` is the result of `strstr(sts_fqdn, ".")`). The check means "the host begins with a `.`", so compare the pointers instead. `ptr == sts_fqdn` is well defined for a null `ptr` and evaluates false — exactly the fall-through the UB happens to produce today.

**2. Test.** Existing cases already pin the behavior the fix must preserve (`"."` → error, `"first"` → `us-east-1`). Added `".abc"`, the case the comparison directly encodes.

**3. utf8proc exclusion.** The other two findings are in vendored `src/utf8proc-2.8.0/utf8proc.c` (lines 368, 554), which uses the upstream "pass a null buffer to measure the required size" idiom. Rather than patching third-party sources, exclude the directory via `scan-build --exclude`.

`--exclude` has existed since LLVM 7 and is present in scan-build 12, covering the oldest variant in the matrix (`scan-build-ubuntu2204-clang-12-i686`).

Known cosmetic limitation: exclusion is a post-hoc report filter, so the two utf8proc `warning:` lines still appear in the build log. The task passes.

## Not addressed here

The underlying fragility is that the scan-build task pins no analyzer version, so its results shift under the CI hosts. Pinning a Homebrew LLVM version is a separate change; this PR only clears the current findings.

Note: The task failures in the PR build are related to SERVER-132246, not related to any changes in this PR.
