### PR TITLE
Fix wrong comments in headers and source files

### DIFF
--- a/src/common/src/common-thread-private.h
+++ b/src/common/src/common-thread-private.h
@@ -48,7 +48,7 @@ BSON_BEGIN_DECLS
 #define BSON_THREAD_FUN_TYPE(_function_name) void *(*(_function_name))(void *)
 #define BSON_THREAD_RETURN return NULL
 
-/* this macro can be defined as a as a build configuration option
+/* this macro can be defined as a build configuration option
  * with -DENABLE_DEBUG_ASSERTIONS=ON.  its purpose is to allow for functions
  * that require a mutex to be locked on entry to assert that the mutex
  * is actually locked.

--- a/src/common/src/mlib/ckdint.h
+++ b/src/common/src/mlib/ckdint.h
@@ -13,7 +13,7 @@
  * - `mlib_narrow(Dst, V)` (not from stdckdint, but defined as `mlib_add(Dst, V, 0)`)
  *
  * Where `Dst` is a pointer to integral storage, and `L` and `R` are arbitrary
- * integral expressions. The two-argument variants treat `Dst` as the the left-hand
+ * integral expressions. The two-argument variants treat `Dst` as the left-hand
  * operand for in-place arithmetic.
  *
  * Each macro accepts arguments of arbitrary type at any position, and will "do

--- a/src/common/src/mlib/time_point.h
+++ b/src/common/src/mlib/time_point.h
@@ -205,7 +205,7 @@ mlib_time_difference(mlib_time_point stop, mlib_time_point start)
  * @param t The time point to be inspected
  * @return mlib_duration If `t` is in the past, returns the duration of time
  * that has elapsed since that point-in-time. If `t` is in the future, returns
- * a negative time representing the amount of time that be be waited until we
+ * a negative time representing the amount of time that be waited until we
  * reach `t`.
  */
 static inline mlib_duration

