### PR TITLE
Fix intermittent 'uvx: command not found' in debug-compile-aws

### DIFF
--- a/.evergreen/generated_configs/legacy-config.yml
+++ b/.evergreen/generated_configs/legacy-config.yml
@@ -1376,10 +1376,14 @@ tasks:
         # Use ccache if able.
         . .evergreen/scripts/find-ccache.sh
         find_ccache_and_export_vars "$(pwd)" || true
-        # Ubuntu 20.04 does not have uv.
-        if ! command -v uv >/dev/null; then
+        # Ubuntu 20.04 does not have uv. Test for `uvx` rather than `uv`: `uvx` is what is
+        # invoked below, and a host may have the `uv` package installed in a site-packages
+        # directory that is not on PATH. Use --ignore-installed so that such an existing
+        # installation does not cause pip to skip installing into "$prefix", which would
+        # leave "$prefix/bin" empty and `uvx` still not found.
+        if ! command -v uvx >/dev/null; then
             prefix="$(mktemp -d)"
-            python3 -m pip install --prefix "$prefix" uv
+            python3 -m pip install --ignore-installed --prefix "$prefix" uv
             PATH="$prefix/bin:$PATH"
         fi
         # Compile test-awsauth. Disable unnecessary dependencies since test-awsauth is copied to a remote Ubuntu 20.04 ECS cluster for testing, which may not have all dependent libraries.

--- a/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
+++ b/.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py
@@ -674,10 +674,14 @@ aws_compile_task = NamedTask(
             . .evergreen/scripts/find-ccache.sh
             find_ccache_and_export_vars "$(pwd)" || true
 
-            # Ubuntu 20.04 does not have uv.
-            if ! command -v uv >/dev/null; then
+            # Ubuntu 20.04 does not have uv. Test for `uvx` rather than `uv`: `uvx` is what is
+            # invoked below, and a host may have the `uv` package installed in a site-packages
+            # directory that is not on PATH. Use --ignore-installed so that such an existing
+            # installation does not cause pip to skip installing into "$prefix", which would
+            # leave "$prefix/bin" empty and `uvx` still not found.
+            if ! command -v uvx >/dev/null; then
                 prefix="$(mktemp -d)"
-                python3 -m pip install --prefix "$prefix" uv
+                python3 -m pip install --ignore-installed --prefix "$prefix" uv
                 PATH="$prefix/bin:$PATH"
             fi
 


### PR DESCRIPTION
Note: this issue was diagnosed and fixed by Claude.

## Problem

`debug-compile-aws` on `aws-ubuntu2004` fails intermittently with exit code 127:

```
Requirement already satisfied: uv in /home/ubuntu/.local/lib/python3.8/site-packages (0.12.5)
bash: line 14: uvx: command not found
```

The task bootstraps `uv` like this, then invokes `uvx`:

```bash
if ! command -v uv >/dev/null; then
    prefix="$(mktemp -d)"
    python3 -m pip install --prefix "$prefix" uv
    PATH="$prefix/bin:$PATH"
fi
uvx cmake ...
```

Two things combine:

1. The guard tests `uv`, but the script actually invokes `uvx`.
2. `pip install --prefix` does **not** isolate pip from packages already installed elsewhere. If `uv` is present in a site-packages directory that is not on `PATH`, pip reports "Requirement already satisfied" and installs *nothing* into `$prefix`, leaving `$prefix/bin` empty. `PATH` then gains nothing and `uvx` is still missing.

That explains the intermittency: the task passes when `uv` is on `PATH` (guard skipped) or absent entirely (pip really installs into `$prefix`), and fails only in the middle state.

Recent mainline occurrences: order 6147 (`40ea0f41ae`) and order 6143 (`d7e6a989ab`). When it fires it also blocks the dependent `.test-aws` tasks — 12 tasks were `blocked` behind it at 6147.

## Change

Guard on `uvx`, which is what the script invokes, and pass `--ignore-installed` so an existing installation elsewhere cannot cause pip to skip installing into `$prefix`.

Edited `.evergreen/legacy_config_generator/evergreen_config_lib/tasks.py` and regenerated `.evergreen/generated_configs/legacy-config.yml` with `uv run --frozen mc-evg-generate`.

## Validation

Patch build: https://spruce.corp.mongodb.com/version/6a88b7e9f6b0090007428d4f — **passes**.

The log shows the fixed path executing end to end, which is the part that was previously broken:

```
Collecting uv
  Downloading uv-0.12.5-py3-none-manylinux_2_17_x86_64...whl (23.7 MB)
Installing collected packages: uv
Successfully installed uv-0.12.5
...
Downloading cmake (28.8MiB)
 Downloaded cmake
[100%] Built target test-awsauth
```

Note `Collecting uv` / `Successfully installed` rather than `Requirement already satisfied` — pip really populated `$prefix`, so `uvx` resolved.

The mechanism was also reproduced locally, independent of CI: with a package already installed and visible, `pip install --prefix <dir> <pkg>` prints "Requirement already satisfied" and does not even create `<dir>`; adding `--ignore-installed` installs it into `<dir>` as intended.

**Caveat, stated honestly:** because the bug only fires on hosts in the middle state, a green patch build cannot by itself prove the *old* code would have failed on that particular host. The evidence above is about the fixed code path working plus the reproduced pip mechanism, not an A/B on one host.