### PR TITLE
migrate distros for AWS tests

### DIFF
--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -13176,7 +13176,7 @@ buildvariants:
   display_name: AWS Tests (Ubuntu 24.04)
   expansions:
     CC: clang
-  run_on: ubuntu2204-small
+  run_on: ubuntu2404-small
   tasks:
   - debug-compile-aws
   - .test-aws .8.0

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -1390,6 +1390,7 @@ tasks:
   tags:
   - latest
   - test-aws
+  - test-aws-regular
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1410,6 +1411,7 @@ tasks:
   tags:
   - rapid
   - test-aws
+  - test-aws-regular
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1430,6 +1432,7 @@ tasks:
   tags:
   - '9.0'
   - test-aws
+  - test-aws-regular
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1450,6 +1453,7 @@ tasks:
   tags:
   - '8.0'
   - test-aws
+  - test-aws-regular
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1470,6 +1474,7 @@ tasks:
   tags:
   - '7.0'
   - test-aws
+  - test-aws-regular
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1490,6 +1495,7 @@ tasks:
   tags:
   - '6.0'
   - test-aws
+  - test-aws-regular
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1510,6 +1516,7 @@ tasks:
   tags:
   - '5.0'
   - test-aws
+  - test-aws-regular
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1530,6 +1537,7 @@ tasks:
   tags:
   - '4.4'
   - test-aws
+  - test-aws-regular
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1550,6 +1558,7 @@ tasks:
   tags:
   - latest
   - test-aws
+  - test-aws-ec2
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1570,6 +1579,7 @@ tasks:
   tags:
   - rapid
   - test-aws
+  - test-aws-ec2
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1590,6 +1600,7 @@ tasks:
   tags:
   - '9.0'
   - test-aws
+  - test-aws-ec2
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1610,6 +1621,7 @@ tasks:
   tags:
   - '8.0'
   - test-aws
+  - test-aws-ec2
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1630,6 +1642,7 @@ tasks:
   tags:
   - '7.0'
   - test-aws
+  - test-aws-ec2
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1650,6 +1663,7 @@ tasks:
   tags:
   - '6.0'
   - test-aws
+  - test-aws-ec2
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1670,6 +1684,7 @@ tasks:
   tags:
   - '5.0'
   - test-aws
+  - test-aws-ec2
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1690,6 +1705,7 @@ tasks:
   tags:
   - '4.4'
   - test-aws
+  - test-aws-ec2
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1710,6 +1726,7 @@ tasks:
   tags:
   - latest
   - test-aws
+  - test-aws-ecs
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1730,6 +1747,7 @@ tasks:
   tags:
   - rapid
   - test-aws
+  - test-aws-ecs
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1750,6 +1768,7 @@ tasks:
   tags:
   - '9.0'
   - test-aws
+  - test-aws-ecs
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1770,6 +1789,7 @@ tasks:
   tags:
   - '8.0'
   - test-aws
+  - test-aws-ecs
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1790,6 +1810,7 @@ tasks:
   tags:
   - '7.0'
   - test-aws
+  - test-aws-ecs
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1810,6 +1831,7 @@ tasks:
   tags:
   - '6.0'
   - test-aws
+  - test-aws-ecs
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1830,6 +1852,7 @@ tasks:
   tags:
   - '5.0'
   - test-aws
+  - test-aws-ecs
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1850,6 +1873,7 @@ tasks:
   tags:
   - '4.4'
   - test-aws
+  - test-aws-ecs
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1870,6 +1894,7 @@ tasks:
   tags:
   - latest
   - test-aws
+  - test-aws-lambda
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1890,6 +1915,7 @@ tasks:
   tags:
   - rapid
   - test-aws
+  - test-aws-lambda
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1910,6 +1936,7 @@ tasks:
   tags:
   - '9.0'
   - test-aws
+  - test-aws-lambda
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1930,6 +1957,7 @@ tasks:
   tags:
   - '8.0'
   - test-aws
+  - test-aws-lambda
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1950,6 +1978,7 @@ tasks:
   tags:
   - '7.0'
   - test-aws
