### PR TITLE
Fix NULL pointer dereference in SCRAM auth after unchecked bson_malloc

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-scram.c
+++ b/src/libmongoc/src/mongoc/mongoc-scram.c
@@ -635,6 +635,10 @@ _mongoc_scram_step2(mongoc_scram_t *scram,
       }
 
       *current_val = (uint8_t *)bson_malloc(*current_val_len + 1);
+      if (!*current_val) {
+         *current_val_len = 0u;
+         return false;
+      }
       memcpy(*current_val, ptr, *current_val_len);
       (*current_val)[*current_val_len] = '\0';
 
@@ -905,6 +909,10 @@ _mongoc_scram_step3(mongoc_scram_t *scram,
       }
 
       *current_val = (uint8_t *)bson_malloc(*current_val_len + 1);
+      if (!*current_val) {
+         *current_val_len = 0u;
+         return false;
+      }
       memcpy(*current_val, ptr, *current_val_len);
       (*current_val)[*current_val_len] = '\0';
 


### PR DESCRIPTION
## Summary

Add NULL pointer checks after `bson_malloc` in `_mongoc_scram_step2` and `_mongoc_scram_step3` to prevent a potential NULL pointer dereference (segfault) on memory allocation failure.

## Details

In SCRAM authentication, the server SASL response is parsed and field values are dynamically allocated via `bson_malloc`. If `bson_malloc` fails (e.g., memory exhaustion or an attacker sending an abnormally large SASL response), the returned NULL pointer is used immediately in `memcpy` without a NULL check.

## Fix

Add NULL checks after both `bson_malloc` calls, returning `false` to gracefully fail authentication.

## Risk

Low. This is a defense-in-depth fix. Failing gracefully is preferable to crashing in a library used by long-running server processes.