### PR TITLE
CDRIVER-6353 CDRIVER-6374 client backpressure with baseBackoffMS

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,7 @@ libmongoc 2.4.0 [UNRELEASED]
 
 * The Queryable Encryption "String" algorithm (`MONGOC_ENCRYPT_ALGORITHM_STRING`) is now generally available, supporting `prefix`, `suffix`, and `substring` query types.
   * The `prefixPreview`, `suffixPreview`, and `substringPreview` query types remains experimental.
+* Honor the server-supplied `baseBackoffMS` on responses labeled `SystemOverloadedError`, using it in place of the driver's default base delay when calculating how long to wait before retrying.
 
 libmongoc 2.3.3
 ===============

--- a/src/libmongoc/src/mongoc/mongoc-client-session.c
+++ b/src/libmongoc/src/mongoc/mongoc-client-session.c
@@ -986,7 +986,6 @@ mongoc_client_session_with_transaction(mongoc_client_session_t *session,
 
    const mongoc_retry_backoff_params_t retry_backoff_params = {
       .growth_factor = MONGOC_WITH_TRANSACTION_RETRY_BACKOFF_GROWTH_FACTOR,
-      .backoff_initial = MONGOC_WITH_TRANSACTION_RETRY_BACKOFF_INITIAL,
       .backoff_max = MONGOC_WITH_TRANSACTION_RETRY_BACKOFF_MAX,
    };
 
@@ -1006,7 +1005,8 @@ mongoc_client_session_with_transaction(mongoc_client_session_t *session,
       if (is_first_attempt) {
          is_first_attempt = false;
       } else {
-         const mlib_duration backoff_duration = _mongoc_retry_backoff_generator_next(retry_backoff_generator);
+         const mlib_duration backoff_duration = _mongoc_retry_backoff_generator_next(
+            retry_backoff_generator, MONGOC_WITH_TRANSACTION_RETRY_BACKOFF_INITIAL);
 
          const mlib_timer backoff_timer = mlib_expires_after(backoff_duration);
 

--- a/src/libmongoc/src/mongoc/mongoc-handshake-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-handshake-private.h
@@ -30,6 +30,10 @@ BSON_BEGIN_DECLS
 
 #define HANDSHAKE_BACKPRESSURE_FIELD "backpressure"
 
+// The version of the Client Backpressure specification supported by this driver. Must be sent as a UTF-8 string, not as
+// a number.
+#define HANDSHAKE_BACKPRESSURE_VERSION "2"
+
 #define HANDSHAKE_FIELD "client"
 #define HANDSHAKE_PLATFORM_FIELD "platform"
 

--- a/src/libmongoc/src/mongoc/mongoc-handshake-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-handshake-private.h
@@ -29,7 +29,6 @@
 BSON_BEGIN_DECLS
 
 #define HANDSHAKE_BACKPRESSURE_FIELD "backpressure"
-
 // The version of the Client Backpressure specification supported by this driver. Must be sent as a UTF-8 string, not as
 // a number.
 #define HANDSHAKE_BACKPRESSURE_VERSION "2"

--- a/src/libmongoc/src/mongoc/mongoc-retry-backoff-generator-private.h
+++ b/src/libmongoc/src/mongoc/mongoc-retry-backoff-generator-private.h
@@ -25,7 +25,6 @@
 
 typedef struct {
    double growth_factor;
-   mlib_duration backoff_initial;
    mlib_duration backoff_max;
 } mongoc_retry_backoff_params_t;
 
@@ -37,8 +36,11 @@ _mongoc_retry_backoff_generator_new(mongoc_retry_backoff_params_t params, mongoc
 void
 _mongoc_retry_backoff_generator_destroy(mongoc_retry_backoff_generator_t *generator);
 
+// `_mongoc_retry_backoff_generator_next` advances to the next attempt and returns its backoff. `backoff_base` is
+// supplied per attempt because a server may attach a `baseBackoffMS` to an individual error to replace the driver's
+// default base backoff. See the Client Backpressure specification. `backoff_base` must be positive.
 mlib_duration
-_mongoc_retry_backoff_generator_next(mongoc_retry_backoff_generator_t *generator);
+_mongoc_retry_backoff_generator_next(mongoc_retry_backoff_generator_t *generator, mlib_duration backoff_base);
 
 void
 _mongoc_retry_backoff_generator_skip(mongoc_retry_backoff_generator_t *generator);

--- a/src/libmongoc/src/mongoc/mongoc-retry-backoff-generator.c
+++ b/src/libmongoc/src/mongoc/mongoc-retry-backoff-generator.c
@@ -94,8 +94,8 @@ _mongoc_retry_backoff_generator_next(mongoc_retry_backoff_generator_t *generator
 
    const mongoc_retry_backoff_params_t *const params = &generator->params;
 
-   // `pow` may overflow to INFINITY, so clamp to `backoff_max` before converting to a duration: casting an
-   // out-of-range double to an integer type is undefined behavior.
+   // May overflow to INFINITY, so clamp to `backoff_max` before converting to a duration: casting an out-of-range
+   // double to an integer type is undefined behavior.
    const double backoff_us =
       fmin((double)mlib_microseconds_count(params->backoff_max),
            (double)mlib_microseconds_count(backoff_base) * pow(params->growth_factor, (double)generator->attempt));

--- a/src/libmongoc/src/mongoc/mongoc-retry-backoff-generator.c
+++ b/src/libmongoc/src/mongoc/mongoc-retry-backoff-generator.c
@@ -21,20 +21,27 @@
 
 #include <math.h>
 
+// MONGOC_RETRY_BACKOFF_BASE_MIN is the smallest positive base backoff representable by mlib_duration, and therefore the
+// smallest a caller can supply. It bounds the attempt counter: for any positive base backoff, backoff saturates to
+// `backoff_max` at or before the attempt cap, so incrementing the counter beyond that cannot change a result.
+#define MONGOC_RETRY_BACKOFF_BASE_MIN mlib_duration(1, us)
+#define MONGOC_DURATION_ZERO mlib_duration()
+
 struct _mongoc_retry_backoff_generator_t {
    int attempt;
-   int max_attempt;
+   int attempt_cap;
    mongoc_retry_backoff_params_t params;
    mongoc_jitter_source_t *jitter_source;
 };
 
+// _compute_attempt_cap returns the lowest attempt at which a MONGOC_RETRY_BACKOFF_BASE_MIN base backoff saturates to
+// `backoff_max`.
 static int
-_compute_max_attempt(mongoc_retry_backoff_params_t params)
+_compute_attempt_cap(mongoc_retry_backoff_params_t params)
 {
    return (int)ceil(log((double)mlib_microseconds_count(params.backoff_max) /
-                        (double)mlib_microseconds_count(params.backoff_initial)) /
-                    log(params.growth_factor)) +
-          1;
+                        (double)mlib_microseconds_count(MONGOC_RETRY_BACKOFF_BASE_MIN)) /
+                    log(params.growth_factor));
 }
 
 mongoc_retry_backoff_generator_t *
@@ -42,12 +49,17 @@ _mongoc_retry_backoff_generator_new(mongoc_retry_backoff_params_t params, mongoc
 {
    BSON_ASSERT_PARAM(jitter_source);
 
+   // Keep the attempt cap computation well-defined: `log(growth_factor)` is zero or negative for a growth factor of 1.0
+   // or less, and `log(backoff_max)` is negative infinity for a zero `backoff_max`.
+   BSON_ASSERT(params.growth_factor > 1.0);
+   BSON_ASSERT(mlib_duration_cmp(params.backoff_max, >, MONGOC_DURATION_ZERO));
+
    mongoc_retry_backoff_generator_t *const generator =
       (mongoc_retry_backoff_generator_t *)bson_malloc(sizeof(mongoc_retry_backoff_generator_t));
 
    *generator = (mongoc_retry_backoff_generator_t){
       .attempt = 0,
-      .max_attempt = _compute_max_attempt(params),
+      .attempt_cap = _compute_attempt_cap(params),
       .params = params,
       .jitter_source = jitter_source,
    };
@@ -61,22 +73,18 @@ _mongoc_retry_backoff_generator_destroy(mongoc_retry_backoff_generator_t *genera
    bson_free(generator);
 }
 
-static mlib_duration
-_duration_double_multiply(mlib_duration duration, double factor)
-{
-   return mlib_duration((mlib_duration_rep_t)round((double)mlib_microseconds_count(duration) * factor), us);
-}
-
 static void
 _increment_attempt(mongoc_retry_backoff_generator_t *generator)
 {
-   generator->attempt = BSON_MIN(generator->attempt + 1, generator->max_attempt);
+   generator->attempt = BSON_MIN(generator->attempt + 1, generator->attempt_cap);
 }
 
 mlib_duration
-_mongoc_retry_backoff_generator_next(mongoc_retry_backoff_generator_t *generator)
+_mongoc_retry_backoff_generator_next(mongoc_retry_backoff_generator_t *generator, mlib_duration backoff_base)
 {
    BSON_ASSERT_PARAM(generator);
+
+   BSON_ASSERT(mlib_duration_cmp(backoff_base, >, MONGOC_DURATION_ZERO));
 
    _increment_attempt(generator);
 
@@ -86,13 +94,13 @@ _mongoc_retry_backoff_generator_next(mongoc_retry_backoff_generator_t *generator
 
    const mongoc_retry_backoff_params_t *const params = &generator->params;
 
-   if (generator->attempt >= generator->max_attempt) {
-      return _duration_double_multiply(params->backoff_max, jitter);
-   }
+   // `pow` may overflow to INFINITY, so clamp to `backoff_max` before converting to a duration: casting an
+   // out-of-range double to an integer type is undefined behavior.
+   const double backoff_us =
+      fmin((double)mlib_microseconds_count(params->backoff_max),
+           (double)mlib_microseconds_count(backoff_base) * pow(params->growth_factor, (double)generator->attempt));
 
-   const double backoff_factor = pow(params->growth_factor, (double)generator->attempt - 1);
-
-   return _duration_double_multiply(params->backoff_initial, jitter * backoff_factor);
+   return mlib_duration((mlib_duration_rep_t)round(backoff_us * jitter), us);
 }
 
 void

--- a/src/libmongoc/src/mongoc/mongoc-retryable-cmd.c
+++ b/src/libmongoc/src/mongoc/mongoc-retryable-cmd.c
@@ -23,8 +23,28 @@
 #include <mlib/time_point.h>
 
 #define MONGOC_RETRYABLE_CMD_BACKOFF_GROWTH_FACTOR 2.0
-#define MONGOC_RETRYABLE_CMD_BACKOFF_INITIAL mlib_duration(100, ms)
+#define MONGOC_RETRYABLE_CMD_BACKOFF_BASE_DEFAULT mlib_duration(100, ms)
 #define MONGOC_RETRYABLE_CMD_BACKOFF_MAX mlib_duration(10, s)
+
+// _get_base_backoff returns the base backoff to apply for an overload error. A server may attach a positive
+// `baseBackoffMS` to the error to replace the driver's default base backoff. The returned duration is always positive.
+static mlib_duration
+_get_base_backoff(const bson_t *reply)
+{
+   BSON_ASSERT_PARAM(reply);
+
+   bson_iter_t iter;
+
+   if (bson_iter_init_find(&iter, reply, "baseBackoffMS") && BSON_ITER_HOLDS_INT(&iter)) {
+      const int64_t base_backoff_ms = bson_iter_as_int64(&iter);
+
+      if (base_backoff_ms > 0) {
+         return mlib_duration(base_backoff_ms, ms);
+      }
+   }
+
+   return MONGOC_RETRYABLE_CMD_BACKOFF_BASE_DEFAULT;
+}
 
 bool
 _mongoc_retryable_cmd_run(const mongoc_retryable_cmd_t *cmd, bson_t *reply, bson_error_t *error)
@@ -46,7 +66,6 @@ _mongoc_retryable_cmd_run(const mongoc_retryable_cmd_t *cmd, bson_t *reply, bson
 
    const mongoc_retry_backoff_params_t retry_backoff_params = {
       .growth_factor = MONGOC_RETRYABLE_CMD_BACKOFF_GROWTH_FACTOR,
-      .backoff_initial = MONGOC_RETRYABLE_CMD_BACKOFF_INITIAL,
       .backoff_max = MONGOC_RETRYABLE_CMD_BACKOFF_MAX,
    };
 
@@ -95,7 +114,8 @@ _mongoc_retryable_cmd_run(const mongoc_retryable_cmd_t *cmd, bson_t *reply, bson
       }
 
       if (is_overload) {
-         const mlib_duration backoff_duration = _mongoc_retry_backoff_generator_next(retry_backoff_generator);
+         const mlib_duration backoff_duration =
+            _mongoc_retry_backoff_generator_next(retry_backoff_generator, _get_base_backoff(reply));
          mlib_sleep_for(backoff_duration);
       } else {
          _mongoc_retry_backoff_generator_skip(retry_backoff_generator);

--- a/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
+++ b/src/libmongoc/src/mongoc/mongoc-topology-scanner.c
@@ -321,7 +321,7 @@ _build_handshake_cmd(const mongoc_handshake_t *handshake,
       bson_destroy(doc);
       return NULL;
    }
-   BSON_APPEND_BOOL(doc, HANDSHAKE_BACKPRESSURE_FIELD, true);
+   BSON_APPEND_UTF8(doc, HANDSHAKE_BACKPRESSURE_FIELD, HANDSHAKE_BACKPRESSURE_VERSION);
    bson_append_document(doc, HANDSHAKE_FIELD, -1, handshake_doc);
    bson_destroy(handshake_doc);
 

--- a/src/libmongoc/tests/test-client-backpressure.c
+++ b/src/libmongoc/tests/test-client-backpressure.c
@@ -555,11 +555,11 @@ test_backpressure_prose_1(void *ctx)
    // Step 3.5: Execute step 3.3 again.
    const mlib_duration with_backoff_duration = backpressure_prose_1_step_3_3(collection);
 
-   // Step 3.6: Compare the time between the two runs. The sum of 2 backoffs is 0.3 seconds. There is a 0.3-second
+   // Step 3.6: Compare the time between the two runs. The sum of 2 backoffs is 0.6 seconds. There is a 0.6-second
    // window to account for potential variance between the two runs.
-   const mlib_duration diff = mlib_duration(with_backoff_duration, minus, (no_backoff_duration, plus, (300, ms)));
+   const mlib_duration diff = mlib_duration(with_backoff_duration, minus, (no_backoff_duration, plus, (600, ms)));
    const mlib_duration abs_diff = mlib_duration(imaxabs(mlib_microseconds_count(diff)), us);
-   ASSERT_CMPDURATION(abs_diff, <, mlib_duration(300, ms));
+   ASSERT_CMPDURATION(abs_diff, <, mlib_duration(600, ms));
 
    disable_fail_point();
 

--- a/src/libmongoc/tests/test-client-backpressure.c
+++ b/src/libmongoc/tests/test-client-backpressure.c
@@ -715,6 +715,134 @@ test_backpressure_prose_4(void *ctx)
    mongoc_client_destroy(client);
 }
 
+typedef struct {
+   int insert_failed_count;
+   bool base_backoff_ms_is_set;
+   int64_t base_backoff_ms;
+} base_backoff_ms_observer_ctx_t;
+
+// prose_test_5_command_failed_cb records whether the server attached `baseBackoffMS` to a failed `insert` reply.
+static void
+prose_test_5_command_failed_cb(const mongoc_apm_command_failed_t *event)
+{
+   base_backoff_ms_observer_ctx_t *const ctx =
+      (base_backoff_ms_observer_ctx_t *)mongoc_apm_command_failed_get_context(event);
+
+   if (strcmp(mongoc_apm_command_failed_get_command_name(event), "insert") != 0) {
+      return;
+   }
+
+   ctx->insert_failed_count++;
+
+   bson_iter_t iter;
+   if (bson_iter_init_find(&iter, mongoc_apm_command_failed_get_reply(event), "baseBackoffMS") &&
+       BSON_ITER_HOLDS_NUMBER(&iter)) {
+      ctx->base_backoff_ms = bson_iter_as_int64(&iter);
+      ctx->base_backoff_ms_is_set = true;
+   }
+}
+
+// backpressure_prose_5_step_5 inserts the document `{ a: 1 }`, expects the command to error, and measures the duration
+// of the command execution.
+static mlib_duration
+backpressure_prose_5_step_5(mongoc_collection_t *collection)
+{
+   const mlib_time_point start = mlib_now();
+
+   bson_error_t error;
+   ASSERT(!mongoc_collection_insert_one(collection, tmp_bson("{'a': 1}"), NULL, NULL, &error));
+   ASSERT(error.domain == MONGOC_ERROR_QUERY);
+
+   return mlib_elapsed_since(start);
+}
+
+static void
+backpressure_prose_5_set_external_client_base_backoff_ms(int value)
+{
+   char *const cmd = bson_strdup_printf("{'setParameter': 1, 'externalClientBaseBackoffMS': %d}", value);
+   run_admin_command(cmd);
+   bson_free(cmd);
+}
+
+static void
+test_backpressure_prose_5(void *ctx)
+{
+   BSON_UNUSED(ctx);
+
+   // Step 1: Let `client` be a `mongoc_client_t`.
+   mongoc_client_t *client = NULL;
+   {
+      mongoc_uri_t *const uri = test_framework_get_uri();
+      mongoc_uri_set_option_as_bool(uri, MONGOC_URI_RETRYWRITES, true);
+
+      client = test_framework_client_new_from_uri(uri, NULL);
+
+      mongoc_uri_destroy(uri);
+   }
+   test_framework_set_ssl_opts(client);
+
+   base_backoff_ms_observer_ctx_t apm_ctx = {0};
+
+   {
+      mongoc_apm_callbacks_t *const callbacks = mongoc_apm_callbacks_new();
+      mongoc_apm_set_command_failed_cb(callbacks, prose_test_5_command_failed_cb);
+      mongoc_client_set_apm_callbacks(client, callbacks, &apm_ctx);
+      mongoc_apm_callbacks_destroy(callbacks);
+   }
+
+   // Step 2: Let `coll` be a collection.
+   mongoc_collection_t *const coll = mongoc_client_get_collection(client, "db", "coll");
+
+   // Step 3: Configure the random number generator used for exponential backoff jitter to always return a number as
+   // close as possible to `1`.
+   _mongoc_client_set_jitter_source(client, _mongoc_jitter_source_new(always_1_jitter_source_generate));
+
+   // Step 4: Configure a failPoint to trigger with `SystemOverloadedError` and `RetryableError` labels on `insert`.
+   run_admin_command(BSON_STR({
+      "configureFailPoint" : "failCommand",
+      "mode" : "alwaysOn",
+      "data" : {
+         "failCommands" : ["insert"],
+         "errorCode" : 462, // IngressRequestRateLimitExceeded
+         "errorLabels" : [ "SystemOverloadedError", "RetryableError" ]
+      }
+   }));
+
+   // Step 5: Insert the document `{ a: 1 }`. Expect that the command errors. Measure the duration of the command
+   // execution.
+   const mlib_duration exponential_backoff_duration = backpressure_prose_5_step_5(coll);
+
+   // Only the replies observed during step 7 are relevant to step 8.
+   apm_ctx = (base_backoff_ms_observer_ctx_t){0};
+
+   // Step 6: Set up `baseBackoffMS` on overload errors.
+   backpressure_prose_5_set_external_client_base_backoff_ms(50);
+
+   // Step 7: Execute step 5 again.
+   const mlib_duration with_base_backoff_ms_duration = backpressure_prose_5_step_5(coll);
+
+   // Step 9: Disable `baseBackoffMS` on overload errors. Performed before the assertions of steps 8 so that server
+   // state is restored even when an assertion aborts the test.
+   backpressure_prose_5_set_external_client_base_backoff_ms(0);
+   disable_fail_point();
+
+   // Step 8: Assert that the server attached `baseBackoffMS` to the error and that the driver parsed it. That the
+   // driver parsed the value is observable in the backoff durations asserted by step 10.
+   ASSERT_CMPINT(apm_ctx.insert_failed_count, >, 0);
+   ASSERT_WITH_MSG(apm_ctx.base_backoff_ms_is_set, "server did not attach `baseBackoffMS` to the overload error");
+   ASSERT_CMPINT64(apm_ctx.base_backoff_ms, ==, INT64_C(50));
+
+   // Step 10: Assert absolute bounds on each run's duration. A run can never be faster than the sum of its backoffs.
+   // With jitter pinned to 1, the default backoffs are `0.2 + 0.4 = 0.6s` and the `baseBackoffMS=50` backoffs are
+   // `0.1 + 0.2 = 0.3s`.
+   ASSERT_CMPDURATION(exponential_backoff_duration, >=, mlib_duration(600, ms));
+   ASSERT_CMPDURATION(with_base_backoff_ms_duration, >=, mlib_duration(300, ms));
+   ASSERT_CMPDURATION(with_base_backoff_ms_duration, <, mlib_duration(600, ms));
+
+   mongoc_collection_destroy(coll);
+   mongoc_client_destroy(client);
+}
+
 static void
 test_backpressure_max_adaptive_retries_0(void *ctx)
 {
@@ -967,6 +1095,14 @@ test_backpressure_install(TestSuite *suite)
                      NULL,
                      NULL,
                      test_framework_skip_if_max_wire_version_less_than_9 /* Require server 4.3.1+ for `errorLabels` */);
+
+   TestSuite_AddFull(
+      suite,
+      "/backpressure/prose_test_5",
+      test_backpressure_prose_5,
+      NULL,
+      NULL,
+      test_framework_skip_if_max_wire_version_less_than_29 /* Require server 9.0+ for `baseBackoffMS` */);
 
    TestSuite_AddFull(suite,
                      "/backpressure/max_adaptive_retries_zero",

--- a/src/libmongoc/tests/test-client-backpressure.c
+++ b/src/libmongoc/tests/test-client-backpressure.c
@@ -770,16 +770,7 @@ test_backpressure_prose_5(void *ctx)
    BSON_UNUSED(ctx);
 
    // Step 1: Let `client` be a `mongoc_client_t`.
-   mongoc_client_t *client = NULL;
-   {
-      mongoc_uri_t *const uri = test_framework_get_uri();
-      mongoc_uri_set_option_as_bool(uri, MONGOC_URI_RETRYWRITES, true);
-
-      client = test_framework_client_new_from_uri(uri, NULL);
-
-      mongoc_uri_destroy(uri);
-   }
-   test_framework_set_ssl_opts(client);
+   mongoc_client_t *const client = test_framework_new_default_client();
 
    base_backoff_ms_observer_ctx_t apm_ctx = {0};
 

--- a/src/libmongoc/tests/test-mongoc-handshake.c
+++ b/src/libmongoc/tests/test-mongoc-handshake.c
@@ -1383,8 +1383,8 @@ test_mongoc_handshake_includes_backpressure_version(void)
    ASSERT(bson_iter_init_find(&iter, request_doc, HANDSHAKE_BACKPRESSURE_FIELD));
    // The value MUST be the string "2", not a literal number 2.
    ASSERT_WITH_MSG(BSON_ITER_HOLDS_UTF8(&iter),
-                   "expected \"" HANDSHAKE_BACKPRESSURE_FIELD "\" to hold a UTF-8 string, got type %d",
-                   (int)bson_iter_type(&iter));
+                   "expected \"" HANDSHAKE_BACKPRESSURE_FIELD "\" to hold a UTF-8 string, got type %s",
+                   _mongoc_bson_type_to_str(bson_iter_type(&iter)));
    uint32_t len;
    const char *const value = bson_iter_utf8(&iter, &len);
    ASSERT_CMPUINT32(len, ==, 1u);

--- a/src/libmongoc/tests/test-mongoc-handshake.c
+++ b/src/libmongoc/tests/test-mongoc-handshake.c
@@ -1361,10 +1361,10 @@ test_mongoc_handshake_cpp(void)
    bson_destroy(handshake);
 }
 
-// Prose test 9 in the Handshake spec validates the presence of the backpressure flag, but we instead use a mock server
-// test because the C Driver lacks a mechanism for inspecting handshake documents sent to the server.
+// Prose test 9 in the Handshake spec validates the presence of the backpressure version, but we instead use a mock
+// server test because the C Driver lacks a mechanism for inspecting handshake documents sent to the server.
 static void
-test_mongoc_handshake_includes_backpressure_flag(void)
+test_mongoc_handshake_includes_backpressure_version(void)
 {
    mock_server_t *const server = mock_server_new();
    mock_server_run(server);
@@ -1381,8 +1381,14 @@ test_mongoc_handshake_includes_backpressure_flag(void)
    ASSERT(bson_has_field(request_doc, HANDSHAKE_BACKPRESSURE_FIELD));
    bson_iter_t iter;
    ASSERT(bson_iter_init_find(&iter, request_doc, HANDSHAKE_BACKPRESSURE_FIELD));
-   ASSERT(BSON_ITER_HOLDS_BOOL(&iter));
-   ASSERT(bson_iter_bool(&iter));
+   // The value MUST be the string "2", not a literal number 2.
+   ASSERT_WITH_MSG(BSON_ITER_HOLDS_UTF8(&iter),
+                   "expected \"" HANDSHAKE_BACKPRESSURE_FIELD "\" to hold a UTF-8 string, got type %d",
+                   (int)bson_iter_type(&iter));
+   uint32_t len;
+   const char *const value = bson_iter_utf8(&iter, &len);
+   ASSERT_CMPUINT32(len, ==, 1u);
+   ASSERT_CMPSTR(value, "2");
 
    reply_to_request_simple(request, "{'ok': 1, 'isWritablePrimary': true}");
 
@@ -2524,7 +2530,7 @@ test_handshake_install(TestSuite *suite)
                      test_framework_skip_if_no_setenv);
    TestSuite_Add(suite, "/MongoDB/handshake/includes_c++", test_mongoc_handshake_cpp);
    TestSuite_AddMockServerTest(
-      suite, "/MongoDB/handshake/includes_backpressure_flag", test_mongoc_handshake_includes_backpressure_flag);
+      suite, "/MongoDB/handshake/includes_backpressure_version", test_mongoc_handshake_includes_backpressure_version);
 
    TestSuite_AddMockServerTest(
       suite, "/MongoDB/handshake/metadata_append/single/case_1", test_handshake_metadata_append_single_case_1);

--- a/src/libmongoc/tests/test-mongoc-retry-backoff-generator.c
+++ b/src/libmongoc/tests/test-mongoc-retry-backoff-generator.c
@@ -64,7 +64,6 @@ test_retry_backoff_generator(void)
 {
    const mongoc_retry_backoff_params_t backoff_params = {
       .growth_factor = 2.0,
-      .backoff_initial = mlib_duration(100, ms),
       .backoff_max = mlib_duration(10, s),
    };
 
@@ -74,11 +73,12 @@ test_retry_backoff_generator(void)
       mongoc_retry_backoff_generator_t *const generator =
          _mongoc_retry_backoff_generator_new(backoff_params, jitter_source);
 
+      const mlib_duration base_backoff = mlib_duration(100, ms);
       const mlib_duration duration_zero = mlib_duration();
 
-      ASSERT_CMPDURATION(_mongoc_retry_backoff_generator_next(generator), ==, duration_zero);
-      ASSERT_CMPDURATION(_mongoc_retry_backoff_generator_next(generator), ==, duration_zero);
-      ASSERT_CMPDURATION(_mongoc_retry_backoff_generator_next(generator), ==, duration_zero);
+      ASSERT_CMPDURATION(_mongoc_retry_backoff_generator_next(generator, base_backoff), ==, duration_zero);
+      ASSERT_CMPDURATION(_mongoc_retry_backoff_generator_next(generator, base_backoff), ==, duration_zero);
+      ASSERT_CMPDURATION(_mongoc_retry_backoff_generator_next(generator, base_backoff), ==, duration_zero);
 
       _mongoc_retry_backoff_generator_destroy(generator);
       _mongoc_jitter_source_destroy(jitter_source);
@@ -90,16 +90,23 @@ test_retry_backoff_generator(void)
       mongoc_retry_backoff_generator_t *const generator =
          _mongoc_retry_backoff_generator_new(backoff_params, jitter_source);
 
-      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator), mlib_duration(50, ms));
-      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator), mlib_duration(100, ms));
-      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator), mlib_duration(200, ms));
-      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator), mlib_duration(400, ms));
-      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator), mlib_duration(800, ms));
-      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator), mlib_duration(1600, ms));
-      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator), mlib_duration(3200, ms));
-      // After 8 retries, backoff should saturate to 5s (BACKOFF_MAX * 0.5).
-      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator), mlib_duration(5, s));
-      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator), mlib_duration(5, s));
+      const mlib_duration base_backoff = mlib_duration(100, ms);
+
+      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator, base_backoff),
+                                   mlib_duration(100, ms));
+      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator, base_backoff),
+                                   mlib_duration(200, ms));
+      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator, base_backoff),
+                                   mlib_duration(400, ms));
+      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator, base_backoff),
+                                   mlib_duration(800, ms));
+      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator, base_backoff),
+                                   mlib_duration(1600, ms));
+      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator, base_backoff),
+                                   mlib_duration(3200, ms));
+      // On the 7th attempt, backoff should saturate to 5s (BACKOFF_MAX * 0.5).
+      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator, base_backoff), mlib_duration(5, s));
+      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator, base_backoff), mlib_duration(5, s));
 
       _mongoc_retry_backoff_generator_destroy(generator);
       _mongoc_jitter_source_destroy(jitter_source);
