### PR TITLE
CDRIVER-6413: update `range-encryptedFields-*` test files

### DIFF
--- a/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-Date.json
+++ b/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-Date.json
@@ -15,7 +15,7 @@
           "$numberLong": "0"
         },
         "trimFactor": {
-          "$numberLong": "1"
+          "$numberInt": "1"
         },
         "sparsity": {
           "$numberLong": "1"

--- a/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-DecimalNoPrecision.json
+++ b/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-DecimalNoPrecision.json
@@ -14,6 +14,9 @@
         "contention": {
           "$numberLong": "0"
         },
+        "trimFactor": {
+          "$numberInt": "1"
+        },
         "sparsity": {
           "$numberLong": "1"
         }

--- a/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-DecimalPrecision.json
+++ b/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-DecimalPrecision.json
@@ -15,7 +15,7 @@
           "$numberLong": "0"
         },
         "trimFactor": {
-          "$numberLong": "1"
+          "$numberInt": "1"
         },
         "sparsity": {
           "$numberLong": "1"

--- a/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-DoubleNoPrecision.json
+++ b/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-DoubleNoPrecision.json
@@ -14,6 +14,9 @@
         "contention": {
           "$numberLong": "0"
         },
+        "trimFactor": {
+          "$numberInt": "1"
+        },
         "sparsity": {
           "$numberLong": "1"
         }

--- a/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-DoublePrecision.json
+++ b/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-DoublePrecision.json
@@ -15,7 +15,7 @@
           "$numberLong": "0"
         },
         "trimFactor": {
-          "$numberLong": "1"
+          "$numberInt": "1"
         },
         "sparsity": {
           "$numberLong": "1"

--- a/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-Int.json
+++ b/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-Int.json
@@ -15,7 +15,7 @@
           "$numberLong": "0"
         },
         "trimFactor": {
-          "$numberLong": "1"
+          "$numberInt": "1"
         },
         "sparsity": {
           "$numberLong": "1"

--- a/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-Long.json
+++ b/src/libmongoc/tests/client_side_encryption_prose/explicit_encryption/range-encryptedFields-Long.json
@@ -15,7 +15,7 @@
           "$numberLong": "0"
         },
         "trimFactor": {
-          "$numberLong": "1"
+          "$numberInt": "1"
         },
         "sparsity": {
           "$numberLong": "1"


### PR DESCRIPTION
Applies https://github.com/mongodb/mongo-c-driver/pull/2365 to the r2.4 branch to fix test failures.