--- a/src/libmongoc/src/mongoc/mcd-rpc.c
+++ b/src/libmongoc/src/mongoc/mcd-rpc.c
@@ -378,7 +378,7 @@ _consume_op_msg_section(
       // (section length). Actual minimum length would also account for the
       // identifier field, but 4 bytes is sufficient to avoid unsigned integer
       // overflow when computing `remaining_section_bytes` and to encourage as
-      // much progress is made parsing input data as able.
+      // much progress is made parsing input data as possible.
       if (mlib_cmp(section.payload.document_sequence.section_len, <, sizeof(int32_t))) {
          *ptr -= sizeof(int32_t); // Revert so *data_end points to start of
                                   // document sequence as invalid input.

--- a/src/libmongoc/src/mongoc/mcd-rpc.h
+++ b/src/libmongoc/src/mongoc/mcd-rpc.h
@@ -310,7 +310,7 @@ mcd_rpc_op_msg_section_set_kind(mcd_rpc_message *rpc, size_t index, uint8_t kind
 // Set the length of the OP_MSG document sequence section at the given index.
 //
 // Note: the section length of an OP_MSG body section is equal to the length
-// of the single BSON object, thus does not require a seperate setter.
+// of the single BSON object, thus does not require a separate setter.
 //
 // The msgHeader.opCode field MUST equal MONGOC_OP_CODE_MSG.
 // The given index MUST be a valid index into the OP_MSG sections array.
@@ -330,7 +330,7 @@ mcd_rpc_op_msg_section_set_identifier(mcd_rpc_message *rpc, size_t index, const 
 // Set the BSON object for the OP_MSG body section at the given index.
 //
 // Note: the section length of an OP_MSG body section is equal to the length
-// of the single BSON object, thus does not require a seperate setter.
+// of the single BSON object, thus does not require a separate setter.
 //
 // The msgHeader.opCode field MUST equal MONGOC_OP_CODE_MSG.
 // The given index MUST be a valid index into the OP_MSG sections array.

--- a/src/libmongoc/src/mongoc/mongoc-stream-tls.c
+++ b/src/libmongoc/src/mongoc/mongoc-stream-tls.c
@@ -130,7 +130,7 @@ mongoc_stream_tls_handshake_block(mongoc_stream_t *stream, const char *host, int
 // mongoc_stream_tls_new_with_hostname creates a TLS stream.
 //
 // base_stream: underlying data stream. Ownership is transferred to the returned stream on success.
-// host: hostname used to verify the the server certificate.
+// host: hostname used to verify the server certificate.
 // opt: TLS options.
 // client: indicates a client or server stream. Secure Channel implementation does not support server streams.
 //
@@ -174,7 +174,7 @@ mongoc_stream_tls_new_with_hostname(mongoc_stream_t *base_stream, const char *ho
 // This is an internal extension to mongoc_stream_tls_new_with_hostname.
 //
 // base_stream: underlying data stream. Ownership is transferred to the returned stream on success.
-// host: hostname used to verify the the server certificate.
+// host: hostname used to verify the server certificate.
 // opt: TLS options.
 // client: indicates a client or server stream.
 // ssl_ctx: shared context.

--- a/src/libmongoc/src/mongoc/mongoc-ts-pool.c
+++ b/src/libmongoc/src/mongoc/mongoc-ts-pool.c
@@ -78,7 +78,7 @@ _pool_node_data_offset(const mongoc_ts_pool *pool)
 
 /**
  * @brief Allocate a pool_node object with the appropriate flexible array member
- * length to accomodate the alignment and size of the element type.
+ * length to accommodate the alignment and size of the element type.
  */
 static pool_node *
 _pool_node_new(const mongoc_ts_pool *pool)

--- a/src/libmongoc/src/mongoc/service-gcp.h
+++ b/src/libmongoc/src/mongoc/service-gcp.h
@@ -83,7 +83,7 @@ gcp_request_destroy(gcp_request *req);
 /**
  * @brief Destroy and zero-fill GCP service account token
  *
- * @param token The service account token to destory
+ * @param token The service account token to destroy
  */
 void
 gcp_access_token_destroy(gcp_service_account_token *token);

--- a/src/libmongoc/tests/test-mongoc-retryable-writes.c
+++ b/src/libmongoc/tests/test-mongoc-retryable-writes.c
@@ -1324,7 +1324,7 @@ retryable_writes_prose_test_6_case_1(void *ctx)
    }));
 
    // Step 3: Via the command monitoring CommandFailedEvent, configure a fail point with error code `10107`
-   // (NotWritablePrimary). Configure the `10107` fail point command only if the the failed event is for the `91` error
+   // (NotWritablePrimary). Configure the `10107` fail point command only if the failed event is for the `91` error
    // configured in step 2.
    prose_test_6_case_1_to_3_apm_ctx_t apm_ctx = {.first_fail_point_error_code = 91u,
                                                  .second_fail_point_cmd_str = BSON_STR({
@@ -1370,7 +1370,7 @@ retryable_writes_prose_test_6_case_2(void *ctx)
    }));
 
    // Step 3: Via the command monitoring CommandFailedEvent, configure a fail point with error code `10107`
-   // (NotWritablePrimary) and a NoWritesPerformed label. Configure the `10107` fail point command only if the the
+    // (NotWritablePrimary) and a NoWritesPerformed label. Configure the `10107` fail point command only if the
    // failed event is for the `91` error configured in step 2.
    prose_test_6_case_1_to_3_apm_ctx_t apm_ctx = {
       .first_fail_point_error_code = 91u,

--- a/src/libmongoc/tests/test-mongoc-write-commands.c
+++ b/src/libmongoc/tests/test-mongoc-write-commands.c
@@ -378,7 +378,7 @@ test_disconnect_mid_batch(void)
    coll = mongoc_client_get_collection(client, "db", "coll");
 
    future = future_collection_insert_many(coll, (const bson_t **)docs, n_docs, NULL, NULL, &error);
-   /* Mock server recieves first insert. */
+   /* Mock server receives first insert. */
    request = mock_server_receives_request(server);
    BSON_ASSERT(request);
    reply_to_request_with_hang_up(request);


### PR DESCRIPTION
## Summary

Correct several spelling mistakes and repeated words found in comments across headers and source files.

## Changes

| File | Original | Corrected |
|---|---|---|
| `src/libmongoc/tests/test-mongoc-write-commands.c` | recieves | receives |
| `src/libmongoc/src/mongoc/mcd-rpc.h` | seperate | separate |
| `src/libmongoc/src/mongoc/mongoc-ts-pool.c` | accomodate | accommodate |
| `src/libmongoc/src/mongoc/service-gcp.h` | destory | destroy |
| `src/common/src/mlib/ckdint.h` | the the | the |
| `src/libmongoc/src/mongoc/mongoc-stream-tls.c` | the the | the |
| `src/libmongoc/tests/test-mongoc-retryable-writes.c` | the the | the |
| `src/common/src/common-thread-private.h` | a as a | as a |
| `src/common/src/mlib/time_point.h` | be be | be |
| `src/libmongoc/src/mongoc/mcd-rpc.c` | as able | as possible |

10 files changed, 13 lines. All changes are comment-only; no code logic is affected.