+  - test-aws-lambda
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1970,6 +1999,7 @@ tasks:
   tags:
   - '6.0'
   - test-aws
+  - test-aws-lambda
   depends_on:
     name: debug-compile-aws
   commands:
@@ -1990,6 +2020,7 @@ tasks:
   tags:
   - '5.0'
   - test-aws
+  - test-aws-lambda
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2010,6 +2041,7 @@ tasks:
   tags:
   - '4.4'
   - test-aws
+  - test-aws-lambda
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2030,6 +2062,7 @@ tasks:
   tags:
   - latest
   - test-aws
+  - test-aws-assume_role
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2050,6 +2083,7 @@ tasks:
   tags:
   - rapid
   - test-aws
+  - test-aws-assume_role
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2070,6 +2104,7 @@ tasks:
   tags:
   - '9.0'
   - test-aws
+  - test-aws-assume_role
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2090,6 +2125,7 @@ tasks:
   tags:
   - '8.0'
   - test-aws
+  - test-aws-assume_role
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2110,6 +2146,7 @@ tasks:
   tags:
   - '7.0'
   - test-aws
+  - test-aws-assume_role
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2130,6 +2167,7 @@ tasks:
   tags:
   - '6.0'
   - test-aws
+  - test-aws-assume_role
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2150,6 +2188,7 @@ tasks:
   tags:
   - '5.0'
   - test-aws
+  - test-aws-assume_role
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2170,6 +2209,7 @@ tasks:
   tags:
   - '4.4'
   - test-aws
+  - test-aws-assume_role
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2190,6 +2230,7 @@ tasks:
   tags:
   - latest
   - test-aws
+  - test-aws-assume_role_with_web_identity
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2210,6 +2251,7 @@ tasks:
   tags:
   - rapid
   - test-aws
+  - test-aws-assume_role_with_web_identity
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2230,6 +2272,7 @@ tasks:
   tags:
   - '9.0'
   - test-aws
+  - test-aws-assume_role_with_web_identity
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2250,6 +2293,7 @@ tasks:
   tags:
   - '8.0'
   - test-aws
+  - test-aws-assume_role_with_web_identity
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2270,6 +2314,7 @@ tasks:
   tags:
   - '7.0'
   - test-aws
+  - test-aws-assume_role_with_web_identity
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2290,6 +2335,7 @@ tasks:
   tags:
   - '6.0'
   - test-aws
+  - test-aws-assume_role_with_web_identity
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2310,6 +2356,7 @@ tasks:
   tags:
   - '5.0'
   - test-aws
+  - test-aws-assume_role_with_web_identity
   depends_on:
     name: debug-compile-aws
   commands:
@@ -2330,6 +2377,7 @@ tasks:
   tags:
   - '4.4'
   - test-aws
+  - test-aws-assume_role_with_web_identity
   depends_on:
     name: debug-compile-aws
   commands:
@@ -13161,27 +13209,35 @@ buildvariants:
   - .latest .nossl
   patchable: false
   batchtime: 1440
-- name: aws-ubuntu2004
-  display_name: AWS Tests (Ubuntu 20.04)
+- name: aws-rhel8
+  display_name: AWS Tests (RHEL 8)
+  expansions:
+    CC: clang
+  run_on: rhel87-small
+  tasks:
+  - debug-compile-aws
+  - .test-aws !.test-aws-ecs
+- name: aws-ecs-ubuntu2004
+  display_name: AWS ECS Tests (Ubuntu 20.04)
   expansions:
     CC: clang
   run_on: ubuntu2004-small
   tasks:
   - debug-compile-aws
-  - .test-aws .4.4
-  - .test-aws .5.0
-  - .test-aws .6.0
-  - .test-aws .7.0
-- name: aws-ubuntu2404
-  display_name: AWS Tests (Ubuntu 24.04)
+  - .test-aws-ecs .4.4
+  - .test-aws-ecs .5.0
+  - .test-aws-ecs .6.0
+  - .test-aws-ecs .7.0
+- name: aws-ecs-ubuntu2404
+  display_name: AWS ECS Tests (Ubuntu 24.04)
   expansions:
     CC: clang
   run_on: ubuntu2404-small
   tasks:
   - debug-compile-aws
