### PR TITLE
Updates to AGENTS.md from prior Claude work

### DIFF
--- a/.agents/skills/running-test-libmongoc/SKILL.md
+++ b/.agents/skills/running-test-libmongoc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: running-test-libmongoc
-description: Use when running, filtering, or debugging tests in the test-libmongoc executable of the MongoDB C Driver — the custom TestSuite framework in src/libmongoc/tests/TestSuite.h with its own flags (-l, -d, -f), test-naming rules, and JSON spec tests.
+description: Use when running, filtering, or debugging tests in the test-libmongoc executable of the MongoDB C Driver — the custom TestSuite framework in src/libmongoc/tests/TestSuite.h with its own flags (-l, -d, -f), test-naming rules, tags, and JSON spec tests, whether run directly or through CTest.
 ---
 
 # Running `test-libmongoc`
@@ -9,18 +9,50 @@ description: Use when running, filtering, or debugging tests in the test-libmong
 
 `test-libmongoc` is the executable holding most `libmongoc` and `libbson` tests. It uses a **custom** test framework (`src/libmongoc/tests/TestSuite.h`), not a mainstream one, so its invocation, filtering, and test-naming rules are unique. This skill explains how to run and select tests with it.
 
-The executable is excluded from the CMake `ALL` target. Build it first with the `--target` flag:
+Build it first — it is not part of the default `ALL` target (`<build-dir>` is the CMake binary directory):
 
 ```bash
-cmake --build cmake-build --target test-libmongoc
+cmake --build <build-dir> --target test-libmongoc
 ```
 
