### PR TITLE
use Ubuntu 22.04 distro for AWS tasks

### DIFF
--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -13174,7 +13174,7 @@ buildvariants:
   display_name: AWS Tests (Ubuntu 22.04)
   expansions:
     CC: clang
-  run_on: ubuntu2004-small
+  run_on: ubuntu2204-small
   tasks:
   - debug-compile-aws
   - .test-aws .6.0

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -285,7 +285,7 @@ all_variants = [
     Variant(
         'aws-ubuntu2204',
         'AWS Tests (Ubuntu 22.04)',
-        'ubuntu2004-small',
+        'ubuntu2204-small',
         [
             'debug-compile-aws',
             '.test-aws .6.0',


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/mongo-c-driver/pull/2370.

Fixes Evergreen [failures](https://spruce.corp.mongodb.com/task/mongo_c_driver_aws_ubuntu2204_test_aws_openssl_assume_role_9.0_2a99963db2be1d88166543fa074fd572de45dd0b_26_08_19_11_27_21/logs?execution=0) of AWS tasks of 9.0 server logging `Failed to download`. 9.0 server builds are not available on Ubuntu 20.04 (see the "MongoDB Platform Roadmap" bookmark in `#dbx-c-cxx`). AWS tasks on server 6.0+ intended to use Ubuntu 22.04, but were accidentally using Ubuntu 20.04. This PR fixes the tasks to use Ubuntu 22.04.

Evergreen patch: https://spruce.corp.mongodb.com/version/6a8762d6819e10000798457e/