-  - .test-aws .8.0
-  - .test-aws .9.0
-  - .test-aws .latest
+  - .test-aws-ecs .8.0
+  - .test-aws-ecs .9.0
+  - .test-aws-ecs .latest
 - name: ocsp
   display_name: OCSP tests
   run_on: ubuntu2204-small

--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -13170,15 +13170,15 @@ buildvariants:
   - debug-compile-aws
   - .test-aws .4.4
   - .test-aws .5.0
-- name: aws-ubuntu2204
-  display_name: AWS Tests (Ubuntu 22.04)
+  - .test-aws .6.0
+  - .test-aws .7.0
+- name: aws-ubuntu2404
+  display_name: AWS Tests (Ubuntu 24.04)
   expansions:
     CC: clang
   run_on: ubuntu2204-small
   tasks:
   - debug-compile-aws
-  - .test-aws .6.0
-  - .test-aws .7.0
   - .test-aws .8.0
   - .test-aws .9.0
   - .test-aws .latest

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -712,6 +712,7 @@ class AWSTestTask(MatrixTask):
         yield from super().additional_tags()
         yield f'{self.settings.version}'
         yield 'test-aws'
+        yield f'test-aws-{self.settings.testcase}'
 
     def post_commands(self) -> Iterable[Value]:
         return [

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -269,7 +269,7 @@ all_variants = [
         patchable=False,
         batchtime=days(1),
     ),
-    # Run AWS ECS test set-up is only supported on Ubuntu 20.04 and 24.04 distros.
+    # AWS ECS test set-up is only supported on Ubuntu 20.04 and 24.04 distros.
     # Use RHEL 8 for other AWS tasks. AWS EC2 tests fail to assign an instance policy on Ubuntu 24.04.
     Variant(
         'aws-rhel8',

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -287,7 +287,7 @@ all_variants = [
     Variant(
         'aws-ubuntu2404',
         'AWS Tests (Ubuntu 24.04)',
-        'ubuntu2204-small',
+        'ubuntu2404-small',
         [
             'debug-compile-aws',
             '.test-aws .8.0',

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -269,8 +269,8 @@ all_variants = [
         patchable=False,
         batchtime=days(1),
     ),
-    # Run AWS tests for MongoDB 4.4 and 5.0 on Ubuntu 20.04. AWS setup scripts
-    # expect Ubuntu 20.04+. MongoDB 4.4 and 5.0 are not available on 22.04.
+    # Run AWS tests for MongoDB 4.4 - 7.0 on Ubuntu 20.04. AWS setup scripts
+    # expect Ubuntu 20.04 or 24.04. MongoDB 4.4 - 7.0 are not available on 24.04.
     Variant(
         'aws-ubuntu2004',
         'AWS Tests (Ubuntu 20.04)',
@@ -279,17 +279,17 @@ all_variants = [
             'debug-compile-aws',
             '.test-aws .4.4',
             '.test-aws .5.0',
+            '.test-aws .6.0',
+            '.test-aws .7.0',
         ],
         {'CC': 'clang'},
     ),
     Variant(
-        'aws-ubuntu2204',
-        'AWS Tests (Ubuntu 22.04)',
+        'aws-ubuntu2404',
+        'AWS Tests (Ubuntu 24.04)',
         'ubuntu2204-small',
         [
             'debug-compile-aws',
-            '.test-aws .6.0',
-            '.test-aws .7.0',
             '.test-aws .8.0',
             '.test-aws .9.0',
             '.test-aws .latest',

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/variants.py
@@ -269,30 +269,42 @@ all_variants = [
         patchable=False,
         batchtime=days(1),
     ),
-    # Run AWS tests for MongoDB 4.4 - 7.0 on Ubuntu 20.04. AWS setup scripts
-    # expect Ubuntu 20.04 or 24.04. MongoDB 4.4 - 7.0 are not available on 24.04.
+    # Run AWS ECS test set-up is only supported on Ubuntu 20.04 and 24.04 distros.
+    # Use RHEL 8 for other AWS tasks. AWS EC2 tests fail to assign an instance policy on Ubuntu 24.04.
     Variant(
-        'aws-ubuntu2004',
-        'AWS Tests (Ubuntu 20.04)',
+        'aws-rhel8',
+        'AWS Tests (RHEL 8)',
+        'rhel87-small',
+        [
+            'debug-compile-aws',
+            '.test-aws !.test-aws-ecs',
+        ],
+        {'CC': 'clang'},
+    ),
+    # Use Ubuntu for ECS tasks. ECS set-up is only supported on Ubuntu distros.
+    # Ubuntu 24.04 supports server 8.0+. Use Ubuntu 20.04 for prior server versions (Ubuntu 22.04 does not support ECS set-up).
+    Variant(
+        'aws-ecs-ubuntu2004',
+        'AWS ECS Tests (Ubuntu 20.04)',
         'ubuntu2004-small',
         [
             'debug-compile-aws',
-            '.test-aws .4.4',
-            '.test-aws .5.0',
-            '.test-aws .6.0',
-            '.test-aws .7.0',
+            '.test-aws-ecs .4.4',
+            '.test-aws-ecs .5.0',
+            '.test-aws-ecs .6.0',
+            '.test-aws-ecs .7.0',
         ],
         {'CC': 'clang'},
     ),
     Variant(
-        'aws-ubuntu2404',
-        'AWS Tests (Ubuntu 24.04)',
+        'aws-ecs-ubuntu2404',
+        'AWS ECS Tests (Ubuntu 24.04)',
         'ubuntu2404-small',
         [
             'debug-compile-aws',
-            '.test-aws .8.0',
-            '.test-aws .9.0',
-            '.test-aws .latest',
+            '.test-aws-ecs .8.0',
+            '.test-aws-ecs .9.0',
+            '.test-aws-ecs .latest',
         ],
         {'CC': 'clang'},
     ),


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/mongo-c-driver/pull/2373. I neglected to check the linked Evergreen patch and missed that Ubuntu 22.04 is not supported in the AWS _ECS_ set-up scripts, triggering [an error](https://spruce.corp.mongodb.com/task/mongo_c_driver_aws_ubuntu2204_test_aws_openssl_ecs_6.0_a047e0bc10f1a1e1419ac6ae2b87386d8c8ec9d3_26_08_21_18_36_31/logs?execution=0):

```
[2026/08/21 14:54:42.134]   File "/data/mci/78f559bedb4848c9e9e9c467e5fc158a/drivers-evergreen-tools/.evergreen/auth_aws/aws_tester.py", line 138, in setup_ecs
[2026/08/21 14:54:42.134]     raise ValueError("Unsupported ubuntu release")
```

Migrating to Ubuntu 24.04 fixed the ECS tasks, but triggered [an error](https://spruce.corp.mongodb.com/task/mongo_c_driver_aws_ubuntu2404_test_aws_openssl_ec2_latest_patch_a047e0bc10f1a1e1419ac6ae2b87386d8c8ec9d3_6a88b2b328ea3c0007dbc3c3_26_08_21_20_19_04/logs?execution=1) on AWS _EC2_ tests:

```
[2026/08/22 08:48:28.459] ERROR    HTTP Error 401: Unauthorized
```

I checked PyMongo for reference. PyMongo uses RHEL 8 hosts for AWS tasks, [except for AWS ECS](https://github.com/mongodb/mongo-python-driver/blob/ebc4bffcc842464e48a3edbd04802d1a42bc818a/.evergreen/scripts/generate_config.py#L507-L538), noting: "The ECS test must be run on Ubuntu 24 to match the Fargate Config."

So all AWS tasks are migrated to RHEL 8, excluding the ECS tasks that must run on Ubuntu. This matches the PyMongo configuration.

Evergreen patch: https://spruce.corp.mongodb.com/version/6a89fbef21b17e00071bcebc