-## Running tests
+There are two ways to run the resulting tests, and they suit different jobs:
+
+| | Use for |
+|---|---|
+| **CTest** (`ctest`) | Running many cases, parallelism (`-j`), selecting by label, per-case timeouts, and machine-readable results. |
+| **The executable directly** | Running or debugging a single case, where `-d` / `-f` and immediate output matter. |
+
+## Running via CTest
+
+Every test case is registered as an individual CTest test named `mongoc/<case-name>`:
+
+```bash
+# List matching tests without running them:
+ctest --test-dir <build-dir> -N -R "/server_selection/"
+
+# Run the matching tests:
+ctest --test-dir <build-dir> --output-on-failure -R "/server_selection/"
+```
+
+`-R` is a regex over the full CTest test name, which includes the `mongoc` prefix and the case's leading `/`.
+
+Each case's `[...]` tags (see [Finding a test's name](#finding-a-tests-name)) are translated into CTest properties by `build/cmake/LoadTests.cmake`:
+
+| Tag | Becomes |
+|-----|---------|
+| any tag | a CTest **label**, so `ctest -L "lock:live-server"` selects by tag. All generated cases also get the label `test-libmongoc-generated`. |
+| `lock:<name>` | a `RESOURCE_LOCK`, serializing cases that share a lock name against each other. |
+| `uses:<name>` | a required test fixture, `mongoc/fixtures/<name>`. |
+| `timeout:<seconds>` | that `TIMEOUT`. **Cases without this tag get a 10 second timeout**, so a genuinely slow test must declare one or it will be killed. |
+
+Cases run with the working directory set to the source root, and a case that reports itself skipped is recorded as skipped rather than passed. The `MONGOC_TEST_*` environment variables documented in `CONTRIBUTING.md` apply to `ctest` runs as well.
+
+## Running the executable directly
 
 Typical invocation:
 
 ```bash
-./cmake-build/src/libmongoc/test-libmongoc -d -f -l "<test-name-or-pattern>"
+./<build-dir>/src/libmongoc/test-libmongoc -d -f -l "<test-name-or-pattern>"
 ```
 
 | Flag | Meaning |
@@ -29,7 +61,7 @@ Typical invocation:
 | `-d` | Print debug output. Useful when a test hangs. |
 | `-f` | Do not fork a process per test; abort on the first error. |
 
-Run `./cmake-build/src/libmongoc/test-libmongoc --help` for the full flag list.
+Run `./<build-dir>/src/libmongoc/test-libmongoc --help` for the full flag list.
 
 ### `-l` matching rules
 
@@ -72,3 +104,5 @@ Tests register with the suite through these functions; which one is used tells y
 - **Using a leading or interior wildcard** — `-l "*aggregate"` will not work; only a trailing `*` is supported.
 - **Forgetting to build the target first** — `test-libmongoc` is not built by the default `ALL` target.
 - **Expecting a fork-per-test by default when debugging** — add `-f` so the run aborts on the first failure instead of continuing, and `-d` to see where a hang occurs.
+- **Reading a CTest timeout as a test failure** — an untagged case is killed at 10 seconds, so a slow-but-correct test looks like a failure until it declares a `timeout:` tag. Confirm by running that one case directly.
+- **Passing an `-l` pattern to `ctest -R`, or vice versa** — `-l` is an exact/prefix match on the bare test name, while `-R` is a regex over the CTest name (which carries the `mongoc` prefix).

--- a/.agents/skills/running-test-libmongoc/SKILL.md
+++ b/.agents/skills/running-test-libmongoc/SKILL.md
@@ -52,7 +52,7 @@ Cases run with the working directory set to the source root, and a case that rep
 Typical invocation:
 
 ```bash
-./<build-dir>/src/libmongoc/test-libmongoc -d -f -l "<test-name-or-pattern>"
+<build-dir>/src/libmongoc/test-libmongoc -d -f -l "<test-name-or-pattern>"
 ```
 
 | Flag | Meaning |
@@ -61,7 +61,7 @@ Typical invocation:
 | `-d` | Print debug output. Useful when a test hangs. |
 | `-f` | Do not fork a process per test; abort on the first error. |
 
-Run `./<build-dir>/src/libmongoc/test-libmongoc --help` for the full flag list.
+Run `<build-dir>/src/libmongoc/test-libmongoc --help` for the full flag list.
 
 ### `-l` matching rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,9 @@ This file provides guidance to AI coding agents working with code in this reposi
 
 This project uses CMake.
 
-`<build-dir>` below stands for the CMake binary directory. Use whichever directory the user specifies; `cmake-build/` and `_build/` are both already listed in `.gitignore`.
+`<build-dir>` below stands for the CMake binary directory. Use whichever
+directory the user specifies. `cmake-build/` and `_build/` are both already
+listed in `.gitignore`.
 
 > [!IMPORTANT]
 > Do not use `build/` as the binary directory. Unlike in most CMake projects, `build/` here is a tracked source directory holding the project's CMake modules, so configuring into it mixes build output into the working tree.
@@ -100,21 +102,41 @@ Public headers have no `private` suffix (e.g., `mongoc-client.h`). Internal head
 
 ### Navigating libmongoc
 
-Implementation files are named `mongoc-<subsystem>*.c`, so the file listing is itself a serviceable index: `mongoc-uri.c` (connection string parsing), `mongoc-collection.c` / `mongoc-database.c`, `mongoc-bulkwrite.c` / `mongoc-bulk-operation.c`, `mongoc-client-session.c` (sessions and transactions), `mongoc-gridfs*.c`, `mongoc-structured-log.c`, and so on. The `mcd-` prefix marks assorted newer internal components rather than one subsystem (`mcd-rpc.c` is the wire protocol message representation).
+Implementation files are named `mongoc-<subsystem>*.c`, so the file listing is
+itself a serviceable index: `mongoc-uri.c` (connection string parsing),
+`mongoc-collection.c` / `mongoc-database.c`, `mongoc-bulkwrite.c` /
+`mongoc-bulk-operation.c`, `mongoc-client-session.c` (sessions and
+transactions), `mongoc-gridfs*.c`, `mongoc-structured-log.c`, and so on. The
+`mcd-` prefix marks assorted newer internal components rather than one subsystem
+(`mcd-rpc.c` is the wire protocol message representation).
 
 The relationships that the file names do *not* convey:
 
-- **Client, pool, and topology.** A single-threaded `mongoc_client_t` owns its `mongoc_topology_t` directly, while every client handed out by a `mongoc_client_pool_t` shares the pool's single topology. Which objects are shared between threads follows from this split.
-- **SDAM** spans more than `mongoc-topology*.c`: `mongoc-server-description.c`, `mongoc-server-monitor.c`, and `mongoc-topology-background-monitoring.c` are all part of it.
-- **Cluster** (`mongoc-cluster.c`) owns the open connections to servers and dispatches commands — the layer between a client operation and the wire. Authentication mechanisms are *also* here, as `mongoc-cluster-<mechanism>.c` (`-aws`, `-cyrus`, `-oidc`, `-sasl`, `-sspi`), alongside `mongoc-scram.c`.
-- **Cursor** is one public type over several backends: `mongoc-cursor-find.c`, `-cmd.c`, `-array.c`, `-change-stream.c`.
-- **Streams** are layered behind the `mongoc_stream_t` vtable: a TLS stream (`mongoc-stream-tls-*.c`, one per TLS backend) wraps a base socket or buffered stream.
-- **In-Use Encryption** is split between `mongoc-client-side-encryption.c` (the public API) and `mongoc-crypt.c` (the binding to libmongocrypt).
-- **APM** (`mongoc-apm.c`) exposes 12 callbacks, covering command, server/topology, and heartbeat events. There are no connection-pool (CMAP) callbacks.
+- **Client, pool, and topology.** A single-threaded `mongoc_client_t` owns its
+  `mongoc_topology_t` directly, while every client handed out by a
+  `mongoc_client_pool_t` shares the pool's single topology. Which objects are
+  shared between threads follows from this split.
+- **SDAM** spans more than `mongoc-topology*.c`: `mongoc-server-description.c`,
+  `mongoc-server-monitor.c`, and `mongoc-topology-background-monitoring.c` are
+  all part of it.
+- **Cluster** (`mongoc-cluster.c`) owns the open connections to servers and
+  dispatches commands — the layer between a client operation and the wire.
+  Authentication mechanisms are *also* here, as `mongoc-cluster-<mechanism>.c`
+  (`-aws`, `-cyrus`, `-oidc`, `-sasl`, `-sspi`), alongside `mongoc-scram.c`.
+- **Cursor** is one public type over several backends: `mongoc-cursor-find.c`,
+  `-cmd.c`, `-array.c`, `-change-stream.c`.
+- **Streams** are layered behind the `mongoc_stream_t` vtable: a TLS stream
+  (`mongoc-stream-tls-*.c`, one per TLS backend) wraps a base socket or buffered
+  stream.
+- **In-Use Encryption** is split between `mongoc-client-side-encryption.c` (the
+  public API) and `mongoc-crypt.c` (the binding to libmongocrypt).
+- **APM** (`mongoc-apm.c`) exposes callbacks, covering command, server/topology,
+  and heartbeat events. There are no connection-pool (CMAP) callbacks.
 
 ### Vendored Third-Party Libraries
 
-There are several third-party libraries in the repository source tree to enable self-contained builds:
+There are several third-party libraries in the repository source tree to enable
+self-contained builds:
 
 | Repository | Source Tree Location (where `<version>` is a placeholder for the version number) |
 |---|---|
@@ -131,10 +153,19 @@ Uses C99. Contributions shall not use features from newer standards.
 
 See *Coding Style* in `CONTRIBUTING.md` and `.clang-format` for indentation. In addition:
 
-- **Column limit**: 120 characters.
-- **clangd**: requires configuring with `-D CMAKE_EXPORT_COMPILE_COMMANDS=ON`, which is not enabled by default. If clangd reports unknown headers or missing symbols, check that `<build-dir>/compile_commands.json` exists before looking anywhere else.
-- Include directives for `mlib/`, `bson/`, and `mongoc/` headers use angle brackets (`<mlib/str.h>`, not `"mlib/str.h"`).
-- New `.c`/`.h` files carry an Apache 2.0 license header; copy the boilerplate from an existing file rather than composing it from memory.
+- Format using formatting scripts. Don't try to manipulate things by hand when
+  you can just run the formatters described below.
+- **clangd**: requires configuring with `-D CMAKE_EXPORT_COMPILE_COMMANDS=ON`,
+  which is not enabled by default. If clangd reports unknown headers or missing
+  symbols, check that `<build-dir>/compile_commands.json` exists before looking
+  anywhere else. You may also require a `.clangd` configuration file that
+  directs clangd where to find the compilation database.
+- Include directives for `mlib/`, `bson/`, and `mongoc/` headers use angle
+  brackets (`<mlib/str.h>`, not `"mlib/str.h"`). This will be enforced
+  automatically by the formatting scripts. Be aware that formatting may
+  rearrange `#include` directives.
+- New `.c`/`.h` files carry an Apache 2.0 license header. Copy the boilerplate
+  from an existing file rather than composing it from memory.
 
 ## Documentation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,42 +6,33 @@ This file provides guidance to AI coding agents working with code in this reposi
 
 This project uses CMake.
 
-Use `cmake-build/` as the CMake binary directory unless otherwise specified by the user. When the user specifies a custom binary directory, always use that directory - do not fall back to `cmake-build/`.
+`<build-dir>` below stands for the CMake binary directory. Use whichever directory the user specifies; `cmake-build/` and `_build/` are both already listed in `.gitignore`.
 
 > [!IMPORTANT]
-> Despite `build/` being a common choice for a CMake binary directory name, that is not recommended in this repository because the `build/` directory is tracked by Git.
+> Do not use `build/` as the binary directory. Unlike in most CMake projects, `build/` here is a tracked source directory holding the project's CMake modules, so configuring into it mixes build output into the working tree.
 
 The typical configure and build steps (for release and installation):
 
 ```bash
-cmake -D CMAKE_BUILD_TYPE=RelWithDebInfo -B cmake-build
-cmake --build cmake-build
+cmake -D CMAKE_BUILD_TYPE=RelWithDebInfo -B <build-dir>
+cmake --build <build-dir>
 ```
 
 The optional install step:
 
 ```bash
-cmake --install cmake-build
+cmake --install <build-dir>
 ```
 
-> [!IMPORTANT]
-> For multi-configuration generators (e.g. "Visual Studio *", "Ninja Multi-Config", etc.), use `--config <config>` during the build, install, and test steps instead of `CMAKE_BUILD_TYPE=<config>`.
-> The `CMAKE_BUILD_TYPE` option will be ignored by the configuration step.
-> Only use `CMAKE_BUILD_TYPE` with single-configuration generators (e.g. Makefile Generators, Ninja, etc.).
+Key CMake configuration options specific to this project (given `option=(default|alternatives...)`):
 
-Key CMake configuration options (given `option=(default|alternatives...)`):
-
-- `-G <generator-name>`: specify a build system generator.
 - `-D CMAKE_PREFIX_PATH:PATH=<libmongocrypt-prefix>`: specify installation prefixes to search with `find_*()` CMake commands (e.g., to link with `libmongocrypt`).
-- `-D CMAKE_INSTALL_PREFIX:PATH=<install-prefix>`: install directory used by `install()`. Defaults to:
-  - The `CMAKE_INSTALL_PREFIX` environment variable when set (with CMake 3.29 or newer).
-  - `/usr/local` on UNIX platforms.
-  - `C:/Program Files/${PROJECT_NAME}` on Windows.
-  - Use `cmake-build/install/` as the custom install prefix when system modification is undesirable or disallowed by the user.
-- `-D CMAKE_BUILD_TYPE:STRING=<config>`: specify the build type on single-configuration generators.
-- `-D BUILD_SHARED_LIBS:BOOL=(ON|OFF)`: specify whether to build shared (`ON`) or static (`OFF`) libraries.
+- `-D ENABLE_CLIENT_SIDE_ENCRYPTION:STRING=(AUTO|ON|OFF)`: In-Use Encryption support. Requires additional support libraries.
+- `-D ENABLE_MAINTAINER_FLAGS:BOOL=(OFF|ON)`: stricter build-time checks, including the warning set that CI builds with. A default build does not enable these.
+- `-D MONGO_SANITIZE:STRING=<list>`: semicolon/comma-separated list of sanitizers to build with (e.g. `address,undefined`).
 
-**Build performance:** Ninja parallelizes builds across all available cores by default; to cap the job count, set `CMAKE_BUILD_PARALLEL_LEVEL=<N>` in the environment before running `cmake --build`.
+> [!TIP]
+> Setting the environment variable `MONGODB_DEVELOPER` to a true value changes the *defaults* of many of this project's settings to development-appropriate values: on non-MSVC compilers it turns `ENABLE_MAINTAINER_FLAGS` on and defaults `MONGO_SANITIZE` to `address,undefined`. This can explain build behavior that otherwise looks surprising. See `build/cmake/MongoSettings.cmake`.
 
 > [!NOTE]
 > `.evergreen/scripts/compile.sh` is the authoritative reference for CI configure-build-install routines. Consult it for details on Ninja generator selection, ccache integration, sanitizer flags (`MONGO_SANITIZE`), client-side encryption (`ENABLE_CLIENT_SIDE_ENCRYPTION`), and other platform-specific options.
@@ -51,25 +42,23 @@ Key CMake configuration options (given `option=(default|alternatives...)`):
 The typical configure and build steps for testing:
 
 ```bash
-cmake -D CMAKE_BUILD_TYPE=Debug -B cmake-build
-cmake --build cmake-build --target test-libmongoc
+cmake -D CMAKE_BUILD_TYPE=Debug -B <build-dir>
+cmake --build <build-dir> --target test-libmongoc
 ```
 
 > [!IMPORTANT]
-> The "Debug" config type is recommended for local testing and development.
-> If the project was already built with a different build type and the user has not requested a change, preserve the existing `CMAKE_BUILD_TYPE` rather than switching to `Debug`, and advise the user that switching to `Debug` is recommended for local testing and development.
-> This configure step replaces the release/installation configure above - running both is unnecessary when developing.
-
-> [!IMPORTANT]
-> For multi-configuration generators (e.g., "Visual Studio *", "Ninja Multi-Config"), executables appear under a `<config>/` subdirectory (e.g., `cmake-build/src/libmongoc/Debug/test-libmongoc`).
+> The "Debug" config type is recommended for local testing and development, and this configure step replaces the release/installation configure above - running both is unnecessary when developing.
+> If the project was already built with a different build type and the user has not requested a change, preserve the existing `CMAKE_BUILD_TYPE` rather than switching to `Debug`, and advise the user that switching to `Debug` is recommended.
 
 Test executables are excluded from the `ALL` CMake target, so it is necessary to specify a target with the `--target` flag when building tests. The target `test-libmongoc` contains the majority of the test cases. The target `mongo_c_driver_tests` is a custom CMake target that can be used to build all test executables.
 
-Most tests require a live MongoDB server. Server-dependent tests may be skipped with the environment variable `MONGOC_TEST_SKIP_LIVE`.
+Every `test-libmongoc` case is additionally registered as an individual CTest test, so the suite can be run either through `ctest` or by invoking the executable directly. The `running-test-libmongoc` skill in `.agents/skills/` covers both paths, along with test naming, filtering, tags, and debugging.
+
+Most tests require a live MongoDB server. Server-dependent tests may be skipped with the environment variable `MONGOC_TEST_SKIP_LIVE`. The other `MONGOC_TEST_*` variables that configure the suite are documented under *Testing* in `CONTRIBUTING.md`.
 
 Test executables include:
 
-- `test-libmongoc`: Most of the tests for `libmongoc` and `libbson`. Uses a custom test framework; see the `running-test-libmongoc` skill in `.agents/skills/` for how to build, run, filter, and debug these tests.
+- `test-libmongoc`: Most of the tests for `libmongoc` and `libbson`. Uses a custom test framework, with its own naming and filtering rules (see the skill referenced above).
 - `test-mongoc-gssapi`: GSSAPI / Kerberos authentication tests. Requires a configured Kerberos environment (via `MONGOC_TEST_GSSAPI_HOST` / `MONGOC_TEST_GSSAPI_USER`) and connects concurrently from multiple threads.
 - `test-sfp`: Connectivity tests against the Atlas Secure Front-End Processor (SFP), exercising unauthenticated, SCRAM, and X.509 auth across baseline, compressed, and Server API variants.
 - `test-mongoc-cache`: End-to-end test for the OCSP response cache (Linux only). Confirms a revoked certificate stays revoked (TLS handshake keeps failing) from the cached OCSP response even after the OCSP responder is replaced with a valid one; it pauses itself with `SIGSTOP` so the harness can swap responders between connection attempts.
@@ -77,33 +66,51 @@ Test executables include:
 - `test-gcpkms`: CSFLE test for automatic GCP KMS credentials. Creates a data key with an empty `gcp` KMS provider so credentials are obtained from a GCP attached service account. Must run on a configured GCP VM.
 - `test-awsauth`: `MONGODB-AWS` authentication mechanism tests, intended to run within an AWS ECS task or EC2 instance.
 
+### Test Infrastructure
+
+- `src/libmongoc/tests/test-libmongoc.c` — the test runner and its internal `TestSuite` framework.
+- `src/libmongoc/tests/mock_server/` — mock MongoDB server for protocol-level tests.
+- `src/libbson/tests/` — libbson unit tests.
+- Spec tests are JSON files under `src/libmongoc/tests/json/` and `src/libbson/tests/json/`.
+
 ## Architecture
 
-The repository provides several public, private, and vendored libraries, each under `src/`:
+The repository provides several public, private, and vendored libraries, each under `src/`. Both public libraries build from the same CMake project.
 
 ### Public Libraries
 
-#### `libbson`
-
-A public standalone BSON document library with no MongoDB dependency.
-
-#### `libmongoc`
-
-The public MongoDB C Driver. Depends on the `libbson` library.
+- **`libbson`** (`src/libbson/src/bson/`): a public standalone BSON document library with no MongoDB dependency.
+- **`libmongoc`** (`src/libmongoc/src/mongoc/`): the public MongoDB C Driver. Depends on the `libbson` library.
 
 ### Private Libraries
 
-#### `kms-message`
+- **`kms-message`** (`src/kms-message/`): creates signed Amazon Web Services (AWS) requests for the `MONGODB-AWS` auth mechanism, and handles the KMS wire protocol used by In-Use Encryption.
+- **`mlib`** (`src/common/src/mlib/`): header-only facilities for checked arithmetic, macros, date/time, integer utilities, OS headers, strings, testing, and vector containers. Used by both `libbson` and `libmongoc`. Key headers: `str.h` (string type), `ckdint.h` (checked integer arithmetic), `vec.th`/`str_vec.h` (generic vectors), `cmp.h` (comparisons), `loop.h` (iteration helpers).
+- **`common`** (`src/common/src/`): various utilities such as concurrency primitives and JSON serialization. Technically not a library, but a collection of private headers and source files that are compiled with both `libbson` and `libmongoc`.
 
-A library used to create signed Amazon Web Services (AWS) requests for the `MONGODB-AWS` auth mechanism.
+`mlib/ckdint.h` is a C99-compatible backport of the C23 `stdckdint.h` API (`mlib_add`, `mlib_sub`, `mlib_mul`, `mlib_narrow`, and the `mlib_assert_*` variants). Prefer these over raw arithmetic and narrowing casts wherever overflow or truncation is possible. See `src/common/src/mlib/ckdint.md` for usage details.
 
-#### `mlib` (found under `src/common/src/mlib`)
+### BSON DSL (`common-bson-dsl-private.h`)
 
-Facilities for checked arithmetic, macros, date/time, integer utilities, OS headers, strings, testing, and vector containers. Used by both `libbson` and `libmongoc`. Header only.
+An internal macro DSL for constructing and parsing `bson_t` objects declaratively. Use `bsonBuild`/`bsonBuildDecl` for writing and `bsonParse`/`bsonVisitEach` for reading. See `src/common/src/bson-dsl.md` for full documentation.
 
-#### `common`
+### Header Conventions
 
-Provides various utilities such as concurrency primitives and JSON serialization. Technically not a library, but a collection of private headers and source files that are compiled with both `libbson` and `libmongoc`.
+Public headers have no `private` suffix (e.g., `mongoc-client.h`). Internal headers are named `*-private.h`. The `_private.h` suffix indicates the struct definition is exposed for internal use only.
+
+### Navigating libmongoc
+
+Implementation files are named `mongoc-<subsystem>*.c`, so the file listing is itself a serviceable index: `mongoc-uri.c` (connection string parsing), `mongoc-collection.c` / `mongoc-database.c`, `mongoc-bulkwrite.c` / `mongoc-bulk-operation.c`, `mongoc-client-session.c` (sessions and transactions), `mongoc-gridfs*.c`, `mongoc-structured-log.c`, and so on. The `mcd-` prefix marks assorted newer internal components rather than one subsystem (`mcd-rpc.c` is the wire protocol message representation).
+
+The relationships that the file names do *not* convey:
+
+- **Client, pool, and topology.** A single-threaded `mongoc_client_t` owns its `mongoc_topology_t` directly, while every client handed out by a `mongoc_client_pool_t` shares the pool's single topology. Which objects are shared between threads follows from this split.
+- **SDAM** spans more than `mongoc-topology*.c`: `mongoc-server-description.c`, `mongoc-server-monitor.c`, and `mongoc-topology-background-monitoring.c` are all part of it.
+- **Cluster** (`mongoc-cluster.c`) owns the open connections to servers and dispatches commands — the layer between a client operation and the wire. Authentication mechanisms are *also* here, as `mongoc-cluster-<mechanism>.c` (`-aws`, `-cyrus`, `-oidc`, `-sasl`, `-sspi`), alongside `mongoc-scram.c`.
+- **Cursor** is one public type over several backends: `mongoc-cursor-find.c`, `-cmd.c`, `-array.c`, `-change-stream.c`.
+- **Streams** are layered behind the `mongoc_stream_t` vtable: a TLS stream (`mongoc-stream-tls-*.c`, one per TLS backend) wraps a base socket or buffered stream.
+- **In-Use Encryption** is split between `mongoc-client-side-encryption.c` (the public API) and `mongoc-crypt.c` (the binding to libmongocrypt).
+- **APM** (`mongoc-apm.c`) exposes 12 callbacks, covering command, server/topology, and heartbeat events. There are no connection-pool (CMAP) callbacks.
 
 ### Vendored Third-Party Libraries
 
@@ -120,17 +127,20 @@ There are several third-party libraries in the repository source tree to enable 
 
 Uses C99. Contributions shall not use features from newer standards.
 
+## Code Style
+
+See *Coding Style* in `CONTRIBUTING.md` and `.clang-format` for indentation. In addition:
+
+- **Column limit**: 120 characters.
+- **clangd**: requires configuring with `-D CMAKE_EXPORT_COMPILE_COMMANDS=ON`, which is not enabled by default. If clangd reports unknown headers or missing symbols, check that `<build-dir>/compile_commands.json` exists before looking anywhere else.
+- Include directives for `mlib/`, `bson/`, and `mongoc/` headers use angle brackets (`<mlib/str.h>`, not `"mlib/str.h"`).
+- New `.c`/`.h` files carry an Apache 2.0 license header; copy the boilerplate from an existing file rather than composing it from memory.
+
 ## Documentation
 
-Documentation is authored as separate `.rst` files under `src/libbson/doc` and `src/libmongoc/doc`, and generated with Sphinx. There is a document for each public API type (e.g., `src/libmongoc/doc/mongoc_client_t.rst`) and function (e.g., `src/libmongoc/doc/mongoc_client_new.rst`).
+Documentation is authored as separate `.rst` files under `src/libbson/doc` and `src/libmongoc/doc`, and generated with Sphinx. There is a document for each public API type (e.g., `src/libmongoc/doc/mongoc_client_t.rst`) and function (e.g., `src/libmongoc/doc/mongoc_client_new.rst`), so adding a new public symbol requires adding its `.rst` file.
 
-To build `libmongoc` documentation from a fresh environment with warnings treated as errors:
-
-```bash
-uv run --frozen sphinx-build -j auto -WEn src/libmongoc/doc src/libmongoc/doc/html
-```
-
-Replace `libmongoc` with `libbson` in the above command for `libbson` documentation.
+See *Documentation* in `CONTRIBUTING.md` for the `sphinx-build` and `sphinx-autobuild` invocations, and for the comment-block convention used on complex internal functions.
 
 ## Before Committing
 
@@ -146,6 +156,8 @@ uv run --frozen tools/shfmt-format-all.sh # Shell scripts.
 
 See `CONTRIBUTING.md` for guidance on:
 
+- AI usage (all changes require human review; low-effort AI-generated PRs may be rejected)
+- Portability across supported platforms
 - Indentation
 - Error codes and domains
 - API/ABI policy


### PR DESCRIPTION
# Summary

I was working with Claude on mongo-c-driver for a while before the `AGENTS.md` was added. This PR just consolidates a few things I found useful, as well as applies some cleanup and things discussed in the AGENTS.md for libmongocrypt.

The initial merge was performed by Opus 5 on `ultrathink`, with some iteration. I have read over the full changeset and applied manual fixes as well.

# Editorial rules applied

Two rules drove most of the diff, both from review feedback on the sibling `libmongocrypt` AGENTS.md (mongodb/libmongocrypt#1211):

1. **Don't document what the model already knows.** Generic CMake behavior is already baked-in for the model. Removed the multi-configuration generator explanations (which appeared three times), and the `-G` / `CMAKE_BUILD_TYPE` / `BUILD_SHARED_LIBS` / `CMAKE_INSTALL_PREFIX` / `CMAKE_EXPORT_COMPILE_COMMANDS` bullets. The options list is now titled "specific to this project" as a guardrail against this drifting back.
2. **Don't duplicate `CONTRIBUTING.md`.** It stays the source of truth for indentation, commit style, adding a symbol or error code, the `MONGOC_TEST_*` variables, and the Sphinx invocations. Those are now pointers, and AI-usage and portability were added to that pointer list.

The binary directory is now a `<build-dir>` placeholder rather than a prescribed name, keeping only the repo-specific fact that matters: `build/` is a tracked source directory here, so it must not be configured-into.

# Additions

- The *Private Libraries* section was expanded with more specifics about what can be found in each subcomponent.
- It specifically calls out using `ckdint.h` for arithmetic, to steer agents toward using that if there is a risk of arithmetic overflow.
- A section that directs the agent to use the bson-dsl components for decomposing and building BSON documents.
- The *Header Conventions* section documents how/why the `-private.h` headers are used and what they mean.
- The *Navigating libmongoc* section details briefly the large subsystem of the C driver, with pointers to the relevant filenames.
- A brief *Code Style* section that directs toward `CONTRIBUTING.md` AND `.clang-format`.
  - Directs to use formatting script rather than fiddling with whitespace.
  - Notes how to make sure `clangd` is running properly so it doesn't spam the agent with false diagnostics.
  - Documents header style and notes that the formatting script will rewrite/rearrange them.
  - Directs how to create new files, and tells it to duplicate the license header into new files.
- Note the `MONGODB_DEVELOPER` environment variable and how it affects configuration.
- AGENTS.md now calls out the testing skill directly, and notes that CTest is also available for test running.
- In the test skill: 
  - More emphasis that `test-libmongoc` is not built in `all`. This has continually tripped up my agents. Directs it on how to ensure it is built.
  - Direction on running tests via CTest.
  - An explanation of the test label system used in test cases.

# Removals

- Dropped general CMake knowledge from the guidance, only noting the load-bearing CMake configuration parameters. (May need more? It's sparse)
- Direction about how to run Sphinx is now a pointer to CONTRIBUTING.md

# Notes for reviewers

- No Jira ticket is attached.
- Prose wrapping is mixed: reflowed paragraphs are ones this PR touched, matching the deferral of a whole-file reformat discussed in mongodb/libmongocrypt#1211. A separate pass could normalize the file.
- This may be easier to read in the rich diff viewer.