### PR TITLE
[CDRIVER-6411] Add support for aws sts regional endpoint

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-cluster-aws-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-aws-private.h
@@ -134,4 +134,7 @@ _mongoc_aws_credentials_cleanup(_mongoc_aws_credentials_t *creds);
 bool
 _mongoc_validate_and_derive_region(char *sts_fqdn, size_t sts_fqdn_len, char **region, bson_error_t *error);
 
+char *
+_mongoc_get_aws_sts_endpoint(void);
+
 #endif /* MONGOC_CLUSTER_AWS_PRIVATE_H */

--- a/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
+++ b/src/libmongoc/src/mongoc/mongoc-cluster-aws.c
@@ -460,6 +460,7 @@ _obtain_creds_from_assumerolewithwebidentity(_mongoc_aws_credentials_t *creds, b
    mongoc_stream_t *fstream = NULL;
    mcommon_string_t *token_file_contents = NULL;
    char *path_and_query = NULL;
+   char *sts_endpoint = NULL;
 
    aws_web_identity_token_file = _mongoc_getenv("AWS_WEB_IDENTITY_TOKEN_FILE");
    aws_role_arn = _mongoc_getenv("AWS_ROLE_ARN");
@@ -522,9 +523,10 @@ _obtain_creds_from_assumerolewithwebidentity(_mongoc_aws_credentials_t *creds, b
                                        aws_role_arn,
                                        MSTR_FMT(jwt_token));
 
-   // send an HTTP request to sts.amazonaws.com.
+   sts_endpoint = _mongoc_get_aws_sts_endpoint();
+
    if (!_send_http_request(true /* use_tls */,
-                           "sts.amazonaws.com",
+                           sts_endpoint,
                            443,
                            "POST",
                            path_and_query,
@@ -532,13 +534,14 @@ _obtain_creds_from_assumerolewithwebidentity(_mongoc_aws_credentials_t *creds, b
                            &http_response_body,
                            &http_response_headers,
                            &http_error)) {
-      AUTH_ERROR_AND_FAIL("failed to contact sts.amazonaws.com: %s", http_error.message);
+      AUTH_ERROR_AND_FAIL("failed to contact %s: %s", sts_endpoint, http_error.message);
    }
 
    response_bson = bson_new_from_json((const uint8_t *)http_response_body, strlen(http_response_body), error);
    if (!response_bson) {
-      AUTH_ERROR_AND_FAIL("invalid JSON in response from sts.amazonaws.com. "
+      AUTH_ERROR_AND_FAIL("invalid JSON in response from %s. "
                           "Response headers: %s",
+                          sts_endpoint,
                           http_response_headers);
    }
 
@@ -572,32 +575,33 @@ _obtain_creds_from_assumerolewithwebidentity(_mongoc_aws_credentials_t *creds, b
                                   &iter)) {
       AUTH_ERROR_AND_FAIL("did not find "
                           "AssumeRoleWithWebIdentityResponse.AssumeRoleWithWebIdentityResult."
-                          "Credentials in response from sts.amazonaws.com.");
+                          "Credentials in response from %s.",
+                          sts_endpoint);
    }
 
    if (!bson_iter_recurse(&iter, &Credentials_iter)) {
-      AUTH_ERROR_AND_FAIL("Unable to recurse in Credentials in response from sts.amazonaws.com");
+      AUTH_ERROR_AND_FAIL("Unable to recurse in Credentials in response from %s", sts_endpoint);
    }
 
    iter = Credentials_iter;
    if (bson_iter_find(&iter, "AccessKeyId") && BSON_ITER_HOLDS_UTF8(&iter)) {
       access_key_id = bson_iter_utf8(&iter, NULL);
    } else {
-      AUTH_ERROR_AND_FAIL("did not find AccessKeyId in response from sts.amazonaws.com");
+      AUTH_ERROR_AND_FAIL("did not find AccessKeyId in response from %s", sts_endpoint);
    }
 
    iter = Credentials_iter;
    if (bson_iter_find(&iter, "SecretAccessKey") && BSON_ITER_HOLDS_UTF8(&iter)) {
       secret_access_key = bson_iter_utf8(&iter, NULL);
    } else {
-      AUTH_ERROR_AND_FAIL("did not find SecretAccessKey in response from sts.amazonaws.com");
+      AUTH_ERROR_AND_FAIL("did not find SecretAccessKey in response from %s", sts_endpoint);
    }
 
    iter = Credentials_iter;
    if (bson_iter_find(&iter, "SessionToken") && BSON_ITER_HOLDS_UTF8(&iter)) {
       session_token = bson_iter_utf8(&iter, NULL);
    } else {
-      AUTH_ERROR_AND_FAIL("did not find SessionToken in response from sts.amazonaws.com");
+      AUTH_ERROR_AND_FAIL("did not find SessionToken in response from %s", sts_endpoint);
    }
 
    iter = Credentials_iter;
@@ -611,7 +615,7 @@ _obtain_creds_from_assumerolewithwebidentity(_mongoc_aws_credentials_t *creds, b
       }
       creds->expiration.set = true;
    } else {
-      AUTH_ERROR_AND_FAIL("did not find Expiration in response from sts.amazonaws.com");
+      AUTH_ERROR_AND_FAIL("did not find Expiration in response from %s", sts_endpoint);
    }
 
    if (!_validate_and_set_creds(access_key_id, secret_access_key, session_token, creds, error)) {
@@ -620,6 +624,7 @@ _obtain_creds_from_assumerolewithwebidentity(_mongoc_aws_credentials_t *creds, b
 
    ret = true;
 fail:
+   bson_free(sts_endpoint);
    bson_free(path_and_query);
    bson_destroy(response_bson);
    bson_free(http_response_headers);
@@ -748,6 +753,27 @@ fail:
    bson_free(relative_ecs_uri);
    bson_free(path_with_role);
    return ret;
+}
+
+char *
+_mongoc_get_aws_sts_endpoint(void)
+{
+   char *aws_region = _mongoc_getenv("AWS_REGION");
+   char *aws_sts_regional_endpoints = _mongoc_getenv("AWS_STS_REGIONAL_ENDPOINTS");
+   char *sts_endpoint;
+
+   // Use the regional endpoint only when explicitly requested by the AWS SDK
+   // endpoint-selection contract. Otherwise, retain the global endpoint.
+   if (aws_sts_regional_endpoints && 0 == strcmp(aws_sts_regional_endpoints, "regional") && aws_region &&
+       strlen(aws_region) > 0) {
+      sts_endpoint = bson_strdup_printf("sts.%s.amazonaws.com", aws_region);
+   } else {
+      sts_endpoint = bson_strdup("sts.amazonaws.com");
+   }
+
+   bson_free(aws_sts_regional_endpoints);
+   bson_free(aws_region);
+   return sts_endpoint;
 }
 
 /*
@@ -1264,6 +1290,12 @@ _mongoc_validate_and_derive_region(char *sts_fqdn, size_t sts_fqdn_len, char **r
                        "ENABLE_MONGODB_AWS_AUTH=ON");
 fail:
    return false;
+}
+
+char *
+_mongoc_get_aws_sts_endpoint(void)
+{
+   return bson_strdup("sts.amazonaws.com");
 }
 
 #endif /* MONGOC_ENABLE_MONGODB_AWS_AUTH */

--- a/src/libmongoc/tests/test-mongoc-aws.c
+++ b/src/libmongoc/tests/test-mongoc-aws.c
@@ -193,6 +193,32 @@ test_obtain_credentials_from_env(void *unused)
 }
 
 static void