@@ -111,16 +118,69 @@ test_retry_backoff_generator(void)
       mongoc_retry_backoff_generator_t *const generator =
          _mongoc_retry_backoff_generator_new(backoff_params, jitter_source);
 
-      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator), mlib_duration(100, ms));
-      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator), mlib_duration(200, ms));
-      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator), mlib_duration(400, ms));
-      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator), mlib_duration(800, ms));
-      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator), mlib_duration(1600, ms));
-      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator), mlib_duration(3200, ms));
-      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator), mlib_duration(6400, ms));
-      // After 8 retries, backoff should saturate to 10s.
-      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator), mlib_duration(10, s));
-      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator), mlib_duration(10, s));
+      const mlib_duration base_backoff = mlib_duration(100, ms);
+
+      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator, base_backoff),
+                                   mlib_duration(200, ms));
+      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator, base_backoff),
+                                   mlib_duration(400, ms));
+      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator, base_backoff),
+                                   mlib_duration(800, ms));
+      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator, base_backoff),
+                                   mlib_duration(1600, ms));
+      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator, base_backoff),
+                                   mlib_duration(3200, ms));
+      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator, base_backoff),
+                                   mlib_duration(6400, ms));
+      // On the 7th attempt, backoff should saturate to 10s.
+      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator, base_backoff), mlib_duration(10, s));
+      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator, base_backoff), mlib_duration(10, s));
+
+      _mongoc_retry_backoff_generator_destroy(generator);
+      _mongoc_jitter_source_destroy(jitter_source);
+   }
+
+   // jitter = 1.0, variable base backoff
+   {
+      mongoc_jitter_source_t *const jitter_source = _mongoc_jitter_source_new(always_1_jitter_source_generate);
+      mongoc_retry_backoff_generator_t *const generator =
+         _mongoc_retry_backoff_generator_new(backoff_params, jitter_source);
+
+      // Attempt 1 with 100ms base backoff: 100ms * 2^1 = 200ms.
+      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator, mlib_duration(100, ms)),
+                                   mlib_duration(200, ms));
+
+      // Attempt 2 with 50ms base backoff: 50ms * 2^2 = 200ms.
+      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator, mlib_duration(50, ms)),
+                                   mlib_duration(200, ms));
+
+      // Attempt 3 with 400ms base backoff: 400ms * 2^3 = 3200ms.
+      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator, mlib_duration(400, ms)),
+                                   mlib_duration(3200, ms));
+
+      // Attempt 4 with 800ms base backoff: 800ms * 2^4 = 12800ms (saturates to 10s).
+      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator, mlib_duration(800, ms)),
+                                   mlib_duration(10, s));
+
+      // Attempt 5 with 300ms base backoff: 300ms * 2^5 = 9600ms (should not saturate).
+      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator, mlib_duration(300, ms)),
+                                   mlib_duration(9600, ms));
+
+      _mongoc_retry_backoff_generator_destroy(generator);
+      _mongoc_jitter_source_destroy(jitter_source);
+   }
+
+   // jitter = 1.0, first attempt skipped
+   {
+      mongoc_jitter_source_t *const jitter_source = _mongoc_jitter_source_new(always_1_jitter_source_generate);
+      mongoc_retry_backoff_generator_t *const generator =
+         _mongoc_retry_backoff_generator_new(backoff_params, jitter_source);
+
+      _mongoc_retry_backoff_generator_skip(generator);
+
+      // Attempt 2: 100ms * 2^2 = 400ms.
+      ASSERT_DURATION_ALMOST_EQUAL(_mongoc_retry_backoff_generator_next(generator, mlib_duration(100, ms)),
+                                   mlib_duration(400, ms));
 
       _mongoc_retry_backoff_generator_destroy(generator);
       _mongoc_jitter_source_destroy(jitter_source);

--- a/src/libmongoc/tests/test-mongoc-with-transaction.c
+++ b/src/libmongoc/tests/test-mongoc-with-transaction.c
@@ -186,8 +186,12 @@ test_with_transaction_retry_backoff_is_enforced_prose(void *ctx)
 
    mongoc_client_session_destroy(with_backoff_session);
 
-   // Step 5
-   const mlib_duration diff = mlib_duration(with_backoff_time, minus, (no_backoff_time, plus, (1800, ms)));
+   // Step 5: The sum of 13 backoffs is roughly 2.3 seconds. There is a half-second window to account for potential
+   // variance between the two runs.
+   //
+   // With jitter pinned to 1, the nth backoff is `min(500ms, 5ms * 1.5^n)`, which sums to ~2282ms over 13 retries. The
+   // last two backoffs are clamped to the 500ms maximum.
+   const mlib_duration diff = mlib_duration(with_backoff_time, minus, (no_backoff_time, plus, (2300, ms)));
    ASSERT_CMPINT64(imaxabs(mlib_microseconds_count(diff)), <, mlib_microseconds_count(mlib_duration(500, ms)));
 
    mongoc_collection_destroy(coll);


### PR DESCRIPTION
CDRIVER-6353 (DRIVERS-3535)
CDRIVER-6374 (DRIVERS-3578)

# Summary

This PR implements the latest phase of changes in client backpressure.

## Handshake

The `"backpressure": True` is now `"backpressure": "2"`, where the "2" indicates the client backpressure version supported by the driver.

## Support for `baseBackoffMS`

The server may attach a `baseBackoffMS` field to the error returned on a failed attempt. If present, this value replaces the default of 100ms.

## Backoff Algorithm Changes

There are two notable differences in the backoff algorithm, which implicates `mongoc_retry_backoff_generator_t` in particular:

- The formula for exponential backoff is changed from `base_backoff * 2^(attempt - 1)` to `base_backoff * 2^attempt`, where `attempt` starts at `1`. In other words,the first attempt now uses double the base backoff rather than exactly the base backoff.
- Base backoff is passed on every invocation of `_mongoc_retry_backoff_generator_next` instead of being passed as part of initialization since it can change on each attempt. Notably, this means we cannot precompute the "max attempt" during initialization to clamp the attempt counter. To avoid integer overflow, a similar cap is computed using the same formula where the initial backoff is replaced by the smallest positive value that can be represented by `mlib_duration`, i.e., one microsecond. Any attempt value larger than this cap would result in a backoff that exceeds max backoff.

