### PR TITLE
CDRIVER-6413: update `range-encryptedFields-*` test files

### DIFF
--- a/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-Date.json
+++ b/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-Date.json
@@ -15,7 +15,7 @@
           "$numberLong": "0"
         },
         "trimFactor": {
-          "$numberLong": "1"
+          "$numberInt": "1"
         },
         "sparsity": {
           "$numberLong": "1"

--- a/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-DecimalNoPrecision.json
+++ b/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-DecimalNoPrecision.json
@@ -14,6 +14,9 @@
         "contention": {
           "$numberLong": "0"
         },
+        "trimFactor": {
+          "$numberInt": "1"
+        },
         "sparsity": {
           "$numberLong": "1"
         }

--- a/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-DecimalPrecision.json
+++ b/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-DecimalPrecision.json
@@ -15,7 +15,7 @@
           "$numberLong": "0"
         },
         "trimFactor": {
-          "$numberLong": "1"
+          "$numberInt": "1"
         },
         "sparsity": {
           "$numberLong": "1"

--- a/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-DoubleNoPrecision.json
+++ b/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-DoubleNoPrecision.json
@@ -14,6 +14,9 @@
         "contention": {
           "$numberLong": "0"
         },
+        "trimFactor": {
+          "$numberInt": "1"
+        },
         "sparsity": {
           "$numberLong": "1"
         }

--- a/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-DoublePrecision.json
+++ b/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-DoublePrecision.json
@@ -15,7 +15,7 @@
           "$numberLong": "0"
         },
         "trimFactor": {
-          "$numberLong": "1"
+          "$numberInt": "1"
         },
         "sparsity": {
           "$numberLong": "1"

--- a/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-Int.json
+++ b/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-Int.json
@@ -15,7 +15,7 @@
           "$numberLong": "0"
         },
         "trimFactor": {
-          "$numberLong": "1"
+          "$numberInt": "1"
         },
         "sparsity": {
           "$numberLong": "1"

--- a/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-Long.json
+++ b/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-Long.json
@@ -15,7 +15,7 @@
           "$numberLong": "0"
         },
         "trimFactor": {
-          "$numberLong": "1"
+          "$numberInt": "1"
         },
         "sparsity": {
           "$numberLong": "1"


### PR DESCRIPTION
Update the `range-encryptedFields-*` test files to fix recent Evergreen failures on latest servers:
```
trimFactor 1 in payload for field 'encryptedDecimalNoPrecision' does not match collection's default trimFactor 6
```

# Details
A recent server change (SERVER-127899) enabled validation. The test file in specifications [includes a correct](https://github.com/mongodb/specifications/blob/615e0f9ca5f554614636c098225fbbf1be55565d/source/client-side-encryption/etc/data/range-encryptedFields-DecimalNoPrecision.json#L18) `trimFactor`, but the C driver's copy of the test file omitted `trimFactor`. I copied over all `range-encryptedFields-*` files from https://github.com/mongodb/specifications/commit/615e0f9ca5f554614636c098225fbbf1be55565d.