+test_sts_endpoint(void *unused)
+{
+   char *sts_endpoint;
+
+   BSON_UNUSED(unused);
+
+   _mongoc_setenv("AWS_STS_REGIONAL_ENDPOINTS", "");
+   _mongoc_setenv("AWS_REGION", "us-gov-west-1");
+   sts_endpoint = _mongoc_get_aws_sts_endpoint();
+   ASSERT_CMPSTR(sts_endpoint, "sts.amazonaws.com");
+   bson_free(sts_endpoint);
+
+   _mongoc_setenv("AWS_STS_REGIONAL_ENDPOINTS", "regional");
+   sts_endpoint = _mongoc_get_aws_sts_endpoint();
+   ASSERT_CMPSTR(sts_endpoint, "sts.us-gov-west-1.amazonaws.com");
+   bson_free(sts_endpoint);
+
+   _mongoc_setenv("AWS_REGION", "");
+   sts_endpoint = _mongoc_get_aws_sts_endpoint();
+   ASSERT_CMPSTR(sts_endpoint, "sts.amazonaws.com");
+   bson_free(sts_endpoint);
+
+   _mongoc_setenv("AWS_STS_REGIONAL_ENDPOINTS", "");
+}
+
+static void
 test_derive_region(void *unused)
 {
    bson_error_t error;
@@ -359,6 +385,13 @@ test_aws_install(TestSuite *suite)
                      test_framework_skip_if_no_setenv);
    TestSuite_AddFull(
       suite, "/aws/derive_region", test_derive_region, NULL /* dtor */, NULL /* ctx */, test_framework_skip_if_no_aws);
+   TestSuite_AddFull(suite,
+                     "/aws/sts_endpoint",
+                     test_sts_endpoint,
+                     NULL /* dtor */,
+                     NULL /* ctx */,
+                     test_framework_skip_if_no_aws,
+                     test_framework_skip_if_no_setenv);
    TestSuite_AddFull(
       suite, "/aws/cache", test_aws_cache, NULL /* dtor */, NULL /* ctx */, test_framework_skip_if_no_aws);
 }


### PR DESCRIPTION
Similar to a proposal here https://github.com/mongodb/mongo-go-driver/pull/2376

The default STS endpoint `sts.amazonaws.com` does not work in AWS Gov cloud, as stated in the documentation https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-iam.html:
> - In the AWS GovCloud (US) Regions, there is no AWS STS global endpoint. AWS provides Regional AWS STS endpoints.
> - When using the IAM or AWS STS service in AWS GovCloud (US), you must use [AWS GovCloud (US)IAM/AWS STS endpoints](https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/using-govcloud-endpoints.html). Use SSL (HTTPS) when you make calls to the IAM or AWS STS service in AWS GovCloud (US) Regions.

Since the driver was hardcoding the global sts endpoint, this driver wouldn't work when using IAM with IRSA (in EKS pods).

Also adding the option to enable/disable the feature with and environmental variable as per the documentation https://docs.aws.amazon.com/sdkref/latest/guide/feature-sts-regionalized-endpoints.html

For this new code to have effect, these environmental variables need to be set
```
AWS_STS_REGIONAL_ENDPOINTS=regional
AWS_REGION='your region'
```

The ideal solution would be to adapt the code to use the official aws sdk, so it can delegate all types of aws authentication. That would also add support for Pod Identity. But it's a major refactorization, like what's being done in https://github.com/mongodb/mongo-go-driver/pull/2508. That is also the pattern being followed by [Python](https://www.mongodb.com/docs/languages/python/pymongo-driver/current/security/authentication/aws-iam/#using-aws-iam-authentication-in-your-application) and [Java](https://www.mongodb.com/docs/drivers/java/sync/current/security/auth/aws-iam/#use-aws-sdk-for-java)

The Go solution was to use the Factory to register a custom authenticator, but that doesn't seem to be a possibility in this codebase. Adapting the code to be able to use a regional sts endpoint is the simplest way to support AWS Gov cloud.